### PR TITLE
Fixed bug in find function causing crash

### DIFF
--- a/src/gui/SearchBar.cpp
+++ b/src/gui/SearchBar.cpp
@@ -84,7 +84,7 @@ void SearchBar::search(const char* text)
 	}
 	else
 	{
-		searchTextonCurrentPage(NULL, NULL, NULL);
+		searchTextonCurrentPage("", NULL, NULL);
 		gtk_label_set_text(GTK_LABEL(lbSearchState), "");
 	}
 


### PR DESCRIPTION
Emptying the search field of the find function caused the program to crash (because NULL was passed as parameter, and not a valid string)

Fixes #257 