### PR TITLE
Fixed LaTex scaling for long text

### DIFF
--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: xournalpp 1.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-12-09 10:10+0100\n"
+"POT-Creation-Date: 2018-12-09 10:20+0100\n"
 "PO-Revision-Date: 2017-09-18 09:58+0200\n"
 "Last-Translator: Jan Hrdina <jan.hrdka@gmail.com>\n"
 "Language-Team: čeština <>\n"
@@ -413,7 +413,7 @@ msgstr ""
 #: ../src/control/AudioController.cpp:99
 msgid ""
 "Audio folder not set! Recording won't work!\n"
-"Plase set the recording folder under \"Preferences > Audio recording\""
+"Please set the recording folder under \"Preferences > Audio recording\""
 msgstr ""
 
 #: ../ui/about.glade:151
@@ -1087,7 +1087,7 @@ msgid ""
 "Missing the needed UI file, could not find them at any location.\n"
 "Not relative\n"
 "Not in the Working Path\n"
-"Not in "
+"Not in {1}"
 msgstr ""
 
 #: ../ui/settings.glade:858

--- a/po/de.po
+++ b/po/de.po
@@ -43,1243 +43,13 @@ msgstr " Linie"
 msgid " text"
 msgstr " Text"
 
-#: ../src/control/settings/Settings.cpp:86
-msgid "%F-Note-%H-%M.xopp"
-msgstr "Notiz-%d-%m-%Y-%H-%M.xopp"
-
-#: ../src/control/XournalMain.cpp:229
-msgid "Absolute path for the audio files playback"
-msgstr "Absoluter Pfad für die Audiodateien"
-
-#: ../src/control/stockdlg/XojOpenDlg.cpp:49
-msgid "All files"
-msgstr "Alle Dateien"
-
-#: ../src/control/stockdlg/ImageOpenDlg.cpp:29
-#: ../src/control/stockdlg/XojOpenDlg.cpp:148
-msgid "Attach file to the journal"
-msgstr "Datei ans .xoj anhängen"
-
-#: ../src/control/xojfile/LoadHandlerHelper.cpp:140
-msgid "Attribute \"{1}\" could not be parsed as double, the value is \"{2}\""
-msgstr ""
-"Attribut \"{1}\" konnte nicht als Fließkommazahl ausgelesen werden, der Wert "
-"ist \"{2}\""
-
-#: ../src/control/xojfile/LoadHandlerHelper.cpp:132
-msgid "Attribute \"{1}\" could not be parsed as double, the value is NULL"
-msgstr ""
-"Attribut \"{1}\" konnte nicht als Fließkommazahl ausgelesen werden, der Wert "
-"ist NULL"
-
-#: ../src/control/xojfile/LoadHandlerHelper.cpp:160
-#: ../src/control/xojfile/LoadHandlerHelper.cpp:183
-msgid "Attribute \"{1}\" could not be parsed as int, the value is \"{2}\""
-msgstr ""
-"Attribut \"{1}\" konnte nicht als Ganzzahl ausgelesen werden, der Wert ist "
-"\"{1}\""
-
-#: ../src/control/xojfile/LoadHandlerHelper.cpp:152
-msgid "Attribute \"{1}\" could not be parsed as int, the value is NULL"
-msgstr ""
-"Attribut \"{1}\" konnte nicht als Ganzzahl ausgelesen werden, der Wert ist "
-"NULL"
-
-#: ../src/control/xojfile/LoadHandlerHelper.cpp:70
-msgid "Attribute color not set!"
-msgstr "Attribut Farbe ist nicht gesetzt!"
-
-#: ../src/control/AudioController.cpp:99
-msgid ""
-"Audio folder not set! Recording won't work!\n"
-"Please set the recording folder under \"Preferences > Audio recording\""
-msgstr ""
-"Audio Ordner nicht gesetzt! Aufzeichnung wird nicht funktionieren!\n"
-"Bitte den Ordner festlegen unter \"Einstellungen > Audioaufzeichnung\""
-
-#: ../src/control/jobs/AutosaveJob.cpp:24
-msgid "Autosave: {1}"
-msgstr "Autospeichern: {1}"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:332
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:335
-msgid "Back"
-msgstr "Zurück"
-
-#: ../src/gui/toolbarMenubar/ToolPageLayer.cpp:71
-msgid "Background"
-msgstr "Hintergrund"
-
-#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:10
-#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:132
-msgid "Black"
-msgstr "schwarz"
-
-#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:14
-#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:136
-msgid "Blue"
-msgstr "blau"
-
-#: ../src/control/Control.cpp:2009 ../src/control/Control.cpp:2533
-#: ../src/control/Control.cpp:2570 ../src/control/XournalMain.cpp:111
-msgid "Cancel"
-msgstr "Abbrechen"
-
-#: ../src/undo/ColorUndoAction.cpp:118
-msgid "Change color"
-msgstr "Farbe ändern"
-
-#: ../src/undo/FontUndoAction.cpp:133
-msgid "Change font"
-msgstr "Schriftart ändern"
-
-#: ../src/undo/SizeUndoAction.cpp:145
-msgid "Change stroke width"
-msgstr "Liniendicke ändern"
-
-#: ../src/control/xojfile/LoadHandlerHelper.cpp:98
-msgid "Color \"{1}\" unknown (not defined in default color list)!"
-msgstr "Farbe \"{1}\" unbekannt (nicht in der Farbliste)"
-
-#: ../src/gui/sidebar/indextree/SidebarIndexPage.cpp:273
-msgid "Contents"
-msgstr "Inhalt"
-
-#: ../src/control/Control.cpp:990 ../src/control/Control.cpp:998
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:320
-msgid "Copy"
-msgstr "Kopieren"
-
-#: ../src/control/pagetype/PageTypeHandler.cpp:30
-msgid "Copy current"
-msgstr "Aktuellen Hintergrund kopieren"
-
-#: ../src/undo/CopyUndoAction.cpp:80
-msgid "Copy page"
-msgstr "Kopiere Seite"
-
-#: ../src/control/jobs/SaveJob.cpp:144
-msgid ""
-"Could not create backup! (The file was created from an older Xournal version)"
-msgstr ""
-"Konnte kein Backup erstellen! (Diese Datei wurde mit einer alten Version von "
-"Xournal erstellt.)"
-
-#: ../src/control/LatexController.cpp:361
-msgid ""
-"Could not find Xournal++ LaTeX executable relative or in Path.\n"
-"Searched for: mathtex-xournalpp.cgi"
-msgstr ""
-"Konnte Xournal++ LaTeX programm nicht finden, relativ oder im Pfad.\n"
-"Suche nach: mathtex-xournalpp.cgi"
-
-#: ../src/control/pagetype/PageTypeHandler.cpp:18
-msgid "Could not load pagetemplates.ini file"
-msgstr "Konnte die Datei pagetemplates.ini nicht öffnen"
-
-#: ../src/control/xojfile/LoadHandler.cpp:110
-msgid "Could not open file: \"{1}\""
-msgstr "Konnte die Datei nicht öffnen: \"{1}\""
-
-#: ../src/gui/MainWindow.cpp:91
-msgid ""
-"Could not parse custom toolbar.ini file: {1}\n"
-"Toolbars will not be available"
-msgstr ""
-"Konnte die benutzerdefinierte Datei toolbar.ini nicht lesen: {1}\n"
-"Es werden keine Werkzeugleisten zur Verfügung stehen"
-
-#: ../src/gui/MainWindow.cpp:81
-msgid ""
-"Could not parse general toolbar.ini file: {1}\n"
-"No Toolbars will be available"
-msgstr ""
-"Konnte die globale Datei toolbar.ini nicht lesen: {1}\n"
-"Es werden keine Werkzeugleisten zur Verfügung stehen"
-
-#: ../src/control/xojfile/LoadHandler.cpp:315
-msgid "Could not read image: {1}. Error message: {2}"
-msgstr "Das Bild {1} konnte nicht geladen werden. Fehlermeldung: {2}"
-
-#: ../src/undo/UndoRedoHandler.cpp:183
-msgid ""
-"Could not redo \"{1}\"\n"
-"Something went wrong… Please write a bug report…"
-msgstr ""
-"Rückgängig ist fehlgeschlagen '{1}'\n"
-"Etwas ist schief gelaufen... Bitte erstellen Sie einen Fehlerbericht."
-
-#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:214
-msgid "Could not remove tool item from Toolbar {1} on position {2}"
-msgstr ""
-"Konnte Werkzeug von der Werkzeugleiste {1} Position {2} nicht entfernen"
-
-#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:209
-msgid "Could not remove tool item {1} from Toolbar {2} on position {3}"
-msgstr ""
-"Konnte Werkzeug von {1} von der Werkzeugleiste {2} Position {3} nicht "
-"entfernen"
-
-#: ../src/control/LatexController.cpp:290
-msgid "Could not retrieve LaTeX image file: {1}"
-msgstr "Die LaTeX-Bilddatei konnte nicht geladen werden: {1}"
-
-#: ../src/undo/UndoRedoHandler.cpp:146
-msgid ""
-"Could not undo \"{1}\"\n"
-"Something went wrong… Please write a bug report…"
-msgstr ""
-"Wiederherstellen ist fehlgeschlagen '{1}'\n"
-"Etwas ist schief gelaufen... Bitte Erstellen Sie einen Fehlerbericht."
-
-#: ../src/control/xojfile/SaveHandler.cpp:271
-msgid "Could not write background \"{1}\", {2}"
-msgstr "Konnte Hintergrund \"{1}\" nicht speichern, {2}"
-
-#: ../src/control/xojfile/SaveHandler.cpp:396
-msgid "Could not write background \"{1}\". Continuing anyway."
-msgstr "Konnte Hintergrund nicht speichern \"{1}\". Fahre trotzdem fort."
-
-#: ../src/gui/dialog/FormatDialog.cpp:79
-msgid "Custom"
-msgstr "Benutzerdefiniert"
-
-#: ../src/control/jobs/CustomExportJob.cpp:16
-msgid "Custom Export"
-msgstr "Benutzerdefinierter Export"
-
-#: ../src/gui/dialog/ToolbarManageDialog.cpp:40
-msgid "Customized"
-msgstr "Anpassen"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:319
-msgid "Cut"
-msgstr "Ausschneiden"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:436
-msgid "Default Tool"
-msgstr "Standard Werkzeug"
-
-#: ../src/undo/DeleteUndoAction.cpp:102
-msgid "Delete"
-msgstr "Löschen"
-
-#: ../src/control/XournalMain.cpp:110
-msgid "Delete Logfile"
-msgstr "Logdatei löschen"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:383
-msgid "Delete current page"
-msgstr "Aktuelle Seite löschen"
-
-#: ../src/undo/RemoveLayerUndoAction.cpp:38
-msgid "Delete layer"
-msgstr "Ebene löschen"
-
-#: ../src/control/Control.cpp:2532 ../src/control/Control.cpp:2569
-msgid "Discard"
-msgstr "Verwerfen"
-
-#: ../src/control/Control.cpp:1939
-msgid ""
-"Do not open Autosave files. They may will be overwritten!\n"
-"Copy the files to another folder.\n"
-"Files from Folder {1} cannot be opened."
-msgstr ""
-"Öffnen sie keine automatisch gespeicherten Dateien. Diese werden ansonsten "
-"überschrieben!\n"
-"Kopieren Sie diese Dateien an einen anderen Ort.\n"
-"Dateien aus dem Ordner {1} können nicht geöffnet werden."
-
-#: ../src/control/jobs/PdfExportJob.cpp:56
-msgid "Do not overwrite the background PDF! This will cause errors!"
-msgstr ""
-"Das Hintergrund PDF darf nicht überschrieben werden! Dies verursacht Fehler!"
-
-#: ../src/control/Control.cpp:2566
-msgid "Document file was removed."
-msgstr "Datei des Dokuments wurde entfernt."
-
-#: ../src/control/xojfile/LoadHandler.cpp:189
-msgid "Document is not complete (maybe the end is cut off?)"
-msgstr "Dokument ist nicht vollständig (z.B. nicht komplett übertragen?)"
-
-#: ../src/model/Document.cpp:355
-msgid "Document not loaded! ({1}), {2}"
-msgstr "Dokument nicht geladen! ({1}), {2}"
-
-#: ../src/gui/dialog/ButtonConfigGui.cpp:54
-#: ../src/gui/dialog/ButtonConfigGui.cpp:81
-#: ../src/gui/dialog/ButtonConfigGui.cpp:91
-msgid "Don't change"
-msgstr "Nicht ändern"
-
-#: ../src/control/XournalMain.cpp:226
-msgid "Don't compress PDF files (for debugging)"
-msgstr "PDF-Datei nicht komprimieren (zur Fehlersuche)"
-
-#: ../src/control/pagetype/PageTypeHandler.cpp:26
-msgid "Dotted"
-msgstr "Gepunktet"
-
-#: ../src/gui/dialog/ButtonConfigGui.cpp:101
-#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:40
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:416
-msgid "Draw Arrow"
-msgstr "Pfeil zeichnen"
-
-#: ../src/gui/dialog/ButtonConfigGui.cpp:99
-#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:39
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:412
-msgid "Draw Circle"
-msgstr "Kreis zeichnen"
-
-#: ../src/gui/dialog/ButtonConfigGui.cpp:95
-#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:41
-msgid "Draw Line"
-msgstr "Strecke zeichnen"
-
-#: ../src/gui/dialog/ButtonConfigGui.cpp:97
-#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:29
-#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:38
-#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:119
-#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:122
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:414
-msgid "Draw Rectangle"
-msgstr "Rechteck Zeichnen"
-
-#: ../src/undo/InsertUndoAction.cpp:39
-msgid "Draw stroke"
-msgstr "Linie zeichen"
-
-#: ../src/undo/TextBoxUndoAction.cpp:52
-msgid "Edit text"
-msgstr "Text schreiben"
-
-#: ../src/undo/EraseUndoAction.cpp:130 ../src/undo/DeleteUndoAction.cpp:99
-#: ../src/undo/AddUndoAction.cpp:104
-msgid "Erase stroke"
-msgstr "Linie löschen"
-
-#: ../src/gui/dialog/ButtonConfigGui.cpp:56
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:281
-msgid "Eraser"
-msgstr "Radierer"
-
-#: ../src/control/Control.cpp:2218
-msgid ""
-"Error annotate PDF file \"{1}\"\n"
-"{2}"
-msgstr ""
-"Fehler beim Öffnen des PDFs \"{1}\"\n"
-"{2}"
-
-#: ../src/control/jobs/CustomExportJob.cpp:187
-msgid "Error export PDF Page"
-msgstr "Fehler beim Exportieren der PDF Seite"
-
-#: ../src/gui/GladeGui.cpp:25
-msgid "Error loading glade file \"{1}\" (try to load \"{2}\")"
-msgstr "Fehler beim Laden der Glade-Datei \"{1}\" (Datei \"{2}\")"
-
-#: ../src/control/Control.cpp:2034
-msgid "Error opening file \"{1}\""
-msgstr "Fehler beim Öffnen der Datei '{1}'"
-
-#: ../src/pdf/popplerdirect/PdfWriter.cpp:57
-msgid "Error opening file {1} for writing: {2}"
-msgstr "Datei {1} konnte nicht zum Schreiben geöffnet werden: {2}"
-
-#: ../src/util/OutputStream.cpp:39
-msgid "Error opening file: \"{1}\""
-msgstr "Fehler beim Öffnen der Datei '{1}'"
-
-#: ../src/control/xojfile/LoadHandler.cpp:415
-msgid "Error reading PDF: {1}"
-msgstr "Fehler beim Lesen des PDFs: {1}"
-
-#: ../src/control/xojfile/LoadHandler.cpp:488
-msgid "Error reading width of a stroke: {1}"
-msgstr "Fehler beim Lesen der Dicke einer Linie: {1}"
-
-#: ../src/pdf/popplerdirect/PdfWriter.cpp:80
-msgid "Error writing stream: {1}"
-msgstr "Fehler beim Schreiben des Datenstroms: {1}"
-
-#: ../src/util/CrashHandler.cpp:148
-msgid "Error: {1}"
-msgstr "Fehler: {1}"
-
-#: ../src/control/XournalMain.cpp:134
-msgid ""
-"Errorlog cannot be deleted. You have to do it manually.\n"
-"Logfile: {1}"
-msgstr ""
-"Fehlerlog konnte nicht gelöscht werden. Sie müssen die Datei manuell "
-"löschen.\n"
-"Logdatei: {1}"
-
-#: ../src/control/jobs/BaseExportJob.cpp:25
-msgid "Export PDF"
-msgstr "Exportieren als PDF"
-
-#: ../src/control/LatexController.cpp:378
-msgid "Failed to generate LaTeX image!"
-msgstr "Fehler beim erstellen des LaTeX Bild!"
-
-#: ../src/util/Util.cpp:141 ../src/util/Util.cpp:168
-msgid ""
-"File couldn't be opened. You have to do it manually:\n"
-"URL: {1}"
-msgstr ""
-"Datei konnte nicht geöffnet werden, Sie müssen sie manuell öffnen\n"
-":URL: {1}"
-
-#: ../src/control/jobs/PdfExportJob.cpp:49
-msgid "File name needs to end with .pdf"
-msgstr "Dateiname muss mit .pdf enden"
-
-#: ../src/control/jobs/CustomExportJob.cpp:61
-msgid "File name needs to end with .pdf, .png or .xoj"
-msgstr "Dateiname muss mit .pdf, .png oder .xoj enden"
-
-#: ../src/control/Control.cpp:1969
-msgid "Filename: {1}"
-msgstr "Dateiname: {1}"
-
-#: ../src/gui/toolbarMenubar/FontButton.cpp:71
-msgid "Font"
-msgstr "Schriftart"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:330
-msgid "Go to first page"
-msgstr "Gehe zur ersten Seite"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:343
-msgid "Go to last page"
-msgstr "Gehe zur letzten Seite"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:348
-msgid "Go to next layer"
-msgstr "Zur nächsten ebene Springen"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:338
-msgid "Go to page"
-msgstr "Gehe zur Seite"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:346
-msgid "Go to previous layer"
-msgstr "Zur vorherigen Ebene springe"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:350
-msgid "Go to top layer"
-msgstr "Zur obersten Ebene springen"
-
-#: ../src/control/pagetype/PageTypeHandler.cpp:25
-msgid "Graph"
-msgstr "Kariert"
-
-#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:15
-#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:137
-msgid "Gray"
-msgstr "grau"
-
-#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:11
-#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:133
-msgid "Green"
-msgstr "grün"
-
-#: ../src/gui/dialog/ButtonConfigGui.cpp:65
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:420
-msgid "Hand"
-msgstr "Hand"
-
-#: ../src/gui/dialog/ButtonConfigGui.cpp:57
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:395
-msgid "Highlighter"
-msgstr "Textmarker"
-
-#: ../src/control/pagetype/PageTypeHandler.cpp:32
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:399
-msgid "Image"
-msgstr "Bild"
-
-#: ../src/control/stockdlg/ImageOpenDlg.cpp:17
-msgid "Images"
-msgstr "Bilddateien"
-
-#: ../src/undo/InsertUndoAction.cpp:115
-msgid "Insert elements"
-msgstr "Elemente einfügen"
-
-#: ../src/undo/InsertUndoAction.cpp:47 ../src/gui/dialog/ButtonConfigGui.cpp:59
-msgid "Insert image"
-msgstr "Bild einfügen"
-
-#: ../src/undo/InsertUndoAction.cpp:51
-msgid "Insert latex"
-msgstr "LaTeX einfügen"
-
-#: ../src/undo/InsertLayerUndoAction.cpp:36
-msgid "Insert layer"
-msgstr "Ebene einfügen"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:390
-msgid "Insert page"
-msgstr "Seite einfügen"
-
-#: ../src/control/XournalMain.cpp:228
-msgid "Jump to Page (first Page: 1)"
-msgstr "Springe zur Seite (erste Seite: 1)"
-
-#: ../src/gui/toolbarMenubar/ToolPageLayer.cpp:105
-msgid "Layer"
-msgstr "Ebene"
-
-#: ../src/gui/sidebar/previews/layer/SidebarPreviewLayers.cpp:27
-msgid "Layer Preview"
-msgstr "Ebenen-Vorschau"
-
-#: ../src/gui/toolbarMenubar/ToolPageLayer.cpp:88
-msgid "Layer selection"
-msgstr "Ebenenauswahl"
-
-#: ../src/gui/toolbarMenubar/ToolPageLayer.cpp:74
-msgid "Layer {1}"
-msgstr "Ebene {1}"
-
-#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:12
-#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:134
-msgid "Light Blue"
-msgstr "hellblau"
-
-#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:13
-#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:135
-msgid "Light Green"
-msgstr "hellgrün"
-
-#: ../src/control/pagetype/PageTypeHandler.cpp:23
-msgid "Lined"
-msgstr "Liniert mit Rand"
-
-#: ../src/gui/PageView.cpp:884
-#: ../src/gui/sidebar/previews/base/SidebarPreviewBaseEntry.cpp:115
-msgid "Loading..."
-msgstr "Laden..."
-
-#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:17
-#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:139
-msgid "Mangenta"
-msgstr "magenta"
-
-#: ../src/gui/dialog/ButtonConfigGui.cpp:83
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:431
-msgid "Medium"
-msgstr "mittel"
-
-#: ../src/control/XournalMain.cpp:455
-msgid ""
-"Missing the needed UI file, could not find them at any location.\n"
-"Not relative\n"
-"Not in the Working Path\n"
-"Not in {1}"
-msgstr ""
-"Konnte die nötigen UI Dateien nicht finden!\n"
-"Nicht relativ\n"
-"Nicht im Arbeitspfad\n"
-"Nicht in {1}"
-
-#: ../src/undo/MoveUndoAction.cpp:19
-msgid "Move"
-msgstr "Verschieben"
-
-#: ../src/undo/SwapUndoAction.cpp:89
-msgid "Move page downwards"
-msgstr "Verschiebe Seite nach unten"
-
-#: ../src/undo/SwapUndoAction.cpp:89
-msgid "Move page upwards"
-msgstr "Verschiebe Seite nach oben"
-
-#: ../src/gui/dialog/ToolbarManageDialog.cpp:93
-msgid "New"
-msgstr "Neu"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:315
-msgid "New Xournal"
-msgstr "Neues Xournal"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:341
-msgid "Next"
-msgstr "Nächste Seite"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:354
-msgid "Next annotated page"
-msgstr "Nächste beschriftete Seite"
-
-#: ../src/gui/dialog/ButtonConfigGui.cpp:35
-msgid "No device"
-msgstr "Kein Gerät"
-
-#: ../src/pdf/base/XojCairoPdfExport.cpp:84
-#: ../src/pdf/base/XojCairoPdfExport.cpp:134
-msgid "No pages to export!"
-msgstr "Keine Seite zu exportieren!"
-
-#: ../src/gui/dialog/ButtonConfigGui.cpp:93
-msgid "Normal drawing"
-msgstr "Normal zeichnen"
-
-#: ../src/control/jobs/BaseExportJob.cpp:116
-msgid ""
-"Only local files are supported\n"
-"Path: {1}"
-msgstr ""
-"Es werden nur lokale Dateien unterstützt\n"
-"Pfad: {1}"
-
-#: ../src/control/stockdlg/ImageOpenDlg.cpp:10
-msgid "Open Image"
-msgstr "Öffne Bild"
-
-#: ../src/control/XournalMain.cpp:108
-msgid "Open Logfile"
-msgstr "Öffne Logdatei"
-
-#: ../src/control/XournalMain.cpp:109
-msgid "Open Logfile directory"
-msgstr "Öffne Verzeichnis der Logdateien"
-
-#: ../src/gui/MainWindow.cpp:263
-msgid "Open URI: {1}"
-msgstr "Öffne URI: {1}"
-
-#: ../src/control/stockdlg/XojOpenDlg.cpp:17
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:317
-msgid "Open file"
-msgstr "Öffne Datei"
-
-#: ../src/control/RecentManager.cpp:241
-msgctxt "{1} is a URI"
-msgid "Open {1}"
-msgstr "Öffne {1}"
-
-#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:18
-#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:140
-msgid "Orange"
-msgstr "orange"
-
-#: ../src/control/jobs/PdfExportJob.cpp:10
-msgid "PDF Export"
-msgstr "PDF Exportieren"
-
-#: ../src/gui/MainWindow.cpp:667
-msgid "PDF Page {1}"
-msgstr "PDF-Seite {1}"
-
-#: ../src/view/PdfView.cpp:40
-msgid "PDF background missing"
-msgstr "PDF-Hintergrund fehlt"
-
-#: ../src/control/XournalMain.cpp:207
-msgid "PDF file successfully created"
-msgstr "PDF-Datei erfolgreich erstellt"
-
-#: ../src/control/stockdlg/XojOpenDlg.cpp:59
-#: ../src/control/jobs/PdfExportJob.cpp:24
-#: ../src/control/jobs/CustomExportJob.cpp:44
-msgid "PDF files"
-msgstr "PDF Dateien"
-
-#: ../src/control/XournalMain.cpp:227
-msgid "PDF output filename"
-msgstr "Dateiname der PDF-Ausgabe"
-
-#: ../src/control/jobs/CustomExportJob.cpp:45
-msgid "PNG graphics"
-msgstr "PNG Bild"
-
-#: ../src/gui/toolbarMenubar/ToolPageSpinner.cpp:69
-msgid "Page"
-msgstr "Seite"
-
-#: ../src/gui/sidebar/previews/page/SidebarPreviewPages.cpp:26
-msgid "Page Preview"
-msgstr "Seitenvorschau"
-
-#: ../src/undo/PageBackgroundChangedUndoAction.cpp:109
-msgid "Page background changed"
-msgstr "Seitenhintergrund geändert"
-
-#: ../src/undo/InsertDeletePageUndoAction.cpp:129
-msgid "Page deleted"
-msgstr "Seite gelöscht"
-
-#: ../src/undo/InsertDeletePageUndoAction.cpp:125
-msgid "Page inserted"
-msgstr "Seite hinzugefügt"
-
-#: ../src/gui/toolbarMenubar/ToolPageSpinner.cpp:51
-msgid "Page number"
-msgstr "Seitennummer"
-
-#: ../src/undo/AddUndoAction.cpp:108
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:321
-msgid "Paste"
-msgstr "Einfügen"
-
-#: ../src/gui/dialog/ButtonConfigGui.cpp:55
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:378
-msgid "Pen"
-msgstr "Stift"
-
-#: ../src/control/pagetype/PageTypeHandler.cpp:22
-msgid "Plain"
-msgstr "Einfarbig"
-
-#: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:32
-#: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:106
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:409
-msgid "Play Object"
-msgstr "Objekt abspielen"
-
-#: ../src/gui/dialog/ToolbarManageDialog.cpp:25
-msgid "Predefined"
-msgstr "Vordefiniert"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:452
-msgid "Presentation mode"
-msgstr "Präsentationsmodus"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:370
-msgid "Rec / Stop"
-msgstr "Aufname / Stop"
-
-#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:16
-#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:138
-msgid "Red"
-msgstr "rot"
-
-#: ../src/undo/UndoRedoHandler.cpp:292
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:326
-msgid "Redo"
-msgstr "Wiederherstellen"
-
-#: ../src/undo/UndoRedoHandler.cpp:286
-msgid "Redo: "
-msgstr "Wiederherstellen: "
-
-#: ../src/control/Control.cpp:2008
-msgid "Remove PDF Background"
-msgstr "PDF-Hintergrund entfernen"
-
-#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:202
-msgid "Removed tool item from Toolbar {1} ID {2}"
-msgstr "Entferne Werkzeug von der Werkzeugleiste {1} ID {2}"
-
-#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:198
-msgid "Removed tool item {1} from Toolbar {2} ID {3}"
-msgstr "Entferne Werkzeug {1} von der Werkzeugleiste {2} ID {3}"
-
-#: ../src/undo/RotateUndoAction.cpp:74
-msgid "Rotation"
-msgstr "Drehung"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:374
-msgid "Rotation Snapping"
-msgstr "Drehung Einrasten"
-
-#: ../src/control/pagetype/PageTypeHandler.cpp:24
-msgid "Ruled"
-msgstr "Liniert"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:426
-msgid "Ruler"
-msgstr "Lineal"
-
-#: ../src/control/jobs/SaveJob.cpp:17 ../src/control/Control.cpp:2531
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:314
-msgid "Save"
-msgstr "Speichern"
-
-#: ../src/control/Control.cpp:2568
-msgid "Save As"
-msgstr "Speichern als..."
-
-#: ../src/control/Control.cpp:2338 ../src/gui/dialog/PageTemplateDialog.cpp:185
-msgid "Save File"
-msgstr "Speichere Datei"
-
-#: ../src/control/jobs/SaveJob.cpp:157
-#: ../src/control/jobs/CustomExportJob.cpp:261
-msgid "Save file error: {1}"
-msgstr "Fehler beim Speichern der Datei: {1}"
-
-#: ../src/undo/ScaleUndoAction.cpp:73
-msgid "Scale"
-msgstr "Skalieren"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:323
-msgid "Search"
-msgstr "Suchen"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:438
-msgid "Select Font"
-msgstr "Schriftart auswählen"
-
-#: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:31
-#: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:99
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:406
-msgid "Select Object"
-msgstr "Objekt auswählen"
-
-#: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:10
-#: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:29
-#: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:85
-#: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:125
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:404
-msgid "Select Rectangle"
-msgstr "Rechteck auswählen"
-
-#: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:30
-#: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:92
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:402
-msgid "Select Region"
-msgstr "Bereich auswählen"
-
-#: ../src/control/Control.cpp:2007
-msgid "Select another PDF"
-msgstr "Andere PDF-Datei auswählen"
-
-#: ../src/gui/dialog/SelectBackgroundColorDialog.cpp:144
-msgid "Select background color"
-msgstr "Hintergrundfarbe wählen"
-
-#: ../src/gui/toolbarMenubar/ColorToolItem.cpp:47
-#: ../src/gui/toolbarMenubar/ColorToolItem.cpp:157
-msgid "Select color"
-msgstr "Farbe auswählen"
-
-#: ../src/gui/dialog/ButtonConfigGui.cpp:62
-msgid "Select rectangle"
-msgstr "Rechteck auswählen"
-
-#: ../src/gui/dialog/ButtonConfigGui.cpp:61
-msgid "Select region"
-msgstr "Bereich auswählen"
-
-#: ../src/control/XournalMain.cpp:107
-msgid "Send Bugreport"
-msgstr "Fehlerbericht senden"
-
-#: ../src/gui/dialog/toolbarCustomize/ToolbarCustomizeDialog.cpp:53
-msgid "Separator"
-msgstr "Trenner"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:424
-msgid "Shape Recognizer"
-msgstr "Figurenerkennung"
-
-#: ../src/gui/dialog/backgroundSelect/PdfPagesDialog.cpp:134
-msgid "Show only not used pages (one unused page)"
-msgstr "Nur nicht benutzte Seiten anzeigen (eine nicht benutzte Seiten)"
-
-#: ../src/gui/dialog/backgroundSelect/PdfPagesDialog.cpp:135
-msgid "Show only not used pages ({1} unused pages)"
-msgstr "Nur nicht benutzte Seiten anzeigen ({1} nicht benutzte Seiten)"
-
-#: ../src/control/XournalMain.cpp:286
-msgid ""
-"Sorry, Xournal++ can only open one file from the command line.\n"
-"Others are ignored."
-msgstr ""
-"Entschuldigung, Xournal++ kann nur eine Datei von der Kommandozeile öffnen.\n"
-"Alle weiteren werden ignoriert."
-
-#: ../src/control/XournalMain.cpp:305
-msgid ""
-"Sorry, Xournal++ cannot open remote files at the moment.\n"
-"You have to copy the file to a local directory."
-msgstr ""
-"Entschuldigung, Xournal++ kann derzeit keine entfernten Dateien öffnen.\n"
-"Kopieren Sie die Datei in einen lokalen Ordner."
-
-#: ../src/undo/RecognizerUndoAction.cpp:101
-#: ../src/gui/dialog/ButtonConfigGui.cpp:103
-#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:42
-msgid "Stroke recognizer"
-msgstr "Figurenerkennung"
-
-#: ../src/util/CrashHandler.cpp:152
-msgid "Successfully saved document to \"{1}\""
-msgstr "Dokument erfolgreich nach \"{1}\" gespeichert."
-
-#: ../src/control/stockdlg/XojOpenDlg.cpp:129
-msgid "Supported files"
-msgstr "Unterstützte Dateiformate"
-
-#: ../src/gui/dialog/ButtonConfigGui.cpp:58
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:397
-msgid "Text"
-msgstr "Text"
-
-#: ../src/gui/SearchBar.cpp:73
-#, c-format
-msgid "Text %i times found on this page"
-msgstr "Text auf dieser Seite %i mal gefunden"
-
-#: ../src/undo/TextUndoAction.cpp:47
-msgid "Text changes"
-msgstr "Text geändert"
-
-#: ../src/gui/SearchBar.cpp:69
-msgid "Text found on this page"
-msgstr "Text auf dieser Seite gefunden"
-
-#: ../src/gui/SearchBar.cpp:153 ../src/gui/SearchBar.cpp:209
-msgid "Text found once on page {1}"
-msgstr "Text einmal auf Seite {1} gefunden"
-
-#: ../src/gui/SearchBar.cpp:154 ../src/gui/SearchBar.cpp:210
-msgid "Text found {1} times on page {2}"
-msgstr "Text {1}-mal auf Seite {2} gefunden"
-
-#: ../src/gui/SearchBar.cpp:80
-msgid "Text not found"
-msgstr "Text nicht gefunden"
-
-#: ../src/gui/SearchBar.cpp:167 ../src/gui/SearchBar.cpp:223
-msgid "Text not found, searched on all pages"
-msgstr "Text nicht gefunden, auf allen Seiten gesucht"
-
-#: ../src/control/Control.cpp:960
-msgid ""
-"The Toolbarconfiguration \"{1}\" is predefined, would you create a copy to "
-"edit?"
-msgstr ""
-"Die Werkzeugleistenkonfiguration \"{1}\" ist vordefiniert, möchten Sie eine "
-"Kopie erstellen?"
-
-#: ../src/control/Control.cpp:2004
-msgid "The attached background PDF could not be found."
-msgstr "Der angehängte PDF-Hintergrund konnte nicht gefunden werden."
-
-#: ../src/control/Control.cpp:2005
-msgid "The background PDF could not be found."
-msgstr "Der PDF-Hintergrund konnte nicht gefunden werden."
-
-#: ../src/control/XournalMain.cpp:102
-msgid "The most recent log file name: {1}"
-msgstr "Der aktuelleste Logdateiname: {1}"
-
-#: ../src/control/XournalMain.cpp:95
-msgid ""
-"There are errorlogfiles from Xournal++. Please send a Bugreport, so the bug "
-"may be fixed."
-msgstr ""
-"Es ist ein Xournal++ Fehlerlog vorhanden. Bitte senden Sie einen "
-"Fehlerbericht (auf Englisch wenn möglich), damit der Fehler korrigiert "
-"werden kann."
-
-#: ../src/control/XournalMain.cpp:94
-msgid ""
-"There is an errorlogfile from Xournal++. Please send a Bugreport, so the bug "
-"may be fixed."
-msgstr ""
-"Es ist ein Xournal++ Fehlerlog vorhanden. Bitte senden Sie einen "
-"Fehlerbericht (auf Englisch wenn möglich), damit der Fehler korrigiert "
-"werden kann."
-
-#: ../src/control/Control.cpp:864
-msgid "There was an error displaying help: {1}"
-msgstr "Es ist ein Fehler aufgetreten beim Anzeigen der Hilfe: {1}"
-
-#: ../src/gui/dialog/ButtonConfigGui.cpp:84
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:433
-msgid "Thick"
-msgstr "dick"
-
-#: ../src/gui/dialog/ButtonConfigGui.cpp:82
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:429
-msgid "Thin"
-msgstr "dünn"
-
-#: ../src/control/Control.cpp:2529
-msgid "This document is not saved yet."
-msgstr "Dieses Dokument wurde noch nicht gespeichert."
-
-#: ../src/control/tools/ImageHandler.cpp:55
-#: ../src/control/PageBackgroundChangeController.cpp:135
-msgid "This image could not be loaded. Error message: {1}"
-msgstr "Das Bild konnte nicht geladen werden. Fehlermeldung: {1}"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:367
-msgid "Toggle fullscreen"
-msgstr "Vollbild umschalten"
-
-#: ../src/gui/toolbarMenubar/model/ToolbarData.cpp:155
-msgid "Toolbar found: {1}"
-msgstr "Werkzeugleiste gefunden: {1}"
-
-#: ../src/gui/dialog/ToolbarManageDialog.cpp:57
-msgid "Toolbars"
-msgstr "Werkzeugleisten"
-
-#: ../src/util/CrashHandler.cpp:138
-msgid "Trying to emergency save the current open document…"
-msgstr "Versuche ein Notfall-Speichern des aktuell geöffneten Dokuments…"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:449
-msgid "Two pages"
-msgstr "Zwei Seiten"
-
-#: ../src/undo/UndoRedoHandler.cpp:273
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:325
-msgid "Undo"
-msgstr "Rückgängig"
-
-#: ../src/undo/UndoRedoHandler.cpp:268
-msgid "Undo: "
-msgstr "Rückgängig: "
-
-#: ../src/control/xojfile/LoadHandler.cpp:228
-msgid "Unexpected root tag: {1}"
-msgstr "Unerwarteter Root Tag: {1}"
-
-#: ../src/control/xojfile/LoadHandler.cpp:257
-msgid "Unexpected tag in document: \"{1}\""
-msgstr "Unerwarteter Tag im Dokument: \"{1}\""
-
-#: ../src/control/xojfile/LoadHandler.cpp:462
-msgid "Unknown background type: {1}"
-msgstr "Unbekannter Hintergrundtyp: {1}"
-
-#: ../src/control/xojfile/LoadHandlerHelper.cpp:80
-msgid "Unknown color value \"{1}\""
-msgstr "Unbekannter Farbwert \"{1}\""
-
-#: ../src/control/xojfile/LoadHandler.cpp:397
-msgid "Unknown domain type: {1}"
-msgstr "Unbekannter Domänentyp: {1}"
-
-#: ../src/control/xojfile/LoadHandler.cpp:180
-msgid "Unknown parser error"
-msgstr "Unbekannter Lesefehler"
-
-#: ../src/control/xojfile/LoadHandler.cpp:332
-msgid "Unknown pixmap::domain type: {1}"
-msgstr "Unbekannter pixmap::domain Typ: {1}"
-
-#: ../src/control/xojfile/LoadHandler.cpp:539
-msgid "Unknown stroke type: \"{1}\", assuming pen"
-msgstr "Unbekannter Linientyp: \"{1}\", verwende Stift"
-
-#: ../src/control/Control.cpp:2423
-msgid "Unsaved Document"
-msgstr "Ungespeichertes Dokument"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:419
-msgid "Vertical Space"
-msgstr "Vertikaler Platz"
-
-#: ../src/gui/dialog/ButtonConfigGui.cpp:60
-msgid "Vertical space"
-msgstr "Vertikaler Platz"
-
-#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:20
-#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:142
-msgid "White"
-msgstr "weiß"
-
-#: ../src/control/pagetype/PageTypeHandler.cpp:31
-msgid "With PDF background"
-msgstr "Mit PDF-Hintergrund"
-
-#: ../src/undo/InsertUndoAction.cpp:43
-msgid "Write text"
-msgstr "Text schreiben"
-
-#: ../src/control/xojfile/LoadHandler.cpp:802
-msgid "Wrong count of points ({1})"
-msgstr "Falsche Punktanzahl ({1})"
-
-#: ../src/control/xojfile/LoadHandler.cpp:817
-msgid "Wrong number of points, got {1}, expected {2}"
-msgstr "Falsche Punktzahl {1}, erwartet wurde {2}"
-
-#: ../src/control/xojfile/LoadHandler.cpp:175
-msgid "XML Parser error: {1}"
-msgstr "XML Parser Fehler: {1}"
-
-#: ../src/control/jobs/CustomExportJob.cpp:46
-msgid "Xournal (Compatibility)"
-msgstr "Xournal (Kompatibilitätsmodus)"
-
-#: ../src/control/stockdlg/XojOpenDlg.cpp:70
-msgid "Xournal files"
-msgstr "Xournal Dateien"
-
-#: ../src/control/stockdlg/XojOpenDlg.cpp:80 ../src/control/Control.cpp:2345
-msgid "Xournal++ files"
-msgstr "Xournal++ Dateien"
-
-#: ../src/control/stockdlg/XojOpenDlg.cpp:90
-#: ../src/gui/dialog/PageTemplateDialog.cpp:192
-msgid "Xournal++ template"
-msgstr "Xournal++ Vorlage"
-
-#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:19
-#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:141
-msgid "Yellow"
-msgstr "gelb"
-
-#: ../src/control/PageBackgroundChangeController.cpp:177
-msgid ""
-"You don't have any PDF pages to select from. Cancel operation.\n"
-"Please select another background type: Menu \"Journal\" → \"Configure Page "
-"Template\"."
-msgstr ""
-"Es gibt keine PDF Seiten zum Auswählen. Abbruch.\n"
-"Bitte wählen Sie einen anderen Hintergrundtyp: Menü \"Journal\" / "
-"\"Seitenvorlage konfigurieren\"."
-
-#: ../src/control/XournalMain.cpp:98
-msgid ""
-"You're using {1}/{2} branch. Send Bugreport will direct you to this repo's "
-"issue tracker."
-msgstr ""
-"Sie benutzen den {1}/{2} Zweig. Das Senden eines Fehlerberichts wird Siezum "
-"Issue-Tracker dieses Repositoriums führen."
-
-#: ../src/gui/sidebar/indextree/SidebarIndexPage.cpp:80
-msgid ""
-"Your current document does not contain PDF Page no {1}\n"
-"Would you like to insert this page?\n"
-"\n"
-"Tip: You can select Journal → Paper Background → PDF Background to insert a "
-"PDF page."
-msgstr ""
-"Ihr aktuelles Dokument beinhaltet die PDF Seite {1} nicht\n"
-"Möchten Sie diese Seite einfügen?\n"
-"\n"
-"Tipp: Sie können im Menü Journal / Seitenhintergrund / PDF-Hintergrund eine "
-"beliebige PDF Seite einfügen."
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:361
-msgid "Zoom fit to screen"
-msgstr "Passend zoomen"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:359
-msgid "Zoom in"
-msgstr "Hereinzoomen"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:357
-msgid "Zoom out"
-msgstr "Herauszoomen"
-
-#: ../src/gui/toolbarMenubar/ToolZoomSlider.cpp:53
-msgid "Zoom slider"
-msgstr "Zoomregler"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:363
-msgid "Zoom to 100%"
-msgstr "Zoom auf 100%"
-
-#: ../src/control/stockdlg/ImageOpenDlg.cpp:11
-#: ../src/control/stockdlg/XojOpenDlg.cpp:18
-#: ../src/control/jobs/BaseExportJob.cpp:26 ../src/control/Control.cpp:2339
-#: ../src/gui/dialog/PageTemplateDialog.cpp:186
-msgid "_Cancel"
-msgstr "_Abbrechen"
-
-#: ../src/control/stockdlg/ImageOpenDlg.cpp:12
-#: ../src/control/stockdlg/XojOpenDlg.cpp:19
-msgid "_Open"
-msgstr "Ö_ffnen"
-
-#: ../src/control/jobs/BaseExportJob.cpp:27 ../src/control/Control.cpp:2340
-#: ../src/gui/dialog/PageTemplateDialog.cpp:187
-msgid "_Save"
-msgstr "_Speichern"
-
-#: ../src/util/DeviceListHelper.cpp:86
-msgid "cursor"
-msgstr "Cursor"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:298
-msgid "delete stroke"
-msgstr "Linie löschen"
-
-#: ../src/util/DeviceListHelper.cpp:82
-msgid "eraser"
-msgstr "Radierer"
-
-#: ../src/util/DeviceListHelper.cpp:91
-msgid "keyboard"
-msgstr "Tastatur"
-
-#: ../src/util/DeviceListHelper.cpp:74
-msgid "mouse"
-msgstr "Maus"
-
-#: ../src/util/DeviceListHelper.cpp:78
-msgid "pen"
-msgstr "Stift"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:284
-msgid "standard"
-msgstr "standard"
-
-#: ../src/util/DeviceListHelper.cpp:99
-msgid "touchpad"
-msgstr "Touchpad"
-
-#: ../src/util/DeviceListHelper.cpp:95
-msgid "touchscreen"
-msgstr "Touchscreen"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:291
-msgid "whiteout"
-msgstr "weiß übermalen"
-
-#: ../src/control/xojfile/LoadHandler.cpp:816
-msgid "xoj-File: {1}"
-msgstr "xoj-Datei: {1}"
-
-#: ../src/xoj-preview-extractor/xournal-thumbnailer.cpp:88
-msgid "xoj-preview-extractor: call with INPUT.xoj OUTPUT.png"
-msgstr "xoj-Vorschau-Extraktor: rufe auf mit INPUT.xoj OUTPUT.png"
-
-#: ../src/xoj-preview-extractor/xournal-thumbnailer.cpp:110
-msgid "xoj-preview-extractor: file \"{1}\" contains no preview"
-msgstr "xoj-Vorschau-Extraktor: Datei \"{1}\" enthält keine Vorschau"
-
-#: ../src/xoj-preview-extractor/xournal-thumbnailer.cpp:102
-msgid "xoj-preview-extractor: file \"{1}\" is not .xoj file"
-msgstr "xoj-Vorschau-Extraktor: Datei \"{1}\" ist keine xoj-Datei"
-
-#: ../src/xoj-preview-extractor/xournal-thumbnailer.cpp:115
-msgid ""
-"xoj-preview-extractor: no preview and page found, maybe an invalid file?"
-msgstr ""
-"xoj-Vorschau-Extraktor: keine Vorschau und keine Seite gefunden: ungültige "
-"Datei?"
-
-#: ../src/xoj-preview-extractor/xournal-thumbnailer.cpp:106
-msgid "xoj-preview-extractor: opening input file \"{1}\" failed"
-msgstr "xoj-Vorschau-Extraktor: Öffnen der Datei \"{1}\" fehlgeschlagen"
-
-#: ../src/xoj-preview-extractor/xournal-thumbnailer.cpp:122
-msgid "xoj-preview-extractor: opening output file \"{1}\" failed"
-msgstr "xoj-Vorschau-Extraktor: Öffnen der Ausgabedatei \"{1}\" fehlgeschlagen"
-
-#: ../src/xoj-preview-extractor/xournal-thumbnailer.cpp:131
-msgid "xoj-preview-extractor: successfully extracted"
-msgstr "xoj-Vorschau-Extraktor: erfolgreich extrahiert"
-
 #: ../ui/settings.glade:503
 msgid "%F-Note-%H-%M.xoj"
 msgstr "Notiz-%d-%m-%Y-%H-%M.xoj"
