### PR TITLE
Resolves xournalpp/xournalpp#187 and resolves xournalpp/xournalpp#168…

### DIFF
--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -892,7 +892,7 @@ void Settings::save()
 		saveData(root, p.first, p.second);
 	}
 
-	xmlSaveFormatFile(filename.c_str(), doc, 1);
+	xmlSaveFormatFileEnc(filename.c_str(), doc, "ISO-8859-1", 1);
 	xmlFreeDoc(doc);
 }
 


### PR DESCRIPTION
Fix bug 187/168 (168i should still be open imho - I'm able to repro with libxml2 2.9.4+12+ge905f08-2 on Arch Linux consistently). Simple change to explicitly set the encoding to ISO-8859-1 (ASCII + Western Europe extensions - just incase an extra symbol is required) on XML save.