### PR TITLE
Added Pen icon when in BigCursor mode

### DIFF
--- a/src/gui/Cursor.cpp
+++ b/src/gui/Cursor.cpp
@@ -328,23 +328,35 @@ GdkCursor* Cursor::createHighlighterOrPenCursor(int size, double alpha)
 	if (big)
 	{
 		height = 22;
-		width = 12;
+		width = 22;
 	}
 
 	cairo_surface_t* crCursor = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
 	cairo_t* cr = cairo_create(crCursor);
 
-	if (big)
+	if (big && size != 5) //size == 5 for highlighter
 	{
 		cairo_set_source_rgb(cr, 1, 1, 1);
 		cairo_set_line_width(cr, 1.2);
-		cairo_move_to(cr, 1.5, 1.5);
-		cairo_line_to(cr, 2, 19);
-		cairo_line_to(cr, 5.5, 15.5);
-		cairo_line_to(cr, 8.5, 20.5);
-		cairo_line_to(cr, 10.5, 19);
-		cairo_line_to(cr, 8.5, 14);
-		cairo_line_to(cr, 13, 14);
+		
+		// Plain cursor drawing + color dot
+		// cairo_move_to(cr, 1.5, 1.5);
+		// cairo_line_to(cr, 2, 19);
+		// cairo_line_to(cr, 5.5, 15.5);
+		// cairo_line_to(cr, 8.5, 20.5);
+		// cairo_line_to(cr, 10.5, 19);
+		// cairo_line_to(cr, 8.5, 14);
+		// cairo_line_to(cr, 13, 14);
+
+
+		// Color dot
+		cairo_move_to(cr, 2, 19);
+		// Pencil cursor
+		cairo_line_to(cr, 2, 15);
+		cairo_line_to(cr, 15, 0.5);
+		cairo_line_to(cr, 19, 4);
+		cairo_line_to(cr, 6, 19);
+
 		cairo_close_path(cr);
 		cairo_fill_preserve(cr);
 
@@ -353,7 +365,8 @@ GdkCursor* Cursor::createHighlighterOrPenCursor(int size, double alpha)
 	}
 
 	cairo_set_source_rgba(cr, r, g, b, alpha);
-	cairo_rectangle(cr, 0, 0, size, size);
+	// Correct the offset of the coloured dot for big-cursor mode
+	cairo_rectangle(cr, 0, big ? height-size : 0, size, size);
 	cairo_fill(cr);
 
 	cairo_destroy(cr);
@@ -364,9 +377,9 @@ GdkCursor* Cursor::createHighlighterOrPenCursor(int size, double alpha)
 	//	gdk_pixbuf_save(pixbuf, "/home/andreas/xoj-cursor.png", "png", NULL, NULL);
 
 	cairo_surface_destroy(crCursor);
-
+	
 	GdkCursor* cursor = gdk_cursor_new_from_pixbuf(
-			gtk_widget_get_display(control->getWindow()->getXournal()->getWidget()), pixbuf, 1, 1);
+			gtk_widget_get_display(control->getWindow()->getXournal()->getWidget()), pixbuf, 1, height-size);
 
 	g_object_unref(pixbuf);
 


### PR DESCRIPTION
Hi! 
As the title says, i changed the icon of the cursor when in Big Cursor mode in order to make it look like a pencil.
I still have that problem in Text Box as in #470 , but even checking for imContext or event for NULL values didn't solve the issue. My debugger found a Segmentation Error in the 
`gtk_im_context_filter_keypress(this->imContext, event)` condition.