### PR TITLE
Gtk input2

### DIFF
--- a/src/control/tools/BaseStrokeHandler.cpp
+++ b/src/control/tools/BaseStrokeHandler.cpp
@@ -27,7 +27,7 @@ void BaseStrokeHandler::draw(cairo_t* cr)
 	view.drawStroke(cr, stroke, 0);
 }
 
-bool BaseStrokeHandler::onMotionNotifyEvent(GdkEventMotion* event, bool shiftDown)
+bool BaseStrokeHandler::onMotionNotifyEvent(double pageX, double pageY, double pressure, bool shiftDown)
 {
 	XOJ_CHECK_TYPE(BaseStrokeHandler);
 
@@ -37,8 +37,8 @@ bool BaseStrokeHandler::onMotionNotifyEvent(GdkEventMotion* event, bool shiftDow
 	}
 
 	double zoom = xournal->getZoom();
-	double x = event->x / zoom;
-	double y = event->y / zoom;
+	double x = pageX / zoom;
+	double y = pageY / zoom;
 	int pointCount = stroke->getPointCount();
 
 	Point currentPoint(x, y);

--- a/src/control/tools/BaseStrokeHandler.h
+++ b/src/control/tools/BaseStrokeHandler.h
@@ -25,7 +25,7 @@ public:
 
 	void draw(cairo_t* cr);
 
-	bool onMotionNotifyEvent(GdkEventMotion* event, bool shiftDown);
+	bool onMotionNotifyEvent(double pageX, double pageY, double pressure, bool shiftDown);
 	void onButtonReleaseEvent(GdkEventButton* event);
 	void onButtonPressEvent(GdkEventButton* event);
 

--- a/src/control/tools/InputHandler.h
+++ b/src/control/tools/InputHandler.h
@@ -53,7 +53,7 @@ public:
 	 * structures and queue repaints of the XojPageView
 	 * if necessary
 	 */
-	virtual bool onMotionNotifyEvent(GdkEventMotion* event, bool shiftDown) = 0;
+	virtual bool onMotionNotifyEvent(double pageX, double pageY, double pressure, bool shiftDown) = 0;
 
  	/**
 	 * The current input device for stroken, do not react on other devices (linke mices)

--- a/src/control/tools/StrokeHandler.cpp
+++ b/src/control/tools/StrokeHandler.cpp
@@ -44,7 +44,7 @@ void StrokeHandler::draw(cairo_t* cr)
 	cairo_mask_surface(cr, surfMask, visRect.x, visRect.y);
 }
 
-bool StrokeHandler::onMotionNotifyEvent(GdkEventMotion* event, bool shiftDown)
+bool StrokeHandler::onMotionNotifyEvent(double pageX, double pageY, double pressure, bool shiftDown)
 {
 	XOJ_CHECK_TYPE(StrokeHandler);
 
@@ -54,9 +54,8 @@ bool StrokeHandler::onMotionNotifyEvent(GdkEventMotion* event, bool shiftDown)
 	}
 
 	double zoom = xournal->getZoom();
-	double x = event->x / zoom;
-	double y = event->y / zoom;
-	bool presureSensitivity = xournal->getControl()->getSettings()->isPresureSensitivity();
+	double x = pageX / zoom;
+	double y = pageY / zoom;
 	int pointCount = stroke->getPointCount();
 
 	Point currentPoint(x, y);
@@ -69,24 +68,9 @@ bool StrokeHandler::onMotionNotifyEvent(GdkEventMotion* event, bool shiftDown)
 		}
 	}
 
-	ToolHandler* h = xournal->getControl()->getToolHandler();
-
-	if (presureSensitivity)
+	if (Point::NO_PRESURE != pressure)
 	{
-		double pressure = Point::NO_PRESURE;
-		if (h->getToolType() == TOOL_PEN)
-		{
-			if (getPressureMultiplier((GdkEvent*) event, pressure))
-			{
-				pressure = pressure * stroke->getWidth();
-			}
-			else
-			{
-				pressure = Point::NO_PRESURE;
-			}
-		}
-
-		stroke->setLastPressure(pressure);
+		stroke->setLastPressure(pressure * stroke->getWidth());
 	}
 
 	if (pointCount > 0)
@@ -273,58 +257,6 @@ void StrokeHandler::onButtonPressEvent(GdkEventButton* event)
 
 		createStroke(Point(x, y));
 	}
-}
-
-bool StrokeHandler::getPressureMultiplier(GdkEvent* event, double& pressure)
-{
-	XOJ_CHECK_TYPE(StrokeHandler);
-
-	GdkDevice* device = gdk_event_get_device(event);
-	int axesCount = gdk_device_get_n_axes(device);
-	if (axesCount <= 4)
-	{
-		pressure = 1.0;
-		return false;
-	}
-
-	// This causes some memory corruption
-	// If touch and pen is active at the same time
-	// Here are random crashes. It cannot be reproduced
-	// without touch and pen at the same time
-//	gdouble* axes = event->button.axes;
-//	gdk_device_get_state(device,
-//						 gtk_widget_get_parent_window(xournal->getWidget()),
-//						 axes, NULL);
-//
-//	if (!gdk_device_get_axis(device, axes, GDK_AXIS_PRESSURE, &pressure))
-//	{
-//		pressure = 1.0;
-//		return false;
-//	}
-
-	double* axes;
-	if (event->type == GDK_MOTION_NOTIFY)
-	{
-		axes = event->motion.axes;
-	}
-	else
-	{
-		axes = event->button.axes;
-	}
-
-	pressure = axes[2];
-	Settings* settings = xournal->getControl()->getSettings();
-
-	if (!finite(pressure))
-	{
-		pressure = 1.0;
-		return false;
-	}
-
-	pressure = ((1 - pressure) * settings->getWidthMinimumMultiplier()
-			+ pressure * settings->getWidthMaximumMultiplier());
-
-	return true;
 }
 
 void StrokeHandler::destroySurface()

--- a/src/control/tools/StrokeHandler.h
+++ b/src/control/tools/StrokeHandler.h
@@ -34,7 +34,7 @@ public:
 
 	void draw(cairo_t* cr);
 
-	bool onMotionNotifyEvent(GdkEventMotion* event, bool shiftDown);
+	bool onMotionNotifyEvent(double pageX, double pageY, double pressure, bool shiftDown);
 	void onButtonReleaseEvent(GdkEventButton* event);
 	void onButtonPressEvent(GdkEventButton* event);
 
@@ -47,7 +47,6 @@ public:
 private:
 	XOJ_TYPE_ATTRIB;
 
-	bool getPressureMultiplier(GdkEvent* event, double& presure);
 	void destroySurface();
 
 	/**

--- a/src/gui/Layout.cpp
+++ b/src/gui/Layout.cpp
@@ -50,12 +50,7 @@ void Layout::checkScroll(GtkAdjustment* adjustment, double& lastScroll)
 {
 	XOJ_CHECK_TYPE(Layout);
 
-	if (!view->shouldIgnoreTouchEvents())
-	{
-		lastScroll = gtk_adjustment_get_value(adjustment);
-		return;
-	}
-
+	lastScroll = gtk_adjustment_get_value(adjustment);
 	gtk_adjustment_set_value(adjustment, lastScroll);
 }
 

--- a/src/gui/PageView.cpp
+++ b/src/gui/PageView.cpp
@@ -579,19 +579,19 @@ void XojPageView::resetShapeRecognizer()
 	}
 }
 
-bool XojPageView::onMotionNotifyEvent(GtkWidget* widget, GdkEventMotion* event, bool shiftDown)
+bool XojPageView::onMotionNotifyEvent(GtkWidget* widget, double pageX, double pageY, double pressure, bool shiftDown)
 {
 	XOJ_CHECK_TYPE(XojPageView);
 
 	double zoom = xournal->getZoom();
-	double x = event->x / zoom;
-	double y = event->y / zoom;
+	double x = pageX / zoom;
+	double y = pageY / zoom;
 
 	ToolHandler* h = xournal->getControl()->getToolHandler();
 
 	if (containsPoint(x, y, true) &&
 		this->inputHandler &&
-		this->inputHandler->onMotionNotifyEvent(event, shiftDown))
+		this->inputHandler->onMotionNotifyEvent(pageX, pageY, pressure, shiftDown))
 	{
 		//input	handler used this event
 	}

--- a/src/gui/PageView.h
+++ b/src/gui/PageView.h
@@ -139,7 +139,7 @@ public:
 public: // event handler
 	bool onButtonPressEvent(GtkWidget* widget, GdkEventButton* event);
 	bool onButtonReleaseEvent(GtkWidget* widget, GdkEventButton* event);
-	bool onMotionNotifyEvent(GtkWidget* widget, GdkEventMotion* event, bool shiftDown);
+	bool onMotionNotifyEvent(GtkWidget* widget, double pageX, double pageY, double pressure, bool shiftDown);
 	void translateEvent(GdkEvent* event, int xOffset, int yOffset);
 
 	/**

--- a/src/gui/XournalView.cpp
+++ b/src/gui/XournalView.cpp
@@ -49,7 +49,6 @@ XournalView::XournalView(GtkWidget* parent, Control* control)
 	this->margin = 75;
 	this->currentPage = 0;
 	this->lastSelectedPage = -1;
-	this->lastPenAction = 0;
 
 	control->getZoomControl()->addZoomListener(this);
 
@@ -370,11 +369,6 @@ void XournalView::zoom_gesture_begin_cb(GtkGesture* gesture, GdkEventSequence* s
 {
 	XOJ_CHECK_TYPE_OBJ(view, XournalView);
 
-	if (view->shouldIgnoreTouchEvents())
-	{
-		return;
-	}
-
 	Layout* layout = gtk_xournal_get_layout(view->widget);
 	// Save visible rectangle at beginning of gesture
 	view->visRect_gesture_begin = layout->getVisibleRect();
@@ -400,12 +394,6 @@ void XournalView::zoom_gesture_end_cb(GtkGesture* gesture, GdkEventSequence* seq
 void XournalView::zoom_gesture_scale_changed_cb(GtkGestureZoom* gesture, gdouble scale, XournalView* view)
 {
 	XOJ_CHECK_TYPE_OBJ(view, XournalView);
-
-	if (view->shouldIgnoreTouchEvents())
-	{
-		return;
-	}
-
 	view->setZoom(scale * view->zoom_gesture_begin);
 }
 
@@ -586,33 +574,6 @@ GtkContainer* XournalView::getParent()
 	XOJ_CHECK_TYPE(XournalView);
 
 	return this->parent;
-}
-
-/**
- * A pen action was detected now, therefore ignore touch events
- * for a short time
- */
-void XournalView::penActionDetected()
-{
-	XOJ_CHECK_TYPE(XournalView);
-
-	this->lastPenAction = g_get_monotonic_time() / 1000;
-}
-
-/**
- * If the pen was active a short time before, ignore touch events
- */
-bool XournalView::shouldIgnoreTouchEvents()
-{
-	XOJ_CHECK_TYPE(XournalView);
-
-	if ((g_get_monotonic_time() / 1000 - this->lastPenAction) < 1000)
-	{
-		// printf("Ignore touch, pen was active\n");
-		return true;
-	}
-
-	return false;
 }
 
 GtkWidget* XournalView::getWidget()

--- a/src/gui/XournalView.h
+++ b/src/gui/XournalView.h
@@ -107,17 +107,6 @@ public:
 
 	GtkContainer* getParent();
 
-	/**
-	 * A pen action was detected now, therefore ignore touch events
-	 * for a short time
-	 */
-	void penActionDetected();
-
-	/**
-	 * If the pen was active a short time before, ignore touch events
-	 */
-	bool shouldIgnoreTouchEvents();
-
 public:
 	// ZoomListener interface
 	void zoomChanged(double lastZoom);
@@ -194,11 +183,6 @@ private:
 	 * Memory cleanup timeout
 	 */
 	int cleanupTimeout;
-
-	/**
-	 * Last Pen action, to ignore touch events within a time frame
-	 */
-	gint64 lastPenAction;
 
 	friend class Layout;
 };