+
+#: ../src/control/settings/Settings.cpp:86
+msgid "%F-Note-%H-%M.xopp"
+msgstr "Notiz-%d-%m-%Y-%H-%M.xopp"
 
 #: ../ui/settings.glade:526
 msgid ""
@@ -1597,13 +367,55 @@ msgstr ""
 msgid "About Xournal"
 msgstr "Über Xournal"
 
+#: ../src/control/XournalMain.cpp:229
+msgid "Absolute path for the audio files playback"
+msgstr "Absoluter Pfad für die Audiodateien"
+
 #: ../ui/main.glade:1010
 msgid "Add/Edit Tex"
 msgstr "LaTeX  editieren/hinzufügen"
 
+#: ../src/control/stockdlg/XojOpenDlg.cpp:49
+msgid "All files"
+msgstr "Alle Dateien"
+
 #: ../ui/exportSettings.glade:136
 msgid "All pages"
 msgstr "Alle Seiten"
+
+#: ../src/control/stockdlg/ImageOpenDlg.cpp:29
+#: ../src/control/stockdlg/XojOpenDlg.cpp:148
+msgid "Attach file to the journal"
+msgstr "Datei ans .xoj anhängen"
+
+#: ../src/control/xojfile/LoadHandlerHelper.cpp:140
+msgid "Attribute \"{1}\" could not be parsed as double, the value is \"{2}\""
+msgstr ""
+"Attribut \"{1}\" konnte nicht als Fließkommazahl ausgelesen werden, der Wert "
+"ist \"{2}\""
+
+#: ../src/control/xojfile/LoadHandlerHelper.cpp:132
+msgid "Attribute \"{1}\" could not be parsed as double, the value is NULL"
+msgstr ""
+"Attribut \"{1}\" konnte nicht als Fließkommazahl ausgelesen werden, der Wert "
+"ist NULL"
+
+#: ../src/control/xojfile/LoadHandlerHelper.cpp:160
+#: ../src/control/xojfile/LoadHandlerHelper.cpp:183
+msgid "Attribute \"{1}\" could not be parsed as int, the value is \"{2}\""
+msgstr ""
+"Attribut \"{1}\" konnte nicht als Ganzzahl ausgelesen werden, der Wert ist "
+"\"{1}\""
+
+#: ../src/control/xojfile/LoadHandlerHelper.cpp:152
+msgid "Attribute \"{1}\" could not be parsed as int, the value is NULL"
+msgstr ""
+"Attribut \"{1}\" konnte nicht als Ganzzahl ausgelesen werden, der Wert ist "
+"NULL"
+
+#: ../src/control/xojfile/LoadHandlerHelper.cpp:70
+msgid "Attribute color not set!"
+msgstr "Attribut Farbe ist nicht gesetzt!"
 
 #: ../ui/settings.glade:1671
 msgid "Audio Folder"
