### PR TITLE
Disable motion event compression

### DIFF
--- a/src/gui/XournalView.cpp
+++ b/src/gui/XournalView.cpp
@@ -882,7 +882,7 @@ void XournalView::setEventCompression(gboolean enable)
 
 	if(gtk_widget_get_realized(getWidget()))
 	gdk_window_set_event_compression(gtk_widget_get_window(getWidget()),
-	                                 enable);
+	                                 FALSE);
 }
 
 void XournalView::layoutPages()


### PR DESCRIPTION
Having event compression enabled extra unprocessed motion events in the event
queue can be discarded. Only the most recent event will be delivered.
This may result in edgy strokes.
This is solved by disabling event compression.

Reference: #109