--- a/src/gui/dialog/SettingsDialog.cpp
+++ b/src/gui/dialog/SettingsDialog.cpp
@@ -5,6 +5,7 @@
 
 #include <config.h>
 #include <Util.h>
+#include <i18n.h>
 
 #include <string.h>
 
@@ -40,6 +41,7 @@ SettingsDialog::SettingsDialog(GladeSearchpath* gladeSearchPath, Settings* setti
 	gtk_widget_show(callib);
 
 	initMouseButtonEvents();
+	initAdvanceInputConfig();
 }
 
 SettingsDialog::~SettingsDialog()
@@ -55,6 +57,36 @@ SettingsDialog::~SettingsDialog()
 	this->settings = NULL;
 
 	XOJ_RELEASE_TYPE(SettingsDialog);
+}
+
+void SettingsDialog::initAdvanceInputConfig()
+{
+	GtkComboBoxText* cbSelectInputType = GTK_COMBO_BOX_TEXT(get("cbSelectInputType"));
+	gtk_combo_box_text_append_text(cbSelectInputType, _C("Auto"));
+	gtk_combo_box_text_append_text(cbSelectInputType, _C("01: GTK / may crash on X11"));
+	gtk_combo_box_text_append_text(cbSelectInputType, _C("02: Direct read axes"));
+	gtk_combo_box_text_append_text(cbSelectInputType, _C("03: GTK 3.24 Sample way"));
+
+	string selectedInputType;
+	SElement& inputSettings = settings->getCustomElement("inputHandling");
+	inputSettings.getString("type", selectedInputType);
+
+	if (selectedInputType == "01-gtk")
+	{
+		gtk_combo_box_set_active(GTK_COMBO_BOX(cbSelectInputType), 1);
+	}
+	else if (selectedInputType == "02-direct")
+	{
+		gtk_combo_box_set_active(GTK_COMBO_BOX(cbSelectInputType), 2);
+	}
+	else if (selectedInputType == "03-gtk")
+	{
+		gtk_combo_box_set_active(GTK_COMBO_BOX(cbSelectInputType), 3);
+	}
+	else // selectedInputType == "auto"
+	{
+		gtk_combo_box_set_active(GTK_COMBO_BOX(cbSelectInputType), 0);
+	}
 }
 
 void SettingsDialog::initMouseButtonEvents(const char* hbox, int button, bool withDevice)
@@ -347,6 +379,28 @@ void SettingsDialog::save()
 	{
 		bcg->saveSettings();
 	}
+
+	SElement& inputSettings = settings->getCustomElement("inputHandling");
+	GtkComboBox* cbSelectInputType = GTK_COMBO_BOX(get("cbSelectInputType"));
+	int activeInput = gtk_combo_box_get_active(cbSelectInputType);
+
+	if (activeInput == 1)
+	{
+		inputSettings.setString("type", "01-gtk");
+	}
+	else if (activeInput == 2)
+	{
+		inputSettings.setString("type", "02-direct");
+	}
+	else if (activeInput == 3)
+	{
+		inputSettings.setString("type", "03-gtk");
+	}
+	else
+	{
+		inputSettings.setString("type", "auto");
+	}
+
 
 	settings->transactionEnd();
 }

--- a/src/gui/dialog/SettingsDialog.cpp
+++ b/src/gui/dialog/SettingsDialog.cpp
@@ -65,7 +65,9 @@ void SettingsDialog::initAdvanceInputConfig()
 	gtk_combo_box_text_append_text(cbSelectInputType, _C("Auto"));
 	gtk_combo_box_text_append_text(cbSelectInputType, _C("01: GTK / may crash on X11"));
 	gtk_combo_box_text_append_text(cbSelectInputType, _C("02: Direct read axes"));
-	gtk_combo_box_text_append_text(cbSelectInputType, _C("03: GTK multi device support"));
+
+	// Not fully working yet
+	// gtk_combo_box_text_append_text(cbSelectInputType, _C("03: GTK multi device support"));
 
 	string selectedInputType;
 	SElement& inputSettings = settings->getCustomElement("inputHandling");

--- a/src/gui/dialog/SettingsDialog.cpp
+++ b/src/gui/dialog/SettingsDialog.cpp
@@ -65,7 +65,7 @@ void SettingsDialog::initAdvanceInputConfig()
 	gtk_combo_box_text_append_text(cbSelectInputType, _C("Auto"));
 	gtk_combo_box_text_append_text(cbSelectInputType, _C("01: GTK / may crash on X11"));
 	gtk_combo_box_text_append_text(cbSelectInputType, _C("02: Direct read axes"));
-	gtk_combo_box_text_append_text(cbSelectInputType, _C("03: GTK 3.24 Sample way"));
+	gtk_combo_box_text_append_text(cbSelectInputType, _C("03: GTK multi device support"));
 
 	string selectedInputType;
 	SElement& inputSettings = settings->getCustomElement("inputHandling");

--- a/src/gui/dialog/SettingsDialog.h
+++ b/src/gui/dialog/SettingsDialog.h
@@ -40,6 +40,7 @@ public:
 
 private:
 	void load();
+	void initAdvanceInputConfig();
 	void loadCheckbox(const char* name, gboolean value);
 	bool getCheckbox(const char* name);
 

--- a/src/gui/inputdevices/AbstractInputDevice.cpp
+++ b/src/gui/inputdevices/AbstractInputDevice.cpp
@@ -1,8 +1,65 @@
 #include "AbstractInputDevice.h"
 
+#include "control/Control.h"
+#include "control/settings/ButtonConfig.h"
+#include "gui/Cursor.h"
+#include "gui/Layout.h"
+#include "gui/pageposition/PagePositionHandler.h"
+#include "gui/widgets/XournalWidget.h"
+#include "gui/XournalView.h"
+
+
+bool gtk_xournal_scroll_callback(GtkXournal* xournal)
+{
+	xournal->layout->scrollRelativ(xournal->scrollOffsetX, xournal->scrollOffsetY);
+
+	// Scrolling done, so reset our counters
+	xournal->scrollOffsetX = 0;
+	xournal->scrollOffsetY = 0;
+
+	return false;
+}
+
+static void gtk_xournal_scroll_mouse_event(GtkXournal* xournal, GdkEventMotion* event)
+{
+	// use root coordinates as reference point because
+	// scrolling changes window relative coordinates
+	// see github Gnome/evince@1adce5486b10e763bed869
+	int x_root = event->x_root;
+	int y_root = event->y_root;
+
+	if (xournal->lastMousePositionX - x_root == 0 && xournal->lastMousePositionY - y_root == 0)
+	{
+		return;
+	}
+
+	if (xournal->scrollOffsetX == 0 && xournal->scrollOffsetY == 0)
+	{
+		xournal->scrollOffsetX = xournal->lastMousePositionX - x_root;
+		xournal->scrollOffsetY = xournal->lastMousePositionY - y_root;
+
+		g_idle_add((GSourceFunc) gtk_xournal_scroll_callback, xournal);
+		//gtk_xournal_scroll_callback(xournal);
+		xournal->lastMousePositionX = x_root;
+		xournal->lastMousePositionY = y_root;
+	}
+}
+
+XojPageView* gtk_xournal_get_page_view_for_pos_cached(GtkXournal* xournal, int x, int y)
+{
+	x += xournal->x;
+	y += xournal->y;
+
+	PagePositionHandler* pph = xournal->view->getPagePositionHandler();
+
+	return pph->getViewAt(x, y, xournal->pagePositionCache);
+}
+
+
 AbstractInputDevice::AbstractInputDevice(GtkWidget* widget, XournalView* view)
  : widget(widget),
-   view(view)
+   view(view),
+   current_view(NULL)
 {
 	XOJ_INIT_TYPE(AbstractInputDevice);
 }
@@ -16,3 +73,260 @@ AbstractInputDevice::~AbstractInputDevice()
 
 	XOJ_RELEASE_TYPE(AbstractInputDevice);
 }