@@ -1613,6 +425,14 @@ msgstr "Audio Ordner"
 msgid "Audio Recording"
 msgstr "Audioaufzeichnung"
 
+#: ../src/control/AudioController.cpp:99
+msgid ""
+"Audio folder not set! Recording won't work!\n"
+"Please set the recording folder under \"Preferences > Audio recording\""
+msgstr ""
+"Audio Ordner nicht gesetzt! Aufzeichnung wird nicht funktionieren!\n"
+"Bitte den Ordner festlegen unter \"Einstellungen > Audioaufzeichnung\""
+
 #: ../ui/about.glade:151
 msgid "Authors:"
 msgstr "Autoren:"
@@ -1621,6 +441,19 @@ msgstr "Autoren:"
 msgid "Autosave every ... minutes:"
 msgstr "Alle ... automatisch speichern:"
 
+#: ../src/control/jobs/AutosaveJob.cpp:24
+msgid "Autosave: {1}"
+msgstr "Autospeichern: {1}"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:332
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:335
+msgid "Back"
+msgstr "Zurück"
+
+#: ../src/gui/toolbarMenubar/ToolPageLayer.cpp:71
+msgid "Background"
+msgstr "Hintergrund"
+
 #: ../ui/settings.glade:1195
 msgid "Background color for window Background"
 msgstr "Hintergrundfarbe des Fensters"
