### PR TITLE
Added icon for highlighter and fixed method in Export dialog

### DIFF
--- a/src/gui/Cursor.cpp
+++ b/src/gui/Cursor.cpp
@@ -339,9 +339,16 @@ GdkCursor* Cursor::createHighlighterOrPenCursor(int size, double alpha)
 	cairo_surface_t* crCursor = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
 	cairo_t* cr = cairo_create(crCursor);
 
-	if (big && size != 5) //size == 5 for highlighter
+	if (big)
 	{
-		cairo_set_source_rgb(cr, 1, 1, 1);
+		if(size == 5)
+		{
+			cairo_set_source_rgb(cr, r, g, b);
+		}
+		else
+		{
+			cairo_set_source_rgb(cr, 1, 1, 1);
+		}
 		cairo_set_line_width(cr, 1.2);
 		
 		// Plain cursor drawing + color dot

--- a/src/gui/dialog/ExportDialog.cpp
+++ b/src/gui/dialog/ExportDialog.cpp
@@ -104,10 +104,6 @@ void ExportDialog::show(GtkWindow* parent)
 	{
 		confirmed = true;
 	}
-	else
-	{
-		return;
-	}
 
 	gtk_widget_hide(this->window);
 }


### PR DESCRIPTION
Nothing fancy
* Edited the Pen Icon's drawing method in order to change the layout of the Highlighter in BigCursor mode
* Fixed a return statement in an Export as dialog which caused the impossibility to cancel the operation by exiting the dialog

Fixes #514 