### PR TITLE
Fixed Error when launching LatexDialog when tex.png is missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ src/pdf/popplerdirect/workaround/workaround.sh
 # NetBeans
 nbproject/
 
+#Visual Studio Code
+.vscode/
+
 #CLion
 .idea
 cmake-build-debug

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,7 +149,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
 endif ()
 
 set (POPPLER_MIN_VER "0.58")
-set (POPPLER_MAX_VER  "0.68")
+set (POPPLER_MAX_VER  "0.69")
 set (POPPLER_BUILD_FROM "git" CACHE STRING "Source to build poppler from: git (default), tarball, sourcefolder")
 set (POPPLER_GIT_VER "0.61.1" CACHE STRING "Version of Poppler to build")
 set (POPPLER_SRC_DIR "/path/to/poppler/source" CACHE STRING "Directory with poppler source")

--- a/src/control/LatexController.cpp
+++ b/src/control/LatexController.cpp
@@ -193,8 +193,6 @@ void LatexController::showTexEditDialog()
 	dlg->setTex(initalTex);
 
 	// The controller owns the tempRender because, on signal changed, he has to handle the old/new renders
-	insertTexImage(true);
-
 	if (temporaryRender != NULL)
 	{
 		dlg->setTempRender(temporaryRender->getImage());


### PR DESCRIPTION
Hi!
I found out the problem which caused an error when LaTex dialog was lauched: basically I previously put `insertTexImage(true)` in the `LatexController->showTexEditDialog()` but when that method is executed, there isn't the tex.png image yet, so I removed it because the first effective tex.png file is created right when the Dialog appears, because a "changed" signal is launched at its creation!
I also added `.vscode` to the gitignore and raised the `POPPLER_MAX_VERSION` to 0.69 since it works!