### PR TITLE
Improve CPack package generation and version number

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,9 +3,21 @@ cmake_minimum_required (VERSION 2.8.8)
 project ("Xournal++" CXX C)
 set (PROJECT_VERSION "1.0.2")
 set (PROJECT_PACKAGE "xournalpp")
+set (PROJECT_STRING "${PROJECT_NAME} ${PROJECT_VERSION}")
+set (PROJECT_URL "https://github.com/xournalpp/xournalpp")
+
+set (CMAKE_MODULE_PATH
+    "${PROJECT_SOURCE_DIR}/cmake/find"
+    "${PROJECT_SOURCE_DIR}/cmake/include"
+)
+
+# package version
+include (Version)
+core_find_git_rev(RELEASE_IDENTIFIER)
+string(TIMESTAMP PACKAGE_TIMESTAMP "%Y%m%d.%H%M" UTC)
+set(CPACK_PACKAGE_VERSION ${PROJECT_VERSION}~git${PACKAGE_TIMESTAMP}-${RELEASE_IDENTIFIER}-${DISTRO_CODENAME})
 
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Xournal++: Notetaking software designed around a tablet")
-string(TIMESTAMP CPACK_PACKAGE_VERSION "nightly-build-%Y-%m-%dT%H%M%SZ")
 set(CPACK_GENERATOR "DEB"  CACHE STRING "Alternativelly generate RPM. Needs rpmbuild.")
 set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Xournal++ Team")
 set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${CMAKE_CURRENT_BINARY_DIR}/cmake/postinst")
