### PR TITLE
configure.ac: fix python support when the $PYTHON envvar isn't set

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -65,22 +65,26 @@ dnl  	AM_CHECK_PYTHON_HEADERS([],[have_python=no])
 dnl fi
 
 if test "x$have_python" != "xno"; then
-	PY_EXEC_PREFIX=`$PYTHON -c 'import sys ; print sys.exec_prefix'`
-	PYTHON_LIBS="-lpython$PYTHON_VERSION"
-
-	if test "$os_win32" = yes; then
-		PYTHON_LIBS=`echo $PYTHON_LIBS | sed 's/\.//g'`
-		PYTHON_LIB_LOC="-I$PY_EXEC_PREFIX/libs"
-		PYTHON_CFLAGS="-I$PY_EXEC_PREFIX/include"
-		PYTHON_EXTRA_LIBS=
+	if test "$PYTHON" == ""; then
+		PKG_CHECK_MODULES(PYTHON, [python2])
 	else
-		PY_PREFIX=`$PYTHON -c 'import sys ; print sys.prefix'`
-		PYTHON_LIB_LOC="-L$PY_EXEC_PREFIX/lib/python$PYTHON_VERSION/config"
-		PYTHON_CFLAGS="-I$PY_PREFIX/include/python$PYTHON_VERSION"
-		PYTHON_MAKEFILE="$PY_EXEC_PREFIX/lib/python$PYTHON_VERSION/config/Makefile"
-		PYTHON_BASEMODLIBS=`sed -n -e 's/^BASEMODLIBS=\(.*\)/\1/p' $PYTHON_MAKEFILE`
-		PYTHON_OTHER_LIBS=`sed -n -e 's/^LIBS=\(.*\)/\1/p' $PYTHON_MAKEFILE`
-		PYTHON_EXTRA_LIBS="$PYTHON_BASEMODLIBS $PYTHON_OTHER_LIBS"
+		PY_EXEC_PREFIX=`$PYTHON -c 'import sys ; print sys.exec_prefix'`
+		PYTHON_LIBS="-lpython$PYTHON_VERSION"
+
+		if test "$os_win32" = yes; then
+			PYTHON_LIBS=`echo $PYTHON_LIBS | sed 's/\.//g'`
+			PYTHON_LIB_LOC="-I$PY_EXEC_PREFIX/libs"
+			PYTHON_CFLAGS="-I$PY_EXEC_PREFIX/include"
+			PYTHON_EXTRA_LIBS=
+		else
+			PY_PREFIX=`$PYTHON -c 'import sys ; print sys.prefix'`
+			PYTHON_LIB_LOC="-L$PY_EXEC_PREFIX/lib/python$PYTHON_VERSION/config"
+			PYTHON_CFLAGS="-I$PY_PREFIX/include/python$PYTHON_VERSION"
+			PYTHON_MAKEFILE="$PY_EXEC_PREFIX/lib/python$PYTHON_VERSION/config/Makefile"
+			PYTHON_BASEMODLIBS=`sed -n -e 's/^BASEMODLIBS=\(.*\)/\1/p' $PYTHON_MAKEFILE`
+			PYTHON_OTHER_LIBS=`sed -n -e 's/^LIBS=\(.*\)/\1/p' $PYTHON_MAKEFILE`
+			PYTHON_EXTRA_LIBS="$PYTHON_BASEMODLIBS $PYTHON_OTHER_LIBS"
+		fi
 	fi
 
 	AC_SUBST([PYTHON_LIBS])


### PR DESCRIPTION
Use "pkg-config python2" to find PYTHON_{CFLAGS,LIBS} unless $PYTHON is
set.  This makes simplifies the configure command line invocation and enables
cross compiling. All major Linux distros ship their python-{dev,devel} package
with a pkg-config file. The systems that don't can fallback to setting $PYTHON.