@@ -1628,6 +461,16 @@ msgstr "Hintergrundfarbe des Fensters"
 #: ../ui/settings.glade:1509
 msgid "Big cursor for pen"
 msgstr "Großer Cursor für den Stift"
+
+#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:10
+#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:132
+msgid "Black"
+msgstr "schwarz"
+
+#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:14
+#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:136
+msgid "Blue"
+msgstr "blau"
 
 #: ../ui/settings.glade:1184
 msgid "Border color"
@@ -1641,13 +484,47 @@ msgstr "Rahmenfarbe der gewählten Seite und anderer Auswahlen"
 msgid "Built on:"
 msgstr "Kompiliert am:"
 
+#: ../src/control/Control.cpp:2009 ../src/control/Control.cpp:2533
+#: ../src/control/Control.cpp:2570 ../src/control/XournalMain.cpp:111
+msgid "Cancel"
+msgstr "Abbrechen"
+
+#: ../src/undo/ColorUndoAction.cpp:118
+msgid "Change color"
+msgstr "Farbe ändern"
+
+#: ../src/undo/FontUndoAction.cpp:133
+msgid "Change font"
+msgstr "Schriftart ändern"
+
+#: ../src/undo/SizeUndoAction.cpp:145
+msgid "Change stroke width"
+msgstr "Liniendicke ändern"
+
 #: ../ui/settingsButtonConfig.glade:104
 msgid "Color"
 msgstr "Farbe"
 
+#: ../src/control/xojfile/LoadHandlerHelper.cpp:98
+msgid "Color \"{1}\" unknown (not defined in default color list)!"
+msgstr "Farbe \"{1}\" unbekannt (nicht in der Farbliste)"
+
 #: ../ui/main.glade:565
 msgid "Configure Page Template"
 msgstr "Seitenvorlage konfigurieren"
+
+#: ../src/gui/sidebar/indextree/SidebarIndexPage.cpp:273
+msgid "Contents"
+msgstr "Inhalt"
+
+#: ../src/control/Control.cpp:990 ../src/control/Control.cpp:998
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:320
+msgid "Copy"
+msgstr "Kopieren"
+
+#: ../src/control/pagetype/PageTypeHandler.cpp:30
+msgid "Copy current"
+msgstr "Aktuellen Hintergrund kopieren"
 
 #: ../ui/pageTemplate.glade:175
 msgid "Copy last page settings"
@@ -1657,16 +534,138 @@ msgstr "Einstellen der letzten Seite kopieren"
 msgid "Copy last page size"
 msgstr "Grösser der letzten Seite kopieren"
 
