### PR TITLE
Fix fullscreen/resize in presentation mode.

### DIFF
--- a/src/gui/XournalView.cpp
+++ b/src/gui/XournalView.cpp
@@ -55,6 +55,7 @@ XournalView::XournalView(GtkWidget* parent, Control* control)
 	gtk_widget_grab_focus(this->widget);
 
 	this->cleanupTimeout = g_timeout_add_seconds(5, (GSourceFunc) clearMemoryTimer, this);
+	g_signal_connect(this->widget, "size-allocate", G_CALLBACK(staticLayoutPages), this);
 }
 
 XournalView::~XournalView()
@@ -87,6 +88,13 @@ XournalView::~XournalView()
 gint pageViewCmpSize(PageView* a, PageView* b)
 {
 	return a->getLastVisibleTime() - b->getLastVisibleTime();
+}
+
+void XournalView::staticLayoutPages(GtkWidget *widget, GtkAllocation *allocation, void *data)
+{
+	XournalView *xv = (XournalView *)data;
+	XOJ_CHECK_TYPE_OBJ(xv, XournalView);
+	xv->layoutPages();
 }
 
 gboolean XournalView::clearMemoryTimer(XournalView* widget)

--- a/src/gui/XournalView.h
+++ b/src/gui/XournalView.h
@@ -127,6 +127,8 @@ private:
 
 	static gboolean clearMemoryTimer(XournalView* widget);
 
+	static void staticLayoutPages(GtkWidget *widget, GtkAllocation* allocation, void* data);
+
 private:
 	XOJ_TYPE_ATTRIB;
 


### PR DESCRIPTION
Enabling full screen first resizes the layout, and then the
display/pages, which breaks presentation mode. Rather than chase this
loop directly, this fix catches the resize event on the widget holding
the pages, and calls layoutPages again, which makes presentation mode
work in full screen, and when resizing the window directly.

It currently uses a static proxy function for the gtk signal handler, I
couldn't get std::bind to work and gtk doesn't support member function
callbacks (obviously, they're C bindings). The std::bind handler
probably could be made to work, or other alternatives.

This fixes issue #260 but I am definitely happy to take feedback into consideration, especially since the proxy static function feels like a hack.