### PR TITLE
Add missing math header.

### DIFF
--- a/src/control/tools/EditSelection.cpp
+++ b/src/control/tools/EditSelection.cpp
@@ -23,6 +23,7 @@
 #include <serializing/ObjectInputStream.h>
 
 #include <iostream>
+#include <math.h>
 using std::cout;
 using std::endl;
 


### PR DESCRIPTION
Upon compiling the most recent `master` branch, I found that the compilation found due to a missing header.

The call to `atan` in line 465 of the function `EditSelection::mouseMove()` caused the crash as the `math` header for `atan` was missing.