### PR TITLE
Development

### DIFF
--- a/src/gui/dialog/SettingsDialog.cpp
+++ b/src/gui/dialog/SettingsDialog.cpp
@@ -247,45 +247,6 @@ string SettingsDialog::updateHideString(string hidden, bool hideMenubar, bool hi
 
 	string newHidden = "";
 
-	const char* element;
-	StringTokenizer token(hidden, ',');
-	element = token.next();
-	while (element)
-	{
-		if (!strcmp("mainMenubar", element))
-		{
-			if (hideMenubar)
-			{
-				hideMenubar = false;
-			}
-			else
-			{
-				element = token.next();
-				continue;
-			}
-		}
-		else if (!strcmp("sidebarContents", element))
-		{
-			if (hideSidebar)
-			{
-				hideSidebar = false;
-			}
-			else
-			{
-				element = token.next();
-				continue;
-			}
-		}
-
-		if (!newHidden.empty())
-		{
-			newHidden += ",";
-		}
-		newHidden += element;
-
-		element = token.next();
-	}
-
 	if (hideMenubar)
 	{
 		if (!newHidden.empty())

--- a/src/gui/dialog/SettingsDialog.cpp
+++ b/src/gui/dialog/SettingsDialog.cpp
@@ -247,6 +247,45 @@ string SettingsDialog::updateHideString(string hidden, bool hideMenubar, bool hi
 
 	string newHidden = "";
 
+	const char* element;
+	StringTokenizer token(hidden, ',');
+	element = token.next();
+	while (element)
+	{
+		if (!strcmp("mainMenubar", element))
+		{
+			if (hideMenubar)
+			{
+				hideMenubar = false;
+			}
+			else
+			{
+				element = token.next();
+				continue;
+			}
+		}
+		else if (!strcmp("sidebarContents", element))
+		{
+			if (hideSidebar)
+			{
+				hideSidebar = false;
+			}
+			else
+			{
+				element = token.next();
+				continue;
+			}
+		}
+
+		if (!newHidden.empty())
+		{
+			newHidden += ",";
+		}
+		newHidden += element;
+
+		element = token.next();
+	}
+
 	if (hideMenubar)
 	{
 		if (!newHidden.empty())

--- a/src/util/StringUtils.cpp
+++ b/src/util/StringUtils.cpp
@@ -31,8 +31,7 @@ StringTokenizer::StringTokenizer(const string s, char token, bool returnToken)
 {
 	XOJ_INIT_TYPE(StringTokenizer);
 
-	this->str = (char*) g_malloc(s.length() + 1);
-	memcpy(this->str, s.c_str(), s.length() + 1);
+	this->str = const_cast<char*> (s.c_str());
 	this->token = token;
 	this->tokenStr[0] = token;
 	this->tokenStr[1] = 0;
@@ -46,7 +45,7 @@ StringTokenizer::~StringTokenizer()
 {
 	XOJ_CHECK_TYPE(StringTokenizer);
 
-	g_free(this->str);
+	//g_free(this->str);
 	this->str = NULL;
 
 	XOJ_RELEASE_TYPE(StringTokenizer);

--- a/src/util/StringUtils.cpp
+++ b/src/util/StringUtils.cpp
@@ -31,7 +31,8 @@ StringTokenizer::StringTokenizer(const string s, char token, bool returnToken)
 {
 	XOJ_INIT_TYPE(StringTokenizer);
 
-	this->str = const_cast<char*> (s.c_str());
+	this->str = (char*) g_malloc(s.length() + 1);
+	memcpy(this->str, s.c_str(), s.length() + 1);
 	this->token = token;
 	this->tokenStr[0] = token;
 	this->tokenStr[1] = 0;
@@ -45,7 +46,7 @@ StringTokenizer::~StringTokenizer()
 {
 	XOJ_CHECK_TYPE(StringTokenizer);
 
-	//g_free(this->str);
+	g_free(this->str);
 	this->str = NULL;
 
 	XOJ_RELEASE_TYPE(StringTokenizer);

--- a/src/util/StringUtils.cpp
+++ b/src/util/StringUtils.cpp
@@ -31,7 +31,8 @@ StringTokenizer::StringTokenizer(const string s, char token, bool returnToken)
 {
 	XOJ_INIT_TYPE(StringTokenizer);
 
-	this->str = const_cast<char*> (s.c_str());
+	this->str = (char*) g_malloc(s.length() +1);
+	memcpy(this->str, s.c_str(), s.length() +1);
 	this->token = token;
 	this->tokenStr[0] = token;
 	this->tokenStr[1] = 0;
@@ -45,7 +46,7 @@ StringTokenizer::~StringTokenizer()
 {
 	XOJ_CHECK_TYPE(StringTokenizer);
 
-	//g_free(this->str);
+	g_free(this->str);
 	this->str = NULL;
 
 	XOJ_RELEASE_TYPE(StringTokenizer);


### PR DESCRIPTION
str seems to have been pointing to s.c_str(), which is not preserved. StringTokenizer::next() would then return garbage, breaking SettingsDialog::updateHideString, and writing random invalid characters to the settings file (which appears to have been the most recent cause of https://github.com/xournalpp/xournalpp/issues/168).