### PR TITLE
Feature: show/hide Toolbars

### DIFF
--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -60,6 +60,8 @@ void Settings::loadDefault()
 	this->mainWndWidth = 800;
 	this->mainWndHeight = 600;
 
+	this->showToolbar = true;
+
 	this->showSidebar = true;
 	this->sidebarWidth = 150;
 
@@ -289,6 +291,10 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur)
 	else if (xmlStrcmp(name, (const xmlChar*) "maximized") == 0)
 	{
 		this->maximized = xmlStrcmp(value, (const xmlChar*) "true") ? false : true;
+	}
+	else if (xmlStrcmp(name, (const xmlChar*) "showToolbar") == 0)
+	{
+		this->showToolbar = xmlStrcmp(value, (const xmlChar*) "true") ? false : true;
 	}
 	else if (xmlStrcmp(name, (const xmlChar*) "showSidebar") == 0)
 	{
@@ -678,6 +684,8 @@ void Settings::save()
 	WRITE_INT_PROP(mainWndWidth);
 	WRITE_INT_PROP(mainWndHeight);
 	WRITE_BOOL_PROP(maximized);
+
+	WRITE_BOOL_PROP(showToolbar);
 
 	WRITE_BOOL_PROP(showSidebar);
 	WRITE_INT_PROP(sidebarWidth);
@@ -1295,6 +1303,25 @@ void Settings::setDisplayDpi(int dpi)
 int Settings::getDisplayDpi()
 {
 	return this->displayDpi;
+}
+
+bool Settings::isToolbarVisible()
+{
+	XOJ_CHECK_TYPE(Settings);
+
+	return this->showToolbar;
+}
+
+void Settings::setToolbarVisible(bool visible)
+{
+	XOJ_CHECK_TYPE(Settings);
+
+	if (this->showToolbar == visible)
+	{
+		return;
+	}
+	this->showToolbar = visible;
+	save();
 }
 
 bool Settings::isSidebarVisible()

--- a/src/control/settings/Settings.h
+++ b/src/control/settings/Settings.h
@@ -190,6 +190,9 @@ public:
 	int getMainWndHeight();
 	bool isMainWndMaximized();
 
+	bool isToolbarVisible();
+	void setToolbarVisible(bool visible);
+
 	bool isSidebarVisible();
 	void setSidebarVisible(bool visible);
 
@@ -342,6 +345,11 @@ private:
 	 *  Use pen pressure to control stroke width?
 	 */
 	bool presureSensitivity;
+
+	/**
+	 *  If the toolbar is visible
+	 */
+	bool showToolbar;
 
 	/**
 	 *  If the sidebar is visible

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -59,6 +59,7 @@ MainWindow::MainWindow(GladeSearchpath* gladeSearchPath, Control* control)
 	this->xournal = new XournalView(vpXournal, control);
 
 	setSidebarVisible(control->getSettings()->isSidebarVisible());
+	setToolbarVisible(control->getSettings()->isToolbarVisible());
 
 	// Window handler
 	g_signal_connect(this->window, "delete-event", G_CALLBACK(deleteEventCallback), this->control);
@@ -95,6 +96,9 @@ MainWindow::MainWindow(GladeSearchpath* gladeSearchPath, Control* control)
 	}
 
 	createToolbarAndMenu();
+
+	GtkWidget* menuViewToolbarVisible = get("menuViewToolbarVisible");
+	g_signal_connect(menuViewToolbarVisible, "toggled", G_CALLBACK(viewShowToolbar), this);
 
 	GtkWidget* menuViewSidebarVisible = get("menuViewSidebarVisible");
 	g_signal_connect(menuViewSidebarVisible, "toggled", G_CALLBACK(viewShowSidebar), this);
@@ -283,6 +287,19 @@ void MainWindow::viewShowSidebar(GtkCheckMenuItem* checkmenuitem, MainWindow* wi
 	win->setSidebarVisible(a);
 }
 
+void MainWindow::viewShowToolbar(GtkCheckMenuItem* checkmenuitem, MainWindow* win){
+	XOJ_CHECK_TYPE_OBJ(win, MainWindow);
+
+	//Gets the status of the toggled button
+	bool a = gtk_check_menu_item_get_active(checkmenuitem);
+	if (win->control->getSettings()->isToolbarVisible() == a)
+	{
+		return;
+	}
+	//Updates the MainWindow with the new status
+	win->setToolbarVisible(a);
+}
+
 Control* MainWindow::getControl()
 {
 	XOJ_CHECK_TYPE(MainWindow);
@@ -441,6 +458,26 @@ void MainWindow::setSidebarVisible(bool visible)
 
 	GtkWidget* w = get("menuViewSidebarVisible");
 	gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(w), visible);
+}
+
+void MainWindow::setToolbarVisible(bool visible)
+{
+
+	XOJ_CHECK_TYPE(MainWindow);
+
+	Settings* settings = control->getSettings();
+
+	//Saves the visible state to the settings and hide/shows the toolbar
+	settings->setToolbarVisible(visible);
+	for (int i = 0; i < TOOLBAR_DEFINITIONS_LEN; i++)
+	{
+		gtk_widget_set_visible(this->toolbarWidgets[i], visible);
+	}
+
+	GtkWidget* w = get("menuViewToolbarVisible");
+	gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(w), visible);
+	
+	gtk_widget_show(GTK_WIDGET(this->xournal->getWidget()));
 }
 
 void MainWindow::saveSidebarSize()

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -63,6 +63,7 @@ public:
 	XournalView* getXournal();
 
 	void setSidebarVisible(bool visible);
+	void setToolbarVisible(bool visible);
 
 	Control* getControl();
 
@@ -95,6 +96,11 @@ private:
 	 * Sidebar show / hidden
 	 */
 	static void viewShowSidebar(GtkCheckMenuItem* checkmenuitem, MainWindow* control);
+
+	/**
+	 * Toolbar show / hidden
+	 */
+	static void viewShowToolbar(GtkCheckMenuItem* checkmenuitem, MainWindow* win);
 
 	/**
 	 * Window close Button is pressed

--- a/ui/main.glade
+++ b/ui/main.glade
@@ -309,6 +309,15 @@
                       </object>
                     </child>
                     <child>
+                      <object class="GtkCheckMenuItem" id="menuViewToolbarVisible">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Show toolbar</property>
+                        <property name="use_underline">True</property>
+                        <accelerator key="F9" signal="activate"/>
+                      </object>
+                    </child>
+                    <child>
                       <object class="GtkSeparatorMenuItem" id="separatormenuitem7">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>


### PR DESCRIPTION
Hi guys!
I saw that an issue marked as enhancement talked about the ability to hide and show the Toolbar, so I added it, now it can be done from the View menu or by presing F9.
It should work just fine, I also updated the Settings in order to save the state of the Toolbar after closing Xournalpp, but I don't understand one thing: when I de-select "Show Toolbar", the Toolbar disappear, but when I re-enable it, it appears with something like a frame around the document.
I don't know where the issue could be, I did simply hide/show widget on the Toolbar's widget!
Right now it works well, if someone knows how to fix that little issue... that'd be great!