### PR TITLE
Try to fix #318 Allow to disable Backtrace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,24 @@ execute_process(COMMAND ${LSB_RELEASE_EXEC} -rs
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
+# Extended stacktrace enabled
+option (EXTENDED_STACKTRACE "Log extended stacktrace" OFF)
+
+## TODO check for dependency, not for distribution!
+#  find_package (????????????? 1.2.3)
+#  if (STACKTRACE_FOUND)
+#    set(EXTENDED_STACKTRACE ON)
+#  endif (NOT STACKTRACE_FOUND)
+
+if (LSB_RELEASE_ID_SHORT STREQUAL "Ubuntu")
+  set(EXTENDED_STACKTRACE ON)
+  message ("Automatically set EXTENDED_STACKTRACE ON on Ubuntu")
+endif()
+
+if (EXTENDED_STACKTRACE)
+	add_definitions (-DEXTENDED_STACKTRACE)
+endif()
+
 # Poppler
 option (BUILD_POPPLER "Build Poppler from git or other source" DEFAULT_BUILD_POOPPLER)
 
@@ -178,15 +196,17 @@ if (BUILD_POPPLER)
     libpoppler-glib.so
     
     ${OPENJPEG_LIBRARIES}
-# Comment out, seems to be a problem on Debian...
-# Do we need to detect something to enable / disable?
-#    -lopenjpeg
-    -lbacktrace
     ${JPEG_LIBRARIES}
     ${PopplerLibs_LDFLAGS}
     ${lcms_LDFLAGS}
   )
-  # -lopenjpeg added as fallback
+  
+if (EXTENDED_STACKTRACE)
+  set (POPPLER_LIBRARIES
+    ${POPPLER_LIBRARIES}
+    -lbacktrace
+  )
+endif ()
   
   set (POPPLER_INCLUDE_DIRS
     "${POPPLER_PREFIX}/src/poppler-build"
@@ -364,6 +384,7 @@ Configuration:
 	Compiler:                   ${CMAKE_CXX_COMPILER}
 	Mathtex enabled:            ${ENABLE_MATHTEX}
 	CppUnit enabled:            ${ENABLE_CPPUNIT}
+	Extended Stacktrace:        ${EXTENDED_STACKTRACE}
 
 Unstable features:
 	Layers sidebar:             ${UNSTABLE_LAYERS_SIDEBAR}

--- a/src/gui/MainWindowToolbarMenu.cpp
+++ b/src/gui/MainWindowToolbarMenu.cpp
@@ -24,7 +24,7 @@ public:
 
 
 MainWindowToolbarMenu::MainWindowToolbarMenu(MainWindow* win)
- : selectedToolbar(NULL), inPredefinedSection(false), win(win)
+ : win(win), selectedToolbar(NULL), inPredefinedSection(false)
 {
 	XOJ_INIT_TYPE(MainWindowToolbarMenu);
 }
@@ -120,7 +120,7 @@ void MainWindowToolbarMenu::menuClicked(GtkCheckMenuItem* menuitem, MenuSelectTo
 
 	win->toolbarSelected(data->d);
 
-	for(int i = 0; i < this->toolbarMenuData.size(); i++)
+	for (int i = 0; i < (int)this->toolbarMenuData.size(); i++)
 	{
 		if (data->index == i)
 		{

--- a/src/gui/XournalView.cpp
+++ b/src/gui/XournalView.cpp
@@ -366,15 +366,7 @@ void XournalView::zoom_gesture_end_cb(GtkGesture* gesture, GdkEventSequence* seq
 
 void XournalView::zoom_gesture_scale_changed_cb(GtkGestureZoom* gesture, gdouble scale, XournalView* view)
 {
-	ZoomControl* zoom = view->control->getZoomControl();
 	view->setZoom(scale * view->zoom_gesture_begin);
-
-	//Alternative implementation: update bounding box center each time scale changes
-	//Not used at the moment as a single center set at the beginning of the gesture seems
-	//more robust
-	/*
-	gtk_gesture_get_bounding_box_center (GTK_GESTURE (gesture), &zoom->zoom_center_x, &zoom->zoom_center_y);
-	*/
 }
 
 // send the focus back to the appropriate widget

--- a/src/pdf/popplerdirect/poppler/XojPopplerPage.cpp
+++ b/src/pdf/popplerdirect/poppler/XojPopplerPage.cpp
@@ -78,14 +78,15 @@ double XojPopplerPage::getHeight()
     }
 }
 
-static GBool poppler_print_annot_cb(Annot* annot, void* user_data)
-{
-    if (annot->getFlags() & Annot::flagPrint)
-    {
-        return true;
-    }
-    return (annot->getType() == Annot::typeWidget);
-}
+// Currently the call is also comment out
+//static GBool poppler_print_annot_cb(Annot* annot, void* user_data)
+//{
+//    if (annot->getFlags() & Annot::flagPrint)
+//    {
+//        return true;
+//    }
+//    return (annot->getType() == Annot::typeWidget);
+//}
 
 void XojPopplerPage::render(cairo_t* cr, bool forPrinting)
 {

--- a/src/util/Stacktrace.cpp
+++ b/src/util/Stacktrace.cpp
@@ -1,5 +1,7 @@
 #include "Stacktrace.h"
 
+#ifdef EXTENDED_STACKTRACE
+
 #include <iostream>
 
 #include <string.h>
@@ -53,3 +55,17 @@ void Stacktrace::printStracktrace()
 {
 	printStracktrace(std::cerr);
 }
+
+#else
+
+void Stacktrace::printStracktrace()
+{
+	// Does nothing
+}
+
+void Stacktrace::printStracktrace(std::ostream& stream)
+{
+	// Does nothing
+}
+
+#endif


### PR DESCRIPTION
Currently automatically enable on Ubuntu, should detect if available, not the distribution.