### PR TITLE
 Added Input method check (xim unsupported) 

### DIFF
--- a/src/control/XournalMain.cpp
+++ b/src/control/XournalMain.cpp
@@ -264,12 +264,12 @@ int XournalMain::run(int argc, char* argv[])
 	}
 	
 	// Checks for input method compatibility
-	if(strcmp(g_getenv("GTK_IM_MODULE"), "ibus") != 0)
+	if(strcmp(g_getenv("GTK_IM_MODULE"), "xim") == 0)
 	{
 		g_setenv("GTK_IM_MODULE", "ibus", true);
 		g_warning("Unsupported input method: xim, changed to: ibus");
 	}
-	
+
 	// Init GTK Display
 	gtk_init(&argc, &argv);
 

--- a/src/control/XournalMain.cpp
+++ b/src/control/XournalMain.cpp
@@ -262,7 +262,14 @@ int XournalMain::run(int argc, char* argv[])
 	{
 		return exportPdf(*optFilename, pdfFilename);
 	}
-
+	
+	// Checks for input method compatibility
+	if(strcmp(g_getenv("GTK_IM_MODULE"), "ibus") != 0)
+	{
+		g_setenv("GTK_IM_MODULE", "ibus", true);
+		g_warning("Unsupported input method: xim, changed to: ibus");
+	}
+	
 	// Init GTK Display
 	gtk_init(&argc, &argv);
 

--- a/src/gui/Cursor.cpp
+++ b/src/gui/Cursor.cpp
@@ -342,6 +342,7 @@ GdkCursor* Cursor::createHighlighterOrPenCursor(int size, double alpha)
 
 	if (big)
 	{
+		// When using highlighter, paint the icon with the current color
 		if(size == 5)
 		{
 			cairo_set_source_rgb(cr, r, g, b);


### PR DESCRIPTION
Hi! I added a check on the env variable GTK_IM_MODULE which, if set to "xim", caused the Text tool to crash
Fixes #470  