+
+bool AbstractInputDevice::handleButtonPress(GdkEventButton* event)
+{
+	XOJ_CHECK_TYPE(AbstractInputDevice);
+
+	GtkXournal* xournal = GTK_XOURNAL(widget);
+
+	gtk_widget_grab_focus(widget);
+
+	// none button release event was sent, send one now
+	if (xournal->currentInputPage)
+	{
+		GdkEventButton ev = *event;
+		xournal->currentInputPage->translateEvent((GdkEvent*) &ev, xournal->x, xournal->y);
+		xournal->currentInputPage->onButtonReleaseEvent(widget, &ev);
+	}
+
+	ToolHandler* h = xournal->view->getControl()->getToolHandler();
+
+	// Change the tool depending on the key or device
+	if (changeTool(event))
+	{
+		return true;
+	}
+
+	// hand tool don't change the selection, so you can scroll e.g.
+	// with your touchscreen without remove the selection
+	if (h->getToolType() == TOOL_HAND)
+	{
+		Cursor* cursor = xournal->view->getCursor();
+		cursor->setMouseDown(true);
+		xournal->inScrolling = true;
+		//set reference
+		xournal->lastMousePositionX = event->x_root;
+		xournal->lastMousePositionY = event->y_root;
+
+		return TRUE;
+	}
+	else if (xournal->selection)
+	{
+		EditSelection* selection = xournal->selection;
+
+		XojPageView* view = selection->getView();
+		GdkEventButton ev = *event;
+		view->translateEvent((GdkEvent*) &ev, xournal->x, xournal->y);
+		CursorSelectionType selType = selection->getSelectionTypeForPos(ev.x, ev.y, xournal->view->getZoom());
+		if (selType)
+		{
+
+			if (selType == CURSOR_SELECTION_MOVE && event->button == 3)
+			{
+				selection->copySelection();
+			}
+
+			xournal->view->getCursor()->setMouseDown(true);
+			xournal->selection->mouseDown(selType, ev.x, ev.y);
+			return true;
+		}
+		else
+		{
+			xournal->view->clearSelection();
+			if (changeTool(event))
+			{
+				return true;
+			}
+		}
+	}
+
+	XojPageView* pv = gtk_xournal_get_page_view_for_pos_cached(xournal, event->x, event->y);
+
+	current_view = pv;
+
+	if (pv)
+	{
+		xournal->currentInputPage = pv;
+		pv->translateEvent((GdkEvent*) event, xournal->x, xournal->y);
+
+		xournal->view->getDocument()->indexOf(pv->getPage());
+		return pv->onButtonPressEvent(widget, event);
+	}
+
+	return FALSE; // not handled
+}
+
+bool AbstractInputDevice::handleButtonRelease(GdkEventButton* event)
+{
+	XOJ_CHECK_TYPE(AbstractInputDevice);
+
+	current_view = NULL;
+
+	GtkXournal* xournal = GTK_XOURNAL(widget);
+
+	Cursor* cursor = xournal->view->getCursor();
+	ToolHandler* h = xournal->view->getControl()->getToolHandler();
+	if (xournal->view->zoom_gesture_active)
+	{
+		return true;
+	}
+
+	cursor->setMouseDown(false);
+
+	xournal->inScrolling = false;
+
+	EditSelection* sel = xournal->view->getSelection();
+	if (sel)
+	{
+		sel->mouseUp();
+	}
+
+	bool res = false;
+	if (xournal->currentInputPage)
+	{
+		xournal->currentInputPage->translateEvent((GdkEvent*) event, xournal->x, xournal->y);
+		res = xournal->currentInputPage->onButtonReleaseEvent(widget, event);
+		xournal->currentInputPage = NULL;
+	}
+
+	EditSelection* tmpSelection = xournal->selection;
+	xournal->selection = NULL;
+
+	h->restoreLastConfig();
+
+	// we need this workaround so it's possible to select something with the middle button
+	if (tmpSelection)
+	{
+		xournal->view->setSelection(tmpSelection);
+	}
+
+	return res;
+}
+
+bool AbstractInputDevice::handleMotion(GdkEventMotion* event)
+{
+	GtkXournal* xournal = GTK_XOURNAL(widget);
+
+	ToolHandler* h = xournal->view->getControl()->getToolHandler();
+
+	if (xournal->view->zoom_gesture_active)
+	{
+		return true;
+	}
+
+	if (h->getToolType() == TOOL_HAND)
+	{
+		if (xournal->inScrolling)
+		{
+			gtk_xournal_scroll_mouse_event(xournal, event);
+			return TRUE;
+		}
+		return FALSE;
+	}
+	else if (xournal->selection)
+	{
+		EditSelection* selection = xournal->selection;
+
+		XojPageView* view = selection->getView();
+		GdkEventMotion ev = *event;
+		view->translateEvent((GdkEvent*) &ev, xournal->x, xournal->y);
+
+		if (xournal->selection->isMoving())
+		{
+			selection->mouseMove(ev.x, ev.y);
+		}
+		else
+		{
+			CursorSelectionType selType = selection->getSelectionTypeForPos(ev.x, ev.y, xournal->view->getZoom());
+			xournal->view->getCursor()->setMouseSelectionType(selType);
+		}
+		return true;
+	}
+
+	XojPageView* pv = NULL;
+
+	if (current_view)
+	{
+		pv = current_view;
+	}
+	else
+	{
+		pv = gtk_xournal_get_page_view_for_pos_cached(xournal, event->x, event->y);
+	}
+
+	xournal->view->getCursor()->setInsidePage(pv != NULL);
+
+	if (pv)
+	{
+		// allow events only to a single page!
+		if (xournal->currentInputPage == NULL || pv == xournal->currentInputPage)
+		{
+			return motionEvent(pv, event);
+		}
+	}
+
+	return false;
+}
+
+bool AbstractInputDevice::changeTool(GdkEventButton* event)
+{
+	Settings* settings = view->getControl()->getSettings();
+	ButtonConfig* cfgTouch = settings->getTouchButtonConfig();
+	ToolHandler* h = view->getControl()->getToolHandler();
+
+	GdkEvent* rawEvent = (GdkEvent*) event;
+	GdkDevice* device = gdk_event_get_source_device(rawEvent);
+
+	GtkXournal* xournal = GTK_XOURNAL(widget);
+	ButtonConfig* cfg = NULL;
+	if (gdk_device_get_source(device) == GDK_SOURCE_PEN)
+	{
+		if (event->button == 2)
+		{
+			cfg = settings->getStylusButton1Config();
+		}
+		else if (event->button == 3)
+		{
+			cfg = settings->getStylusButton2Config();
+		}
+	}
+	 else if (event->button == 2)   // Middle Button
+	{
+		cfg = settings->getMiddleButtonConfig();
+	}
+	else if (event->button == 3 && !xournal->selection)     // Right Button
+	{
+		cfg = settings->getRightButtonConfig();
+	}
+	else if (gdk_device_get_source(device) == GDK_SOURCE_ERASER)
+	{
+		cfg = settings->getEraserButtonConfig();
+	}
+	else if (cfgTouch->device == gdk_device_get_name(device))
+	{
+		cfg = cfgTouch;
+
+		// If an action is defined we do it, even if it's a drawing action...
+		if (cfg->getDisableDrawing() && cfg->getAction() == TOOL_NONE)
+		{
+			ToolType tool = h->getToolType();
+			if (tool == TOOL_PEN || tool == TOOL_ERASER || tool == TOOL_HILIGHTER)
+			{
+				printf("ignore touchscreen for drawing!\n");
+				return true;
+			}
+		}
+	}
+
+	if (cfg && cfg->getAction() != TOOL_NONE)
+	{
+		h->copyCurrentConfig();
+		cfg->acceptActions(h);
+	}
+
+	return false;
+}
+
+
+

--- a/src/gui/inputdevices/AbstractInputDevice.cpp
+++ b/src/gui/inputdevices/AbstractInputDevice.cpp
@@ -1,0 +1,18 @@
+#include "AbstractInputDevice.h"
+
+AbstractInputDevice::AbstractInputDevice(GtkWidget* widget, XournalView* view)
+ : widget(widget),
+   view(view)
+{
+	XOJ_INIT_TYPE(AbstractInputDevice);
+}
+
+AbstractInputDevice::~AbstractInputDevice()
+{
+	XOJ_CHECK_TYPE(AbstractInputDevice);
+
+	widget = NULL;
+	view = NULL;
+
+	XOJ_RELEASE_TYPE(AbstractInputDevice);
+}

--- a/src/gui/inputdevices/AbstractInputDevice.h
+++ b/src/gui/inputdevices/AbstractInputDevice.h
@@ -31,15 +31,18 @@ public:
 	 */
 	virtual void initWidget() = 0;
 
+protected:
 	/**
-	 * Mouse / pen moved event
+	 * Mouse / pen moved event, handle pressure
 	 */
 	virtual bool motionEvent(XojPageView* pageView, GdkEventMotion* event) = 0;
 
-	/**
-	 * Touch event
-	 */
-	virtual bool touchEvent(GdkEventTouch* event) = 0;
+	// Handling from Xournal Widget
+protected:
+	bool handleButtonPress(GdkEventButton* event);
+	bool handleButtonRelease(GdkEventButton* event);
+	bool handleMotion(GdkEventMotion* event);
+	bool changeTool(GdkEventButton* event);
 
 private:
 	XOJ_TYPE_ATTRIB;
@@ -55,4 +58,6 @@ protected:
 	 * Xournal View
 	 */
 	XournalView* view;
+
+	XojPageView* current_view;
 };

--- a/src/gui/inputdevices/AbstractInputDevice.h
+++ b/src/gui/inputdevices/AbstractInputDevice.h
@@ -1,0 +1,58 @@
+/*
+ * Xournal++
+ *
+ * Base class for device input handling
+ * This is the interface / basis class for all implementations
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+#include <XournalType.h>
+
+#include <gtk/gtk.h>
+
+class XournalView;
+class XojPageView;
+
+class AbstractInputDevice
+{
+public:
+	AbstractInputDevice(GtkWidget* widget, XournalView* view);
+	virtual ~AbstractInputDevice();
+
+public:
+	/**
+	 * Initialize the input handling, set input events
+	 */
+	virtual void initWidget() = 0;
+
+	/**
+	 * Mouse / pen moved event
+	 */
+	virtual bool motionEvent(XojPageView* pageView, GdkEventMotion* event) = 0;
+
+	/**
+	 * Touch event
+	 */
+	virtual bool touchEvent(GdkEventTouch* event) = 0;
+
+private:
+	XOJ_TYPE_ATTRIB;
+
+protected:
+
+	/**
+	 * Xournal Widget
+	 */
+	GtkWidget* widget;
+
+	/**
+	 * Xournal View
+	 */
+	XournalView* view;
+};

