### PR TITLE
Fix export autonames

### DIFF
--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -2339,41 +2339,15 @@ bool Control::showSaveDialog()
 	gtk_file_filter_add_pattern(filterXoj, "*.xopp");
 	gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(dialog), filterXoj);
 
-	path lastSavePath = settings->getLastSavePath();
-
 	this->doc->lock();
-
-	if (!doc->getFilename().empty())
-	{
-		string saveFilename = doc->getFilename().filename().string();
-		string folder = doc->getFilename().parent_path().string();
-
-		gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(dialog), folder.c_str());
-		gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(dialog), saveFilename.c_str());
-	}
-	else if (!doc->getPdfFilename().empty())
-	{
-		string folder = doc->getPdfFilename().parent_path().string();
-		string saveFilename = doc->getPdfFilename().filename().replace_extension(".pdf.xopp").string();
-
-		gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(dialog), folder.c_str());
-		gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(dialog), saveFilename.c_str());
-	}
-	else
-	{
-		time_t curtime = time(NULL);
-		char stime[128];
-		strftime(stime, sizeof(stime), settings->getDefaultSaveName().c_str(), localtime(&curtime));
-
-		// Try to set the folder, the GTK Filechooser is not working that good...
-		gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(dialog), settings->getLastSavePath().c_str());
-
-		// According to the GTK3 Documentation this is the right way for saving a new file
-		// on GTK2 Xournal++ Controls everything, but don't seem to work with GTK3
-		// so hopefully this will work
-		gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(dialog), stime);
-	}
+	path suggested_folder = this->doc->createSaveFolder(this->settings->getLastSavePath());
+	path suggested_name = this->doc->createSaveFilename(Document::XOPP, this->settings->getDefaultSaveName());
 	this->doc->unlock();
+
+	gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(dialog),
+										suggested_folder.c_str());
+	gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(dialog),
+										suggested_name.c_str());
 
 	gtk_file_chooser_set_do_overwrite_confirmation(GTK_FILE_CHOOSER(dialog), true);
 

--- a/src/control/jobs/BaseExportJob.cpp
+++ b/src/control/jobs/BaseExportJob.cpp
@@ -55,30 +55,15 @@ bool BaseExportJob::showFilechooser()
 	Settings* settings = control->getSettings();
 	Document* doc = control->getDocument();
 	doc->lock();
-	if (!doc->getFilename().empty())
-	{
-		savePath = doc->getFilename();
-	}
-	else if (!doc->getPdfFilename().empty())
-	{
-		savePath = doc->getPdfFilename().filename().replace_extension("");
-	}
-	else
-	{
-		time_t curtime = time(NULL);
-		char stime[128];
-		strftime(stime, sizeof(stime), settings->getDefaultSaveName().c_str(), localtime(&curtime));
-		savePath /= stime;
-	}
+	path folder = doc->createSaveFolder(settings->getLastSavePath());
+	path name = doc->createSaveFilename(Document::PDF, settings->getDefaultSaveName());
 	doc->unlock();
 
-	prepareSavePath(savePath);
+	prepareSavePath(name);
 
-	GFile* folder = g_file_new_for_path(savePath.parent_path().c_str());
-	gtk_file_chooser_set_current_folder_uri(GTK_FILE_CHOOSER(dialog), g_file_get_uri(folder));
-	g_object_unref(folder);
-
-	gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(dialog), savePath.filename().c_str());
+	gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(dialog), folder.c_str());
+	gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(dialog), name.c_str());
+	
 	gtk_file_chooser_set_do_overwrite_confirmation(GTK_FILE_CHOOSER(dialog), true);
 
 	gtk_window_set_transient_for(GTK_WINDOW(dialog), GTK_WINDOW(this->control->getWindow()->getWindow()));

--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -83,7 +83,7 @@ void Settings::loadDefault()
 
 	this->enableLeafEnterWorkaround = true;
 