+#: ../src/undo/CopyUndoAction.cpp:80
+msgid "Copy page"
+msgstr "Kopiere Seite"
+
+#: ../src/control/jobs/SaveJob.cpp:144
+msgid ""
+"Could not create backup! (The file was created from an older Xournal version)"
+msgstr ""
+"Konnte kein Backup erstellen! (Diese Datei wurde mit einer alten Version von "
+"Xournal erstellt.)"
+
+#: ../src/control/LatexController.cpp:361
+msgid ""
+"Could not find Xournal++ LaTeX executable relative or in Path.\n"
+"Searched for: mathtex-xournalpp.cgi"
+msgstr ""
+"Konnte Xournal++ LaTeX programm nicht finden, relativ oder im Pfad.\n"
+"Suche nach: mathtex-xournalpp.cgi"
+
+#: ../src/control/pagetype/PageTypeHandler.cpp:18
+msgid "Could not load pagetemplates.ini file"
+msgstr "Konnte die Datei pagetemplates.ini nicht öffnen"
+
+#: ../src/control/xojfile/LoadHandler.cpp:110
+msgid "Could not open file: \"{1}\""
+msgstr "Konnte die Datei nicht öffnen: \"{1}\""
+
+#: ../src/gui/MainWindow.cpp:91
+msgid ""
+"Could not parse custom toolbar.ini file: {1}\n"
+"Toolbars will not be available"
+msgstr ""
+"Konnte die benutzerdefinierte Datei toolbar.ini nicht lesen: {1}\n"
+"Es werden keine Werkzeugleisten zur Verfügung stehen"
+
+#: ../src/gui/MainWindow.cpp:81
+msgid ""
+"Could not parse general toolbar.ini file: {1}\n"
+"No Toolbars will be available"
+msgstr ""
+"Konnte die globale Datei toolbar.ini nicht lesen: {1}\n"
+"Es werden keine Werkzeugleisten zur Verfügung stehen"
+
+#: ../src/control/xojfile/LoadHandler.cpp:315
+msgid "Could not read image: {1}. Error message: {2}"
+msgstr "Das Bild {1} konnte nicht geladen werden. Fehlermeldung: {2}"
+
+#: ../src/undo/UndoRedoHandler.cpp:183
+msgid ""
+"Could not redo \"{1}\"\n"
+"Something went wrong… Please write a bug report…"
+msgstr ""
+"Rückgängig ist fehlgeschlagen '{1}'\n"
+"Etwas ist schief gelaufen... Bitte erstellen Sie einen Fehlerbericht."
+
+#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:214
+msgid "Could not remove tool item from Toolbar {1} on position {2}"
+msgstr ""
+"Konnte Werkzeug von der Werkzeugleiste {1} Position {2} nicht entfernen"
+
+#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:209
+msgid "Could not remove tool item {1} from Toolbar {2} on position {3}"
+msgstr ""
+"Konnte Werkzeug von {1} von der Werkzeugleiste {2} Position {3} nicht "
+"entfernen"
+
+#: ../src/control/LatexController.cpp:290
+msgid "Could not retrieve LaTeX image file: {1}"
+msgstr "Die LaTeX-Bilddatei konnte nicht geladen werden: {1}"
+
+#: ../src/undo/UndoRedoHandler.cpp:146
+msgid ""
+"Could not undo \"{1}\"\n"
+"Something went wrong… Please write a bug report…"
+msgstr ""
+"Wiederherstellen ist fehlgeschlagen '{1}'\n"
+"Etwas ist schief gelaufen... Bitte Erstellen Sie einen Fehlerbericht."
+
+#: ../src/control/xojfile/SaveHandler.cpp:271
+msgid "Could not write background \"{1}\", {2}"
+msgstr "Konnte Hintergrund \"{1}\" nicht speichern, {2}"
+
+#: ../src/control/xojfile/SaveHandler.cpp:396
+msgid "Could not write background \"{1}\". Continuing anyway."
+msgstr "Konnte Hintergrund nicht speichern \"{1}\". Fahre trotzdem fort."
+
 #: ../ui/exportSettings.glade:151
 msgid "Current page"
 msgstr "Aktuelle Seite"
+
+#: ../src/gui/dialog/FormatDialog.cpp:79
+msgid "Custom"
+msgstr "Benutzerdefiniert"
+
+#: ../src/control/jobs/CustomExportJob.cpp:16
+msgid "Custom Export"
+msgstr "Benutzerdefinierter Export"
+
+#: ../src/gui/dialog/ToolbarManageDialog.cpp:40
+msgid "Customized"
+msgstr "Anpassen"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:319
+msgid "Cut"
+msgstr "Ausschneiden"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:436
+msgid "Default Tool"
+msgstr "Standard Werkzeug"
 
 #: ../ui/settings.glade:1633
 msgid "Defaults"
 msgstr "Konfiguration"
 
+#: ../src/undo/DeleteUndoAction.cpp:102
+msgid "Delete"
+msgstr "Löschen"
+
 #: ../ui/main.glade:597
 msgid "Delete Layer"
+msgstr "Ebene löschen"
+
+#: ../src/control/XournalMain.cpp:110
+msgid "Delete Logfile"
+msgstr "Logdatei löschen"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:383
+msgid "Delete current page"
+msgstr "Aktuelle Seite löschen"
+
+#: ../src/undo/RemoveLayerUndoAction.cpp:38
+msgid "Delete layer"
 msgstr "Ebene löschen"
 
 #: ../ui/settingsButtonConfig.glade:155
@@ -1685,21 +684,111 @@ msgstr "Eingabegerät"
 msgid "Disable drawing for this device"
 msgstr "Deaktivieren des Zeichnens mit diesem Gerät"
 
+#: ../src/control/Control.cpp:2532 ../src/control/Control.cpp:2569
+msgid "Discard"
+msgstr "Verwerfen"
+
+#: ../src/control/Control.cpp:1939
+msgid ""
+"Do not open Autosave files. They may will be overwritten!\n"
+"Copy the files to another folder.\n"
+"Files from Folder {1} cannot be opened."
+msgstr ""
+"Öffnen sie keine automatisch gespeicherten Dateien. Diese werden ansonsten "
+"überschrieben!\n"
+"Kopieren Sie diese Dateien an einen anderen Ort.\n"
+"Dateien aus dem Ordner {1} können nicht geöffnet werden."
+
+#: ../src/control/jobs/PdfExportJob.cpp:56
+msgid "Do not overwrite the background PDF! This will cause errors!"
+msgstr ""
+"Das Hintergrund PDF darf nicht überschrieben werden! Dies verursacht Fehler!"
+
+#: ../src/control/Control.cpp:2566
+msgid "Document file was removed."
+msgstr "Datei des Dokuments wurde entfernt."
+
+#: ../src/control/xojfile/LoadHandler.cpp:189
+msgid "Document is not complete (maybe the end is cut off?)"
+msgstr "Dokument ist nicht vollständig (z.B. nicht komplett übertragen?)"
+
+#: ../src/model/Document.cpp:355
+msgid "Document not loaded! ({1}), {2}"
+msgstr "Dokument nicht geladen! ({1}), {2}"
+
+#: ../src/gui/dialog/ButtonConfigGui.cpp:54
+#: ../src/gui/dialog/ButtonConfigGui.cpp:81
+#: ../src/gui/dialog/ButtonConfigGui.cpp:91
+msgid "Don't change"
+msgstr "Nicht ändern"
+
+#: ../src/control/XournalMain.cpp:226
+msgid "Don't compress PDF files (for debugging)"
+msgstr "PDF-Datei nicht komprimieren (zur Fehlersuche)"
+
+#: ../src/control/pagetype/PageTypeHandler.cpp:26
+msgid "Dotted"
+msgstr "Gepunktet"
+
 #: ../ui/toolbarCustomizeDialog.glade:55
 msgid "Drag and drop Components fom here to the toolbars and back."
 msgstr "Ziehen Sie Objekte von hier in die Werkzeugleiste und zurück"
+
+#: ../src/gui/dialog/ButtonConfigGui.cpp:101
+#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:40
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:416
+msgid "Draw Arrow"
+msgstr "Pfeil zeichnen"
+
+#: ../src/gui/dialog/ButtonConfigGui.cpp:99
+#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:39
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:412
+msgid "Draw Circle"
+msgstr "Kreis zeichnen"
+
+#: ../src/gui/dialog/ButtonConfigGui.cpp:95
+#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:41
+msgid "Draw Line"
+msgstr "Strecke zeichnen"
+
+#: ../src/gui/dialog/ButtonConfigGui.cpp:97
+#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:29
+#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:38
+#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:119
+#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:122
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:414
+msgid "Draw Rectangle"
+msgstr "Rechteck Zeichnen"
 
 #: ../ui/main.glade:747
 msgid "Draw _Line"
 msgstr "Strecke _zeichnen"
 
+#: ../src/undo/InsertUndoAction.cpp:39
+msgid "Draw stroke"
+msgstr "Linie zeichen"
+
 #: ../ui/settingsButtonConfig.glade:128
 msgid "Drawing type"
 msgstr "Zeichnungstyp"
 
+#: ../src/undo/TextBoxUndoAction.cpp:52
+msgid "Edit text"
+msgstr "Text schreiben"
+
 #: ../ui/texdialog.glade:66
 msgid "Enter / edit LaTeX Text"
 msgstr "Bearbeite- / editiere LaTeX Text"
+
+#: ../src/undo/EraseUndoAction.cpp:130 ../src/undo/DeleteUndoAction.cpp:99
+#: ../src/undo/AddUndoAction.cpp:104
+msgid "Erase stroke"
+msgstr "Linie löschen"
+
+#: ../src/gui/dialog/ButtonConfigGui.cpp:56
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:281
+msgid "Eraser"
+msgstr "Radierer"
 
 #: ../ui/main.glade:886
 msgid "Eraser Optio_ns"
@@ -1709,13 +798,94 @@ msgstr "Radierer Optionen"
 msgid "Eraser type"
 msgstr "Radierer type"
 
+#: ../src/control/Control.cpp:2218
+msgid ""
+"Error annotate PDF file \"{1}\"\n"
+"{2}"
+msgstr ""
+"Fehler beim Öffnen des PDFs \"{1}\"\n"
+"{2}"
+
+#: ../src/control/jobs/CustomExportJob.cpp:187
+msgid "Error export PDF Page"
+msgstr "Fehler beim Exportieren der PDF Seite"
+
+#: ../src/gui/GladeGui.cpp:25
+msgid "Error loading glade file \"{1}\" (try to load \"{2}\")"
+msgstr "Fehler beim Laden der Glade-Datei \"{1}\" (Datei \"{2}\")"
+
+#: ../src/control/Control.cpp:2034
+msgid "Error opening file \"{1}\""
+msgstr "Fehler beim Öffnen der Datei '{1}'"
+
+#: ../src/pdf/popplerdirect/PdfWriter.cpp:57
+msgid "Error opening file {1} for writing: {2}"
+msgstr "Datei {1} konnte nicht zum Schreiben geöffnet werden: {2}"
+
+#: ../src/util/OutputStream.cpp:39
+msgid "Error opening file: \"{1}\""
+msgstr "Fehler beim Öffnen der Datei '{1}'"
+
+#: ../src/control/xojfile/LoadHandler.cpp:415
+msgid "Error reading PDF: {1}"
+msgstr "Fehler beim Lesen des PDFs: {1}"
+
+#: ../src/control/xojfile/LoadHandler.cpp:488
+msgid "Error reading width of a stroke: {1}"
+msgstr "Fehler beim Lesen der Dicke einer Linie: {1}"
+
+#: ../src/pdf/popplerdirect/PdfWriter.cpp:80
+msgid "Error writing stream: {1}"
+msgstr "Fehler beim Schreiben des Datenstroms: {1}"
+
+#: ../src/util/CrashHandler.cpp:148
+msgid "Error: {1}"
+msgstr "Fehler: {1}"
+
+#: ../src/control/XournalMain.cpp:134
+msgid ""
+"Errorlog cannot be deleted. You have to do it manually.\n"
+"Logfile: {1}"
+msgstr ""
+"Fehlerlog konnte nicht gelöscht werden. Sie müssen die Datei manuell "
+"löschen.\n"
+"Logdatei: {1}"
+
 #: ../ui/exportSettings.glade:24
 msgid "Export"
 msgstr "Exportieren"
 
+#: ../src/control/jobs/BaseExportJob.cpp:25
+msgid "Export PDF"
+msgstr "Exportieren als PDF"
+
 #: ../ui/main.glade:113
 msgid "Export as..."
 msgstr "Exportieren als..."
+
+#: ../src/control/LatexController.cpp:378
+msgid "Failed to generate LaTeX image!"
+msgstr "Fehler beim erstellen des LaTeX Bild!"
+
+#: ../src/util/Util.cpp:141 ../src/util/Util.cpp:168
+msgid ""
+"File couldn't be opened. You have to do it manually:\n"
+"URL: {1}"
+msgstr ""
+"Datei konnte nicht geöffnet werden, Sie müssen sie manuell öffnen\n"
+":URL: {1}"
+
+#: ../src/control/jobs/PdfExportJob.cpp:49
+msgid "File name needs to end with .pdf"
+msgstr "Dateiname muss mit .pdf enden"
+
+#: ../src/control/jobs/CustomExportJob.cpp:61
+msgid "File name needs to end with .pdf, .png or .xoj"
+msgstr "Dateiname muss mit .pdf, .png oder .xoj enden"
+
+#: ../src/control/Control.cpp:1969
+msgid "Filename: {1}"
+msgstr "Dateiname: {1}"
 
 #: ../ui/main.glade:1416
 msgid "Find next occurrence of the search string"
@@ -1725,6 +895,10 @@ msgstr "Nächstes Vorkommen des Textes suchen"
 msgid "Find previous occurrence of the search string"
 msgstr "Vorheriges Vorkommen des Textes suchen"
 
+#: ../src/gui/toolbarMenubar/FontButton.cpp:71
+msgid "Font"
+msgstr "Schriftart"
+
 #: ../ui/main.glade:289
 msgid "Fullscreen"
 msgstr "Vollbild"
@@ -1733,13 +907,56 @@ msgstr "Vollbild"
 msgid "GNU GPLv2 or later"
 msgstr "GNU GPLv2 oder neuer"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:330
+msgid "Go to first page"
+msgstr "Gehe zur ersten Seite"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:343
+msgid "Go to last page"
+msgstr "Gehe zur letzten Seite"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:348
+msgid "Go to next layer"
+msgstr "Zur nächsten ebene Springen"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:338
+msgid "Go to page"
+msgstr "Gehe zur Seite"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:346
+msgid "Go to previous layer"
+msgstr "Zur vorherigen Ebene springe"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:350
+msgid "Go to top layer"
+msgstr "Zur obersten Ebene springen"
+
 #: ../ui/goto.glade:13
 msgid "Goto Page"
 msgstr "_Gehe zur Seite"
 
