### PR TITLE
[BUGFIX] - CTRL-Z deletion recovery segfault

### DIFF
--- a/src/model/Layer.cpp
+++ b/src/model/Layer.cpp
@@ -82,6 +82,9 @@ void Layer::insertElement(Element* e, int pos)
 		}
 	}
 
+	if(pos == -1) pos=0; 	//otherwise it segfaults on the next step trying
+				//to access a negative index on the elements array 
+
 	this->elements.insert(this->elements.begin() + pos, e);
 }
 


### PR DESCRIPTION
xournalpp segfaults upon item restore from deletion.

How to replicate the issue:

1) draw something on the page
2) delete it with CTRL+X or `canc`
3) CTRL+Z

I'm not entirely sure why do we have to sum `pos` to the element list.
Anyway the program segfaults upon element restoration due to negative array index.
I've inserted the -1 check and everything seem to work alright.