-	this->defaultSaveName = _("%F-Note-%H-%M.xopp");
+	this->defaultSaveName = _("%F-Note-%H-%M");
 
 	// Eraser
 	this->buttonConfig[0] = new ButtonConfig(TOOL_ERASER, 0, TOOL_SIZE_NONE, DRAWING_TYPE_DEFAULT, ERASER_TYPE_NONE);

--- a/src/model/Document.cpp
+++ b/src/model/Document.cpp
@@ -141,6 +141,69 @@ path Document::getPdfFilename()
 	return pdfFilename;
 }
 
+path Document::getSaveFolder(path lastSavePath)
+{
+	if (!filename.empty())
+	{
+		return filename().parent_path();
+	}
+	else if (!pdfFilename().empty())
+	{
+		return pdfFilename.parent_path();
+	}
+	else
+	{
+		return lastSavePath;
+	}
+}
+
+path Document::createSaveFilename(DocumentType type, string defaultSaveName)
+{
+	if (!filename.empty())
+	{
+		//This can be any extension
+		return filename.filename();
+	}
+	else if (!pdfFilename().empty())
+	{
+		path extension;
+		if (type == Document::XOPP)
+		{
+			extension = path(".pdf.xopp");
+		}
+		else if (type == Document::PDF)
+		{
+			extension = path(".xopp.pdf");
+		}
+		else
+		{
+			extension = path("");
+		}
+		return pdfFilename().filename().replace_extension(extension);
+	}
+	else
+	{
+		time_t curtime = time(NULL);
+		char stime[128];
+		strftime(stime, sizeof(stime), defaultSaveName.c_str(), localtime(&curtime));
+		path automaticName = path(stime);
+		if (type == Document::XOPP)
+		{
+			automaticName.replace_extension(".xopp");
+		}
+		else if (type == Document::XOJ)
+		{
+			automaticName.replace_extension(".xoj");
+		}
+		else if (type == Document::PDF)
+		{
+			automaticName.replace_extension(".pdf");
+		}
+		return automaticName.c_str();
+	}
+}
+
+
 cairo_surface_t* Document::getPreview()
 {
 	XOJ_CHECK_TYPE(Document);

--- a/src/model/Document.cpp
+++ b/src/model/Document.cpp
@@ -141,13 +141,13 @@ path Document::getPdfFilename()
 	return pdfFilename;
 }
 
-path Document::getSaveFolder(path lastSavePath)
+path Document::createSaveFolder(path lastSavePath)
 {
 	if (!filename.empty())
 	{
-		return filename().parent_path();
+		return filename.parent_path();
 	}
-	else if (!pdfFilename().empty())
+	else if (!pdfFilename.empty())
 	{
 		return pdfFilename.parent_path();
 	}
@@ -164,7 +164,7 @@ path Document::createSaveFilename(DocumentType type, string defaultSaveName)
 		//This can be any extension
 		return filename.filename();
 	}
-	else if (!pdfFilename().empty())
+	else if (!pdfFilename.empty())
 	{
 		path extension;
 		if (type == Document::XOPP)
@@ -179,7 +179,7 @@ path Document::createSaveFilename(DocumentType type, string defaultSaveName)
 		{
 			extension = path("");
 		}
-		return pdfFilename().filename().replace_extension(extension);
+		return pdfFilename.filename().replace_extension(extension);
 	}
 	else
 	{

--- a/src/model/Document.h
+++ b/src/model/Document.h
@@ -37,6 +37,13 @@ public:
 	virtual ~Document();
 
 public:
+	enum DocumentType
+	{
+		XOPP,
+		XOJ,
+		PDF
+	};
+
 	bool readPdf(path filename, bool initPages, bool attachToDocument);
 
 	size_t getPageCount();
@@ -63,6 +70,8 @@ public:
 	void setFilename(path filename);
 	path getFilename();
 	path getPdfFilename();
+	path createSaveFolder(path);
+	path createSaveFilename(DocumentType, string);
 
 	path getEvMetadataFilename();
 


### PR DESCRIPTION
Generalizes the autonaming to the document. Supposed to fix: #463 .