### PR TITLE
Added real-time LaTex rendering in LatexDialog

### DIFF
--- a/src/control/LatexController.h
+++ b/src/control/LatexController.h
@@ -18,7 +18,7 @@
 #include "model/Text.h"
 
 #include <XournalType.h>
-
+#include "gui/dialog/LatexDialog.h"
 #include <string>
 using std::string;
 
@@ -50,13 +50,44 @@ private:
 	void findSelectedTexElement();
 
 	/**
+	 * If a previous image/text is selected, delete it 
+	 */
+	void deleteOldImage();
+
+	/**
 	 * Run LaTeX Command
 	 */
 	bool runCommand();
 
+	/**
+	 * Show the LaTex Editor dialog
+	 */
 	void showTexEditDialog();
-	void insertTexImage();
-	void deleteOldImage();
+
+	/**
+	 * Signal handler, updates the rendered image when the text in the editor changes
+	 */
+	static void handleTexChanged(GtkWidget* widget, gpointer data);
+
+	/*******/
+	//Wrappers for signal handler who can't access non-static fields 
+	//(see implementation for further explanation)
+	TexImage* getTemporaryRender();
+	void setImageInDialog(cairo_surface_t* image);
+	void deletePreviousRender();
+	void setCurrentTex(string currentTex);
+	/*******/
+
+	/**
+	 * Actual image creation, if 'forTemporaryRender' is true, it does not
+	 * add the image to the doc because it means that it has been called
+	 * during the render in the Editor dialog
+	 */
+	void insertTexImage(bool forTemporaryRender);
+	
+	
+	
+	
 
 private:
 	XOJ_TYPE_ATTRIB;
@@ -128,6 +159,21 @@ private:
 	 */
 	string texImage;
 
+	/**
+	 * Previously existin TexImage
+	 */
 	TexImage* selectedTexImage;
+
 	Text* selectedText;
+
+	/**
+	 * LaTex editor dialog
+	 */
+	LatexDialog* dlg;
+
+	/**
+	 * The controller holds the 'on-the-go' render in order
+	 * to be able to delete it when a new render is created
+	 */
+	TexImage* temporaryRender;
 };

--- a/src/gui/dialog/LatexDialog.cpp
+++ b/src/gui/dialog/LatexDialog.cpp
@@ -1,16 +1,21 @@
 #include "LatexDialog.h"
 
-LatexDialog::LatexDialog(GladeSearchpath* gladeSearchPath)
- : GladeGui(gladeSearchPath, "texdialog.glade", "texDialog")
+LatexDialog::LatexDialog(GladeSearchpath *gladeSearchPath)
+	: GladeGui(gladeSearchPath, "texdialog.glade", "texDialog")
 {
 	XOJ_INIT_TYPE(LatexDialog);
 
 	this->texBox = get("texEntry");
+	this->texTempRender = get("texImage");
 
 	// increase the maximum length to something reasonable.
 	gtk_entry_set_max_length(GTK_ENTRY(this->texBox), 500);
 
-	gtk_widget_show(this->texBox);
+	//Background color for the temporary render, default is white because
+	//on dark themed DE the LaTex is hard to read
+	GtkCssProvider* cssProvider = gtk_css_provider_new();
+	gtk_css_provider_load_from_data(cssProvider, "*{background-color:white;padding:10px;}", -1, NULL);
+	gtk_style_context_add_provider(gtk_widget_get_style_context(this->texTempRender), GTK_STYLE_PROVIDER(cssProvider), GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
 }
 
 LatexDialog::~LatexDialog()
@@ -28,6 +33,27 @@ string LatexDialog::getTex()
 {
 	XOJ_CHECK_TYPE(LatexDialog);
 	return this->theLatex;
+}
+
+void LatexDialog::setTempRender(cairo_surface_t *cairoTexTempRender)
+{
+	XOJ_CHECK_TYPE(LatexDialog);
+	this->cairoTexTempRender = cairoTexTempRender;
+	//Every time the controller updates the temporary render, we update
+	//our corresponding GtkWidget
+	gtk_image_set_from_surface(GTK_IMAGE(this->texTempRender), this->cairoTexTempRender);
+}
+
+cairo_surface_t *LatexDialog::getTempRender()
+{
+	XOJ_CHECK_TYPE(LatexDialog);
+	return this->cairoTexTempRender;
+}
+
+GtkWidget *LatexDialog::getTexBox()
+{
+	XOJ_CHECK_TYPE(LatexDialog);
+	return this->texBox;
 }
 
 void LatexDialog::save()
@@ -48,10 +74,9 @@ void LatexDialog::load()
 	gtk_entry_set_text(GTK_ENTRY(this->texBox), this->theLatex.c_str());
 }
 
-void LatexDialog::show(GtkWindow* parent)
+void LatexDialog::show(GtkWindow *parent)
 {
 	XOJ_CHECK_TYPE(LatexDialog);
-
 	this->load();
 	gtk_window_set_transient_for(GTK_WINDOW(this->window), parent);
 	int res = gtk_dialog_run(GTK_DIALOG(this->window));

--- a/src/gui/dialog/LatexDialog.h
+++ b/src/gui/dialog/LatexDialog.h
@@ -15,24 +15,41 @@
 
 #include "gui/GladeGui.h"
 
+#include "model/TexImage.h"
+
 #include <XournalType.h>
 
 class LatexDialog : public GladeGui
 {
-public:
-	LatexDialog(GladeSearchpath* gladeSearchPath);
+  public:
+	LatexDialog(GladeSearchpath *gladeSearchPath);
 	virtual ~LatexDialog();
 
-public:
-	virtual void show(GtkWindow* parent);
+  public:
+	virtual void show(GtkWindow *parent);
 	void save();
 	void load();
+
+	//Set and retrieve text from text box
 	void setTex(string texString);
 	string getTex();
+	
+	//Set and retrieve temporary Tex render
+	void setTempRender(cairo_surface_t *cairoTexTempRender);
+	cairo_surface_t *getTempRender();
 
+	//Necessary for the controller in order to connect the 'text-changed'
+	//signal handler
+	GtkWidget* getTexBox();
 
-private:
+  private:
 	XOJ_TYPE_ATTRIB;
-	GtkWidget* texBox;
+	
+	//Temporary render
+	GtkWidget *texTempRender;
+	cairo_surface_t *cairoTexTempRender;
+	
+	//Text field
+	GtkWidget *texBox;
 	string theLatex;
 };

--- a/ui/texdialog.glade
+++ b/ui/texdialog.glade
@@ -83,6 +83,19 @@
             <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">3</property>
+
+          </packing>
+        </child>
+        <child>
+          <object class="GtkImage" id="texImage">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="padding">12</property>
+            <property name="position">2</property>
           </packing>
         </child>
       </object>


### PR DESCRIPTION
Hi!
I was so interested in your project that I wanted to help a little bit!
I liked the LaTex functionality a lot but I tought that a real time display of what a user was 'LaTexting' could have been really handy, so I added it!

Basically I modified only the LaTex Dialog/Controller sources in order to intercept a 'text changed' signal from the Dialog and re-render a new LaTex image while deleting the old one.
I needed to add a white background to the render displayer inside the dialog because for those who use a dark themed DE (as I do), reading the black-fonted Tex would have been really hard.

I tried to follow your code formatting rules and your 'developing pattern' as much as I could, I hope you'll like this feature!