### PR TITLE
Make apt command in README cut-n-paste compatible.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,12 @@ dnf install cmake libglade2-devel texlive-scheme-basic texlive-dvipng glibmm24-d
 
 For Ubuntu/Debian:
 ````bash
-sudo apt-get install cmake libboost-all-dev libcppunit-dev dvipng texlive
-liblcms2-dev libopenjpeg-dev libjpeg-dev fontconfig librsvg2-dev libgtk-3-dev
-libpoppler-dev libpoppler-cpp-dev libpoppler-glib-dev libpoppler-private-dev
-libxml2-dev
+sudo apt-get install cmake libboost-all-dev libcppunit-dev dvipng texlive \
+liblcms2-dev libjpeg-dev fontconfig librsvg2-dev libgtk-3-dev \
+libpoppler-dev libpoppler-cpp-dev libpoppler-glib-dev libpoppler-private-dev \
+libxml2-dev libopenjpeg-dev
 ````
+(On Ubuntu 18.04, remove the last `libopenjpeg-dev`, it's not in the repository any more).
 
 Basic steps are:
 ````bash


### PR DESCRIPTION
Also added a warning for libopenjpeg which is not available
on newer Ubuntus

This works adding a backslash at the end of every line, so that the shell will read it as a single line. 
 