--- a/src/gui/inputdevices/BaseInputDevice.cpp
+++ b/src/gui/inputdevices/BaseInputDevice.cpp
@@ -1,0 +1,175 @@
+#include "BaseInputDevice.h"
+
+#include "control/Control.h"
+#include "gui/PageView.h"
+#include "gui/widgets/XournalWidget.h"
+#include "gui/XournalView.h"
+#include "model/Point.h"
+
+
+BaseInputDevice::BaseInputDevice(GtkWidget* widget, XournalView* view)
+ : widget(widget),
+   view(view)
+{
+	XOJ_INIT_TYPE(BaseInputDevice);
+}
+
+BaseInputDevice::~BaseInputDevice()
+{
+	XOJ_CHECK_TYPE(BaseInputDevice);
+
+	widget = NULL;
+	view = NULL;
+
+	XOJ_RELEASE_TYPE(BaseInputDevice);
+}
+
+/**
+ * Initialize the input handling, set input events
+ */
+void BaseInputDevice::initWidget()
+{
+	XOJ_CHECK_TYPE(BaseInputDevice);
+
+	int events = GDK_EXPOSURE_MASK;
+	events |= GDK_POINTER_MOTION_MASK;
+	events |= GDK_EXPOSURE_MASK;
+	events |= GDK_BUTTON_MOTION_MASK;
+
+	// See documentation: https://developer.gnome.org/gtk3/stable/chap-input-handling.html
+	events |= GDK_TOUCH_MASK;
+	events |= GDK_BUTTON_PRESS_MASK;
+	events |= GDK_BUTTON_RELEASE_MASK;
+	events |= GDK_ENTER_NOTIFY_MASK;
+	events |= GDK_LEAVE_NOTIFY_MASK;
+	events |= GDK_KEY_PRESS_MASK;
+	events |= GDK_SCROLL_MASK;
+
+	// NOT Working with GTK3, only with GTK2
+	// Therefore listening for mouse move events
+	// of the pen, and add a timeout
+	//	events |= GDK_PROXIMITY_IN_MASK;
+	//	events |= GDK_PROXIMITY_OUT_MASK;
+
+	gtk_widget_set_events(widget, events);
+}
+
+/**
+ * Mouse / pen moved event
+ */
+bool BaseInputDevice::motionEvent(XojPageView* pageView, GdkEventMotion* event)
+{
+	XOJ_CHECK_TYPE(BaseInputDevice);
+
+	double x = 0;
+	double y = 0;
+	double pressure = Point::NO_PRESURE;
+	readPositionAndPressure(event, x, y, pressure);
+
+	GtkXournal* xournal = GTK_XOURNAL(widget);
+
+	double pageX = x - pageView->getX() - xournal->x;
+	double pageY = y - pageView->getY() - xournal->y;
+
+	return pageView->onMotionNotifyEvent(widget, pageX, pageY, pressure, xournal->shiftDown);
+}
+
+/**
+ * Read pressure and position of the pen, if a pen is active
+ */
+void BaseInputDevice::readPositionAndPressure(GdkEventMotion* event, double& x, double& y, double& pressure)
+{
+	XOJ_CHECK_TYPE(BaseInputDevice);
+
+	x = event->x;
+	y = event->y;
+
+	bool presureSensitivity = view->getControl()->getSettings()->isPresureSensitivity();
+
+	if (presureSensitivity)
+	{
+		return;
+	}
+
+	ToolHandler* h = view->getControl()->getToolHandler();
+
+	if (h->getToolType() != TOOL_PEN)
+	{
+		return;
+	}
+
+	if (!getPressureMultiplier((GdkEvent*) event, pressure))
+	{
+		pressure = Point::NO_PRESURE;
+	}
+}
+
+/**
+ * Read Pressure over GTK
+ */
+bool BaseInputDevice::getPressureMultiplier(GdkEvent* event, double& pressure)
+{
+	XOJ_CHECK_TYPE(BaseInputDevice);
+
+	GdkDevice* device = gdk_event_get_device(event);
+	int axesCount = gdk_device_get_n_axes(device);
+	if (axesCount <= 4)
+	{
+		return false;
+	}
+
+	// TODO Enable this, the fix should be in a base class!
+	// This causes some memory corruption
+	// If touch and pen is active at the same time
+	// Here are random crashes. It cannot be reproduced
+	// without touch and pen at the same time
+//	gdouble* axes = event->button.axes;
+//	gdk_device_get_state(device,
+//						 gtk_widget_get_parent_window(xournal->getWidget()),
+//						 axes, NULL);
+//
+//	if (!gdk_device_get_axis(device, axes, GDK_AXIS_PRESSURE, &pressure))
+//	{
+//		return false;
+//	}
+
+	double* axes;
+	if (event->type == GDK_MOTION_NOTIFY)
+	{
+		axes = event->motion.axes;
+	}
+	else
+	{
+		axes = event->button.axes;
+	}
+
+	pressure = axes[2];
+	Settings* settings = view->getControl()->getSettings();
+
+	if (!finite(pressure))
+	{
+		return false;
+	}
+
+	pressure = ((1 - pressure) * settings->getWidthMinimumMultiplier()
+			+ pressure * settings->getWidthMaximumMultiplier());
+
+	return true;
+}
+
+/**
+ * Touch event
+ */
+bool BaseInputDevice::touchEvent(GdkEventTouch* event)
+{
+	XOJ_CHECK_TYPE(BaseInputDevice);
+
+
+	// This handler consume some touch events
+	// Not fully working, but fixes some touch
+	// issues
+
+	// Consume event
+	return true;
+}
+

--- a/src/gui/inputdevices/BaseInputDevice.cpp
+++ b/src/gui/inputdevices/BaseInputDevice.cpp
@@ -113,8 +113,9 @@ void BaseInputDevice::readPositionAndPressure(GdkEventMotion* event, double& x, 
 
 	bool presureSensitivity = view->getControl()->getSettings()->isPresureSensitivity();
 
-	if (presureSensitivity)
+	if (!presureSensitivity)
 	{
+		// No pressure sensitivity
 		return;
 	}
 

--- a/src/gui/inputdevices/BaseInputDevice.h
+++ b/src/gui/inputdevices/BaseInputDevice.h
@@ -26,10 +26,28 @@ public:
 	 */
 	virtual void initWidget();
 
+protected:
 	/**
-	 * Mouse / pen moved event
+	 * Mouse / pen moved event, handle pressure
 	 */
 	virtual bool motionEvent(XojPageView* pageView, GdkEventMotion* event);
+
+	// GTK Event handling
+public:
+	/**
+	 * Button pressed event
+	 */
+	virtual bool buttonPressEvent(GdkEventButton* event);
+
+	/**
+	 * Button release event
+	 */
+	virtual bool buttonReleaseEvent(GdkEventButton* event);
+
+	/**
+	 * Moved event
+	 */
+	virtual bool motionNotifyEvent(GdkEventMotion* event);
 
 	/**
 	 * Touch event
@@ -37,7 +55,6 @@ public:
 	virtual bool touchEvent(GdkEventTouch* event);
 
 protected:
-
 	/**
 	 * Read Pressure over GTK
 	 */
@@ -47,6 +64,13 @@ protected:
 	 * Read pressure and position of the pen, if a pen is active
 	 */
 	virtual void readPositionAndPressure(GdkEventMotion* event, double& x, double& y, double& pressure);
+
+	// Static GTK Callbacks
+private:
+	static bool button_press_event_cb(GtkWidget* widget, GdkEventButton* event, BaseInputDevice* self);
+	static bool button_release_event_cb(GtkWidget* widget, GdkEventButton* event, BaseInputDevice* self);
+	static bool motion_notify_event_cb(GtkWidget* widget, GdkEventMotion* event, BaseInputDevice* self);
+	static bool touch_event_cb(GtkWidget* widget, GdkEventTouch* event, BaseInputDevice* self);
 
 private:
 	XOJ_TYPE_ATTRIB;

--- a/src/gui/inputdevices/BaseInputDevice.h
+++ b/src/gui/inputdevices/BaseInputDevice.h
@@ -1,0 +1,70 @@
+/*
+ * Xournal++
+ *
+ * Base class for device input handling
+ * This class uses Standard GTK Functionality without any hacks
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+#include <XournalType.h>
+
+#include <gtk/gtk.h>
+
+class XournalView;
+class XojPageView;
+
+class BaseInputDevice
+{
+public:
+	BaseInputDevice(GtkWidget* widget, XournalView* view);
+	virtual ~BaseInputDevice();
+
+public:
+	/**
+	 * Initialize the input handling, set input events
+	 */
+	virtual void initWidget();
+
+	/**
+	 * Mouse / pen moved event
+	 */
+	virtual bool motionEvent(XojPageView* pageView, GdkEventMotion* event);
+
+	/**
+	 * Touch event
+	 */
+	virtual bool touchEvent(GdkEventTouch* event);
+
+protected:
+
+	/**
+	 * Read Pressure over GTK
+	 */
+	bool getPressureMultiplier(GdkEvent* event, double& presure);
+
+	/**
+	 * Read pressure and position of the pen, if a pen is active
+	 */
+	virtual void readPositionAndPressure(GdkEventMotion* event, double& x, double& y, double& pressure);
+
+private:
+	XOJ_TYPE_ATTRIB;
+
+protected:
+
+	/**
+	 * Xournal Widget
+	 */
+	GtkWidget* widget;
+
+	/**
+	 * Xournal View
+	 */
+	XournalView* view;
+};

--- a/src/gui/inputdevices/DirectAxisInputDevice.cpp
+++ b/src/gui/inputdevices/DirectAxisInputDevice.cpp
@@ -3,6 +3,7 @@
 #include "control/Control.h"
 #include "gui/XournalView.h"
 
+#include <cmath>
 
 DirectAxisInputDevice::DirectAxisInputDevice(GtkWidget* widget, XournalView* view)
  : BaseInputDevice(widget, view)

--- a/src/gui/inputdevices/DirectAxisInputDevice.cpp
+++ b/src/gui/inputdevices/DirectAxisInputDevice.cpp
@@ -1,0 +1,54 @@
+#include "DirectAxisInputDevice.h"
+
+#include "control/Control.h"
+#include "gui/XournalView.h"
+
+
+DirectAxisInputDevice::DirectAxisInputDevice(GtkWidget* widget, XournalView* view)
+ : BaseInputDevice(widget, view)
+{
+	XOJ_INIT_TYPE(DirectAxisInputDevice);
+}
+
+DirectAxisInputDevice::~DirectAxisInputDevice()
+{
+	XOJ_RELEASE_TYPE(DirectAxisInputDevice);
+}
+
+/**
+ * Read Pressure over GTK
+ */
+bool DirectAxisInputDevice::getPressureMultiplier(GdkEvent* event, double& pressure)
+{
+	XOJ_CHECK_TYPE(DirectAxisInputDevice);
+
+	GdkDevice* device = gdk_event_get_device(event);
+	int axesCount = gdk_device_get_n_axes(device);
+	if (axesCount <= 4)
+	{
+		return false;
+	}
+
+	double* axes;
+	if (event->type == GDK_MOTION_NOTIFY)
+	{
+		axes = event->motion.axes;
+	}
+	else
+	{
+		axes = event->button.axes;
+	}
+
+	pressure = axes[2];
+	Settings* settings = view->getControl()->getSettings();
+
+	if (!finite(pressure))
+	{
+		return false;
+	}
+
+	pressure = ((1 - pressure) * settings->getWidthMinimumMultiplier()
+			+ pressure * settings->getWidthMaximumMultiplier());
+
+	return true;
+}

--- a/src/gui/inputdevices/DirectAxisInputDevice.h
+++ b/src/gui/inputdevices/DirectAxisInputDevice.h
@@ -1,0 +1,31 @@
+/*
+ * Xournal++
+ *
+ * Base class for device input handling
+ * This class axes the axes direct, which prevents crashes on some X11 systems
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+#include "BaseInputDevice.h"
+
+class DirectAxisInputDevice : public BaseInputDevice
+{
+public:
+	DirectAxisInputDevice(GtkWidget* widget, XournalView* view);
+	virtual ~DirectAxisInputDevice();
+
+protected:
+	/**
+	 * Read Pressure over GTK
+	 */
+	bool getPressureMultiplier(GdkEvent* event, double& presure);
+
+private:
+	XOJ_TYPE_ATTRIB;
+};

--- a/src/gui/inputdevices/NewGtkInputDevice.cpp
+++ b/src/gui/inputdevices/NewGtkInputDevice.cpp
@@ -1,4 +1,4 @@
-#include "BaseInputDevice.h"
+#include "NewGtkInputDevice.h"
 
 #include "control/Control.h"
 #include "gui/PageView.h"
@@ -7,23 +7,23 @@
 #include "model/Point.h"
 
 
-BaseInputDevice::BaseInputDevice(GtkWidget* widget, XournalView* view)
+NewGtkInputDevice::NewGtkInputDevice(GtkWidget* widget, XournalView* view)
  : AbstractInputDevice(widget, view)
 {
-	XOJ_INIT_TYPE(BaseInputDevice);
+	XOJ_INIT_TYPE(NewGtkInputDevice);
 }
 
-BaseInputDevice::~BaseInputDevice()
+NewGtkInputDevice::~NewGtkInputDevice()
 {
-	XOJ_RELEASE_TYPE(BaseInputDevice);
+	XOJ_RELEASE_TYPE(NewGtkInputDevice);
 }
 
 /**
  * Initialize the input handling, set input events
  */
