### PR TITLE
Audio folder check set

### DIFF
--- a/src/control/AudioController.cpp
+++ b/src/control/AudioController.cpp
@@ -1,11 +1,12 @@
 #include "AudioController.h"
+#include "Util.h"
 #include <iostream>
 
-
-AudioController::AudioController(Settings* settings)
+AudioController::AudioController(Settings* settings, Control* control)
 {
 	XOJ_INIT_TYPE(AudioController);
 	this->settings = settings;
+	this->control = control;
 }
 
 AudioController::~AudioController()
@@ -30,6 +31,11 @@ void AudioController::recStartStop(bool rec)
 
 	if (rec)
 	{
+		if (getAudioFolder() == "")
+		{
+			return;
+		}
+
 		this->recording = true;
 		sttime = (g_get_monotonic_time() / 1000000);
 
@@ -37,7 +43,7 @@ void AudioController::recStartStop(bool rec)
 		time_t secs = time(0);
 		tm *t = localtime(&secs);
 		//This prints the date and time in ISO format.
-		sprintf(buffer, "%04d-%02d-%02d_%02d:%02d:%02d", t->tm_year + 1900, t->tm_mon + 1, t->tm_mday, t->tm_hour,
+		sprintf(buffer, "%04d-%02d-%02d_%02d-%02d-%02d", t->tm_year + 1900, t->tm_mon + 1, t->tm_mday, t->tm_hour,
 				t->tm_min, t->tm_sec);
 		string data(buffer);
 		data += ".mp3";
@@ -85,6 +91,16 @@ string AudioController::getAudioFolder()
 	XOJ_CHECK_TYPE(AudioController);
 
 	string af = this->settings->getAudioFolder();
+
+	if (af.length() < 8)
+	{
+		string msg ="Audio folder not set! Recording won't work!\nPlase set the "\
+					"recording folder under \"Preferences > Audio recording\"";
+		g_warning(msg.c_str());
+		Util::showErrorToUser(this->control->getGtkWindow(), msg);
+		return "";
+	}
+
 	af.erase(af.begin(),af.begin()+7);
 	return af;
 }

--- a/src/control/AudioController.h
+++ b/src/control/AudioController.h
@@ -2,13 +2,14 @@
 
 #include <XournalType.h>
 #include "settings/Settings.h"
+#include "Control.h"
 #include <string>
 using std::string;
 
 class AudioController
 {
 public:
-	AudioController(Settings* settings);
+	AudioController(Settings* settings, Control* control);
 	virtual ~AudioController();
 
 	bool isRecording();
@@ -22,7 +23,8 @@ protected:
 	bool recording = false;
 	string audioFilename;
 	gint sttime = 0;	
-	Settings * settings;
+	Settings* settings;
+	Control* control;
 
 private:
 	XOJ_TYPE_ATTRIB;

--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -103,7 +103,7 @@ Control::Control(GladeSearchpath* gladeSearchPath)
 	this->sidebar = NULL;
 	this->searchBar = NULL;
 	
-	this->audioController = new AudioController(this->settings);
+	this->audioController = new AudioController(this->settings,this);
 
 	this->scrollHandler = new ScrollHandler(this);
 

--- a/src/control/Control.h
+++ b/src/control/Control.h
@@ -34,6 +34,7 @@
 #include <vector>
 #include "../gui/dialog/LatexDialog.h"
 
+class AudioController;
 class Sidebar;
 class XojPageView;
 class SaveHandler;

--- a/src/control/tools/EditSelection.cpp
+++ b/src/control/tools/EditSelection.cpp
@@ -319,6 +319,8 @@ void EditSelection::mouseUp()
 	PageRef page = this->view->getPage();
 	Layer* layer = page->getSelectedLayer();
 
+	snapRotation();
+
 	this->contents->updateContent(this->x, this->y, this->rotation, this->width, this->height, this->aspectRatio,
 								  layer, page, this->view, this->undo, this->mouseDownType);
 
@@ -639,6 +641,43 @@ CursorSelectionType EditSelection::getSelectionTypeForPos(double x, double y, do
 	return CURSOR_SELECTION_NONE;
 }
 
+void EditSelection::snapRotation()
+{
+	double epsilon = 0.1;
+	if(std::abs(this->rotation) < epsilon)
+	{
+		this->rotation = 0;
+	}
+	else if (std::abs(this->rotation - M_PI / 2.0) < epsilon)
+	{
+		this->rotation = M_PI / 2.0;
+	}
+	else if (std::abs(this->rotation - M_PI) < epsilon)
+	{
+		this->rotation = M_PI;
+	}
+	else if (std::abs(this->rotation - M_PI / 4.0) < epsilon)	
+	{
+		this->rotation = M_PI / 4.0;
+	}
+	else if (std::abs(this->rotation - 3.0 * M_PI / 4.0) < epsilon)
+	{
+		this->rotation = 3.0 * M_PI / 4.0;
+	}
+	else if (std::abs(this->rotation + M_PI / 4.0) < epsilon)
+	{
+		this->rotation = - (M_PI / 4.0);
+	}
+	else if (std::abs(this->rotation + 3.0 * M_PI / 4.0) < epsilon)
+	{
+		this->rotation = - (3.0 * M_PI / 4.0);
+	}
+	else if (std::abs(this->rotation + M_PI / 2.0) < epsilon)
+	{
+		this->rotation = - (M_PI / 2.0);
+	}
+}
+
 /**
  * Paints the selection to cr, with the given zoom factor. The coordinates of cr
  * should be relative to the provideded view by getView() (use translateEvent())
@@ -654,6 +693,8 @@ void EditSelection::paint(cairo_t* cr, double zoom)
 	if (abs(this->rotation) > __DBL_EPSILON__)
 	{
 		
+		snapRotation();
+
 		double rx = (x + width / 2) * zoom;
 		double ry = (y + height / 2) * zoom;
 

--- a/src/control/tools/EditSelection.cpp
+++ b/src/control/tools/EditSelection.cpp
@@ -644,37 +644,15 @@ CursorSelectionType EditSelection::getSelectionTypeForPos(double x, double y, do
 void EditSelection::snapRotation()
 {
 	double epsilon = 0.1;
-	if(std::abs(this->rotation) < epsilon)
+	const double ROTATION_LOCK[8] = {0, M_PI / 2.0, M_PI, M_PI / 4.0, 3.0 * M_PI / 4.0,
+									- M_PI / 4.0, - 3.0 * M_PI / 4.0, - M_PI / 2.0};
+
+	for ( int i = 0; i < sizeof(ROTATION_LOCK) / sizeof(ROTATION_LOCK[0]); i++ )
 	{
-		this->rotation = 0;
-	}
-	else if (std::abs(this->rotation - M_PI / 2.0) < epsilon)
-	{
-		this->rotation = M_PI / 2.0;
-	}
-	else if (std::abs(this->rotation - M_PI) < epsilon)
-	{
-		this->rotation = M_PI;
-	}
-	else if (std::abs(this->rotation - M_PI / 4.0) < epsilon)	
-	{
-		this->rotation = M_PI / 4.0;
-	}
-	else if (std::abs(this->rotation - 3.0 * M_PI / 4.0) < epsilon)
-	{
-		this->rotation = 3.0 * M_PI / 4.0;
-	}
-	else if (std::abs(this->rotation + M_PI / 4.0) < epsilon)
-	{
-		this->rotation = - (M_PI / 4.0);
-	}
-	else if (std::abs(this->rotation + 3.0 * M_PI / 4.0) < epsilon)
-	{
-		this->rotation = - (3.0 * M_PI / 4.0);
-	}
-	else if (std::abs(this->rotation + M_PI / 2.0) < epsilon)
-	{
-		this->rotation = - (M_PI / 2.0);
+		if (std::abs(this->rotation - ROTATION_LOCK[i]) < epsilon)
+		{
+			this->rotation = ROTATION_LOCK[i];
+		}
 	}
 }
 
@@ -692,7 +670,6 @@ void EditSelection::paint(cairo_t* cr, double zoom)
 
 	if (abs(this->rotation) > __DBL_EPSILON__)
 	{
-		
 		snapRotation();
 
 		double rx = (x + width / 2) * zoom;

--- a/src/control/tools/EditSelection.h
+++ b/src/control/tools/EditSelection.h
@@ -44,6 +44,8 @@ private:
 	 */
 	void contstruct(UndoRedoHandler* undo, XojPageView* view, PageRef sourcePage);
 
+	void snapRotation();
+
 public:
 	/**
 	 * get the X coordinate relative to the provided view (getView())

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -1647,7 +1647,7 @@ Here you can disable your touchscreen.&lt;/i&gt;</property>
                   <object class="GtkLabel" id="label45">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">&lt;i&gt;If audio recording is running the time possitions are stored to the written Text and can be replayed.
+                    <property name="label" translatable="yes">&lt;i&gt;If audio recording is running, the time stamps are stored to the handwritten Text and can be replayed.
 The Audio track is recorded to a separate folder, and liked to there.&lt;/i&gt;</property>
                     <property name="use_markup">True</property>
                     <property name="xalign">0</property>


### PR DESCRIPTION
* Prevent crash by showing an error to the user if the Audio recording folder is not being set when "Record" is hit.
* Improve file name convention for audio recordings to be supported on platforms other than Linux
* Fix audio recording description under settings