### PR TITLE
Fixed some make warnings

### DIFF
--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -871,7 +871,7 @@ void Control::help()
 {
 	GError* error = NULL;
 
-	gtk_show_uri(gtk_window_get_screen(getGtkWindow()), XOJ_HELP, gtk_get_current_event_time(), &error);
+	gtk_show_uri_on_window(getGtkWindow(), XOJ_HELP, gtk_get_current_event_time(), &error);
 	if (error)
 	{
 

--- a/src/gui/dialog/PageTemplateDialog.cpp
+++ b/src/gui/dialog/PageTemplateDialog.cpp
@@ -17,64 +17,6 @@ static void menu_detacher(GtkWidget* widget, GtkMenu* menu)
 {
 	// Nothing to do
 }
-// See gtkmenutooltogglebutton.cpp
-static void menu_position_func(GtkMenu* menu, int* x, int* y, gboolean* push_in, GtkWidget* widget)
-{
-	GtkRequisition minimum_size;
-	GtkRequisition menu_req;
-	gtk_widget_get_preferred_size(GTK_WIDGET(menu), &minimum_size, &menu_req);
-
-	GtkTextDirection direction = gtk_widget_get_direction(widget);
-
-	GdkScreen* screen = gtk_widget_get_screen(GTK_WIDGET (menu));
-
-	gint monitor_num = gdk_screen_get_monitor_at_window(screen, gtk_widget_get_window(widget));
-
-	if (monitor_num < 0)
-	{
-		monitor_num = 0;
-	}
-	GdkRectangle monitor;
-	gdk_screen_get_monitor_geometry(screen, monitor_num, &monitor);
-
-	GtkAllocation arrow_allocation;
-	gtk_widget_get_allocation(widget, &arrow_allocation);
-
-	GtkAllocation allocation;
-	gtk_widget_get_allocation(widget, &allocation);
-
-	gdk_window_get_origin(gtk_widget_get_window(widget), x, y);
-	*x += allocation.x;
-	*y += allocation.y;
-
-	if (direction == GTK_TEXT_DIR_LTR)
-	{
-		*x += MAX(allocation.width - menu_req.width, 0);
-	}
-	else if (menu_req.width > allocation.width)
-	{
-		*x -= menu_req.width - allocation.width;
-	}
-
-	if ((*y + arrow_allocation.height + menu_req.height) <= monitor.y + monitor.height)
-	{
-		*y += arrow_allocation.height;
-	}
-	else if ((*y - menu_req.height) >= monitor.y)
-	{
-		*y -= menu_req.height;
-	}
-	else if (monitor.y + monitor.height - (*y + arrow_allocation.height) > *y)
-	{
-		*y += arrow_allocation.height;
-	}
-	else
-	{
-		*y -= menu_req.height;
-	}
-
-	*push_in = FALSE;
-}
 
 PageTemplateDialog::PageTemplateDialog(GladeSearchpath* gladeSearchPath, Settings* settings, PageTypeHandler* types)
  : GladeGui(gladeSearchPath, "pageTemplate.glade", "templateDialog"),
@@ -115,12 +57,10 @@ PageTemplateDialog::PageTemplateDialog(GladeSearchpath* gladeSearchPath, Setting
 			XOJ_CHECK_TYPE_OBJ(self, PageTemplateDialog);
 			GtkWidget* menu = self->pageMenu->getMenu();
 
-			gtk_menu_popup(GTK_MENU(menu), NULL, NULL, (GtkMenuPositionFunc) menu_position_func,
-			               button, 0, gtk_get_current_event_time());
+			// GTK 3.22: 
+			gtk_menu_popup_at_widget(GTK_MENU(menu), GTK_WIDGET(button), GDK_GRAVITY_SOUTH_WEST, GDK_GRAVITY_NORTH_WEST, NULL);
 
 			gtk_menu_shell_select_first(GTK_MENU_SHELL(menu), FALSE);
-
-			// GTK 3.22: gtk_menu_popup_at_widget(menu, button, GDK_GRAVITY_SOUTH_WEST, GDK_GRAVITY_NORTH_WEST, NULL);
 
 		}), this);
 


### PR DESCRIPTION
Hi! 
I fixed some compilation warnings generated from deprecated methods. I also switched from `gtk_menu_popup` to `gtk_menu_popup_at_widget` because of the cleaner code and because I saw that only Ubuntu 16.X and earlier doesn't support GTK 3.22, so I thought this could be a good improvement! What do you think? 