### PR TITLE
Quick hacks to make it build in Ubuntu 18.10

### DIFF
--- a/src/pdf/popplerdirect/PdfObjectWriter.cpp
+++ b/src/pdf/popplerdirect/PdfObjectWriter.cpp
@@ -85,7 +85,7 @@ void PdfObjectWriter::writeObject(Object* obj, XojPopplerDocument doc)
 		this->writer->write(FORMAT("%g ", obj->getReal()));
 		break;
 	case objString:
-		this->writeString(obj->getString());
+		this->writeString(const_cast<GooString *>(obj->getString()));
 		break;
 	case objName:
 	{

--- a/src/pdf/popplerdirect/poppler/XojPopplerAction.cpp
+++ b/src/pdf/popplerdirect/poppler/XojPopplerAction.cpp
@@ -112,7 +112,7 @@ XojLinkDest* XojPopplerAction::getDestination()
     {
         LinkGoTo* link = dynamic_cast<LinkGoTo*> (this->linkAction);
 
-        GooString* namedDest = link->getNamedDest();
+        GooString* namedDest = const_cast<GooString *>(link->getNamedDest());
         LinkDest* d = NULL;
         if (namedDest)
         {
@@ -121,7 +121,7 @@ XojLinkDest* XojPopplerAction::getDestination()
 
         if (!d)
         {
-            d = link->getDest();
+            d = const_cast<LinkDest *>(link->getDest());
         }
 
         if (d)

--- a/src/pdf/popplerdirect/poppler/XojPopplerDocument.cpp
+++ b/src/pdf/popplerdirect/poppler/XojPopplerDocument.cpp
@@ -210,7 +210,7 @@ XojPopplerIter* XojPopplerDocument::getContentsIter()
 		return NULL;
 	}
 
-	GooList* items = outline->getItems();
+	GooList* items = const_cast<GooList *>(outline->getItems());
 	if (items == NULL)
 	{
 		return NULL;

--- a/src/pdf/popplerdirect/poppler/XojPopplerIter.cpp
+++ b/src/pdf/popplerdirect/poppler/XojPopplerIter.cpp
@@ -50,8 +50,8 @@ XojPopplerIter* XojPopplerIter::getChildIter()
     {
         return NULL;
     }
-
-    XojPopplerIter* child = new XojPopplerIter(doc, item->getKids());
+    GooList *tmp = const_cast<GooList *>(item->getKids());
+    XojPopplerIter* child = new XojPopplerIter(doc, tmp);
 
     return child;
 }
@@ -87,9 +87,9 @@ XojPopplerAction* XojPopplerIter::getAction()
     {
         return NULL;
     }
-    LinkAction* linkAction = item->getAction();
+    LinkAction* linkAction = const_cast<LinkAction *>(item->getAction());
 
-    string title = unicodeToChar(item->getTitle(), item->getTitleLength());
+    string title = unicodeToChar(const_cast<Unicode *>(item->getTitle()), item->getTitleLength());
 
     return new XojPopplerAction(this->doc, linkAction, title);
 }


### PR DESCRIPTION
Doesn't build in Ubuntu 18.10 (Cosmic Cuttlefish) with errors like:

```make
error: invalid conversion from ‘const GooString*’ to ‘GooString*’ [-fpermissive]
```

So I temporarily fix it with `const_cast<GooString *>()` so that it builds. Tested it and it works for my use case (import PDF, write something using pencil, export PDF).