+#: ../src/control/pagetype/PageTypeHandler.cpp:25
+msgid "Graph"
+msgstr "Kariert"
+
+#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:15
+#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:137
+msgid "Gray"
+msgstr "grau"
+
+#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:11
+#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:133
+msgid "Green"
+msgstr "grün"
+
 #: ../ui/main.glade:811
 msgid "H_and Tool"
 msgstr "Hand-Werkzeug"
+
+#: ../src/gui/dialog/ButtonConfigGui.cpp:65
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:420
+msgid "Hand"
+msgstr "Hand"
 
 #: ../ui/pagesize.glade:205
 msgid "Height:"
@@ -1761,9 +978,23 @@ msgstr "Horizontale Scrollbar ausblenden"
 msgid "Hide the vertical scrollbar"
 msgstr "Vertikale Scrollbar ausblenden"
 
+#: ../src/gui/dialog/ButtonConfigGui.cpp:57
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:395
+msgid "Highlighter"
+msgstr "Textmarker"
+
 #: ../ui/main.glade:960
 msgid "Highlighter Opti_ons"
 msgstr "Textmarker _Optionen"
+
+#: ../src/control/pagetype/PageTypeHandler.cpp:32
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:399
+msgid "Image"
+msgstr "Bild"
+
+#: ../src/control/stockdlg/ImageOpenDlg.cpp:17
+msgid "Images"
+msgstr "Bilddateien"
 
 #: ../ui/settings.glade:319
 msgid "Input"
@@ -1781,9 +1012,63 @@ msgstr "LaTeX einfügen"
 msgid "Insert a copy of the current page below"
 msgstr "Eine kopie der aktuellen Seite unten einfügen"
 
+#: ../src/undo/InsertUndoAction.cpp:115
+msgid "Insert elements"
+msgstr "Elemente einfügen"
+
+#: ../src/undo/InsertUndoAction.cpp:47 ../src/gui/dialog/ButtonConfigGui.cpp:59
+msgid "Insert image"
+msgstr "Bild einfügen"
+
+#: ../src/undo/InsertUndoAction.cpp:51
+msgid "Insert latex"
+msgstr "LaTeX einfügen"
+
+#: ../src/undo/InsertLayerUndoAction.cpp:36
+msgid "Insert layer"
+msgstr "Ebene einfügen"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:390
+msgid "Insert page"
+msgstr "Seite einfügen"
+
+#: ../src/control/XournalMain.cpp:228
+msgid "Jump to Page (first Page: 1)"
+msgstr "Springe zur Seite (erste Seite: 1)"
+
+#: ../src/gui/toolbarMenubar/ToolPageLayer.cpp:105
+msgid "Layer"
+msgstr "Ebene"
+
+#: ../src/gui/sidebar/previews/layer/SidebarPreviewLayers.cpp:27
+msgid "Layer Preview"
+msgstr "Ebenen-Vorschau"
+
+#: ../src/gui/toolbarMenubar/ToolPageLayer.cpp:88
+msgid "Layer selection"
+msgstr "Ebenenauswahl"
+
+#: ../src/gui/toolbarMenubar/ToolPageLayer.cpp:74
+msgid "Layer {1}"
+msgstr "Ebene {1}"
+
 #: ../ui/about.glade:217
 msgid "License"
 msgstr "Lizenz"
+
+#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:12
+#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:134
+msgid "Light Blue"
+msgstr "hellblau"
+
+#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:13
+#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:135
+msgid "Light Green"
+msgstr "hellgrün"
+
+#: ../src/control/pagetype/PageTypeHandler.cpp:23
+msgid "Lined"
+msgstr "Liniert mit Rand"
 
 #: ../ui/settings.glade:685
 msgid "Load / Save"
@@ -1793,17 +1078,60 @@ msgstr "Laden / Speichern"
 msgid "Load file"
 msgstr "Datei laden"
 
+#: ../src/gui/PageView.cpp:884
+#: ../src/gui/sidebar/previews/base/SidebarPreviewBaseEntry.cpp:115
+msgid "Loading..."
+msgstr "Laden..."
+
 #: ../ui/toolbarManageDialog.glade:8 ../ui/toolbarCustomizeDialog.glade:10
 msgid "Manage Toolbar"
 msgstr "Werkzeugleisten verwalten"
+
+#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:17
+#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:139
+msgid "Mangenta"
+msgstr "magenta"
+
+#: ../src/gui/dialog/ButtonConfigGui.cpp:83
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:431
+msgid "Medium"
+msgstr "mittel"
+
+#: ../src/control/XournalMain.cpp:455
+msgid ""
+"Missing the needed UI file, could not find them at any location.\n"
+"Not relative\n"
+"Not in the Working Path\n"
+"Not in {1}"
+msgstr ""
+"Konnte die nötigen UI Dateien nicht finden!\n"
+"Nicht relativ\n"
+"Nicht im Arbeitspfad\n"
+"Nicht in {1}"
 
 #: ../ui/settings.glade:858
 msgid "Mouse Button"
 msgstr "Maustaste"
 
+#: ../src/undo/MoveUndoAction.cpp:19
+msgid "Move"
+msgstr "Verschieben"
+
+#: ../src/undo/SwapUndoAction.cpp:89
+msgid "Move page downwards"
+msgstr "Verschiebe Seite nach unten"
+
+#: ../src/undo/SwapUndoAction.cpp:89
+msgid "Move page upwards"
+msgstr "Verschiebe Seite nach oben"
+
 #: ../ui/main.glade:508
 msgid "N_ext annotated page"
 msgstr "Nächste b_eschriftete Seite"
+
+#: ../src/gui/dialog/ToolbarManageDialog.cpp:93
+msgid "New"
+msgstr "Neu"
 
 #: ../ui/main.glade:548
 msgid "New Page _After"
@@ -1817,17 +1145,135 @@ msgstr "Neue Seite davor"
 msgid "New Page at _End"
 msgstr "Neue Seite am Ende"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:315
+msgid "New Xournal"
+msgstr "Neues Xournal"
+
 #: ../ui/main.glade:588
 msgid "New _Layer"
 msgstr "Neue Ebene"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:341
+msgid "Next"
+msgstr "Nächste Seite"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:354
+msgid "Next annotated page"
+msgstr "Nächste beschriftete Seite"
+
+#: ../src/gui/dialog/ButtonConfigGui.cpp:35
+msgid "No device"
+msgstr "Kein Gerät"
+
+#: ../src/pdf/base/XojCairoPdfExport.cpp:84
+#: ../src/pdf/base/XojCairoPdfExport.cpp:134
+msgid "No pages to export!"
+msgstr "Keine Seite zu exportieren!"
+
+#: ../src/gui/dialog/ButtonConfigGui.cpp:93
+msgid "Normal drawing"
+msgstr "Normal zeichnen"
+
+#: ../src/control/jobs/BaseExportJob.cpp:116
+msgid ""
+"Only local files are supported\n"
+"Path: {1}"
+msgstr ""
+"Es werden nur lokale Dateien unterstützt\n"
+"Pfad: {1}"
+
+#: ../src/control/stockdlg/ImageOpenDlg.cpp:10
+msgid "Open Image"
+msgstr "Öffne Bild"
+
+#: ../src/control/XournalMain.cpp:108
+msgid "Open Logfile"
+msgstr "Öffne Logdatei"
+
+#: ../src/control/XournalMain.cpp:109
+msgid "Open Logfile directory"
+msgstr "Öffne Verzeichnis der Logdateien"
+
+#: ../src/gui/MainWindow.cpp:263
+msgid "Open URI: {1}"
+msgstr "Öffne URI: {1}"
+
+#: ../src/control/stockdlg/XojOpenDlg.cpp:17
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:317
+msgid "Open file"
+msgstr "Öffne Datei"
+
+#: ../src/control/RecentManager.cpp:241
+msgctxt "{1} is a URI"
+msgid "Open {1}"
+msgstr "Öffne {1}"
+
+#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:18
+#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:140
+msgid "Orange"
+msgstr "orange"
+
+#: ../src/control/jobs/PdfExportJob.cpp:10
+msgid "PDF Export"
+msgstr "PDF Exportieren"
+
+#: ../src/gui/MainWindow.cpp:667
+msgid "PDF Page {1}"
+msgstr "PDF-Seite {1}"
+
+#: ../src/view/PdfView.cpp:40
+msgid "PDF background missing"
+msgstr "PDF-Hintergrund fehlt"
+
+#: ../src/control/XournalMain.cpp:207
+msgid "PDF file successfully created"
+msgstr "PDF-Datei erfolgreich erstellt"
+
+#: ../src/control/stockdlg/XojOpenDlg.cpp:59
+#: ../src/control/jobs/PdfExportJob.cpp:24
+#: ../src/control/jobs/CustomExportJob.cpp:44
+msgid "PDF files"
+msgstr "PDF Dateien"
+
+#: ../src/control/XournalMain.cpp:227
+msgid "PDF output filename"
+msgstr "Dateiname der PDF-Ausgabe"
+
+#: ../src/control/jobs/CustomExportJob.cpp:45
+msgid "PNG graphics"
+msgstr "PNG Bild"
 
 #: ../ui/main.glade:517
 msgid "P_revious annotated Page"
 msgstr "_Vorherige beschriftete Seite"
 
+#: ../src/gui/toolbarMenubar/ToolPageSpinner.cpp:69
+msgid "Page"
+msgstr "Seite"
+
+#: ../src/gui/sidebar/previews/page/SidebarPreviewPages.cpp:26
+msgid "Page Preview"
+msgstr "Seitenvorschau"
+
 #: ../ui/pageTemplate.glade:17
 msgid "Page Template"
 msgstr "Seitenvorlage"
+
+#: ../src/undo/PageBackgroundChangedUndoAction.cpp:109
+msgid "Page background changed"
+msgstr "Seitenhintergrund geändert"
+
+#: ../src/undo/InsertDeletePageUndoAction.cpp:129
+msgid "Page deleted"
+msgstr "Seite gelöscht"
+
+#: ../src/undo/InsertDeletePageUndoAction.cpp:125
+msgid "Page inserted"
+msgstr "Seite hinzugefügt"
+
+#: ../src/gui/toolbarMenubar/ToolPageSpinner.cpp:51
+msgid "Page number"
+msgstr "Seitennummer"
 
 #: ../ui/exportSettings.glade:167
 msgid "Pages:"
@@ -1857,17 +1303,49 @@ msgstr ""
 "Teilweise basierend auf Xounal\n"
 "von Denis Auroux"
 
+#: ../src/undo/AddUndoAction.cpp:108
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:321
+msgid "Paste"
+msgstr "Einfügen"
+
+#: ../src/gui/dialog/ButtonConfigGui.cpp:55
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:378
+msgid "Pen"
+msgstr "Stift"
+
 #: ../ui/main.glade:827
 msgid "Pen _Options"
 msgstr "Stift Optionen"
+
+#: ../src/control/pagetype/PageTypeHandler.cpp:22
+msgid "Plain"
+msgstr "Einfarbig"
+
+#: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:32
+#: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:106
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:409
+msgid "Play Object"
+msgstr "Objekt abspielen"
+
+#: ../src/gui/dialog/ToolbarManageDialog.cpp:25
+msgid "Predefined"
+msgstr "Vordefiniert"
 
 #: ../ui/main.glade:251
 msgid "Preferences"
 msgstr "Einstellungen"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:452
+msgid "Presentation mode"
+msgstr "Präsentationsmodus"
+
 #: ../ui/exportSettings.glade:122
 msgid "Range"
 msgstr "Bereich"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:370
+msgid "Rec / Stop"
+msgstr "Aufname / Stop"
 
 #: ../ui/main.glade:299
 msgid "Rec-Stop"
@@ -1877,9 +1355,77 @@ msgstr "Aufnameh stoppen"
 msgid "Recent _Documents"
 msgstr "Zuletzt geöffnete _Dokumente"
 
+#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:16
+#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:138
+msgid "Red"
+msgstr "rot"
+
+#: ../src/undo/UndoRedoHandler.cpp:292
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:326
+msgid "Redo"
+msgstr "Wiederherstellen"
+
+#: ../src/undo/UndoRedoHandler.cpp:286
+msgid "Redo: "
+msgstr "Wiederherstellen: "
+
+#: ../src/control/Control.cpp:2008
+msgid "Remove PDF Background"
+msgstr "PDF-Hintergrund entfernen"
+
+#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:202
+msgid "Removed tool item from Toolbar {1} ID {2}"
+msgstr "Entferne Werkzeug von der Werkzeugleiste {1} ID {2}"
+
+#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:198
+msgid "Removed tool item {1} from Toolbar {2} ID {3}"
+msgstr "Entferne Werkzeug {1} von der Werkzeugleiste {2} ID {3}"
+
 #: ../ui/exportSettings.glade:107
 msgid "Resolution"
 msgstr "Auflösung"
+
+#: ../src/undo/RotateUndoAction.cpp:74
+msgid "Rotation"
+msgstr "Drehung"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:374
+msgid "Rotation Snapping"
+msgstr "Drehung Einrasten"
+
+#: ../src/control/pagetype/PageTypeHandler.cpp:24
+msgid "Ruled"
+msgstr "Liniert"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:426
+msgid "Ruler"
+msgstr "Lineal"
+
+#: ../src/control/jobs/SaveJob.cpp:17 ../src/control/Control.cpp:2531
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:314
+msgid "Save"
+msgstr "Speichern"
+
+#: ../src/control/Control.cpp:2568
+msgid "Save As"
+msgstr "Speichern als..."
+
+#: ../src/control/Control.cpp:2338 ../src/gui/dialog/PageTemplateDialog.cpp:185
+msgid "Save File"
+msgstr "Speichere Datei"
+
+#: ../src/control/jobs/SaveJob.cpp:157
+#: ../src/control/jobs/CustomExportJob.cpp:261
+msgid "Save file error: {1}"
+msgstr "Fehler beim Speichern der Datei: {1}"
+
+#: ../src/undo/ScaleUndoAction.cpp:73
+msgid "Scale"
+msgstr "Skalieren"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:323
+msgid "Search"
+msgstr "Suchen"
 
 #: ../ui/pageTemplate.glade:165
 msgid "Select Background Color"
