### PR TITLE
DO NOT MERGE - Stroke recognizer width

### DIFF
--- a/src/model/Stroke.cpp
+++ b/src/model/Stroke.cpp
@@ -54,7 +54,7 @@ void Stroke::applyStyleFrom(const Stroke* other)
 {
 	setColor(other->getColor());
 	setToolType(other->getToolType());
-	setWidth(other->getWidth());
+	setWidth(other->hasPressure() ? other->getAvgPressure() : other->getWidth());
 	setAudioFilename(other->getAudioFilename());
 	setTimestamp(other->getTimestamp());
 	setFill(other->getFill());
@@ -459,7 +459,7 @@ void Stroke::scale(double x0, double y0, double fx, double fy)
 	this->sizeCalculated = false;
 }
 
-bool Stroke::hasPressure()
+bool Stroke::hasPressure() const
 {
 	XOJ_CHECK_TYPE(Stroke);
 
@@ -468,6 +468,17 @@ bool Stroke::hasPressure()
 		return this->points[0].z != Point::NO_PRESURE;
 	}
 	return false;
+}
+
+double Stroke::getAvgPressure() const
+{
+	XOJ_CHECK_TYPE(Stroke);
+	double summatory = 0;
+	for (int i = 0; i < this->pointCount; i++)
+	{
+		summatory += this->points[i].z;
+	}
+	return summatory / this->pointCount;
 }
 
 void Stroke::scalePressure(double factor)

--- a/src/model/Stroke.h
+++ b/src/model/Stroke.h
@@ -95,8 +95,9 @@ public:
 	void setLastPressure(double pressure);
 	void clearPressure();
 	void scalePressure(double factor);
-
-	bool hasPressure();
+	
+	bool hasPressure() const;
+	double getAvgPressure() const;
 
 	virtual void move(double dx, double dy);
 	virtual void scale(double x0, double y0, double fx, double fy);


### PR DESCRIPTION
Hi! 
I think this could be a fix to #713 , but since I don't have a teblet to try this on yet, I'd like to ask you if this could be a solution and if not, which are the consequences.
If you could test this "fix" that would be perfect, even if I think this could mess up other things which don't involve Shape Recognition