### PR TITLE
Fix for hand tool jitter; pinch-to-zoom

### DIFF
--- a/src/gui/XournalView.h
+++ b/src/gui/XournalView.h
@@ -39,6 +39,15 @@ public:
 public:
 	void zoomIn();
 	void zoomOut();
+  void setZoom(gdouble scale);
+
+  //Gestures
+  GtkGesture* zoom_gesture;
+  gdouble prev_zoom_gesture_scale;
+  gdouble zoom_gesture_begin;
+  //Problems with pinch to zoom:
+  //-keep view centred between pinching fingers
+  //-gtk_gesture_is_recognized not working (always false in XournalWidget.cpp code)
 
 	bool paint(GtkWidget* widget, GdkEventExpose* event);
 
@@ -120,8 +129,14 @@ public:
 public:
 	bool onKeyPressEvent(GdkEventKey* event);
 	bool onKeyReleaseEvent(GdkEventKey* event);
-
+  bool zoom_gesture_active;
 	static void onRealized(GtkWidget* widget, XournalView* view);
+  static void zoom_gesture_begin_cb(GtkGesture* gesture,GdkEventSequence* sequence,XournalView* view);
+  static void zoom_gesture_end_cb(GtkGesture* gesture,GdkEventSequence* sequence,XournalView* view);
+  static void zoom_gesture_scale_changed_cb(GtkGestureZoom* gesture,gdouble sclae,XournalView* view);
+
+
+
 
 private:
 

--- a/src/gui/widgets/XournalWidget.cpp
+++ b/src/gui/widgets/XournalWidget.cpp
@@ -348,7 +348,12 @@ gboolean gtk_xournal_button_press_event(GtkWidget* widget,
 {
 	GtkXournal* xournal = GTK_XOURNAL(widget);
 	Settings* settings = xournal->view->getControl()->getSettings();
-
+   //gtk_gesture_is_recognized is always false (bug, programming error?)
+   //workaround with additional variable zoom_gesture_active 
+   if (xournal->view->zoom_gesture_active)
+	  {
+      return TRUE;
+    }
 	if (event->type != GDK_BUTTON_PRESS)
 	{
 		return FALSE; // this event is not handled here
@@ -449,6 +454,11 @@ gboolean gtk_xournal_button_release_event(GtkWidget* widget,
 
 	Cursor* cursor = xournal->view->getCursor();
 	ToolHandler* h = xournal->view->getControl()->getToolHandler();
+  if (xournal->view->zoom_gesture_active)
+    {
+      return TRUE;
+    }
+
 	cursor->setMouseDown(false);
 
 	xournal->inScrolling = false;
@@ -487,6 +497,12 @@ gboolean gtk_xournal_motion_notify_event(GtkWidget* widget,
 {
 	GtkXournal* xournal = GTK_XOURNAL(widget);
 	ToolHandler* h = xournal->view->getControl()->getToolHandler();
+
+  if (xournal->view->zoom_gesture_active)
+    {
+      return TRUE;
+    }
+
 
 	if (h->getToolType() == TOOL_HAND)
 	{
@@ -556,6 +572,8 @@ static void gtk_xournal_init(GtkXournal* xournal)
 	events |= GDK_POINTER_MOTION_MASK;
 	events |= GDK_EXPOSURE_MASK;
 	events |= GDK_BUTTON_MOTION_MASK;
+	//not sure if GDK_TOUCH_MASK is needed
+  events |= GDK_TOUCH_MASK;
 	events |= GDK_BUTTON_PRESS_MASK;
 	events |= GDK_BUTTON_RELEASE_MASK;
 	events |= GDK_ENTER_NOTIFY_MASK;

--- a/src/gui/widgets/XournalWidget.cpp
+++ b/src/gui/widgets/XournalWidget.cpp
@@ -252,23 +252,27 @@ bool gtk_xournal_scroll_callback(GtkXournal* xournal)
 static void gtk_xournal_scroll_mouse_event(GtkXournal* xournal,
                                            GdkEventMotion* event)
 {
-	int x = event->x;
-	int y = event->y;
+  // use root coordinates as reference point because
+  //scrolling changes window relative coordinates
+  //see github Gnome/evince@1adce5486b10e763bed869
+  int x_root = event->x_root;
+  int y_root = event->y_root;
 
-	if (xournal->lastMousePositionX - x == 0 &&
-	    xournal->lastMousePositionY - y == 0)
+	if (xournal->lastMousePositionX - x_root == 0 &&
+	    xournal->lastMousePositionY - y_root == 0)
 	{
 		return;
 	}
 
 	if (xournal->scrollOffsetX == 0 && xournal->scrollOffsetY == 0)
 	{
-		xournal->scrollOffsetX = xournal->lastMousePositionX - x;
-		xournal->scrollOffsetY = xournal->lastMousePositionY - y;
-		g_idle_add((GSourceFunc) gtk_xournal_scroll_callback, xournal);
+    xournal->scrollOffsetX = xournal->lastMousePositionX - x_root;
+    xournal->scrollOffsetY = xournal->lastMousePositionY - y_root;
 
-		xournal->lastMousePositionX = x;
-		xournal->lastMousePositionY = y;
+		g_idle_add((GSourceFunc) gtk_xournal_scroll_callback, xournal);
+		//gtk_xournal_scroll_callback(xournal);
+    xournal->lastMousePositionX = x_root;
+		xournal->lastMousePositionY = y_root;
 	}
 }
 
@@ -378,11 +382,10 @@ gboolean gtk_xournal_button_press_event(GtkWidget* widget,
 	{
 		Cursor* cursor = xournal->view->getCursor();
 		cursor->setMouseDown(true);
-		xournal->lastMousePositionX = 0;
-		xournal->lastMousePositionY = 0;
 		xournal->inScrolling = true;
-		gtk_widget_get_pointer(widget, &xournal->lastMousePositionX,
-		                       &xournal->lastMousePositionY);
+    //set reference
+    xournal->lastMousePositionX=event->x_root;
+		xournal->lastMousePositionY=event->y_root;
 
 		return TRUE;
 	}


### PR DESCRIPTION
Use root coordinates as handtool reference instead of relative coordinates to avoid jittering. (see GNOME/evince@1adce54). Should fix issue #162.
Second commit is the (non-centered) pinch-to-zoom functionality. Issue #160 