@@ -1889,13 +1435,58 @@ msgstr "Hintergrundfarbe wählen"
 msgid "Select Folder"
 msgstr "Gewähler Ordner"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:438
+msgid "Select Font"
+msgstr "Schriftart auswählen"
+
 #: ../ui/images.glade:7
 msgid "Select Image"
 msgstr "Bild auswählen"
 
+#: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:31
+#: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:99
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:406
+msgid "Select Object"
+msgstr "Objekt auswählen"
+
 #: ../ui/pdfpages.glade:7
 msgid "Select PDF Page"
 msgstr "PDF-Seite auswählen"
+
+#: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:10
+#: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:29
+#: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:85
+#: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:125
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:404
+msgid "Select Rectangle"
+msgstr "Rechteck auswählen"
+
+#: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:30
+#: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:92
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:402
+msgid "Select Region"
+msgstr "Bereich auswählen"
+
+#: ../src/control/Control.cpp:2007
+msgid "Select another PDF"
+msgstr "Andere PDF-Datei auswählen"
+
+#: ../src/gui/dialog/SelectBackgroundColorDialog.cpp:144
+msgid "Select background color"
+msgstr "Hintergrundfarbe wählen"
+
+#: ../src/gui/toolbarMenubar/ColorToolItem.cpp:47
+#: ../src/gui/toolbarMenubar/ColorToolItem.cpp:157
+msgid "Select color"
+msgstr "Farbe auswählen"
+
+#: ../src/gui/dialog/ButtonConfigGui.cpp:62
+msgid "Select rectangle"
+msgstr "Rechteck auswählen"
+
+#: ../src/gui/dialog/ButtonConfigGui.cpp:61
+msgid "Select region"
+msgstr "Bereich auswählen"
 
 #: ../ui/settings.glade:1600
 msgid "Select the tool and Settings if you press the Default Button"
@@ -1907,6 +1498,18 @@ msgstr ""
 msgid "Select toolbar:"
 msgstr "Wähle Werkzeugleiste:"
 
+#: ../src/control/XournalMain.cpp:107
+msgid "Send Bugreport"
+msgstr "Fehlerbericht senden"
+
+#: ../src/gui/dialog/toolbarCustomize/ToolbarCustomizeDialog.cpp:53
+msgid "Separator"
+msgstr "Trenner"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:424
+msgid "Shape Recognizer"
+msgstr "Figurenerkennung"
+
 #: ../ui/pdfpages.glade:67
 msgid ""
 "Show only not used pages\n"
@@ -1914,6 +1517,14 @@ msgid ""
 msgstr ""
 "Zeige nur nicht benutzte Seiten\n"
 "DIESER TEXT IST EIN PLATZHALTER!"
+
+#: ../src/gui/dialog/backgroundSelect/PdfPagesDialog.cpp:134
+msgid "Show only not used pages (one unused page)"
+msgstr "Nur nicht benutzte Seiten anzeigen (eine nicht benutzte Seiten)"
+
+#: ../src/gui/dialog/backgroundSelect/PdfPagesDialog.cpp:135
+msgid "Show only not used pages ({1} unused pages)"
+msgstr "Nur nicht benutzte Seiten anzeigen ({1} nicht benutzte Seiten)"
 
 #: ../ui/main.glade:314
 msgid "Show sidebar"
@@ -1927,6 +1538,22 @@ msgstr "Seitenleiste auf der rechten Seite anzeigen"
 msgid "Show vertical scrollbar on the left side"
 msgstr "Vertikale Bildlaufleiste auf der linken Seite anzeigen"
 
+#: ../src/control/XournalMain.cpp:286
+msgid ""
+"Sorry, Xournal++ can only open one file from the command line.\n"
+"Others are ignored."
+msgstr ""
+"Entschuldigung, Xournal++ kann nur eine Datei von der Kommandozeile öffnen.\n"
+"Alle weiteren werden ignoriert."
+
+#: ../src/control/XournalMain.cpp:305
+msgid ""
+"Sorry, Xournal++ cannot open remote files at the moment.\n"
+"You have to copy the file to a local directory."
+msgstr ""
+"Entschuldigung, Xournal++ kann derzeit keine entfernten Dateien öffnen.\n"
+"Kopieren Sie die Datei in einen lokalen Ordner."
+
 #: ../ui/settingsButtonConfig.glade:154
 msgid "Standard"
 msgstr "Standard"
@@ -1934,6 +1561,20 @@ msgstr "Standard"
 #: ../ui/main.glade:1534
 msgid "State PLACEHOLDER"
 msgstr "Zustand PLATZHALTER"
+
+#: ../src/undo/RecognizerUndoAction.cpp:101
+#: ../src/gui/dialog/ButtonConfigGui.cpp:103
+#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:42
+msgid "Stroke recognizer"
+msgstr "Figurenerkennung"
+
+#: ../src/util/CrashHandler.cpp:152
+msgid "Successfully saved document to \"{1}\""
+msgstr "Dokument erfolgreich nach \"{1}\" gespeichert."
+
+#: ../src/control/stockdlg/XojOpenDlg.cpp:129
+msgid "Supported files"
+msgstr "Unterstützte Dateiformate"
 
 #: ../ui/main.glade:1160
 msgid "Swap the current page with the one above"
@@ -1951,21 +1592,128 @@ msgstr "Werkzeugleisten"
 msgid "Template:"
 msgstr "Vorlage:"
 
+#: ../src/gui/dialog/ButtonConfigGui.cpp:58
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:397
+msgid "Text"
+msgstr "Text"
+
+#: ../src/gui/SearchBar.cpp:73
+#, c-format
+msgid "Text %i times found on this page"
+msgstr "Text auf dieser Seite %i mal gefunden"
+
 #: ../ui/main.glade:1001
 msgid "Text Font..."
 msgstr "Schriftart..."
+
+#: ../src/undo/TextUndoAction.cpp:47
+msgid "Text changes"
+msgstr "Text geändert"
+
+#: ../src/gui/SearchBar.cpp:69
+msgid "Text found on this page"
+msgstr "Text auf dieser Seite gefunden"
+
+#: ../src/gui/SearchBar.cpp:153 ../src/gui/SearchBar.cpp:209
+msgid "Text found once on page {1}"
+msgstr "Text einmal auf Seite {1} gefunden"
+
+#: ../src/gui/SearchBar.cpp:154 ../src/gui/SearchBar.cpp:210
+msgid "Text found {1} times on page {2}"
+msgstr "Text {1}-mal auf Seite {2} gefunden"
+
+#: ../src/gui/SearchBar.cpp:80
+msgid "Text not found"
+msgstr "Text nicht gefunden"
+
+#: ../src/gui/SearchBar.cpp:167 ../src/gui/SearchBar.cpp:223
+msgid "Text not found, searched on all pages"
+msgstr "Text nicht gefunden, auf allen Seiten gesucht"
+
+#: ../src/control/Control.cpp:960
+msgid ""
+"The Toolbarconfiguration \"{1}\" is predefined, would you create a copy to "
+"edit?"
+msgstr ""
+"Die Werkzeugleistenkonfiguration \"{1}\" ist vordefiniert, möchten Sie eine "
+"Kopie erstellen?"
+
+#: ../src/control/Control.cpp:2004
+msgid "The attached background PDF could not be found."
+msgstr "Der angehängte PDF-Hintergrund konnte nicht gefunden werden."
+
+#: ../src/control/Control.cpp:2005
+msgid "The background PDF could not be found."
+msgstr "Der PDF-Hintergrund konnte nicht gefunden werden."
+
+#: ../src/control/XournalMain.cpp:102
+msgid "The most recent log file name: {1}"
+msgstr "Der aktuelleste Logdateiname: {1}"
 
 #: ../ui/settings.glade:746
 msgid "The unit of the ruler is cm"
 msgstr "Die Einheit des Maßstabes ist cm"
 
+#: ../src/control/XournalMain.cpp:95
+msgid ""
+"There are errorlogfiles from Xournal++. Please send a Bugreport, so the bug "
+"may be fixed."
+msgstr ""
+"Es ist ein Xournal++ Fehlerlog vorhanden. Bitte senden Sie einen "
+"Fehlerbericht (auf Englisch wenn möglich), damit der Fehler korrigiert "
+"werden kann."
+
+#: ../src/control/XournalMain.cpp:94
+msgid ""
+"There is an errorlogfile from Xournal++. Please send a Bugreport, so the bug "
+"may be fixed."
+msgstr ""
+"Es ist ein Xournal++ Fehlerlog vorhanden. Bitte senden Sie einen "
+"Fehlerbericht (auf Englisch wenn möglich), damit der Fehler korrigiert "
+"werden kann."
+
+#: ../src/control/Control.cpp:864
+msgid "There was an error displaying help: {1}"
+msgstr "Es ist ein Fehler aufgetreten beim Anzeigen der Hilfe: {1}"
+
+#: ../src/gui/dialog/ButtonConfigGui.cpp:84
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:433
+msgid "Thick"
+msgstr "dick"
+
 #: ../ui/settingsButtonConfig.glade:91
 msgid "Thickness"
 msgstr "Dicke"
 
+#: ../src/gui/dialog/ButtonConfigGui.cpp:82
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:429
+msgid "Thin"
+msgstr "dünn"
+
+#: ../src/control/Control.cpp:2529
+msgid "This document is not saved yet."
+msgstr "Dieses Dokument wurde noch nicht gespeichert."
+
+#: ../src/control/tools/ImageHandler.cpp:55
+#: ../src/control/PageBackgroundChangeController.cpp:135
+msgid "This image could not be loaded. Error message: {1}"
+msgstr "Das Bild konnte nicht geladen werden. Fehlermeldung: {1}"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:367
+msgid "Toggle fullscreen"
+msgstr "Vollbild umschalten"
+
 #: ../ui/settingsButtonConfig.glade:56
 msgid "Tool"
 msgstr "Werkzeug"
+
+#: ../src/gui/toolbarMenubar/model/ToolbarData.cpp:155
+msgid "Toolbar found: {1}"
+msgstr "Werkzeugleiste gefunden: {1}"
+
+#: ../src/gui/dialog/ToolbarManageDialog.cpp:57
+msgid "Toolbars"
+msgstr "Werkzeugleisten"
 
 #: ../ui/settings.glade:1005
 msgid ""
@@ -1975,33 +1723,200 @@ msgstr ""
 "Touch eingaben welche von GTK erkannt werden, werden speziell verarbeitet, "
 "und nicht hier konfiguriert."
 
+#: ../src/util/CrashHandler.cpp:138
+msgid "Trying to emergency save the current open document…"
+msgstr "Versuche ein Notfall-Speichern des aktuell geöffneten Dokuments…"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:449
+msgid "Two pages"
+msgstr "Zwei Seiten"
+
+#: ../src/undo/UndoRedoHandler.cpp:273
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:325
+msgid "Undo"
+msgstr "Rückgängig"
+
+#: ../src/undo/UndoRedoHandler.cpp:268
+msgid "Undo: "
+msgstr "Rückgängig: "
+
+#: ../src/control/xojfile/LoadHandler.cpp:228
+msgid "Unexpected root tag: {1}"
+msgstr "Unerwarteter Root Tag: {1}"
+
+#: ../src/control/xojfile/LoadHandler.cpp:257
+msgid "Unexpected tag in document: \"{1}\""
+msgstr "Unerwarteter Tag im Dokument: \"{1}\""
+
+#: ../src/control/xojfile/LoadHandler.cpp:462
+msgid "Unknown background type: {1}"
+msgstr "Unbekannter Hintergrundtyp: {1}"
+
+#: ../src/control/xojfile/LoadHandlerHelper.cpp:80
+msgid "Unknown color value \"{1}\""
+msgstr "Unbekannter Farbwert \"{1}\""
+
+#: ../src/control/xojfile/LoadHandler.cpp:397
+msgid "Unknown domain type: {1}"
+msgstr "Unbekannter Domänentyp: {1}"
+
+#: ../src/control/xojfile/LoadHandler.cpp:180
+msgid "Unknown parser error"
+msgstr "Unbekannter Lesefehler"
+
+#: ../src/control/xojfile/LoadHandler.cpp:332
+msgid "Unknown pixmap::domain type: {1}"
+msgstr "Unbekannter pixmap::domain Typ: {1}"
+
+#: ../src/control/xojfile/LoadHandler.cpp:539
+msgid "Unknown stroke type: \"{1}\", assuming pen"
+msgstr "Unbekannter Linientyp: \"{1}\", verwende Stift"
+
+#: ../src/control/Control.cpp:2423
+msgid "Unsaved Document"
+msgstr "Ungespeichertes Dokument"
+
 #: ../ui/about.glade:92
 msgid "Version"
 msgstr "Version"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:419
+msgid "Vertical Space"
+msgstr "Vertikaler Platz"
+
+#: ../src/gui/dialog/ButtonConfigGui.cpp:60
+msgid "Vertical space"
+msgstr "Vertikaler Platz"
 
 #: ../ui/settings.glade:1547
 msgid "View"
 msgstr "Ansicht"
 
+#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:20
+#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:142
+msgid "White"
+msgstr "weiß"
+
 #: ../ui/pagesize.glade:182
 msgid "Width:"
 msgstr "Breite:"
+
+#: ../src/control/pagetype/PageTypeHandler.cpp:31
+msgid "With PDF background"
+msgstr "Mit PDF-Hintergrund"
 
 #: ../ui/about.glade:187
 msgid "With help from the community"
 msgstr "mit Hilfe der Community"
 
