### PR TITLE
Fixed Preview Image

### DIFF
--- a/src/control/stockdlg/XojOpenDlg.cpp
+++ b/src/control/stockdlg/XojOpenDlg.cpp
@@ -185,9 +185,18 @@ void XojOpenDlg::updatePreviewCallback(GtkFileChooser* fileChooser, void* userDa
 	}
 
 	GError* error = NULL;
-	GInputStream* in = g_memory_input_stream_new_from_data(extractor.getData().c_str(), extractor.getData().length(), NULL);
+	gsize dataLen = 0;
+	unsigned char* imageData = extractor.getData(dataLen);
+
+	GInputStream* in = g_memory_input_stream_new_from_data(imageData, dataLen, NULL);
 	GdkPixbuf* pixbuf = gdk_pixbuf_new_from_stream(in, NULL, &error);
-	g_input_stream_close(in, NULL, &error);
+	if (error != NULL)
+	{
+		g_warning("Could not load preview image, error: %s\n", error->message);
+		g_error_free(error);
+	}
+
+	g_input_stream_close(in, NULL, NULL);
 
 	if (pixbuf)
 	{

--- a/src/util/XojPreviewExtractor.cpp
+++ b/src/util/XojPreviewExtractor.cpp
@@ -20,11 +20,26 @@ using std::unique_ptr;
 #define TAG_PAGE_NAME "page"
 #define BUF_SIZE 8192
 
+XojPreviewExtractor::XojPreviewExtractor()
+ : data(NULL),
+   dataLen(0)
+{
+}
+
+XojPreviewExtractor::~XojPreviewExtractor()
+{
+	g_free(data);
+	data = NULL;
+	dataLen = 0;
+}
+
+
 /**
  * @return The preview data, should be a binary PNG
  */
-string XojPreviewExtractor::getData() const
+unsigned char* XojPreviewExtractor::getData(gsize& dataLen)
 {
+	dataLen = this->dataLen;
 	return this->data;
 }
 
@@ -116,9 +131,8 @@ PreviewExtractResult XojPreviewExtractor::readFile(std::string file)
 			if (inTag)
 			{
 				gsize size;
-				const auto buf = g_base64_decode(preview.c_str(), &size);
-				this->data = string(buf, buf + size);
-				g_free(buf);
+
+				this->data = g_base64_decode(preview.c_str(), &this->dataLen);
 				CLOSE PREVIEW_RESULT_IMAGE_READ;
 			}
 			else

--- a/src/util/XojPreviewExtractor.h
+++ b/src/util/XojPreviewExtractor.h
@@ -12,6 +12,8 @@
 
 #pragma once
 
+#include <gdk/gdk.h>
+
 #include <string>
 using std::string;
 
@@ -45,6 +47,10 @@ enum PreviewExtractResult {
 class XojPreviewExtractor
 {
 public:
+	XojPreviewExtractor();
+	~XojPreviewExtractor();
+
+public:
 
 	/**
 	 * Try to read the preview from file
@@ -56,7 +62,7 @@ public:
 	/**
 	 * @return The preview data, should be a binary PNG
 	 */
-	string getData() const;
+	unsigned char* getData(gsize& dataLen);
 
 	// Member
 private:
@@ -64,5 +70,6 @@ private:
 	/**
 	 * Preview data
 	 */
-	string data;
+	unsigned char* data;
+	gsize dataLen;
 };

--- a/src/xoj-preview-extractor/xournal-thumbnailer.cpp
+++ b/src/xoj-preview-extractor/xournal-thumbnailer.cpp
@@ -92,14 +92,17 @@ int main(int argc, char* argv[])
 		return 5;
 	}
 	
-	ofstream ofile(argv[2], ofstream::out | ofstream::binary);
-	if (!ofile.is_open())
+	FILE* fp = fopen(argv[2], "wb");
+	if (!fp)
 	{
 		cerr << _F("xoj-preview-extractor: opening output file \"{1}\" failed") % argv[2] << endl;
 		return 6;
 	}
-	ofile << extractor.getData();
-	ofile.close();
+
+	gsize dataLen = 0;
+	unsigned char* imageData = extractor.getData(dataLen);
+	fwrite(imageData, dataLen, 1, fp);
+	fclose(fp);
 
 	cout << _("xoj-preview-extractor: successfully extracted") << endl;
 	return 0;

--- a/test/util/XojPreviewExtractorTest.cpp
+++ b/test/util/XojPreviewExtractorTest.cpp
@@ -68,7 +68,9 @@ public:
 
 		CPPUNIT_ASSERT_EQUAL(PREVIEW_RESULT_IMAGE_READ, result);
 		
-		CPPUNIT_ASSERT_EQUAL(string("CppUnitTestString"), string(extractor.getData()));
+		gsize dataLen = 0;
+		unsigned char* imageData = extractor.getData(dataLen);
+		CPPUNIT_ASSERT_EQUAL(string("CppUnitTestString"), string((char*)imageData, (size_t)dataLen));
 	}
 
 	void testLoadGzipped2()
@@ -78,7 +80,9 @@ public:
 
 		CPPUNIT_ASSERT_EQUAL(PREVIEW_RESULT_IMAGE_READ, result);
 
-		CPPUNIT_ASSERT_EQUAL((std::string::size_type) 2856, extractor.getData().length());
+		gsize dataLen = 0;
+		extractor.getData(dataLen);
+		CPPUNIT_ASSERT_EQUAL((std::string::size_type) 2856, dataLen);
 	}
 
 	void testLoad1Unzipped()
@@ -88,7 +92,9 @@ public:
 
 		CPPUNIT_ASSERT_EQUAL(PREVIEW_RESULT_IMAGE_READ, result);
 
-		CPPUNIT_ASSERT_EQUAL(string("CppUnitTestString"), string(extractor.getData()));
+		gsize dataLen = 0;
+		unsigned char* imageData = extractor.getData(dataLen);
+		CPPUNIT_ASSERT_EQUAL(string("CppUnitTestString"), string((char*)imageData, (size_t)dataLen));
 	}
 
 	void testNoPreview()


### PR DESCRIPTION
There was a std::string used a binary container, gives errors, probably
signed / unsigned stuff. Fixed with unsinged char array, preview is
working now.