### PR TITLE
added vlc recording backend

### DIFF
--- a/utility/usr/local/bin/xopp-recording.sh
+++ b/utility/usr/local/bin/xopp-recording.sh
@@ -18,13 +18,13 @@ then
         amixer sset 'Capture' ${vol}%
         amixer sset 'Master' 0%
 	dst="${directory}${filename}"
-        #arecord -f cd -t wav |lame --preset 56 -mm - "$dst" &
-	cvlc alsa://default --sout "#transcode{acodec=mp3,ab=128,channels=2, samplerate=44100}:duplicate{dst=std{access=file,mux=mp3,dst=\"$dst\"}}}" &
+        arecord -f cd -t wav |lame --preset 56 -mm - "$dst" &
+	#cvlc alsa://default --sout "#transcode{acodec=mp3,ab=128,channels=2, samplerate=44100}:duplicate{dst=std{access=file,mux=mp3,dst=\"$dst\"}}}" &
 
 elif [[ $1 == "stop" ]]
 then
-        #pkill -f "arecord" && notify-send "Recording stopped"
-	killall vlc && notify-send "Recording stopped"
+        pkill -f "arecord" && notify-send "Recording stopped"
+	#killall vlc && notify-send "Recording stopped"
 fi
 
 

--- a/utility/usr/local/bin/xopp-recording.sh
+++ b/utility/usr/local/bin/xopp-recording.sh
@@ -17,10 +17,14 @@ then
         notify-send "Recording started with ${vol}% gain"
         amixer sset 'Capture' ${vol}%
         amixer sset 'Master' 0%
-        arecord -f cd -t wav |lame --preset 56 -mm - "$directory""$filename" &
+	dst="${directory}${filename}"
+        #arecord -f cd -t wav |lame --preset 56 -mm - "$dst" &
+	cvlc alsa://default --sout "#transcode{acodec=mp3,ab=128,channels=2, samplerate=44100}:duplicate{dst=std{access=file,mux=mp3,dst=\"$dst\"}}}" &
+
 elif [[ $1 == "stop" ]]
 then
-        pkill -f "arecord" && notify-send "Recording stopped"
+        #pkill -f "arecord" && notify-send "Recording stopped"
+	killall vlc && notify-send "Recording stopped"
 fi
 
 


### PR DESCRIPTION
Future plans are to:
- do not relay on `arecord` anymore (not multiplatform)
- get rid completely of `xopp-recording.sh` script (for the same reason)
- use vlc backend for cross-platform audio recording