+#: ../src/undo/InsertUndoAction.cpp:43
+msgid "Write text"
+msgstr "Text schreiben"
+
+#: ../src/control/xojfile/LoadHandler.cpp:802
+msgid "Wrong count of points ({1})"
+msgstr "Falsche Punktanzahl ({1})"
+
+#: ../src/control/xojfile/LoadHandler.cpp:817
+msgid "Wrong number of points, got {1}, expected {2}"
+msgstr "Falsche Punktzahl {1}, erwartet wurde {2}"
+
+#: ../src/control/xojfile/LoadHandler.cpp:175
+msgid "XML Parser error: {1}"
+msgstr "XML Parser Fehler: {1}"
+
+#: ../src/control/jobs/CustomExportJob.cpp:46
+msgid "Xournal (Compatibility)"
+msgstr "Xournal (Kompatibilitätsmodus)"
+
+#: ../src/control/stockdlg/XojOpenDlg.cpp:70
+msgid "Xournal files"
+msgstr "Xournal Dateien"
+
 #: ../ui/settings.glade:21
 msgid "Xournal++ Preferences"
 msgstr "Xournal++ Einstellungen"
+
+#: ../src/control/stockdlg/XojOpenDlg.cpp:80 ../src/control/Control.cpp:2345
+msgid "Xournal++ files"
+msgstr "Xournal++ Dateien"
+
+#: ../src/control/stockdlg/XojOpenDlg.cpp:90
+#: ../src/gui/dialog/PageTemplateDialog.cpp:192
+msgid "Xournal++ template"
+msgstr "Xournal++ Vorlage"
+
+#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:19
+#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:141
+msgid "Yellow"
+msgstr "gelb"
+
+#: ../src/control/PageBackgroundChangeController.cpp:177
+msgid ""
+"You don't have any PDF pages to select from. Cancel operation.\n"
+"Please select another background type: Menu \"Journal\" → \"Configure Page "
+"Template\"."
+msgstr ""
+"Es gibt keine PDF Seiten zum Auswählen. Abbruch.\n"
+"Bitte wählen Sie einen anderen Hintergrundtyp: Menü \"Journal\" / "
+"\"Seitenvorlage konfigurieren\"."
+
+#: ../src/control/XournalMain.cpp:98
+msgid ""
+"You're using {1}/{2} branch. Send Bugreport will direct you to this repo's "
+"issue tracker."
+msgstr ""
+"Sie benutzen den {1}/{2} Zweig. Das Senden eines Fehlerberichts wird Siezum "
+"Issue-Tracker dieses Repositoriums führen."
+
+#: ../src/gui/sidebar/indextree/SidebarIndexPage.cpp:80
+msgid ""
+"Your current document does not contain PDF Page no {1}\n"
+"Would you like to insert this page?\n"
+"\n"
+"Tip: You can select Journal → Paper Background → PDF Background to insert a "
+"PDF page."
+msgstr ""
+"Ihr aktuelles Dokument beinhaltet die PDF Seite {1} nicht\n"
+"Möchten Sie diese Seite einfügen?\n"
+"\n"
+"Tipp: Sie können im Menü Journal / Seitenhintergrund / PDF-Hintergrund eine "
+"beliebige PDF Seite einfügen."
 
 #: ../ui/settings.glade:763
 msgid "Zoom"
 msgstr "Zoom"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:361
+msgid "Zoom fit to screen"
+msgstr "Passend zoomen"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:359
+msgid "Zoom in"
+msgstr "Hereinzoomen"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:357
+msgid "Zoom out"
+msgstr "Herauszoomen"
+
+#: ../src/gui/toolbarMenubar/ToolZoomSlider.cpp:53
+msgid "Zoom slider"
+msgstr "Zoomregler"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:363
+msgid "Zoom to 100%"
+msgstr "Zoom auf 100%"
+
 #: ../ui/main.glade:69
 msgid "_Annotate PDF"
 msgstr "_PDF beschriften"
+
+#: ../src/control/stockdlg/ImageOpenDlg.cpp:11
+#: ../src/control/stockdlg/XojOpenDlg.cpp:18
+#: ../src/control/jobs/BaseExportJob.cpp:26 ../src/control/Control.cpp:2339
+#: ../src/gui/dialog/PageTemplateDialog.cpp:186
+msgid "_Cancel"
+msgstr "_Abbrechen"
 
 #: ../ui/main.glade:353
 msgid "_Customize"
@@ -2075,6 +1990,11 @@ msgstr "_Nächste Ebene"
 msgid "_Next Page"
 msgstr "_Nächste Seite"
 
+#: ../src/control/stockdlg/ImageOpenDlg.cpp:12
+#: ../src/control/stockdlg/XojOpenDlg.cpp:19
+msgid "_Open"
+msgstr "Ö_ffnen"
+
 #: ../ui/main.glade:650
 msgid "_Pen"
 msgstr "_Stift"
@@ -2090,6 +2010,11 @@ msgstr "_Vorherige Ebene"
 #: ../ui/main.glade:434
 msgid "_Previous Page"
 msgstr "_Vorherige Seite"
+
+#: ../src/control/jobs/BaseExportJob.cpp:27 ../src/control/Control.cpp:2340
+#: ../src/gui/dialog/PageTemplateDialog.cpp:187
+msgid "_Save"
+msgstr "_Speichern"
 
 #: ../ui/main.glade:714
 msgid "_Shape Recognizer"
@@ -2151,21 +2076,96 @@ msgstr "_weiß übermalen"
 msgid "change"
 msgstr "ändern"
 
+#: ../src/util/DeviceListHelper.cpp:86
+msgid "cursor"
+msgstr "Cursor"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:298
+msgid "delete stroke"
+msgstr "Linie löschen"
+
 #: ../ui/exportSettings.glade:213
 msgid "dpi"
 msgstr "dpi"
+
+#: ../src/util/DeviceListHelper.cpp:82
+msgid "eraser"
+msgstr "Radierer"
+
+#: ../src/util/DeviceListHelper.cpp:91
+msgid "keyboard"
+msgstr "Tastatur"
 
 #: ../ui/pageTemplate.glade:47
 msgid "load from file"
 msgstr "Von Datei laden"
 
+#: ../src/util/DeviceListHelper.cpp:74
+msgid "mouse"
+msgstr "Maus"
+
+#: ../src/util/DeviceListHelper.cpp:78
+msgid "pen"
+msgstr "Stift"
+
 #: ../ui/pageTemplate.glade:34
 msgid "save to file"
 msgstr "Speichere in Datei"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:284
+msgid "standard"
+msgstr "standard"
+
+#: ../src/util/DeviceListHelper.cpp:99
+msgid "touchpad"
+msgstr "Touchpad"
+
+#: ../src/util/DeviceListHelper.cpp:95
+msgid "touchscreen"
+msgstr "Touchscreen"
+
 #: ../ui/main.glade:873
 msgid "ver_y thick"
 msgstr "sehr dick"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:291
+msgid "whiteout"
+msgstr "weiß übermalen"
+
+#: ../src/control/xojfile/LoadHandler.cpp:816
+msgid "xoj-File: {1}"
+msgstr "xoj-Datei: {1}"
+
+#: ../src/xoj-preview-extractor/xournal-thumbnailer.cpp:88
+msgid "xoj-preview-extractor: call with INPUT.xoj OUTPUT.png"
+msgstr "xoj-Vorschau-Extraktor: rufe auf mit INPUT.xoj OUTPUT.png"
+
+#: ../src/xoj-preview-extractor/xournal-thumbnailer.cpp:110
+msgid "xoj-preview-extractor: file \"{1}\" contains no preview"
+msgstr "xoj-Vorschau-Extraktor: Datei \"{1}\" enthält keine Vorschau"
+
+#: ../src/xoj-preview-extractor/xournal-thumbnailer.cpp:102
+msgid "xoj-preview-extractor: file \"{1}\" is not .xoj file"
+msgstr "xoj-Vorschau-Extraktor: Datei \"{1}\" ist keine xoj-Datei"
+
+#: ../src/xoj-preview-extractor/xournal-thumbnailer.cpp:115
+msgid ""
+"xoj-preview-extractor: no preview and page found, maybe an invalid file?"
+msgstr ""
+"xoj-Vorschau-Extraktor: keine Vorschau und keine Seite gefunden: ungültige "
+"Datei?"
+
+#: ../src/xoj-preview-extractor/xournal-thumbnailer.cpp:106
+msgid "xoj-preview-extractor: opening input file \"{1}\" failed"
+msgstr "xoj-Vorschau-Extraktor: Öffnen der Datei \"{1}\" fehlgeschlagen"
+
+#: ../src/xoj-preview-extractor/xournal-thumbnailer.cpp:122
+msgid "xoj-preview-extractor: opening output file \"{1}\" failed"
+msgstr "xoj-Vorschau-Extraktor: Öffnen der Ausgabedatei \"{1}\" fehlgeschlagen"
+
+#: ../src/xoj-preview-extractor/xournal-thumbnailer.cpp:131
+msgid "xoj-preview-extractor: successfully extracted"
+msgstr "xoj-Vorschau-Extraktor: erfolgreich extrahiert"
 
 #~ msgid "<b>Custom color</b>"
 #~ msgstr "<b>selbstdefinierte Farbe</b>"

--- a/po/pl.po
+++ b/po/pl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: xournalpp 1.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-12-09 10:10+0100\n"
+"POT-Creation-Date: 2018-12-09 10:20+0100\n"
 "PO-Revision-Date: 2015-10-01 00:00+0200\n"
 "Last-Translator: Marek Pikuła <marek@pikula.co>\n"
 "Language-Team: Xournal++ team\n"
@@ -410,7 +410,7 @@ msgstr ""
 #: ../src/control/AudioController.cpp:99
 msgid ""
 "Audio folder not set! Recording won't work!\n"
-"Plase set the recording folder under \"Preferences > Audio recording\""
+"Please set the recording folder under \"Preferences > Audio recording\""
 msgstr ""
 
 #: ../ui/about.glade:151
@@ -1086,7 +1086,7 @@ msgid ""
 "Missing the needed UI file, could not find them at any location.\n"
 "Not relative\n"
 "Not in the Working Path\n"
-"Not in "
+"Not in {1}"
 msgstr ""
 
 #: ../ui/settings.glade:858

--- a/po/zh.po
+++ b/po/zh.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: xournalpp 1.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-12-09 10:10+0100\n"
+"POT-Creation-Date: 2018-12-09 10:20+0100\n"
 "PO-Revision-Date: 2018-11-14 19:55+0100\n"
 "Last-Translator: Andreas Butti <andreasbutti at gmail dot com>\n"
 "Language-Team: Xournal++ team\n"
@@ -380,7 +380,7 @@ msgstr ""
 #: ../src/control/AudioController.cpp:99
 msgid ""
 "Audio folder not set! Recording won't work!\n"
-"Plase set the recording folder under \"Preferences > Audio recording\""
+"Please set the recording folder under \"Preferences > Audio recording\""
 msgstr ""
 
 #: ../ui/about.glade:151
@@ -1054,7 +1054,7 @@ msgid ""
 "Missing the needed UI file, could not find them at any location.\n"
 "Not relative\n"
 "Not in the Working Path\n"
-"Not in "
+"Not in {1}"
 msgstr ""
 
 #: ../ui/settings.glade:858

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: xournalpp 1.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-12-09 10:10+0100\n"
+"POT-Creation-Date: 2018-12-09 10:20+0100\n"
 "PO-Revision-Date: 2018-11-14 20:04+0100\n"
 "Last-Translator: Andreas Butti <andreasbutti at gmail dot com>\n"
 "Language-Team: Xournal++ team\n"
@@ -380,7 +380,7 @@ msgstr ""
 #: ../src/control/AudioController.cpp:99
 msgid ""
 "Audio folder not set! Recording won't work!\n"
-"Plase set the recording folder under \"Preferences > Audio recording\""
+"Please set the recording folder under \"Preferences > Audio recording\""
 msgstr ""
 
 #: ../ui/about.glade:151
@@ -1055,7 +1055,7 @@ msgid ""
 "Missing the needed UI file, could not find them at any location.\n"
 "Not relative\n"
 "Not in the Working Path\n"
-"Not in "
+"Not in {1}"
 msgstr ""
 
 #: ../ui/settings.glade:858

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: xournalpp 1.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-12-09 10:10+0100\n"
+"POT-Creation-Date: 2018-12-09 10:20+0100\n"
 "PO-Revision-Date: 2018-11-14 19:57+0100\n"
 "Last-Translator: Andreas Butti <andreasbutti at gmail dot com>\n"
 "Language-Team: Xournal++ team\n"
@@ -380,7 +380,7 @@ msgstr ""
 #: ../src/control/AudioController.cpp:99
 msgid ""
 "Audio folder not set! Recording won't work!\n"
-"Plase set the recording folder under \"Preferences > Audio recording\""
+"Please set the recording folder under \"Preferences > Audio recording\""
 msgstr ""
 
 #: ../ui/about.glade:151
@@ -1054,7 +1054,7 @@ msgid ""
 "Missing the needed UI file, could not find them at any location.\n"
 "Not relative\n"
 "Not in the Working Path\n"
-"Not in "
+"Not in {1}"
 msgstr ""
 
 #: ../ui/settings.glade:858

--- a/src/gui/dialog/LatexDialog.h
+++ b/src/gui/dialog/LatexDialog.h
@@ -46,6 +46,7 @@ class LatexDialog : public GladeGui
 	
 	// Temporary render
 	GtkWidget* texTempRender;
+	cairo_surface_t* scaledRender;
 	
 	// Text field
 	GtkWidget* texBox;


### PR DESCRIPTION
Hi!
I managed to downscale the LaTex preview when long strings are inserted.
I still need to change the Dialog entry from a simple one-line entry to a small TextView (is this the right way?), but for now let me know if the scaling works a little better!
(I didn't change .po files, I don't know why they're different)