### PR TITLE
Only store a tool if one hasn't been stored.

### DIFF
--- a/src/control/ToolHandler.cpp
+++ b/src/control/ToolHandler.cpp
@@ -642,7 +642,8 @@ void ToolHandler::copyCurrentConfig()
 {
 	XOJ_CHECK_TYPE(ToolHandler);
 
-	this->lastSelectedTool = this->current;
+	if (this->lastSelectedTool == NULL)
+		this->lastSelectedTool = this->current;
 }
 
 void ToolHandler::restoreLastConfig()


### PR DESCRIPTION
Fixes #194 which is caused by some hardware sending multiple touch
events. This ensures that a stored tool is not over-written by a
repeated touch event.

An alternative implementation idea is to maintain a stack of stored
tools, but that seems unnecessary.