@@ -18,14 +30,7 @@ configure_file (
 
 include(CPack)
 
-set (PROJECT_STRING "${PROJECT_NAME} ${PROJECT_VERSION}")
-set (PROJECT_URL "https://github.com/xournalpp/xournalpp")
-
 include (FindPkgConfig)
-set (CMAKE_MODULE_PATH
-    "${PROJECT_SOURCE_DIR}/cmake/find"
-    "${PROJECT_SOURCE_DIR}/cmake/include"
-)
 
 set (PACKAGE_DATA_DIR "${CMAKE_INSTALL_PREFIX}/share")
 
@@ -407,7 +412,6 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 	install(PROGRAMS utility/usr/local/bin/xopp-recording.sh
 			DESTINATION ${CMAKE_INSTALL_PREFIX}/local/bin/)
 
-
 	install(CODE "execute_process(COMMAND ${CMAKE_CURRENT_BINARY_DIR}/cmake/postinst configure)")
 
 endif ()
@@ -434,7 +438,7 @@ endif()
 configure_file (
   cmake/cmake_uninstall.cmake.in
   cmake/cmake_uninstall.cmake
-  IMMEDIATE @ONLY
+  @ONLY
 )
 
 add_custom_target (uninstall

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,13 @@ set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Xournal++: Notetaking software designed a
 string(TIMESTAMP CPACK_PACKAGE_VERSION "nightly-build-%Y-%m-%dT%H%M%SZ")
 set(CPACK_GENERATOR "DEB"  CACHE STRING "Alternativelly generate RPM. Needs rpmbuild.")
 set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Xournal++ Team")
+set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${CMAKE_CURRENT_BINARY_DIR}/cmake/postinst")
+
+configure_file (
+    cmake/postinst.in
+    cmake/postinst
+    @ONLY
+)
 
 include(CPack)
 
@@ -397,16 +404,11 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 	
 	install(FILES desktop/xournalpp.thumbnailer
 			DESTINATION ${CMAKE_INSTALL_PREFIX}/share/thumbnailers)
-	install(FILES utility/usr/local/bin/xopp-recording.sh
-			DESTINATION ${CMAKE_INSTALL_PREFIX}/local/bin/
-			PERMISSIONS OWNER_EXECUTE GROUP_EXECUTE WORLD_EXECUTE)
+	install(PROGRAMS utility/usr/local/bin/xopp-recording.sh
+			DESTINATION ${CMAKE_INSTALL_PREFIX}/local/bin/)
 
 
-	install(CODE "
-		execute_process(COMMAND update-desktop-database)
-		execute_process(COMMAND update-mime-database ${CMAKE_INSTALL_PREFIX}/share/mime)
-		execute_process(COMMAND gtk-update-icon-cache -f -t ${CMAKE_INSTALL_PREFIX}/share/icons/hicolor)"
-	  )
+	install(CODE "execute_process(COMMAND ${CMAKE_CURRENT_BINARY_DIR}/cmake/postinst configure)")
 
 endif ()
 

--- a/cmake/include/Version.cmake
+++ b/cmake/include/Version.cmake
@@ -1,0 +1,79 @@
+# Adopted from https://github.com/xbmc/xbmc
+
+# distro codename
+if(NOT DISTRO_CODENAME)
+  if(NOT LSB_RELEASE_CMD)
+    message(WARNING "DEB Generator: Can't find lsb_release in your path. Setting DISTRO_CODENAME to unknown.")
+    set(DISTRO_CODENAME unknown)
+  else()
+    execute_process(COMMAND ${LSB_RELEASE_CMD} -cs
+                    OUTPUT_VARIABLE DISTRO_CODENAME
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  endif()
+endif()
+
+# Parses git info and sets variables used to identify the build
+# Arguments:
+#   stamp variable name to return
+# Optional Arguments:
+#   FULL: generate git HEAD commit in the form of 'YYYYMMDD-hash'
+#         if git tree is dirty, value is set in the form of 'YYYYMMDD-hash-dirty'
+#         if no git tree is found, value is set in the form of 'YYYYMMDD-nogitfound'
+#         if FULL is not given, stamp is generated following the same process as above
+#         but without 'YYYYMMDD'
+# On return:
+#   Variable is set with generated stamp to PARENT_SCOPE
+function(core_find_git_rev stamp)
+  # allow manual setting GIT_VERSION
+  if(GIT_VERSION)
+    set(${stamp} ${GIT_VERSION} PARENT_SCOPE)
+  else()
+    find_package(Git)
+    if(GIT_FOUND AND EXISTS ${CMAKE_SOURCE_DIR}/.git)
+      # get tree status i.e. clean working tree vs dirty (uncommited or unstashed changes, etc.)
+      execute_process(COMMAND ${GIT_EXECUTABLE} update-index --ignore-submodules -q --refresh
+                      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+      execute_process(COMMAND ${GIT_EXECUTABLE} diff-files --ignore-submodules --quiet --
+                      RESULT_VARIABLE status_code
+                      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+        if(NOT status_code)
+          execute_process(COMMAND ${GIT_EXECUTABLE} diff-index --ignore-submodules --quiet HEAD --
+                        RESULT_VARIABLE status_code
+                        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+        endif()
+        # get HEAD commit SHA-1
+        execute_process(COMMAND ${GIT_EXECUTABLE} log -n 1 --pretty=format:"%h" HEAD
+                        OUTPUT_VARIABLE HASH
+                        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+        string(REPLACE "\"" "" HASH ${HASH})
+
+        if(status_code)
+          string(CONCAT HASH ${HASH} "-dirty")
+        endif()
+
+      # get HEAD commit date
+      execute_process(COMMAND ${GIT_EXECUTABLE} log -1 --pretty=format:"%cd" --date=short HEAD
+                      OUTPUT_VARIABLE DATE
+                      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+      string(REPLACE "\"" "" DATE ${DATE})
+      string(REPLACE "-" "" DATE ${DATE})
+    else()
+      if(EXISTS ${CMAKE_SOURCE_DIR}/BUILDDATE)
+        file(STRINGS ${CMAKE_SOURCE_DIR}/BUILDDATE DATE LIMIT_INPUT 8)
+      else()
+        string(TIMESTAMP DATE "%Y%m%d" UTC)
+      endif()
+      if(EXISTS ${CMAKE_SOURCE_DIR}/VERSION)
+        file(STRINGS ${CMAKE_SOURCE_DIR}/VERSION HASH LIMIT_INPUT 16)
+      else()
+        set(HASH "nogitfound")
+      endif()
+    endif()
+    cmake_parse_arguments(arg "FULL" "" "" ${ARGN})
+    if(arg_FULL)
+      set(${stamp} ${DATE}-${HASH} PARENT_SCOPE)
+    else()
+      set(${stamp} ${HASH} PARENT_SCOPE)
+    endif()
+  endif()
+endfunction()

--- a/cmake/postinst.in
+++ b/cmake/postinst.in
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+if [ "$1" = "configure" ]; then
+    if [ -x "`which update-desktop-database 2>/dev/null`" ]; then
+        update-desktop-database
+    fi
+    if [ -x "`which update-mime-database 2>/dev/null`" ]; then
+        update-mime-database "@CMAKE_INSTALL_PREFIX@/share/mime"
+    fi
+    if [ -x "`which gtk-update-icon-cache 2>/dev/null`" ]; then
+        gtk-update-icon-cache -f -t "@CMAKE_INSTALL_PREFIX@/share/icons/hicolor"
+    fi
+fi


### PR DESCRIPTION
The second commit is only a proposal to change the version number to a valid one, as installing deb packages with the previous version is not possible. The version style is adopted from kodi (former xbmc), but of couse I can remove that part again.
By the way, their code could speedup implementing ppa support as their license match the xournalpp license.