### PR TITLE
Centered zooming for pinch-to-zoom gesture and Shift-Mousewheel;

### DIFF
--- a/src/control/ZoomControl.cpp
+++ b/src/control/ZoomControl.cpp
@@ -1,4 +1,5 @@
 #include "ZoomControl.h"
+#include <math.h>
 
 const double zoomStep = 0.04;
 
@@ -12,6 +13,9 @@ ZoomControl::ZoomControl()
 	this->zoom100Value = 1.0;
 	this->zoomFitValue = 1.0;
 	this->zoomFitMode = true;
+	this->zoom_center_x = -1;
+	this->zoom_center_y = -1;
+
 }
 
 ZoomControl::~ZoomControl()
@@ -43,14 +47,14 @@ void ZoomControl::fireZoomChanged(double lastZoom)
 {
 	XOJ_CHECK_TYPE(ZoomControl);
 
-	if (this->zoom < 0.3)
+	if (this->zoom < MIN_ZOOM)
 	{
-		this->zoom = 0.3;
+		this->zoom = MIN_ZOOM;
 	}
 
-	if (this->zoom > 5)
+	if (this->zoom > MAX_ZOOM)
 	{
-		this->zoom = 5;
+		this->zoom = MAX_ZOOM;
 	}
 
 	for (GList* l = this->listener; l != NULL; l = l->next)
@@ -81,8 +85,7 @@ double ZoomControl::getZoom()
 void ZoomControl::setZoom(double zoom)
 {
 	XOJ_CHECK_TYPE(ZoomControl);
-
-	double lastZoom = zoom;
+	double lastZoom = this->zoom;
 	this->zoom = zoom;
 	this->zoomFitMode = false;
 	fireZoomChanged(lastZoom);
@@ -180,6 +183,9 @@ bool ZoomControl::onScrolledwindowMainScrollEvent(GtkWidget* widget,
 
 	if (state & GDK_CONTROL_MASK)
 	{
+		//set zoom center (for shift centered scroll)
+		zoom->zoom_center_x = event->x;
+		zoom->zoom_center_y = event->y;
 		if (event->direction == GDK_SCROLL_UP || event->direction == GDK_SCROLL_LEFT)
 		{
 			zoom->zoomIn();

--- a/src/control/ZoomControl.h
+++ b/src/control/ZoomControl.h
@@ -12,6 +12,11 @@
 #ifndef __ZOOMCONTROL_H__
 #define __ZOOMCONTROL_H__
 
+//Hardcode max and min zoom
+//this should probably be user-adjustable in future
+#define MAX_ZOOM 5
+#define MIN_ZOOM .3
+
 #include <gtk/gtk.h>
 
 #include <XournalType.h>
@@ -47,6 +52,10 @@ public:
 	void addZoomListener(ZoomListener* listener);
 
 	void initZoomHandler(GtkWidget* widget);
+
+	// Current zoom center
+	gdouble zoom_center_x;
+	gdouble zoom_center_y;
 
 protected:
 	void fireZoomChanged(double lastZoom);

--- a/src/gui/Layout.cpp
+++ b/src/gui/Layout.cpp
@@ -200,6 +200,7 @@ void Layout::layoutPages()
 
 	if (horizontalSpace)
 	{
+		//A quarter of the document is always visible in window
 		marginLeft = MAX(marginLeft, visRect.width * 0.75);
 	}
 
@@ -342,6 +343,15 @@ void Layout::scrollRelativ(int x, int y)
 	gtk_adjustment_set_value(adjVertical,
 	                         gtk_adjustment_get_value(adjVertical) + y);
 }
+
+void Layout::scrollAbs(int x, int y)
+{
+	XOJ_CHECK_TYPE(Layout);
+
+	gtk_adjustment_set_value(adjHorizontal,x);
+	gtk_adjustment_set_value(adjVertical,y);
+}
+
 
 void Layout::ensureRectIsVisible(int x, int y, int width, int height)
 {

--- a/src/gui/Layout.h
+++ b/src/gui/Layout.h
@@ -44,6 +44,10 @@ public:
 	 * Increases the adjustments by the given amounts
 	 */
 	void scrollRelativ(int x, int y);
+		/**
+	 * Changes the adjustments by absolute amounts (for pinch-to-zoom)
+	 */
+	void scrollAbs(int x, int y);
 
 	/**
 	 * Changes the adjustments in such a way as to make sure that

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -338,6 +338,10 @@ void MainWindow::updateScrollbarSidebarPosition()
 	GtkWidget* sidebar = get("sidebar");
 	GtkWidget* winXournal = get("winXournal");
 	GtkScrolledWindow* scrolledWindow = GTK_SCROLLED_WINDOW(winXournal);
+	// Turn on/off kinetic scrolling (in gnome 3.18 on by default)
+	// Kinetic scrolling works fine btw
+	// comment line to turn on
+	gtk_scrolled_window_set_kinetic_scrolling(scrolledWindow,false);
 
 	bool scrollbarOnLeft = control->getSettings()->isScrollbarOnLeft();
 

--- a/src/gui/XournalView.h
+++ b/src/gui/XournalView.h
@@ -43,8 +43,8 @@ public:
 
   //Gestures
   GtkGesture* zoom_gesture;
-  gdouble prev_zoom_gesture_scale;
   gdouble zoom_gesture_begin;
+	Rectangle visRect_gesture_begin;
   //Problems with pinch to zoom:
   //-keep view centred between pinching fingers
   //-gtk_gesture_is_recognized not working (always false in XournalWidget.cpp code)
@@ -133,7 +133,7 @@ public:
 	static void onRealized(GtkWidget* widget, XournalView* view);
   static void zoom_gesture_begin_cb(GtkGesture* gesture,GdkEventSequence* sequence,XournalView* view);
   static void zoom_gesture_end_cb(GtkGesture* gesture,GdkEventSequence* sequence,XournalView* view);
-  static void zoom_gesture_scale_changed_cb(GtkGestureZoom* gesture,gdouble sclae,XournalView* view);
+  static void zoom_gesture_scale_changed_cb(GtkGestureZoom* gesture,gdouble scale,XournalView* view);
 
 
 

--- a/src/gui/toolbarMenubar/ToolZoomSlider.cpp
+++ b/src/gui/toolbarMenubar/ToolZoomSlider.cpp
@@ -157,12 +157,12 @@ GtkToolItem* ToolZoomSlider::newItem()
 	if (this->horizontal)
 	{
 		this->slider = gtk_scale_new_with_range(GTK_ORIENTATION_HORIZONTAL,
-		                                        0.3, 3, 0.1);
+		                                        MIN_ZOOM, MAX_ZOOM, 0.1);
 	}
 	else
 	{
 		this->slider = gtk_scale_new_with_range(GTK_ORIENTATION_VERTICAL,
-		                                        0.3, 3, 0.1);
+		                                        MIN_ZOOM, MAX_ZOOM, 0.1);
 		gtk_range_set_inverted(GTK_RANGE(this->slider), true);
 	}
 	g_signal_connect(this->slider, "value-changed", G_CALLBACK(sliderChanged),


### PR DESCRIPTION
-turned off kinetic scrolling; 
-hardcoded the min/max zoom levels via "#define" to have them consistent in zoomcontrol and the slider
-Shift-Mousewheel works via scrollRelativ while the gesture uses absolute adjustments
- performance should be improved in a future commit

See issue #161.