### PR TITLE
Fix preferences not saving to settings.xml file, both within the application and when restarting it

### DIFF
--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -892,7 +892,7 @@ void Settings::save()
 		saveData(root, p.first, p.second);
 	}
 
-	xmlSaveFormatFileEnc(filename.c_str(), doc, "ISO-8859-1", 1);
+	xmlSaveFormatFileEnc(filename.c_str(), doc, "UTF-8", 1);
 	xmlFreeDoc(doc);
 }
 

--- a/src/util/StringUtils.cpp
+++ b/src/util/StringUtils.cpp
@@ -46,7 +46,7 @@ StringTokenizer::~StringTokenizer()
 {
 	XOJ_CHECK_TYPE(StringTokenizer);
 
-	//g_free(this->str);
+	g_free(this->str);
 	this->str = NULL;
 
 	XOJ_RELEASE_TYPE(StringTokenizer);

--- a/src/util/StringUtils.cpp
+++ b/src/util/StringUtils.cpp
@@ -31,7 +31,8 @@ StringTokenizer::StringTokenizer(const string s, char token, bool returnToken)
 {
 	XOJ_INIT_TYPE(StringTokenizer);
 
-	this->str = const_cast<char*> (s.c_str());
+	this->str = (char*) g_malloc(s.length() +1);
+	memcpy(this->str, s.c_str(), s.length() +1);
 	this->token = token;
 	this->tokenStr[0] = token;
 	this->tokenStr[1] = 0;


### PR DESCRIPTION
Resolves issue #168 and uses pull request #223.
Platform: using Arch Linux, Linux 4.14.27, GTK3 3.22.28-1. Latest pull to the master branch, cherry-picked these fixes to my own repo.

I have tried combining both fixes (Hoeze's `UTF-8` fix from issue #168 and the official pull request to the development branch https://github.com/xournalpp/xournalpp/pull/223) and they seem to work well! Just to be sure, I've deleted the existing settings.xml file to avoid other issues. I also tried it with my existing `ISO-8859-1` encoded file, and it seems to work just fine with the new commits, maybe because the string is being read properly.

I've tried a few different settings (e.g. Xinput, sidebar on the right hand side, and zoom ruler DPI setting) and tested it in the master branch with mathtex flag in Cmake, to be sure all dependencies work. Now the error of "UTF8 string not found" when I click on the edit menu has also disappeared. The preferences are being written properly to settings.xml file in the .xournalpp folder in my home directory.

I'm opening this pull request so that there can be further discussion on this issue and if there is anything else that needs consideration before merging it into master.