### PR TITLE
fixed build error on clang ( now using C++11 standard )

### DIFF
--- a/src/gui/dialog/SelectBackgroundColorDialog.cpp
+++ b/src/gui/dialog/SelectBackgroundColorDialog.cpp
@@ -37,7 +37,7 @@ const int backgroundXournalCount = sizeof(backgroundXournal) / sizeof(GdkRGBA);
 
 SelectBackgroundColorDialog::SelectBackgroundColorDialog(Control* control)
  : control(control),
-   lastBackgroundColors({
+   lastBackgroundColors{
 	RGBA_FROM_HEX(0xffffff),
 	RGBA_FROM_HEX(0xffffff),
 	RGBA_FROM_HEX(0xffffff),
@@ -47,7 +47,7 @@ SelectBackgroundColorDialog::SelectBackgroundColorDialog(Control* control)
 	RGBA_FROM_HEX(0xffffff),
 	RGBA_FROM_HEX(0xffffff),
 	RGBA_FROM_HEX(0xffffff)
-   }),
+   },
    selected(-1)
 {
 	XOJ_INIT_TYPE(SelectBackgroundColorDialog);


### PR DESCRIPTION
Small change as seen on https://stackoverflow.com/questions/29743745/c-member-array-initalisation-without-default-constructors fixes small build error on clang (mac os)