-void BaseInputDevice::initWidget()
+void NewGtkInputDevice::initWidget()
 {
-	XOJ_CHECK_TYPE(BaseInputDevice);
+	XOJ_CHECK_TYPE(NewGtkInputDevice);
 
 	int events = GDK_EXPOSURE_MASK;
 	events |= GDK_POINTER_MOTION_MASK;
@@ -51,9 +51,9 @@ void BaseInputDevice::initWidget()
 /**
  * Mouse / pen moved event
  */
-bool BaseInputDevice::motionEvent(XojPageView* pageView, GdkEventMotion* event)
+bool NewGtkInputDevice::motionEvent(XojPageView* pageView, GdkEventMotion* event)
 {
-	XOJ_CHECK_TYPE(BaseInputDevice);
+	XOJ_CHECK_TYPE(NewGtkInputDevice);
 
 	double x = 0;
 	double y = 0;
@@ -71,9 +71,9 @@ bool BaseInputDevice::motionEvent(XojPageView* pageView, GdkEventMotion* event)
 /**
  * Read pressure and position of the pen, if a pen is active
  */
-void BaseInputDevice::readPositionAndPressure(GdkEventMotion* event, double& x, double& y, double& pressure)
+void NewGtkInputDevice::readPositionAndPressure(GdkEventMotion* event, double& x, double& y, double& pressure)
 {
-	XOJ_CHECK_TYPE(BaseInputDevice);
+	XOJ_CHECK_TYPE(NewGtkInputDevice);
 
 	x = event->x;
 	y = event->y;
@@ -101,32 +101,9 @@ void BaseInputDevice::readPositionAndPressure(GdkEventMotion* event, double& x, 
 /**
  * Read Pressure over GTK
  */
-bool BaseInputDevice::getPressureMultiplier(GdkEvent* event, double& pressure)
+bool NewGtkInputDevice::getPressureMultiplier(GdkEvent* event, double& pressure)
 {
-	XOJ_CHECK_TYPE(BaseInputDevice);
-
-	GdkDevice* device = gdk_event_get_device(event);
-
-	// This causes some memory corruption
-	// If touch and pen is active at the same time
-	// Here are random crashes. It cannot be reproduced
-	// without touch and pen at the same time
-	// Currently only on X11 reproduced.
-	// In this case DirectAxisInputDevice should solve it
-
-	gdouble* axes = event->button.axes;
-	gdk_device_get_state(device,
-						 gtk_widget_get_parent_window(widget),
-						 axes, NULL);
-
-	if (!gdk_device_get_axis(device, axes, GDK_AXIS_PRESSURE, &pressure))
-	{
-		return false;
-	}
-
-	Settings* settings = view->getControl()->getSettings();
-	pressure = ((1 - pressure) * settings->getWidthMinimumMultiplier()
-			+ pressure * settings->getWidthMaximumMultiplier());
+	XOJ_CHECK_TYPE(NewGtkInputDevice);
 
 	return true;
 }
@@ -134,9 +111,9 @@ bool BaseInputDevice::getPressureMultiplier(GdkEvent* event, double& pressure)
 /**
  * Touch event
  */
-bool BaseInputDevice::touchEvent(GdkEventTouch* event)
+bool NewGtkInputDevice::touchEvent(GdkEventTouch* event)
 {
-	XOJ_CHECK_TYPE(BaseInputDevice);
+	XOJ_CHECK_TYPE(NewGtkInputDevice);
 
 
 	// This handler consume some touch events

--- a/src/gui/inputdevices/NewGtkInputDevice.h
+++ b/src/gui/inputdevices/NewGtkInputDevice.h
@@ -2,7 +2,7 @@
  * Xournal++
  *
  * Base class for device input handling
- * This class uses Standard GTK Functionality without any hacks
+ * This class uses the Example from GTK 3.24.x
  *
  * @author Xournal++ Team
  * https://github.com/xournalpp/xournalpp
@@ -14,11 +14,11 @@
 
 #include "AbstractInputDevice.h"
 
-class BaseInputDevice : public AbstractInputDevice
+class NewGtkInputDevice : public AbstractInputDevice
 {
 public:
-	BaseInputDevice(GtkWidget* widget, XournalView* view);
-	virtual ~BaseInputDevice();
+	NewGtkInputDevice(GtkWidget* widget, XournalView* view);
+	virtual ~NewGtkInputDevice();
 
 public:
 	/**

--- a/src/gui/inputdevices/NewGtkInputDevice.h
+++ b/src/gui/inputdevices/NewGtkInputDevice.h
@@ -26,18 +26,18 @@ public:
 	 */
 	virtual void initWidget();
 
+protected:
 	/**
 	 * Mouse / pen moved event
 	 */
 	virtual bool motionEvent(XojPageView* pageView, GdkEventMotion* event);
 
 	/**
-	 * Touch event
+	 * Handle all GTK Events
 	 */
-	virtual bool touchEvent(GdkEventTouch* event);
+	virtual bool eventHandler(GdkEvent* event);
 
 protected:
-
 	/**
 	 * Read Pressure over GTK
 	 */
@@ -47,6 +47,10 @@ protected:
 	 * Read pressure and position of the pen, if a pen is active
 	 */
 	virtual void readPositionAndPressure(GdkEventMotion* event, double& x, double& y, double& pressure);
+
+private:
+	static bool event_cb(GtkWidget* widget, GdkEvent* event, NewGtkInputDevice* self);
+
 
 private:
 	XOJ_TYPE_ATTRIB;

--- a/src/gui/inputdevices/exampleinput.c.txt
+++ b/src/gui/inputdevices/exampleinput.c.txt
@@ -1,0 +1,680 @@
+#include <glib/gi18n.h>
+#include <gtk/gtk.h>
+
+typedef struct {
+  GdkDevice *last_source;
+  GdkDeviceTool *last_tool;
+  gdouble *axes;
+  GdkRGBA color;
+  gdouble x;
+  gdouble y;
+} AxesInfo;
+
+typedef struct {
+  GHashTable *pointer_info; /* GdkDevice -> AxesInfo */
+  GHashTable *touch_info; /* GdkEventSequence -> AxesInfo */
+} EventData;
+
+const gchar *colors[] = {
+  "black",
+  "orchid",
+  "fuchsia",
+  "indigo",
+  "thistle",
+  "sienna",
+  "azure",
+  "plum",
+  "lime",
+  "navy",
+  "maroon",
+  "burlywood"
+};
+
+static GtkPadActionEntry pad_actions[] = {
+  { GTK_PAD_ACTION_BUTTON, 1, -1, N_("Nuclear strike"), "pad.nuke" },
+  { GTK_PAD_ACTION_BUTTON, 2, -1, N_("Release siberian methane reserves"), "pad.heat" },
+  { GTK_PAD_ACTION_BUTTON, 3, -1, N_("Release solar flare"), "pad.fry" },
+  { GTK_PAD_ACTION_BUTTON, 4, -1, N_("De-stabilize Oort cloud"), "pad.fall" },
+  { GTK_PAD_ACTION_BUTTON, 5, -1, N_("Ignite WR-104"), "pad.burst" },
+  { GTK_PAD_ACTION_BUTTON, 6, -1, N_("Lart whoever asks about this button"), "pad.lart" },
+  { GTK_PAD_ACTION_RING, -1, -1, N_("Earth axial tilt"), "pad.tilt" },
+  { GTK_PAD_ACTION_STRIP, -1, -1, N_("Extent of weak nuclear force"), "pad.dissolve" },
+};
+
+static const gchar *pad_action_results[] = {
+  "☢",
+  "♨",
+  "☼",
+  "☄",
+  "⚡",
+  "💫",
+  "◑",
+  "⚛"
+};
+
+static guint cur_color = 0;
+static guint pad_action_timeout_id = 0;
+
+static AxesInfo *
+axes_info_new (void)
+{
+  AxesInfo *info;
+
+  info = g_new0 (AxesInfo, 1);
+  gdk_rgba_parse (&info->color, colors[cur_color]);
+
+  cur_color = (cur_color + 1) % G_N_ELEMENTS (colors);
+
+  return info;
+}
+
+static EventData *
+event_data_new (void)
+{
+  EventData *data;
+
+  data = g_new0 (EventData, 1);
+  data->pointer_info = g_hash_table_new_full (NULL, NULL, NULL,
+                                              (GDestroyNotify) g_free);
+  data->touch_info = g_hash_table_new_full (NULL, NULL, NULL,
+                                            (GDestroyNotify) g_free);
+
+  return data;
+}
+
+static void
+event_data_free (EventData *data)
+{
+  g_hash_table_destroy (data->pointer_info);
+  g_hash_table_destroy (data->touch_info);
+  g_free (data);
+}
+
+static void
+update_axes_from_event (GdkEvent  *event,
+                        EventData *data)
+{
+  GdkDevice *device, *source_device;
+  GdkEventSequence *sequence;
+  GdkDeviceTool *tool;
+  gdouble x, y;
+  AxesInfo *info;
+
+  device = gdk_event_get_device (event);
+  source_device = gdk_event_get_source_device (event);
+  sequence = gdk_event_get_event_sequence (event);
+  tool = gdk_event_get_device_tool (event);
+
+  if (event->type == GDK_TOUCH_END ||
+      event->type == GDK_TOUCH_CANCEL)
+    {
+      g_hash_table_remove (data->touch_info, sequence);
+      return;
+    }
+  else if (event->type == GDK_LEAVE_NOTIFY)
+    {
+      g_hash_table_remove (data->pointer_info, device);
+      return;
+    }
+
+  if (!sequence)
+    {
+      info = g_hash_table_lookup (data->pointer_info, device);
+
+      if (!info)
+        {
+          info = axes_info_new ();
+          g_hash_table_insert (data->pointer_info, device, info);
+        }
+    }
+  else
+    {
+      info = g_hash_table_lookup (data->touch_info, sequence);
+
+      if (!info)
+        {
+          info = axes_info_new ();
+          g_hash_table_insert (data->touch_info, sequence, info);
+        }
+    }
+
+  if (info->last_source != source_device)
+    info->last_source = source_device;
+
+  if (info->last_tool != tool)
+    info->last_tool = tool;
+
+  g_clear_pointer (&info->axes, g_free);
+
+  if (event->type == GDK_TOUCH_BEGIN ||
+      event->type == GDK_TOUCH_UPDATE)
+    {
+      if (sequence && event->touch.emulating_pointer)
+        g_hash_table_remove (data->pointer_info, device);
+    }
+  if (event->type == GDK_MOTION_NOTIFY)
+    {
+      info->axes =
+      g_memdup (event->motion.axes,
+                sizeof (gdouble) * gdk_device_get_n_axes (source_device));
+    }
+  else if (event->type == GDK_BUTTON_PRESS ||
+           event->type == GDK_BUTTON_RELEASE)
+    {
+      info->axes =
+      g_memdup (event->button.axes,
+                sizeof (gdouble) * gdk_device_get_n_axes (source_device));
+    }
+
+  if (gdk_event_get_coords (event, &x, &y))
+    {
+      info->x = x;
+      info->y = y;
+    }
+}
+
+static gboolean
+event_cb (GtkWidget *widget,
+          GdkEvent  *event,
+          gpointer   user_data)
+{
+  update_axes_from_event (event, user_data);
+  gtk_widget_queue_draw (widget);
+  return FALSE;
+}
+
+static void
+render_arrow (cairo_t     *cr,
+              gdouble      x_diff,
+              gdouble      y_diff,
+              const gchar *label)
+{
+  cairo_save (cr);
+
+  cairo_set_source_rgb (cr, 0, 0, 0);
+  cairo_new_path (cr);
+  cairo_move_to (cr, 0, 0);
+  cairo_line_to (cr, x_diff, y_diff);
+  cairo_stroke (cr);
+
+  cairo_move_to (cr, x_diff, y_diff);
+  cairo_show_text (cr, label);
+
+  cairo_restore (cr);
+}
+
+static void
+draw_axes_info (cairo_t       *cr,
+                AxesInfo      *info,
+                GtkAllocation *allocation)
+{
+  gdouble pressure, tilt_x, tilt_y, distance, wheel, rotation, slider;
+  GdkAxisFlags axes = gdk_device_get_axes (info->last_source);
+
+  cairo_save (cr);
+
+  cairo_set_line_width (cr, 1);
+  gdk_cairo_set_source_rgba (cr, &info->color);
+
+  cairo_move_to (cr, 0, info->y);
+  cairo_line_to (cr, allocation->width, info->y);
+  cairo_move_to (cr, info->x, 0);
+  cairo_line_to (cr, info->x, allocation->height);
+  cairo_stroke (cr);
+
+  cairo_translate (cr, info->x, info->y);
+
+  if (!info->axes)
+    {
+      cairo_restore (cr);
+      return;
+    }
+
+  if (axes & GDK_AXIS_FLAG_PRESSURE)
+    {
+      cairo_pattern_t *pattern;
+
+      gdk_device_get_axis (info->last_source, info->axes, GDK_AXIS_PRESSURE,
+                           &pressure);
+
+      pattern = cairo_pattern_create_radial (0, 0, 0, 0, 0, 100);
+      cairo_pattern_add_color_stop_rgba (pattern, pressure, 1, 0, 0, pressure);
+      cairo_pattern_add_color_stop_rgba (pattern, 1, 0, 0, 1, 0);
+
+      cairo_set_source (cr, pattern);
+
+      cairo_arc (cr, 0, 0, 100, 0, 2 * G_PI);
+      cairo_fill (cr);
+
+      cairo_pattern_destroy (pattern);
+    }
+
+  if (axes & GDK_AXIS_FLAG_XTILT &&
+      axes & GDK_AXIS_FLAG_YTILT)
+    {
+      gdk_device_get_axis (info->last_source, info->axes, GDK_AXIS_XTILT,
+                           &tilt_x);
+      gdk_device_get_axis (info->last_source, info->axes, GDK_AXIS_YTILT,
+                           &tilt_y);
+
+      render_arrow (cr, tilt_x * 100, tilt_y * 100, "Tilt");
+    }
+
+  if (axes & GDK_AXIS_FLAG_DISTANCE)
+    {
+      double dashes[] = { 5.0, 5.0 };
+      cairo_text_extents_t extents;
+
+      gdk_device_get_axis (info->last_source, info->axes, GDK_AXIS_DISTANCE,
+                           &distance);
+
+      cairo_save (cr);
+
+      cairo_move_to (cr, distance * 100, 0);
+
+      cairo_set_source_rgb (cr, 0.0, 0.0, 0.0);
+      cairo_set_dash (cr, dashes, 2, 0.0);
+      cairo_arc (cr, 0, 0, distance * 100, 0, 2 * G_PI);
+      cairo_stroke (cr);
+
+      cairo_move_to (cr, 0, -distance * 100);
+      cairo_text_extents (cr, "Distance", &extents);
+      cairo_rel_move_to (cr, -extents.width / 2, 0);
+      cairo_show_text (cr, "Distance");
+
+      cairo_move_to (cr, 0, 0);
+
+      cairo_restore (cr);
+    }
+
+  if (axes & GDK_AXIS_FLAG_WHEEL)
+    {
+      gdk_device_get_axis (info->last_source, info->axes, GDK_AXIS_WHEEL,
+                           &wheel);
+
+      cairo_save (cr);
+      cairo_set_line_width (cr, 10);
+      cairo_set_source_rgba (cr, 0, 0, 0, 0.5);
+
+      cairo_new_sub_path (cr);
+      cairo_arc (cr, 0, 0, 100, 0, wheel * 2 * G_PI);
+      cairo_stroke (cr);
+      cairo_restore (cr);
+    }
+
+  if (axes & GDK_AXIS_FLAG_ROTATION)
+    {
+      gdk_device_get_axis (info->last_source, info->axes, GDK_AXIS_ROTATION,
+                           &rotation);
+      rotation *= 2 * G_PI;
+
+      cairo_save (cr);
+      cairo_rotate (cr, - G_PI / 2);
+      cairo_set_line_cap (cr, CAIRO_LINE_CAP_ROUND);
+      cairo_set_line_width (cr, 5);
+
+      cairo_new_sub_path (cr);
+      cairo_arc (cr, 0, 0, 100, 0, rotation);
+      cairo_stroke (cr);
+      cairo_restore (cr);
+    }
+
+  if (axes & GDK_AXIS_FLAG_SLIDER)
+    {
+      cairo_pattern_t *pattern, *mask;
+
+      gdk_device_get_axis (info->last_source, info->axes, GDK_AXIS_SLIDER,
+                           &slider);
+
+      cairo_save (cr);
+
+      cairo_move_to (cr, 0, -10);
+      cairo_rel_line_to (cr, 0, -50);
+      cairo_rel_line_to (cr, 10, 0);
+      cairo_rel_line_to (cr, -5, 50);
+      cairo_close_path (cr);
+
+      cairo_clip_preserve (cr);
+
+      pattern = cairo_pattern_create_linear (0, -10, 0, -60);
+      cairo_pattern_add_color_stop_rgb (pattern, 0, 0, 1, 0);
+      cairo_pattern_add_color_stop_rgb (pattern, 1, 1, 0, 0);
+      cairo_set_source (cr, pattern);
+      cairo_pattern_destroy (pattern);
+
+      mask = cairo_pattern_create_linear (0, -10, 0, -60);
+      cairo_pattern_add_color_stop_rgba (mask, 0, 0, 0, 0, 1);
+      cairo_pattern_add_color_stop_rgba (mask, slider, 0, 0, 0, 1);
+      cairo_pattern_add_color_stop_rgba (mask, slider, 0, 0, 0, 0);
+      cairo_pattern_add_color_stop_rgba (mask, 1, 0, 0, 0, 0);
+      cairo_mask (cr, mask);
+      cairo_pattern_destroy (mask);
+
+      cairo_set_source_rgb (cr, 0, 0, 0);
+      cairo_stroke (cr);
+
+      cairo_restore (cr);
+    }
+
+  cairo_restore (cr);
+}
+
+static const gchar *
+tool_type_to_string (GdkDeviceToolType tool_type)
+{
+  switch (tool_type)
+    {
+    case GDK_DEVICE_TOOL_TYPE_PEN:
+      return "Pen";
+    case GDK_DEVICE_TOOL_TYPE_ERASER:
+      return "Eraser";
+    case GDK_DEVICE_TOOL_TYPE_BRUSH:
+      return "Brush";
+    case GDK_DEVICE_TOOL_TYPE_PENCIL:
+      return "Pencil";
+    case GDK_DEVICE_TOOL_TYPE_AIRBRUSH:
+      return "Airbrush";
+    case GDK_DEVICE_TOOL_TYPE_MOUSE:
+      return "Mouse";
+    case GDK_DEVICE_TOOL_TYPE_LENS:
+      return "Lens cursor";
+    case GDK_DEVICE_TOOL_TYPE_UNKNOWN:
+    default:
+      return "Unknown";
+    }
+}
+
+static void
+draw_device_info (GtkWidget        *widget,
+                  cairo_t          *cr,
+                  GdkEventSequence *sequence,
+                  gint             *y,
+                  AxesInfo         *info)
+{
+  PangoLayout *layout;
+  GString *string;
+  gint height;
+
+  cairo_save (cr);
+
+  string = g_string_new (NULL);
+  g_string_append_printf (string, "Source: %s",
+                          gdk_device_get_name (info->last_source));
+
+  if (sequence)
+    g_string_append_printf (string, "\nSequence: %d",
+                            GPOINTER_TO_UINT (sequence));
+
+  if (info->last_tool)
+    {
+      const gchar *tool_type;
+      guint64 serial;
+
+      tool_type = tool_type_to_string (gdk_device_tool_get_tool_type (info->last_tool));
+      serial = gdk_device_tool_get_serial (info->last_tool);
+      g_string_append_printf (string, "\nTool: %s", tool_type);
+
+      if (serial != 0)
+        g_string_append_printf (string, ", Serial: %lx", serial);
+    }
+
+  cairo_move_to (cr, 10, *y);
+  layout = gtk_widget_create_pango_layout (widget, string->str);
+  pango_cairo_show_layout (cr, layout);
+  cairo_stroke (cr);
+
+  pango_layout_get_pixel_size (layout, NULL, &height);
+
+  gdk_cairo_set_source_rgba (cr, &info->color);
+  cairo_set_line_width (cr, 10);
+  cairo_move_to (cr, 0, *y);
+
+  *y = *y + height;
+  cairo_line_to (cr, 0, *y);
+  cairo_stroke (cr);
+
+  cairo_restore (cr);
+
+  g_object_unref (layout);
+  g_string_free (string, TRUE);
+}
+
+static gboolean
+draw_cb (GtkWidget *widget,
+         cairo_t   *cr,
+         gpointer   user_data)
+{
+  EventData *data = user_data;
+  GtkAllocation allocation;
+  AxesInfo *info;
+  GHashTableIter iter;
+  gpointer key, value;
+  gint y = 0;
+
+  gtk_widget_get_allocation (widget, &allocation);
+
+  /* Draw Abs info */
+  g_hash_table_iter_init (&iter, data->pointer_info);
+
+  while (g_hash_table_iter_next (&iter, NULL, &value))
+    {
+      info = value;
+      draw_axes_info (cr, info, &allocation);
+    }
+
+  g_hash_table_iter_init (&iter, data->touch_info);
+
+  while (g_hash_table_iter_next (&iter, NULL, &value))
+    {
+      info = value;
+      draw_axes_info (cr, info, &allocation);
+    }
+
+  /* Draw name, color legend and misc data */
+  g_hash_table_iter_init (&iter, data->pointer_info);
+
+  while (g_hash_table_iter_next (&iter, NULL, &value))
+    {
+      info = value;
+      draw_device_info (widget, cr, NULL, &y, info);
+    }
+
+  g_hash_table_iter_init (&iter, data->touch_info);
+
+  while (g_hash_table_iter_next (&iter, &key, &value))
+    {
+      info = value;
+      draw_device_info (widget, cr, key, &y, info);
+    }
+
+  return FALSE;
+}
+
+static void
+update_label_text (GtkWidget   *label,
+                   const gchar *text)
+{
+  gchar *markup = NULL;
+
+  if (text)
+    markup = g_strdup_printf ("<span font='48.0'>%s</span>", text);
+  gtk_label_set_markup (GTK_LABEL (label), markup);
+  g_free (markup);
+}
+
+static gboolean
+reset_label_text_timeout_cb (gpointer user_data)
+{
+  GtkWidget *label = user_data;
+
+  update_label_text (label, NULL);
+  pad_action_timeout_id = 0;
+  return G_SOURCE_REMOVE;
+}
+
+static void
+update_label_and_timeout (GtkWidget   *label,
+                          const gchar *text)
+{
+  if (pad_action_timeout_id)
+    g_source_remove (pad_action_timeout_id);
+
+  update_label_text (label, text);
+  pad_action_timeout_id = g_timeout_add (200, reset_label_text_timeout_cb, label);
+}
+
+static void
+on_action_activate (GSimpleAction *action,
+                    GVariant      *parameter,
+                    gpointer       user_data)
+{
+  GtkWidget *label = user_data;
+  const gchar *result;
+  gchar *str;
+
+  result = g_object_get_data (G_OBJECT (action), "action-result");
+
+  if (!parameter)
+    update_label_and_timeout (label, result);
+  else
+    {
+      str = g_strdup_printf ("%s %.2f", result, g_variant_get_double (parameter));
+      update_label_and_timeout (label, str);
+      g_free (str);
+    }
+}
+
+static void
+init_pad_controller (GtkWidget *window,
+                     GtkWidget *label)
+{
+  GtkPadController *pad_controller;
+  GSimpleActionGroup *action_group;
+  GSimpleAction *action;
+  gint i;
+
+  action_group = g_simple_action_group_new ();
+  pad_controller = gtk_pad_controller_new (GTK_WINDOW (window),
+                                           G_ACTION_GROUP (action_group),
+                                           NULL);
+
+  for (i = 0; i < G_N_ELEMENTS (pad_actions); i++)
+    {
+      if (pad_actions[i].type == GTK_PAD_ACTION_BUTTON)
+        {
+          action = g_simple_action_new (pad_actions[i].action_name, NULL);
+        }
+      else
+        {
+          action = g_simple_action_new_stateful (pad_actions[i].action_name,
+                                                 G_VARIANT_TYPE_DOUBLE, NULL);
+        }
+
+      g_signal_connect (action, "activate",
+                        G_CALLBACK (on_action_activate), label);
+      g_object_set_data (G_OBJECT (action), "action-result",
+                         (gpointer) pad_action_results[i]);
+      g_action_map_add_action (G_ACTION_MAP (action_group), G_ACTION (action));
+      g_object_unref (action);
+    }
+
+  gtk_pad_controller_set_action_entries (pad_controller, pad_actions,
+                                         G_N_ELEMENTS (pad_actions));
+  g_object_set_data_full (G_OBJECT (window), "pad-controller",
+                          pad_controller, g_object_unref);
+
+  g_object_unref (action_group);
+}
+
+GtkWidget *
+do_event_axes (GtkWidget *toplevel)
+{
+  static GtkWidget *window = NULL;
+  EventData *event_data;
+  GtkWidget *box, *label;
+
+  if (!window)
+    {
+      window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
+      gtk_window_set_title (GTK_WINDOW (window), "Event Axes");
+      gtk_window_set_default_size (GTK_WINDOW (window), 400, 400);
+
+      g_signal_connect (window, "destroy",
+                        G_CALLBACK (gtk_widget_destroyed), &window);
+
+      box = gtk_event_box_new ();
+      gtk_container_add (GTK_CONTAINER (window), box);
+      gtk_widget_set_support_multidevice (box, TRUE);
+      gtk_widget_add_events (box,
+			     GDK_POINTER_MOTION_MASK |
+			     GDK_BUTTON_PRESS_MASK |
+			     GDK_BUTTON_RELEASE_MASK |
+			     GDK_SMOOTH_SCROLL_MASK |
+			     GDK_ENTER_NOTIFY_MASK |
+			     GDK_LEAVE_NOTIFY_MASK |
+			     GDK_TOUCH_MASK);
+
+      event_data = event_data_new ();
+      g_object_set_data_full (G_OBJECT (box), "gtk-demo-event-data",
+                              event_data, (GDestroyNotify) event_data_free);
+
+      g_signal_connect (box, "event",
+                        G_CALLBACK (event_cb), event_data);
+      g_signal_connect (box, "draw",
+                        G_CALLBACK (draw_cb), event_data);
+
+      label = gtk_label_new ("");
+      gtk_label_set_use_markup (GTK_LABEL (label), TRUE);
+      gtk_container_add (GTK_CONTAINER (box), label);
+
+      init_pad_controller (window, label);
+    }
+
+  if (!gtk_widget_get_visible (window))
+    gtk_widget_show_all (window);
+  else
+    gtk_widget_destroy (window);
+
+  return window;
+}
+
+
+
+
+
+static void
+activate (GtkApplication* app,
+          gpointer        user_data)
+{
+  GtkWidget *window;
+
+  window = gtk_application_window_new (app);
+  gtk_window_set_title (GTK_WINDOW (window), "Window");
+  gtk_window_set_default_size (GTK_WINDOW (window), 200, 200);
+  gtk_widget_show_all (window);
+
+
+do_event_axes(window);
+}
+
+int
+main (int    argc,
+      char **argv)
+{
+  GtkApplication *app;
+  int status;
+
+  app = gtk_application_new ("org.gtk.example", G_APPLICATION_FLAGS_NONE);
+  g_signal_connect (app, "activate", G_CALLBACK (activate), NULL);
+  status = g_application_run (G_APPLICATION (app), argc, argv);
+  g_object_unref (app);
+
+  return status;
+}
+
+
+
+
+
+
+

--- a/src/gui/widgets/XournalWidget.cpp
+++ b/src/gui/widgets/XournalWidget.cpp
@@ -119,10 +119,11 @@ GtkWidget* gtk_xournal_new(XournalView* view, GtkScrollable* parent)
 	{
 		xoj->input = new DirectAxisInputDevice(GTK_WIDGET(xoj), view);
 	}
-	else if (selectedInputType == "03-gtk")
-	{
-		xoj->input = new NewGtkInputDevice(GTK_WIDGET(xoj), view);
-	}
+	// Not working yet, work in progress
+//	else if (selectedInputType == "03-gtk")
+//	{
+//		xoj->input = new NewGtkInputDevice(GTK_WIDGET(xoj), view);
+//	}
 	else // selectedInputType == "auto"
 	{
 		// No autodection performed yet, need some infos from users

--- a/src/gui/widgets/XournalWidget.cpp
+++ b/src/gui/widgets/XournalWidget.cpp
@@ -114,8 +114,23 @@ GtkWidget* gtk_xournal_new(XournalView* view, GtkScrollable* parent)
 	xoj->selection = NULL;
 	xoj->shiftDown = false;
 
-	// TODO Here the correct instance needs to be created
-	xoj->input = new BaseInputDevice(GTK_WIDGET(xoj), view);
+	Settings* settings = view->getControl()->getSettings();
+
+	SElement& inputSettings = settings->getCustomElement("inputHandling");
+
+	string selectedInputType;
+	inputSettings.getString("type", selectedInputType);
+
+	if (selectedInputType == "auto")
+	{
+		// TODO Options not yet finished
+		xoj->input = new BaseInputDevice(GTK_WIDGET(xoj), view);
+	}
+	else // selectedInputType == "auto"
+	{
+		xoj->input = new BaseInputDevice(GTK_WIDGET(xoj), view);
+	}
+	xoj->input->initWidget();
 
 	return GTK_WIDGET(xoj);
 }
@@ -591,8 +606,6 @@ static void gtk_xournal_init(GtkXournal* xournal)
 	GtkWidget* widget = GTK_WIDGET(xournal);
 
 	gtk_widget_set_can_focus(widget, TRUE);
-
-	xournal->input->initWidget();
 }
 
 static void

--- a/src/gui/widgets/XournalWidget.cpp
+++ b/src/gui/widgets/XournalWidget.cpp
@@ -7,6 +7,8 @@
 #include "gui/Cursor.h"
 #include "gui/Layout.h"
 #include "gui/inputdevices/BaseInputDevice.h"
+#include "gui/inputdevices/DirectAxisInputDevice.h"
+#include "gui/inputdevices/NewGtkInputDevice.h"
 #include "gui/pageposition/PagePositionCache.h"
 #include "gui/pageposition/PagePositionHandler.h"
 #include "gui/Shadow.h"
@@ -121,15 +123,24 @@ GtkWidget* gtk_xournal_new(XournalView* view, GtkScrollable* parent)
 	string selectedInputType;
 	inputSettings.getString("type", selectedInputType);
 
-	if (selectedInputType == "auto")
+	if (selectedInputType == "01-gtk")
 	{
-		// TODO Options not yet finished
 		xoj->input = new BaseInputDevice(GTK_WIDGET(xoj), view);
+	}
+	else if (selectedInputType == "02-direct")
+	{
+		xoj->input = new DirectAxisInputDevice(GTK_WIDGET(xoj), view);
+	}
+	else if (selectedInputType == "03-gtk")
+	{
+		xoj->input = new NewGtkInputDevice(GTK_WIDGET(xoj), view);
 	}
 	else // selectedInputType == "auto"
 	{
-		xoj->input = new BaseInputDevice(GTK_WIDGET(xoj), view);
+		// TODO No autodection performed yet
+		xoj->input = new DirectAxisInputDevice(GTK_WIDGET(xoj), view);
 	}
+
 	xoj->input->initWidget();
 
 	return GTK_WIDGET(xoj);

--- a/src/gui/widgets/XournalWidget.h
+++ b/src/gui/widgets/XournalWidget.h
@@ -19,6 +19,7 @@ G_BEGIN_DECLS
 #define GTK_XOURNAL_CLASS(klass) GTK_CHECK_CLASS_CAST(klass, gtk_xournal_get_type(), GtkXournalClass)
 #define GTK_IS_XOURNAL(obj) G_TYPE_CHECK_INSTANCE_TYPE(obj, gtk_xournal_get_type())
 
+class BaseInputDevice;
 class EditSelection;
 class Layout;
 class XojPageView;
@@ -70,6 +71,11 @@ struct _GtkXournal
 	 * Shift is currently pressed
 	 */
 	bool shiftDown = false;
+
+	/**
+	 * Input handling
+	 */
+	BaseInputDevice* input;
 };
 
 struct _GtkXournalClass

--- a/src/gui/widgets/XournalWidget.h
+++ b/src/gui/widgets/XournalWidget.h
@@ -19,7 +19,7 @@ G_BEGIN_DECLS
 #define GTK_XOURNAL_CLASS(klass) GTK_CHECK_CLASS_CAST(klass, gtk_xournal_get_type(), GtkXournalClass)
 #define GTK_IS_XOURNAL(obj) G_TYPE_CHECK_INSTANCE_TYPE(obj, gtk_xournal_get_type())
 
-class BaseInputDevice;
+class AbstractInputDevice;
 class EditSelection;
 class Layout;
 class XojPageView;
@@ -75,7 +75,7 @@ struct _GtkXournal
 	/**
 	 * Input handling
 	 */
-	BaseInputDevice* input;
+	AbstractInputDevice* input;
 };
 
 struct _GtkXournalClass

--- a/src/util/XournalTypeList.h
+++ b/src/util/XournalTypeList.h
@@ -257,5 +257,7 @@ XOJ_DECLARE_TYPE(PopplerGlibPage, 245);
 XOJ_DECLARE_TYPE(PopplerGlibPageBookmarkIterator, 246);
 XOJ_DECLARE_TYPE(PopplerGlibAction, 247);
 XOJ_DECLARE_TYPE(XojCairoPdfExport, 248);
-
+XOJ_DECLARE_TYPE(BaseInputDevice, 249);
+XOJ_DECLARE_TYPE(X11InputFixInputDevice, 250);
+XOJ_DECLARE_TYPE(WinapiInputDevice, 251);
 

--- a/src/util/XournalTypeList.h
+++ b/src/util/XournalTypeList.h
@@ -258,6 +258,7 @@ XOJ_DECLARE_TYPE(PopplerGlibPageBookmarkIterator, 246);
 XOJ_DECLARE_TYPE(PopplerGlibAction, 247);
 XOJ_DECLARE_TYPE(XojCairoPdfExport, 248);
 XOJ_DECLARE_TYPE(BaseInputDevice, 249);
-XOJ_DECLARE_TYPE(X11InputFixInputDevice, 250);
-XOJ_DECLARE_TYPE(WinapiInputDevice, 251);
+XOJ_DECLARE_TYPE(AbstractInputDevice, 250);
+XOJ_DECLARE_TYPE(DirectAxisInputDevice, 251);
+XOJ_DECLARE_TYPE(NewGtkInputDevice, 252);
 

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -75,7 +75,6 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="show_border">False</property>
-            <property name="scrollable">True</property>
             <child>
               <object class="GtkBox" id="box17">
                 <property name="visible">True</property>

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -75,6 +75,7 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="show_border">False</property>
+            <property name="scrollable">True</property>
             <child>
               <object class="GtkBox" id="box17">
                 <property name="visible">True</property>
@@ -1054,6 +1055,70 @@ Here you can disable your touchscreen.&lt;/i&gt;</property>
               </packing>
             </child>
             <child>
+              <object class="GtkBox" id="box5">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">10</property>
+                <child>
+                  <object class="GtkLabel" id="label49">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">&lt;i&gt;To best support all system Xournal++ allows to do some export configurations.
+Usually you should set the Input Handling to &lt;b&gt;Auto&lt;/b&gt;.
+If there are problems / crashes on drawing, try the other methods.&lt;/i&gt;</property>
+                    <property name="use_markup">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkComboBoxText" id="cbSelectInputType">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkAspectFrame" id="aspectframe1">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label_xalign">0</property>
+                    <property name="shadow_type">none</property>
+                    <child>
+                      <placeholder/>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="position">5</property>
+              </packing>
+            </child>
+            <child type="tab">
+              <object class="GtkLabel" id="label48">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Advanced Input Handling</property>
+              </object>
+              <packing>
+                <property name="position">5</property>
+                <property name="tab_fill">False</property>
+              </packing>
+            </child>
+            <child>
               <object class="GtkBox" id="vbox5">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
@@ -1537,7 +1602,7 @@ Here you can disable your touchscreen.&lt;/i&gt;</property>
                 </child>
               </object>
               <packing>
-                <property name="position">5</property>
+                <property name="position">6</property>
               </packing>
             </child>
             <child type="tab">
@@ -1547,7 +1612,7 @@ Here you can disable your touchscreen.&lt;/i&gt;</property>
                 <property name="label" translatable="yes">View</property>
               </object>
               <packing>
-                <property name="position">5</property>
+                <property name="position">6</property>
                 <property name="tab_fill">False</property>
               </packing>
             </child>
@@ -1623,7 +1688,7 @@ Here you can disable your touchscreen.&lt;/i&gt;</property>
                 </child>
               </object>
               <packing>
-                <property name="position">6</property>
+                <property name="position">7</property>
               </packing>
             </child>
             <child type="tab">
@@ -1633,7 +1698,7 @@ Here you can disable your touchscreen.&lt;/i&gt;</property>
                 <property name="label" translatable="yes">Defaults</property>
               </object>
               <packing>
-                <property name="position">6</property>
+                <property name="position">7</property>
                 <property name="tab_fill">False</property>
               </packing>
             </child>
@@ -1698,7 +1763,7 @@ The Audio track is recorded to a separate folder, and liked to there.&lt;/i&gt;<
                 </child>
               </object>
               <packing>
-                <property name="position">7</property>
+                <property name="position">8</property>
               </packing>
             </child>
             <child type="tab">
@@ -1708,7 +1773,7 @@ The Audio track is recorded to a separate folder, and liked to there.&lt;/i&gt;<
                 <property name="label" translatable="yes">Audio Recording</property>
               </object>
               <packing>
-                <property name="position">7</property>
+                <property name="position">8</property>
                 <property name="tab_fill">False</property>
               </packing>
             </child>

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -236,6 +236,20 @@ If there are problems / crashes on drawing, try the other methods.&lt;/i&gt;</pr
                             <property name="position">7</property>
                           </packing>
                         </child>
+                        <child>
+                          <object class="GtkLabel" id="label48">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">&lt;i&gt;Restart after chnage&lt;/i&gt;</property>
+                            <property name="use_markup">True</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">8</property>
+                          </packing>
+                        </child>
                       </object>
                       <packing>
                         <property name="expand">True</property>

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -81,6 +81,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="orientation">vertical</property>
+                <property name="spacing">10</property>
                 <child>
                   <object class="GtkLabel" id="label27">
                     <property name="visible">True</property>
@@ -104,6 +105,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="orientation">vertical</property>
+                        <property name="spacing">5</property>
                         <child>
                           <object class="GtkLabel" id="labeXInput">
                             <property name="visible">True</property>
@@ -193,6 +195,47 @@ when drawn too fast&lt;/i&gt;</property>
                             <property name="position">4</property>
                           </packing>
                         </child>
+                        <child>
+                          <object class="GtkLabel" id="label50">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">&lt;b&gt;Input handling&lt;/b&gt;</property>
+                            <property name="use_markup">True</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">5</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkComboBoxText" id="cbSelectInputType">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">6</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label49">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">&lt;i&gt;To best support all system Xournal++ allows to do some export configurations.
+Usually you should set the Input Handling to &lt;b&gt;Auto&lt;/b&gt;.
+If there are problems / crashes on drawing, try the other methods.&lt;/i&gt;</property>
+                            <property name="use_markup">True</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">7</property>
+                          </packing>
+                        </child>
                       </object>
                       <packing>
                         <property name="expand">True</property>
@@ -221,7 +264,7 @@ when drawn too fast&lt;/i&gt;</property>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
                     <property name="padding">10</property>
-                    <property name="position">2</property>
+                    <property name="position">5</property>
                   </packing>
                 </child>
                 <child>
@@ -308,7 +351,7 @@ like to work on&lt;/i&gt;</property>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="position">3</property>
+                    <property name="position">6</property>
                   </packing>
                 </child>
               </object>
@@ -1055,70 +1098,6 @@ Here you can disable your touchscreen.&lt;/i&gt;</property>
               </packing>
             </child>
             <child>
-              <object class="GtkBox" id="box5">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="orientation">vertical</property>
-                <property name="spacing">10</property>
-                <child>
-                  <object class="GtkLabel" id="label49">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">&lt;i&gt;To best support all system Xournal++ allows to do some export configurations.
-Usually you should set the Input Handling to &lt;b&gt;Auto&lt;/b&gt;.
-If there are problems / crashes on drawing, try the other methods.&lt;/i&gt;</property>
-                    <property name="use_markup">True</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkComboBoxText" id="cbSelectInputType">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkAspectFrame" id="aspectframe1">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label_xalign">0</property>
-                    <property name="shadow_type">none</property>
-                    <child>
-                      <placeholder/>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">2</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="position">5</property>
-              </packing>
-            </child>
-            <child type="tab">
-              <object class="GtkLabel" id="label48">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Advanced Input Handling</property>
-              </object>
-              <packing>
-                <property name="position">5</property>
-                <property name="tab_fill">False</property>
-              </packing>
-            </child>
-            <child>
               <object class="GtkBox" id="vbox5">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
@@ -1602,7 +1581,7 @@ If there are problems / crashes on drawing, try the other methods.&lt;/i&gt;</pr
                 </child>
               </object>
               <packing>
-                <property name="position">6</property>
+                <property name="position">5</property>
               </packing>
             </child>
             <child type="tab">
@@ -1612,7 +1591,7 @@ If there are problems / crashes on drawing, try the other methods.&lt;/i&gt;</pr
                 <property name="label" translatable="yes">View</property>
               </object>
               <packing>
-                <property name="position">6</property>
+                <property name="position">5</property>
                 <property name="tab_fill">False</property>
               </packing>
             </child>
@@ -1688,7 +1667,7 @@ If there are problems / crashes on drawing, try the other methods.&lt;/i&gt;</pr
                 </child>
               </object>
               <packing>
-                <property name="position">7</property>
+                <property name="position">6</property>
               </packing>
             </child>
             <child type="tab">
@@ -1698,7 +1677,7 @@ If there are problems / crashes on drawing, try the other methods.&lt;/i&gt;</pr
                 <property name="label" translatable="yes">Defaults</property>
               </object>
               <packing>
-                <property name="position">7</property>
+                <property name="position">6</property>
                 <property name="tab_fill">False</property>
               </packing>
             </child>
@@ -1763,7 +1742,7 @@ The Audio track is recorded to a separate folder, and liked to there.&lt;/i&gt;<
                 </child>
               </object>
               <packing>
-                <property name="position">8</property>
+                <property name="position">7</property>
               </packing>
             </child>
             <child type="tab">
@@ -1773,7 +1752,7 @@ The Audio track is recorded to a separate folder, and liked to there.&lt;/i&gt;<
                 <property name="label" translatable="yes">Audio Recording</property>
               </object>
               <packing>
-                <property name="position">8</property>
+                <property name="position">7</property>
                 <property name="tab_fill">False</property>
               </packing>
             </child>


### PR DESCRIPTION
Moved input handling to a Strategy pattern, currently there are two methods available: the X11 crash fix, and the standard GTK input as it was on GTK2.

Planed is to handle all like in the GTK3 example, but this is a really big change, so need to merge even if the new features are not implemented. 