### PR TITLE
Fix up presentation mode

### DIFF
--- a/src/control/ScrollHandler.cpp
+++ b/src/control/ScrollHandler.cpp
@@ -33,7 +33,7 @@ void ScrollHandler::goToPreviousPage()
 				double disHeight = this->control->getWindow()->getLayout()->getDisplayHeight();
 				double top = (dHeight - disHeight) / 2.0 + 7.5;
 				//the magic 7.5 is from XOURNAL_PADDING_BETWEEN/2
-				scrollToPage(this->control->getWindow()->getXournal()->getCurrentPage() - 1, top);
+				scrollToPage(this->control->getWindow()->getXournal()->getCurrentPage() - 1, 0);
 			}
 		}
 		else
@@ -60,7 +60,7 @@ void ScrollHandler::goToNextPage()
 				//this gets reversed when we are going down if the page is smaller than the display height
 				double top = (-dHeight + disHeight) / 2.0 - 7.5;
 				//the magic 7.5 is from XOURNAL_PADDING_BETWEEN/2
-				scrollToPage(this->control->getWindow()->getXournal()->getCurrentPage() + 1, top);
+				scrollToPage(this->control->getWindow()->getXournal()->getCurrentPage() + 1, 0);
 			}
 		}
 		else

--- a/src/gui/XournalView.cpp
+++ b/src/gui/XournalView.cpp
@@ -246,12 +246,22 @@ bool XournalView::onKeyPressEvent(GdkEventKey* event)
 
 	if (event->keyval == GDK_Left)
 	{
+		if (control->getSettings()->isPresentationMode())
+		{
+			control->getScrollHandler()->goToPreviousPage();
+			return true;
+		}
 		layout->scrollRelativ(-scrollKeySize, 0);
 		return true;
 	}
 
 	if (event->keyval == GDK_Right)
 	{
+		if (control->getSettings()->isPresentationMode())
+		{
+			control->getScrollHandler()->goToNextPage();
+			return true;
+		}
 		layout->scrollRelativ(scrollKeySize, 0);
 		return true;
 	}
@@ -633,6 +643,18 @@ double XournalView::getZoom()
 {
 	XOJ_CHECK_TYPE(XournalView);
 
+	size_t p = getCurrentPage();
+	if (p != size_t_npos && p < viewPagesLen)
+	{
+		PageView* page = viewPages[p];
+		if (this->getControl()->getSettings()->isPresentationMode())
+		{
+			double heightZoom = this->getDisplayHeight() / page->getHeight();
+			double widthZoom = this->getDisplayWidth() / page->getWidth();
+			return (heightZoom < widthZoom) ? heightZoom : widthZoom;
+		}
+	}
+
 	return control->getZoomControl()->getZoom();
 }
 
@@ -756,6 +778,22 @@ void XournalView::layoutPages()
 
 	Layout* layout = gtk_xournal_get_layout(this->widget);
 	layout->layoutPages();
+}
+
+int XournalView::getDisplayHeight() const {
+	XOJ_CHECK_TYPE(XournalView);
+
+	GtkAllocation allocation = { 0 };
+	gtk_widget_get_allocation(this->widget, &allocation);
+	return allocation.height;
+}
+
+int XournalView::getDisplayWidth() const {
+	XOJ_CHECK_TYPE(XournalView);
+
+	GtkAllocation allocation = { 0 };
+	gtk_widget_get_allocation(this->widget, &allocation);
+	return allocation.width;
 }
 
 bool XournalView::isPageVisible(int page, int* visibleHeight)

--- a/src/gui/XournalView.h
+++ b/src/gui/XournalView.h
@@ -77,6 +77,9 @@ public:
 
 	void resetShapeRecognizer();
 
+	int getDisplayWidth() const;
+	int getDisplayHeight() const;
+
 	bool isPageVisible(int page, int* visibleHeight);
 
 	void ensureRectIsVisible(int x, int y, int width, int heigth);


### PR DESCRIPTION
This fixes #91 and also completes presentation mode, at least for me. Happy to take notes or adjust implementation, especially considering the "Things that aren't done" section in the commit message.

I remove any "padding" between or around pages, except for the padding
between dual-page layouts (I don't know how people want to use dual-page
and presentation at the same time, is padding desirable?). Then just
force the zoom to be the appropriate value when in presentation mode,
and skip to next/previous pages as buttons are pressed.

Things that aren't done:
 - Toolbars aren't hiding. I don't actually want this, since I want to
 be able to draw on presentations. Maybe as an option it could be done.
 - Scrollbar is visible. Honestly, I couldn't yet work out how to hide
 it. It should be easy, I feel, so maybe in another commit.
 - The current slide has a red border. I don't mind this, I feel it
 helps highlight the slide against the background. Easy to remove
 though.

ScrollHandler::goTo[Next|Previous]Page()
 - Don't add "top" to add padding when seeing next/previous page

Layout::layoutPages()
 - If in presentation mode, set padding = 0. Also allow zero-width
 margins.

Layout::ensureRectIsVisible()
 - If in presentation mode, don't add extra space around the page.

XournalView::getZoom()
 - If in presentation mode, force zoom to be the appropriate level.

XournalView::onKeyPressEvent()
 - If in presentation mode, left/right also go forwards/backwards in
 presentation. This is useful for things like laser pointers when
 presenting.

XournalView class
 - Add getDisplayWidth/Height functions.