### PR TITLE
Highlight cursor position - added

### DIFF
--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: xournalpp 1.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-12-30 12:21+0100\n"
+"POT-Creation-Date: 2019-01-23 10:36+0100\n"
 "PO-Revision-Date: 2017-09-18 09:58+0200\n"
 "Last-Translator: Jan Hrdina <jan.hrdka@gmail.com>\n"
 "Language-Team: čeština <>\n"
@@ -20,41 +20,41 @@ msgstr ""
 "X-Source-Language: C\n"
 "X-Generator: Poedit 2.0.3\n"
 
-#: ../src/undo/DeleteUndoAction.cpp:113 ../src/undo/AddUndoAction.cpp:119
+#: ../src/undo/AddUndoAction.cpp:119 ../src/undo/DeleteUndoAction.cpp:113
 msgid " elements"
 msgstr " prvky"
 
-#: ../src/undo/DeleteUndoAction.cpp:128 ../src/undo/AddUndoAction.cpp:134
+#: ../src/undo/AddUndoAction.cpp:134 ../src/undo/DeleteUndoAction.cpp:128
 msgid " image"
 msgstr " obrázek"
 
-#: ../src/undo/DeleteUndoAction.cpp:132 ../src/undo/AddUndoAction.cpp:138
+#: ../src/undo/AddUndoAction.cpp:138 ../src/undo/DeleteUndoAction.cpp:132
 msgid " latex"
 msgstr " latex"
 
-#: ../src/gui/MainWindow.cpp:734
+#: ../src/gui/MainWindow.cpp:818
 msgctxt "Page {pagenumber} \"of {pagecount}\""
 msgid " of {1}{2}"
 msgstr " z {1}{2}"
 
-#: ../src/undo/DeleteUndoAction.cpp:120 ../src/undo/AddUndoAction.cpp:126
+#: ../src/undo/AddUndoAction.cpp:126 ../src/undo/DeleteUndoAction.cpp:120
 msgid " stroke"
 msgstr " čáru"
 
-#: ../src/undo/DeleteUndoAction.cpp:124 ../src/undo/AddUndoAction.cpp:130
+#: ../src/undo/AddUndoAction.cpp:130 ../src/undo/DeleteUndoAction.cpp:124
 msgid " text"
 msgstr " text"
 
-#: ../src/control/settings/Settings.cpp:79
+#: ../src/control/settings/Settings.cpp:90
 #, fuzzy
 msgid "%F-Note-%H-%M"
 msgstr "%F-Poznámka-%H-%M.xoj"
 
-#: ../ui/settings.glade:590
+#: ../ui/settings.glade:604
 msgid "%F-Note-%H-%M.xoj"
 msgstr "%F-Poznámka-%H-%M.xoj"
 
-#: ../ui/settings.glade:613
+#: ../ui/settings.glade:627
 msgid ""
 "%a\tAbbreviated weekday name \t(e.g. Thu)\n"
 "%A\tFull weekday name (e.g. Thursday)\n"
@@ -106,19 +106,19 @@ msgstr ""
 msgid "<b>... or select already used Image:</b>"
 msgstr "<b>… nebo vyberte již použitý obrázek:</b>"
 
-#: ../ui/settings.glade:271
+#: ../ui/settings.glade:285
 msgid "<b>Add horizontal space</b>"
 msgstr "<b>Přidat horizontální místo</b>"
 
-#: ../ui/settings.glade:248
+#: ../ui/settings.glade:262
 msgid "<b>Add vertical space</b>"
 msgstr "<b>Přidat vertikální místo</b>"
 
-#: ../ui/settings.glade:704
+#: ../ui/settings.glade:718
 msgid "<b>Autoload .pdf.xoj</b>"
 msgstr "<b>Automaticky načíst .pdf.xoj</b>"
 
-#: ../ui/settings.glade:488
+#: ../ui/settings.glade:502
 msgid ""
 "<b>Autosave Folder</b>\n"
 "<i>If the document already was saved you can find it in the same folder\n"
@@ -132,7 +132,7 @@ msgstr ""
 "Pokud soubor nebyl uložen, najdete jej ve vašem domovském adresáři\n"
 "v ~/.xournalpp/autosave</i>"
 
-#: ../ui/settings.glade:428
+#: ../ui/settings.glade:442
 msgid "<b>Autosave</b>"
 msgstr "<b>Automatické ukládání</b>"
 
@@ -150,7 +150,7 @@ msgstr "Pozadí"
 msgid "<b>Color</b>"
 msgstr "<b>Barva</b>"
 
-#: ../ui/settings.glade:1464
+#: ../ui/settings.glade:1521
 #, fuzzy
 msgid "<b>Colors</b>"
 msgstr "<b>Barva</b>"
@@ -168,7 +168,7 @@ msgid ""
 "for the fist Page"
 msgstr ""
 
-#: ../ui/settings.glade:1835
+#: ../ui/settings.glade:1907
 msgid "<b>Cursor</b>"
 msgstr "<b>Kurzor</b>"
 
@@ -176,15 +176,15 @@ msgstr "<b>Kurzor</b>"
 msgid "<b>Default Tools</b>"
 msgstr "<b>Výchozí nástroje</b>"
 
-#: ../ui/settings.glade:577
+#: ../ui/settings.glade:591
 msgid "<b>Default name:</b>"
 msgstr "<b>Výchozí název:</b>"
 
-#: ../ui/settings.glade:524
+#: ../ui/settings.glade:538
 msgid "<b>Default save name</b>"
 msgstr "<b>Výchozí název uložení</b>"
 
-#: ../ui/settings.glade:1943
+#: ../ui/settings.glade:2030
 msgid "<b>Default</b>"
 msgstr "<b>Výchozí</b>"
 
@@ -194,11 +194,11 @@ msgid ""
 "Select pages to export"
 msgstr ""
 
-#: ../ui/settings.glade:1002
+#: ../ui/settings.glade:1016
 msgid "<b>Eraser</b>"
 msgstr "<b>Guma</b>"
 
-#: ../ui/settings.glade:110
+#: ../ui/settings.glade:124
 msgid "<b>Extended Input</b>"
 msgstr "<b>Rozšířený vstup</b>"
 
@@ -208,19 +208,19 @@ msgid ""
 "Select transparency for fill color"
 msgstr ""
 
-#: ../ui/settings.glade:1661
+#: ../ui/settings.glade:1733
 msgid "<b>Fullscreen</b>"
 msgstr "<b>Celá obrazovka</b>"
 
-#: ../ui/settings.glade:658
+#: ../ui/settings.glade:672
 msgid "<b>Help</b> (Placeholders)"
 msgstr "<b>Nápověda</b> (zástupné symboly)"
 
-#: ../ui/settings.glade:1390
+#: ../ui/settings.glade:1447
 msgid "<b>Left / Right</b>"
 msgstr "<b>Levá / Pravá</b>"
 
-#: ../ui/settings.glade:819
+#: ../ui/settings.glade:833
 msgid "<b>Middle Mouse Button</b>"
 msgstr "<b>Prostřední tlačítko myši</b>"
 
@@ -233,25 +233,25 @@ msgstr "<b>Velikost stránky</b>"
 msgid "<b>Pagesize</b>"
 msgstr "<b>Velikost stránky</b>"
 
-#: ../ui/settings.glade:1731
+#: ../ui/settings.glade:1803
 msgid "<b>Presentation</b> Another Fullscreen Mode, <i>Start with F5</i>"
 msgstr ""
 "<b>Prezentace</b> Další režim pro celou obrazovku, <i>spusťte klávesou F5</i>"
 
-#: ../ui/settings.glade:155
+#: ../ui/settings.glade:169
 msgid "<b>Pressure sensitivity</b>"
 msgstr "<b>Citlivost na tlak</b>"
 
-#: ../ui/settings.glade:849
+#: ../ui/settings.glade:863
 msgid "<b>Right Mouse Button</b>"
 msgstr "<b>Pravé tlačítko myši</b>"
 
-#: ../ui/settings.glade:1584
+#: ../ui/settings.glade:1656
 #, fuzzy
 msgid "<b>Scrollbars</b>"
 msgstr "<b>Barva</b>"
 
-#: ../ui/settings.glade:200
+#: ../ui/settings.glade:214
 msgid "<b>Scrolling outside the page</b>"
 msgstr "<b>Posouvání mimo stránku</b>"
 
@@ -259,15 +259,15 @@ msgstr "<b>Posouvání mimo stránku</b>"
 msgid "<b>Separator</b>"
 msgstr "<b>Oddělovač</b>"
 
-#: ../ui/settings.glade:944
+#: ../ui/settings.glade:958
 msgid "<b>Stylus Button 1</b> Action if the pen button is pressed"
 msgstr ""
 
-#: ../ui/settings.glade:973
+#: ../ui/settings.glade:987
 msgid "<b>Stylus Button 2</b> Action if the pen button is pressed"
 msgstr ""
 
-#: ../ui/settings.glade:1031
+#: ../ui/settings.glade:1045
 msgid ""
 "<b>Touch Screen</b> <i>You can also configure other devices like mice</i>"
 msgstr ""
@@ -277,7 +277,7 @@ msgstr ""
 msgid "<i>Example:</i> 1-3 or 1,3,5-7 etc."
 msgstr "<i>Příklad:</i> 1-3 nebo 1,3,5-7 atd."
 
-#: ../ui/settings.glade:929
+#: ../ui/settings.glade:943
 msgid ""
 "<i>Here you can define which tools will be selected If you\n"
 "use the eraser or other device.\n"
@@ -287,7 +287,7 @@ msgstr ""
 "použijete gumu na vašem peru nebo jiné zařízení.\n"
 "Můžete zde také zakázat dotykovou obrazovku.</i>"
 
-#: ../ui/settings.glade:804
+#: ../ui/settings.glade:818
 msgid ""
 "<i>Here you can define which tools will be selected if you press\n"
 "a button; after you release the button the previously selected\n"
@@ -297,14 +297,14 @@ msgstr ""
 "jednotlivých tlačítek. Po uvolnění tlačítka bude vybrán\n"
 "nástroj předchozí.</i>"
 
-#: ../ui/settings.glade:2030
+#: ../ui/settings.glade:2188
 msgid ""
 "<i>If audio recording is running, the time stamps are stored to the "
 "handwritten Text and can be replayed.\n"
 "The Audio track is recorded to a separate folder, and liked to there.</i>"
 msgstr ""
 
-#: ../ui/settings.glade:224
+#: ../ui/settings.glade:238
 msgid ""
 "<i>If you add <b>additional space</b> beside the pages\n"
 "you can choose the area of the screen you would\n"
@@ -313,12 +313,12 @@ msgstr ""
 "<i>Když přidáte kolem stránky <b>místo navíc</b>,\n"
 "můžete si stránku posunout do jaké části obrazovky chcete.</i>"
 
-#: ../ui/settings.glade:170
+#: ../ui/settings.glade:184
 msgid "<i>If you have a tablet pen you can get different line widths</i>"
 msgstr ""
 "<i>Jestliže máte tabletové pero, můžete psát různými tloušťkami čar.</i>"
 
-#: ../ui/settings.glade:728
+#: ../ui/settings.glade:742
 msgid ""
 "<i>If you open a PDF and there is a\n"
 "Xournal file with the same name it will open the xoj file.</i>"
@@ -326,7 +326,7 @@ msgstr ""
 "<i>Když otevřete PDF a ve stejné složce již je soubor Xournalu\n"
 "se stejným jménem, automaticky se tento xoj soubor načte.</i>"
 
-#: ../ui/settings.glade:324
+#: ../ui/settings.glade:338
 msgid ""
 "<i>Put a ruler on your screen to calibrate the zoom level to fit your "
 "screen. Takes effect after restarting xournalpp.\n"
@@ -336,17 +336,17 @@ msgstr ""
 "obrazovky. Změna se projeví po restartu Xournal++.\n"
 "Jednotky jsou cm pro pravítko, dpi pro posuvník.</i>"
 
-#: ../ui/settings.glade:133
+#: ../ui/settings.glade:147
 msgid "<i>Select some advanced input options</i>"
 msgstr ""
 
-#: ../ui/settings.glade:1339
+#: ../ui/settings.glade:1396
 msgid ""
 "<i>The commands will be executed in the UI Thread, make sure\n"
 "they are not blocking!</i>"
 msgstr ""
 
-#: ../ui/settings.glade:548
+#: ../ui/settings.glade:562
 msgid "<i>This name will be proposed if you save a new document</i>"
 msgstr "<i>Tento název bude navržen, když uložíte nový dokument</i>"
 
@@ -362,15 +362,15 @@ msgstr ""
 msgid "About Xournal++"
 msgstr "O aplikaci Xournal++"
 
-#: ../src/control/XournalMain.cpp:245
+#: ../src/control/XournalMain.cpp:250
 msgid "Absolute path for the audio files playback"
 msgstr ""
 
-#: ../ui/main.glade:1086
+#: ../ui/main.glade:1233
 msgid "Add/Edit Tex"
 msgstr "Přidat/Upravit TeX"
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:48
+#: ../src/control/stockdlg/XojOpenDlg.cpp:51
 msgid "All files"
 msgstr "Všechny soubory"
 
@@ -389,7 +389,7 @@ msgid "Apply to current page"
 msgstr "Smazat aktuální stránku"
 
 #: ../src/control/stockdlg/ImageOpenDlg.cpp:30
-#: ../src/control/stockdlg/XojOpenDlg.cpp:147
+#: ../src/control/stockdlg/XojOpenDlg.cpp:152
 msgid "Attach file to the journal"
 msgstr "Přiložit soubor k zápisníku"
 
@@ -414,15 +414,15 @@ msgstr "Atribut „{1}“ nemohl být načten jako int, hodnota je NULL"
 msgid "Attribute color not set!"
 msgstr "Atribut color není nastaven!"
 
-#: ../ui/settings.glade:2051
+#: ../ui/settings.glade:2209
 msgid "Audio Folder"
 msgstr ""
 
-#: ../ui/settings.glade:2088
+#: ../ui/settings.glade:2246
 msgid "Audio Recording"
 msgstr ""
 
-#: ../src/control/AudioController.cpp:100
+#: ../src/control/AudioController.cpp:98
 msgid ""
 "Audio folder not set! Recording won't work!\n"
 "Please set the recording folder under \"Preferences > Audio recording\""
@@ -433,16 +433,16 @@ msgstr ""
 msgid "Authors:"
 msgstr "<b>Autoři:</b>"
 
-#: ../ui/settings.glade:1170
+#: ../ui/settings.glade:1227
 msgid "Autodetect"
 msgstr ""
 
-#: ../ui/settings.glade:456
+#: ../ui/settings.glade:470
 #, fuzzy
 msgid "Autosave every ... minutes:"
 msgstr "Automaticky ukládat každých ... minut:"
 
-#: ../src/control/Control.cpp:254
+#: ../src/control/Control.cpp:256
 #, fuzzy
 msgid "Autosave failed with an error: {1}"
 msgstr "Chyba otevírání souboru: {1}"
@@ -451,8 +451,7 @@ msgstr "Chyba otevírání souboru: {1}"
 msgid "Autosave: {1}"
 msgstr "Automatické uložení: {1}"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:333
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:336
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:429
 msgid "Back"
 msgstr "Zpět"
 
@@ -462,11 +461,11 @@ msgstr "Zpět"
 msgid "Background"
 msgstr "Pozadí"
 
-#: ../ui/settings.glade:1520
+#: ../ui/settings.glade:1577
 msgid "Background color for window Background"
 msgstr ""
 
-#: ../ui/settings.glade:1857
+#: ../ui/settings.glade:1929
 msgid "Big cursor for pen"
 msgstr "Velký kurzor pro pero"
 
@@ -480,11 +479,11 @@ msgstr "Černá"
 msgid "Blue"
 msgstr "Modrá"
 
-#: ../ui/settings.glade:1509
+#: ../ui/settings.glade:1566
 msgid "Border color"
 msgstr "Barva okraje"
 
-#: ../ui/settings.glade:1495
+#: ../ui/settings.glade:1552
 #, fuzzy
 msgid "Border color for current page and other selections"
 msgstr "Barva okraje pro aktuální stránku a jiné výběry"
@@ -493,8 +492,8 @@ msgstr "Barva okraje pro aktuální stránku a jiné výběry"
 msgid "Built on:"
 msgstr ""
 
-#: ../src/control/Control.cpp:2022 ../src/control/Control.cpp:2534
-#: ../src/control/Control.cpp:2570 ../src/control/XournalMain.cpp:124
+#: ../src/control/Control.cpp:2058 ../src/control/Control.cpp:2581
+#: ../src/control/Control.cpp:2619 ../src/control/XournalMain.cpp:128
 msgid "Cancel"
 msgstr "Zrušit"
 
@@ -511,7 +510,7 @@ msgstr "Změnit písmo"
 msgid "Change stroke fill"
 msgstr "Změnit tloušťku čáry"
 
-#: ../src/undo/SizeUndoAction.cpp:145
+#: ../src/undo/SizeUndoAction.cpp:139
 msgid "Change stroke width"
 msgstr "Změnit tloušťku čáry"
 
@@ -519,7 +518,7 @@ msgstr "Změnit tloušťku čáry"
 msgid "Color \"{1}\" unknown (not defined in default color list)!"
 msgstr "Neznámá barva „{1}“ (nedefinovaná ve výchozím seznamu barev)!"
 
-#: ../ui/main.glade:588
+#: ../ui/main.glade:633
 msgid "Configure Page Template"
 msgstr ""
 
@@ -527,8 +526,8 @@ msgstr ""
 msgid "Contents"
 msgstr "Obsah"
 
-#: ../src/control/Control.cpp:1036 ../src/control/Control.cpp:1044
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:321
+#: ../src/control/Control.cpp:1047 ../src/control/Control.cpp:1055
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:402
 msgid "Copy"
 msgstr "Kopírovat"
 
@@ -549,37 +548,51 @@ msgstr "Přejít na poslední stránku"
 msgid "Copy page"
 msgstr "Kopírovat stránku"
 
+#: ../src/control/LatexController.cpp:103
+msgid "Could not convert tex to PDF: {1} (exit code: {2})"
+msgstr ""
+
 #: ../src/control/jobs/SaveJob.cpp:137
 msgid ""
 "Could not create backup! (The file was created from an older Xournal version)"
 msgstr "Nelze vytvořit zálohu! (Soubor byl vytvořen ve starší verzi Xournalu)"
 
-#: ../src/util/Util.cpp:97
+#: ../src/util/Util.cpp:94
 #, fuzzy
 msgid "Could not create folder: {1}"
 msgstr "Nelze otevřít soubor: „{1}“"
 
-#: ../src/control/Control.cpp:218 ../src/control/Control.cpp:235
+#: ../src/control/Control.cpp:220 ../src/control/Control.cpp:237
 #, fuzzy
 msgid "Could not delete old autosave file \"{1}\""
 msgstr "Nelze otevřít soubor: „{1}“"
 
-#: ../src/control/LatexController.cpp:381
+#: ../src/control/LatexController.cpp:428
 msgid ""
-"Could not find Xournal++ LaTeX executable relative or in Path.\n"
-"Searched for: mathtex-xournalpp.cgi"
+"Could not find pdflatex in Path.\n"
+"Please install pdflatex first and make sure it's in the Path."
 msgstr ""
+
+#: ../src/control/LatexController.cpp:299
+#, fuzzy
+msgid "Could not load LaTeX PDF file, URL-Error: {1}"
+msgstr "Nelze načíst soubor s LaTeX obrázkem: {1}"
+
+#: ../src/control/LatexController.cpp:307
+#, fuzzy
+msgid "Could not load LaTeX PDF file: {1}"
+msgstr "Nelze otevřít soubor: „{1}“"
 
 #: ../src/control/pagetype/PageTypeHandler.cpp:18
 #, fuzzy
 msgid "Could not load pagetemplates.ini file"
 msgstr "Nelze otevřít soubor: „{1}“"
 
-#: ../src/control/xojfile/LoadHandler.cpp:123
+#: ../src/control/xojfile/LoadHandler.cpp:124
 msgid "Could not open file: \"{1}\""
 msgstr "Nelze otevřít soubor: „{1}“"
 
-#: ../src/gui/MainWindow.cpp:93
+#: ../src/gui/MainWindow.cpp:86
 msgid ""
 "Could not parse custom toolbar.ini file: {1}\n"
 "Toolbars will not be available"
@@ -587,7 +600,7 @@ msgstr ""
 "Nelze načíst vlastní soubor toolbar.ini: {1}\n"
 "Nástrojové lišty nebudou k dispozici"
 
-#: ../src/gui/MainWindow.cpp:83
+#: ../src/gui/MainWindow.cpp:76
 msgid ""
 "Could not parse general toolbar.ini file: {1}\n"
 "No Toolbars will be available"
@@ -595,7 +608,7 @@ msgstr ""
 "Nelze načíst obecný soubor toolbar.ini: {1}\n"
 "Žádné nástrojové lišty nebudou k dispozici"
 
-#: ../src/control/xojfile/LoadHandler.cpp:328
+#: ../src/control/xojfile/LoadHandler.cpp:347
 msgid "Could not read image: {1}. Error message: {2}"
 msgstr "Nelze načíst obrázek: {1}. Chybová zpráva: {2}"
 
@@ -607,22 +620,23 @@ msgstr ""
 "Nelze znovuprovést „{1}“\n"
 "Něco je špatně… Napište prosím hlášení o chybě…"
 
-#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:214
+#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:210
 msgid "Could not remove tool item from Toolbar {1} on position {2}"
 msgstr ""
 
-#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:209
+#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:205
 msgid "Could not remove tool item {1} from Toolbar {2} on position {3}"
 msgstr ""
 
-#: ../src/control/Control.cpp:228 ../src/control/Control.cpp:247
+#: ../src/control/Control.cpp:230 ../src/control/Control.cpp:249
 #, fuzzy
 msgid "Could not rename autosave file from \"{1}\" to \"{2}\""
 msgstr "Nelze zapsat soubor metadat: {1} ({2})"
 
-#: ../src/control/LatexController.cpp:310
-msgid "Could not retrieve LaTeX image file: {1}"
-msgstr "Nelze načíst soubor s LaTeX obrázkem: {1}"
+#: ../src/control/LatexController.cpp:89
+#, fuzzy
+msgid "Could not save .tex file: {1}"
+msgstr "Nelze otevřít soubor: „{1}“"
 
 #: ../src/undo/UndoRedoHandler.cpp:144
 msgid ""
@@ -632,11 +646,11 @@ msgstr ""
 "Nelze vrátit zpět „{1}“\n"
 "Něco je špatně… Napište prosím hlášení o chybě…"
 
-#: ../src/control/xojfile/SaveHandler.cpp:294
+#: ../src/control/xojfile/SaveHandler.cpp:290
 msgid "Could not write background \"{1}\", {2}"
 msgstr "Nelze zapsat pozadí „{1}“, {2}"
 
-#: ../src/control/xojfile/SaveHandler.cpp:419
+#: ../src/control/xojfile/SaveHandler.cpp:415
 msgid "Could not write background \"{1}\". Continuing anyway."
 msgstr "Nelze zapsat pozadí „{1}“. Přesto pokračujeme."
 
@@ -653,7 +667,7 @@ msgstr "Aktuální stránka"
 msgid "Custom"
 msgstr "Vlastní"
 
-#: ../ui/settings.glade:1231
+#: ../ui/settings.glade:1288
 msgid "Custom Commands (for Method \"Custom\")"
 msgstr ""
 
@@ -666,35 +680,40 @@ msgstr "Vlastní"
 msgid "Customized"
 msgstr "Přizpůsobený"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:320
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:401
 msgid "Cut"
 msgstr "Vyjmout"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:442
+#: ../ui/settings.glade:1621
+msgid "Dark Theme (restart needed)"
+msgstr ""
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:460
 msgid "Default Tool"
 msgstr "Výchozí nástroj"
 
-#: ../ui/settings.glade:1997
+#: ../ui/settings.glade:2155
 msgid "Defaults"
 msgstr "Výchozí"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:407
 #: ../src/undo/DeleteUndoAction.cpp:102
 msgid "Delete"
 msgstr "Smazat"
 
-#: ../ui/main.glade:620
+#: ../ui/main.glade:668
 msgid "Delete Layer"
 msgstr "Smazat vrstvu"
 
-#: ../src/control/XournalMain.cpp:123
+#: ../src/control/XournalMain.cpp:127
 msgid "Delete Logfile"
 msgstr "Smazat soubor protokolu"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:387
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:447
 msgid "Delete current page"
 msgstr "Smazat aktuální stránku"
 
-#: ../src/control/XournalMain.cpp:173
+#: ../src/control/XournalMain.cpp:177
 #, fuzzy
 msgid "Delete file"
 msgstr "Smazat soubor protokolu"
@@ -707,7 +726,7 @@ msgstr "Smazat vrstvu"
 msgid "Delete stroke"
 msgstr "Odstranit čáru"
 
-#: ../ui/main.glade:1297
+#: ../ui/main.glade:1447
 #, fuzzy
 msgid "Delete this page"
 msgstr "Smazat aktuální stránku"
@@ -716,7 +735,7 @@ msgstr "Smazat aktuální stránku"
 msgid "Device"
 msgstr "Zařízení"
 
-#: ../ui/settings.glade:1261
+#: ../ui/settings.glade:1318
 msgid "Disable"
 msgstr ""
 
@@ -724,19 +743,19 @@ msgstr ""
 msgid "Disable drawing for this device"
 msgstr "Zakázat kreslení tímto zařízením"
 
-#: ../ui/settings.glade:1134
+#: ../ui/settings.glade:1191
 msgid "Disable touch if pen is near screen"
 msgstr ""
 
-#: ../ui/settings.glade:1156
+#: ../ui/settings.glade:1213
 msgid "Disabling Method"
 msgstr ""
 
-#: ../src/control/Control.cpp:2533 ../src/control/Control.cpp:2569
+#: ../src/control/Control.cpp:2577 ../src/control/Control.cpp:2618
 msgid "Discard"
 msgstr "Zahodit"
 
-#: ../src/control/Control.cpp:1952
+#: ../src/control/Control.cpp:1988
 msgid ""
 "Do not open Autosave files. They may will be overwritten!\n"
 "Copy the files to another folder.\n"
@@ -747,21 +766,17 @@ msgstr ""
 msgid "Do not overwrite the background PDF! This will cause errors!"
 msgstr ""
 
-#: ../src/control/Control.cpp:2566
+#: ../src/control/Control.cpp:2615
 msgid "Document file was removed."
 msgstr "Soubor s dokumentem byl odstraněn."
 
-#: ../src/control/xojfile/LoadHandler.cpp:202
+#: ../src/control/xojfile/LoadHandler.cpp:203
 msgid "Document is not complete (maybe the end is cut off?)"
 msgstr "Dokument není kompletní (jeho konec je nejspíš uřízlý)"
 
 #: ../src/model/Document.cpp:393
 msgid "Document not loaded! ({1}), {2}"
 msgstr "Dokument není načten! ({1}), {2}"
-
-#: ../src/control/XournalMain.cpp:242
-msgid "Don't compress PDF files (for debugging)"
-msgstr "Nekomprimovat PDF soubory (kvůli ladění)"
 
 #: ../src/control/pagetype/PageTypeHandler.cpp:26
 msgid "Dotted"
@@ -773,13 +788,13 @@ msgstr "Přetáhněte komponenty odsud do nástrojové lišty a zpět."
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:99
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:40
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:420
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:465
 msgid "Draw Arrow"
 msgstr "Kreslit šipku"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:97
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:39
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:416
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:464
 msgid "Draw Circle"
 msgstr "Kreslit kruh"
 
@@ -791,20 +806,20 @@ msgstr "Kreslit čáru"
 #: ../src/gui/dialog/ButtonConfigGui.cpp:95
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:29
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:38
-#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:120
-#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:123
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:418
+#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:122
+#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:125
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:463
 msgid "Draw Rectangle"
 msgstr "Kreslit obdélník"
 
-#: ../ui/main.glade:778
+#: ../ui/main.glade:844
 #, fuzzy
 msgid "Draw _Line"
 msgstr "Kreslit čáru"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:101
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:42
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:422
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:466
 msgid "Draw coordinate system"
 msgstr ""
 
@@ -821,26 +836,35 @@ msgstr "Beze změny"
 msgid "Edit text"
 msgstr "Upravit text"
 
-#: ../ui/settings.glade:1249
+#: ../src/undo/EmergencySaveRestore.cpp:35
+#, fuzzy
+msgid "Emergency saved document"
+msgstr "Neuložený dokument"
+
+#: ../ui/settings.glade:1306
 #, fuzzy
 msgid "Enable"
 msgstr "Povolit pravítko"
+
+#: ../ui/settings.glade:1176
+msgid "Enable zoom gestures (needs restart)"
+msgstr ""
 
 #: ../ui/texdialog.glade:66
 msgid "Enter / edit LaTeX Text"
 msgstr ""
 
-#: ../src/undo/EraseUndoAction.cpp:130 ../src/undo/DeleteUndoAction.cpp:99
-#: ../src/undo/AddUndoAction.cpp:104
+#: ../src/undo/AddUndoAction.cpp:104 ../src/undo/DeleteUndoAction.cpp:99
+#: ../src/undo/EraseUndoAction.cpp:130
 msgid "Erase stroke"
 msgstr "Vymazat čáru"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:56
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:282
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:308
 msgid "Eraser"
 msgstr "Guma"
 
-#: ../ui/main.glade:940
+#: ../ui/main.glade:1066
 msgid "Eraser Optio_ns"
 msgstr "_Nastavení gumy"
 
@@ -848,7 +872,7 @@ msgstr "_Nastavení gumy"
 msgid "Eraser Type - don't change"
 msgstr ""
 
-#: ../src/control/Control.cpp:2232
+#: ../src/control/Control.cpp:2268
 msgid ""
 "Error annotate PDF file \"{1}\"\n"
 "{2}"
@@ -861,11 +885,11 @@ msgstr ""
 msgid "Error export PDF Page"
 msgstr "Export PDF"
 
-#: ../src/gui/GladeGui.cpp:25
+#: ../src/gui/GladeGui.cpp:26
 msgid "Error loading glade file \"{1}\" (try to load \"{2}\")"
 msgstr "Chyba načítání glade souboru „{1}“ (zkuste načíst „{2}“)"
 
-#: ../src/control/Control.cpp:2047
+#: ../src/control/Control.cpp:2083
 msgid "Error opening file \"{1}\""
 msgstr "Chyba otevírání souboru „{1}“"
 
@@ -873,11 +897,11 @@ msgstr "Chyba otevírání souboru „{1}“"
 msgid "Error opening file: \"{1}\""
 msgstr "Chyba otevírání souboru: „{1}“"
 
-#: ../src/control/xojfile/LoadHandler.cpp:428
+#: ../src/control/xojfile/LoadHandler.cpp:447
 msgid "Error reading PDF: {1}"
 msgstr "Chyba čtení PDF: {1}"
 
-#: ../src/control/xojfile/LoadHandler.cpp:499
+#: ../src/control/xojfile/LoadHandler.cpp:518
 msgid "Error reading width of a stroke: {1}"
 msgstr "Chyba čtení šířky čáry: {1}"
 
@@ -885,7 +909,7 @@ msgstr "Chyba čtení šířky čáry: {1}"
 msgid "Error: {1}"
 msgstr "Chyba: {1}"
 
-#: ../src/control/XournalMain.cpp:147
+#: ../src/control/XournalMain.cpp:151
 msgid ""
 "Errorlog cannot be deleted. You have to do it manually.\n"
 "Logfile: {1}"
@@ -901,19 +925,19 @@ msgstr "Export"
 msgid "Export PDF"
 msgstr "Export PDF"
 
-#: ../ui/main.glade:113
+#: ../ui/main.glade:119
 msgid "Export as..."
 msgstr "Exportovat jako..."
 
-#: ../src/control/LatexController.cpp:398
+#: ../src/control/LatexController.cpp:445
 msgid "Failed to generate LaTeX image!"
 msgstr ""
 
-#: ../ui/main.glade:920 ../ui/main.glade:1057
+#: ../ui/main.glade:1044 ../ui/main.glade:1192
 msgid "Fi_ll"
 msgstr ""
 
-#: ../src/util/Util.cpp:127 ../src/util/Util.cpp:148
+#: ../src/util/Util.cpp:123 ../src/util/Util.cpp:143
 msgid ""
 "File couldn't be opened. You have to do it manually:\n"
 "URL: {1}"
@@ -921,23 +945,23 @@ msgstr ""
 "Soubor se nepodařilo otevřít. Udělejte to prosím ručně:\n"
 "URL: {1}"
 
-#: ../src/control/Control.cpp:1982
+#: ../src/control/Control.cpp:2018
 msgid "Filename: {1}"
 msgstr "Název souboru: {1}"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:445
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:500
 msgid "Fill"
 msgstr ""
 
-#: ../ui/main.glade:928 ../ui/main.glade:1065
+#: ../ui/main.glade:1053 ../ui/main.glade:1201
 msgid "Fill transparency"
 msgstr ""
 
-#: ../ui/main.glade:1492
+#: ../ui/main.glade:1634
 msgid "Find next occurrence of the search string"
 msgstr ""
 
-#: ../ui/main.glade:1471
+#: ../ui/main.glade:1613
 msgid "Find previous occurrence of the search string"
 msgstr ""
 
@@ -945,37 +969,43 @@ msgstr ""
 msgid "Font"
 msgstr "Písmo"
 
-#: ../ui/main.glade:289
+#: ../ui/main.glade:338
 msgid "Fullscreen"
 msgstr "Celá obrazovka"
 
-#: ../ui/about.glade:233
+#: ../ui/about.glade:234
 msgid "GNU GPLv2 or later"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:331
+#: ../ui/settings.glade:1072
+msgid ""
+"GTK Touch / Scrolling workaround. Change Scroll / Touch behavoir. Enabled "
+"touch drawing. Needs restart."
+msgstr ""
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:428
 msgid "Go to first page"
 msgstr "Přejít na první stránku"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:344
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:432
 msgid "Go to last page"
 msgstr "Přejít na poslední stránku"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:349
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:435
 #, fuzzy
 msgid "Go to next layer"
 msgstr "Přejít na poslední stránku"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:339
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:430
 msgid "Go to page"
 msgstr "Přejít na stránku"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:347
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:434
 #, fuzzy
 msgid "Go to previous layer"
 msgstr "Přejít na první stránku"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:351
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:436
 #, fuzzy
 msgid "Go to top layer"
 msgstr "Přejít na stránku"
@@ -999,16 +1029,20 @@ msgstr "Šedá"
 msgid "Green"
 msgstr "Zelená"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:378
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:411
 msgid "Grid Snapping"
 msgstr ""
 
-#: ../ui/main.glade:843
+#: ../ui/settings.glade:2113
+msgid "Grid snapping tolerance:"
+msgstr ""
+
+#: ../ui/main.glade:915
 msgid "H_and Tool"
 msgstr "_Nástroj prohlížení"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:63
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:426
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:474
 msgid "Hand"
 msgstr "Ruka"
 
@@ -1016,16 +1050,16 @@ msgstr "Ruka"
 msgid "Height:"
 msgstr "Výška:"
 
-#: ../ui/main.glade:379
+#: ../ui/main.glade:407
 #, fuzzy
 msgid "Hide Menu"
 msgstr "Skrýt lištu menu"
 
-#: ../ui/settings.glade:1683 ../ui/settings.glade:1753
+#: ../ui/settings.glade:1755 ../ui/settings.glade:1825
 msgid "Hide Menubar"
 msgstr "Skrýt lištu menu"
 
-#: ../ui/settings.glade:1698 ../ui/settings.glade:1768
+#: ../ui/settings.glade:1770 ../ui/settings.glade:1840
 msgid "Hide Sidebar"
 msgstr "Skrýt postranní panel"
 
@@ -1034,26 +1068,31 @@ msgstr "Skrýt postranní panel"
 msgid "Hide all"
 msgstr "Skrýt lištu menu"
 
-#: ../ui/settings.glade:1613
+#: ../ui/settings.glade:1685
 msgid "Hide the horizontal scrollbar"
 msgstr ""
 
-#: ../ui/settings.glade:1628
+#: ../ui/settings.glade:1700
 msgid "Hide the vertical scrollbar"
 msgstr ""
 
+#: ../ui/settings.glade:1944
+#, fuzzy
+msgid "Highlight cursor position"
+msgstr "Volby _zvýrazňovače"
+
 #: ../src/gui/dialog/ButtonConfigGui.cpp:57
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:399
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:457
 msgid "Highlighter"
 msgstr "Zvýrazňovač"
 
-#: ../ui/main.glade:1014
+#: ../ui/main.glade:1146
 #, fuzzy
 msgid "Highlighter Opti_ons"
 msgstr "Volby _zvýrazňovače"
 
 #: ../src/control/pagetype/PageTypeHandler.cpp:32
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:403
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:459
 msgid "Image"
 msgstr "Obrázek"
 
@@ -1061,11 +1100,11 @@ msgstr "Obrázek"
 msgid "Images"
 msgstr "Obrázky"
 
-#: ../ui/settings.glade:390
+#: ../ui/settings.glade:404
 msgid "Input"
 msgstr "Vstup"
 
-#: ../ui/settings.glade:1090
+#: ../ui/settings.glade:1119
 msgid "Input Device"
 msgstr "Vstupní zařízení"
 
@@ -1073,7 +1112,7 @@ msgstr "Vstupní zařízení"
 msgid "Insert Latex"
 msgstr "Vložit LaTeX"
 
-#: ../ui/main.glade:1277
+#: ../ui/main.glade:1427
 msgid "Insert a copy of the current page below"
 msgstr ""
 
@@ -1081,7 +1120,7 @@ msgstr ""
 msgid "Insert elements"
 msgstr "Vložit prvky"
 
-#: ../src/undo/InsertUndoAction.cpp:47 ../src/gui/dialog/ButtonConfigGui.cpp:59
+#: ../src/gui/dialog/ButtonConfigGui.cpp:59 ../src/undo/InsertUndoAction.cpp:47
 msgid "Insert image"
 msgstr "Vložit obrázek"
 
@@ -1093,11 +1132,11 @@ msgstr "Vložit LaTeX"
 msgid "Insert layer"
 msgstr "Vložit vrstvu"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:394
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:443
 msgid "Insert page"
 msgstr "Vložit stránku"
 
-#: ../src/control/XournalMain.cpp:244
+#: ../src/control/XournalMain.cpp:249
 msgid "Jump to Page (first Page: 1)"
 msgstr "Přejít na stránku (první stránka: 1)"
 
@@ -1119,7 +1158,7 @@ msgstr "Výběr vrstvy"
 msgid "Layer {1}"
 msgstr "Vrstva {1}"
 
-#: ../ui/about.glade:217
+#: ../ui/about.glade:218
 msgid "License"
 msgstr ""
 
@@ -1137,7 +1176,7 @@ msgstr "Světle zelená"
 msgid "Lined"
 msgstr "Linkovaný s okrajem"
 
-#: ../ui/settings.glade:772
+#: ../ui/settings.glade:786
 msgid "Load / Save"
 msgstr "Načítání / ukládání"
 
@@ -1145,13 +1184,13 @@ msgstr "Načítání / ukládání"
 msgid "Load file"
 msgstr "Načíst soubor"
 
-#: ../src/gui/PageView.cpp:738
+#: ../src/gui/PageView.cpp:739
 #: ../src/gui/sidebar/previews/base/SidebarPreviewBaseEntry.cpp:105
 #: ../src/gui/toolbarMenubar/ToolPageLayer.cpp:20
 msgid "Loading..."
 msgstr "Načítání..."
 
-#: ../ui/toolbarManageDialog.glade:8 ../ui/toolbarCustomizeDialog.glade:10
+#: ../ui/toolbarCustomizeDialog.glade:10 ../ui/toolbarManageDialog.glade:8
 msgid "Manage Toolbar"
 msgstr "Spravovat nástrojovou lištu"
 
@@ -1161,11 +1200,17 @@ msgid "Mangenta"
 msgstr "Purpurová"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:81
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:437
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:514
 msgid "Medium"
 msgstr "Střední"
 
-#: ../src/control/XournalMain.cpp:462
+#: ../src/control/XournalMain.cpp:460
+msgid ""
+"Missing the needed UI file! .app corrupted?\n"
+"Path: {1}"
+msgstr ""
+
+#: ../src/control/XournalMain.cpp:474
 msgid ""
 "Missing the needed UI file, could not find them at any location.\n"
 "Not relative\n"
@@ -1173,7 +1218,7 @@ msgid ""
 "Not in {1}"
 msgstr ""
 
-#: ../ui/settings.glade:883
+#: ../ui/settings.glade:897
 msgid "Mouse Button"
 msgstr "Tlačítko myši"
 
@@ -1194,7 +1239,7 @@ msgstr "Přesunout stránku dolů"
 msgid "Move page upwards"
 msgstr "Přesunout stránku nahoru"
 
-#: ../ui/main.glade:531
+#: ../ui/main.glade:571
 msgid "N_ext annotated page"
 msgstr "_Další anotovaná stránka"
 
@@ -1202,31 +1247,31 @@ msgstr "_Další anotovaná stránka"
 msgid "New"
 msgstr "Nový"
 
-#: ../ui/main.glade:571
+#: ../ui/main.glade:614
 msgid "New Page _After"
 msgstr "Nová stránka _před"
 
-#: ../ui/main.glade:563
+#: ../ui/main.glade:605
 msgid "New Page _Before"
 msgstr "Nová stránka _za"
 
-#: ../ui/main.glade:580
+#: ../ui/main.glade:624
 msgid "New Page at _End"
 msgstr "Nová stránka na _konec"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:316
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:388
 msgid "New Xournal"
 msgstr "Nový Xournal"
 
-#: ../ui/main.glade:611
+#: ../ui/main.glade:658
 msgid "New _Layer"
 msgstr "_Nová vrstva"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:342
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:431
 msgid "Next"
 msgstr "Další"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:355
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:438
 msgid "Next annotated page"
 msgstr "Další anotovaná stránka"
 
@@ -1253,20 +1298,20 @@ msgstr ""
 msgid "Open Image"
 msgstr "Otevřít obrázek"
 
-#: ../src/control/XournalMain.cpp:121
+#: ../src/control/XournalMain.cpp:125
 msgid "Open Logfile"
 msgstr "Otevřít soubor protokolu"
 
-#: ../src/control/XournalMain.cpp:122
+#: ../src/control/XournalMain.cpp:126
 msgid "Open Logfile directory"
 msgstr "Otevřít složku s protokoly"
 
 #: ../src/control/stockdlg/XojOpenDlg.cpp:16
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:318
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:389
 msgid "Open file"
 msgstr "Otevřít soubor"
 
-#: ../src/control/RecentManager.cpp:241
+#: ../src/control/RecentManager.cpp:244
 msgctxt "{1} is a URI"
 msgid "Open {1}"
 msgstr "Otevřít {1}"
@@ -1280,7 +1325,7 @@ msgstr "Oranžová"
 msgid "PDF Export"
 msgstr "PDF Export"
 
-#: ../src/gui/MainWindow.cpp:732
+#: ../src/gui/MainWindow.cpp:816
 msgid "PDF Page {1}"
 msgstr "PDF stránka {1}"
 
@@ -1288,17 +1333,17 @@ msgstr "PDF stránka {1}"
 msgid "PDF background missing"
 msgstr "PDF pozadí chybí"
 
-#: ../src/control/XournalMain.cpp:223
+#: ../src/control/XournalMain.cpp:230
 msgid "PDF file successfully created"
 msgstr "PDF soubor úspěšně vytvořen"
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:58
-#: ../src/control/jobs/PdfExportJob.cpp:23
 #: ../src/control/jobs/CustomExportJob.cpp:27
+#: ../src/control/jobs/PdfExportJob.cpp:23
+#: ../src/control/stockdlg/XojOpenDlg.cpp:61
 msgid "PDF files"
 msgstr "PDF soubory"
 
-#: ../src/control/XournalMain.cpp:243
+#: ../src/control/XournalMain.cpp:248
 msgid "PDF output filename"
 msgstr "Název výstupního PDF"
 
@@ -1316,7 +1361,7 @@ msgstr ""
 msgid "PNG with transparent background"
 msgstr "Pozadí _papíru"
 
-#: ../ui/main.glade:540
+#: ../ui/main.glade:581
 #, fuzzy
 msgid "P_revious annotated Page"
 msgstr "_Předchozí anotovaná stránka"
@@ -1358,35 +1403,35 @@ msgstr "Stránky:"
 msgid "Paper Format"
 msgstr "Formát papíru"
 
-#: ../ui/main.glade:643
+#: ../ui/main.glade:693
 msgid "Paper _Color"
 msgstr "_Barva papíru"
 
-#: ../ui/main.glade:635
+#: ../ui/main.glade:684
 msgid "Paper _Format"
 msgstr "_Formát papíru"
 
-#: ../ui/main.glade:651
+#: ../ui/main.glade:702
 msgid "Paper b_ackground"
 msgstr "Pozadí _papíru"
 
-#: ../ui/about.glade:201
+#: ../ui/about.glade:202
 msgid ""
 "Partial based on Xournal\n"
 "by Denis Auroux"
 msgstr ""
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:403
 #: ../src/undo/AddUndoAction.cpp:108
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:322
 msgid "Paste"
 msgstr "Vložit"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:55
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:382
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:286
 msgid "Pen"
 msgstr "Pero"
 
-#: ../ui/main.glade:859
+#: ../ui/main.glade:932
 msgid "Pen _Options"
 msgstr "N_astavení pera"
 
@@ -1394,9 +1439,9 @@ msgstr "N_astavení pera"
 msgid "Plain"
 msgstr "Čistá"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:473
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:32
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:106
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:413
 #, fuzzy
 msgid "Play Object"
 msgstr "Výběr objektu"
@@ -1405,11 +1450,11 @@ msgstr "Výběr objektu"
 msgid "Predefined"
 msgstr "Předdefinované"
 
-#: ../ui/main.glade:251
+#: ../ui/main.glade:297
 msgid "Preferences"
 msgstr "Nastavení"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:461
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:417
 msgid "Presentation mode"
 msgstr "Prezentace"
 
@@ -1417,15 +1462,15 @@ msgstr "Prezentace"
 msgid "Range"
 msgstr "Rozsah"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:371
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:479
 msgid "Rec / Stop"
 msgstr ""
 
-#: ../ui/main.glade:299
+#: ../ui/main.glade:1225
 msgid "Rec-Stop"
 msgstr ""
 
-#: ../ui/main.glade:61
+#: ../ui/main.glade:63
 msgid "Recent _Documents"
 msgstr "Nedávné _dokumenty"
 
@@ -1434,8 +1479,8 @@ msgstr "Nedávné _dokumenty"
 msgid "Red"
 msgstr "Červená"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:397
 #: ../src/undo/UndoRedoHandler.cpp:293
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:327
 msgid "Redo"
 msgstr "Znovu"
 
@@ -1443,15 +1488,15 @@ msgstr "Znovu"
 msgid "Redo: "
 msgstr "Znovu: "
 
-#: ../src/control/Control.cpp:2021
+#: ../src/control/Control.cpp:2057
 msgid "Remove PDF Background"
 msgstr "Odstranit PDF pozadí"
 
-#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:202
+#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:198
 msgid "Removed tool item from Toolbar {1} ID {2}"
 msgstr ""
 
-#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:198
+#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:194
 msgid "Removed tool item {1} from Toolbar {2} ID {3}"
 msgstr ""
 
@@ -1464,7 +1509,7 @@ msgstr ""
 msgid "Resolution"
 msgstr "Rozlišení:"
 
-#: ../src/control/XournalMain.cpp:174
+#: ../src/control/XournalMain.cpp:178
 #, fuzzy
 msgid "Restore file"
 msgstr "Uložit soubor"
@@ -1474,33 +1519,37 @@ msgstr "Uložit soubor"
 msgid "Rotation"
 msgstr "Rozlišení:"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:375
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:410
 msgid "Rotation Snapping"
+msgstr ""
+
+#: ../ui/settings.glade:2083
+msgid "Rotation snapping tolerance:"
 msgstr ""
 
 #: ../src/control/pagetype/PageTypeHandler.cpp:24
 msgid "Ruled"
 msgstr "Linkovaný"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:432
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:467
 msgid "Ruler"
 msgstr "Pravítko"
 
-#: ../src/control/jobs/SaveJob.cpp:13 ../src/control/Control.cpp:2532
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:315
+#: ../src/control/Control.cpp:2576 ../src/control/jobs/SaveJob.cpp:13
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:390
 msgid "Save"
 msgstr "Uložit"
 
-#: ../src/control/Control.cpp:2568
+#: ../src/control/Control.cpp:2617
 msgid "Save As"
 msgstr "Uložit jako…"
 
-#: ../src/control/Control.cpp:2352 ../src/gui/dialog/PageTemplateDialog.cpp:112
+#: ../src/control/Control.cpp:2388 ../src/gui/dialog/PageTemplateDialog.cpp:112
 msgid "Save File"
 msgstr "Uložit soubor"
 
-#: ../src/control/jobs/SaveJob.cpp:151
 #: ../src/control/jobs/CustomExportJob.cpp:276
+#: ../src/control/jobs/SaveJob.cpp:151
 #, fuzzy
 msgid "Save file error: {1}"
 msgstr "Chyba otevírání souboru: {1}"
@@ -1509,7 +1558,7 @@ msgstr "Chyba otevírání souboru: {1}"
 msgid "Scale"
 msgstr "Škálovat"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:324
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:405
 msgid "Search"
 msgstr "Hledat"
 
@@ -1518,12 +1567,12 @@ msgstr "Hledat"
 msgid "Select Background Color"
 msgstr "Vybrat barvu"
 
-#: ../ui/settings.glade:2065
+#: ../ui/settings.glade:2223
 #, fuzzy
 msgid "Select Folder"
 msgstr "Vybrat barvu"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:447
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:476
 msgid "Select Font"
 msgstr "Výběr písma"
 
@@ -1531,9 +1580,9 @@ msgstr "Výběr písma"
 msgid "Select Image"
 msgstr "Výběr obrázku"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:471
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:31
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:99
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:410
 msgid "Select Object"
 msgstr "Výběr objektu"
 
@@ -1541,21 +1590,21 @@ msgstr "Výběr objektu"
 msgid "Select PDF Page"
 msgstr "Výběr PDF stránky"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:470
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:10
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:29
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:85
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:125
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:408
 msgid "Select Rectangle"
 msgstr "Obdélníkový výběr"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:469
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:30
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:92
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:406
 msgid "Select Region"
 msgstr "Výběr oblasti"
 
-#: ../src/control/Control.cpp:2020
+#: ../src/control/Control.cpp:2056
 msgid "Select another PDF"
 msgstr "Vybrat jiné PDF"
 
@@ -1582,19 +1631,19 @@ msgstr "Obdélníkový výběr"
 msgid "Select region"
 msgstr "Výběr oblasti"
 
-#: ../ui/settings.glade:1964
+#: ../ui/settings.glade:2051
 msgid "Select the tool and Settings if you press the Default Button"
 msgstr "Vyberte nástroj a nastavení pro tlačítko \"Výchozí\""
 
-#: ../ui/settings.glade:1789
+#: ../ui/settings.glade:1861
 msgid "Select toolbar:"
 msgstr "Vyberte nástrojovou lištu:"
 
-#: ../ui/settings.glade:1543
+#: ../ui/settings.glade:1600
 msgid "Selection Color (Text, Stroke Selection etc.)"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:120
+#: ../src/control/XournalMain.cpp:124
 msgid "Send Bugreport"
 msgstr "Zaslat hlášení o chybě"
 
@@ -1602,11 +1651,15 @@ msgstr "Zaslat hlášení o chybě"
 msgid "Separator"
 msgstr "Oddělovač"
 
-#: ../ui/settings.glade:1123
+#: ../ui/settings.glade:1165
+msgid "Settings for Touch devices"
+msgstr ""
+
+#: ../ui/settings.glade:1152
 msgid "Settings for Touch devices which are detected by GTK."
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:430
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:462
 msgid "Shape Recognizer"
 msgstr "Rozpoznávání tvarů"
 
@@ -1631,19 +1684,19 @@ msgstr "Zobrazit pouze nevyužité stránky (jedna nevyužitá stránka)"
 msgid "Show only not used pages ({1} unused pages)"
 msgstr "Zobrazit pouze nevyužité stránky ({1} nevyužitých stránek)"
 
-#: ../ui/main.glade:322
+#: ../ui/main.glade:348
 msgid "Show sidebar"
 msgstr "Zobrazit postranní panel"
 
-#: ../ui/settings.glade:1412
+#: ../ui/settings.glade:1469
 msgid "Show sidebar on the right side"
 msgstr "Zobrazit postranní panel na pravé straně"
 
-#: ../ui/settings.glade:1427
+#: ../ui/settings.glade:1484
 msgid "Show vertical scrollbar on the left side"
 msgstr "Zobrazit vertikální posuvník na levé straně"
 
-#: ../src/control/XournalMain.cpp:309
+#: ../src/control/XournalMain.cpp:308
 #, fuzzy
 msgid ""
 "Sorry, Xournal++ can only open one file at once.\n"
@@ -1653,7 +1706,7 @@ msgstr ""
 "soubor.\n"
 "Ostatní jsou ignorovány."
 
-#: ../src/control/XournalMain.cpp:324
+#: ../src/control/XournalMain.cpp:323
 #, fuzzy
 msgid ""
 "Sorry, Xournal++ cannot open remote files at the moment.\n"
@@ -1666,13 +1719,13 @@ msgstr ""
 msgid "Standard"
 msgstr "Standardní"
 
-#: ../ui/main.glade:1610
+#: ../ui/main.glade:1752
 msgid "State PLACEHOLDER"
 msgstr "PROSTOR pro stav"
 
-#: ../src/undo/RecognizerUndoAction.cpp:101
 #: ../src/gui/dialog/ButtonConfigGui.cpp:103
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:43
+#: ../src/undo/RecognizerUndoAction.cpp:101
 msgid "Stroke recognizer"
 msgstr "Rozpoznání čáry"
 
@@ -1680,19 +1733,19 @@ msgstr "Rozpoznání čáry"
 msgid "Successfully saved document to \"{1}\""
 msgstr "Dokument úspěšně uložen do \"\""
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:128
+#: ../src/control/stockdlg/XojOpenDlg.cpp:132
 msgid "Supported files"
 msgstr "Podporované soubory"
 
-#: ../ui/main.glade:1236
+#: ../ui/main.glade:1386
 msgid "Swap the current page with the one above"
 msgstr ""
 
-#: ../ui/main.glade:1257
+#: ../ui/main.glade:1407
 msgid "Swap the current page with the one below"
 msgstr ""
 
-#: ../ui/main.glade:337
+#: ../ui/main.glade:363
 msgid "T_oolbars"
 msgstr "Ná_strojové lišty"
 
@@ -1700,16 +1753,16 @@ msgstr "Ná_strojové lišty"
 msgid "Template:"
 msgstr "Šablona:"
 
-#: ../ui/settings.glade:1317
+#: ../ui/settings.glade:1374
 msgid "Test disable"
 msgstr ""
 
-#: ../ui/settings.glade:1304
+#: ../ui/settings.glade:1361
 msgid "Test enable"
 msgstr ""
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:58
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:401
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:458
 msgid "Text"
 msgstr "Text"
 
@@ -1718,7 +1771,7 @@ msgstr "Text"
 msgid "Text %i times found on this page"
 msgstr "Text %ikrát nalezen na této stránce"
 
-#: ../ui/main.glade:1077
+#: ../ui/main.glade:1214
 msgid "Text Font..."
 msgstr "Písmo textu..."
 
@@ -1746,7 +1799,7 @@ msgstr "Text nenalezen"
 msgid "Text not found, searched on all pages"
 msgstr "Text nenalezen, prohledány byly všechny stránky"
 
-#: ../src/control/Control.cpp:1006
+#: ../src/control/Control.cpp:1017
 msgid ""
 "The Toolbarconfiguration \"{1}\" is predefined, would you create a copy to "
 "edit?"
@@ -1754,23 +1807,23 @@ msgstr ""
 "Konfigurace nástrojové lišty „{1}“ je předdefinována. Přejete si vytvořit "
 "kopii pro úpravy?"
 
-#: ../src/control/Control.cpp:2017
+#: ../src/control/Control.cpp:2053
 msgid "The attached background PDF could not be found."
 msgstr "Přiložené PDF pozadí nebylo nalezeno."
 
-#: ../src/control/Control.cpp:2018
+#: ../src/control/Control.cpp:2054
 msgid "The background PDF could not be found."
 msgstr "PDF pozadí nebylo nalezeno."
 
-#: ../src/control/XournalMain.cpp:115
+#: ../src/control/XournalMain.cpp:119
 msgid "The most recent log file name: {1}"
 msgstr "Název nejnovějšího souboru protokolu: {1}"
 
-#: ../ui/settings.glade:369
+#: ../ui/settings.glade:383
 msgid "The unit of the ruler is cm"
 msgstr "Jednotkou pravítka jsou cm"
 
-#: ../src/control/XournalMain.cpp:108
+#: ../src/control/XournalMain.cpp:112
 msgid ""
 "There are errorlogfiles from Xournal++. Please send a Bugreport, so the bug "
 "may be fixed."
@@ -1778,7 +1831,7 @@ msgstr ""
 "Xournal++ vytvořil soubory se záznamy o chybách. Zašlete prosím hlášení o "
 "chybě, abychom ji mohli opravit."
 
-#: ../src/control/XournalMain.cpp:107
+#: ../src/control/XournalMain.cpp:111
 msgid ""
 "There is an errorlogfile from Xournal++. Please send a Bugreport, so the bug "
 "may be fixed."
@@ -1791,7 +1844,7 @@ msgid "There was an error displaying help: {1}"
 msgstr "Při zobrazování nápovědy došlo k chybě: {1}"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:82
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:439
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:515
 msgid "Thick"
 msgstr "Tlustá"
 
@@ -1801,25 +1854,25 @@ msgid "Thickness - don't change"
 msgstr "Beze změny"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:80
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:435
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:513
 msgid "Thin"
 msgstr "Tenká"
 
-#: ../src/control/Control.cpp:2530
+#: ../src/control/Control.cpp:2574
 msgid "This document is not saved yet."
 msgstr "Tento dokument ještě nebyl uložen."
 
-#: ../src/control/tools/ImageHandler.cpp:56
 #: ../src/control/PageBackgroundChangeController.cpp:177
+#: ../src/control/tools/ImageHandler.cpp:56
 msgid "This image could not be loaded. Error message: {1}"
 msgstr "Obrázek se nepodařilo načíst. Chybová zpráva: {1}"
 
-#: ../ui/settings.glade:1185
+#: ../ui/settings.glade:1242
 #, fuzzy
 msgid "Timeout"
 msgstr "Bělení"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:368
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:418
 msgid "Toggle fullscreen"
 msgstr "Přepnout režim celé obrazovky"
 
@@ -1828,7 +1881,7 @@ msgstr "Přepnout režim celé obrazovky"
 msgid "Tool - don't change"
 msgstr "Beze změny"
 
-#: ../src/gui/toolbarMenubar/model/ToolbarData.cpp:156
+#: ../src/gui/toolbarMenubar/model/ToolbarData.cpp:152
 msgid "Toolbar found: {1}"
 msgstr "Nástrojová lišta nalezena: {1}"
 
@@ -1836,11 +1889,11 @@ msgstr "Nástrojová lišta nalezena: {1}"
 msgid "Toolbars"
 msgstr "Nástrojové lišty"
 
-#: ../ui/settings.glade:1358
+#: ../ui/settings.glade:1415
 msgid "Touch"
 msgstr ""
 
-#: ../ui/settings.glade:1046
+#: ../ui/settings.glade:1060
 msgid ""
 "Touch Screens which are detected by GTK are handled specially, and don't "
 "need to be configured here."
@@ -1854,12 +1907,12 @@ msgstr ""
 msgid "Trying to emergency save the current open document…"
 msgstr "Pokus o nouzové uložení aktuálně otevřeného dokumentu…"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:458
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:416
 msgid "Two pages"
 msgstr "Dvě stránky"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:396
 #: ../src/undo/UndoRedoHandler.cpp:274
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:326
 msgid "Undo"
 msgstr "Zpět"
 
@@ -1867,15 +1920,15 @@ msgstr "Zpět"
 msgid "Undo: "
 msgstr "Zpět: "
 
-#: ../src/control/xojfile/LoadHandler.cpp:241
+#: ../src/control/xojfile/LoadHandler.cpp:260
 msgid "Unexpected root tag: {1}"
 msgstr "Neočekávaný kořenový tag: {1}"
 
-#: ../src/control/xojfile/LoadHandler.cpp:270
+#: ../src/control/xojfile/LoadHandler.cpp:289
 msgid "Unexpected tag in document: \"{1}\""
 msgstr "Neočekávaný tag v dokumentu: „{1}“"
 
-#: ../src/control/xojfile/LoadHandler.cpp:475
+#: ../src/control/xojfile/LoadHandler.cpp:494
 msgid "Unknown background type: {1}"
 msgstr "Neznámý typ pozadí: {1}"
 
@@ -1883,23 +1936,23 @@ msgstr "Neznámý typ pozadí: {1}"
 msgid "Unknown color value \"{1}\""
 msgstr "Neznámá hodnota barvy „{1}“"
 
-#: ../src/control/xojfile/LoadHandler.cpp:410
+#: ../src/control/xojfile/LoadHandler.cpp:429
 msgid "Unknown domain type: {1}"
 msgstr "Neznámý typ domény: {1}"
 
-#: ../src/control/xojfile/LoadHandler.cpp:193
+#: ../src/control/xojfile/LoadHandler.cpp:194
 msgid "Unknown parser error"
 msgstr "Neznámá chyba načítání XML"
 
-#: ../src/control/xojfile/LoadHandler.cpp:345
+#: ../src/control/xojfile/LoadHandler.cpp:364
 msgid "Unknown pixmap::domain type: {1}"
 msgstr "Neznámý typ pixmap::domain: {1}"
 
-#: ../src/control/xojfile/LoadHandler.cpp:558
+#: ../src/control/xojfile/LoadHandler.cpp:591
 msgid "Unknown stroke type: \"{1}\", assuming pen"
 msgstr "Neznámý typ čáry: „{1}“, bereme jej jako pero"
 
-#: ../src/control/Control.cpp:2424
+#: ../src/control/Control.cpp:2460
 msgid "Unsaved Document"
 msgstr "Neuložený dokument"
 
@@ -1908,7 +1961,7 @@ msgstr "Neuložený dokument"
 msgid "Version"
 msgstr "Přípona"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:425
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:472
 msgid "Vertical Space"
 msgstr "Vertikální mezera"
 
@@ -1916,7 +1969,7 @@ msgstr "Vertikální mezera"
 msgid "Vertical space"
 msgstr "Vertikální mezera"
 
-#: ../ui/settings.glade:1895
+#: ../ui/settings.glade:1982
 msgid "View"
 msgstr "Zobrazení"
 
@@ -1937,7 +1990,7 @@ msgstr "Šířka:"
 msgid "With PDF background"
 msgstr "S PDF pozadím"
 
-#: ../ui/about.glade:187
+#: ../ui/about.glade:188
 #, fuzzy
 msgid "With help from the community"
 msgstr "S pomocí komunity\n"
@@ -1946,19 +1999,19 @@ msgstr "S pomocí komunity\n"
 msgid "Write text"
 msgstr "Psát text"
 
-#: ../src/control/xojfile/LoadHandler.cpp:821
+#: ../src/control/xojfile/LoadHandler.cpp:852
 msgid "Wrong count of points ({1})"
 msgstr "Špatný počet bodů ({1})"
 
-#: ../src/control/xojfile/LoadHandler.cpp:836
+#: ../src/control/xojfile/LoadHandler.cpp:866
 msgid "Wrong number of points, got {1}, expected {2}"
 msgstr "Špatný počet bodů, obdrženo {1}, očekáváno {2}"
 
-#: ../ui/settings.glade:1171
+#: ../ui/settings.glade:1228
 msgid "X11"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:188
+#: ../src/control/xojfile/LoadHandler.cpp:189
 msgid "XML Parser error: {1}"
 msgstr "Chyba načítání XML: {1}"
 
@@ -1966,24 +2019,24 @@ msgstr "Chyba načítání XML: {1}"
 msgid "Xournal (Compatibility)"
 msgstr ""
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:69
+#: ../src/control/stockdlg/XojOpenDlg.cpp:72
 msgid "Xournal files"
 msgstr "Soubory Xournalu"
 
-#: ../ui/settings.glade:28
+#: ../ui/settings.glade:42
 msgid "Xournal++ Preferences"
 msgstr "Nastavení Xournal++"
 
-#: ../src/control/XournalMain.cpp:168
+#: ../src/control/XournalMain.cpp:172
 msgid "Xournal++ crashed last time. Would you restore it?"
 msgstr ""
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:79 ../src/control/Control.cpp:2359
+#: ../src/control/Control.cpp:2395 ../src/control/stockdlg/XojOpenDlg.cpp:82
 #, fuzzy
 msgid "Xournal++ files"
 msgstr "Soubory Xournalu"
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:89
+#: ../src/control/stockdlg/XojOpenDlg.cpp:92
 #: ../src/gui/dialog/PageTemplateDialog.cpp:119
 #, fuzzy
 msgid "Xournal++ template"
@@ -2004,7 +2057,7 @@ msgstr ""
 "Nemáte žádné PDF stránky pro výběr. Operace se ruší.\n"
 "Vyberte prosím jiný druh pozadí: Menu „Zápisník“ → „Vložit stránku typu“."
 
-#: ../src/control/XournalMain.cpp:111
+#: ../src/control/XournalMain.cpp:115
 msgid ""
 "You're using {1}/{2} branch. Send Bugreport will direct you to this repo's "
 "issue tracker."
@@ -2026,19 +2079,19 @@ msgstr ""
 "Tip: Můžete vybrat Zápisník → Pozadí papíru → PDF pozadí pro vložení stránky "
 "z PDF."
 
-#: ../ui/settings.glade:302
+#: ../ui/settings.glade:316
 msgid "Zoom"
 msgstr "Zvětšení"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:362
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:422
 msgid "Zoom fit to screen"
 msgstr "Přizpůsobit přiblížení obrazovce"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:360
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:421
 msgid "Zoom in"
 msgstr "Přiblížit"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:358
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:420
 msgid "Zoom out"
 msgstr "Oddálit"
 
@@ -2046,44 +2099,44 @@ msgstr "Oddálit"
 msgid "Zoom slider"
 msgstr "Nastavení přiblížení"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:364
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:423
 msgid "Zoom to 100%"
 msgstr "Přiblížit na 100%"
 
-#: ../ui/main.glade:69
+#: ../ui/main.glade:71
 msgid "_Annotate PDF"
 msgstr "_Anotovat PDF"
 
+#: ../src/control/Control.cpp:2389 ../src/control/jobs/BaseExportJob.cpp:26
 #: ../src/control/stockdlg/ImageOpenDlg.cpp:12
 #: ../src/control/stockdlg/XojOpenDlg.cpp:17
-#: ../src/control/jobs/BaseExportJob.cpp:26 ../src/control/Control.cpp:2353
 #: ../src/gui/dialog/PageTemplateDialog.cpp:113
 #, fuzzy
 msgid "_Cancel"
 msgstr "Zrušit"
 
-#: ../ui/main.glade:361
+#: ../ui/main.glade:388
 msgid "_Customize"
 msgstr "_Přizpůsobit"
 
-#: ../ui/main.glade:723
+#: ../ui/main.glade:779
 #, fuzzy
 msgid "_Default Tools"
 msgstr "_Výchozí nástroj"
 
-#: ../ui/main.glade:596
+#: ../ui/main.glade:642
 msgid "_Delete Page"
 msgstr "_Smazat stránku"
 
-#: ../ui/main.glade:153
+#: ../ui/main.glade:162
 msgid "_Edit"
 msgstr "Ú_pravy"
 
-#: ../ui/main.glade:683
+#: ../ui/main.glade:735
 msgid "_Eraser"
 msgstr "_Guma"
 
-#: ../ui/main.glade:104
+#: ../ui/main.glade:109
 msgid "_Export as PDF"
 msgstr "_Exportovat jako PDF"
 
@@ -2091,49 +2144,49 @@ msgstr "_Exportovat jako PDF"
 msgid "_File"
 msgstr "_Soubor"
 
-#: ../ui/main.glade:448
+#: ../ui/main.glade:480
 msgid "_First Page"
 msgstr "_První stránka"
 
-#: ../ui/main.glade:466
+#: ../ui/main.glade:500
 #, fuzzy
 msgid "_Goto Page"
 msgstr "Př_ejít na stránku…"
 
-#: ../ui/main.glade:1099
+#: ../ui/main.glade:1247
 msgid "_Help"
 msgstr "_Nápověda"
 
-#: ../ui/main.glade:693
+#: ../ui/main.glade:746
 msgid "_Highlighter"
 msgstr "_Zvýrazňovač"
 
-#: ../ui/main.glade:713
+#: ../ui/main.glade:768
 msgid "_Image"
 msgstr "_Obrázek"
 
-#: ../ui/main.glade:553
+#: ../ui/main.glade:595
 msgid "_Journal"
 msgstr "_Zápisník"
 
-#: ../ui/main.glade:484
+#: ../ui/main.glade:520
 msgid "_Last Page"
 msgstr "Po_slední stránka"
 
-#: ../ui/main.glade:353
+#: ../ui/main.glade:379
 msgid "_Manage"
 msgstr "_Spravovat"
 
-#: ../ui/main.glade:438
+#: ../ui/main.glade:470
 msgid "_Navigation"
 msgstr "_Navigace"
 
-#: ../ui/main.glade:508
+#: ../ui/main.glade:546
 #, fuzzy
 msgid "_Next Layer"
 msgstr "_Další stránka"
 
-#: ../ui/main.glade:475
+#: ../ui/main.glade:510
 msgid "_Next Page"
 msgstr "_Další stránka"
 
@@ -2143,83 +2196,83 @@ msgstr "_Další stránka"
 msgid "_Open"
 msgstr "Otevřít {1}"
 
-#: ../ui/main.glade:673
+#: ../ui/main.glade:724
 msgid "_Pen"
 msgstr "_Pero"
 
-#: ../ui/main.glade:281
+#: ../ui/main.glade:329
 msgid "_Presentation Mode"
 msgstr "_Prezentace"
 
-#: ../ui/main.glade:499
+#: ../ui/main.glade:536
 #, fuzzy
 msgid "_Previous Layer"
 msgstr "_Předchozí stránka"
 
-#: ../ui/main.glade:457
+#: ../ui/main.glade:490
 msgid "_Previous Page"
 msgstr "_Předchozí stránka"
 
-#: ../src/control/jobs/BaseExportJob.cpp:27 ../src/control/Control.cpp:2354
+#: ../src/control/Control.cpp:2390 ../src/control/jobs/BaseExportJob.cpp:27
 #: ../src/gui/dialog/PageTemplateDialog.cpp:114
 #, fuzzy
 msgid "_Save"
 msgstr "Uložit"
 
-#: ../ui/main.glade:737
+#: ../ui/main.glade:794
 msgid "_Shape Recognizer"
 msgstr "_Rozpoznávání tvarů"
 
-#: ../ui/main.glade:703
+#: ../ui/main.glade:757
 msgid "_Text"
 msgstr "_Text"
 
-#: ../ui/main.glade:663
+#: ../ui/main.glade:714
 msgid "_Tools"
 msgstr "_Nástroje"
 
-#: ../ui/main.glade:517
+#: ../ui/main.glade:556
 #, fuzzy
 msgid "_Top Layer"
 msgstr "Vrstva"
 
-#: ../ui/main.glade:273
+#: ../ui/main.glade:320
 msgid "_Two Pages"
 msgstr "_Dvě stránky"
 
-#: ../ui/main.glade:823
+#: ../ui/main.glade:893
 msgid "_Vertical Space"
 msgstr "_Vertikální místo"
 
-#: ../ui/main.glade:263
+#: ../ui/main.glade:310
 msgid "_View"
 msgstr "_Zobrazení"
 
-#: ../ui/main.glade:1001
+#: ../ui/main.glade:1132
 msgid "_delete strokes"
 msgstr "_smazat čáry"
 
-#: ../ui/main.glade:878 ../ui/main.glade:950 ../ui/main.glade:1024
+#: ../ui/main.glade:952 ../ui/main.glade:1076 ../ui/main.glade:1156
 msgid "_fine"
 msgstr "_tenká"
 
-#: ../ui/main.glade:887 ../ui/main.glade:959 ../ui/main.glade:1033
+#: ../ui/main.glade:962 ../ui/main.glade:1086 ../ui/main.glade:1166
 msgid "_medium"
 msgstr "_střední"
 
-#: ../ui/main.glade:983
+#: ../ui/main.glade:1112
 msgid "_standard"
 msgstr "_výchozí"
 
-#: ../ui/main.glade:896 ../ui/main.glade:968 ../ui/main.glade:1042
+#: ../ui/main.glade:972 ../ui/main.glade:1096 ../ui/main.glade:1176
 msgid "_thick"
 msgstr "_tlustá"
 
-#: ../ui/main.glade:869
+#: ../ui/main.glade:942
 msgid "_very fine"
 msgstr "_velmi tenká"
 
-#: ../ui/main.glade:992
+#: ../ui/main.glade:1122
 msgid "_whiteout"
 msgstr "_bělení"
 
@@ -2232,9 +2285,21 @@ msgstr "Rozsah"
 msgid "cursor"
 msgstr "kurzor"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:299
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:294
+msgid "dash-/ doted"
+msgstr ""
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:291
+msgid "dashed"
+msgstr ""
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:312
 msgid "delete stroke"
 msgstr "odstranit čáru"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:297
+msgid "dotted"
+msgstr ""
 
 #: ../ui/exportSettings.glade:213
 msgid "dpi"
@@ -2261,7 +2326,7 @@ msgstr "myš"
 msgid "pen"
 msgstr "pero"
 
-#: ../ui/settings.glade:1212
+#: ../ui/settings.glade:1269
 msgid "s"
 msgstr ""
 
@@ -2274,7 +2339,8 @@ msgstr "Uložit soubor"
 msgid "show"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:285
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:288
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:310
 msgid "standard"
 msgstr "standardní"
 
@@ -2287,15 +2353,15 @@ msgstr ""
 msgid "touchscreen"
 msgstr "Celá obrazovka"
 
-#: ../ui/main.glade:905
+#: ../ui/main.glade:982
 msgid "ver_y thick"
 msgstr "vel_mi tlustá"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:292
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:311
 msgid "whiteout"
 msgstr "bělení"
 
-#: ../src/control/xojfile/LoadHandler.cpp:835
+#: ../src/control/xojfile/LoadHandler.cpp:865
 msgid "xoj-File: {1}"
 msgstr "xoj-soubor: {1}"
 
@@ -2398,6 +2464,9 @@ msgstr "xoj-preview-extractor: úspěšně extrahováno"
 
 #~ msgid "Disable Ruler & Stroke Recognizer"
 #~ msgstr "Zakázat pravítko a rozpoznávání tvarů"
+
+#~ msgid "Don't compress PDF files (for debugging)"
+#~ msgstr "Nekomprimovat PDF soubory (kvůli ladění)"
 
 #, fuzzy
 #~ msgid "Drawing type"

--- a/po/de.po
+++ b/po/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Xournalpp 0.9\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-12-30 12:21+0100\n"
+"POT-Creation-Date: 2019-01-23 10:36+0100\n"
 "PO-Revision-Date: 2018-12-30 12:21+0100\n"
 "Last-Translator: Andreas Butti <andreasbutti at gmail dot com>\n"
 "Language-Team: DE\n"
@@ -18,40 +18,40 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.7.1\n"
 
-#: ../src/undo/DeleteUndoAction.cpp:113 ../src/undo/AddUndoAction.cpp:119
+#: ../src/undo/AddUndoAction.cpp:119 ../src/undo/DeleteUndoAction.cpp:113
 msgid " elements"
 msgstr " Elemente"
 
-#: ../src/undo/DeleteUndoAction.cpp:128 ../src/undo/AddUndoAction.cpp:134
+#: ../src/undo/AddUndoAction.cpp:134 ../src/undo/DeleteUndoAction.cpp:128
 msgid " image"
 msgstr " Bilddateien"
 
-#: ../src/undo/DeleteUndoAction.cpp:132 ../src/undo/AddUndoAction.cpp:138
+#: ../src/undo/AddUndoAction.cpp:138 ../src/undo/DeleteUndoAction.cpp:132
 msgid " latex"
 msgstr " LaTeX"
 
-#: ../src/gui/MainWindow.cpp:734
+#: ../src/gui/MainWindow.cpp:818
 msgctxt "Page {pagenumber} \"of {pagecount}\""
 msgid " of {1}{2}"
 msgstr "von {1}{2}"
 
-#: ../src/undo/DeleteUndoAction.cpp:120 ../src/undo/AddUndoAction.cpp:126
+#: ../src/undo/AddUndoAction.cpp:126 ../src/undo/DeleteUndoAction.cpp:120
 msgid " stroke"
 msgstr " Linie"
 
-#: ../src/undo/DeleteUndoAction.cpp:124 ../src/undo/AddUndoAction.cpp:130
+#: ../src/undo/AddUndoAction.cpp:130 ../src/undo/DeleteUndoAction.cpp:124
 msgid " text"
 msgstr " Text"
 
-#: ../src/control/settings/Settings.cpp:79
+#: ../src/control/settings/Settings.cpp:90
 msgid "%F-Note-%H-%M"
 msgstr "Notiz-%d-%m-%Y-%H-%M.xoj"
 
-#: ../ui/settings.glade:590
+#: ../ui/settings.glade:604
 msgid "%F-Note-%H-%M.xoj"
 msgstr "Notiz-%d-%m-%Y-%H-%M.xoj"
 
-#: ../ui/settings.glade:613
+#: ../ui/settings.glade:627
 msgid ""
 "%a\tAbbreviated weekday name \t(e.g. Thu)\n"
 "%A\tFull weekday name (e.g. Thursday)\n"
@@ -103,19 +103,19 @@ msgstr ""
 msgid "<b>... or select already used Image:</b>"
 msgstr "<b>... oder wählen Sie ein bereits verwendetes Bild:</b>"
 
-#: ../ui/settings.glade:271
+#: ../ui/settings.glade:285
 msgid "<b>Add horizontal space</b>"
 msgstr "<b>Horizontalen Platz hinzufügen</b>"
 
-#: ../ui/settings.glade:248
+#: ../ui/settings.glade:262
 msgid "<b>Add vertical space</b>"
 msgstr "<b>Vertikalen Platz einfügen</b>"
 
-#: ../ui/settings.glade:704
+#: ../ui/settings.glade:718
 msgid "<b>Autoload .pdf.xoj</b>"
 msgstr "<b>Automatisch .pdf.xoj laden</b>"
 
-#: ../ui/settings.glade:488
+#: ../ui/settings.glade:502
 msgid ""
 "<b>Autosave Folder</b>\n"
 "<i>If the document already was saved you can find it in the same folder\n"
@@ -129,7 +129,7 @@ msgstr ""
 "Wenn die Datei noch nicht gespeichert wurde, finden Sie das Dokument in\n"
 "~/.xournalpp/autosave</i>"
 
-#: ../ui/settings.glade:428
+#: ../ui/settings.glade:442
 msgid "<b>Autosave</b>"
 msgstr "<b>Automatisch speichern</b>"
 
@@ -145,7 +145,7 @@ msgstr "<b>Hintergrund</b>"
 msgid "<b>Color</b>"
 msgstr "<b>Farbe</b>"
 
-#: ../ui/settings.glade:1464
+#: ../ui/settings.glade:1521
 msgid "<b>Colors</b>"
 msgstr "<b>Farben</b>"
 
@@ -167,7 +167,7 @@ msgstr ""
 "Die Einstellungen oben werden\n"
 " für die erste Seite verwendet"
 
-#: ../ui/settings.glade:1835
+#: ../ui/settings.glade:1907
 msgid "<b>Cursor</b>"
 msgstr "<b>Cursor</b>"
 
@@ -175,15 +175,15 @@ msgstr "<b>Cursor</b>"
 msgid "<b>Default Tools</b>"
 msgstr "<b>Standard Werkzeuge</b>"
 
-#: ../ui/settings.glade:577
+#: ../ui/settings.glade:591
 msgid "<b>Default name:</b>"
 msgstr "<b>Standard Name:</b>"
 
-#: ../ui/settings.glade:524
+#: ../ui/settings.glade:538
 msgid "<b>Default save name</b>"
 msgstr "<b>Standard Dateiname</b>"
 
-#: ../ui/settings.glade:1943
+#: ../ui/settings.glade:2030
 msgid "<b>Default</b>"
 msgstr "<b>Standard</b>"
 
@@ -195,11 +195,11 @@ msgstr ""
 "<b>Dokumentenexport Einstellungen</b>\n"
 "Seiten zum Exportieren wählen"
 
-#: ../ui/settings.glade:1002
+#: ../ui/settings.glade:1016
 msgid "<b>Eraser</b>"
 msgstr "<b>Radierer</b>"
 
-#: ../ui/settings.glade:110
+#: ../ui/settings.glade:124
 msgid "<b>Extended Input</b>"
 msgstr "<b>Extended Input</b>"
 
@@ -211,19 +211,19 @@ msgstr ""
 "<b>Ausfüllung Tranzparenz Einstellungen</b>\n"
 "Wählen der Transparenz für die Füllfarbe"
 
-#: ../ui/settings.glade:1661
+#: ../ui/settings.glade:1733
 msgid "<b>Fullscreen</b>"
 msgstr "<b>Vollbild</b>"
 
-#: ../ui/settings.glade:658
+#: ../ui/settings.glade:672
 msgid "<b>Help</b> (Placeholders)"
 msgstr "<b>Hilfe</b> (Platzhalter)"
 
-#: ../ui/settings.glade:1390
+#: ../ui/settings.glade:1447
 msgid "<b>Left / Right</b>"
 msgstr "<b>Links / Rechts</b>"
 
-#: ../ui/settings.glade:819
+#: ../ui/settings.glade:833
 msgid "<b>Middle Mouse Button</b>"
 msgstr "<b>Mittlere Maustaste</b>"
 
@@ -235,23 +235,23 @@ msgstr "<b>Seitengröße</b>"
 msgid "<b>Pagesize</b>"
 msgstr "<b>Seitengröße</b>"
 
-#: ../ui/settings.glade:1731
+#: ../ui/settings.glade:1803
 msgid "<b>Presentation</b> Another Fullscreen Mode, <i>Start with F5</i>"
 msgstr "<b>Präsentationsmodus</b> <i>Starten mit F5</i>"
 
-#: ../ui/settings.glade:155
+#: ../ui/settings.glade:169
 msgid "<b>Pressure sensitivity</b>"
 msgstr "<b>Druckempfindlichkeit</b>"
 
-#: ../ui/settings.glade:849
+#: ../ui/settings.glade:863
 msgid "<b>Right Mouse Button</b>"
 msgstr "<b>Rechte Maustaste</b>"
 
-#: ../ui/settings.glade:1584
+#: ../ui/settings.glade:1656
 msgid "<b>Scrollbars</b>"
 msgstr "<b>Scrollbars</b>"
 
-#: ../ui/settings.glade:200
+#: ../ui/settings.glade:214
 msgid "<b>Scrolling outside the page</b>"
 msgstr "<b>Scrollen über die Seitenränder hinaus erlauben</b>"
 
@@ -259,15 +259,15 @@ msgstr "<b>Scrollen über die Seitenränder hinaus erlauben</b>"
 msgid "<b>Separator</b>"
 msgstr "<b>Separator</b>"
 
-#: ../ui/settings.glade:944
+#: ../ui/settings.glade:958
 msgid "<b>Stylus Button 1</b> Action if the pen button is pressed"
 msgstr "<b>Stift Knopf 1</b> Aktion des 1. Stift Knopfs"
 
-#: ../ui/settings.glade:973
+#: ../ui/settings.glade:987
 msgid "<b>Stylus Button 2</b> Action if the pen button is pressed"
 msgstr "<b>Stift Knopf 2</b> Aktion des 2. Stift Knopfs"
 
-#: ../ui/settings.glade:1031
+#: ../ui/settings.glade:1045
 msgid ""
 "<b>Touch Screen</b> <i>You can also configure other devices like mice</i>"
 msgstr "<b>Touch Screen</b> <i>Sie können auch andere Geräte konfigurieren</i>"
@@ -276,7 +276,7 @@ msgstr "<b>Touch Screen</b> <i>Sie können auch andere Geräte konfigurieren</i>
 msgid "<i>Example:</i> 1-3 or 1,3,5-7 etc."
 msgstr "<i>Beispiel</i> 1-3 oder 1,3,5-7 etc."
 
-#: ../ui/settings.glade:929
+#: ../ui/settings.glade:943
 msgid ""
 "<i>Here you can define which tools will be selected If you\n"
 "use the eraser or other device.\n"
@@ -286,7 +286,7 @@ msgstr ""
 "oder anderen Geräten zugeordnet werden.\n"
 "Hier können Sie den Touchscreen deaktivieren.</i>"
 
-#: ../ui/settings.glade:804
+#: ../ui/settings.glade:818
 msgid ""
 "<i>Here you can define which tools will be selected if you press\n"
 "a button; after you release the button the previously selected\n"
@@ -296,7 +296,7 @@ msgstr ""
 "Sie eine (Maus-)Taste drücken, beim Loslassen wird wieder\n"
 "das vorherige Werkzeug gewählt</i>"
 
-#: ../ui/settings.glade:2030
+#: ../ui/settings.glade:2188
 msgid ""
 "<i>If audio recording is running, the time stamps are stored to the "
 "handwritten Text and can be replayed.\n"
@@ -307,7 +307,7 @@ msgstr ""
 "und können widergeben werden.\n"
 "Die Audiodaten werden in separate Dateien gespeichert, und verlinkt.</i>"
 
-#: ../ui/settings.glade:224
+#: ../ui/settings.glade:238
 msgid ""
 "<i>If you add <b>additional space</b> beside the pages\n"
 "you can choose the area of the screen you would\n"
@@ -317,13 +317,13 @@ msgstr ""
 "um die Seite eingefügt, Sie können die Seite somit weiter verschieben\n"
 "und wählen, wo auf dem Bildschirm Sie arbeiten möchten</i>"
 
-#: ../ui/settings.glade:170
+#: ../ui/settings.glade:184
 msgid "<i>If you have a tablet pen you can get different line widths</i>"
 msgstr ""
 "<i>Wenn Sie einen Tablet-Stift verwenden, wird die Linienbreite durch den "
 "Druck festgelegt.</i>"
 
-#: ../ui/settings.glade:728
+#: ../ui/settings.glade:742
 msgid ""
 "<i>If you open a PDF and there is a\n"
 "Xournal file with the same name it will open the xoj file.</i>"
@@ -331,7 +331,7 @@ msgstr ""
 "<i>Wenn Sie ein PDF öffnen, wird auch ein dazugehöriges .xoj-Dokument\n"
 "geöffnet, falls vorhanden.</i>"
 
-#: ../ui/settings.glade:324
+#: ../ui/settings.glade:338
 msgid ""
 "<i>Put a ruler on your screen to calibrate the zoom level to fit your "
 "screen. Takes effect after restarting xournalpp.\n"
@@ -342,11 +342,11 @@ msgstr ""
 "aus.\n"
 "Die Einheit des Maßstabs ist cm, für den Regler DPI.</i>"
 
-#: ../ui/settings.glade:133
+#: ../ui/settings.glade:147
 msgid "<i>Select some advanced input options</i>"
 msgstr "<i>Wähle erweiterte Eingabe Einstellungen</i>"
 
-#: ../ui/settings.glade:1339
+#: ../ui/settings.glade:1396
 msgid ""
 "<i>The commands will be executed in the UI Thread, make sure\n"
 "they are not blocking!</i>"
@@ -354,7 +354,7 @@ msgstr ""
 "<i>Die Kommandos werden im UI Thread ausgeführt.\n"
 "Sie dürfen somit nicht blockierend sein!</i>"
 
-#: ../ui/settings.glade:548
+#: ../ui/settings.glade:562
 msgid "<i>This name will be proposed if you save a new document</i>"
 msgstr ""
 "<i>Dieser Name wird vorgeschlagen, wenn Sie ein neues Dokument speichern</i>"
@@ -371,15 +371,15 @@ msgstr ""
 msgid "About Xournal++"
 msgstr "Über Xournal++"
 
-#: ../src/control/XournalMain.cpp:245
+#: ../src/control/XournalMain.cpp:250
 msgid "Absolute path for the audio files playback"
 msgstr "Absoluter Pfad für die Audiodateien"
 
-#: ../ui/main.glade:1086
+#: ../ui/main.glade:1233
 msgid "Add/Edit Tex"
 msgstr "LaTeX  editieren/hinzufügen"
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:48
+#: ../src/control/stockdlg/XojOpenDlg.cpp:51
 msgid "All files"
 msgstr "Alle Dateien"
 
@@ -396,7 +396,7 @@ msgid "Apply to current page"
 msgstr "Auf aktuelle Seite anwenden"
 
 #: ../src/control/stockdlg/ImageOpenDlg.cpp:30
-#: ../src/control/stockdlg/XojOpenDlg.cpp:147
+#: ../src/control/stockdlg/XojOpenDlg.cpp:152
 msgid "Attach file to the journal"
 msgstr "Datei ans .xoj anhängen"
 
@@ -429,15 +429,15 @@ msgstr ""
 msgid "Attribute color not set!"
 msgstr "Attribut Farbe ist nicht gesetzt!"
 
-#: ../ui/settings.glade:2051
+#: ../ui/settings.glade:2209
 msgid "Audio Folder"
 msgstr "Audio Ordner"
 
-#: ../ui/settings.glade:2088
+#: ../ui/settings.glade:2246
 msgid "Audio Recording"
 msgstr "Audioaufzeichnung"
 
-#: ../src/control/AudioController.cpp:100
+#: ../src/control/AudioController.cpp:98
 msgid ""
 "Audio folder not set! Recording won't work!\n"
 "Please set the recording folder under \"Preferences > Audio recording\""
@@ -449,15 +449,15 @@ msgstr ""
 msgid "Authors:"
 msgstr "Autoren:"
 
-#: ../ui/settings.glade:1170
+#: ../ui/settings.glade:1227
 msgid "Autodetect"
 msgstr "Automatisch"
 
-#: ../ui/settings.glade:456
+#: ../ui/settings.glade:470
 msgid "Autosave every ... minutes:"
 msgstr "Alle ... automatisch speichern:"
 
-#: ../src/control/Control.cpp:254
+#: ../src/control/Control.cpp:256
 msgid "Autosave failed with an error: {1}"
 msgstr "Autospeichern fehlgeschlagen mit Fehler: {1}"
 
@@ -465,8 +465,7 @@ msgstr "Autospeichern fehlgeschlagen mit Fehler: {1}"
 msgid "Autosave: {1}"
 msgstr "Autospeichern: {1}"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:333
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:336
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:429
 msgid "Back"
 msgstr "Zurück"
 
@@ -476,11 +475,11 @@ msgstr "Zurück"
 msgid "Background"
 msgstr "Hintergrund"
 
-#: ../ui/settings.glade:1520
+#: ../ui/settings.glade:1577
 msgid "Background color for window Background"
 msgstr "Hintergrundfarbe des Fensters"
 
-#: ../ui/settings.glade:1857
+#: ../ui/settings.glade:1929
 msgid "Big cursor for pen"
 msgstr "Großer Cursor für den Stift"
 
@@ -494,11 +493,11 @@ msgstr "schwarz"
 msgid "Blue"
 msgstr "blau"
 
-#: ../ui/settings.glade:1509
+#: ../ui/settings.glade:1566
 msgid "Border color"
 msgstr "Rahmenfarbe"
 
-#: ../ui/settings.glade:1495
+#: ../ui/settings.glade:1552
 msgid "Border color for current page and other selections"
 msgstr "Rahmenfarbe der gewählten Seite und anderer Auswahlen"
 
@@ -506,8 +505,8 @@ msgstr "Rahmenfarbe der gewählten Seite und anderer Auswahlen"
 msgid "Built on:"
 msgstr "Kompiliert am:"
 
-#: ../src/control/Control.cpp:2022 ../src/control/Control.cpp:2534
-#: ../src/control/Control.cpp:2570 ../src/control/XournalMain.cpp:124
+#: ../src/control/Control.cpp:2058 ../src/control/Control.cpp:2581
+#: ../src/control/Control.cpp:2619 ../src/control/XournalMain.cpp:128
 msgid "Cancel"
 msgstr "Abbrechen"
 
@@ -523,7 +522,7 @@ msgstr "Schriftart ändern"
 msgid "Change stroke fill"
 msgstr "Figurenfüllung ändern"
 
-#: ../src/undo/SizeUndoAction.cpp:145
+#: ../src/undo/SizeUndoAction.cpp:139
 msgid "Change stroke width"
 msgstr "Liniendicke ändern"
 
@@ -531,7 +530,7 @@ msgstr "Liniendicke ändern"
 msgid "Color \"{1}\" unknown (not defined in default color list)!"
 msgstr "Farbe \"{1}\" unbekannt (nicht in der Farbliste)"
 
-#: ../ui/main.glade:588
+#: ../ui/main.glade:633
 msgid "Configure Page Template"
 msgstr "Seitenvorlage konfigurieren"
 
@@ -539,8 +538,8 @@ msgstr "Seitenvorlage konfigurieren"
 msgid "Contents"
 msgstr "Inhalt"
 
-#: ../src/control/Control.cpp:1036 ../src/control/Control.cpp:1044
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:321
+#: ../src/control/Control.cpp:1047 ../src/control/Control.cpp:1055
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:402
 msgid "Copy"
 msgstr "Kopieren"
 
@@ -560,6 +559,10 @@ msgstr "Größe der letzten Seite kopieren"
 msgid "Copy page"
 msgstr "Kopiere Seite"
 
+#: ../src/control/LatexController.cpp:103
+msgid "Could not convert tex to PDF: {1} (exit code: {2})"
+msgstr ""
+
 #: ../src/control/jobs/SaveJob.cpp:137
 msgid ""
 "Could not create backup! (The file was created from an older Xournal version)"
@@ -567,31 +570,39 @@ msgstr ""
 "Konnte kein Backup erstellen! (Diese Datei wurde mit einer alten Version von "
 "Xournal erstellt.)"
 
-#: ../src/util/Util.cpp:97
+#: ../src/util/Util.cpp:94
 msgid "Could not create folder: {1}"
 msgstr "Konnte den Ordner \"{1}\" nicht erstellen"
 
-#: ../src/control/Control.cpp:218 ../src/control/Control.cpp:235
+#: ../src/control/Control.cpp:220 ../src/control/Control.cpp:237
 msgid "Could not delete old autosave file \"{1}\""
 msgstr "Konnte die alte automatisch gespeicherte Datei \"{1}\" nicht löschen"
 
-#: ../src/control/LatexController.cpp:381
+#: ../src/control/LatexController.cpp:428
 msgid ""
-"Could not find Xournal++ LaTeX executable relative or in Path.\n"
-"Searched for: mathtex-xournalpp.cgi"
+"Could not find pdflatex in Path.\n"
+"Please install pdflatex first and make sure it's in the Path."
 msgstr ""
-"Konnte Xournal++ LaTeX Programm nicht finden, relativ oder im Pfad.\n"
-"Suche nach: mathtex-xournalpp.cgi"
+
+#: ../src/control/LatexController.cpp:299
+#, fuzzy
+msgid "Could not load LaTeX PDF file, URL-Error: {1}"
+msgstr "Die LaTeX-Bilddatei konnte nicht geladen werden: {1}"
+
+#: ../src/control/LatexController.cpp:307
+#, fuzzy
+msgid "Could not load LaTeX PDF file: {1}"
+msgstr "Konnte die Datei nicht öffnen: \"{1}\""
 
 #: ../src/control/pagetype/PageTypeHandler.cpp:18
 msgid "Could not load pagetemplates.ini file"
 msgstr "Konnte die Datei pagetemplates.ini nicht öffnen"
 
-#: ../src/control/xojfile/LoadHandler.cpp:123
+#: ../src/control/xojfile/LoadHandler.cpp:124
 msgid "Could not open file: \"{1}\""
 msgstr "Konnte die Datei nicht öffnen: \"{1}\""
 
-#: ../src/gui/MainWindow.cpp:93
+#: ../src/gui/MainWindow.cpp:86
 msgid ""
 "Could not parse custom toolbar.ini file: {1}\n"
 "Toolbars will not be available"
@@ -599,7 +610,7 @@ msgstr ""
 "Konnte die benutzerdefinierte Datei toolbar.ini nicht lesen: {1}\n"
 "Es werden keine Werkzeugleisten zur Verfügung stehen"
 
-#: ../src/gui/MainWindow.cpp:83
+#: ../src/gui/MainWindow.cpp:76
 msgid ""
 "Could not parse general toolbar.ini file: {1}\n"
 "No Toolbars will be available"
@@ -607,7 +618,7 @@ msgstr ""
 "Konnte die globale Datei toolbar.ini nicht lesen: {1}\n"
 "Es werden keine Werkzeugleisten zur Verfügung stehen"
 
-#: ../src/control/xojfile/LoadHandler.cpp:328
+#: ../src/control/xojfile/LoadHandler.cpp:347
 msgid "Could not read image: {1}. Error message: {2}"
 msgstr "Das Bild {1} konnte nicht geladen werden. Fehlermeldung: {2}"
 
@@ -619,23 +630,24 @@ msgstr ""
 "Konnte '{1}' nicht wiederherstellen\n"
 "Etwas ist schief gelaufen... Bitte erstellen Sie einen Fehlerbericht."
 
-#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:214
+#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:210
 msgid "Could not remove tool item from Toolbar {1} on position {2}"
 msgstr ""
 "Konnte Werkzeug von der Werkzeugleiste {1} Position {2} nicht entfernen"
 
-#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:209
+#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:205
 msgid "Could not remove tool item {1} from Toolbar {2} on position {3}"
 msgstr ""
 "Konnte Werkzeug {1} von der Werkzeugleiste {2} Position {3} nicht entfernen"
 
-#: ../src/control/Control.cpp:228 ../src/control/Control.cpp:247
+#: ../src/control/Control.cpp:230 ../src/control/Control.cpp:249
 msgid "Could not rename autosave file from \"{1}\" to \"{2}\""
 msgstr "Konnte Datei \"{1}\" nicht umbennen zu \"{2}\""
 
-#: ../src/control/LatexController.cpp:310
-msgid "Could not retrieve LaTeX image file: {1}"
-msgstr "Die LaTeX-Bilddatei konnte nicht geladen werden: {1}"
+#: ../src/control/LatexController.cpp:89
+#, fuzzy
+msgid "Could not save .tex file: {1}"
+msgstr "Konnte den Ordner \"{1}\" nicht erstellen"
 
 #: ../src/undo/UndoRedoHandler.cpp:144
 msgid ""
@@ -645,11 +657,11 @@ msgstr ""
 "Konnte '{1}' nicht rückgängig machen\n"
 "Etwas ist schief gelaufen... Bitte erstellen Sie einen Fehlerbericht."
 
-#: ../src/control/xojfile/SaveHandler.cpp:294
+#: ../src/control/xojfile/SaveHandler.cpp:290
 msgid "Could not write background \"{1}\", {2}"
 msgstr "Konnte Hintergrund \"{1}\" nicht speichern, {2}"
 
-#: ../src/control/xojfile/SaveHandler.cpp:419
+#: ../src/control/xojfile/SaveHandler.cpp:415
 msgid "Could not write background \"{1}\". Continuing anyway."
 msgstr "Konnte Hintergrund nicht speichern \"{1}\". Fahre trotzdem fort."
 
@@ -665,7 +677,7 @@ msgstr "Aktuelle Seite"
 msgid "Custom"
 msgstr "Benutzerdefiniert"
 
-#: ../ui/settings.glade:1231
+#: ../ui/settings.glade:1288
 msgid "Custom Commands (for Method \"Custom\")"
 msgstr "Kommandos (für die Methode \"Custom\")"
 
@@ -677,35 +689,40 @@ msgstr "Benutzerdefinierter Export"
 msgid "Customized"
 msgstr "Anpassen"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:320
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:401
 msgid "Cut"
 msgstr "Ausschneiden"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:442
+#: ../ui/settings.glade:1621
+msgid "Dark Theme (restart needed)"
+msgstr ""
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:460
 msgid "Default Tool"
 msgstr "Standard Werkzeug"
 
-#: ../ui/settings.glade:1997
+#: ../ui/settings.glade:2155
 msgid "Defaults"
 msgstr "Konfiguration"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:407
 #: ../src/undo/DeleteUndoAction.cpp:102
 msgid "Delete"
 msgstr "Löschen"
 
-#: ../ui/main.glade:620
+#: ../ui/main.glade:668
 msgid "Delete Layer"
 msgstr "Ebene löschen"
 
-#: ../src/control/XournalMain.cpp:123
+#: ../src/control/XournalMain.cpp:127
 msgid "Delete Logfile"
 msgstr "Logdatei löschen"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:387
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:447
 msgid "Delete current page"
 msgstr "Aktuelle Seite löschen"
 
-#: ../src/control/XournalMain.cpp:173
+#: ../src/control/XournalMain.cpp:177
 msgid "Delete file"
 msgstr "Datei löschen"
 
@@ -717,7 +734,7 @@ msgstr "Ebene löschen"
 msgid "Delete stroke"
 msgstr "Linie löschen"
 
-#: ../ui/main.glade:1297
+#: ../ui/main.glade:1447
 msgid "Delete this page"
 msgstr "Aktuelle Seite löschen"
 
@@ -725,7 +742,7 @@ msgstr "Aktuelle Seite löschen"
 msgid "Device"
 msgstr "Eingabegerät"
 
-#: ../ui/settings.glade:1261
+#: ../ui/settings.glade:1318
 msgid "Disable"
 msgstr "Deaktivieren"
 
@@ -733,19 +750,19 @@ msgstr "Deaktivieren"
 msgid "Disable drawing for this device"
 msgstr "Deaktivieren des Zeichnens mit diesem Gerät"
 
-#: ../ui/settings.glade:1134
+#: ../ui/settings.glade:1191
 msgid "Disable touch if pen is near screen"
 msgstr "Touch deaktivieren wenn der Stift in der Nähe des Bildschirms ist"
 
-#: ../ui/settings.glade:1156
+#: ../ui/settings.glade:1213
 msgid "Disabling Method"
 msgstr "Deaktivierungsmethode"
 
-#: ../src/control/Control.cpp:2533 ../src/control/Control.cpp:2569
+#: ../src/control/Control.cpp:2577 ../src/control/Control.cpp:2618
 msgid "Discard"
 msgstr "Verwerfen"
 
-#: ../src/control/Control.cpp:1952
+#: ../src/control/Control.cpp:1988
 msgid ""
 "Do not open Autosave files. They may will be overwritten!\n"
 "Copy the files to another folder.\n"
@@ -761,21 +778,17 @@ msgid "Do not overwrite the background PDF! This will cause errors!"
 msgstr ""
 "Das Hintergrund PDF darf nicht überschrieben werden! Dies verursacht Fehler!"
 
-#: ../src/control/Control.cpp:2566
+#: ../src/control/Control.cpp:2615
 msgid "Document file was removed."
 msgstr "Datei des Dokuments wurde entfernt."
 
-#: ../src/control/xojfile/LoadHandler.cpp:202
+#: ../src/control/xojfile/LoadHandler.cpp:203
 msgid "Document is not complete (maybe the end is cut off?)"
 msgstr "Dokument ist nicht vollständig (z.B. nicht komplett übertragen?)"
 
 #: ../src/model/Document.cpp:393
 msgid "Document not loaded! ({1}), {2}"
 msgstr "Dokument nicht geladen! ({1}), {2}"
-
-#: ../src/control/XournalMain.cpp:242
-msgid "Don't compress PDF files (for debugging)"
-msgstr "PDF-Datei nicht komprimieren (zur Fehlersuche)"
 
 #: ../src/control/pagetype/PageTypeHandler.cpp:26
 msgid "Dotted"
@@ -787,13 +800,13 @@ msgstr "Ziehen Sie Objekte von hier in die Werkzeugleiste und zurück"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:99
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:40
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:420
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:465
 msgid "Draw Arrow"
 msgstr "Pfeil zeichnen"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:97
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:39
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:416
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:464
 msgid "Draw Circle"
 msgstr "Kreis zeichnen"
 
@@ -805,19 +818,19 @@ msgstr "Strecke zeichnen"
 #: ../src/gui/dialog/ButtonConfigGui.cpp:95
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:29
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:38
-#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:120
-#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:123
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:418
+#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:122
+#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:125
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:463
 msgid "Draw Rectangle"
 msgstr "Rechteck Zeichnen"
 
-#: ../ui/main.glade:778
+#: ../ui/main.glade:844
 msgid "Draw _Line"
 msgstr "Strecke _zeichnen"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:101
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:42
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:422
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:466
 msgid "Draw coordinate system"
 msgstr "Koordinatensystem zeichnen"
 
@@ -833,25 +846,34 @@ msgstr "Zeichnungstyp - nicht ändern"
 msgid "Edit text"
 msgstr "Text schreiben"
 
-#: ../ui/settings.glade:1249
+#: ../src/undo/EmergencySaveRestore.cpp:35
+#, fuzzy
+msgid "Emergency saved document"
+msgstr "Ungespeichertes Dokument"
+
+#: ../ui/settings.glade:1306
 msgid "Enable"
 msgstr "Aktivieren"
+
+#: ../ui/settings.glade:1176
+msgid "Enable zoom gestures (needs restart)"
+msgstr ""
 
 #: ../ui/texdialog.glade:66
 msgid "Enter / edit LaTeX Text"
 msgstr "Bearbeite- / editiere LaTeX Text"
 
-#: ../src/undo/EraseUndoAction.cpp:130 ../src/undo/DeleteUndoAction.cpp:99
-#: ../src/undo/AddUndoAction.cpp:104
+#: ../src/undo/AddUndoAction.cpp:104 ../src/undo/DeleteUndoAction.cpp:99
+#: ../src/undo/EraseUndoAction.cpp:130
 msgid "Erase stroke"
 msgstr "Linie löschen"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:56
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:282
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:308
 msgid "Eraser"
 msgstr "Radierer"
 
-#: ../ui/main.glade:940
+#: ../ui/main.glade:1066
 msgid "Eraser Optio_ns"
 msgstr "Radierer Optionen"
 
@@ -859,7 +881,7 @@ msgstr "Radierer Optionen"
 msgid "Eraser Type - don't change"
 msgstr "Radierer - nicht ändern"
 
-#: ../src/control/Control.cpp:2232
+#: ../src/control/Control.cpp:2268
 msgid ""
 "Error annotate PDF file \"{1}\"\n"
 "{2}"
@@ -871,11 +893,11 @@ msgstr ""
 msgid "Error export PDF Page"
 msgstr "Fehler beim Exportieren der PDF Seite"
 
-#: ../src/gui/GladeGui.cpp:25
+#: ../src/gui/GladeGui.cpp:26
 msgid "Error loading glade file \"{1}\" (try to load \"{2}\")"
 msgstr "Fehler beim Laden der Glade-Datei \"{1}\" (Datei \"{2}\")"
 
-#: ../src/control/Control.cpp:2047
+#: ../src/control/Control.cpp:2083
 msgid "Error opening file \"{1}\""
 msgstr "Fehler beim Öffnen der Datei '{1}'"
 
@@ -883,11 +905,11 @@ msgstr "Fehler beim Öffnen der Datei '{1}'"
 msgid "Error opening file: \"{1}\""
 msgstr "Fehler beim Öffnen der Datei '{1}'"
 
-#: ../src/control/xojfile/LoadHandler.cpp:428
+#: ../src/control/xojfile/LoadHandler.cpp:447
 msgid "Error reading PDF: {1}"
 msgstr "Fehler beim Lesen des PDFs: {1}"
 
-#: ../src/control/xojfile/LoadHandler.cpp:499
+#: ../src/control/xojfile/LoadHandler.cpp:518
 msgid "Error reading width of a stroke: {1}"
 msgstr "Fehler beim Lesen der Dicke einer Linie: {1}"
 
@@ -895,7 +917,7 @@ msgstr "Fehler beim Lesen der Dicke einer Linie: {1}"
 msgid "Error: {1}"
 msgstr "Fehler: {1}"
 
-#: ../src/control/XournalMain.cpp:147
+#: ../src/control/XournalMain.cpp:151
 msgid ""
 "Errorlog cannot be deleted. You have to do it manually.\n"
 "Logfile: {1}"
@@ -912,19 +934,19 @@ msgstr "Exportieren"
 msgid "Export PDF"
 msgstr "Exportieren als PDF"
 
-#: ../ui/main.glade:113
+#: ../ui/main.glade:119
 msgid "Export as..."
 msgstr "Exportieren als..."
 
-#: ../src/control/LatexController.cpp:398
+#: ../src/control/LatexController.cpp:445
 msgid "Failed to generate LaTeX image!"
 msgstr "Fehler beim erstellen des LaTeX Bild!"
 
-#: ../ui/main.glade:920 ../ui/main.glade:1057
+#: ../ui/main.glade:1044 ../ui/main.glade:1192
 msgid "Fi_ll"
 msgstr "Ausfü_llen"
 
-#: ../src/util/Util.cpp:127 ../src/util/Util.cpp:148
+#: ../src/util/Util.cpp:123 ../src/util/Util.cpp:143
 msgid ""
 "File couldn't be opened. You have to do it manually:\n"
 "URL: {1}"
@@ -932,23 +954,23 @@ msgstr ""
 "Datei konnte nicht geöffnet werden, Sie müssen sie manuell öffnen\n"
 ":URL: {1}"
 
-#: ../src/control/Control.cpp:1982
+#: ../src/control/Control.cpp:2018
 msgid "Filename: {1}"
 msgstr "Dateiname: {1}"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:445
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:500
 msgid "Fill"
 msgstr "Füllung"
 
-#: ../ui/main.glade:928 ../ui/main.glade:1065
+#: ../ui/main.glade:1053 ../ui/main.glade:1201
 msgid "Fill transparency"
 msgstr "Ausfüllung Transparenz"
 
-#: ../ui/main.glade:1492
+#: ../ui/main.glade:1634
 msgid "Find next occurrence of the search string"
 msgstr "Nächstes Vorkommen des Textes suchen"
 
-#: ../ui/main.glade:1471
+#: ../ui/main.glade:1613
 msgid "Find previous occurrence of the search string"
 msgstr "Vorheriges Vorkommen des Textes suchen"
 
@@ -956,35 +978,41 @@ msgstr "Vorheriges Vorkommen des Textes suchen"
 msgid "Font"
 msgstr "Schriftart"
 
-#: ../ui/main.glade:289
+#: ../ui/main.glade:338
 msgid "Fullscreen"
 msgstr "Vollbild"
 
-#: ../ui/about.glade:233
+#: ../ui/about.glade:234
 msgid "GNU GPLv2 or later"
 msgstr "GNU GPLv2 oder neuer"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:331
+#: ../ui/settings.glade:1072
+msgid ""
+"GTK Touch / Scrolling workaround. Change Scroll / Touch behavoir. Enabled "
+"touch drawing. Needs restart."
+msgstr ""
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:428
 msgid "Go to first page"
 msgstr "Gehe zur ersten Seite"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:344
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:432
 msgid "Go to last page"
 msgstr "Gehe zur letzten Seite"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:349
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:435
 msgid "Go to next layer"
 msgstr "Zur nächsten Ebene springen"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:339
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:430
 msgid "Go to page"
 msgstr "Gehe zur Seite"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:347
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:434
 msgid "Go to previous layer"
 msgstr "Zur vorherigen Ebene springen"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:351
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:436
 msgid "Go to top layer"
 msgstr "Zur obersten Ebene springen"
 
@@ -1006,16 +1034,21 @@ msgstr "grau"
 msgid "Green"
 msgstr "grün"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:378
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:411
 msgid "Grid Snapping"
 msgstr "Am Raster einrasten"
 
-#: ../ui/main.glade:843
+#: ../ui/settings.glade:2113
+#, fuzzy
+msgid "Grid snapping tolerance:"
+msgstr "Am Raster einrasten"
+
+#: ../ui/main.glade:915
 msgid "H_and Tool"
 msgstr "Hand-Werkzeug"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:63
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:426
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:474
 msgid "Hand"
 msgstr "Hand"
 
@@ -1023,15 +1056,15 @@ msgstr "Hand"
 msgid "Height:"
 msgstr "Höhe:"
 
-#: ../ui/main.glade:379
+#: ../ui/main.glade:407
 msgid "Hide Menu"
 msgstr "Menüleiste ausblenden"
 
-#: ../ui/settings.glade:1683 ../ui/settings.glade:1753
+#: ../ui/settings.glade:1755 ../ui/settings.glade:1825
 msgid "Hide Menubar"
 msgstr "Menüleiste ausblenden"
 
-#: ../ui/settings.glade:1698 ../ui/settings.glade:1768
+#: ../ui/settings.glade:1770 ../ui/settings.glade:1840
 msgid "Hide Sidebar"
 msgstr "Seitenleiste ausblenden"
 
@@ -1039,25 +1072,30 @@ msgstr "Seitenleiste ausblenden"
 msgid "Hide all"
 msgstr "Alle ausblenden"
 
-#: ../ui/settings.glade:1613
+#: ../ui/settings.glade:1685
 msgid "Hide the horizontal scrollbar"
 msgstr "Horizontale Scrollbar ausblenden"
 
-#: ../ui/settings.glade:1628
+#: ../ui/settings.glade:1700
 msgid "Hide the vertical scrollbar"
 msgstr "Vertikale Scrollbar ausblenden"
 
+#: ../ui/settings.glade:1944
+#, fuzzy
+msgid "Highlight cursor position"
+msgstr "Textmarker _Optionen"
+
 #: ../src/gui/dialog/ButtonConfigGui.cpp:57
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:399
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:457
 msgid "Highlighter"
 msgstr "Textmarker"
 
-#: ../ui/main.glade:1014
+#: ../ui/main.glade:1146
 msgid "Highlighter Opti_ons"
 msgstr "Textmarker _Optionen"
 
 #: ../src/control/pagetype/PageTypeHandler.cpp:32
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:403
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:459
 msgid "Image"
 msgstr "Bild"
 
@@ -1065,11 +1103,11 @@ msgstr "Bild"
 msgid "Images"
 msgstr "Bilddateien"
 
-#: ../ui/settings.glade:390
+#: ../ui/settings.glade:404
 msgid "Input"
 msgstr "Eingabe"
 
-#: ../ui/settings.glade:1090
+#: ../ui/settings.glade:1119
 msgid "Input Device"
 msgstr "Eingabegerät"
 
@@ -1077,7 +1115,7 @@ msgstr "Eingabegerät"
 msgid "Insert Latex"
 msgstr "LaTeX einfügen"
 
-#: ../ui/main.glade:1277
+#: ../ui/main.glade:1427
 msgid "Insert a copy of the current page below"
 msgstr "Eine Kopie der aktuellen Seite unten einfügen"
 
@@ -1085,7 +1123,7 @@ msgstr "Eine Kopie der aktuellen Seite unten einfügen"
 msgid "Insert elements"
 msgstr "Elemente einfügen"
 
-#: ../src/undo/InsertUndoAction.cpp:47 ../src/gui/dialog/ButtonConfigGui.cpp:59
+#: ../src/gui/dialog/ButtonConfigGui.cpp:59 ../src/undo/InsertUndoAction.cpp:47
 msgid "Insert image"
 msgstr "Bild einfügen"
 
@@ -1097,11 +1135,11 @@ msgstr "LaTeX einfügen"
 msgid "Insert layer"
 msgstr "Ebene einfügen"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:394
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:443
 msgid "Insert page"
 msgstr "Seite einfügen"
 
-#: ../src/control/XournalMain.cpp:244
+#: ../src/control/XournalMain.cpp:249
 msgid "Jump to Page (first Page: 1)"
 msgstr "Springe zur Seite (erste Seite: 1)"
 
@@ -1123,7 +1161,7 @@ msgstr "Ebenenauswahl"
 msgid "Layer {1}"
 msgstr "Ebene {1}"
 
-#: ../ui/about.glade:217
+#: ../ui/about.glade:218
 msgid "License"
 msgstr "Lizenz"
 
@@ -1141,7 +1179,7 @@ msgstr "hellgrün"
 msgid "Lined"
 msgstr "Liniert mit Rand"
 
-#: ../ui/settings.glade:772
+#: ../ui/settings.glade:786
 msgid "Load / Save"
 msgstr "Laden / Speichern"
 
@@ -1149,13 +1187,13 @@ msgstr "Laden / Speichern"
 msgid "Load file"
 msgstr "Datei laden"
 
-#: ../src/gui/PageView.cpp:738
+#: ../src/gui/PageView.cpp:739
 #: ../src/gui/sidebar/previews/base/SidebarPreviewBaseEntry.cpp:105
 #: ../src/gui/toolbarMenubar/ToolPageLayer.cpp:20
 msgid "Loading..."
 msgstr "Laden..."
 
-#: ../ui/toolbarManageDialog.glade:8 ../ui/toolbarCustomizeDialog.glade:10
+#: ../ui/toolbarCustomizeDialog.glade:10 ../ui/toolbarManageDialog.glade:8
 msgid "Manage Toolbar"
 msgstr "Werkzeugleisten verwalten"
 
@@ -1165,11 +1203,17 @@ msgid "Mangenta"
 msgstr "magenta"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:81
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:437
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:514
 msgid "Medium"
 msgstr "mittel"
 
-#: ../src/control/XournalMain.cpp:462
+#: ../src/control/XournalMain.cpp:460
+msgid ""
+"Missing the needed UI file! .app corrupted?\n"
+"Path: {1}"
+msgstr ""
+
+#: ../src/control/XournalMain.cpp:474
 msgid ""
 "Missing the needed UI file, could not find them at any location.\n"
 "Not relative\n"
@@ -1181,7 +1225,7 @@ msgstr ""
 "Nicht im Arbeitspfad\n"
 "Nicht in {1}"
 
-#: ../ui/settings.glade:883
+#: ../ui/settings.glade:897
 msgid "Mouse Button"
 msgstr "Maustaste"
 
@@ -1201,7 +1245,7 @@ msgstr "Verschiebe Seite nach unten"
 msgid "Move page upwards"
 msgstr "Verschiebe Seite nach oben"
 
-#: ../ui/main.glade:531
+#: ../ui/main.glade:571
 msgid "N_ext annotated page"
 msgstr "Nächste b_eschriftete Seite"
 
@@ -1209,31 +1253,31 @@ msgstr "Nächste b_eschriftete Seite"
 msgid "New"
 msgstr "Neu"
 
-#: ../ui/main.glade:571
+#: ../ui/main.glade:614
 msgid "New Page _After"
 msgstr "Neue Seite danach"
 
-#: ../ui/main.glade:563
+#: ../ui/main.glade:605
 msgid "New Page _Before"
 msgstr "Neue Seite davor"
 
-#: ../ui/main.glade:580
+#: ../ui/main.glade:624
 msgid "New Page at _End"
 msgstr "Neue Seite am Ende"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:316
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:388
 msgid "New Xournal"
 msgstr "Neues Xournal"
 
-#: ../ui/main.glade:611
+#: ../ui/main.glade:658
 msgid "New _Layer"
 msgstr "Neue Ebene"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:342
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:431
 msgid "Next"
 msgstr "Nächste Seite"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:355
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:438
 msgid "Next annotated page"
 msgstr "Nächste beschriftete Seite"
 
@@ -1262,20 +1306,20 @@ msgstr ""
 msgid "Open Image"
 msgstr "Öffne Bild"
 
-#: ../src/control/XournalMain.cpp:121
+#: ../src/control/XournalMain.cpp:125
 msgid "Open Logfile"
 msgstr "Öffne Logdatei"
 
-#: ../src/control/XournalMain.cpp:122
+#: ../src/control/XournalMain.cpp:126
 msgid "Open Logfile directory"
 msgstr "Öffne Verzeichnis der Logdateien"
 
 #: ../src/control/stockdlg/XojOpenDlg.cpp:16
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:318
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:389
 msgid "Open file"
 msgstr "Öffne Datei"
 
-#: ../src/control/RecentManager.cpp:241
+#: ../src/control/RecentManager.cpp:244
 msgctxt "{1} is a URI"
 msgid "Open {1}"
 msgstr "Öffne {1}"
@@ -1289,7 +1333,7 @@ msgstr "orange"
 msgid "PDF Export"
 msgstr "PDF Exportieren"
 
-#: ../src/gui/MainWindow.cpp:732
+#: ../src/gui/MainWindow.cpp:816
 msgid "PDF Page {1}"
 msgstr "PDF-Seite {1}"
 
@@ -1297,17 +1341,17 @@ msgstr "PDF-Seite {1}"
 msgid "PDF background missing"
 msgstr "PDF-Hintergrund fehlt"
 
-#: ../src/control/XournalMain.cpp:223
+#: ../src/control/XournalMain.cpp:230
 msgid "PDF file successfully created"
 msgstr "PDF-Datei erfolgreich erstellt"
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:58
-#: ../src/control/jobs/PdfExportJob.cpp:23
 #: ../src/control/jobs/CustomExportJob.cpp:27
+#: ../src/control/jobs/PdfExportJob.cpp:23
+#: ../src/control/stockdlg/XojOpenDlg.cpp:61
 msgid "PDF files"
 msgstr "PDF Dateien"
 
-#: ../src/control/XournalMain.cpp:243
+#: ../src/control/XournalMain.cpp:248
 msgid "PDF output filename"
 msgstr "Dateiname der PDF-Ausgabe"
 
@@ -1323,7 +1367,7 @@ msgstr "PNG Bild"
 msgid "PNG with transparent background"
 msgstr "PNG mit transparentem Hintergrund"
 
-#: ../ui/main.glade:540
+#: ../ui/main.glade:581
 msgid "P_revious annotated Page"
 msgstr "_Vorherige beschriftete Seite"
 
@@ -1363,19 +1407,19 @@ msgstr "Seiten:"
 msgid "Paper Format"
 msgstr "Seitenformat"
 
-#: ../ui/main.glade:643
+#: ../ui/main.glade:693
 msgid "Paper _Color"
 msgstr "Seite Hintergrundfarbe"
 
-#: ../ui/main.glade:635
+#: ../ui/main.glade:684
 msgid "Paper _Format"
 msgstr "Seitenformat"
 
-#: ../ui/main.glade:651
+#: ../ui/main.glade:702
 msgid "Paper b_ackground"
 msgstr "Seitenhintergrund"
 
-#: ../ui/about.glade:201
+#: ../ui/about.glade:202
 msgid ""
 "Partial based on Xournal\n"
 "by Denis Auroux"
@@ -1383,17 +1427,17 @@ msgstr ""
 "Teilweise basierend auf Xounal\n"
 "von Denis Auroux"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:403
 #: ../src/undo/AddUndoAction.cpp:108
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:322
 msgid "Paste"
 msgstr "Einfügen"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:55
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:382
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:286
 msgid "Pen"
 msgstr "Stift"
 
-#: ../ui/main.glade:859
+#: ../ui/main.glade:932
 msgid "Pen _Options"
 msgstr "Stift Optionen"
 
@@ -1401,9 +1445,9 @@ msgstr "Stift Optionen"
 msgid "Plain"
 msgstr "Einfarbig"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:473
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:32
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:106
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:413
 msgid "Play Object"
 msgstr "Objekt abspielen"
 
@@ -1411,11 +1455,11 @@ msgstr "Objekt abspielen"
 msgid "Predefined"
 msgstr "Vordefiniert"
 
-#: ../ui/main.glade:251
+#: ../ui/main.glade:297
 msgid "Preferences"
 msgstr "Einstellungen"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:461
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:417
 msgid "Presentation mode"
 msgstr "Präsentationsmodus"
 
@@ -1423,15 +1467,15 @@ msgstr "Präsentationsmodus"
 msgid "Range"
 msgstr "Bereich"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:371
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:479
 msgid "Rec / Stop"
 msgstr "Aufnahme / Stopp"
 
-#: ../ui/main.glade:299
+#: ../ui/main.glade:1225
 msgid "Rec-Stop"
 msgstr "Aufnahme stoppen"
 
-#: ../ui/main.glade:61
+#: ../ui/main.glade:63
 msgid "Recent _Documents"
 msgstr "Zuletzt geöffnete _Dokumente"
 
@@ -1440,8 +1484,8 @@ msgstr "Zuletzt geöffnete _Dokumente"
 msgid "Red"
 msgstr "rot"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:397
 #: ../src/undo/UndoRedoHandler.cpp:293
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:327
 msgid "Redo"
 msgstr "Wiederherstellen"
 
@@ -1449,15 +1493,15 @@ msgstr "Wiederherstellen"
 msgid "Redo: "
 msgstr "Wiederherstellen: "
 
-#: ../src/control/Control.cpp:2021
+#: ../src/control/Control.cpp:2057
 msgid "Remove PDF Background"
 msgstr "PDF-Hintergrund entfernen"
 
-#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:202
+#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:198
 msgid "Removed tool item from Toolbar {1} ID {2}"
 msgstr "Entferne Werkzeug von der Werkzeugleiste {1} ID {2}"
 
-#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:198
+#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:194
 msgid "Removed tool item {1} from Toolbar {2} ID {3}"
 msgstr "Entferne Werkzeug {1} von der Werkzeugleiste {2} ID {3}"
 
@@ -1469,7 +1513,7 @@ msgstr "Ersetzten"
 msgid "Resolution"
 msgstr "Auflösung"
 
-#: ../src/control/XournalMain.cpp:174
+#: ../src/control/XournalMain.cpp:178
 msgid "Restore file"
 msgstr "Datei widerherstellen"
 
@@ -1477,33 +1521,38 @@ msgstr "Datei widerherstellen"
 msgid "Rotation"
 msgstr "Drehung"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:375
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:410
 msgid "Rotation Snapping"
+msgstr "Drehung einrasten"
+
+#: ../ui/settings.glade:2083
+#, fuzzy
+msgid "Rotation snapping tolerance:"
 msgstr "Drehung einrasten"
 
 #: ../src/control/pagetype/PageTypeHandler.cpp:24
 msgid "Ruled"
 msgstr "Liniert"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:432
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:467
 msgid "Ruler"
 msgstr "Lineal"
 
-#: ../src/control/jobs/SaveJob.cpp:13 ../src/control/Control.cpp:2532
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:315
+#: ../src/control/Control.cpp:2576 ../src/control/jobs/SaveJob.cpp:13
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:390
 msgid "Save"
 msgstr "Speichern"
 
-#: ../src/control/Control.cpp:2568
+#: ../src/control/Control.cpp:2617
 msgid "Save As"
 msgstr "Speichern als..."
 
-#: ../src/control/Control.cpp:2352 ../src/gui/dialog/PageTemplateDialog.cpp:112
+#: ../src/control/Control.cpp:2388 ../src/gui/dialog/PageTemplateDialog.cpp:112
 msgid "Save File"
 msgstr "Speichere Datei"
 
-#: ../src/control/jobs/SaveJob.cpp:151
 #: ../src/control/jobs/CustomExportJob.cpp:276
+#: ../src/control/jobs/SaveJob.cpp:151
 msgid "Save file error: {1}"
 msgstr "Fehler beim Speichern der Datei: {1}"
 
@@ -1511,7 +1560,7 @@ msgstr "Fehler beim Speichern der Datei: {1}"
 msgid "Scale"
 msgstr "Skalieren"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:324
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:405
 msgid "Search"
 msgstr "Suchen"
 
@@ -1519,11 +1568,11 @@ msgstr "Suchen"
 msgid "Select Background Color"
 msgstr "Hintergrundfarbe wählen"
 
-#: ../ui/settings.glade:2065
+#: ../ui/settings.glade:2223
 msgid "Select Folder"
 msgstr "Ordner auswählen"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:447
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:476
 msgid "Select Font"
 msgstr "Schriftart auswählen"
 
@@ -1531,9 +1580,9 @@ msgstr "Schriftart auswählen"
 msgid "Select Image"
 msgstr "Bild auswählen"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:471
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:31
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:99
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:410
 msgid "Select Object"
 msgstr "Objekt auswählen"
 
@@ -1541,21 +1590,21 @@ msgstr "Objekt auswählen"
 msgid "Select PDF Page"
 msgstr "PDF-Seite auswählen"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:470
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:10
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:29
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:85
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:125
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:408
 msgid "Select Rectangle"
 msgstr "Rechteck auswählen"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:469
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:30
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:92
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:406
 msgid "Select Region"
 msgstr "Bereich auswählen"
 
-#: ../src/control/Control.cpp:2020
+#: ../src/control/Control.cpp:2056
 msgid "Select another PDF"
 msgstr "Andere PDF-Datei auswählen"
 
@@ -1580,21 +1629,21 @@ msgstr "Rechteck auswählen"
 msgid "Select region"
 msgstr "Bereich auswählen"
 
-#: ../ui/settings.glade:1964
+#: ../ui/settings.glade:2051
 msgid "Select the tool and Settings if you press the Default Button"
 msgstr ""
 "Wählen Sie die Werkzeuge und Einstellungen, die als Standard festgelegt "
 "werden sollen"
 
-#: ../ui/settings.glade:1789
+#: ../ui/settings.glade:1861
 msgid "Select toolbar:"
 msgstr "Wähle Werkzeugleiste:"
 
-#: ../ui/settings.glade:1543
+#: ../ui/settings.glade:1600
 msgid "Selection Color (Text, Stroke Selection etc.)"
 msgstr "Auswahlfarbe (Text-, Figuren Selektion etc.)"
 
-#: ../src/control/XournalMain.cpp:120
+#: ../src/control/XournalMain.cpp:124
 msgid "Send Bugreport"
 msgstr "Fehlerbericht senden"
 
@@ -1602,11 +1651,16 @@ msgstr "Fehlerbericht senden"
 msgid "Separator"
 msgstr "Trenner"
 
-#: ../ui/settings.glade:1123
+#: ../ui/settings.glade:1165
+#, fuzzy
+msgid "Settings for Touch devices"
+msgstr "Einstellungen für Touchgeräte welche von GTK erkannt werden"
+
+#: ../ui/settings.glade:1152
 msgid "Settings for Touch devices which are detected by GTK."
 msgstr "Einstellungen für Touchgeräte welche von GTK erkannt werden"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:430
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:462
 msgid "Shape Recognizer"
 msgstr "Figurenerkennung"
 
@@ -1630,19 +1684,19 @@ msgstr "Nur nicht benutzte Seiten anzeigen (eine nicht benutzte Seiten)"
 msgid "Show only not used pages ({1} unused pages)"
 msgstr "Nur nicht benutzte Seiten anzeigen ({1} nicht benutzte Seiten)"
 
-#: ../ui/main.glade:322
+#: ../ui/main.glade:348
 msgid "Show sidebar"
 msgstr "Seitenleiste anzeigen"
 
-#: ../ui/settings.glade:1412
+#: ../ui/settings.glade:1469
 msgid "Show sidebar on the right side"
 msgstr "Seitenleiste auf der rechten Seite anzeigen"
 
-#: ../ui/settings.glade:1427
+#: ../ui/settings.glade:1484
 msgid "Show vertical scrollbar on the left side"
 msgstr "Vertikale Bildlaufleiste auf der linken Seite anzeigen"
 
-#: ../src/control/XournalMain.cpp:309
+#: ../src/control/XournalMain.cpp:308
 msgid ""
 "Sorry, Xournal++ can only open one file at once.\n"
 "Others are ignored."
@@ -1650,7 +1704,7 @@ msgstr ""
 "Entschuldigung, Xournal++ kann nur eine Datei aufs mal öffnen.\n"
 "Alle weiteren werden ignoriert."
 
-#: ../src/control/XournalMain.cpp:324
+#: ../src/control/XournalMain.cpp:323
 msgid ""
 "Sorry, Xournal++ cannot open remote files at the moment.\n"
 "You have to copy the file to a local directory."
@@ -1662,13 +1716,13 @@ msgstr ""
 msgid "Standard"
 msgstr "Standard"
 
-#: ../ui/main.glade:1610
+#: ../ui/main.glade:1752
 msgid "State PLACEHOLDER"
 msgstr "Zustand PLATZHALTER"
 
-#: ../src/undo/RecognizerUndoAction.cpp:101
 #: ../src/gui/dialog/ButtonConfigGui.cpp:103
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:43
+#: ../src/undo/RecognizerUndoAction.cpp:101
 msgid "Stroke recognizer"
 msgstr "Figurenerkennung"
 
@@ -1676,19 +1730,19 @@ msgstr "Figurenerkennung"
 msgid "Successfully saved document to \"{1}\""
 msgstr "Dokument erfolgreich nach \"{1}\" gespeichert."
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:128
+#: ../src/control/stockdlg/XojOpenDlg.cpp:132
 msgid "Supported files"
 msgstr "Unterstützte Dateiformate"
 
-#: ../ui/main.glade:1236
+#: ../ui/main.glade:1386
 msgid "Swap the current page with the one above"
 msgstr "Seite mit darüberliegenden tauschen"
 
-#: ../ui/main.glade:1257
+#: ../ui/main.glade:1407
 msgid "Swap the current page with the one below"
 msgstr "Seite mit darunterliegenden tauschen"
 
-#: ../ui/main.glade:337
+#: ../ui/main.glade:363
 msgid "T_oolbars"
 msgstr "Werkzeugleisten"
 
@@ -1696,16 +1750,16 @@ msgstr "Werkzeugleisten"
 msgid "Template:"
 msgstr "Vorlage:"
 
-#: ../ui/settings.glade:1317
+#: ../ui/settings.glade:1374
 msgid "Test disable"
 msgstr "Test deaktivieren"
 
-#: ../ui/settings.glade:1304
+#: ../ui/settings.glade:1361
 msgid "Test enable"
 msgstr "Test atkvieren"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:58
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:401
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:458
 msgid "Text"
 msgstr "Text"
 
@@ -1714,7 +1768,7 @@ msgstr "Text"
 msgid "Text %i times found on this page"
 msgstr "Text auf dieser Seite %i mal gefunden"
 
-#: ../ui/main.glade:1077
+#: ../ui/main.glade:1214
 msgid "Text Font..."
 msgstr "Schriftart..."
 
@@ -1742,7 +1796,7 @@ msgstr "Text nicht gefunden"
 msgid "Text not found, searched on all pages"
 msgstr "Text nicht gefunden, auf allen Seiten gesucht"
 
-#: ../src/control/Control.cpp:1006
+#: ../src/control/Control.cpp:1017
 msgid ""
 "The Toolbarconfiguration \"{1}\" is predefined, would you create a copy to "
 "edit?"
@@ -1750,23 +1804,23 @@ msgstr ""
 "Die Werkzeugleistenkonfiguration \"{1}\" ist vordefiniert, möchten Sie eine "
 "Kopie erstellen?"
 
-#: ../src/control/Control.cpp:2017
+#: ../src/control/Control.cpp:2053
 msgid "The attached background PDF could not be found."
 msgstr "Der angehängte PDF-Hintergrund konnte nicht gefunden werden."
 
-#: ../src/control/Control.cpp:2018
+#: ../src/control/Control.cpp:2054
 msgid "The background PDF could not be found."
 msgstr "Der PDF-Hintergrund konnte nicht gefunden werden."
 
-#: ../src/control/XournalMain.cpp:115
+#: ../src/control/XournalMain.cpp:119
 msgid "The most recent log file name: {1}"
 msgstr "Der aktuelleste Logdateiname: {1}"
 
-#: ../ui/settings.glade:369
+#: ../ui/settings.glade:383
 msgid "The unit of the ruler is cm"
 msgstr "Die Einheit des Maßstabes ist cm"
 
-#: ../src/control/XournalMain.cpp:108
+#: ../src/control/XournalMain.cpp:112
 msgid ""
 "There are errorlogfiles from Xournal++. Please send a Bugreport, so the bug "
 "may be fixed."
@@ -1775,7 +1829,7 @@ msgstr ""
 "Fehlerbericht (auf Englisch wenn möglich), damit der Fehler korrigiert "
 "werden kann."
 
-#: ../src/control/XournalMain.cpp:107
+#: ../src/control/XournalMain.cpp:111
 msgid ""
 "There is an errorlogfile from Xournal++. Please send a Bugreport, so the bug "
 "may be fixed."
@@ -1789,7 +1843,7 @@ msgid "There was an error displaying help: {1}"
 msgstr "Es ist ein Fehler aufgetreten beim Anzeigen der Hilfe: {1}"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:82
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:439
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:515
 msgid "Thick"
 msgstr "dick"
 
@@ -1798,24 +1852,24 @@ msgid "Thickness - don't change"
 msgstr "Dicke - nicht ändern"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:80
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:435
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:513
 msgid "Thin"
 msgstr "dünn"
 
-#: ../src/control/Control.cpp:2530
+#: ../src/control/Control.cpp:2574
 msgid "This document is not saved yet."
 msgstr "Dieses Dokument wurde noch nicht gespeichert."
 
-#: ../src/control/tools/ImageHandler.cpp:56
 #: ../src/control/PageBackgroundChangeController.cpp:177
+#: ../src/control/tools/ImageHandler.cpp:56
 msgid "This image could not be loaded. Error message: {1}"
 msgstr "Das Bild konnte nicht geladen werden. Fehlermeldung: {1}"
 
-#: ../ui/settings.glade:1185
+#: ../ui/settings.glade:1242
 msgid "Timeout"
 msgstr "Wartezeit"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:368
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:418
 msgid "Toggle fullscreen"
 msgstr "Vollbild umschalten"
 
@@ -1823,7 +1877,7 @@ msgstr "Vollbild umschalten"
 msgid "Tool - don't change"
 msgstr "Werkzeug - nicht ändern"
 
-#: ../src/gui/toolbarMenubar/model/ToolbarData.cpp:156
+#: ../src/gui/toolbarMenubar/model/ToolbarData.cpp:152
 msgid "Toolbar found: {1}"
 msgstr "Werkzeugleiste gefunden: {1}"
 
@@ -1831,11 +1885,11 @@ msgstr "Werkzeugleiste gefunden: {1}"
 msgid "Toolbars"
 msgstr "Werkzeugleisten"
 
-#: ../ui/settings.glade:1358
+#: ../ui/settings.glade:1415
 msgid "Touch"
 msgstr "Touch"
 
-#: ../ui/settings.glade:1046
+#: ../ui/settings.glade:1060
 msgid ""
 "Touch Screens which are detected by GTK are handled specially, and don't "
 "need to be configured here."
@@ -1851,12 +1905,12 @@ msgstr "Tranzparenz Einstellungen"
 msgid "Trying to emergency save the current open document…"
 msgstr "Versuche ein Notfall-Speichern des aktuell geöffneten Dokuments…"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:458
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:416
 msgid "Two pages"
 msgstr "Zwei Seiten"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:396
 #: ../src/undo/UndoRedoHandler.cpp:274
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:326
 msgid "Undo"
 msgstr "Rückgängig"
 
@@ -1864,15 +1918,15 @@ msgstr "Rückgängig"
 msgid "Undo: "
 msgstr "Rückgängig: "
 
-#: ../src/control/xojfile/LoadHandler.cpp:241
+#: ../src/control/xojfile/LoadHandler.cpp:260
 msgid "Unexpected root tag: {1}"
 msgstr "Unerwarteter Root Tag: {1}"
 
-#: ../src/control/xojfile/LoadHandler.cpp:270
+#: ../src/control/xojfile/LoadHandler.cpp:289
 msgid "Unexpected tag in document: \"{1}\""
 msgstr "Unerwarteter Tag im Dokument: \"{1}\""
 
-#: ../src/control/xojfile/LoadHandler.cpp:475
+#: ../src/control/xojfile/LoadHandler.cpp:494
 msgid "Unknown background type: {1}"
 msgstr "Unbekannter Hintergrundtyp: {1}"
 
@@ -1880,23 +1934,23 @@ msgstr "Unbekannter Hintergrundtyp: {1}"
 msgid "Unknown color value \"{1}\""
 msgstr "Unbekannter Farbwert \"{1}\""
 
-#: ../src/control/xojfile/LoadHandler.cpp:410
+#: ../src/control/xojfile/LoadHandler.cpp:429
 msgid "Unknown domain type: {1}"
 msgstr "Unbekannter Domänentyp: {1}"
 
-#: ../src/control/xojfile/LoadHandler.cpp:193
+#: ../src/control/xojfile/LoadHandler.cpp:194
 msgid "Unknown parser error"
 msgstr "Unbekannter Lesefehler"
 
-#: ../src/control/xojfile/LoadHandler.cpp:345
+#: ../src/control/xojfile/LoadHandler.cpp:364
 msgid "Unknown pixmap::domain type: {1}"
 msgstr "Unbekannter pixmap::domain Typ: {1}"
 
-#: ../src/control/xojfile/LoadHandler.cpp:558
+#: ../src/control/xojfile/LoadHandler.cpp:591
 msgid "Unknown stroke type: \"{1}\", assuming pen"
 msgstr "Unbekannter Linientyp: \"{1}\", verwende Stift"
 
-#: ../src/control/Control.cpp:2424
+#: ../src/control/Control.cpp:2460
 msgid "Unsaved Document"
 msgstr "Ungespeichertes Dokument"
 
@@ -1904,7 +1958,7 @@ msgstr "Ungespeichertes Dokument"
 msgid "Version"
 msgstr "Version"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:425
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:472
 msgid "Vertical Space"
 msgstr "Vertikaler Platz"
 
@@ -1912,7 +1966,7 @@ msgstr "Vertikaler Platz"
 msgid "Vertical space"
 msgstr "Vertikaler Platz"
 
-#: ../ui/settings.glade:1895
+#: ../ui/settings.glade:1982
 msgid "View"
 msgstr "Ansicht"
 
@@ -1933,7 +1987,7 @@ msgstr "Breite:"
 msgid "With PDF background"
 msgstr "Mit PDF-Hintergrund"
 
-#: ../ui/about.glade:187
+#: ../ui/about.glade:188
 msgid "With help from the community"
 msgstr "mit Hilfe der Community"
 
@@ -1941,19 +1995,19 @@ msgstr "mit Hilfe der Community"
 msgid "Write text"
 msgstr "Text schreiben"
 
-#: ../src/control/xojfile/LoadHandler.cpp:821
+#: ../src/control/xojfile/LoadHandler.cpp:852
 msgid "Wrong count of points ({1})"
 msgstr "Falsche Punktanzahl ({1})"
 
-#: ../src/control/xojfile/LoadHandler.cpp:836
+#: ../src/control/xojfile/LoadHandler.cpp:866
 msgid "Wrong number of points, got {1}, expected {2}"
 msgstr "Falsche Punktzahl {1}, erwartet wurde {2}"
 
-#: ../ui/settings.glade:1171
+#: ../ui/settings.glade:1228
 msgid "X11"
 msgstr "X11"
 
-#: ../src/control/xojfile/LoadHandler.cpp:188
+#: ../src/control/xojfile/LoadHandler.cpp:189
 msgid "XML Parser error: {1}"
 msgstr "XML Parser Fehler: {1}"
 
@@ -1961,25 +2015,25 @@ msgstr "XML Parser Fehler: {1}"
 msgid "Xournal (Compatibility)"
 msgstr "Xournal (Kompatibilitätsmodus)"
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:69
+#: ../src/control/stockdlg/XojOpenDlg.cpp:72
 msgid "Xournal files"
 msgstr "Xournal Dateien"
 
-#: ../ui/settings.glade:28
+#: ../ui/settings.glade:42
 msgid "Xournal++ Preferences"
 msgstr "Xournal++ Einstellungen"
 
-#: ../src/control/XournalMain.cpp:168
+#: ../src/control/XournalMain.cpp:172
 msgid "Xournal++ crashed last time. Would you restore it?"
 msgstr ""
 "Xournal++ ist das letzte mal abgestürzt. Soll die Datei widerhergestellt "
 "werden?"
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:79 ../src/control/Control.cpp:2359
+#: ../src/control/Control.cpp:2395 ../src/control/stockdlg/XojOpenDlg.cpp:82
 msgid "Xournal++ files"
 msgstr "Xournal++ Dateien"
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:89
+#: ../src/control/stockdlg/XojOpenDlg.cpp:92
 #: ../src/gui/dialog/PageTemplateDialog.cpp:119
 msgid "Xournal++ template"
 msgstr "Xournal++ Vorlage"
@@ -1999,7 +2053,7 @@ msgstr ""
 "Bitte wählen Sie einen anderen Hintergrundtyp: Menü \"Journal\" / "
 "\"Seitenvorlage konfigurieren\"."
 
-#: ../src/control/XournalMain.cpp:111
+#: ../src/control/XournalMain.cpp:115
 msgid ""
 "You're using {1}/{2} branch. Send Bugreport will direct you to this repo's "
 "issue tracker."
@@ -2021,19 +2075,19 @@ msgstr ""
 "Tipp: Sie können im Menü Journal / Seitenhintergrund / PDF-Hintergrund eine "
 "beliebige PDF Seite einfügen."
 
-#: ../ui/settings.glade:302
+#: ../ui/settings.glade:316
 msgid "Zoom"
 msgstr "Zoom"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:362
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:422
 msgid "Zoom fit to screen"
 msgstr "Passend zoomen"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:360
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:421
 msgid "Zoom in"
 msgstr "Hereinzoomen"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:358
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:420
 msgid "Zoom out"
 msgstr "Herauszoomen"
 
@@ -2041,42 +2095,42 @@ msgstr "Herauszoomen"
 msgid "Zoom slider"
 msgstr "Zoomregler"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:364
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:423
 msgid "Zoom to 100%"
 msgstr "Zoom auf 100%"
 
-#: ../ui/main.glade:69
+#: ../ui/main.glade:71
 msgid "_Annotate PDF"
 msgstr "_PDF beschriften"
 
+#: ../src/control/Control.cpp:2389 ../src/control/jobs/BaseExportJob.cpp:26
 #: ../src/control/stockdlg/ImageOpenDlg.cpp:12
 #: ../src/control/stockdlg/XojOpenDlg.cpp:17
-#: ../src/control/jobs/BaseExportJob.cpp:26 ../src/control/Control.cpp:2353
 #: ../src/gui/dialog/PageTemplateDialog.cpp:113
 msgid "_Cancel"
 msgstr "_Abbrechen"
 
-#: ../ui/main.glade:361
+#: ../ui/main.glade:388
 msgid "_Customize"
 msgstr "_Anpassen"
 
-#: ../ui/main.glade:723
+#: ../ui/main.glade:779
 msgid "_Default Tools"
 msgstr "_Standard Werkzeuge"
 
-#: ../ui/main.glade:596
+#: ../ui/main.glade:642
 msgid "_Delete Page"
 msgstr "_Seite löschen"
 
-#: ../ui/main.glade:153
+#: ../ui/main.glade:162
 msgid "_Edit"
 msgstr "_Bearbeiten"
 
-#: ../ui/main.glade:683
+#: ../ui/main.glade:735
 msgid "_Eraser"
 msgstr "_Radierer"
 
-#: ../ui/main.glade:104
+#: ../ui/main.glade:109
 msgid "_Export as PDF"
 msgstr "_Exportieren als PDF"
 
@@ -2084,47 +2138,47 @@ msgstr "_Exportieren als PDF"
 msgid "_File"
 msgstr "_Datei"
 
-#: ../ui/main.glade:448
+#: ../ui/main.glade:480
 msgid "_First Page"
 msgstr "_Erste Seite"
 
-#: ../ui/main.glade:466
+#: ../ui/main.glade:500
 msgid "_Goto Page"
 msgstr "_Gehe zur Seite"
 
-#: ../ui/main.glade:1099
+#: ../ui/main.glade:1247
 msgid "_Help"
 msgstr "_Hilfe"
 
-#: ../ui/main.glade:693
+#: ../ui/main.glade:746
 msgid "_Highlighter"
 msgstr "_Textmarker"
 
-#: ../ui/main.glade:713
+#: ../ui/main.glade:768
 msgid "_Image"
 msgstr "_Bild"
 
-#: ../ui/main.glade:553
+#: ../ui/main.glade:595
 msgid "_Journal"
 msgstr "_Journal"
 
-#: ../ui/main.glade:484
+#: ../ui/main.glade:520
 msgid "_Last Page"
 msgstr "_Letzte Seite"
 
-#: ../ui/main.glade:353
+#: ../ui/main.glade:379
 msgid "_Manage"
 msgstr "_Werkzeugleisten verwalten"
 
-#: ../ui/main.glade:438
+#: ../ui/main.glade:470
 msgid "_Navigation"
 msgstr "_Navigation"
 
-#: ../ui/main.glade:508
+#: ../ui/main.glade:546
 msgid "_Next Layer"
 msgstr "_Nächste Ebene"
 
-#: ../ui/main.glade:475
+#: ../ui/main.glade:510
 msgid "_Next Page"
 msgstr "_Nächste Seite"
 
@@ -2133,80 +2187,80 @@ msgstr "_Nächste Seite"
 msgid "_Open"
 msgstr "Ö_ffnen"
 
-#: ../ui/main.glade:673
+#: ../ui/main.glade:724
 msgid "_Pen"
 msgstr "_Stift"
 
-#: ../ui/main.glade:281
+#: ../ui/main.glade:329
 msgid "_Presentation Mode"
 msgstr "_Präsentationsmodus"
 
-#: ../ui/main.glade:499
+#: ../ui/main.glade:536
 msgid "_Previous Layer"
 msgstr "_Vorherige Ebene"
 
-#: ../ui/main.glade:457
+#: ../ui/main.glade:490
 msgid "_Previous Page"
 msgstr "_Vorherige Seite"
 
-#: ../src/control/jobs/BaseExportJob.cpp:27 ../src/control/Control.cpp:2354
+#: ../src/control/Control.cpp:2390 ../src/control/jobs/BaseExportJob.cpp:27
 #: ../src/gui/dialog/PageTemplateDialog.cpp:114
 msgid "_Save"
 msgstr "_Speichern"
 
-#: ../ui/main.glade:737
+#: ../ui/main.glade:794
 msgid "_Shape Recognizer"
 msgstr "_Figurenerkennung"
 
-#: ../ui/main.glade:703
+#: ../ui/main.glade:757
 msgid "_Text"
 msgstr "_Text"
 
-#: ../ui/main.glade:663
+#: ../ui/main.glade:714
 msgid "_Tools"
 msgstr "_Werkzeuge"
 
-#: ../ui/main.glade:517
+#: ../ui/main.glade:556
 msgid "_Top Layer"
 msgstr "_Oberste Ebene"
 
-#: ../ui/main.glade:273
+#: ../ui/main.glade:320
 msgid "_Two Pages"
 msgstr "_Zwei Seiten"
 
-#: ../ui/main.glade:823
+#: ../ui/main.glade:893
 msgid "_Vertical Space"
 msgstr "_Vertikaler Platz"
 
-#: ../ui/main.glade:263
+#: ../ui/main.glade:310
 msgid "_View"
 msgstr "_Ansicht"
 
-#: ../ui/main.glade:1001
+#: ../ui/main.glade:1132
 msgid "_delete strokes"
 msgstr "_Linien löschen"
 
-#: ../ui/main.glade:878 ../ui/main.glade:950 ../ui/main.glade:1024
+#: ../ui/main.glade:952 ../ui/main.glade:1076 ../ui/main.glade:1156
 msgid "_fine"
 msgstr "_dünn"
 
-#: ../ui/main.glade:887 ../ui/main.glade:959 ../ui/main.glade:1033
+#: ../ui/main.glade:962 ../ui/main.glade:1086 ../ui/main.glade:1166
 msgid "_medium"
 msgstr "_mittel"
 
-#: ../ui/main.glade:983
+#: ../ui/main.glade:1112
 msgid "_standard"
 msgstr "_standard"
 
-#: ../ui/main.glade:896 ../ui/main.glade:968 ../ui/main.glade:1042
+#: ../ui/main.glade:972 ../ui/main.glade:1096 ../ui/main.glade:1176
 msgid "_thick"
 msgstr "_dick"
 
-#: ../ui/main.glade:869
+#: ../ui/main.glade:942
 msgid "_very fine"
 msgstr "_sehr dünn"
 
-#: ../ui/main.glade:992
+#: ../ui/main.glade:1122
 msgid "_whiteout"
 msgstr "_weiß übermalen"
 
@@ -2218,9 +2272,22 @@ msgstr "ändern"
 msgid "cursor"
 msgstr "Cursor"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:299
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:294
+msgid "dash-/ doted"
+msgstr ""
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:291
+msgid "dashed"
+msgstr ""
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:312
 msgid "delete stroke"
 msgstr "Linie löschen"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:297
+#, fuzzy
+msgid "dotted"
+msgstr "Gepunktet"
 
 #: ../ui/exportSettings.glade:213
 msgid "dpi"
@@ -2246,7 +2313,7 @@ msgstr "Maus"
 msgid "pen"
 msgstr "Stift"
 
-#: ../ui/settings.glade:1212
+#: ../ui/settings.glade:1269
 msgid "s"
 msgstr "s"
 
@@ -2258,7 +2325,8 @@ msgstr "Speichere in Datei"
 msgid "show"
 msgstr "anzeigen"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:285
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:288
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:310
 msgid "standard"
 msgstr "standard"
 
@@ -2270,15 +2338,15 @@ msgstr "Touchpad"
 msgid "touchscreen"
 msgstr "Touchscreen"
 
-#: ../ui/main.glade:905
+#: ../ui/main.glade:982
 msgid "ver_y thick"
 msgstr "sehr dick"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:292
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:311
 msgid "whiteout"
 msgstr "weiß übermalen"
 
-#: ../src/control/xojfile/LoadHandler.cpp:835
+#: ../src/control/xojfile/LoadHandler.cpp:865
 msgid "xoj-File: {1}"
 msgstr "xoj-Datei: {1}"
 
@@ -2386,8 +2454,18 @@ msgstr "xoj-Vorschau-Extraktor: erfolgreich extrahiert"
 #~ msgid "Command is being run."
 #~ msgstr "Befehl wird ausgeführt."
 
+#~ msgid ""
+#~ "Could not find Xournal++ LaTeX executable relative or in Path.\n"
+#~ "Searched for: mathtex-xournalpp.cgi"
+#~ msgstr ""
+#~ "Konnte Xournal++ LaTeX Programm nicht finden, relativ oder im Pfad.\n"
+#~ "Suche nach: mathtex-xournalpp.cgi"
+
 #~ msgid "Disable Ruler & Stroke Recognizer"
 #~ msgstr "Maßstab und Figurenerkennung deaktivieren"
+
+#~ msgid "Don't compress PDF files (for debugging)"
+#~ msgstr "PDF-Datei nicht komprimieren (zur Fehlersuche)"
 
 #~ msgid "Drawing type"
 #~ msgstr "Zeichnungstyp"

--- a/po/it.po
+++ b/po/it.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: xournalpp 1.0.4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-12-30 12:21+0100\n"
-"PO-Revision-Date: 2019-01-05 18:20+0100\n"
+"POT-Creation-Date: 2019-01-23 10:36+0100\n"
+"PO-Revision-Date: 2019-01-23 10:44+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: it\n"
@@ -18,40 +18,40 @@ msgstr ""
 "X-Generator: Poedit 2.2\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../src/undo/DeleteUndoAction.cpp:113 ../src/undo/AddUndoAction.cpp:119
+#: ../src/undo/AddUndoAction.cpp:119 ../src/undo/DeleteUndoAction.cpp:113
 msgid " elements"
 msgstr " elementi"
 
-#: ../src/undo/DeleteUndoAction.cpp:128 ../src/undo/AddUndoAction.cpp:134
+#: ../src/undo/AddUndoAction.cpp:134 ../src/undo/DeleteUndoAction.cpp:128
 msgid " image"
 msgstr " immagine"
 
-#: ../src/undo/DeleteUndoAction.cpp:132 ../src/undo/AddUndoAction.cpp:138
+#: ../src/undo/AddUndoAction.cpp:138 ../src/undo/DeleteUndoAction.cpp:132
 msgid " latex"
 msgstr " latex"
 
-#: ../src/gui/MainWindow.cpp:734
+#: ../src/gui/MainWindow.cpp:818
 msgctxt "Page {pagenumber} \"of {pagecount}\""
 msgid " of {1}{2}"
 msgstr " di {1}{2}"
 
-#: ../src/undo/DeleteUndoAction.cpp:120 ../src/undo/AddUndoAction.cpp:126
+#: ../src/undo/AddUndoAction.cpp:126 ../src/undo/DeleteUndoAction.cpp:120
 msgid " stroke"
 msgstr " tratto"
 
-#: ../src/undo/DeleteUndoAction.cpp:124 ../src/undo/AddUndoAction.cpp:130
+#: ../src/undo/AddUndoAction.cpp:130 ../src/undo/DeleteUndoAction.cpp:124
 msgid " text"
 msgstr " testo"
 
-#: ../src/control/settings/Settings.cpp:79
+#: ../src/control/settings/Settings.cpp:90
 msgid "%F-Note-%H-%M"
 msgstr "%F-Note-%H-%M"
 
-#: ../ui/settings.glade:590
+#: ../ui/settings.glade:604
 msgid "%F-Note-%H-%M.xoj"
 msgstr "%F-Note-%H-%M.xoj"
 
-#: ../ui/settings.glade:613
+#: ../ui/settings.glade:627
 msgid ""
 "%a\tAbbreviated weekday name \t(e.g. Thu)\n"
 "%A\tFull weekday name (e.g. Thursday)\n"
@@ -103,19 +103,19 @@ msgstr ""
 msgid "<b>... or select already used Image:</b>"
 msgstr "<b>... o seleziona un'immagine già utilizzata:</b>"
 
-#: ../ui/settings.glade:271
+#: ../ui/settings.glade:285
 msgid "<b>Add horizontal space</b>"
 msgstr "<b>Aggiungi spazio orizzontale</b>"
 
-#: ../ui/settings.glade:248
+#: ../ui/settings.glade:262
 msgid "<b>Add vertical space</b>"
 msgstr "<b>Aggiungi spazio verticale</b>"
 
-#: ../ui/settings.glade:704
+#: ../ui/settings.glade:718
 msgid "<b>Autoload .pdf.xoj</b>"
 msgstr "<b>Autocarica .pdf.xoj</b>"
 
-#: ../ui/settings.glade:488
+#: ../ui/settings.glade:502
 msgid ""
 "<b>Autosave Folder</b>\n"
 "<i>If the document already was saved you can find it in the same folder\n"
@@ -129,7 +129,7 @@ msgstr ""
 "Se il file non è mai stato salvato, puoi trovarlo nella tua Home, come\n"
 "~/.xournalpp/autosave</i>"
 
-#: ../ui/settings.glade:428
+#: ../ui/settings.glade:442
 msgid "<b>Autosave</b>"
 msgstr "<b>Salvataggio Automatico</b>"
 
@@ -145,7 +145,7 @@ msgstr "<b>Sfondo</b>"
 msgid "<b>Color</b>"
 msgstr "<b>Colore</b>"
 
-#: ../ui/settings.glade:1464
+#: ../ui/settings.glade:1521
 msgid "<b>Colors</b>"
 msgstr "<b>Colori</b>"
 
@@ -167,7 +167,7 @@ msgstr ""
 "Usa queste impostazioni\n"
 "per la prima pagina"
 
-#: ../ui/settings.glade:1835
+#: ../ui/settings.glade:1907
 msgid "<b>Cursor</b>"
 msgstr "<b>Cursore</b>"
 
@@ -175,15 +175,15 @@ msgstr "<b>Cursore</b>"
 msgid "<b>Default Tools</b>"
 msgstr "<b>Strumenti di Default</b>"
 
-#: ../ui/settings.glade:577
+#: ../ui/settings.glade:591
 msgid "<b>Default name:</b>"
 msgstr "<b>Nome predefinito:</b>"
 
-#: ../ui/settings.glade:524
+#: ../ui/settings.glade:538
 msgid "<b>Default save name</b>"
 msgstr "<b>Nome salvataggio predefinito</b>"
 
-#: ../ui/settings.glade:1943
+#: ../ui/settings.glade:2030
 msgid "<b>Default</b>"
 msgstr "<b>Default</b>"
 
@@ -195,11 +195,11 @@ msgstr ""
 "<b>Impostazioni Esportazione Documento</b>\n"
 "Seleziona le pagine da esportare"
 
-#: ../ui/settings.glade:1002
+#: ../ui/settings.glade:1016
 msgid "<b>Eraser</b>"
 msgstr "<b>Gomma</b>"
 
-#: ../ui/settings.glade:110
+#: ../ui/settings.glade:124
 msgid "<b>Extended Input</b>"
 msgstr "<b>Input Esteso</b>"
 
@@ -211,19 +211,19 @@ msgstr ""
 "<b>Impostazioni Riempi trasparenza</b>\n"
 "Seleziona la trasparenza per il colore di riempimento"
 
-#: ../ui/settings.glade:1661
+#: ../ui/settings.glade:1733
 msgid "<b>Fullscreen</b>"
 msgstr "<b>Schermo intero</b>"
 
-#: ../ui/settings.glade:658
+#: ../ui/settings.glade:672
 msgid "<b>Help</b> (Placeholders)"
 msgstr "<b>Aiuto</b> (Placeholders)"
 
-#: ../ui/settings.glade:1390
+#: ../ui/settings.glade:1447
 msgid "<b>Left / Right</b>"
 msgstr "<b>Sinistra / Destra</b>"
 
-#: ../ui/settings.glade:819
+#: ../ui/settings.glade:833
 msgid "<b>Middle Mouse Button</b>"
 msgstr "<b>Pulsante centrale del mouse</b>"
 
@@ -235,24 +235,24 @@ msgstr "<b>Dimensione pagina</b>"
 msgid "<b>Pagesize</b>"
 msgstr "<b>Dimensione Pagina</b>"
 
-#: ../ui/settings.glade:1731
+#: ../ui/settings.glade:1803
 msgid "<b>Presentation</b> Another Fullscreen Mode, <i>Start with F5</i>"
 msgstr ""
 "<b>Presentazione</b> Un'altra Modalità Schermo intero, <i>Inizia con F5</i>"
 
-#: ../ui/settings.glade:155
+#: ../ui/settings.glade:169
 msgid "<b>Pressure sensitivity</b>"
 msgstr "<b>Sensibilità alla Pressione</b>"
 
-#: ../ui/settings.glade:849
+#: ../ui/settings.glade:863
 msgid "<b>Right Mouse Button</b>"
 msgstr "<b>Pulsante Destro del Mouse</b>"
 
-#: ../ui/settings.glade:1584
+#: ../ui/settings.glade:1656
 msgid "<b>Scrollbars</b>"
 msgstr "<b>Barre di scorrimento</b>"
 
-#: ../ui/settings.glade:200
+#: ../ui/settings.glade:214
 msgid "<b>Scrolling outside the page</b>"
 msgstr "<b>Scrolling fuori dalla pagina</b>"
 
@@ -260,15 +260,15 @@ msgstr "<b>Scrolling fuori dalla pagina</b>"
 msgid "<b>Separator</b>"
 msgstr "<b>Separatore</b>"
 
-#: ../ui/settings.glade:944
+#: ../ui/settings.glade:958
 msgid "<b>Stylus Button 1</b> Action if the pen button is pressed"
 msgstr "<b>Pulsante Penna 1</b> Azionato se è premuto il pulsante sulla penna"
 
-#: ../ui/settings.glade:973
+#: ../ui/settings.glade:987
 msgid "<b>Stylus Button 2</b> Action if the pen button is pressed"
 msgstr "<b>Pulsante Penna 2</b> Azionato se è premuto il pulsante sulla penna"
 
-#: ../ui/settings.glade:1031
+#: ../ui/settings.glade:1045
 msgid ""
 "<b>Touch Screen</b> <i>You can also configure other devices like mice</i>"
 msgstr ""
@@ -279,7 +279,7 @@ msgstr ""
 msgid "<i>Example:</i> 1-3 or 1,3,5-7 etc."
 msgstr "<i>Esempio:</i> 1-3 o 1,3,5-7 ecc."
 
-#: ../ui/settings.glade:929
+#: ../ui/settings.glade:943
 msgid ""
 "<i>Here you can define which tools will be selected If you\n"
 "use the eraser or other device.\n"
@@ -289,7 +289,7 @@ msgstr ""
 "utilizzi la gomma o altri dispositivi.\n"
 "Qui puoi disattivare il touchscreen.</i>"
 
-#: ../ui/settings.glade:804
+#: ../ui/settings.glade:818
 msgid ""
 "<i>Here you can define which tools will be selected if you press\n"
 "a button; after you release the button the previously selected\n"
@@ -299,7 +299,7 @@ msgstr ""
 "un pulsante; quando rilascerai il pulsante, sarà selezionato\n"
 "lo strumento precedente</i>"
 
-#: ../ui/settings.glade:2030
+#: ../ui/settings.glade:2188
 msgid ""
 "<i>If audio recording is running, the time stamps are stored to the "
 "handwritten Text and can be replayed.\n"
@@ -310,7 +310,7 @@ msgstr ""
 "La traccia Audio è salvata in una cartella separata, ma sarà collegata qui.</"
 "i>"
 
-#: ../ui/settings.glade:224
+#: ../ui/settings.glade:238
 msgid ""
 "<i>If you add <b>additional space</b> beside the pages\n"
 "you can choose the area of the screen you would\n"
@@ -320,13 +320,13 @@ msgstr ""
 "puoi scegliere l'area dello schermo in cui \n"
 "desideri lavorare</i>"
 
-#: ../ui/settings.glade:170
+#: ../ui/settings.glade:184
 msgid "<i>If you have a tablet pen you can get different line widths</i>"
 msgstr ""
 "<i>Se sei in possesso di una penna da tablet puoi ottenere linee di spessore "
 "diverso</i>"
 
-#: ../ui/settings.glade:728
+#: ../ui/settings.glade:742
 msgid ""
 "<i>If you open a PDF and there is a\n"
 "Xournal file with the same name it will open the xoj file.</i>"
@@ -334,7 +334,7 @@ msgstr ""
 "<i>Se apri un PDF ed esiste un file\n"
 "Xournal con lo stesso nome, verrà aperto il file .xoj.</i>"
 
-#: ../ui/settings.glade:324
+#: ../ui/settings.glade:338
 msgid ""
 "<i>Put a ruler on your screen to calibrate the zoom level to fit your "
 "screen. Takes effect after restarting xournalpp.\n"
@@ -344,11 +344,11 @@ msgstr ""
 "effetto dopo il riavvio di xournalpp.\n"
 "Le unità sono cm per il richello, dpi per lo slider.</i>"
 
-#: ../ui/settings.glade:133
+#: ../ui/settings.glade:147
 msgid "<i>Select some advanced input options</i>"
 msgstr "<i>Seleziona alcune opzioni di input avanzate</i>"
 
-#: ../ui/settings.glade:1339
+#: ../ui/settings.glade:1396
 msgid ""
 "<i>The commands will be executed in the UI Thread, make sure\n"
 "they are not blocking!</i>"
@@ -356,7 +356,7 @@ msgstr ""
 "<i>I comandi saranno eseguiti nel Thread UI, assicurati\n"
 "che non blocchino nulla!</i>"
 
-#: ../ui/settings.glade:548
+#: ../ui/settings.glade:562
 msgid "<i>This name will be proposed if you save a new document</i>"
 msgstr "<i>Questo nome sarà proposto in fase di un nuovo salvataggio</i>"
 
@@ -372,15 +372,15 @@ msgstr ""
 msgid "About Xournal++"
 msgstr "Informazioni su Xournal++"
 
-#: ../src/control/XournalMain.cpp:245
+#: ../src/control/XournalMain.cpp:250
 msgid "Absolute path for the audio files playback"
 msgstr "Percorso assoluto per il playback audio"
 
-#: ../ui/main.glade:1086
+#: ../ui/main.glade:1233
 msgid "Add/Edit Tex"
 msgstr "Aggiungi/Modifica Tex"
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:48
+#: ../src/control/stockdlg/XojOpenDlg.cpp:51
 msgid "All files"
 msgstr "Tutti i files"
 
@@ -397,7 +397,7 @@ msgid "Apply to current page"
 msgstr "Applica alla pagina corrente"
 
 #: ../src/control/stockdlg/ImageOpenDlg.cpp:30
-#: ../src/control/stockdlg/XojOpenDlg.cpp:147
+#: ../src/control/stockdlg/XojOpenDlg.cpp:152
 msgid "Attach file to the journal"
 msgstr "Allega file al Journal"
 
@@ -427,15 +427,15 @@ msgstr ""
 msgid "Attribute color not set!"
 msgstr "Colore non impostato!"
 
-#: ../ui/settings.glade:2051
+#: ../ui/settings.glade:2209
 msgid "Audio Folder"
 msgstr "Cartella Audio"
 
-#: ../ui/settings.glade:2088
+#: ../ui/settings.glade:2246
 msgid "Audio Recording"
 msgstr "Registrazione Audio"
 
-#: ../src/control/AudioController.cpp:100
+#: ../src/control/AudioController.cpp:98
 msgid ""
 "Audio folder not set! Recording won't work!\n"
 "Please set the recording folder under \"Preferences > Audio recording\""
@@ -447,15 +447,15 @@ msgstr ""
 msgid "Authors:"
 msgstr "Autori:"
 
-#: ../ui/settings.glade:1170
+#: ../ui/settings.glade:1227
 msgid "Autodetect"
 msgstr "Rilevamento automatico"
 
-#: ../ui/settings.glade:456
+#: ../ui/settings.glade:470
 msgid "Autosave every ... minutes:"
 msgstr "Autosalva ogni ... minuti:"
 
-#: ../src/control/Control.cpp:254
+#: ../src/control/Control.cpp:256
 msgid "Autosave failed with an error: {1}"
 msgstr "Autosalvataggio fallito con un errore: {1}"
 
@@ -463,8 +463,7 @@ msgstr "Autosalvataggio fallito con un errore: {1}"
 msgid "Autosave: {1}"
 msgstr "Autosalvataggio: {1}"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:333
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:336
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:429
 msgid "Back"
 msgstr "Indietro"
 
@@ -474,11 +473,11 @@ msgstr "Indietro"
 msgid "Background"
 msgstr "Sfondo"
 
-#: ../ui/settings.glade:1520
+#: ../ui/settings.glade:1577
 msgid "Background color for window Background"
 msgstr "Colore di sfondo per lo Sfondo della finestra"
 
-#: ../ui/settings.glade:1857
+#: ../ui/settings.glade:1929
 msgid "Big cursor for pen"
 msgstr "Cursore Grande per Penna"
 
@@ -492,11 +491,11 @@ msgstr "Nero"
 msgid "Blue"
 msgstr "Blu"
 
-#: ../ui/settings.glade:1509
+#: ../ui/settings.glade:1566
 msgid "Border color"
 msgstr "Colore bordi"
 
-#: ../ui/settings.glade:1495
+#: ../ui/settings.glade:1552
 msgid "Border color for current page and other selections"
 msgstr "Colore bordi per la pagina corrente e le altre selezioni"
 
@@ -504,8 +503,8 @@ msgstr "Colore bordi per la pagina corrente e le altre selezioni"
 msgid "Built on:"
 msgstr "Compilato il:"
 
-#: ../src/control/Control.cpp:2022 ../src/control/Control.cpp:2534
-#: ../src/control/Control.cpp:2570 ../src/control/XournalMain.cpp:124
+#: ../src/control/Control.cpp:2058 ../src/control/Control.cpp:2581
+#: ../src/control/Control.cpp:2619 ../src/control/XournalMain.cpp:128
 msgid "Cancel"
 msgstr "Annulla"
 
@@ -521,7 +520,7 @@ msgstr "Cambia font"
 msgid "Change stroke fill"
 msgstr "Cambia riempimento tratto"
 
-#: ../src/undo/SizeUndoAction.cpp:145
+#: ../src/undo/SizeUndoAction.cpp:139
 msgid "Change stroke width"
 msgstr "Cambia spessore tratto"
 
@@ -529,7 +528,7 @@ msgstr "Cambia spessore tratto"
 msgid "Color \"{1}\" unknown (not defined in default color list)!"
 msgstr "Colore sconosciuto: \"{1}\" (non definito nella lista di default)"
 
-#: ../ui/main.glade:588
+#: ../ui/main.glade:633
 msgid "Configure Page Template"
 msgstr "Configura Template Pagina"
 
@@ -537,8 +536,8 @@ msgstr "Configura Template Pagina"
 msgid "Contents"
 msgstr "Contenuti"
 
-#: ../src/control/Control.cpp:1036 ../src/control/Control.cpp:1044
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:321
+#: ../src/control/Control.cpp:1047 ../src/control/Control.cpp:1055
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:402
 msgid "Copy"
 msgstr "Copia"
 
@@ -558,6 +557,10 @@ msgstr "Copia le dimensioni dell'ultima pagina"
 msgid "Copy page"
 msgstr "Copia pagina"
 
+#: ../src/control/LatexController.cpp:103
+msgid "Could not convert tex to PDF: {1} (exit code: {2})"
+msgstr "Impossibile convertire il tex in PDF: {1} (codice uscita: {2})"
+
 #: ../src/control/jobs/SaveJob.cpp:137
 msgid ""
 "Could not create backup! (The file was created from an older Xournal version)"
@@ -565,31 +568,39 @@ msgstr ""
 "Impossbile creare un backup! (Il file è stato creato da una versione di "
 "Xournal più vecchia)"
 
-#: ../src/util/Util.cpp:97
+#: ../src/util/Util.cpp:94
 msgid "Could not create folder: {1}"
 msgstr "Impossibile creare la cartella: {1}"
 
-#: ../src/control/Control.cpp:218 ../src/control/Control.cpp:235
+#: ../src/control/Control.cpp:220 ../src/control/Control.cpp:237
 msgid "Could not delete old autosave file \"{1}\""
 msgstr "Impossibile eliminare il file di autosalvataggio precedente: \"{1}\""
 
-#: ../src/control/LatexController.cpp:381
+#: ../src/control/LatexController.cpp:428
 msgid ""
-"Could not find Xournal++ LaTeX executable relative or in Path.\n"
-"Searched for: mathtex-xournalpp.cgi"
+"Could not find pdflatex in Path.\n"
+"Please install pdflatex first and make sure it's in the Path."
 msgstr ""
-"Impossibile trovare l'eseguibile Xournal++ LaTeX nel percorso.\n"
-"File cercato: mathtex-xournalpp.cgi"
+"Impossibile trovare pdflatex nel PATH.\n"
+"Per favore, instlla pdflatex e assicurati sia nel tuo PATH"
+
+#: ../src/control/LatexController.cpp:299
+msgid "Could not load LaTeX PDF file, URL-Error: {1}"
+msgstr "Impossibile caricare il file PDF LaTeX, Errore-URL: {1}"
+
+#: ../src/control/LatexController.cpp:307
+msgid "Could not load LaTeX PDF file: {1}"
+msgstr "Impossibile caricare il file PDF LaTeX: {1}"
 
 #: ../src/control/pagetype/PageTypeHandler.cpp:18
 msgid "Could not load pagetemplates.ini file"
 msgstr "Impossibile caricare il file pagetemplates.ini"
 
-#: ../src/control/xojfile/LoadHandler.cpp:123
+#: ../src/control/xojfile/LoadHandler.cpp:124
 msgid "Could not open file: \"{1}\""
 msgstr "Impossibile aprire il file: \"{1}\""
 
-#: ../src/gui/MainWindow.cpp:93
+#: ../src/gui/MainWindow.cpp:86
 msgid ""
 "Could not parse custom toolbar.ini file: {1}\n"
 "Toolbars will not be available"
@@ -597,7 +608,7 @@ msgstr ""
 "Impossbile leggere il file toolbar.ini personalizzato: {1}\n"
 "Nessuna Barra degli Strumenti sarà disponibile"
 
-#: ../src/gui/MainWindow.cpp:83
+#: ../src/gui/MainWindow.cpp:76
 msgid ""
 "Could not parse general toolbar.ini file: {1}\n"
 "No Toolbars will be available"
@@ -605,7 +616,7 @@ msgstr ""
 "Impossbile leggere il file toolbar.ini: {1}\n"
 "Nessuna Barra degli Strumenti sarà disponibile"
 
-#: ../src/control/xojfile/LoadHandler.cpp:328
+#: ../src/control/xojfile/LoadHandler.cpp:347
 msgid "Could not read image: {1}. Error message: {2}"
 msgstr "Impossibile leggere l'immagine: {1}. Messaggio d'errore: {2}"
 
@@ -617,25 +628,25 @@ msgstr ""
 "Impossibile ripetere \"{1}\"\n"
 "Qualcosa è andato storto... Per favore inviaci un bug report…"
 
-#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:214
+#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:210
 msgid "Could not remove tool item from Toolbar {1} on position {2}"
 msgstr ""
 "Impossibile rimuovere lo strumento dalla Barra degli Strumenti {1} in "
 "posizione {2}"
 
-#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:209
+#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:205
 msgid "Could not remove tool item {1} from Toolbar {2} on position {3}"
 msgstr ""
 "Impossibile rimuovere lo strumento {1} dalla Barra degli Strumenti {2} in "
 "posizione {3}"
 
-#: ../src/control/Control.cpp:228 ../src/control/Control.cpp:247
+#: ../src/control/Control.cpp:230 ../src/control/Control.cpp:249
 msgid "Could not rename autosave file from \"{1}\" to \"{2}\""
 msgstr "Impossibile rinominare il file di autosalvataggio da \"{1}\" a \"{2}\""
 
-#: ../src/control/LatexController.cpp:310
-msgid "Could not retrieve LaTeX image file: {1}"
-msgstr "Impossibile trovare il file immagine LaTeX: {1}"
+#: ../src/control/LatexController.cpp:89
+msgid "Could not save .tex file: {1}"
+msgstr "Impossibile salvare il file .tex: {1}"
 
 #: ../src/undo/UndoRedoHandler.cpp:144
 msgid ""
@@ -645,11 +656,11 @@ msgstr ""
 "Impossibile annullare \"{1}\"\n"
 "Qualcosa è andato storto... Per favore inviaci un bug report…"
 
-#: ../src/control/xojfile/SaveHandler.cpp:294
+#: ../src/control/xojfile/SaveHandler.cpp:290
 msgid "Could not write background \"{1}\", {2}"
 msgstr "Impossibile scrivere lo sfondo \"{1}\", {2}"
 
-#: ../src/control/xojfile/SaveHandler.cpp:419
+#: ../src/control/xojfile/SaveHandler.cpp:415
 msgid "Could not write background \"{1}\". Continuing anyway."
 msgstr "Impossibile scrivere lo sfondo \"{1}\". Continuando comunque."
 
@@ -665,7 +676,7 @@ msgstr "Pagina corrente"
 msgid "Custom"
 msgstr "Personalizzato"
 
-#: ../ui/settings.glade:1231
+#: ../ui/settings.glade:1288
 msgid "Custom Commands (for Method \"Custom\")"
 msgstr "Comandi Personalizzati (per Metodo \"Personalizzato\")"
 
@@ -677,35 +688,40 @@ msgstr "Esportazione Personalizzata"
 msgid "Customized"
 msgstr "Personalizzato"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:320
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:401
 msgid "Cut"
 msgstr "Taglia"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:442
+#: ../ui/settings.glade:1621
+msgid "Dark Theme (restart needed)"
+msgstr "Tema Scuro (necessita riavvio)"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:460
 msgid "Default Tool"
 msgstr "Strumento di Default"
 
-#: ../ui/settings.glade:1997
+#: ../ui/settings.glade:2155
 msgid "Defaults"
 msgstr "Predefinite"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:407
 #: ../src/undo/DeleteUndoAction.cpp:102
 msgid "Delete"
 msgstr "Cancella"
 
-#: ../ui/main.glade:620
+#: ../ui/main.glade:668
 msgid "Delete Layer"
 msgstr "Cancella Livello"
 
-#: ../src/control/XournalMain.cpp:123
+#: ../src/control/XournalMain.cpp:127
 msgid "Delete Logfile"
 msgstr "Cancella Logfile"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:387
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:447
 msgid "Delete current page"
 msgstr "Cancella pagina corrente"
 
-#: ../src/control/XournalMain.cpp:173
+#: ../src/control/XournalMain.cpp:177
 msgid "Delete file"
 msgstr "Cancella file"
 
@@ -717,7 +733,7 @@ msgstr "Cancella livello"
 msgid "Delete stroke"
 msgstr "Cancella tratto"
 
-#: ../ui/main.glade:1297
+#: ../ui/main.glade:1447
 msgid "Delete this page"
 msgstr "Cancella questa pagina"
 
@@ -725,7 +741,7 @@ msgstr "Cancella questa pagina"
 msgid "Device"
 msgstr "Dispositivo"
 
-#: ../ui/settings.glade:1261
+#: ../ui/settings.glade:1318
 msgid "Disable"
 msgstr "DIsattiva"
 
@@ -733,19 +749,19 @@ msgstr "DIsattiva"
 msgid "Disable drawing for this device"
 msgstr "Disabilita i disegni per questo dispositivo"
 
-#: ../ui/settings.glade:1134
+#: ../ui/settings.glade:1191
 msgid "Disable touch if pen is near screen"
 msgstr "Disattiva il touch se la penna è vicina allo schermo"
 
-#: ../ui/settings.glade:1156
+#: ../ui/settings.glade:1213
 msgid "Disabling Method"
 msgstr "Disattiva Metodo"
 
-#: ../src/control/Control.cpp:2533 ../src/control/Control.cpp:2569
+#: ../src/control/Control.cpp:2577 ../src/control/Control.cpp:2618
 msgid "Discard"
 msgstr "Non salvare"
 
-#: ../src/control/Control.cpp:1952
+#: ../src/control/Control.cpp:1988
 msgid ""
 "Do not open Autosave files. They may will be overwritten!\n"
 "Copy the files to another folder.\n"
@@ -759,21 +775,17 @@ msgstr ""
 msgid "Do not overwrite the background PDF! This will cause errors!"
 msgstr "Non sovrascrivere il PDF di sfondo! Potrebbe causare errori!"
 
-#: ../src/control/Control.cpp:2566
+#: ../src/control/Control.cpp:2615
 msgid "Document file was removed."
 msgstr "Il file del documento è stato rimosso."
 
-#: ../src/control/xojfile/LoadHandler.cpp:202
+#: ../src/control/xojfile/LoadHandler.cpp:203
 msgid "Document is not complete (maybe the end is cut off?)"
 msgstr "Il documento non è completo (forse è stata tagliata la fine?)"
 
 #: ../src/model/Document.cpp:393
 msgid "Document not loaded! ({1}), {2}"
 msgstr "Documento non caricato! ({1}), {2}"
-
-#: ../src/control/XournalMain.cpp:242
-msgid "Don't compress PDF files (for debugging)"
-msgstr "Non comprimere i PDF (debugging)"
 
 #: ../src/control/pagetype/PageTypeHandler.cpp:26
 msgid "Dotted"
@@ -787,13 +799,13 @@ msgstr ""
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:99
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:40
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:420
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:465
 msgid "Draw Arrow"
 msgstr "Disegna Freccia"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:97
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:39
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:416
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:464
 msgid "Draw Circle"
 msgstr "Disegna Cerchio"
 
@@ -805,19 +817,19 @@ msgstr "Disegna Linea"
 #: ../src/gui/dialog/ButtonConfigGui.cpp:95
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:29
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:38
-#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:120
-#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:123
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:418
+#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:122
+#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:125
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:463
 msgid "Draw Rectangle"
 msgstr "Disegna Rettangolo"
 
-#: ../ui/main.glade:778
+#: ../ui/main.glade:844
 msgid "Draw _Line"
 msgstr "Disegna _Linea"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:101
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:42
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:422
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:466
 msgid "Draw coordinate system"
 msgstr "Disegna il sistema di coordinate"
 
@@ -833,25 +845,33 @@ msgstr "Stile Disegno - non cambiare"
 msgid "Edit text"
 msgstr "Modifica testo"
 
-#: ../ui/settings.glade:1249
+#: ../src/undo/EmergencySaveRestore.cpp:35
+msgid "Emergency saved document"
+msgstr "Documento da salvataggio d'emergenza"
+
+#: ../ui/settings.glade:1306
 msgid "Enable"
 msgstr "Attiva"
+
+#: ../ui/settings.glade:1176
+msgid "Enable zoom gestures (needs restart)"
+msgstr "Attiva le gestures per lo zoom (necessita riavvio)"
 
 #: ../ui/texdialog.glade:66
 msgid "Enter / edit LaTeX Text"
 msgstr "Inserisci / modifica Testo LaTeX"
 
-#: ../src/undo/EraseUndoAction.cpp:130 ../src/undo/DeleteUndoAction.cpp:99
-#: ../src/undo/AddUndoAction.cpp:104
+#: ../src/undo/AddUndoAction.cpp:104 ../src/undo/DeleteUndoAction.cpp:99
+#: ../src/undo/EraseUndoAction.cpp:130
 msgid "Erase stroke"
 msgstr "Cancella tratto"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:56
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:282
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:308
 msgid "Eraser"
 msgstr "Gomma"
 
-#: ../ui/main.glade:940
+#: ../ui/main.glade:1066
 msgid "Eraser Optio_ns"
 msgstr "Op_zioni Gomma"
 
@@ -859,7 +879,7 @@ msgstr "Op_zioni Gomma"
 msgid "Eraser Type - don't change"
 msgstr "Tipo di Gomma - non cambiare"
 
-#: ../src/control/Control.cpp:2232
+#: ../src/control/Control.cpp:2268
 msgid ""
 "Error annotate PDF file \"{1}\"\n"
 "{2}"
@@ -871,12 +891,12 @@ msgstr ""
 msgid "Error export PDF Page"
 msgstr "Errore nell'esportazione PDF"
 
-#: ../src/gui/GladeGui.cpp:25
+#: ../src/gui/GladeGui.cpp:26
 msgid "Error loading glade file \"{1}\" (try to load \"{2}\")"
 msgstr ""
 "Errore nel caricamento del file glade \"{1}\" (tentativo di caricare \"{2}\")"
 
-#: ../src/control/Control.cpp:2047
+#: ../src/control/Control.cpp:2083
 msgid "Error opening file \"{1}\""
 msgstr "Errore nell'apertura del file \"{1}\""
 
@@ -884,11 +904,11 @@ msgstr "Errore nell'apertura del file \"{1}\""
 msgid "Error opening file: \"{1}\""
 msgstr "Errore nell'apertura del file: \"{1}\""
 
-#: ../src/control/xojfile/LoadHandler.cpp:428
+#: ../src/control/xojfile/LoadHandler.cpp:447
 msgid "Error reading PDF: {1}"
 msgstr "Errore nella lettura del PDF: {1}"
 
-#: ../src/control/xojfile/LoadHandler.cpp:499
+#: ../src/control/xojfile/LoadHandler.cpp:518
 msgid "Error reading width of a stroke: {1}"
 msgstr "Errore nella lettura dello spessore del tratto: {1}"
 
@@ -896,7 +916,7 @@ msgstr "Errore nella lettura dello spessore del tratto: {1}"
 msgid "Error: {1}"
 msgstr "Errore: {1}"
 
-#: ../src/control/XournalMain.cpp:147
+#: ../src/control/XournalMain.cpp:151
 msgid ""
 "Errorlog cannot be deleted. You have to do it manually.\n"
 "Logfile: {1}"
@@ -912,19 +932,19 @@ msgstr "Esporta"
 msgid "Export PDF"
 msgstr "Esporta PDF"
 
-#: ../ui/main.glade:113
+#: ../ui/main.glade:119
 msgid "Export as..."
 msgstr "Esporta come..."
 
-#: ../src/control/LatexController.cpp:398
+#: ../src/control/LatexController.cpp:445
 msgid "Failed to generate LaTeX image!"
 msgstr "Generazione dell'immagine LaTeX fallita!"
 
-#: ../ui/main.glade:920 ../ui/main.glade:1057
+#: ../ui/main.glade:1044 ../ui/main.glade:1192
 msgid "Fi_ll"
 msgstr "R_iempi"
 
-#: ../src/util/Util.cpp:127 ../src/util/Util.cpp:148
+#: ../src/util/Util.cpp:123 ../src/util/Util.cpp:143
 msgid ""
 "File couldn't be opened. You have to do it manually:\n"
 "URL: {1}"
@@ -932,23 +952,23 @@ msgstr ""
 "Impossibile aprire il file, Devi farlo manualmente:\n"
 "URL: {1}"
 
-#: ../src/control/Control.cpp:1982
+#: ../src/control/Control.cpp:2018
 msgid "Filename: {1}"
 msgstr "Nome File: {1}"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:445
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:500
 msgid "Fill"
 msgstr "Riempi"
 
-#: ../ui/main.glade:928 ../ui/main.glade:1065
+#: ../ui/main.glade:1053 ../ui/main.glade:1201
 msgid "Fill transparency"
 msgstr "Trasparenza riempimento"
 
-#: ../ui/main.glade:1492
+#: ../ui/main.glade:1634
 msgid "Find next occurrence of the search string"
 msgstr "Trova l'occorrenza sucessiva della stringa di ricerca"
 
-#: ../ui/main.glade:1471
+#: ../ui/main.glade:1613
 msgid "Find previous occurrence of the search string"
 msgstr "Trova l'occorrenza precedente della stringa di ricerca"
 
@@ -956,35 +976,43 @@ msgstr "Trova l'occorrenza precedente della stringa di ricerca"
 msgid "Font"
 msgstr "Font"
 
-#: ../ui/main.glade:289
+#: ../ui/main.glade:338
 msgid "Fullscreen"
 msgstr "Schermo intero"
 
-#: ../ui/about.glade:233
+#: ../ui/about.glade:234
 msgid "GNU GPLv2 or later"
 msgstr "GNU GPLv2 o sucessivo"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:331
+#: ../ui/settings.glade:1072
+msgid ""
+"GTK Touch / Scrolling workaround. Change Scroll / Touch behavoir. Enabled "
+"touch drawing. Needs restart."
+msgstr ""
+"Soluzione temporanea per Touch / Scroll GTK. Modifica il comportamento di "
+"Touch / Scroll. Attivato il disegno con le dita. Necessita riavvio."
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:428
 msgid "Go to first page"
 msgstr "Vai alla prima pagina"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:344
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:432
 msgid "Go to last page"
 msgstr "Vai all'ultima pagina"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:349
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:435
 msgid "Go to next layer"
 msgstr "Vai al prossimo livello"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:339
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:430
 msgid "Go to page"
 msgstr "Vai a pagina"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:347
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:434
 msgid "Go to previous layer"
 msgstr "Vai al livello precedente"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:351
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:436
 msgid "Go to top layer"
 msgstr "Vai al livello più alto"
 
@@ -1006,16 +1034,20 @@ msgstr "Grigio"
 msgid "Green"
 msgstr "Verde"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:378
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:411
 msgid "Grid Snapping"
 msgstr "Forza alla Griglia"
 
-#: ../ui/main.glade:843
+#: ../ui/settings.glade:2113
+msgid "Grid snapping tolerance:"
+msgstr "Tolleranza forzatura alla griglia:"
+
+#: ../ui/main.glade:915
 msgid "H_and Tool"
 msgstr "Strumento _Mano"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:63
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:426
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:474
 msgid "Hand"
 msgstr "Mano"
 
@@ -1023,15 +1055,15 @@ msgstr "Mano"
 msgid "Height:"
 msgstr "Altezza:"
 
-#: ../ui/main.glade:379
+#: ../ui/main.glade:407
 msgid "Hide Menu"
 msgstr "Nascondi Menu"
 
-#: ../ui/settings.glade:1683 ../ui/settings.glade:1753
+#: ../ui/settings.glade:1755 ../ui/settings.glade:1825
 msgid "Hide Menubar"
 msgstr "Nascondi Menu"
 
-#: ../ui/settings.glade:1698 ../ui/settings.glade:1768
+#: ../ui/settings.glade:1770 ../ui/settings.glade:1840
 msgid "Hide Sidebar"
 msgstr "Nascondi Barra laterale"
 
@@ -1039,25 +1071,29 @@ msgstr "Nascondi Barra laterale"
 msgid "Hide all"
 msgstr "Nascondi tutto"
 
-#: ../ui/settings.glade:1613
+#: ../ui/settings.glade:1685
 msgid "Hide the horizontal scrollbar"
 msgstr "Nascondi Barra di scorrimento orizzontale"
 
-#: ../ui/settings.glade:1628
+#: ../ui/settings.glade:1700
 msgid "Hide the vertical scrollbar"
 msgstr "Nascondi Barra di scorrimento verticale"
 
+#: ../ui/settings.glade:1944
+msgid "Highlight cursor position"
+msgstr "Evidenzia la posizione del cursore"
+
 #: ../src/gui/dialog/ButtonConfigGui.cpp:57
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:399
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:457
 msgid "Highlighter"
 msgstr "Evidenziatore"
 
-#: ../ui/main.glade:1014
+#: ../ui/main.glade:1146
 msgid "Highlighter Opti_ons"
 msgstr "Opzi_oni Evidenziatore"
 
 #: ../src/control/pagetype/PageTypeHandler.cpp:32
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:403
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:459
 msgid "Image"
 msgstr "Immagine"
 
@@ -1065,11 +1101,11 @@ msgstr "Immagine"
 msgid "Images"
 msgstr "Immagini"
 
-#: ../ui/settings.glade:390
+#: ../ui/settings.glade:404
 msgid "Input"
 msgstr "Input"
 
-#: ../ui/settings.glade:1090
+#: ../ui/settings.glade:1119
 msgid "Input Device"
 msgstr "Dispositivo di Input"
 
@@ -1077,7 +1113,7 @@ msgstr "Dispositivo di Input"
 msgid "Insert Latex"
 msgstr "Inserisci LaTeX"
 
-#: ../ui/main.glade:1277
+#: ../ui/main.glade:1427
 msgid "Insert a copy of the current page below"
 msgstr "Inserisci una copia della pagina corrente sotto"
 
@@ -1085,7 +1121,7 @@ msgstr "Inserisci una copia della pagina corrente sotto"
 msgid "Insert elements"
 msgstr "Inserisci elementi"
 
-#: ../src/undo/InsertUndoAction.cpp:47 ../src/gui/dialog/ButtonConfigGui.cpp:59
+#: ../src/gui/dialog/ButtonConfigGui.cpp:59 ../src/undo/InsertUndoAction.cpp:47
 msgid "Insert image"
 msgstr "Inserisci immagine"
 
@@ -1097,11 +1133,11 @@ msgstr "Inserisci latex"
 msgid "Insert layer"
 msgstr "Inserisci livello"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:394
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:443
 msgid "Insert page"
 msgstr "Inserisci pagina"
 
-#: ../src/control/XournalMain.cpp:244
+#: ../src/control/XournalMain.cpp:249
 msgid "Jump to Page (first Page: 1)"
 msgstr "Vai a Pagina (prima Pagina: 1)"
 
@@ -1123,7 +1159,7 @@ msgstr "Selezione a livello"
 msgid "Layer {1}"
 msgstr "Livello {1}"
 
-#: ../ui/about.glade:217
+#: ../ui/about.glade:218
 msgid "License"
 msgstr "Licenza"
 
@@ -1141,7 +1177,7 @@ msgstr "Verde Chiaro"
 msgid "Lined"
 msgstr "Righe"
 
-#: ../ui/settings.glade:772
+#: ../ui/settings.glade:786
 msgid "Load / Save"
 msgstr "Carica / Salva"
 
@@ -1149,13 +1185,13 @@ msgstr "Carica / Salva"
 msgid "Load file"
 msgstr "Carica file"
 
-#: ../src/gui/PageView.cpp:738
+#: ../src/gui/PageView.cpp:739
 #: ../src/gui/sidebar/previews/base/SidebarPreviewBaseEntry.cpp:105
 #: ../src/gui/toolbarMenubar/ToolPageLayer.cpp:20
 msgid "Loading..."
 msgstr "Caricamento..."
 
-#: ../ui/toolbarManageDialog.glade:8 ../ui/toolbarCustomizeDialog.glade:10
+#: ../ui/toolbarCustomizeDialog.glade:10 ../ui/toolbarManageDialog.glade:8
 msgid "Manage Toolbar"
 msgstr "Gestisci Barra degli Strumenti"
 
@@ -1165,11 +1201,19 @@ msgid "Mangenta"
 msgstr "Magenta"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:81
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:437
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:514
 msgid "Medium"
 msgstr "Medio"
 
-#: ../src/control/XournalMain.cpp:462
+#: ../src/control/XournalMain.cpp:460
+msgid ""
+"Missing the needed UI file! .app corrupted?\n"
+"Path: {1}"
+msgstr ""
+"Manca il file UI necessatio! .app corrotto?\n"
+"Percorso: {1}"
+
+#: ../src/control/XournalMain.cpp:474
 msgid ""
 "Missing the needed UI file, could not find them at any location.\n"
 "Not relative\n"
@@ -1181,7 +1225,7 @@ msgstr ""
 "Nè nel Percorso di Lavoro\n"
 "Nè in {1}"
 
-#: ../ui/settings.glade:883
+#: ../ui/settings.glade:897
 msgid "Mouse Button"
 msgstr "Pulsante del Mouse"
 
@@ -1201,7 +1245,7 @@ msgstr "Muovi pagina giù"
 msgid "Move page upwards"
 msgstr "Muovi pagina su"
 
-#: ../ui/main.glade:531
+#: ../ui/main.glade:571
 msgid "N_ext annotated page"
 msgstr "P_rossima pagina annotata"
 
@@ -1209,31 +1253,31 @@ msgstr "P_rossima pagina annotata"
 msgid "New"
 msgstr "Nuovo"
 
-#: ../ui/main.glade:571
+#: ../ui/main.glade:614
 msgid "New Page _After"
 msgstr "Nuova Pagina _Dopo"
 
-#: ../ui/main.glade:563
+#: ../ui/main.glade:605
 msgid "New Page _Before"
 msgstr "Nuova Pagina _Prima"
 
-#: ../ui/main.glade:580
+#: ../ui/main.glade:624
 msgid "New Page at _End"
 msgstr "Nuova Pagina alla _Fine"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:316
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:388
 msgid "New Xournal"
 msgstr "Nuovo Xournal"
 
-#: ../ui/main.glade:611
+#: ../ui/main.glade:658
 msgid "New _Layer"
 msgstr "Nuovo _Livello"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:342
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:431
 msgid "Next"
 msgstr "Prossima"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:355
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:438
 msgid "Next annotated page"
 msgstr "Prossima pagina annotata"
 
@@ -1262,20 +1306,20 @@ msgstr ""
 msgid "Open Image"
 msgstr "Apri Immagine"
 
-#: ../src/control/XournalMain.cpp:121
+#: ../src/control/XournalMain.cpp:125
 msgid "Open Logfile"
-msgstr "Apri fLogfile"
+msgstr "Apri Logfile"
 
-#: ../src/control/XournalMain.cpp:122
+#: ../src/control/XournalMain.cpp:126
 msgid "Open Logfile directory"
 msgstr "Apri cartella di log"
 
 #: ../src/control/stockdlg/XojOpenDlg.cpp:16
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:318
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:389
 msgid "Open file"
 msgstr "Apri file"
 
-#: ../src/control/RecentManager.cpp:241
+#: ../src/control/RecentManager.cpp:244
 msgctxt "{1} is a URI"
 msgid "Open {1}"
 msgstr "Apri {1}"
@@ -1289,7 +1333,7 @@ msgstr "Arancione"
 msgid "PDF Export"
 msgstr "Esporta PDF"
 
-#: ../src/gui/MainWindow.cpp:732
+#: ../src/gui/MainWindow.cpp:816
 msgid "PDF Page {1}"
 msgstr "Pagina PDF {1}"
 
@@ -1297,17 +1341,17 @@ msgstr "Pagina PDF {1}"
 msgid "PDF background missing"
 msgstr "Sfondo PDF non trovato"
 
-#: ../src/control/XournalMain.cpp:223
+#: ../src/control/XournalMain.cpp:230
 msgid "PDF file successfully created"
 msgstr "PDF creato con successo"
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:58
-#: ../src/control/jobs/PdfExportJob.cpp:23
 #: ../src/control/jobs/CustomExportJob.cpp:27
+#: ../src/control/jobs/PdfExportJob.cpp:23
+#: ../src/control/stockdlg/XojOpenDlg.cpp:61
 msgid "PDF files"
 msgstr "Files PDF"
 
-#: ../src/control/XournalMain.cpp:243
+#: ../src/control/XournalMain.cpp:248
 msgid "PDF output filename"
 msgstr "Nome output PDF"
 
@@ -1323,7 +1367,7 @@ msgstr "Grafica PNG"
 msgid "PNG with transparent background"
 msgstr "PNG con sfondo trasparente"
 
-#: ../ui/main.glade:540
+#: ../ui/main.glade:581
 msgid "P_revious annotated Page"
 msgstr "P_recedente pagina annotata"
 
@@ -1363,19 +1407,19 @@ msgstr "Pagine:"
 msgid "Paper Format"
 msgstr "Formato Carta"
 
-#: ../ui/main.glade:643
+#: ../ui/main.glade:693
 msgid "Paper _Color"
 msgstr "_Colore Carta"
 
-#: ../ui/main.glade:635
+#: ../ui/main.glade:684
 msgid "Paper _Format"
 msgstr "_Formato Carta"
 
-#: ../ui/main.glade:651
+#: ../ui/main.glade:702
 msgid "Paper b_ackground"
 msgstr "_Sfondo Carta"
 
-#: ../ui/about.glade:201
+#: ../ui/about.glade:202
 msgid ""
 "Partial based on Xournal\n"
 "by Denis Auroux"
@@ -1383,17 +1427,17 @@ msgstr ""
 "Parzialmente basato su Xournal\n"
 "di Denis Auroux"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:403
 #: ../src/undo/AddUndoAction.cpp:108
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:322
 msgid "Paste"
 msgstr "Incolla"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:55
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:382
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:286
 msgid "Pen"
 msgstr "Penna"
 
-#: ../ui/main.glade:859
+#: ../ui/main.glade:932
 msgid "Pen _Options"
 msgstr "_Opzioni Penna"
 
@@ -1401,9 +1445,9 @@ msgstr "_Opzioni Penna"
 msgid "Plain"
 msgstr "Bianco"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:473
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:32
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:106
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:413
 msgid "Play Object"
 msgstr "Riproduci Oggetto"
 
@@ -1411,11 +1455,11 @@ msgstr "Riproduci Oggetto"
 msgid "Predefined"
 msgstr "Predefinito"
 
-#: ../ui/main.glade:251
+#: ../ui/main.glade:297
 msgid "Preferences"
 msgstr "Preferenze"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:461
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:417
 msgid "Presentation mode"
 msgstr "Modalità presentazione"
 
@@ -1423,15 +1467,15 @@ msgstr "Modalità presentazione"
 msgid "Range"
 msgstr "Range"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:371
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:479
 msgid "Rec / Stop"
 msgstr "Registra / Stop"
 
-#: ../ui/main.glade:299
+#: ../ui/main.glade:1225
 msgid "Rec-Stop"
 msgstr "Registra-Stop"
 
-#: ../ui/main.glade:61
+#: ../ui/main.glade:63
 msgid "Recent _Documents"
 msgstr "_Documenti Recenti"
 
@@ -1440,8 +1484,8 @@ msgstr "_Documenti Recenti"
 msgid "Red"
 msgstr "Rosso"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:397
 #: ../src/undo/UndoRedoHandler.cpp:293
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:327
 msgid "Redo"
 msgstr "Ripeti"
 
@@ -1449,15 +1493,15 @@ msgstr "Ripeti"
 msgid "Redo: "
 msgstr "Ripeti: "
 
-#: ../src/control/Control.cpp:2021
+#: ../src/control/Control.cpp:2057
 msgid "Remove PDF Background"
 msgstr "Rimuovi lo sfondo PDF"
 
-#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:202
+#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:198
 msgid "Removed tool item from Toolbar {1} ID {2}"
 msgstr "Rimosso lo strumento dalla Barra degli Strumenti {1} ID {2}"
 
-#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:198
+#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:194
 msgid "Removed tool item {1} from Toolbar {2} ID {3}"
 msgstr "Rimosso lo strumento {1} dalla Barra degli Strumenti {2} ID {3}"
 
@@ -1469,7 +1513,7 @@ msgstr "Sostituisci"
 msgid "Resolution"
 msgstr "Risoluzione"
 
-#: ../src/control/XournalMain.cpp:174
+#: ../src/control/XournalMain.cpp:178
 msgid "Restore file"
 msgstr "Ricarica file"
 
@@ -1477,33 +1521,37 @@ msgstr "Ricarica file"
 msgid "Rotation"
 msgstr "Rotazione"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:375
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:410
 msgid "Rotation Snapping"
 msgstr "Rotazione Forzata"
+
+#: ../ui/settings.glade:2083
+msgid "Rotation snapping tolerance:"
+msgstr "Tolleranza rotazione forzata:"
 
 #: ../src/control/pagetype/PageTypeHandler.cpp:24
 msgid "Ruled"
 msgstr "Quadretti"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:432
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:467
 msgid "Ruler"
 msgstr "Righello"
 
-#: ../src/control/jobs/SaveJob.cpp:13 ../src/control/Control.cpp:2532
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:315
+#: ../src/control/Control.cpp:2576 ../src/control/jobs/SaveJob.cpp:13
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:390
 msgid "Save"
 msgstr "Salva"
 
-#: ../src/control/Control.cpp:2568
+#: ../src/control/Control.cpp:2617
 msgid "Save As"
 msgstr "Salva come"
 
-#: ../src/control/Control.cpp:2352 ../src/gui/dialog/PageTemplateDialog.cpp:112
+#: ../src/control/Control.cpp:2388 ../src/gui/dialog/PageTemplateDialog.cpp:112
 msgid "Save File"
 msgstr "Salva File"
 
-#: ../src/control/jobs/SaveJob.cpp:151
 #: ../src/control/jobs/CustomExportJob.cpp:276
+#: ../src/control/jobs/SaveJob.cpp:151
 msgid "Save file error: {1}"
 msgstr "Errore salvataggio file: {1}"
 
@@ -1511,7 +1559,7 @@ msgstr "Errore salvataggio file: {1}"
 msgid "Scale"
 msgstr "Scala"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:324
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:405
 msgid "Search"
 msgstr "Cerca"
 
@@ -1519,11 +1567,11 @@ msgstr "Cerca"
 msgid "Select Background Color"
 msgstr "Seleziona Colore di Sfondo"
 
-#: ../ui/settings.glade:2065
+#: ../ui/settings.glade:2223
 msgid "Select Folder"
 msgstr "Seleziona Cartella"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:447
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:476
 msgid "Select Font"
 msgstr "Seleziona Font"
 
@@ -1531,9 +1579,9 @@ msgstr "Seleziona Font"
 msgid "Select Image"
 msgstr "Seleziona Immagine"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:471
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:31
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:99
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:410
 msgid "Select Object"
 msgstr "Seleziona Oggetto"
 
@@ -1541,21 +1589,21 @@ msgstr "Seleziona Oggetto"
 msgid "Select PDF Page"
 msgstr "Seleziona Pagina PDF"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:470
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:10
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:29
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:85
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:125
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:408
 msgid "Select Rectangle"
 msgstr "Seleziona Rettangolo"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:469
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:30
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:92
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:406
 msgid "Select Region"
 msgstr "Seleziona Regione"
 
-#: ../src/control/Control.cpp:2020
+#: ../src/control/Control.cpp:2056
 msgid "Select another PDF"
 msgstr "Seleziona un altro PDF"
 
@@ -1580,19 +1628,19 @@ msgstr "Seleziona rettangolo"
 msgid "Select region"
 msgstr "Seleziona regione"
 
-#: ../ui/settings.glade:1964
+#: ../ui/settings.glade:2051
 msgid "Select the tool and Settings if you press the Default Button"
 msgstr "Seleziona lo strumento e Impostazioni se premi il Pulsante Default"
 
-#: ../ui/settings.glade:1789
+#: ../ui/settings.glade:1861
 msgid "Select toolbar:"
 msgstr "Seleziona barra degli strumenti:"
 
-#: ../ui/settings.glade:1543
+#: ../ui/settings.glade:1600
 msgid "Selection Color (Text, Stroke Selection etc.)"
 msgstr "Colore della Selezione (Testo, Selezione Tratto, ecc.)"
 
-#: ../src/control/XournalMain.cpp:120
+#: ../src/control/XournalMain.cpp:124
 msgid "Send Bugreport"
 msgstr "Invia Bugreport"
 
@@ -1600,11 +1648,15 @@ msgstr "Invia Bugreport"
 msgid "Separator"
 msgstr "Separatore"
 
-#: ../ui/settings.glade:1123
+#: ../ui/settings.glade:1165
+msgid "Settings for Touch devices"
+msgstr "Impostazioni per i dispositivi Touch"
+
+#: ../ui/settings.glade:1152
 msgid "Settings for Touch devices which are detected by GTK."
 msgstr "Impostazioni per i dispositivi Touch rilevati da GTK."
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:430
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:462
 msgid "Shape Recognizer"
 msgstr "Riconoscitore di Forme"
 
@@ -1628,19 +1680,19 @@ msgstr "Mostra solo le pagine inutilizzate (una pagina inutilizzata)"
 msgid "Show only not used pages ({1} unused pages)"
 msgstr "Mostra solo le pagine inutilizzate ({1} pagine inutilizzate)"
 
-#: ../ui/main.glade:322
+#: ../ui/main.glade:348
 msgid "Show sidebar"
 msgstr "Mostra barra laterale"
 
-#: ../ui/settings.glade:1412
+#: ../ui/settings.glade:1469
 msgid "Show sidebar on the right side"
 msgstr "Mostra barra laterale a destra"
 
-#: ../ui/settings.glade:1427
+#: ../ui/settings.glade:1484
 msgid "Show vertical scrollbar on the left side"
 msgstr "Mostra barra di scorrimento a sinistra"
 
-#: ../src/control/XournalMain.cpp:309
+#: ../src/control/XournalMain.cpp:308
 msgid ""
 "Sorry, Xournal++ can only open one file at once.\n"
 "Others are ignored."
@@ -1648,7 +1700,7 @@ msgstr ""
 "Ci dispiace, Xournal++ può aprire solo un file alla volta.\n"
 "Gli altri saranno ignorati."
 
-#: ../src/control/XournalMain.cpp:324
+#: ../src/control/XournalMain.cpp:323
 msgid ""
 "Sorry, Xournal++ cannot open remote files at the moment.\n"
 "You have to copy the file to a local directory."
@@ -1660,13 +1712,13 @@ msgstr ""
 msgid "Standard"
 msgstr "Standard"
 
-#: ../ui/main.glade:1610
+#: ../ui/main.glade:1752
 msgid "State PLACEHOLDER"
 msgstr "Stato PLACEHOLDER"
 
-#: ../src/undo/RecognizerUndoAction.cpp:101
 #: ../src/gui/dialog/ButtonConfigGui.cpp:103
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:43
+#: ../src/undo/RecognizerUndoAction.cpp:101
 msgid "Stroke recognizer"
 msgstr "Riconosci Tratto"
 
@@ -1674,19 +1726,19 @@ msgstr "Riconosci Tratto"
 msgid "Successfully saved document to \"{1}\""
 msgstr "Salvataggio avvenuto con successo in \"{1}\""
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:128
+#: ../src/control/stockdlg/XojOpenDlg.cpp:132
 msgid "Supported files"
 msgstr "Files supportati"
 
-#: ../ui/main.glade:1236
+#: ../ui/main.glade:1386
 msgid "Swap the current page with the one above"
 msgstr "Scambia la pagina corrente con quella sopra"
 
-#: ../ui/main.glade:1257
+#: ../ui/main.glade:1407
 msgid "Swap the current page with the one below"
 msgstr "Scambia la pagina corrente con quella sotto"
 
-#: ../ui/main.glade:337
+#: ../ui/main.glade:363
 msgid "T_oolbars"
 msgstr "B_arre degli Strumenti"
 
@@ -1694,16 +1746,16 @@ msgstr "B_arre degli Strumenti"
 msgid "Template:"
 msgstr "Template:"
 
-#: ../ui/settings.glade:1317
+#: ../ui/settings.glade:1374
 msgid "Test disable"
 msgstr "Disattiva Test"
 
-#: ../ui/settings.glade:1304
+#: ../ui/settings.glade:1361
 msgid "Test enable"
 msgstr "Attiva Test"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:58
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:401
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:458
 msgid "Text"
 msgstr "Testo"
 
@@ -1712,7 +1764,7 @@ msgstr "Testo"
 msgid "Text %i times found on this page"
 msgstr "Testo %i volte trovato in questa pagina"
 
-#: ../ui/main.glade:1077
+#: ../ui/main.glade:1214
 msgid "Text Font..."
 msgstr "Font Testo..."
 
@@ -1740,7 +1792,7 @@ msgstr "Testo non trovato"
 msgid "Text not found, searched on all pages"
 msgstr "Testo non trovato, cercato su tutte le pagine"
 
-#: ../src/control/Control.cpp:1006
+#: ../src/control/Control.cpp:1017
 msgid ""
 "The Toolbarconfiguration \"{1}\" is predefined, would you create a copy to "
 "edit?"
@@ -1748,23 +1800,23 @@ msgstr ""
 "La configurazione della Barra degli Strumenti \"{1}\" è predefinita, vuoi "
 "crearne una copia da modificare?"
 
-#: ../src/control/Control.cpp:2017
+#: ../src/control/Control.cpp:2053
 msgid "The attached background PDF could not be found."
 msgstr "Il PDF di sfondo allegato non è stato trovato."
 
-#: ../src/control/Control.cpp:2018
+#: ../src/control/Control.cpp:2054
 msgid "The background PDF could not be found."
 msgstr "Il PDF di sfondo non è stato trovato."
 
-#: ../src/control/XournalMain.cpp:115
+#: ../src/control/XournalMain.cpp:119
 msgid "The most recent log file name: {1}"
 msgstr "Il nome del log più recente: {1}"
 
-#: ../ui/settings.glade:369
+#: ../ui/settings.glade:383
 msgid "The unit of the ruler is cm"
 msgstr "L'unità del righello è cm"
 
-#: ../src/control/XournalMain.cpp:108
+#: ../src/control/XournalMain.cpp:112
 msgid ""
 "There are errorlogfiles from Xournal++. Please send a Bugreport, so the bug "
 "may be fixed."
@@ -1772,7 +1824,7 @@ msgstr ""
 "Sono presenti files di errore generati da Xournal++. Per favore invia un "
 "report, così che l'eventuale bug possa essere risolto."
 
-#: ../src/control/XournalMain.cpp:107
+#: ../src/control/XournalMain.cpp:111
 msgid ""
 "There is an errorlogfile from Xournal++. Please send a Bugreport, so the bug "
 "may be fixed."
@@ -1785,7 +1837,7 @@ msgid "There was an error displaying help: {1}"
 msgstr "Si è verificato un errore nella schermata di aiuto: {1}"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:82
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:439
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:515
 msgid "Thick"
 msgstr "Spesso"
 
@@ -1794,24 +1846,24 @@ msgid "Thickness - don't change"
 msgstr "Spessore - non cambiare"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:80
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:435
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:513
 msgid "Thin"
 msgstr "Sottile"
 
-#: ../src/control/Control.cpp:2530
+#: ../src/control/Control.cpp:2574
 msgid "This document is not saved yet."
 msgstr "Questo documento non è ancora stato salvato."
 
-#: ../src/control/tools/ImageHandler.cpp:56
 #: ../src/control/PageBackgroundChangeController.cpp:177
+#: ../src/control/tools/ImageHandler.cpp:56
 msgid "This image could not be loaded. Error message: {1}"
 msgstr "Non è stato possibile caricare questa immagine. Errore: {1}"
 
-#: ../ui/settings.glade:1185
+#: ../ui/settings.glade:1242
 msgid "Timeout"
 msgstr "Timeout"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:368
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:418
 msgid "Toggle fullscreen"
 msgstr "Attiva Schermo intero"
 
@@ -1819,7 +1871,7 @@ msgstr "Attiva Schermo intero"
 msgid "Tool - don't change"
 msgstr "Strumento - non cambiare"
 
-#: ../src/gui/toolbarMenubar/model/ToolbarData.cpp:156
+#: ../src/gui/toolbarMenubar/model/ToolbarData.cpp:152
 msgid "Toolbar found: {1}"
 msgstr "Barra degli Strumenti trovata: {1}"
 
@@ -1827,11 +1879,11 @@ msgstr "Barra degli Strumenti trovata: {1}"
 msgid "Toolbars"
 msgstr "Barre degli Strumenti"
 
-#: ../ui/settings.glade:1358
+#: ../ui/settings.glade:1415
 msgid "Touch"
 msgstr "Touch"
 
-#: ../ui/settings.glade:1046
+#: ../ui/settings.glade:1060
 msgid ""
 "Touch Screens which are detected by GTK are handled specially, and don't "
 "need to be configured here."
@@ -1847,12 +1899,12 @@ msgstr "Impostazioni trasparenza"
 msgid "Trying to emergency save the current open document…"
 msgstr "Tentativo di salvataggio d'emergenza per il documento corrente…"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:458
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:416
 msgid "Two pages"
 msgstr "Due pagine"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:396
 #: ../src/undo/UndoRedoHandler.cpp:274
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:326
 msgid "Undo"
 msgstr "Annulla"
 
@@ -1860,15 +1912,15 @@ msgstr "Annulla"
 msgid "Undo: "
 msgstr "Annulla: "
 
-#: ../src/control/xojfile/LoadHandler.cpp:241
+#: ../src/control/xojfile/LoadHandler.cpp:260
 msgid "Unexpected root tag: {1}"
 msgstr "Root tag inaspettato: {1}"
 
-#: ../src/control/xojfile/LoadHandler.cpp:270
+#: ../src/control/xojfile/LoadHandler.cpp:289
 msgid "Unexpected tag in document: \"{1}\""
 msgstr "Tag inatteso nel documento: \"{1}\""
 
-#: ../src/control/xojfile/LoadHandler.cpp:475
+#: ../src/control/xojfile/LoadHandler.cpp:494
 msgid "Unknown background type: {1}"
 msgstr "Tipo di sfondo sconosciuto: {1}"
 
@@ -1876,23 +1928,23 @@ msgstr "Tipo di sfondo sconosciuto: {1}"
 msgid "Unknown color value \"{1}\""
 msgstr "Colore sconosciuto: \"{1}\""
 
-#: ../src/control/xojfile/LoadHandler.cpp:410
+#: ../src/control/xojfile/LoadHandler.cpp:429
 msgid "Unknown domain type: {1}"
 msgstr "Tipo di dominio sconosciuto: {1}"
 
-#: ../src/control/xojfile/LoadHandler.cpp:193
+#: ../src/control/xojfile/LoadHandler.cpp:194
 msgid "Unknown parser error"
 msgstr "Errore di interpretazione sconosciuto"
 
-#: ../src/control/xojfile/LoadHandler.cpp:345
+#: ../src/control/xojfile/LoadHandler.cpp:364
 msgid "Unknown pixmap::domain type: {1}"
 msgstr "Tipo di pixmap::domain sconosciuto: {1}"
 
-#: ../src/control/xojfile/LoadHandler.cpp:558
+#: ../src/control/xojfile/LoadHandler.cpp:591
 msgid "Unknown stroke type: \"{1}\", assuming pen"
 msgstr "Tipo di tratto sconosciuto: \"{1}\", ipotizzo penna"
 
-#: ../src/control/Control.cpp:2424
+#: ../src/control/Control.cpp:2460
 msgid "Unsaved Document"
 msgstr "Documento non Salvato"
 
@@ -1900,7 +1952,7 @@ msgstr "Documento non Salvato"
 msgid "Version"
 msgstr "Versione"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:425
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:472
 msgid "Vertical Space"
 msgstr "Spazio Verticale"
 
@@ -1908,7 +1960,7 @@ msgstr "Spazio Verticale"
 msgid "Vertical space"
 msgstr "Spazio verticale"
 
-#: ../ui/settings.glade:1895
+#: ../ui/settings.glade:1982
 msgid "View"
 msgstr "Vista"
 
@@ -1929,7 +1981,7 @@ msgstr "Larghezza:"
 msgid "With PDF background"
 msgstr "Con PDF di sfondo"
 
-#: ../ui/about.glade:187
+#: ../ui/about.glade:188
 msgid "With help from the community"
 msgstr "Con aiuto da parte della community"
 
@@ -1937,19 +1989,19 @@ msgstr "Con aiuto da parte della community"
 msgid "Write text"
 msgstr "Scrivi testo"
 
-#: ../src/control/xojfile/LoadHandler.cpp:821
+#: ../src/control/xojfile/LoadHandler.cpp:852
 msgid "Wrong count of points ({1})"
 msgstr "Conto dei punti sbagliato ({1})"
 
-#: ../src/control/xojfile/LoadHandler.cpp:836
+#: ../src/control/xojfile/LoadHandler.cpp:866
 msgid "Wrong number of points, got {1}, expected {2}"
 msgstr "Numero di punti sbagliato, ottenuto {1}, atteso {2}"
 
-#: ../ui/settings.glade:1171
+#: ../ui/settings.glade:1228
 msgid "X11"
 msgstr "X11"
 
-#: ../src/control/xojfile/LoadHandler.cpp:188
+#: ../src/control/xojfile/LoadHandler.cpp:189
 msgid "XML Parser error: {1}"
 msgstr "Errore nel Parser XML: {1}"
 
@@ -1957,25 +2009,25 @@ msgstr "Errore nel Parser XML: {1}"
 msgid "Xournal (Compatibility)"
 msgstr "Xournal (Compatibilità)"
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:69
+#: ../src/control/stockdlg/XojOpenDlg.cpp:72
 msgid "Xournal files"
 msgstr "File Xournal"
 
-#: ../ui/settings.glade:28
+#: ../ui/settings.glade:42
 msgid "Xournal++ Preferences"
 msgstr "Preferenze Xournal++"
 
-#: ../src/control/XournalMain.cpp:168
+#: ../src/control/XournalMain.cpp:172
 msgid "Xournal++ crashed last time. Would you restore it?"
 msgstr ""
 "Xournal++ è crashato la scorsa volta. Vuoi ripartire da dove avevi "
 "interrotto?"
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:79 ../src/control/Control.cpp:2359
+#: ../src/control/Control.cpp:2395 ../src/control/stockdlg/XojOpenDlg.cpp:82
 msgid "Xournal++ files"
 msgstr "File Xournal++"
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:89
+#: ../src/control/stockdlg/XojOpenDlg.cpp:92
 #: ../src/gui/dialog/PageTemplateDialog.cpp:119
 msgid "Xournal++ template"
 msgstr "Template Xournal++"
@@ -1995,7 +2047,7 @@ msgstr ""
 "Per favore, seleziona un altro tipo di sfondo: \"Journal\" → \"Configura "
 "Template Pagina\"."
 
-#: ../src/control/XournalMain.cpp:111
+#: ../src/control/XournalMain.cpp:115
 msgid ""
 "You're using {1}/{2} branch. Send Bugreport will direct you to this repo's "
 "issue tracker."
@@ -2017,19 +2069,19 @@ msgstr ""
 "Consiglio: Puoi selezionare Journal → Sfondo Pagina → Sfondo PDF per "
 "inserire una Pagina PDF."
 
-#: ../ui/settings.glade:302
+#: ../ui/settings.glade:316
 msgid "Zoom"
 msgstr "Zoom"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:362
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:422
 msgid "Zoom fit to screen"
 msgstr "Zoom Adatta allo schermo"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:360
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:421
 msgid "Zoom in"
 msgstr "Aumenta Zoom"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:358
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:420
 msgid "Zoom out"
 msgstr "Diminuisci Zoom"
 
@@ -2037,42 +2089,42 @@ msgstr "Diminuisci Zoom"
 msgid "Zoom slider"
 msgstr "Zoom slider"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:364
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:423
 msgid "Zoom to 100%"
 msgstr "Zoom 100%"
 
-#: ../ui/main.glade:69
+#: ../ui/main.glade:71
 msgid "_Annotate PDF"
 msgstr "_Annota PDF"
 
+#: ../src/control/Control.cpp:2389 ../src/control/jobs/BaseExportJob.cpp:26
 #: ../src/control/stockdlg/ImageOpenDlg.cpp:12
 #: ../src/control/stockdlg/XojOpenDlg.cpp:17
-#: ../src/control/jobs/BaseExportJob.cpp:26 ../src/control/Control.cpp:2353
 #: ../src/gui/dialog/PageTemplateDialog.cpp:113
 msgid "_Cancel"
 msgstr "_Annulla"
 
-#: ../ui/main.glade:361
+#: ../ui/main.glade:388
 msgid "_Customize"
 msgstr "_Personalizza"
 
-#: ../ui/main.glade:723
+#: ../ui/main.glade:779
 msgid "_Default Tools"
 msgstr "_Strumenti di Default"
 
-#: ../ui/main.glade:596
+#: ../ui/main.glade:642
 msgid "_Delete Page"
 msgstr "_Elimina Pagina"
 
-#: ../ui/main.glade:153
+#: ../ui/main.glade:162
 msgid "_Edit"
 msgstr "_Modifica"
 
-#: ../ui/main.glade:683
+#: ../ui/main.glade:735
 msgid "_Eraser"
 msgstr "_Gomma"
 
-#: ../ui/main.glade:104
+#: ../ui/main.glade:109
 msgid "_Export as PDF"
 msgstr "_Esporta come PDF"
 
@@ -2080,47 +2132,47 @@ msgstr "_Esporta come PDF"
 msgid "_File"
 msgstr "_File"
 
-#: ../ui/main.glade:448
+#: ../ui/main.glade:480
 msgid "_First Page"
 msgstr "_Prima Pagina"
 
-#: ../ui/main.glade:466
+#: ../ui/main.glade:500
 msgid "_Goto Page"
 msgstr "_Vai a Pagina"
 
-#: ../ui/main.glade:1099
+#: ../ui/main.glade:1247
 msgid "_Help"
 msgstr "_Aiuto"
 
-#: ../ui/main.glade:693
+#: ../ui/main.glade:746
 msgid "_Highlighter"
 msgstr "_Evidenziatore"
 
-#: ../ui/main.glade:713
+#: ../ui/main.glade:768
 msgid "_Image"
 msgstr "_Immagine"
 
-#: ../ui/main.glade:553
+#: ../ui/main.glade:595
 msgid "_Journal"
 msgstr "_Journal"
 
-#: ../ui/main.glade:484
+#: ../ui/main.glade:520
 msgid "_Last Page"
 msgstr "_Ultima Pagina"
 
-#: ../ui/main.glade:353
+#: ../ui/main.glade:379
 msgid "_Manage"
 msgstr "_Gestisci"
 
-#: ../ui/main.glade:438
+#: ../ui/main.glade:470
 msgid "_Navigation"
 msgstr "_Navigazione"
 
-#: ../ui/main.glade:508
+#: ../ui/main.glade:546
 msgid "_Next Layer"
 msgstr "_Prossimo Livello"
 
-#: ../ui/main.glade:475
+#: ../ui/main.glade:510
 msgid "_Next Page"
 msgstr "_Pagina Sucessiva"
 
@@ -2129,80 +2181,80 @@ msgstr "_Pagina Sucessiva"
 msgid "_Open"
 msgstr "_Apri"
 
-#: ../ui/main.glade:673
+#: ../ui/main.glade:724
 msgid "_Pen"
 msgstr "_Penna"
 
-#: ../ui/main.glade:281
+#: ../ui/main.glade:329
 msgid "_Presentation Mode"
 msgstr "_Modalità Presentazione"
 
-#: ../ui/main.glade:499
+#: ../ui/main.glade:536
 msgid "_Previous Layer"
 msgstr "_Livello Precedente"
 
-#: ../ui/main.glade:457
+#: ../ui/main.glade:490
 msgid "_Previous Page"
 msgstr "_Pagina Precedente"
 
-#: ../src/control/jobs/BaseExportJob.cpp:27 ../src/control/Control.cpp:2354
+#: ../src/control/Control.cpp:2390 ../src/control/jobs/BaseExportJob.cpp:27
 #: ../src/gui/dialog/PageTemplateDialog.cpp:114
 msgid "_Save"
 msgstr "_Salva"
 
-#: ../ui/main.glade:737
+#: ../ui/main.glade:794
 msgid "_Shape Recognizer"
 msgstr "_Riconoscitore di Forme"
 
-#: ../ui/main.glade:703
+#: ../ui/main.glade:757
 msgid "_Text"
 msgstr "_Testo"
 
-#: ../ui/main.glade:663
+#: ../ui/main.glade:714
 msgid "_Tools"
 msgstr "_Strumenti"
 
-#: ../ui/main.glade:517
+#: ../ui/main.glade:556
 msgid "_Top Layer"
 msgstr "_Livello Superiore"
 
-#: ../ui/main.glade:273
+#: ../ui/main.glade:320
 msgid "_Two Pages"
 msgstr "_Due Pagine"
 
-#: ../ui/main.glade:823
+#: ../ui/main.glade:893
 msgid "_Vertical Space"
 msgstr "_Spazio Verticale"
 
-#: ../ui/main.glade:263
+#: ../ui/main.glade:310
 msgid "_View"
 msgstr "_Vista"
 
-#: ../ui/main.glade:1001
+#: ../ui/main.glade:1132
 msgid "_delete strokes"
 msgstr "_elimina tratti"
 
-#: ../ui/main.glade:878 ../ui/main.glade:950 ../ui/main.glade:1024
+#: ../ui/main.glade:952 ../ui/main.glade:1076 ../ui/main.glade:1156
 msgid "_fine"
 msgstr "_sottile"
 
-#: ../ui/main.glade:887 ../ui/main.glade:959 ../ui/main.glade:1033
+#: ../ui/main.glade:962 ../ui/main.glade:1086 ../ui/main.glade:1166
 msgid "_medium"
 msgstr "_medio"
 
-#: ../ui/main.glade:983
+#: ../ui/main.glade:1112
 msgid "_standard"
 msgstr "_standart"
 
-#: ../ui/main.glade:896 ../ui/main.glade:968 ../ui/main.glade:1042
+#: ../ui/main.glade:972 ../ui/main.glade:1096 ../ui/main.glade:1176
 msgid "_thick"
 msgstr "_spesso"
 
-#: ../ui/main.glade:869
+#: ../ui/main.glade:942
 msgid "_very fine"
 msgstr "_molto sottile"
 
-#: ../ui/main.glade:992
+#: ../ui/main.glade:1122
 msgid "_whiteout"
 msgstr "_sbianca"
 
@@ -2214,9 +2266,21 @@ msgstr "cambia"
 msgid "cursor"
 msgstr "cursore"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:299
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:294
+msgid "dash-/ doted"
+msgstr "tratteggiato-/ puntinato"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:291
+msgid "dashed"
+msgstr "tratteggiato"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:312
 msgid "delete stroke"
 msgstr "cancella tratto"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:297
+msgid "dotted"
+msgstr "puntinato"
 
 #: ../ui/exportSettings.glade:213
 msgid "dpi"
@@ -2242,7 +2306,7 @@ msgstr "mouse"
 msgid "pen"
 msgstr "penna"
 
-#: ../ui/settings.glade:1212
+#: ../ui/settings.glade:1269
 msgid "s"
 msgstr "s"
 
@@ -2254,7 +2318,8 @@ msgstr "salva"
 msgid "show"
 msgstr "mostra"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:285
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:288
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:310
 msgid "standard"
 msgstr "standard"
 
@@ -2266,15 +2331,15 @@ msgstr "touchpad"
 msgid "touchscreen"
 msgstr "touchscreen"
 
-#: ../ui/main.glade:905
+#: ../ui/main.glade:982
 msgid "ver_y thick"
 msgstr "molto s_pesso"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:292
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:311
 msgid "whiteout"
 msgstr "sbianca"
 
-#: ../src/control/xojfile/LoadHandler.cpp:835
+#: ../src/control/xojfile/LoadHandler.cpp:865
 msgid "xoj-File: {1}"
 msgstr "xoj-File: {1}"
 
@@ -2321,6 +2386,16 @@ msgstr "xoj-preview-extractor: Estratto con successo"
 
 #~ msgid "Color"
 #~ msgstr "Colore"
+
+#~ msgid ""
+#~ "Could not find Xournal++ LaTeX executable relative or in Path.\n"
+#~ "Searched for: mathtex-xournalpp.cgi"
+#~ msgstr ""
+#~ "Impossibile trovare l'eseguibile Xournal++ LaTeX nel percorso.\n"
+#~ "File cercato: mathtex-xournalpp.cgi"
+
+#~ msgid "Don't compress PDF files (for debugging)"
+#~ msgstr "Non comprimere i PDF (debugging)"
 
 #~ msgid "Drawing type"
 #~ msgstr "Stile disegno"

--- a/po/pl.po
+++ b/po/pl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: xournalpp 1.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-12-30 12:21+0100\n"
+"POT-Creation-Date: 2019-01-23 10:36+0100\n"
 "PO-Revision-Date: 2015-10-01 00:00+0200\n"
 "Last-Translator: Marek Pikuła <marek@pikula.co>\n"
 "Language-Team: Xournal++ team\n"
@@ -16,41 +16,41 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.4\n"
 
-#: ../src/undo/DeleteUndoAction.cpp:113 ../src/undo/AddUndoAction.cpp:119
+#: ../src/undo/AddUndoAction.cpp:119 ../src/undo/DeleteUndoAction.cpp:113
 msgid " elements"
 msgstr "elementy"
 
-#: ../src/undo/DeleteUndoAction.cpp:128 ../src/undo/AddUndoAction.cpp:134
+#: ../src/undo/AddUndoAction.cpp:134 ../src/undo/DeleteUndoAction.cpp:128
 msgid " image"
 msgstr "obraz"
 
-#: ../src/undo/DeleteUndoAction.cpp:132 ../src/undo/AddUndoAction.cpp:138
+#: ../src/undo/AddUndoAction.cpp:138 ../src/undo/DeleteUndoAction.cpp:132
 msgid " latex"
 msgstr "latex"
 
-#: ../src/gui/MainWindow.cpp:734
+#: ../src/gui/MainWindow.cpp:818
 msgctxt "Page {pagenumber} \"of {pagecount}\""
 msgid " of {1}{2}"
 msgstr "z {1}{2}"
 
-#: ../src/undo/DeleteUndoAction.cpp:120 ../src/undo/AddUndoAction.cpp:126
+#: ../src/undo/AddUndoAction.cpp:126 ../src/undo/DeleteUndoAction.cpp:120
 msgid " stroke"
 msgstr "kreska"
 
-#: ../src/undo/DeleteUndoAction.cpp:124 ../src/undo/AddUndoAction.cpp:130
+#: ../src/undo/AddUndoAction.cpp:130 ../src/undo/DeleteUndoAction.cpp:124
 msgid " text"
 msgstr "tekst"
 
-#: ../src/control/settings/Settings.cpp:79
+#: ../src/control/settings/Settings.cpp:90
 #, fuzzy
 msgid "%F-Note-%H-%M"
 msgstr "%F-Notatka-%H-%M.xoj"
 
-#: ../ui/settings.glade:590
+#: ../ui/settings.glade:604
 msgid "%F-Note-%H-%M.xoj"
 msgstr "%F-Notatka-%H-%M.xoj"
 
-#: ../ui/settings.glade:613
+#: ../ui/settings.glade:627
 msgid ""
 "%a\tAbbreviated weekday name \t(e.g. Thu)\n"
 "%A\tFull weekday name (e.g. Thursday)\n"
@@ -103,19 +103,19 @@ msgstr ""
 msgid "<b>... or select already used Image:</b>"
 msgstr "<b>... lub wybierz już używany obraz:</b>"
 
-#: ../ui/settings.glade:271
+#: ../ui/settings.glade:285
 msgid "<b>Add horizontal space</b>"
 msgstr "<b>Dodaj miejsce w poziomie</b>"
 
-#: ../ui/settings.glade:248
+#: ../ui/settings.glade:262
 msgid "<b>Add vertical space</b>"
 msgstr "<b>Dodaj miejsce w pionie</b>"
 
-#: ../ui/settings.glade:704
+#: ../ui/settings.glade:718
 msgid "<b>Autoload .pdf.xoj</b>"
 msgstr "<b>Autoładowanie .pdf.xoj</b>"
 
-#: ../ui/settings.glade:488
+#: ../ui/settings.glade:502
 msgid ""
 "<b>Autosave Folder</b>\n"
 "<i>If the document already was saved you can find it in the same folder\n"
@@ -128,7 +128,7 @@ msgstr ""
 "samym folderze z rozszerzeniem .autosave.xoj\n"
 "W przeciwnym wypadku jest w folderze ~/.xournalpp/autosave</i>"
 
-#: ../ui/settings.glade:428
+#: ../ui/settings.glade:442
 msgid "<b>Autosave</b>"
 msgstr "<b>Autozapis</b>"
 
@@ -146,7 +146,7 @@ msgstr "Tło"
 msgid "<b>Color</b>"
 msgstr "<b>Kolor</b>"
 
-#: ../ui/settings.glade:1464
+#: ../ui/settings.glade:1521
 #, fuzzy
 msgid "<b>Colors</b>"
 msgstr "<b>Kolor</b>"
@@ -164,7 +164,7 @@ msgid ""
 "for the fist Page"
 msgstr ""
 
-#: ../ui/settings.glade:1835
+#: ../ui/settings.glade:1907
 msgid "<b>Cursor</b>"
 msgstr "<b>Kursor</b>"
 
@@ -172,15 +172,15 @@ msgstr "<b>Kursor</b>"
 msgid "<b>Default Tools</b>"
 msgstr "<b>Domyślne narzędzia</b>"
 
-#: ../ui/settings.glade:577
+#: ../ui/settings.glade:591
 msgid "<b>Default name:</b>"
 msgstr "<b>Domyślna nazwa:</b>"
 
-#: ../ui/settings.glade:524
+#: ../ui/settings.glade:538
 msgid "<b>Default save name</b>"
 msgstr "<b>Domyślna nazwa pliku</b>"
 
-#: ../ui/settings.glade:1943
+#: ../ui/settings.glade:2030
 msgid "<b>Default</b>"
 msgstr "<b>Domyślne</b>"
 
@@ -190,11 +190,11 @@ msgid ""
 "Select pages to export"
 msgstr ""
 
-#: ../ui/settings.glade:1002
+#: ../ui/settings.glade:1016
 msgid "<b>Eraser</b>"
 msgstr "<b>Gumka</b>"
 
-#: ../ui/settings.glade:110
+#: ../ui/settings.glade:124
 msgid "<b>Extended Input</b>"
 msgstr "<b>Rozszerzone wprowadzanie</b>"
 
@@ -204,19 +204,19 @@ msgid ""
 "Select transparency for fill color"
 msgstr ""
 
-#: ../ui/settings.glade:1661
+#: ../ui/settings.glade:1733
 msgid "<b>Fullscreen</b>"
 msgstr "<b>Pełny ekran</b>"
 
-#: ../ui/settings.glade:658
+#: ../ui/settings.glade:672
 msgid "<b>Help</b> (Placeholders)"
 msgstr "<b>Pomoc</b> (symbole zastępcze)"
 
-#: ../ui/settings.glade:1390
+#: ../ui/settings.glade:1447
 msgid "<b>Left / Right</b>"
 msgstr "<b>Lewo / Prawo</b>"
 
-#: ../ui/settings.glade:819
+#: ../ui/settings.glade:833
 msgid "<b>Middle Mouse Button</b>"
 msgstr "<b>Środkowy przycisk myszy</b>"
 
@@ -229,25 +229,25 @@ msgstr "<b>Rozmiar strony</b>"
 msgid "<b>Pagesize</b>"
 msgstr "<b>Rozmiar strony</b>"
 
-#: ../ui/settings.glade:1731
+#: ../ui/settings.glade:1803
 msgid "<b>Presentation</b> Another Fullscreen Mode, <i>Start with F5</i>"
 msgstr ""
 "<b>Prezentacja</b> Inny tryb pełnoekranowy, <i>Rozpocznij przy użyciu F5</i>"
 
-#: ../ui/settings.glade:155
+#: ../ui/settings.glade:169
 msgid "<b>Pressure sensitivity</b>"
 msgstr "<b>Czułość nacisku</b>"
 
-#: ../ui/settings.glade:849
+#: ../ui/settings.glade:863
 msgid "<b>Right Mouse Button</b>"
 msgstr "<b>Prawy Przycisk Myszy</b>"
 
-#: ../ui/settings.glade:1584
+#: ../ui/settings.glade:1656
 #, fuzzy
 msgid "<b>Scrollbars</b>"
 msgstr "<b>Kolor</b>"
 
-#: ../ui/settings.glade:200
+#: ../ui/settings.glade:214
 msgid "<b>Scrolling outside the page</b>"
 msgstr "<b>Przewijanie poza granice strony</b>"
 
@@ -255,15 +255,15 @@ msgstr "<b>Przewijanie poza granice strony</b>"
 msgid "<b>Separator</b>"
 msgstr "<b>Separator</b>"
 
-#: ../ui/settings.glade:944
+#: ../ui/settings.glade:958
 msgid "<b>Stylus Button 1</b> Action if the pen button is pressed"
 msgstr ""
 
-#: ../ui/settings.glade:973
+#: ../ui/settings.glade:987
 msgid "<b>Stylus Button 2</b> Action if the pen button is pressed"
 msgstr ""
 
-#: ../ui/settings.glade:1031
+#: ../ui/settings.glade:1045
 msgid ""
 "<b>Touch Screen</b> <i>You can also configure other devices like mice</i>"
 msgstr ""
@@ -274,7 +274,7 @@ msgstr ""
 msgid "<i>Example:</i> 1-3 or 1,3,5-7 etc."
 msgstr "<i>Przykład:</i> 1-3 lub 1,3,5-7 itd."
 
-#: ../ui/settings.glade:929
+#: ../ui/settings.glade:943
 msgid ""
 "<i>Here you can define which tools will be selected If you\n"
 "use the eraser or other device.\n"
@@ -284,7 +284,7 @@ msgstr ""
 "gdy jest używana gumka lub inne urządzenie.\n"
 "Możesz tu dezaktywować ekran dotykowy.</i>"
 
-#: ../ui/settings.glade:804
+#: ../ui/settings.glade:818
 msgid ""
 "<i>Here you can define which tools will be selected if you press\n"
 "a button; after you release the button the previously selected\n"
@@ -294,14 +294,14 @@ msgstr ""
 "jeżeli naciśniesz przycisk; po zwolnieniu przycisku, poprzednie\n"
 "narzędzie zostanie wybrane</i>"
 
-#: ../ui/settings.glade:2030
+#: ../ui/settings.glade:2188
 msgid ""
 "<i>If audio recording is running, the time stamps are stored to the "
 "handwritten Text and can be replayed.\n"
 "The Audio track is recorded to a separate folder, and liked to there.</i>"
 msgstr ""
 
-#: ../ui/settings.glade:224
+#: ../ui/settings.glade:238
 msgid ""
 "<i>If you add <b>additional space</b> beside the pages\n"
 "you can choose the area of the screen you would\n"
@@ -310,12 +310,12 @@ msgstr ""
 "<i>Jeżeli dodasz miejsce poza stroną, można stworzyć\n"
 "miejsce na ekranie na którym można pracować</i>"
 
-#: ../ui/settings.glade:170
+#: ../ui/settings.glade:184
 msgid "<i>If you have a tablet pen you can get different line widths</i>"
 msgstr ""
 "<i>Jeżeli masz piórko z tabletu, możesz uzyskać różne grubości linii</i>"
 
-#: ../ui/settings.glade:728
+#: ../ui/settings.glade:742
 msgid ""
 "<i>If you open a PDF and there is a\n"
 "Xournal file with the same name it will open the xoj file.</i>"
@@ -323,7 +323,7 @@ msgstr ""
 "<i>Jeżeli otworzysz plik PDF, a w folderze jest\n"
 "plik Xournala z taką samą nazwą, otwierany jest plik xoj.</i>"
 
-#: ../ui/settings.glade:324
+#: ../ui/settings.glade:338
 msgid ""
 "<i>Put a ruler on your screen to calibrate the zoom level to fit your "
 "screen. Takes effect after restarting xournalpp.\n"
@@ -333,17 +333,17 @@ msgstr ""
 "ekranu. Efekt widoczny po restarcie Xournal++.\n"
 "Linijka skalowana w cm, suwak w dpi.</i>"
 
-#: ../ui/settings.glade:133
+#: ../ui/settings.glade:147
 msgid "<i>Select some advanced input options</i>"
 msgstr ""
 
-#: ../ui/settings.glade:1339
+#: ../ui/settings.glade:1396
 msgid ""
 "<i>The commands will be executed in the UI Thread, make sure\n"
 "they are not blocking!</i>"
 msgstr ""
 
-#: ../ui/settings.glade:548
+#: ../ui/settings.glade:562
 msgid "<i>This name will be proposed if you save a new document</i>"
 msgstr "<i>Nazwa sugerowana podczas zapisywania nowego dokumentu</i>"
 
@@ -360,15 +360,15 @@ msgstr ""
 msgid "About Xournal++"
 msgstr "O programie Xournal++"
 
-#: ../src/control/XournalMain.cpp:245
+#: ../src/control/XournalMain.cpp:250
 msgid "Absolute path for the audio files playback"
 msgstr ""
 
-#: ../ui/main.glade:1086
+#: ../ui/main.glade:1233
 msgid "Add/Edit Tex"
 msgstr "Dodaj/Edytuj Tex"
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:48
+#: ../src/control/stockdlg/XojOpenDlg.cpp:51
 msgid "All files"
 msgstr "Wszystkie pliki"
 
@@ -387,7 +387,7 @@ msgid "Apply to current page"
 msgstr "Usuń aktywną stronę"
 
 #: ../src/control/stockdlg/ImageOpenDlg.cpp:30
-#: ../src/control/stockdlg/XojOpenDlg.cpp:147
+#: ../src/control/stockdlg/XojOpenDlg.cpp:152
 msgid "Attach file to the journal"
 msgstr "Dołącz plik do dziennika"
 
@@ -412,15 +412,15 @@ msgstr "Atrybut \"{1}\" nie jest typu int (wartość: NULL)"
 msgid "Attribute color not set!"
 msgstr "Atrybut koloru nie został ustawiony!"
 
-#: ../ui/settings.glade:2051
+#: ../ui/settings.glade:2209
 msgid "Audio Folder"
 msgstr ""
 
-#: ../ui/settings.glade:2088
+#: ../ui/settings.glade:2246
 msgid "Audio Recording"
 msgstr ""
 
-#: ../src/control/AudioController.cpp:100
+#: ../src/control/AudioController.cpp:98
 msgid ""
 "Audio folder not set! Recording won't work!\n"
 "Please set the recording folder under \"Preferences > Audio recording\""
@@ -431,16 +431,16 @@ msgstr ""
 msgid "Authors:"
 msgstr "<b>Autorzy:</b>"
 
-#: ../ui/settings.glade:1170
+#: ../ui/settings.glade:1227
 msgid "Autodetect"
 msgstr ""
 
-#: ../ui/settings.glade:456
+#: ../ui/settings.glade:470
 #, fuzzy
 msgid "Autosave every ... minutes:"
 msgstr "Autozapis co ... minut"
 
-#: ../src/control/Control.cpp:254
+#: ../src/control/Control.cpp:256
 #, fuzzy
 msgid "Autosave failed with an error: {1}"
 msgstr "Błąd otwierania pliku: {1}"
@@ -449,8 +449,7 @@ msgstr "Błąd otwierania pliku: {1}"
 msgid "Autosave: {1}"
 msgstr "Autozapis: {1}"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:333
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:336
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:429
 msgid "Back"
 msgstr "Wstecz"
 
@@ -460,11 +459,11 @@ msgstr "Wstecz"
 msgid "Background"
 msgstr "Tło"
 
-#: ../ui/settings.glade:1520
+#: ../ui/settings.glade:1577
 msgid "Background color for window Background"
 msgstr ""
 
-#: ../ui/settings.glade:1857
+#: ../ui/settings.glade:1929
 msgid "Big cursor for pen"
 msgstr "Duży kursor dla pióra"
 
@@ -478,11 +477,11 @@ msgstr "Czarny"
 msgid "Blue"
 msgstr "Niebieski"
 
-#: ../ui/settings.glade:1509
+#: ../ui/settings.glade:1566
 msgid "Border color"
 msgstr "Kolor obramowania"
 
-#: ../ui/settings.glade:1495
+#: ../ui/settings.glade:1552
 #, fuzzy
 msgid "Border color for current page and other selections"
 msgstr "Kolor krawędzi aktualnej strony i innych zaznaczeń"
@@ -491,8 +490,8 @@ msgstr "Kolor krawędzi aktualnej strony i innych zaznaczeń"
 msgid "Built on:"
 msgstr ""
 
-#: ../src/control/Control.cpp:2022 ../src/control/Control.cpp:2534
-#: ../src/control/Control.cpp:2570 ../src/control/XournalMain.cpp:124
+#: ../src/control/Control.cpp:2058 ../src/control/Control.cpp:2581
+#: ../src/control/Control.cpp:2619 ../src/control/XournalMain.cpp:128
 msgid "Cancel"
 msgstr "Anuluj"
 
@@ -509,7 +508,7 @@ msgstr "Zmień czcionkę"
 msgid "Change stroke fill"
 msgstr "Zmień grubość kreski"
 
-#: ../src/undo/SizeUndoAction.cpp:145
+#: ../src/undo/SizeUndoAction.cpp:139
 msgid "Change stroke width"
 msgstr "Zmień grubość kreski"
 
@@ -517,7 +516,7 @@ msgstr "Zmień grubość kreski"
 msgid "Color \"{1}\" unknown (not defined in default color list)!"
 msgstr "Nie rozpoznano koloru \"{1}\" (nie zdefiniowany w domyślnych)!"
 
-#: ../ui/main.glade:588
+#: ../ui/main.glade:633
 msgid "Configure Page Template"
 msgstr ""
 
@@ -525,8 +524,8 @@ msgstr ""
 msgid "Contents"
 msgstr "Zawartość"
 
-#: ../src/control/Control.cpp:1036 ../src/control/Control.cpp:1044
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:321
+#: ../src/control/Control.cpp:1047 ../src/control/Control.cpp:1055
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:402
 msgid "Copy"
 msgstr "Kopiuj"
 
@@ -547,6 +546,10 @@ msgstr "Idź do ostatniej strony"
 msgid "Copy page"
 msgstr "Kopiuj stronę"
 
+#: ../src/control/LatexController.cpp:103
+msgid "Could not convert tex to PDF: {1} (exit code: {2})"
+msgstr ""
+
 #: ../src/control/jobs/SaveJob.cpp:137
 msgid ""
 "Could not create backup! (The file was created from an older Xournal version)"
@@ -554,32 +557,42 @@ msgstr ""
 "Nie można stworzyć kopii zapasowej! (Plik został stworzony w starszej wersji "
 "Xournala)"
 
-#: ../src/util/Util.cpp:97
+#: ../src/util/Util.cpp:94
 #, fuzzy
 msgid "Could not create folder: {1}"
 msgstr "Nie można otworzyć pliku: \"{1}\""
 
-#: ../src/control/Control.cpp:218 ../src/control/Control.cpp:235
+#: ../src/control/Control.cpp:220 ../src/control/Control.cpp:237
 #, fuzzy
 msgid "Could not delete old autosave file \"{1}\""
 msgstr "Nie można otworzyć pliku: \"{1}\""
 
-#: ../src/control/LatexController.cpp:381
+#: ../src/control/LatexController.cpp:428
 msgid ""
-"Could not find Xournal++ LaTeX executable relative or in Path.\n"
-"Searched for: mathtex-xournalpp.cgi"
+"Could not find pdflatex in Path.\n"
+"Please install pdflatex first and make sure it's in the Path."
 msgstr ""
+
+#: ../src/control/LatexController.cpp:299
+#, fuzzy
+msgid "Could not load LaTeX PDF file, URL-Error: {1}"
+msgstr "Nie można wczytać obrazu LaTeXa: {1}"
+
+#: ../src/control/LatexController.cpp:307
+#, fuzzy
+msgid "Could not load LaTeX PDF file: {1}"
+msgstr "Nie można otworzyć pliku: \"{1}\""
 
 #: ../src/control/pagetype/PageTypeHandler.cpp:18
 #, fuzzy
 msgid "Could not load pagetemplates.ini file"
 msgstr "Nie można otworzyć pliku: \"{1}\""
 
-#: ../src/control/xojfile/LoadHandler.cpp:123
+#: ../src/control/xojfile/LoadHandler.cpp:124
 msgid "Could not open file: \"{1}\""
 msgstr "Nie można otworzyć pliku: \"{1}\""
 
-#: ../src/gui/MainWindow.cpp:93
+#: ../src/gui/MainWindow.cpp:86
 msgid ""
 "Could not parse custom toolbar.ini file: {1}\n"
 "Toolbars will not be available"
@@ -587,7 +600,7 @@ msgstr ""
 "Nie można sparsować niestandardowego pliku toolbar.ini: {1}\n"
 "Paski narzędzi nie będą dostępne."
 
-#: ../src/gui/MainWindow.cpp:83
+#: ../src/gui/MainWindow.cpp:76
 msgid ""
 "Could not parse general toolbar.ini file: {1}\n"
 "No Toolbars will be available"
@@ -595,7 +608,7 @@ msgstr ""
 "Nie można sparsować głównego pliku toolbar.ini: {1}\n"
 "Żadne paski narzędzi nie będą dostępne."
 
-#: ../src/control/xojfile/LoadHandler.cpp:328
+#: ../src/control/xojfile/LoadHandler.cpp:347
 msgid "Could not read image: {1}. Error message: {2}"
 msgstr "Nie można odczytać obrazu: {1}. Treść błędu: {2}"
 
@@ -607,22 +620,23 @@ msgstr ""
 "Nie można powtórzyć \"{1}\"\n"
 "Coś poszło źle… Proszę zgłosić błąd…"
 
-#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:214
+#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:210
 msgid "Could not remove tool item from Toolbar {1} on position {2}"
 msgstr ""
 
-#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:209
+#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:205
 msgid "Could not remove tool item {1} from Toolbar {2} on position {3}"
 msgstr ""
 
-#: ../src/control/Control.cpp:228 ../src/control/Control.cpp:247
+#: ../src/control/Control.cpp:230 ../src/control/Control.cpp:249
 #, fuzzy
 msgid "Could not rename autosave file from \"{1}\" to \"{2}\""
 msgstr "Nie można zapisać pliku matadanych: {1} ({2})"
 
-#: ../src/control/LatexController.cpp:310
-msgid "Could not retrieve LaTeX image file: {1}"
-msgstr "Nie można wczytać obrazu LaTeXa: {1}"
+#: ../src/control/LatexController.cpp:89
+#, fuzzy
+msgid "Could not save .tex file: {1}"
+msgstr "Nie można otworzyć pliku: \"{1}\""
 
 #: ../src/undo/UndoRedoHandler.cpp:144
 msgid ""
@@ -632,11 +646,11 @@ msgstr ""
 "Nie można cofnąć \"{1}\n"
 "Coś poszło źle… Proszę zgłosić błąd…"
 
-#: ../src/control/xojfile/SaveHandler.cpp:294
+#: ../src/control/xojfile/SaveHandler.cpp:290
 msgid "Could not write background \"{1}\", {2}"
 msgstr "Nie można zapisać tła \"{1}\", {2}"
 
-#: ../src/control/xojfile/SaveHandler.cpp:419
+#: ../src/control/xojfile/SaveHandler.cpp:415
 msgid "Could not write background \"{1}\". Continuing anyway."
 msgstr "Nie można zapisać tła \"{1}\". Kontynuuję mimo to."
 
@@ -653,7 +667,7 @@ msgstr "Aktywna strona"
 msgid "Custom"
 msgstr "Niestandardowe"
 
-#: ../ui/settings.glade:1231
+#: ../ui/settings.glade:1288
 msgid "Custom Commands (for Method \"Custom\")"
 msgstr ""
 
@@ -666,35 +680,40 @@ msgstr "Niestandardowe"
 msgid "Customized"
 msgstr "Spersonalizowany"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:320
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:401
 msgid "Cut"
 msgstr "Wytnij"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:442
+#: ../ui/settings.glade:1621
+msgid "Dark Theme (restart needed)"
+msgstr ""
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:460
 msgid "Default Tool"
 msgstr "Domyślne narzędzie"
 
-#: ../ui/settings.glade:1997
+#: ../ui/settings.glade:2155
 msgid "Defaults"
 msgstr "Domyślne"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:407
 #: ../src/undo/DeleteUndoAction.cpp:102
 msgid "Delete"
 msgstr "Usuń"
 
-#: ../ui/main.glade:620
+#: ../ui/main.glade:668
 msgid "Delete Layer"
 msgstr "Usuń warstwę"
 
-#: ../src/control/XournalMain.cpp:123
+#: ../src/control/XournalMain.cpp:127
 msgid "Delete Logfile"
 msgstr "Usuń plik loggera"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:387
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:447
 msgid "Delete current page"
 msgstr "Usuń aktywną stronę"
 
-#: ../src/control/XournalMain.cpp:173
+#: ../src/control/XournalMain.cpp:177
 #, fuzzy
 msgid "Delete file"
 msgstr "Usuń plik loggera"
@@ -707,7 +726,7 @@ msgstr "Usuń warstwę"
 msgid "Delete stroke"
 msgstr "Usuń kreskę"
 
-#: ../ui/main.glade:1297
+#: ../ui/main.glade:1447
 #, fuzzy
 msgid "Delete this page"
 msgstr "Usuń aktywną stronę"
@@ -716,7 +735,7 @@ msgstr "Usuń aktywną stronę"
 msgid "Device"
 msgstr "Urządzenie"
 
-#: ../ui/settings.glade:1261
+#: ../ui/settings.glade:1318
 msgid "Disable"
 msgstr ""
 
@@ -724,19 +743,19 @@ msgstr ""
 msgid "Disable drawing for this device"
 msgstr "Wyłącz rysowanie przy użyciu tego urządzenia"
 
-#: ../ui/settings.glade:1134
+#: ../ui/settings.glade:1191
 msgid "Disable touch if pen is near screen"
 msgstr ""
 
-#: ../ui/settings.glade:1156
+#: ../ui/settings.glade:1213
 msgid "Disabling Method"
 msgstr ""
 
-#: ../src/control/Control.cpp:2533 ../src/control/Control.cpp:2569
+#: ../src/control/Control.cpp:2577 ../src/control/Control.cpp:2618
 msgid "Discard"
 msgstr "Odrzuć"
 
-#: ../src/control/Control.cpp:1952
+#: ../src/control/Control.cpp:1988
 msgid ""
 "Do not open Autosave files. They may will be overwritten!\n"
 "Copy the files to another folder.\n"
@@ -747,21 +766,17 @@ msgstr ""
 msgid "Do not overwrite the background PDF! This will cause errors!"
 msgstr ""
 
-#: ../src/control/Control.cpp:2566
+#: ../src/control/Control.cpp:2615
 msgid "Document file was removed."
 msgstr "Dokument został usunięty."
 
-#: ../src/control/xojfile/LoadHandler.cpp:202
+#: ../src/control/xojfile/LoadHandler.cpp:203
 msgid "Document is not complete (maybe the end is cut off?)"
 msgstr "Dokument jest uszkodzony (możliwe, że jest obcięty)"
 
 #: ../src/model/Document.cpp:393
 msgid "Document not loaded! ({1}), {2}"
 msgstr "Dokument nie został załadowany! ({1}), {2}"
-
-#: ../src/control/XournalMain.cpp:242
-msgid "Don't compress PDF files (for debugging)"
-msgstr "Nie kompresuj plików PDF (do debugowania)"
 
 #: ../src/control/pagetype/PageTypeHandler.cpp:26
 msgid "Dotted"
@@ -773,13 +788,13 @@ msgstr "Przeciągnij i upuść Komponenty na paski narzędzi i z powrotem."
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:99
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:40
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:420
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:465
 msgid "Draw Arrow"
 msgstr "Rysuj strzałkę"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:97
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:39
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:416
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:464
 msgid "Draw Circle"
 msgstr "Rysuj koło"
 
@@ -791,20 +806,20 @@ msgstr "Rysuj linię"
 #: ../src/gui/dialog/ButtonConfigGui.cpp:95
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:29
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:38
-#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:120
-#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:123
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:418
+#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:122
+#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:125
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:463
 msgid "Draw Rectangle"
 msgstr "Rysuj prostokąt"
 
-#: ../ui/main.glade:778
+#: ../ui/main.glade:844
 #, fuzzy
 msgid "Draw _Line"
 msgstr "Rysuj linię"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:101
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:42
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:422
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:466
 msgid "Draw coordinate system"
 msgstr ""
 
@@ -821,26 +836,35 @@ msgstr "Nie zmieniaj"
 msgid "Edit text"
 msgstr "Edytuj tekst"
 
-#: ../ui/settings.glade:1249
+#: ../src/undo/EmergencySaveRestore.cpp:35
+#, fuzzy
+msgid "Emergency saved document"
+msgstr "Niezapisany dokument"
+
+#: ../ui/settings.glade:1306
 #, fuzzy
 msgid "Enable"
 msgstr "Włącz linijkę"
+
+#: ../ui/settings.glade:1176
+msgid "Enable zoom gestures (needs restart)"
+msgstr ""
 
 #: ../ui/texdialog.glade:66
 msgid "Enter / edit LaTeX Text"
 msgstr ""
 
-#: ../src/undo/EraseUndoAction.cpp:130 ../src/undo/DeleteUndoAction.cpp:99
-#: ../src/undo/AddUndoAction.cpp:104
+#: ../src/undo/AddUndoAction.cpp:104 ../src/undo/DeleteUndoAction.cpp:99
+#: ../src/undo/EraseUndoAction.cpp:130
 msgid "Erase stroke"
 msgstr "Wymaż kreskę"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:56
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:282
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:308
 msgid "Eraser"
 msgstr "Gumka"
 
-#: ../ui/main.glade:940
+#: ../ui/main.glade:1066
 msgid "Eraser Optio_ns"
 msgstr "Op_cje gumki"
 
@@ -848,7 +872,7 @@ msgstr "Op_cje gumki"
 msgid "Eraser Type - don't change"
 msgstr ""
 
-#: ../src/control/Control.cpp:2232
+#: ../src/control/Control.cpp:2268
 msgid ""
 "Error annotate PDF file \"{1}\"\n"
 "{2}"
@@ -861,11 +885,11 @@ msgstr ""
 msgid "Error export PDF Page"
 msgstr "Eksportuj do PDF"
 
-#: ../src/gui/GladeGui.cpp:25
+#: ../src/gui/GladeGui.cpp:26
 msgid "Error loading glade file \"{1}\" (try to load \"{2}\")"
 msgstr "Błąd przy otwieraniu pliku glade \"{1}\" (spróbuj załadować \"{2}\")"
 
-#: ../src/control/Control.cpp:2047
+#: ../src/control/Control.cpp:2083
 msgid "Error opening file \"{1}\""
 msgstr "Błąd przy otwieraniu pliku \"{1}\""
 
@@ -873,11 +897,11 @@ msgstr "Błąd przy otwieraniu pliku \"{1}\""
 msgid "Error opening file: \"{1}\""
 msgstr "Błąd przy otwieraniu pliku \"{1}\""
 
-#: ../src/control/xojfile/LoadHandler.cpp:428
+#: ../src/control/xojfile/LoadHandler.cpp:447
 msgid "Error reading PDF: {1}"
 msgstr "Błąd przy odczytywaniu pliku PDF: {1}"
 
-#: ../src/control/xojfile/LoadHandler.cpp:499
+#: ../src/control/xojfile/LoadHandler.cpp:518
 msgid "Error reading width of a stroke: {1}"
 msgstr "Błędna grubość kreski: {1}"
 
@@ -885,7 +909,7 @@ msgstr "Błędna grubość kreski: {1}"
 msgid "Error: {1}"
 msgstr "Błąd: {1}"
 
-#: ../src/control/XournalMain.cpp:147
+#: ../src/control/XournalMain.cpp:151
 msgid ""
 "Errorlog cannot be deleted. You have to do it manually.\n"
 "Logfile: {1}"
@@ -901,19 +925,19 @@ msgstr "Eksportuj"
 msgid "Export PDF"
 msgstr "Eksportuj do PDF"
 
-#: ../ui/main.glade:113
+#: ../ui/main.glade:119
 msgid "Export as..."
 msgstr "Eksportuj jako..."
 
-#: ../src/control/LatexController.cpp:398
+#: ../src/control/LatexController.cpp:445
 msgid "Failed to generate LaTeX image!"
 msgstr ""
 
-#: ../ui/main.glade:920 ../ui/main.glade:1057
+#: ../ui/main.glade:1044 ../ui/main.glade:1192
 msgid "Fi_ll"
 msgstr ""
 
-#: ../src/util/Util.cpp:127 ../src/util/Util.cpp:148
+#: ../src/util/Util.cpp:123 ../src/util/Util.cpp:143
 msgid ""
 "File couldn't be opened. You have to do it manually:\n"
 "URL: {1}"
@@ -921,23 +945,23 @@ msgstr ""
 "Nie da się otworzyć dokumentu. Musisz to zrobić ręcznie:\n"
 "URL: {1}"
 
-#: ../src/control/Control.cpp:1982
+#: ../src/control/Control.cpp:2018
 msgid "Filename: {1}"
 msgstr "Nazwa pliku: {1}"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:445
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:500
 msgid "Fill"
 msgstr ""
 
-#: ../ui/main.glade:928 ../ui/main.glade:1065
+#: ../ui/main.glade:1053 ../ui/main.glade:1201
 msgid "Fill transparency"
 msgstr ""
 
-#: ../ui/main.glade:1492
+#: ../ui/main.glade:1634
 msgid "Find next occurrence of the search string"
 msgstr ""
 
-#: ../ui/main.glade:1471
+#: ../ui/main.glade:1613
 msgid "Find previous occurrence of the search string"
 msgstr ""
 
@@ -945,37 +969,43 @@ msgstr ""
 msgid "Font"
 msgstr "Czcionka"
 
-#: ../ui/main.glade:289
+#: ../ui/main.glade:338
 msgid "Fullscreen"
 msgstr "Pełny ekran"
 
-#: ../ui/about.glade:233
+#: ../ui/about.glade:234
 msgid "GNU GPLv2 or later"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:331
+#: ../ui/settings.glade:1072
+msgid ""
+"GTK Touch / Scrolling workaround. Change Scroll / Touch behavoir. Enabled "
+"touch drawing. Needs restart."
+msgstr ""
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:428
 msgid "Go to first page"
 msgstr "Idź do pierwszej strony"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:344
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:432
 msgid "Go to last page"
 msgstr "Idź do ostatniej strony"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:349
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:435
 #, fuzzy
 msgid "Go to next layer"
 msgstr "Idź do ostatniej strony"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:339
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:430
 msgid "Go to page"
 msgstr "Idź do strony"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:347
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:434
 #, fuzzy
 msgid "Go to previous layer"
 msgstr "Idź do pierwszej strony"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:351
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:436
 #, fuzzy
 msgid "Go to top layer"
 msgstr "Idź do strony"
@@ -999,16 +1029,20 @@ msgstr "Szary"
 msgid "Green"
 msgstr "Zielony"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:378
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:411
 msgid "Grid Snapping"
 msgstr ""
 
-#: ../ui/main.glade:843
+#: ../ui/settings.glade:2113
+msgid "Grid snapping tolerance:"
+msgstr ""
+
+#: ../ui/main.glade:915
 msgid "H_and Tool"
 msgstr "N_arzędzie ręki"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:63
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:426
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:474
 msgid "Hand"
 msgstr "Przesuń"
 
@@ -1016,16 +1050,16 @@ msgstr "Przesuń"
 msgid "Height:"
 msgstr "Wysokość:"
 
-#: ../ui/main.glade:379
+#: ../ui/main.glade:407
 #, fuzzy
 msgid "Hide Menu"
 msgstr "Ukryj pasek menu"
 
-#: ../ui/settings.glade:1683 ../ui/settings.glade:1753
+#: ../ui/settings.glade:1755 ../ui/settings.glade:1825
 msgid "Hide Menubar"
 msgstr "Ukryj pasek menu"
 
-#: ../ui/settings.glade:1698 ../ui/settings.glade:1768
+#: ../ui/settings.glade:1770 ../ui/settings.glade:1840
 msgid "Hide Sidebar"
 msgstr "Ukryj pasek boczny"
 
@@ -1034,26 +1068,31 @@ msgstr "Ukryj pasek boczny"
 msgid "Hide all"
 msgstr "Ukryj pasek menu"
 
-#: ../ui/settings.glade:1613
+#: ../ui/settings.glade:1685
 msgid "Hide the horizontal scrollbar"
 msgstr ""
 
-#: ../ui/settings.glade:1628
+#: ../ui/settings.glade:1700
 msgid "Hide the vertical scrollbar"
 msgstr ""
 
+#: ../ui/settings.glade:1944
+#, fuzzy
+msgid "Highlight cursor position"
+msgstr "Opc_je zakreślacza"
+
 #: ../src/gui/dialog/ButtonConfigGui.cpp:57
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:399
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:457
 msgid "Highlighter"
 msgstr "Zakreślacz"
 
-#: ../ui/main.glade:1014
+#: ../ui/main.glade:1146
 #, fuzzy
 msgid "Highlighter Opti_ons"
 msgstr "Opc_je zakreślacza"
 
 #: ../src/control/pagetype/PageTypeHandler.cpp:32
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:403
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:459
 msgid "Image"
 msgstr "Obraz"
 
@@ -1061,11 +1100,11 @@ msgstr "Obraz"
 msgid "Images"
 msgstr "Obrazy"
 
-#: ../ui/settings.glade:390
+#: ../ui/settings.glade:404
 msgid "Input"
 msgstr "Wejście"
 
-#: ../ui/settings.glade:1090
+#: ../ui/settings.glade:1119
 msgid "Input Device"
 msgstr "Urządzenie wejściowe"
 
@@ -1073,7 +1112,7 @@ msgstr "Urządzenie wejściowe"
 msgid "Insert Latex"
 msgstr "Wstaw LaTeX"
 
-#: ../ui/main.glade:1277
+#: ../ui/main.glade:1427
 msgid "Insert a copy of the current page below"
 msgstr ""
 
@@ -1081,7 +1120,7 @@ msgstr ""
 msgid "Insert elements"
 msgstr "Wstaw elementy"
 
-#: ../src/undo/InsertUndoAction.cpp:47 ../src/gui/dialog/ButtonConfigGui.cpp:59
+#: ../src/gui/dialog/ButtonConfigGui.cpp:59 ../src/undo/InsertUndoAction.cpp:47
 msgid "Insert image"
 msgstr "Wstaw obraz"
 
@@ -1093,11 +1132,11 @@ msgstr "Wstaw LaTeX"
 msgid "Insert layer"
 msgstr "Wstaw warstwę"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:394
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:443
 msgid "Insert page"
 msgstr "Wstaw stronę"
 
-#: ../src/control/XournalMain.cpp:244
+#: ../src/control/XournalMain.cpp:249
 msgid "Jump to Page (first Page: 1)"
 msgstr "Skocz do strony (pierwsza strona: 1)"
 
@@ -1119,7 +1158,7 @@ msgstr "Wybór warstw"
 msgid "Layer {1}"
 msgstr "Warstwa {1}"
 
-#: ../ui/about.glade:217
+#: ../ui/about.glade:218
 msgid "License"
 msgstr ""
 
@@ -1137,7 +1176,7 @@ msgstr "Jasnozielony"
 msgid "Lined"
 msgstr "Linie"
 
-#: ../ui/settings.glade:772
+#: ../ui/settings.glade:786
 msgid "Load / Save"
 msgstr "Ładuj / Zapisz"
 
@@ -1145,13 +1184,13 @@ msgstr "Ładuj / Zapisz"
 msgid "Load file"
 msgstr "Wczytaj plik"
 
-#: ../src/gui/PageView.cpp:738
+#: ../src/gui/PageView.cpp:739
 #: ../src/gui/sidebar/previews/base/SidebarPreviewBaseEntry.cpp:105
 #: ../src/gui/toolbarMenubar/ToolPageLayer.cpp:20
 msgid "Loading..."
 msgstr "Ładowanie..."
 
-#: ../ui/toolbarManageDialog.glade:8 ../ui/toolbarCustomizeDialog.glade:10
+#: ../ui/toolbarCustomizeDialog.glade:10 ../ui/toolbarManageDialog.glade:8
 msgid "Manage Toolbar"
 msgstr "Zarządzaj paskiem narzędzi"
 
@@ -1161,11 +1200,17 @@ msgid "Mangenta"
 msgstr "Magenta"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:81
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:437
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:514
 msgid "Medium"
 msgstr "Średnia"
 
-#: ../src/control/XournalMain.cpp:462
+#: ../src/control/XournalMain.cpp:460
+msgid ""
+"Missing the needed UI file! .app corrupted?\n"
+"Path: {1}"
+msgstr ""
+
+#: ../src/control/XournalMain.cpp:474
 msgid ""
 "Missing the needed UI file, could not find them at any location.\n"
 "Not relative\n"
@@ -1173,7 +1218,7 @@ msgid ""
 "Not in {1}"
 msgstr ""
 
-#: ../ui/settings.glade:883
+#: ../ui/settings.glade:897
 msgid "Mouse Button"
 msgstr "Przycisk myszy"
 
@@ -1194,7 +1239,7 @@ msgstr "Przenieś stronę niżej"
 msgid "Move page upwards"
 msgstr "Przenieś stronę wyżej"
 
-#: ../ui/main.glade:531
+#: ../ui/main.glade:571
 msgid "N_ext annotated page"
 msgstr "N_astępna adnotowana strona"
 
@@ -1202,31 +1247,31 @@ msgstr "N_astępna adnotowana strona"
 msgid "New"
 msgstr "Nowy"
 
-#: ../ui/main.glade:571
+#: ../ui/main.glade:614
 msgid "New Page _After"
 msgstr "Nowa strona _za"
 
-#: ../ui/main.glade:563
+#: ../ui/main.glade:605
 msgid "New Page _Before"
 msgstr "Nowa strona _przed"
 
-#: ../ui/main.glade:580
+#: ../ui/main.glade:624
 msgid "New Page at _End"
 msgstr "Nowa strona na _końcu"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:316
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:388
 msgid "New Xournal"
 msgstr "Nowy Xournal"
 
-#: ../ui/main.glade:611
+#: ../ui/main.glade:658
 msgid "New _Layer"
 msgstr "Nowa _warstwa"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:342
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:431
 msgid "Next"
 msgstr "Następny"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:355
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:438
 msgid "Next annotated page"
 msgstr "Następna adnotowana strona"
 
@@ -1253,20 +1298,20 @@ msgstr ""
 msgid "Open Image"
 msgstr "Otwórz obraz"
 
-#: ../src/control/XournalMain.cpp:121
+#: ../src/control/XournalMain.cpp:125
 msgid "Open Logfile"
 msgstr "Otwórz plik loggera"
 
-#: ../src/control/XournalMain.cpp:122
+#: ../src/control/XournalMain.cpp:126
 msgid "Open Logfile directory"
 msgstr "Otwórz folder z plikami loggera"
 
 #: ../src/control/stockdlg/XojOpenDlg.cpp:16
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:318
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:389
 msgid "Open file"
 msgstr "Otwórz plik"
 
-#: ../src/control/RecentManager.cpp:241
+#: ../src/control/RecentManager.cpp:244
 msgctxt "{1} is a URI"
 msgid "Open {1}"
 msgstr "Otwórz {1}"
@@ -1280,7 +1325,7 @@ msgstr "Pomarańczowy"
 msgid "PDF Export"
 msgstr "Eksport do PDF"
 
-#: ../src/gui/MainWindow.cpp:732
+#: ../src/gui/MainWindow.cpp:816
 msgid "PDF Page {1}"
 msgstr "strona PDF {1}"
 
@@ -1288,17 +1333,17 @@ msgstr "strona PDF {1}"
 msgid "PDF background missing"
 msgstr "Nie znaleziono pliku PDF w tle"
 
-#: ../src/control/XournalMain.cpp:223
+#: ../src/control/XournalMain.cpp:230
 msgid "PDF file successfully created"
 msgstr "Utworzono dokument PDF"
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:58
-#: ../src/control/jobs/PdfExportJob.cpp:23
 #: ../src/control/jobs/CustomExportJob.cpp:27
+#: ../src/control/jobs/PdfExportJob.cpp:23
+#: ../src/control/stockdlg/XojOpenDlg.cpp:61
 msgid "PDF files"
 msgstr "Pliki PDF"
 
-#: ../src/control/XournalMain.cpp:243
+#: ../src/control/XournalMain.cpp:248
 msgid "PDF output filename"
 msgstr "Nazwa pliku PDF"
 
@@ -1316,7 +1361,7 @@ msgstr ""
 msgid "PNG with transparent background"
 msgstr "_Tło papieru"
 
-#: ../ui/main.glade:540
+#: ../ui/main.glade:581
 #, fuzzy
 msgid "P_revious annotated Page"
 msgstr "P_oprzednia adnotowana strona"
@@ -1358,35 +1403,35 @@ msgstr "Stron:"
 msgid "Paper Format"
 msgstr "Format papieru"
 
-#: ../ui/main.glade:643
+#: ../ui/main.glade:693
 msgid "Paper _Color"
 msgstr "_Kolor papieru"
 
-#: ../ui/main.glade:635
+#: ../ui/main.glade:684
 msgid "Paper _Format"
 msgstr "_Format papieru"
 
-#: ../ui/main.glade:651
+#: ../ui/main.glade:702
 msgid "Paper b_ackground"
 msgstr "_Tło papieru"
 
-#: ../ui/about.glade:201
+#: ../ui/about.glade:202
 msgid ""
 "Partial based on Xournal\n"
 "by Denis Auroux"
 msgstr ""
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:403
 #: ../src/undo/AddUndoAction.cpp:108
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:322
 msgid "Paste"
 msgstr "Wklej"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:55
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:382
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:286
 msgid "Pen"
 msgstr "Pióro"
 
-#: ../ui/main.glade:859
+#: ../ui/main.glade:932
 msgid "Pen _Options"
 msgstr "_Opcje pióra"
 
@@ -1394,9 +1439,9 @@ msgstr "_Opcje pióra"
 msgid "Plain"
 msgstr "Bez tła"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:473
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:32
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:106
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:413
 #, fuzzy
 msgid "Play Object"
 msgstr "Wybierz objekt"
@@ -1405,11 +1450,11 @@ msgstr "Wybierz objekt"
 msgid "Predefined"
 msgstr "Predefiniowane"
 
-#: ../ui/main.glade:251
+#: ../ui/main.glade:297
 msgid "Preferences"
 msgstr "Preferencje"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:461
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:417
 msgid "Presentation mode"
 msgstr "Tryb prezentacji"
 
@@ -1417,15 +1462,15 @@ msgstr "Tryb prezentacji"
 msgid "Range"
 msgstr "Zakres"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:371
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:479
 msgid "Rec / Stop"
 msgstr ""
 
-#: ../ui/main.glade:299
+#: ../ui/main.glade:1225
 msgid "Rec-Stop"
 msgstr ""
 
-#: ../ui/main.glade:61
+#: ../ui/main.glade:63
 msgid "Recent _Documents"
 msgstr "Ostatnie _dokumenty"
 
@@ -1434,8 +1479,8 @@ msgstr "Ostatnie _dokumenty"
 msgid "Red"
 msgstr "Czerwony"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:397
 #: ../src/undo/UndoRedoHandler.cpp:293
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:327
 msgid "Redo"
 msgstr "Powtórz"
 
@@ -1443,15 +1488,15 @@ msgstr "Powtórz"
 msgid "Redo: "
 msgstr "Powtórz: "
 
-#: ../src/control/Control.cpp:2021
+#: ../src/control/Control.cpp:2057
 msgid "Remove PDF Background"
 msgstr "Usuń PDF w tle"
 
-#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:202
+#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:198
 msgid "Removed tool item from Toolbar {1} ID {2}"
 msgstr ""
 
-#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:198
+#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:194
 msgid "Removed tool item {1} from Toolbar {2} ID {3}"
 msgstr ""
 
@@ -1464,7 +1509,7 @@ msgstr ""
 msgid "Resolution"
 msgstr "Rozdzielczość:"
 
-#: ../src/control/XournalMain.cpp:174
+#: ../src/control/XournalMain.cpp:178
 #, fuzzy
 msgid "Restore file"
 msgstr "Zapisz plik"
@@ -1474,33 +1519,37 @@ msgstr "Zapisz plik"
 msgid "Rotation"
 msgstr "Rozdzielczość:"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:375
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:410
 msgid "Rotation Snapping"
+msgstr ""
+
+#: ../ui/settings.glade:2083
+msgid "Rotation snapping tolerance:"
 msgstr ""
 
 #: ../src/control/pagetype/PageTypeHandler.cpp:24
 msgid "Ruled"
 msgstr "Linie z marginesem"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:432
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:467
 msgid "Ruler"
 msgstr "Linijka"
 
-#: ../src/control/jobs/SaveJob.cpp:13 ../src/control/Control.cpp:2532
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:315
+#: ../src/control/Control.cpp:2576 ../src/control/jobs/SaveJob.cpp:13
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:390
 msgid "Save"
 msgstr "Zapisz"
 
-#: ../src/control/Control.cpp:2568
+#: ../src/control/Control.cpp:2617
 msgid "Save As"
 msgstr "Zapisz jako"
 
-#: ../src/control/Control.cpp:2352 ../src/gui/dialog/PageTemplateDialog.cpp:112
+#: ../src/control/Control.cpp:2388 ../src/gui/dialog/PageTemplateDialog.cpp:112
 msgid "Save File"
 msgstr "Zapisz plik"
 
-#: ../src/control/jobs/SaveJob.cpp:151
 #: ../src/control/jobs/CustomExportJob.cpp:276
+#: ../src/control/jobs/SaveJob.cpp:151
 #, fuzzy
 msgid "Save file error: {1}"
 msgstr "Błąd otwierania pliku: {1}"
@@ -1509,7 +1558,7 @@ msgstr "Błąd otwierania pliku: {1}"
 msgid "Scale"
 msgstr "Skaluj"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:324
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:405
 msgid "Search"
 msgstr "Wyszukaj"
 
@@ -1518,12 +1567,12 @@ msgstr "Wyszukaj"
 msgid "Select Background Color"
 msgstr "Wybierz kolor"
 
-#: ../ui/settings.glade:2065
+#: ../ui/settings.glade:2223
 #, fuzzy
 msgid "Select Folder"
 msgstr "Wybierz kolor"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:447
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:476
 msgid "Select Font"
 msgstr "Wybierz czcionkę"
 
@@ -1531,9 +1580,9 @@ msgstr "Wybierz czcionkę"
 msgid "Select Image"
 msgstr "Wybierz obrazek"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:471
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:31
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:99
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:410
 msgid "Select Object"
 msgstr "Wybierz objekt"
 
@@ -1541,21 +1590,21 @@ msgstr "Wybierz objekt"
 msgid "Select PDF Page"
 msgstr "Wybierz stronę PDF"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:470
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:10
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:29
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:85
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:125
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:408
 msgid "Select Rectangle"
 msgstr "Wybierz prostokąt"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:469
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:30
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:92
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:406
 msgid "Select Region"
 msgstr "Wybierz obszar"
 
-#: ../src/control/Control.cpp:2020
+#: ../src/control/Control.cpp:2056
 msgid "Select another PDF"
 msgstr "Wybierz inny PDF"
 
@@ -1582,21 +1631,21 @@ msgstr "Wybierz prostokąt"
 msgid "Select region"
 msgstr "Wybierz obszar"
 
-#: ../ui/settings.glade:1964
+#: ../ui/settings.glade:2051
 msgid "Select the tool and Settings if you press the Default Button"
 msgstr ""
 "Po naciśnięciu przycisku Domyślne wybierane jest domyślne narzędzie i "
 "ustawienia."
 
-#: ../ui/settings.glade:1789
+#: ../ui/settings.glade:1861
 msgid "Select toolbar:"
 msgstr "Wybierz pasek narzędzi:"
 
-#: ../ui/settings.glade:1543
+#: ../ui/settings.glade:1600
 msgid "Selection Color (Text, Stroke Selection etc.)"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:120
+#: ../src/control/XournalMain.cpp:124
 msgid "Send Bugreport"
 msgstr "Wyślij raport błędu"
 
@@ -1604,11 +1653,15 @@ msgstr "Wyślij raport błędu"
 msgid "Separator"
 msgstr "Separator"
 
-#: ../ui/settings.glade:1123
+#: ../ui/settings.glade:1165
+msgid "Settings for Touch devices"
+msgstr ""
+
+#: ../ui/settings.glade:1152
 msgid "Settings for Touch devices which are detected by GTK."
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:430
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:462
 msgid "Shape Recognizer"
 msgstr "Rozpoznawanie kształtów"
 
@@ -1633,19 +1686,19 @@ msgstr "Pokaż tylko nieużywane strony (jedna nieużywana strona)"
 msgid "Show only not used pages ({1} unused pages)"
 msgstr "Pokaż tylko nieużywane strony ({1} nieużywanych stron)"
 
-#: ../ui/main.glade:322
+#: ../ui/main.glade:348
 msgid "Show sidebar"
 msgstr "Pokaż pasek narzędzi"
 
-#: ../ui/settings.glade:1412
+#: ../ui/settings.glade:1469
 msgid "Show sidebar on the right side"
 msgstr "Pasek narzędzi po prawej stronie"
 
-#: ../ui/settings.glade:1427
+#: ../ui/settings.glade:1484
 msgid "Show vertical scrollbar on the left side"
 msgstr "Pokaż pionowy pasek przewijania po lewej stronie"
 
-#: ../src/control/XournalMain.cpp:309
+#: ../src/control/XournalMain.cpp:308
 #, fuzzy
 msgid ""
 "Sorry, Xournal++ can only open one file at once.\n"
@@ -1654,7 +1707,7 @@ msgstr ""
 "Przepraszamy, Xournal może otworzyć tylko jeden plik z poziomu konsoli.\n"
 "Inne są ignorowane."
 
-#: ../src/control/XournalMain.cpp:324
+#: ../src/control/XournalMain.cpp:323
 #, fuzzy
 msgid ""
 "Sorry, Xournal++ cannot open remote files at the moment.\n"
@@ -1668,13 +1721,13 @@ msgstr ""
 msgid "Standard"
 msgstr "Standardowe"
 
-#: ../ui/main.glade:1610
+#: ../ui/main.glade:1752
 msgid "State PLACEHOLDER"
 msgstr "Status SYMBOL ZASTĘPCZY"
 
-#: ../src/undo/RecognizerUndoAction.cpp:101
 #: ../src/gui/dialog/ButtonConfigGui.cpp:103
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:43
+#: ../src/undo/RecognizerUndoAction.cpp:101
 msgid "Stroke recognizer"
 msgstr "Rozpoznawanie kształtów"
 
@@ -1682,19 +1735,19 @@ msgstr "Rozpoznawanie kształtów"
 msgid "Successfully saved document to \"{1}\""
 msgstr "Zapisano dokument do \"{1}\""
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:128
+#: ../src/control/stockdlg/XojOpenDlg.cpp:132
 msgid "Supported files"
 msgstr "Wspierane pliki"
 
-#: ../ui/main.glade:1236
+#: ../ui/main.glade:1386
 msgid "Swap the current page with the one above"
 msgstr ""
 
-#: ../ui/main.glade:1257
+#: ../ui/main.glade:1407
 msgid "Swap the current page with the one below"
 msgstr ""
 
-#: ../ui/main.glade:337
+#: ../ui/main.glade:363
 msgid "T_oolbars"
 msgstr "_Paski narzędzi"
 
@@ -1702,16 +1755,16 @@ msgstr "_Paski narzędzi"
 msgid "Template:"
 msgstr "Szablon:"
 
-#: ../ui/settings.glade:1317
+#: ../ui/settings.glade:1374
 msgid "Test disable"
 msgstr ""
 
-#: ../ui/settings.glade:1304
+#: ../ui/settings.glade:1361
 msgid "Test enable"
 msgstr ""
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:58
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:401
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:458
 msgid "Text"
 msgstr "Tekst"
 
@@ -1720,7 +1773,7 @@ msgstr "Tekst"
 msgid "Text %i times found on this page"
 msgstr "Tekst został znaleziony %i razy na tej stronie"
 
-#: ../ui/main.glade:1077
+#: ../ui/main.glade:1214
 msgid "Text Font..."
 msgstr "Czcionka tekstu..."
 
@@ -1748,7 +1801,7 @@ msgstr "Tekst nie został znaleziony"
 msgid "Text not found, searched on all pages"
 msgstr "Tekst nie został znaleziony, szukano na wszystkich stronach"
 
-#: ../src/control/Control.cpp:1006
+#: ../src/control/Control.cpp:1017
 msgid ""
 "The Toolbarconfiguration \"{1}\" is predefined, would you create a copy to "
 "edit?"
@@ -1756,23 +1809,23 @@ msgstr ""
 "Konfiguracja paska narzędzi \"{1}\" jest predefiniowana. Czy stworzyć "
 "możliwą do edycji kopię?"
 
-#: ../src/control/Control.cpp:2017
+#: ../src/control/Control.cpp:2053
 msgid "The attached background PDF could not be found."
 msgstr "Załączony PDF w tle nie został znaleziony."
 
-#: ../src/control/Control.cpp:2018
+#: ../src/control/Control.cpp:2054
 msgid "The background PDF could not be found."
 msgstr "PDF w tle nie został znaleziony."
 
-#: ../src/control/XournalMain.cpp:115
+#: ../src/control/XournalMain.cpp:119
 msgid "The most recent log file name: {1}"
 msgstr "Najnowszy plik loggera: {1}"
 
-#: ../ui/settings.glade:369
+#: ../ui/settings.glade:383
 msgid "The unit of the ruler is cm"
 msgstr "Linijka jest skalowana w cm"
 
-#: ../src/control/XournalMain.cpp:108
+#: ../src/control/XournalMain.cpp:112
 msgid ""
 "There are errorlogfiles from Xournal++. Please send a Bugreport, so the bug "
 "may be fixed."
@@ -1780,7 +1833,7 @@ msgstr ""
 "Znaleziono raporty błędów programu Xournal++. Prosimy o ich wysłanie, w celu "
 "umożliwienia naprawy."
 
-#: ../src/control/XournalMain.cpp:107
+#: ../src/control/XournalMain.cpp:111
 msgid ""
 "There is an errorlogfile from Xournal++. Please send a Bugreport, so the bug "
 "may be fixed."
@@ -1793,7 +1846,7 @@ msgid "There was an error displaying help: {1}"
 msgstr "Błąd podczas wyświetlania pomocy: {1}"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:82
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:439
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:515
 msgid "Thick"
 msgstr "Gruby"
 
@@ -1803,25 +1856,25 @@ msgid "Thickness - don't change"
 msgstr "Nie zmieniaj"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:80
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:435
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:513
 msgid "Thin"
 msgstr "Cienki"
 
-#: ../src/control/Control.cpp:2530
+#: ../src/control/Control.cpp:2574
 msgid "This document is not saved yet."
 msgstr "Dokument nie został jeszcze zapisany."
 
-#: ../src/control/tools/ImageHandler.cpp:56
 #: ../src/control/PageBackgroundChangeController.cpp:177
+#: ../src/control/tools/ImageHandler.cpp:56
 msgid "This image could not be loaded. Error message: {1}"
 msgstr "Nie można otworzyć obrazu. Wiadomość błędu: {1}"
 
-#: ../ui/settings.glade:1185
+#: ../ui/settings.glade:1242
 #, fuzzy
 msgid "Timeout"
 msgstr "Wybielanie"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:368
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:418
 msgid "Toggle fullscreen"
 msgstr "Zmień pełny ekran"
 
@@ -1830,7 +1883,7 @@ msgstr "Zmień pełny ekran"
 msgid "Tool - don't change"
 msgstr "Nie zmieniaj"
 
-#: ../src/gui/toolbarMenubar/model/ToolbarData.cpp:156
+#: ../src/gui/toolbarMenubar/model/ToolbarData.cpp:152
 msgid "Toolbar found: {1}"
 msgstr "Znaleziono pasek narzędzi: {1}"
 
@@ -1838,11 +1891,11 @@ msgstr "Znaleziono pasek narzędzi: {1}"
 msgid "Toolbars"
 msgstr "Paski narzędzi"
 
-#: ../ui/settings.glade:1358
+#: ../ui/settings.glade:1415
 msgid "Touch"
 msgstr ""
 
-#: ../ui/settings.glade:1046
+#: ../ui/settings.glade:1060
 msgid ""
 "Touch Screens which are detected by GTK are handled specially, and don't "
 "need to be configured here."
@@ -1856,12 +1909,12 @@ msgstr ""
 msgid "Trying to emergency save the current open document…"
 msgstr "Próba awaryjnego zapisu aktualnie otwartego dokumentu…"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:458
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:416
 msgid "Two pages"
 msgstr "Dwie strony"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:396
 #: ../src/undo/UndoRedoHandler.cpp:274
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:326
 msgid "Undo"
 msgstr "Cofnij"
 
@@ -1869,15 +1922,15 @@ msgstr "Cofnij"
 msgid "Undo: "
 msgstr "Cofnij: "
 
-#: ../src/control/xojfile/LoadHandler.cpp:241
+#: ../src/control/xojfile/LoadHandler.cpp:260
 msgid "Unexpected root tag: {1}"
 msgstr "Niespodziewany tag w korzeniu: {1}"
 
-#: ../src/control/xojfile/LoadHandler.cpp:270
+#: ../src/control/xojfile/LoadHandler.cpp:289
 msgid "Unexpected tag in document: \"{1}\""
 msgstr "Niespodziewany tag w dokumencie: \"{1}\""
 
-#: ../src/control/xojfile/LoadHandler.cpp:475
+#: ../src/control/xojfile/LoadHandler.cpp:494
 msgid "Unknown background type: {1}"
 msgstr "Nieznany rodzaj tła: {1}"
 
@@ -1885,23 +1938,23 @@ msgstr "Nieznany rodzaj tła: {1}"
 msgid "Unknown color value \"{1}\""
 msgstr "Nieznany kolor \"{1}\""
 
-#: ../src/control/xojfile/LoadHandler.cpp:410
+#: ../src/control/xojfile/LoadHandler.cpp:429
 msgid "Unknown domain type: {1}"
 msgstr "Nieznany rodzaj domeny: {1}"
 
-#: ../src/control/xojfile/LoadHandler.cpp:193
+#: ../src/control/xojfile/LoadHandler.cpp:194
 msgid "Unknown parser error"
 msgstr "Nieznany błąd parsera"
 
-#: ../src/control/xojfile/LoadHandler.cpp:345
+#: ../src/control/xojfile/LoadHandler.cpp:364
 msgid "Unknown pixmap::domain type: {1}"
 msgstr "Nieznany typ pixmap::domain: {1}"
 
-#: ../src/control/xojfile/LoadHandler.cpp:558
+#: ../src/control/xojfile/LoadHandler.cpp:591
 msgid "Unknown stroke type: \"{1}\", assuming pen"
 msgstr "Nieznany rodzaj kreski: \"{1}\", zakładam, że to pióro"
 
-#: ../src/control/Control.cpp:2424
+#: ../src/control/Control.cpp:2460
 msgid "Unsaved Document"
 msgstr "Niezapisany dokument"
 
@@ -1910,7 +1963,7 @@ msgstr "Niezapisany dokument"
 msgid "Version"
 msgstr "Rozszerzenie"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:425
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:472
 msgid "Vertical Space"
 msgstr "Odstęp pionowy"
 
@@ -1918,7 +1971,7 @@ msgstr "Odstęp pionowy"
 msgid "Vertical space"
 msgstr "Odstęp pionowy"
 
-#: ../ui/settings.glade:1895
+#: ../ui/settings.glade:1982
 msgid "View"
 msgstr "Widok"
 
@@ -1939,7 +1992,7 @@ msgstr "Szerokość:"
 msgid "With PDF background"
 msgstr "Z PDF w tle"
 
-#: ../ui/about.glade:187
+#: ../ui/about.glade:188
 #, fuzzy
 msgid "With help from the community"
 msgstr "Z pomocą społeczności\n"
@@ -1948,19 +2001,19 @@ msgstr "Z pomocą społeczności\n"
 msgid "Write text"
 msgstr "Wpisz tekst"
 
-#: ../src/control/xojfile/LoadHandler.cpp:821
+#: ../src/control/xojfile/LoadHandler.cpp:852
 msgid "Wrong count of points ({1})"
 msgstr "Nieprawidłowa liczba punktów ({1})"
 
-#: ../src/control/xojfile/LoadHandler.cpp:836
+#: ../src/control/xojfile/LoadHandler.cpp:866
 msgid "Wrong number of points, got {1}, expected {2}"
 msgstr "Nieprawidłowa liczba punktów: {1}, spodziewane {2}"
 
-#: ../ui/settings.glade:1171
+#: ../ui/settings.glade:1228
 msgid "X11"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:188
+#: ../src/control/xojfile/LoadHandler.cpp:189
 msgid "XML Parser error: {1}"
 msgstr "Błąd parsera XML: {1}"
 
@@ -1968,24 +2021,24 @@ msgstr "Błąd parsera XML: {1}"
 msgid "Xournal (Compatibility)"
 msgstr ""
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:69
+#: ../src/control/stockdlg/XojOpenDlg.cpp:72
 msgid "Xournal files"
 msgstr "Pliki Xournala"
 
-#: ../ui/settings.glade:28
+#: ../ui/settings.glade:42
 msgid "Xournal++ Preferences"
 msgstr "Ustawienia Xournal++"
 
-#: ../src/control/XournalMain.cpp:168
+#: ../src/control/XournalMain.cpp:172
 msgid "Xournal++ crashed last time. Would you restore it?"
 msgstr ""
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:79 ../src/control/Control.cpp:2359
+#: ../src/control/Control.cpp:2395 ../src/control/stockdlg/XojOpenDlg.cpp:82
 #, fuzzy
 msgid "Xournal++ files"
 msgstr "Pliki Xournala"
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:89
+#: ../src/control/stockdlg/XojOpenDlg.cpp:92
 #: ../src/gui/dialog/PageTemplateDialog.cpp:119
 #, fuzzy
 msgid "Xournal++ template"
@@ -2006,7 +2059,7 @@ msgstr ""
 "Nie ma stron PDF do wyboru. Anuluj tą operację.\n"
 "Proszę wybrać inny rodzaj tła: Menu Dziennik → Tło papieru."
 
-#: ../src/control/XournalMain.cpp:111
+#: ../src/control/XournalMain.cpp:115
 msgid ""
 "You're using {1}/{2} branch. Send Bugreport will direct you to this repo's "
 "issue tracker."
@@ -2028,19 +2081,19 @@ msgstr ""
 "Wskazówka: Możesz wybrać Dziennik → Tło papieru → Tło z pliku PDF, żeby "
 "wstawić stronę PDF."
 
-#: ../ui/settings.glade:302
+#: ../ui/settings.glade:316
 msgid "Zoom"
 msgstr "Przybliżenie"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:362
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:422
 msgid "Zoom fit to screen"
 msgstr "Dopasuj do ekranu"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:360
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:421
 msgid "Zoom in"
 msgstr "Przybliż"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:358
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:420
 msgid "Zoom out"
 msgstr "Oddal"
 
@@ -2048,44 +2101,44 @@ msgstr "Oddal"
 msgid "Zoom slider"
 msgstr "Suwak przybliżenia"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:364
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:423
 msgid "Zoom to 100%"
 msgstr "Powiększ do 100%"
 
-#: ../ui/main.glade:69
+#: ../ui/main.glade:71
 msgid "_Annotate PDF"
 msgstr "_Adnotuj PDF"
 
+#: ../src/control/Control.cpp:2389 ../src/control/jobs/BaseExportJob.cpp:26
 #: ../src/control/stockdlg/ImageOpenDlg.cpp:12
 #: ../src/control/stockdlg/XojOpenDlg.cpp:17
-#: ../src/control/jobs/BaseExportJob.cpp:26 ../src/control/Control.cpp:2353
 #: ../src/gui/dialog/PageTemplateDialog.cpp:113
 #, fuzzy
 msgid "_Cancel"
 msgstr "Anuluj"
 
-#: ../ui/main.glade:361
+#: ../ui/main.glade:388
 msgid "_Customize"
 msgstr "_Personalizuj"
 
-#: ../ui/main.glade:723
+#: ../ui/main.glade:779
 #, fuzzy
 msgid "_Default Tools"
 msgstr "_Domyślne narzędzie"
 
-#: ../ui/main.glade:596
+#: ../ui/main.glade:642
 msgid "_Delete Page"
 msgstr "_Usuń stronę"
 
-#: ../ui/main.glade:153
+#: ../ui/main.glade:162
 msgid "_Edit"
 msgstr "_Edycja"
 
-#: ../ui/main.glade:683
+#: ../ui/main.glade:735
 msgid "_Eraser"
 msgstr "_Gumka"
 
-#: ../ui/main.glade:104
+#: ../ui/main.glade:109
 msgid "_Export as PDF"
 msgstr "_Eksportuj do PDF"
 
@@ -2093,49 +2146,49 @@ msgstr "_Eksportuj do PDF"
 msgid "_File"
 msgstr "_Plik"
 
-#: ../ui/main.glade:448
+#: ../ui/main.glade:480
 msgid "_First Page"
 msgstr "_Pierwsza strona"
 
-#: ../ui/main.glade:466
+#: ../ui/main.glade:500
 #, fuzzy
 msgid "_Goto Page"
 msgstr "_Idź do strony"
 
-#: ../ui/main.glade:1099
+#: ../ui/main.glade:1247
 msgid "_Help"
 msgstr "P_omoc"
 
-#: ../ui/main.glade:693
+#: ../ui/main.glade:746
 msgid "_Highlighter"
 msgstr "_Zakreślacz"
 
-#: ../ui/main.glade:713
+#: ../ui/main.glade:768
 msgid "_Image"
 msgstr "_Obraz"
 
-#: ../ui/main.glade:553
+#: ../ui/main.glade:595
 msgid "_Journal"
 msgstr "_Dziennik"
 
-#: ../ui/main.glade:484
+#: ../ui/main.glade:520
 msgid "_Last Page"
 msgstr "_Ostatnia strona"
 
-#: ../ui/main.glade:353
+#: ../ui/main.glade:379
 msgid "_Manage"
 msgstr "_Zarządzaj"
 
-#: ../ui/main.glade:438
+#: ../ui/main.glade:470
 msgid "_Navigation"
 msgstr "_Nawigacja"
 
-#: ../ui/main.glade:508
+#: ../ui/main.glade:546
 #, fuzzy
 msgid "_Next Layer"
 msgstr "_Następna strona"
 
-#: ../ui/main.glade:475
+#: ../ui/main.glade:510
 msgid "_Next Page"
 msgstr "_Następna strona"
 
@@ -2145,83 +2198,83 @@ msgstr "_Następna strona"
 msgid "_Open"
 msgstr "Otwórz {1}"
 
-#: ../ui/main.glade:673
+#: ../ui/main.glade:724
 msgid "_Pen"
 msgstr "_Pióro"
 
-#: ../ui/main.glade:281
+#: ../ui/main.glade:329
 msgid "_Presentation Mode"
 msgstr "_Tryb prezentacji"
 
-#: ../ui/main.glade:499
+#: ../ui/main.glade:536
 #, fuzzy
 msgid "_Previous Layer"
 msgstr "_Poprzednia strona"
 
-#: ../ui/main.glade:457
+#: ../ui/main.glade:490
 msgid "_Previous Page"
 msgstr "_Poprzednia strona"
 
-#: ../src/control/jobs/BaseExportJob.cpp:27 ../src/control/Control.cpp:2354
+#: ../src/control/Control.cpp:2390 ../src/control/jobs/BaseExportJob.cpp:27
 #: ../src/gui/dialog/PageTemplateDialog.cpp:114
 #, fuzzy
 msgid "_Save"
 msgstr "Zapisz"
 
-#: ../ui/main.glade:737
+#: ../ui/main.glade:794
 msgid "_Shape Recognizer"
 msgstr "_Rozpoznawanie kształtów"
 
-#: ../ui/main.glade:703
+#: ../ui/main.glade:757
 msgid "_Text"
 msgstr "_Tekst"
 
-#: ../ui/main.glade:663
+#: ../ui/main.glade:714
 msgid "_Tools"
 msgstr "_Narzędzia"
 
-#: ../ui/main.glade:517
+#: ../ui/main.glade:556
 #, fuzzy
 msgid "_Top Layer"
 msgstr "Warstwa"
 
-#: ../ui/main.glade:273
+#: ../ui/main.glade:320
 msgid "_Two Pages"
 msgstr "_Dwie strony"
 
-#: ../ui/main.glade:823
+#: ../ui/main.glade:893
 msgid "_Vertical Space"
 msgstr "Miejsce _pionowe"
 
-#: ../ui/main.glade:263
+#: ../ui/main.glade:310
 msgid "_View"
 msgstr "_Widok"
 
-#: ../ui/main.glade:1001
+#: ../ui/main.glade:1132
 msgid "_delete strokes"
 msgstr "_usuń kreski"
 
-#: ../ui/main.glade:878 ../ui/main.glade:950 ../ui/main.glade:1024
+#: ../ui/main.glade:952 ../ui/main.glade:1076 ../ui/main.glade:1156
 msgid "_fine"
 msgstr "_cienkie"
 
-#: ../ui/main.glade:887 ../ui/main.glade:959 ../ui/main.glade:1033
+#: ../ui/main.glade:962 ../ui/main.glade:1086 ../ui/main.glade:1166
 msgid "_medium"
 msgstr "_średnie"
 
-#: ../ui/main.glade:983
+#: ../ui/main.glade:1112
 msgid "_standard"
 msgstr "_standardowy"
 
-#: ../ui/main.glade:896 ../ui/main.glade:968 ../ui/main.glade:1042
+#: ../ui/main.glade:972 ../ui/main.glade:1096 ../ui/main.glade:1176
 msgid "_thick"
 msgstr "_grube"
 
-#: ../ui/main.glade:869
+#: ../ui/main.glade:942
 msgid "_very fine"
 msgstr "_bardzo cienkie"
 
-#: ../ui/main.glade:992
+#: ../ui/main.glade:1122
 msgid "_whiteout"
 msgstr "_wybielanie"
 
@@ -2234,9 +2287,21 @@ msgstr "Zakres"
 msgid "cursor"
 msgstr "kursor"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:299
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:294
+msgid "dash-/ doted"
+msgstr ""
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:291
+msgid "dashed"
+msgstr ""
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:312
 msgid "delete stroke"
 msgstr "usuń kreski"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:297
+msgid "dotted"
+msgstr ""
 
 #: ../ui/exportSettings.glade:213
 msgid "dpi"
@@ -2263,7 +2328,7 @@ msgstr "myszka"
 msgid "pen"
 msgstr "pióro"
 
-#: ../ui/settings.glade:1212
+#: ../ui/settings.glade:1269
 msgid "s"
 msgstr ""
 
@@ -2276,7 +2341,8 @@ msgstr "Zapisz plik"
 msgid "show"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:285
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:288
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:310
 msgid "standard"
 msgstr "standardowa"
 
@@ -2289,15 +2355,15 @@ msgstr ""
 msgid "touchscreen"
 msgstr "Pełny ekran"
 
-#: ../ui/main.glade:905
+#: ../ui/main.glade:982
 msgid "ver_y thick"
 msgstr "bar_dzo grube"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:292
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:311
 msgid "whiteout"
 msgstr "wybielanie"
 
-#: ../src/control/xojfile/LoadHandler.cpp:835
+#: ../src/control/xojfile/LoadHandler.cpp:865
 msgid "xoj-File: {1}"
 msgstr "Plik xoj: {1}"
 
@@ -2402,6 +2468,9 @@ msgstr "xoj-preview-extractor: stworzono miniaturkę"
 
 #~ msgid "Disable Ruler & Stroke Recognizer"
 #~ msgstr "Wyłącz linijkę i rozpoznawanie kształtów"
+
+#~ msgid "Don't compress PDF files (for debugging)"
+#~ msgstr "Nie kompresuj plików PDF (do debugowania)"
 
 #, fuzzy
 #~ msgid "Drawing type"

--- a/po/xournalpp.pot
+++ b/po/xournalpp.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: xournalpp 1.0.4\n"
+"Project-Id-Version: xournalpp 1.0.7\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-12-30 12:21+0100\n"
+"POT-Creation-Date: 2019-01-23 10:36+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,40 +17,40 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../src/undo/DeleteUndoAction.cpp:113 ../src/undo/AddUndoAction.cpp:119
+#: ../src/undo/AddUndoAction.cpp:119 ../src/undo/DeleteUndoAction.cpp:113
 msgid " elements"
 msgstr ""
 
-#: ../src/undo/DeleteUndoAction.cpp:128 ../src/undo/AddUndoAction.cpp:134
+#: ../src/undo/AddUndoAction.cpp:134 ../src/undo/DeleteUndoAction.cpp:128
 msgid " image"
 msgstr ""
 
-#: ../src/undo/DeleteUndoAction.cpp:132 ../src/undo/AddUndoAction.cpp:138
+#: ../src/undo/AddUndoAction.cpp:138 ../src/undo/DeleteUndoAction.cpp:132
 msgid " latex"
 msgstr ""
 
-#: ../src/gui/MainWindow.cpp:734
+#: ../src/gui/MainWindow.cpp:818
 msgctxt "Page {pagenumber} \"of {pagecount}\""
 msgid " of {1}{2}"
 msgstr ""
 
-#: ../src/undo/DeleteUndoAction.cpp:120 ../src/undo/AddUndoAction.cpp:126
+#: ../src/undo/AddUndoAction.cpp:126 ../src/undo/DeleteUndoAction.cpp:120
 msgid " stroke"
 msgstr ""
 
-#: ../src/undo/DeleteUndoAction.cpp:124 ../src/undo/AddUndoAction.cpp:130
+#: ../src/undo/AddUndoAction.cpp:130 ../src/undo/DeleteUndoAction.cpp:124
 msgid " text"
 msgstr ""
 
-#: ../src/control/settings/Settings.cpp:79
+#: ../src/control/settings/Settings.cpp:90
 msgid "%F-Note-%H-%M"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:245
+#: ../src/control/XournalMain.cpp:250
 msgid "Absolute path for the audio files playback"
 msgstr ""
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:48
+#: ../src/control/stockdlg/XojOpenDlg.cpp:51
 msgid "All files"
 msgstr ""
 
@@ -63,7 +63,7 @@ msgid "Apply to current page"
 msgstr ""
 
 #: ../src/control/stockdlg/ImageOpenDlg.cpp:30
-#: ../src/control/stockdlg/XojOpenDlg.cpp:147
+#: ../src/control/stockdlg/XojOpenDlg.cpp:152
 msgid "Attach file to the journal"
 msgstr ""
 
@@ -88,13 +88,13 @@ msgstr ""
 msgid "Attribute color not set!"
 msgstr ""
 
-#: ../src/control/AudioController.cpp:100
+#: ../src/control/AudioController.cpp:98
 msgid ""
 "Audio folder not set! Recording won't work!\n"
 "Please set the recording folder under \"Preferences > Audio recording\""
 msgstr ""
 
-#: ../src/control/Control.cpp:254
+#: ../src/control/Control.cpp:256
 msgid "Autosave failed with an error: {1}"
 msgstr ""
 
@@ -102,8 +102,7 @@ msgstr ""
 msgid "Autosave: {1}"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:333
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:336
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:429
 msgid "Back"
 msgstr ""
 
@@ -123,8 +122,8 @@ msgstr ""
 msgid "Blue"
 msgstr ""
 
-#: ../src/control/Control.cpp:2022 ../src/control/Control.cpp:2534
-#: ../src/control/Control.cpp:2570 ../src/control/XournalMain.cpp:124
+#: ../src/control/Control.cpp:2058 ../src/control/Control.cpp:2581
+#: ../src/control/Control.cpp:2619 ../src/control/XournalMain.cpp:128
 msgid "Cancel"
 msgstr ""
 
@@ -140,7 +139,7 @@ msgstr ""
 msgid "Change stroke fill"
 msgstr ""
 
-#: ../src/undo/SizeUndoAction.cpp:145
+#: ../src/undo/SizeUndoAction.cpp:139
 msgid "Change stroke width"
 msgstr ""
 
@@ -152,8 +151,8 @@ msgstr ""
 msgid "Contents"
 msgstr ""
 
-#: ../src/control/Control.cpp:1036 ../src/control/Control.cpp:1044
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:321
+#: ../src/control/Control.cpp:1047 ../src/control/Control.cpp:1055
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:402
 msgid "Copy"
 msgstr ""
 
@@ -165,46 +164,58 @@ msgstr ""
 msgid "Copy page"
 msgstr ""
 
+#: ../src/control/LatexController.cpp:103
+msgid "Could not convert tex to PDF: {1} (exit code: {2})"
+msgstr ""
+
 #: ../src/control/jobs/SaveJob.cpp:137
 msgid ""
 "Could not create backup! (The file was created from an older Xournal version)"
 msgstr ""
 
-#: ../src/util/Util.cpp:97
+#: ../src/util/Util.cpp:94
 msgid "Could not create folder: {1}"
 msgstr ""
 
-#: ../src/control/Control.cpp:218 ../src/control/Control.cpp:235
+#: ../src/control/Control.cpp:220 ../src/control/Control.cpp:237
 msgid "Could not delete old autosave file \"{1}\""
 msgstr ""
 
-#: ../src/control/LatexController.cpp:381
+#: ../src/control/LatexController.cpp:428
 msgid ""
-"Could not find Xournal++ LaTeX executable relative or in Path.\n"
-"Searched for: mathtex-xournalpp.cgi"
+"Could not find pdflatex in Path.\n"
+"Please install pdflatex first and make sure it's in the Path."
+msgstr ""
+
+#: ../src/control/LatexController.cpp:299
+msgid "Could not load LaTeX PDF file, URL-Error: {1}"
+msgstr ""
+
+#: ../src/control/LatexController.cpp:307
+msgid "Could not load LaTeX PDF file: {1}"
 msgstr ""
 
 #: ../src/control/pagetype/PageTypeHandler.cpp:18
 msgid "Could not load pagetemplates.ini file"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:123
+#: ../src/control/xojfile/LoadHandler.cpp:124
 msgid "Could not open file: \"{1}\""
 msgstr ""
 
-#: ../src/gui/MainWindow.cpp:93
+#: ../src/gui/MainWindow.cpp:86
 msgid ""
 "Could not parse custom toolbar.ini file: {1}\n"
 "Toolbars will not be available"
 msgstr ""
 
-#: ../src/gui/MainWindow.cpp:83
+#: ../src/gui/MainWindow.cpp:76
 msgid ""
 "Could not parse general toolbar.ini file: {1}\n"
 "No Toolbars will be available"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:328
+#: ../src/control/xojfile/LoadHandler.cpp:347
 msgid "Could not read image: {1}. Error message: {2}"
 msgstr ""
 
@@ -214,20 +225,20 @@ msgid ""
 "Something went wrong… Please write a bug report…"
 msgstr ""
 
-#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:214
+#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:210
 msgid "Could not remove tool item from Toolbar {1} on position {2}"
 msgstr ""
 
-#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:209
+#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:205
 msgid "Could not remove tool item {1} from Toolbar {2} on position {3}"
 msgstr ""
 
-#: ../src/control/Control.cpp:228 ../src/control/Control.cpp:247
+#: ../src/control/Control.cpp:230 ../src/control/Control.cpp:249
 msgid "Could not rename autosave file from \"{1}\" to \"{2}\""
 msgstr ""
 
-#: ../src/control/LatexController.cpp:310
-msgid "Could not retrieve LaTeX image file: {1}"
+#: ../src/control/LatexController.cpp:89
+msgid "Could not save .tex file: {1}"
 msgstr ""
 
 #: ../src/undo/UndoRedoHandler.cpp:144
@@ -236,11 +247,11 @@ msgid ""
 "Something went wrong… Please write a bug report…"
 msgstr ""
 
-#: ../src/control/xojfile/SaveHandler.cpp:294
+#: ../src/control/xojfile/SaveHandler.cpp:290
 msgid "Could not write background \"{1}\", {2}"
 msgstr ""
 
-#: ../src/control/xojfile/SaveHandler.cpp:419
+#: ../src/control/xojfile/SaveHandler.cpp:415
 msgid "Could not write background \"{1}\". Continuing anyway."
 msgstr ""
 
@@ -260,27 +271,28 @@ msgstr ""
 msgid "Customized"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:320
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:401
 msgid "Cut"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:442
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:460
 msgid "Default Tool"
 msgstr ""
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:407
 #: ../src/undo/DeleteUndoAction.cpp:102
 msgid "Delete"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:123
+#: ../src/control/XournalMain.cpp:127
 msgid "Delete Logfile"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:387
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:447
 msgid "Delete current page"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:173
+#: ../src/control/XournalMain.cpp:177
 msgid "Delete file"
 msgstr ""
 
@@ -288,11 +300,11 @@ msgstr ""
 msgid "Delete layer"
 msgstr ""
 
-#: ../src/control/Control.cpp:2533 ../src/control/Control.cpp:2569
+#: ../src/control/Control.cpp:2577 ../src/control/Control.cpp:2618
 msgid "Discard"
 msgstr ""
 
-#: ../src/control/Control.cpp:1952
+#: ../src/control/Control.cpp:1988
 msgid ""
 "Do not open Autosave files. They may will be overwritten!\n"
 "Copy the files to another folder.\n"
@@ -303,20 +315,16 @@ msgstr ""
 msgid "Do not overwrite the background PDF! This will cause errors!"
 msgstr ""
 
-#: ../src/control/Control.cpp:2566
+#: ../src/control/Control.cpp:2615
 msgid "Document file was removed."
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:202
+#: ../src/control/xojfile/LoadHandler.cpp:203
 msgid "Document is not complete (maybe the end is cut off?)"
 msgstr ""
 
 #: ../src/model/Document.cpp:393
 msgid "Document not loaded! ({1}), {2}"
-msgstr ""
-
-#: ../src/control/XournalMain.cpp:242
-msgid "Don't compress PDF files (for debugging)"
 msgstr ""
 
 #: ../src/control/pagetype/PageTypeHandler.cpp:26
@@ -325,13 +333,13 @@ msgstr ""
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:99
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:40
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:420
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:465
 msgid "Draw Arrow"
 msgstr ""
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:97
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:39
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:416
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:464
 msgid "Draw Circle"
 msgstr ""
 
@@ -343,15 +351,15 @@ msgstr ""
 #: ../src/gui/dialog/ButtonConfigGui.cpp:95
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:29
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:38
-#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:120
-#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:123
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:418
+#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:122
+#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:125
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:463
 msgid "Draw Rectangle"
 msgstr ""
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:101
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:42
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:422
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:466
 msgid "Draw coordinate system"
 msgstr ""
 
@@ -367,17 +375,21 @@ msgstr ""
 msgid "Edit text"
 msgstr ""
 
-#: ../src/undo/EraseUndoAction.cpp:130 ../src/undo/DeleteUndoAction.cpp:99
-#: ../src/undo/AddUndoAction.cpp:104
+#: ../src/undo/EmergencySaveRestore.cpp:35
+msgid "Emergency saved document"
+msgstr ""
+
+#: ../src/undo/AddUndoAction.cpp:104 ../src/undo/DeleteUndoAction.cpp:99
+#: ../src/undo/EraseUndoAction.cpp:130
 msgid "Erase stroke"
 msgstr ""
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:56
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:282
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:308
 msgid "Eraser"
 msgstr ""
 
-#: ../src/control/Control.cpp:2232
+#: ../src/control/Control.cpp:2268
 msgid ""
 "Error annotate PDF file \"{1}\"\n"
 "{2}"
@@ -387,11 +399,11 @@ msgstr ""
 msgid "Error export PDF Page"
 msgstr ""
 
-#: ../src/gui/GladeGui.cpp:25
+#: ../src/gui/GladeGui.cpp:26
 msgid "Error loading glade file \"{1}\" (try to load \"{2}\")"
 msgstr ""
 
-#: ../src/control/Control.cpp:2047
+#: ../src/control/Control.cpp:2083
 msgid "Error opening file \"{1}\""
 msgstr ""
 
@@ -399,11 +411,11 @@ msgstr ""
 msgid "Error opening file: \"{1}\""
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:428
+#: ../src/control/xojfile/LoadHandler.cpp:447
 msgid "Error reading PDF: {1}"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:499
+#: ../src/control/xojfile/LoadHandler.cpp:518
 msgid "Error reading width of a stroke: {1}"
 msgstr ""
 
@@ -411,7 +423,7 @@ msgstr ""
 msgid "Error: {1}"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:147
+#: ../src/control/XournalMain.cpp:151
 msgid ""
 "Errorlog cannot be deleted. You have to do it manually.\n"
 "Logfile: {1}"
@@ -421,21 +433,21 @@ msgstr ""
 msgid "Export PDF"
 msgstr ""
 
-#: ../src/control/LatexController.cpp:398
+#: ../src/control/LatexController.cpp:445
 msgid "Failed to generate LaTeX image!"
 msgstr ""
 
-#: ../src/util/Util.cpp:127 ../src/util/Util.cpp:148
+#: ../src/util/Util.cpp:123 ../src/util/Util.cpp:143
 msgid ""
 "File couldn't be opened. You have to do it manually:\n"
 "URL: {1}"
 msgstr ""
 
-#: ../src/control/Control.cpp:1982
+#: ../src/control/Control.cpp:2018
 msgid "Filename: {1}"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:445
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:500
 msgid "Fill"
 msgstr ""
 
@@ -443,27 +455,27 @@ msgstr ""
 msgid "Font"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:331
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:428
 msgid "Go to first page"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:344
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:432
 msgid "Go to last page"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:349
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:435
 msgid "Go to next layer"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:339
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:430
 msgid "Go to page"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:347
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:434
 msgid "Go to previous layer"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:351
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:436
 msgid "Go to top layer"
 msgstr ""
 
@@ -481,12 +493,12 @@ msgstr ""
 msgid "Green"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:378
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:411
 msgid "Grid Snapping"
 msgstr ""
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:63
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:426
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:474
 msgid "Hand"
 msgstr ""
 
@@ -495,12 +507,12 @@ msgid "Hide all"
 msgstr ""
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:57
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:399
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:457
 msgid "Highlighter"
 msgstr ""
 
 #: ../src/control/pagetype/PageTypeHandler.cpp:32
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:403
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:459
 msgid "Image"
 msgstr ""
 
@@ -512,7 +524,7 @@ msgstr ""
 msgid "Insert elements"
 msgstr ""
 
-#: ../src/undo/InsertUndoAction.cpp:47 ../src/gui/dialog/ButtonConfigGui.cpp:59
+#: ../src/gui/dialog/ButtonConfigGui.cpp:59 ../src/undo/InsertUndoAction.cpp:47
 msgid "Insert image"
 msgstr ""
 
@@ -524,11 +536,11 @@ msgstr ""
 msgid "Insert layer"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:394
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:443
 msgid "Insert page"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:244
+#: ../src/control/XournalMain.cpp:249
 msgid "Jump to Page (first Page: 1)"
 msgstr ""
 
@@ -564,7 +576,7 @@ msgstr ""
 msgid "Lined"
 msgstr ""
 
-#: ../src/gui/PageView.cpp:738
+#: ../src/gui/PageView.cpp:739
 #: ../src/gui/sidebar/previews/base/SidebarPreviewBaseEntry.cpp:105
 #: ../src/gui/toolbarMenubar/ToolPageLayer.cpp:20
 msgid "Loading..."
@@ -576,11 +588,17 @@ msgid "Mangenta"
 msgstr ""
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:81
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:437
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:514
 msgid "Medium"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:462
+#: ../src/control/XournalMain.cpp:460
+msgid ""
+"Missing the needed UI file! .app corrupted?\n"
+"Path: {1}"
+msgstr ""
+
+#: ../src/control/XournalMain.cpp:474
 msgid ""
 "Missing the needed UI file, could not find them at any location.\n"
 "Not relative\n"
@@ -608,15 +626,15 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:316
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:388
 msgid "New Xournal"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:342
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:431
 msgid "Next"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:355
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:438
 msgid "Next annotated page"
 msgstr ""
 
@@ -643,20 +661,20 @@ msgstr ""
 msgid "Open Image"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:121
+#: ../src/control/XournalMain.cpp:125
 msgid "Open Logfile"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:122
+#: ../src/control/XournalMain.cpp:126
 msgid "Open Logfile directory"
 msgstr ""
 
 #: ../src/control/stockdlg/XojOpenDlg.cpp:16
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:318
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:389
 msgid "Open file"
 msgstr ""
 
-#: ../src/control/RecentManager.cpp:241
+#: ../src/control/RecentManager.cpp:244
 msgctxt "{1} is a URI"
 msgid "Open {1}"
 msgstr ""
@@ -670,7 +688,7 @@ msgstr ""
 msgid "PDF Export"
 msgstr ""
 
-#: ../src/gui/MainWindow.cpp:732
+#: ../src/gui/MainWindow.cpp:816
 msgid "PDF Page {1}"
 msgstr ""
 
@@ -678,17 +696,17 @@ msgstr ""
 msgid "PDF background missing"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:223
+#: ../src/control/XournalMain.cpp:230
 msgid "PDF file successfully created"
 msgstr ""
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:58
-#: ../src/control/jobs/PdfExportJob.cpp:23
 #: ../src/control/jobs/CustomExportJob.cpp:27
+#: ../src/control/jobs/PdfExportJob.cpp:23
+#: ../src/control/stockdlg/XojOpenDlg.cpp:61
 msgid "PDF files"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:243
+#: ../src/control/XournalMain.cpp:248
 msgid "PDF output filename"
 msgstr ""
 
@@ -728,13 +746,13 @@ msgstr ""
 msgid "Page number"
 msgstr ""
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:403
 #: ../src/undo/AddUndoAction.cpp:108
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:322
 msgid "Paste"
 msgstr ""
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:55
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:382
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:286
 msgid "Pen"
 msgstr ""
 
@@ -742,9 +760,9 @@ msgstr ""
 msgid "Plain"
 msgstr ""
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:473
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:32
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:106
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:413
 msgid "Play Object"
 msgstr ""
 
@@ -752,11 +770,11 @@ msgstr ""
 msgid "Predefined"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:461
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:417
 msgid "Presentation mode"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:371
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:479
 msgid "Rec / Stop"
 msgstr ""
 
@@ -765,8 +783,8 @@ msgstr ""
 msgid "Red"
 msgstr ""
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:397
 #: ../src/undo/UndoRedoHandler.cpp:293
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:327
 msgid "Redo"
 msgstr ""
 
@@ -774,15 +792,15 @@ msgstr ""
 msgid "Redo: "
 msgstr ""
 
-#: ../src/control/Control.cpp:2021
+#: ../src/control/Control.cpp:2057
 msgid "Remove PDF Background"
 msgstr ""
 
-#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:202
+#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:198
 msgid "Removed tool item from Toolbar {1} ID {2}"
 msgstr ""
 
-#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:198
+#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:194
 msgid "Removed tool item {1} from Toolbar {2} ID {3}"
 msgstr ""
 
@@ -790,7 +808,7 @@ msgstr ""
 msgid "Replace"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:174
+#: ../src/control/XournalMain.cpp:178
 msgid "Restore file"
 msgstr ""
 
@@ -798,7 +816,7 @@ msgstr ""
 msgid "Rotation"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:375
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:410
 msgid "Rotation Snapping"
 msgstr ""
 
@@ -806,25 +824,25 @@ msgstr ""
 msgid "Ruled"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:432
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:467
 msgid "Ruler"
 msgstr ""
 
-#: ../src/control/jobs/SaveJob.cpp:13 ../src/control/Control.cpp:2532
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:315
+#: ../src/control/Control.cpp:2576 ../src/control/jobs/SaveJob.cpp:13
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:390
 msgid "Save"
 msgstr ""
 
-#: ../src/control/Control.cpp:2568
+#: ../src/control/Control.cpp:2617
 msgid "Save As"
 msgstr ""
 
-#: ../src/control/Control.cpp:2352 ../src/gui/dialog/PageTemplateDialog.cpp:112
+#: ../src/control/Control.cpp:2388 ../src/gui/dialog/PageTemplateDialog.cpp:112
 msgid "Save File"
 msgstr ""
 
-#: ../src/control/jobs/SaveJob.cpp:151
 #: ../src/control/jobs/CustomExportJob.cpp:276
+#: ../src/control/jobs/SaveJob.cpp:151
 msgid "Save file error: {1}"
 msgstr ""
 
@@ -832,35 +850,35 @@ msgstr ""
 msgid "Scale"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:324
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:405
 msgid "Search"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:447
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:476
 msgid "Select Font"
 msgstr ""
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:471
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:31
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:99
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:410
 msgid "Select Object"
 msgstr ""
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:470
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:10
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:29
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:85
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:125
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:408
 msgid "Select Rectangle"
 msgstr ""
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:469
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:30
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:92
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:406
 msgid "Select Region"
 msgstr ""
 
-#: ../src/control/Control.cpp:2020
+#: ../src/control/Control.cpp:2056
 msgid "Select another PDF"
 msgstr ""
 
@@ -885,7 +903,7 @@ msgstr ""
 msgid "Select region"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:120
+#: ../src/control/XournalMain.cpp:124
 msgid "Send Bugreport"
 msgstr ""
 
@@ -893,7 +911,7 @@ msgstr ""
 msgid "Separator"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:430
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:462
 msgid "Shape Recognizer"
 msgstr ""
 
@@ -909,21 +927,21 @@ msgstr ""
 msgid "Show only not used pages ({1} unused pages)"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:309
+#: ../src/control/XournalMain.cpp:308
 msgid ""
 "Sorry, Xournal++ can only open one file at once.\n"
 "Others are ignored."
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:324
+#: ../src/control/XournalMain.cpp:323
 msgid ""
 "Sorry, Xournal++ cannot open remote files at the moment.\n"
 "You have to copy the file to a local directory."
 msgstr ""
 
-#: ../src/undo/RecognizerUndoAction.cpp:101
 #: ../src/gui/dialog/ButtonConfigGui.cpp:103
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:43
+#: ../src/undo/RecognizerUndoAction.cpp:101
 msgid "Stroke recognizer"
 msgstr ""
 
@@ -931,12 +949,12 @@ msgstr ""
 msgid "Successfully saved document to \"{1}\""
 msgstr ""
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:128
+#: ../src/control/stockdlg/XojOpenDlg.cpp:132
 msgid "Supported files"
 msgstr ""
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:58
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:401
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:458
 msgid "Text"
 msgstr ""
 
@@ -969,31 +987,31 @@ msgstr ""
 msgid "Text not found, searched on all pages"
 msgstr ""
 
-#: ../src/control/Control.cpp:1006
+#: ../src/control/Control.cpp:1017
 msgid ""
 "The Toolbarconfiguration \"{1}\" is predefined, would you create a copy to "
 "edit?"
 msgstr ""
 
-#: ../src/control/Control.cpp:2017
+#: ../src/control/Control.cpp:2053
 msgid "The attached background PDF could not be found."
 msgstr ""
 
-#: ../src/control/Control.cpp:2018
+#: ../src/control/Control.cpp:2054
 msgid "The background PDF could not be found."
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:115
+#: ../src/control/XournalMain.cpp:119
 msgid "The most recent log file name: {1}"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:108
+#: ../src/control/XournalMain.cpp:112
 msgid ""
 "There are errorlogfiles from Xournal++. Please send a Bugreport, so the bug "
 "may be fixed."
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:107
+#: ../src/control/XournalMain.cpp:111
 msgid ""
 "There is an errorlogfile from Xournal++. Please send a Bugreport, so the bug "
 "may be fixed."
@@ -1004,7 +1022,7 @@ msgid "There was an error displaying help: {1}"
 msgstr ""
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:82
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:439
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:515
 msgid "Thick"
 msgstr ""
 
@@ -1013,20 +1031,20 @@ msgid "Thickness - don't change"
 msgstr ""
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:80
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:435
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:513
 msgid "Thin"
 msgstr ""
 
-#: ../src/control/Control.cpp:2530
+#: ../src/control/Control.cpp:2574
 msgid "This document is not saved yet."
 msgstr ""
 
-#: ../src/control/tools/ImageHandler.cpp:56
 #: ../src/control/PageBackgroundChangeController.cpp:177
+#: ../src/control/tools/ImageHandler.cpp:56
 msgid "This image could not be loaded. Error message: {1}"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:368
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:418
 msgid "Toggle fullscreen"
 msgstr ""
 
@@ -1034,7 +1052,7 @@ msgstr ""
 msgid "Tool - don't change"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/model/ToolbarData.cpp:156
+#: ../src/gui/toolbarMenubar/model/ToolbarData.cpp:152
 msgid "Toolbar found: {1}"
 msgstr ""
 
@@ -1046,12 +1064,12 @@ msgstr ""
 msgid "Trying to emergency save the current open document…"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:458
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:416
 msgid "Two pages"
 msgstr ""
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:396
 #: ../src/undo/UndoRedoHandler.cpp:274
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:326
 msgid "Undo"
 msgstr ""
 
@@ -1059,15 +1077,15 @@ msgstr ""
 msgid "Undo: "
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:241
+#: ../src/control/xojfile/LoadHandler.cpp:260
 msgid "Unexpected root tag: {1}"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:270
+#: ../src/control/xojfile/LoadHandler.cpp:289
 msgid "Unexpected tag in document: \"{1}\""
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:475
+#: ../src/control/xojfile/LoadHandler.cpp:494
 msgid "Unknown background type: {1}"
 msgstr ""
 
@@ -1075,27 +1093,27 @@ msgstr ""
 msgid "Unknown color value \"{1}\""
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:410
+#: ../src/control/xojfile/LoadHandler.cpp:429
 msgid "Unknown domain type: {1}"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:193
+#: ../src/control/xojfile/LoadHandler.cpp:194
 msgid "Unknown parser error"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:345
+#: ../src/control/xojfile/LoadHandler.cpp:364
 msgid "Unknown pixmap::domain type: {1}"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:558
+#: ../src/control/xojfile/LoadHandler.cpp:591
 msgid "Unknown stroke type: \"{1}\", assuming pen"
 msgstr ""
 
-#: ../src/control/Control.cpp:2424
+#: ../src/control/Control.cpp:2460
 msgid "Unsaved Document"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:425
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:472
 msgid "Vertical Space"
 msgstr ""
 
@@ -1116,15 +1134,15 @@ msgstr ""
 msgid "Write text"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:821
+#: ../src/control/xojfile/LoadHandler.cpp:852
 msgid "Wrong count of points ({1})"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:836
+#: ../src/control/xojfile/LoadHandler.cpp:866
 msgid "Wrong number of points, got {1}, expected {2}"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:188
+#: ../src/control/xojfile/LoadHandler.cpp:189
 msgid "XML Parser error: {1}"
 msgstr ""
 
@@ -1132,19 +1150,19 @@ msgstr ""
 msgid "Xournal (Compatibility)"
 msgstr ""
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:69
+#: ../src/control/stockdlg/XojOpenDlg.cpp:72
 msgid "Xournal files"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:168
+#: ../src/control/XournalMain.cpp:172
 msgid "Xournal++ crashed last time. Would you restore it?"
 msgstr ""
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:79 ../src/control/Control.cpp:2359
+#: ../src/control/Control.cpp:2395 ../src/control/stockdlg/XojOpenDlg.cpp:82
 msgid "Xournal++ files"
 msgstr ""
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:89
+#: ../src/control/stockdlg/XojOpenDlg.cpp:92
 #: ../src/gui/dialog/PageTemplateDialog.cpp:119
 msgid "Xournal++ template"
 msgstr ""
@@ -1161,7 +1179,7 @@ msgid ""
 "Template\"."
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:111
+#: ../src/control/XournalMain.cpp:115
 msgid ""
 "You're using {1}/{2} branch. Send Bugreport will direct you to this repo's "
 "issue tracker."
@@ -1176,15 +1194,15 @@ msgid ""
 "PDF page."
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:362
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:422
 msgid "Zoom fit to screen"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:360
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:421
 msgid "Zoom in"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:358
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:420
 msgid "Zoom out"
 msgstr ""
 
@@ -1192,13 +1210,13 @@ msgstr ""
 msgid "Zoom slider"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:364
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:423
 msgid "Zoom to 100%"
 msgstr ""
 
+#: ../src/control/Control.cpp:2389 ../src/control/jobs/BaseExportJob.cpp:26
 #: ../src/control/stockdlg/ImageOpenDlg.cpp:12
 #: ../src/control/stockdlg/XojOpenDlg.cpp:17
-#: ../src/control/jobs/BaseExportJob.cpp:26 ../src/control/Control.cpp:2353
 #: ../src/gui/dialog/PageTemplateDialog.cpp:113
 msgid "_Cancel"
 msgstr ""
@@ -1208,7 +1226,7 @@ msgstr ""
 msgid "_Open"
 msgstr ""
 
-#: ../src/control/jobs/BaseExportJob.cpp:27 ../src/control/Control.cpp:2354
+#: ../src/control/Control.cpp:2390 ../src/control/jobs/BaseExportJob.cpp:27
 #: ../src/gui/dialog/PageTemplateDialog.cpp:114
 msgid "_Save"
 msgstr ""
@@ -1217,8 +1235,20 @@ msgstr ""
 msgid "cursor"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:299
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:294
+msgid "dash-/ doted"
+msgstr ""
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:291
+msgid "dashed"
+msgstr ""
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:312
 msgid "delete stroke"
+msgstr ""
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:297
+msgid "dotted"
 msgstr ""
 
 #: ../src/util/DeviceListHelper.cpp:82
@@ -1241,7 +1271,8 @@ msgstr ""
 msgid "show"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:285
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:288
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:310
 msgid "standard"
 msgstr ""
 
@@ -1253,11 +1284,11 @@ msgstr ""
 msgid "touchscreen"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:292
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:311
 msgid "whiteout"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:835
+#: ../src/control/xojfile/LoadHandler.cpp:865
 msgid "xoj-File: {1}"
 msgstr ""
 
@@ -1290,11 +1321,11 @@ msgstr ""
 msgid "xoj-preview-extractor: successfully extracted"
 msgstr ""
 
-#: ../ui/settings.glade:590
+#: ../ui/settings.glade:604
 msgid "%F-Note-%H-%M.xoj"
 msgstr ""
 
-#: ../ui/settings.glade:613
+#: ../ui/settings.glade:627
 msgid ""
 "%a\tAbbreviated weekday name \t(e.g. Thu)\n"
 "%A\tFull weekday name (e.g. Thursday)\n"
@@ -1324,19 +1355,19 @@ msgstr ""
 msgid "<b>... or select already used Image:</b>"
 msgstr ""
 
-#: ../ui/settings.glade:271
+#: ../ui/settings.glade:285
 msgid "<b>Add horizontal space</b>"
 msgstr ""
 
-#: ../ui/settings.glade:248
+#: ../ui/settings.glade:262
 msgid "<b>Add vertical space</b>"
 msgstr ""
 
-#: ../ui/settings.glade:704
+#: ../ui/settings.glade:718
 msgid "<b>Autoload .pdf.xoj</b>"
 msgstr ""
 
-#: ../ui/settings.glade:488
+#: ../ui/settings.glade:502
 msgid ""
 "<b>Autosave Folder</b>\n"
 "<i>If the document already was saved you can find it in the same folder\n"
@@ -1345,7 +1376,7 @@ msgid ""
 "~/.xournalpp/autosave</i>"
 msgstr ""
 
-#: ../ui/settings.glade:428
+#: ../ui/settings.glade:442
 msgid "<b>Autosave</b>"
 msgstr ""
 
@@ -1361,7 +1392,7 @@ msgstr ""
 msgid "<b>Color</b>"
 msgstr ""
 
-#: ../ui/settings.glade:1464
+#: ../ui/settings.glade:1521
 msgid "<b>Colors</b>"
 msgstr ""
 
@@ -1378,7 +1409,7 @@ msgid ""
 "for the fist Page"
 msgstr ""
 
-#: ../ui/settings.glade:1835
+#: ../ui/settings.glade:1907
 msgid "<b>Cursor</b>"
 msgstr ""
 
@@ -1386,15 +1417,15 @@ msgstr ""
 msgid "<b>Default Tools</b>"
 msgstr ""
 
-#: ../ui/settings.glade:577
+#: ../ui/settings.glade:591
 msgid "<b>Default name:</b>"
 msgstr ""
 
-#: ../ui/settings.glade:524
+#: ../ui/settings.glade:538
 msgid "<b>Default save name</b>"
 msgstr ""
 
-#: ../ui/settings.glade:1943
+#: ../ui/settings.glade:2030
 msgid "<b>Default</b>"
 msgstr ""
 
@@ -1404,11 +1435,11 @@ msgid ""
 "Select pages to export"
 msgstr ""
 
-#: ../ui/settings.glade:1002
+#: ../ui/settings.glade:1016
 msgid "<b>Eraser</b>"
 msgstr ""
 
-#: ../ui/settings.glade:110
+#: ../ui/settings.glade:124
 msgid "<b>Extended Input</b>"
 msgstr ""
 
@@ -1418,19 +1449,19 @@ msgid ""
 "Select transparency for fill color"
 msgstr ""
 
-#: ../ui/settings.glade:1661
+#: ../ui/settings.glade:1733
 msgid "<b>Fullscreen</b>"
 msgstr ""
 
-#: ../ui/settings.glade:658
+#: ../ui/settings.glade:672
 msgid "<b>Help</b> (Placeholders)"
 msgstr ""
 
-#: ../ui/settings.glade:1390
+#: ../ui/settings.glade:1447
 msgid "<b>Left / Right</b>"
 msgstr ""
 
-#: ../ui/settings.glade:819
+#: ../ui/settings.glade:833
 msgid "<b>Middle Mouse Button</b>"
 msgstr ""
 
@@ -1442,23 +1473,23 @@ msgstr ""
 msgid "<b>Pagesize</b>"
 msgstr ""
 
-#: ../ui/settings.glade:1731
+#: ../ui/settings.glade:1803
 msgid "<b>Presentation</b> Another Fullscreen Mode, <i>Start with F5</i>"
 msgstr ""
 
-#: ../ui/settings.glade:155
+#: ../ui/settings.glade:169
 msgid "<b>Pressure sensitivity</b>"
 msgstr ""
 
-#: ../ui/settings.glade:849
+#: ../ui/settings.glade:863
 msgid "<b>Right Mouse Button</b>"
 msgstr ""
 
-#: ../ui/settings.glade:1584
+#: ../ui/settings.glade:1656
 msgid "<b>Scrollbars</b>"
 msgstr ""
 
-#: ../ui/settings.glade:200
+#: ../ui/settings.glade:214
 msgid "<b>Scrolling outside the page</b>"
 msgstr ""
 
@@ -1466,15 +1497,15 @@ msgstr ""
 msgid "<b>Separator</b>"
 msgstr ""
 
-#: ../ui/settings.glade:944
+#: ../ui/settings.glade:958
 msgid "<b>Stylus Button 1</b> Action if the pen button is pressed"
 msgstr ""
 
-#: ../ui/settings.glade:973
+#: ../ui/settings.glade:987
 msgid "<b>Stylus Button 2</b> Action if the pen button is pressed"
 msgstr ""
 
-#: ../ui/settings.glade:1031
+#: ../ui/settings.glade:1045
 msgid ""
 "<b>Touch Screen</b> <i>You can also configure other devices like mice</i>"
 msgstr ""
@@ -1483,62 +1514,62 @@ msgstr ""
 msgid "<i>Example:</i> 1-3 or 1,3,5-7 etc."
 msgstr ""
 
-#: ../ui/settings.glade:929
+#: ../ui/settings.glade:943
 msgid ""
 "<i>Here you can define which tools will be selected If you\n"
 "use the eraser or other device.\n"
 "Here you can disable your touchscreen.</i>"
 msgstr ""
 
-#: ../ui/settings.glade:804
+#: ../ui/settings.glade:818
 msgid ""
 "<i>Here you can define which tools will be selected if you press\n"
 "a button; after you release the button the previously selected\n"
 "tool will be selected</i>"
 msgstr ""
 
-#: ../ui/settings.glade:2030
+#: ../ui/settings.glade:2188
 msgid ""
 "<i>If audio recording is running, the time stamps are stored to the "
 "handwritten Text and can be replayed.\n"
 "The Audio track is recorded to a separate folder, and liked to there.</i>"
 msgstr ""
 
-#: ../ui/settings.glade:224
+#: ../ui/settings.glade:238
 msgid ""
 "<i>If you add <b>additional space</b> beside the pages\n"
 "you can choose the area of the screen you would\n"
 "like to work on</i>"
 msgstr ""
 
-#: ../ui/settings.glade:170
+#: ../ui/settings.glade:184
 msgid "<i>If you have a tablet pen you can get different line widths</i>"
 msgstr ""
 
-#: ../ui/settings.glade:728
+#: ../ui/settings.glade:742
 msgid ""
 "<i>If you open a PDF and there is a\n"
 "Xournal file with the same name it will open the xoj file.</i>"
 msgstr ""
 
-#: ../ui/settings.glade:324
+#: ../ui/settings.glade:338
 msgid ""
 "<i>Put a ruler on your screen to calibrate the zoom level to fit your "
 "screen. Takes effect after restarting xournalpp.\n"
 "The units are cm for the ruler, dpi for the slider.</i>"
 msgstr ""
 
-#: ../ui/settings.glade:133
+#: ../ui/settings.glade:147
 msgid "<i>Select some advanced input options</i>"
 msgstr ""
 
-#: ../ui/settings.glade:1339
+#: ../ui/settings.glade:1396
 msgid ""
 "<i>The commands will be executed in the UI Thread, make sure\n"
 "they are not blocking!</i>"
 msgstr ""
 
-#: ../ui/settings.glade:548
+#: ../ui/settings.glade:562
 msgid "<i>This name will be proposed if you save a new document</i>"
 msgstr ""
 
@@ -1552,7 +1583,7 @@ msgstr ""
 msgid "About Xournal++"
 msgstr ""
 
-#: ../ui/main.glade:1086
+#: ../ui/main.glade:1233
 msgid "Add/Edit Tex"
 msgstr ""
 
@@ -1560,11 +1591,11 @@ msgstr ""
 msgid "All pages"
 msgstr ""
 
-#: ../ui/settings.glade:2051
+#: ../ui/settings.glade:2209
 msgid "Audio Folder"
 msgstr ""
 
-#: ../ui/settings.glade:2088
+#: ../ui/settings.glade:2246
 msgid "Audio Recording"
 msgstr ""
 
@@ -1572,27 +1603,27 @@ msgstr ""
 msgid "Authors:"
 msgstr ""
 
-#: ../ui/settings.glade:1170
+#: ../ui/settings.glade:1227
 msgid "Autodetect"
 msgstr ""
 
-#: ../ui/settings.glade:456
+#: ../ui/settings.glade:470
 msgid "Autosave every ... minutes:"
 msgstr ""
 
-#: ../ui/settings.glade:1520
+#: ../ui/settings.glade:1577
 msgid "Background color for window Background"
 msgstr ""
 
-#: ../ui/settings.glade:1857
+#: ../ui/settings.glade:1929
 msgid "Big cursor for pen"
 msgstr ""
 
-#: ../ui/settings.glade:1509
+#: ../ui/settings.glade:1566
 msgid "Border color"
 msgstr ""
 
-#: ../ui/settings.glade:1495
+#: ../ui/settings.glade:1552
 msgid "Border color for current page and other selections"
 msgstr ""
 
@@ -1600,7 +1631,7 @@ msgstr ""
 msgid "Built on:"
 msgstr ""
 
-#: ../ui/main.glade:588
+#: ../ui/main.glade:633
 msgid "Configure Page Template"
 msgstr ""
 
@@ -1616,15 +1647,19 @@ msgstr ""
 msgid "Current page"
 msgstr ""
 
-#: ../ui/settings.glade:1231
+#: ../ui/settings.glade:1288
 msgid "Custom Commands (for Method \"Custom\")"
 msgstr ""
 
-#: ../ui/settings.glade:1997
+#: ../ui/settings.glade:1621
+msgid "Dark Theme (restart needed)"
+msgstr ""
+
+#: ../ui/settings.glade:2155
 msgid "Defaults"
 msgstr ""
 
-#: ../ui/main.glade:620
+#: ../ui/main.glade:668
 msgid "Delete Layer"
 msgstr ""
 
@@ -1632,7 +1667,7 @@ msgstr ""
 msgid "Delete stroke"
 msgstr ""
 
-#: ../ui/main.glade:1297
+#: ../ui/main.glade:1447
 msgid "Delete this page"
 msgstr ""
 
@@ -1640,7 +1675,7 @@ msgstr ""
 msgid "Device"
 msgstr ""
 
-#: ../ui/settings.glade:1261
+#: ../ui/settings.glade:1318
 msgid "Disable"
 msgstr ""
 
@@ -1648,11 +1683,11 @@ msgstr ""
 msgid "Disable drawing for this device"
 msgstr ""
 
-#: ../ui/settings.glade:1134
+#: ../ui/settings.glade:1191
 msgid "Disable touch if pen is near screen"
 msgstr ""
 
-#: ../ui/settings.glade:1156
+#: ../ui/settings.glade:1213
 msgid "Disabling Method"
 msgstr ""
 
@@ -1660,19 +1695,23 @@ msgstr ""
 msgid "Drag and drop Components fom here to the toolbars and back."
 msgstr ""
 
-#: ../ui/main.glade:778
+#: ../ui/main.glade:844
 msgid "Draw _Line"
 msgstr ""
 
-#: ../ui/settings.glade:1249
+#: ../ui/settings.glade:1306
 msgid "Enable"
+msgstr ""
+
+#: ../ui/settings.glade:1176
+msgid "Enable zoom gestures (needs restart)"
 msgstr ""
 
 #: ../ui/texdialog.glade:66
 msgid "Enter / edit LaTeX Text"
 msgstr ""
 
-#: ../ui/main.glade:940
+#: ../ui/main.glade:1066
 msgid "Eraser Optio_ns"
 msgstr ""
 
@@ -1684,39 +1723,49 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: ../ui/main.glade:113
+#: ../ui/main.glade:119
 msgid "Export as..."
 msgstr ""
 
-#: ../ui/main.glade:920 ../ui/main.glade:1057
+#: ../ui/main.glade:1044 ../ui/main.glade:1192
 msgid "Fi_ll"
 msgstr ""
 
-#: ../ui/main.glade:928 ../ui/main.glade:1065
+#: ../ui/main.glade:1053 ../ui/main.glade:1201
 msgid "Fill transparency"
 msgstr ""
 
-#: ../ui/main.glade:1492
+#: ../ui/main.glade:1634
 msgid "Find next occurrence of the search string"
 msgstr ""
 
-#: ../ui/main.glade:1471
+#: ../ui/main.glade:1613
 msgid "Find previous occurrence of the search string"
 msgstr ""
 
-#: ../ui/main.glade:289
+#: ../ui/main.glade:338
 msgid "Fullscreen"
 msgstr ""
 
-#: ../ui/about.glade:233
+#: ../ui/about.glade:234
 msgid "GNU GPLv2 or later"
+msgstr ""
+
+#: ../ui/settings.glade:1072
+msgid ""
+"GTK Touch / Scrolling workaround. Change Scroll / Touch behavoir. Enabled "
+"touch drawing. Needs restart."
 msgstr ""
 
 #: ../ui/goto.glade:13
 msgid "Goto Page"
 msgstr ""
 
-#: ../ui/main.glade:843
+#: ../ui/settings.glade:2113
+msgid "Grid snapping tolerance:"
+msgstr ""
+
+#: ../ui/main.glade:915
 msgid "H_and Tool"
 msgstr ""
 
@@ -1724,35 +1773,39 @@ msgstr ""
 msgid "Height:"
 msgstr ""
 
-#: ../ui/main.glade:379
+#: ../ui/main.glade:407
 msgid "Hide Menu"
 msgstr ""
 
-#: ../ui/settings.glade:1683 ../ui/settings.glade:1753
+#: ../ui/settings.glade:1755 ../ui/settings.glade:1825
 msgid "Hide Menubar"
 msgstr ""
 
-#: ../ui/settings.glade:1698 ../ui/settings.glade:1768
+#: ../ui/settings.glade:1770 ../ui/settings.glade:1840
 msgid "Hide Sidebar"
 msgstr ""
 
-#: ../ui/settings.glade:1613
+#: ../ui/settings.glade:1685
 msgid "Hide the horizontal scrollbar"
 msgstr ""
 
-#: ../ui/settings.glade:1628
+#: ../ui/settings.glade:1700
 msgid "Hide the vertical scrollbar"
 msgstr ""
 
-#: ../ui/main.glade:1014
+#: ../ui/settings.glade:1944
+msgid "Highlight cursor position"
+msgstr ""
+
+#: ../ui/main.glade:1146
 msgid "Highlighter Opti_ons"
 msgstr ""
 
-#: ../ui/settings.glade:390
+#: ../ui/settings.glade:404
 msgid "Input"
 msgstr ""
 
-#: ../ui/settings.glade:1090
+#: ../ui/settings.glade:1119
 msgid "Input Device"
 msgstr ""
 
@@ -1760,15 +1813,15 @@ msgstr ""
 msgid "Insert Latex"
 msgstr ""
 
-#: ../ui/main.glade:1277
+#: ../ui/main.glade:1427
 msgid "Insert a copy of the current page below"
 msgstr ""
 
-#: ../ui/about.glade:217
+#: ../ui/about.glade:218
 msgid "License"
 msgstr ""
 
-#: ../ui/settings.glade:772
+#: ../ui/settings.glade:786
 msgid "Load / Save"
 msgstr ""
 
@@ -1776,35 +1829,35 @@ msgstr ""
 msgid "Load file"
 msgstr ""
 
-#: ../ui/toolbarManageDialog.glade:8 ../ui/toolbarCustomizeDialog.glade:10
+#: ../ui/toolbarCustomizeDialog.glade:10 ../ui/toolbarManageDialog.glade:8
 msgid "Manage Toolbar"
 msgstr ""
 
-#: ../ui/settings.glade:883
+#: ../ui/settings.glade:897
 msgid "Mouse Button"
 msgstr ""
 
-#: ../ui/main.glade:531
+#: ../ui/main.glade:571
 msgid "N_ext annotated page"
 msgstr ""
 
-#: ../ui/main.glade:571
+#: ../ui/main.glade:614
 msgid "New Page _After"
 msgstr ""
 
-#: ../ui/main.glade:563
+#: ../ui/main.glade:605
 msgid "New Page _Before"
 msgstr ""
 
-#: ../ui/main.glade:580
+#: ../ui/main.glade:624
 msgid "New Page at _End"
 msgstr ""
 
-#: ../ui/main.glade:611
+#: ../ui/main.glade:658
 msgid "New _Layer"
 msgstr ""
 
-#: ../ui/main.glade:540
+#: ../ui/main.glade:581
 msgid "P_revious annotated Page"
 msgstr ""
 
@@ -1820,29 +1873,29 @@ msgstr ""
 msgid "Paper Format"
 msgstr ""
 
-#: ../ui/main.glade:643
+#: ../ui/main.glade:693
 msgid "Paper _Color"
 msgstr ""
 
-#: ../ui/main.glade:635
+#: ../ui/main.glade:684
 msgid "Paper _Format"
 msgstr ""
 
-#: ../ui/main.glade:651
+#: ../ui/main.glade:702
 msgid "Paper b_ackground"
 msgstr ""
 
-#: ../ui/about.glade:201
+#: ../ui/about.glade:202
 msgid ""
 "Partial based on Xournal\n"
 "by Denis Auroux"
 msgstr ""
 
-#: ../ui/main.glade:859
+#: ../ui/main.glade:932
 msgid "Pen _Options"
 msgstr ""
 
-#: ../ui/main.glade:251
+#: ../ui/main.glade:297
 msgid "Preferences"
 msgstr ""
 
@@ -1850,11 +1903,11 @@ msgstr ""
 msgid "Range"
 msgstr ""
 
-#: ../ui/main.glade:299
+#: ../ui/main.glade:1225
 msgid "Rec-Stop"
 msgstr ""
 
-#: ../ui/main.glade:61
+#: ../ui/main.glade:63
 msgid "Recent _Documents"
 msgstr ""
 
@@ -1862,11 +1915,15 @@ msgstr ""
 msgid "Resolution"
 msgstr ""
 
+#: ../ui/settings.glade:2083
+msgid "Rotation snapping tolerance:"
+msgstr ""
+
 #: ../ui/pageTemplate.glade:165
 msgid "Select Background Color"
 msgstr ""
 
-#: ../ui/settings.glade:2065
+#: ../ui/settings.glade:2223
 msgid "Select Folder"
 msgstr ""
 
@@ -1878,19 +1935,23 @@ msgstr ""
 msgid "Select PDF Page"
 msgstr ""
 
-#: ../ui/settings.glade:1964
+#: ../ui/settings.glade:2051
 msgid "Select the tool and Settings if you press the Default Button"
 msgstr ""
 
-#: ../ui/settings.glade:1789
+#: ../ui/settings.glade:1861
 msgid "Select toolbar:"
 msgstr ""
 
-#: ../ui/settings.glade:1543
+#: ../ui/settings.glade:1600
 msgid "Selection Color (Text, Stroke Selection etc.)"
 msgstr ""
 
-#: ../ui/settings.glade:1123
+#: ../ui/settings.glade:1165
+msgid "Settings for Touch devices"
+msgstr ""
+
+#: ../ui/settings.glade:1152
 msgid "Settings for Touch devices which are detected by GTK."
 msgstr ""
 
@@ -1900,15 +1961,15 @@ msgid ""
 "THIS TEXT IS A PLACEHOLDER!"
 msgstr ""
 
-#: ../ui/main.glade:322
+#: ../ui/main.glade:348
 msgid "Show sidebar"
 msgstr ""
 
-#: ../ui/settings.glade:1412
+#: ../ui/settings.glade:1469
 msgid "Show sidebar on the right side"
 msgstr ""
 
-#: ../ui/settings.glade:1427
+#: ../ui/settings.glade:1484
 msgid "Show vertical scrollbar on the left side"
 msgstr ""
 
@@ -1916,19 +1977,19 @@ msgstr ""
 msgid "Standard"
 msgstr ""
 
-#: ../ui/main.glade:1610
+#: ../ui/main.glade:1752
 msgid "State PLACEHOLDER"
 msgstr ""
 
-#: ../ui/main.glade:1236
+#: ../ui/main.glade:1386
 msgid "Swap the current page with the one above"
 msgstr ""
 
-#: ../ui/main.glade:1257
+#: ../ui/main.glade:1407
 msgid "Swap the current page with the one below"
 msgstr ""
 
-#: ../ui/main.glade:337
+#: ../ui/main.glade:363
 msgid "T_oolbars"
 msgstr ""
 
@@ -1936,31 +1997,31 @@ msgstr ""
 msgid "Template:"
 msgstr ""
 
-#: ../ui/settings.glade:1317
+#: ../ui/settings.glade:1374
 msgid "Test disable"
 msgstr ""
 
-#: ../ui/settings.glade:1304
+#: ../ui/settings.glade:1361
 msgid "Test enable"
 msgstr ""
 
-#: ../ui/main.glade:1077
+#: ../ui/main.glade:1214
 msgid "Text Font..."
 msgstr ""
 
-#: ../ui/settings.glade:369
+#: ../ui/settings.glade:383
 msgid "The unit of the ruler is cm"
 msgstr ""
 
-#: ../ui/settings.glade:1185
+#: ../ui/settings.glade:1242
 msgid "Timeout"
 msgstr ""
 
-#: ../ui/settings.glade:1358
+#: ../ui/settings.glade:1415
 msgid "Touch"
 msgstr ""
 
-#: ../ui/settings.glade:1046
+#: ../ui/settings.glade:1060
 msgid ""
 "Touch Screens which are detected by GTK are handled specially, and don't "
 "need to be configured here."
@@ -1974,7 +2035,7 @@ msgstr ""
 msgid "Version"
 msgstr ""
 
-#: ../ui/settings.glade:1895
+#: ../ui/settings.glade:1982
 msgid "View"
 msgstr ""
 
@@ -1986,47 +2047,47 @@ msgstr ""
 msgid "Width:"
 msgstr ""
 
-#: ../ui/about.glade:187
+#: ../ui/about.glade:188
 msgid "With help from the community"
 msgstr ""
 
-#: ../ui/settings.glade:1171
+#: ../ui/settings.glade:1228
 msgid "X11"
 msgstr ""
 
-#: ../ui/settings.glade:28
+#: ../ui/settings.glade:42
 msgid "Xournal++ Preferences"
 msgstr ""
 
-#: ../ui/settings.glade:302
+#: ../ui/settings.glade:316
 msgid "Zoom"
 msgstr ""
 
-#: ../ui/main.glade:69
+#: ../ui/main.glade:71
 msgid "_Annotate PDF"
 msgstr ""
 
-#: ../ui/main.glade:361
+#: ../ui/main.glade:388
 msgid "_Customize"
 msgstr ""
 
-#: ../ui/main.glade:723
+#: ../ui/main.glade:779
 msgid "_Default Tools"
 msgstr ""
 
-#: ../ui/main.glade:596
+#: ../ui/main.glade:642
 msgid "_Delete Page"
 msgstr ""
 
-#: ../ui/main.glade:153
+#: ../ui/main.glade:162
 msgid "_Edit"
 msgstr ""
 
-#: ../ui/main.glade:683
+#: ../ui/main.glade:735
 msgid "_Eraser"
 msgstr ""
 
-#: ../ui/main.glade:104
+#: ../ui/main.glade:109
 msgid "_Export as PDF"
 msgstr ""
 
@@ -2034,119 +2095,119 @@ msgstr ""
 msgid "_File"
 msgstr ""
 
-#: ../ui/main.glade:448
+#: ../ui/main.glade:480
 msgid "_First Page"
 msgstr ""
 
-#: ../ui/main.glade:466
+#: ../ui/main.glade:500
 msgid "_Goto Page"
 msgstr ""
 
-#: ../ui/main.glade:1099
+#: ../ui/main.glade:1247
 msgid "_Help"
 msgstr ""
 
-#: ../ui/main.glade:693
+#: ../ui/main.glade:746
 msgid "_Highlighter"
 msgstr ""
 
-#: ../ui/main.glade:713
+#: ../ui/main.glade:768
 msgid "_Image"
 msgstr ""
 
-#: ../ui/main.glade:553
+#: ../ui/main.glade:595
 msgid "_Journal"
 msgstr ""
 
-#: ../ui/main.glade:484
+#: ../ui/main.glade:520
 msgid "_Last Page"
 msgstr ""
 
-#: ../ui/main.glade:353
+#: ../ui/main.glade:379
 msgid "_Manage"
 msgstr ""
 
-#: ../ui/main.glade:438
+#: ../ui/main.glade:470
 msgid "_Navigation"
 msgstr ""
 
-#: ../ui/main.glade:508
+#: ../ui/main.glade:546
 msgid "_Next Layer"
 msgstr ""
 
-#: ../ui/main.glade:475
+#: ../ui/main.glade:510
 msgid "_Next Page"
 msgstr ""
 
-#: ../ui/main.glade:673
+#: ../ui/main.glade:724
 msgid "_Pen"
 msgstr ""
 
-#: ../ui/main.glade:281
+#: ../ui/main.glade:329
 msgid "_Presentation Mode"
 msgstr ""
 
-#: ../ui/main.glade:499
+#: ../ui/main.glade:536
 msgid "_Previous Layer"
 msgstr ""
 
-#: ../ui/main.glade:457
+#: ../ui/main.glade:490
 msgid "_Previous Page"
 msgstr ""
 
-#: ../ui/main.glade:737
+#: ../ui/main.glade:794
 msgid "_Shape Recognizer"
 msgstr ""
 
-#: ../ui/main.glade:703
+#: ../ui/main.glade:757
 msgid "_Text"
 msgstr ""
 
-#: ../ui/main.glade:663
+#: ../ui/main.glade:714
 msgid "_Tools"
 msgstr ""
 
-#: ../ui/main.glade:517
+#: ../ui/main.glade:556
 msgid "_Top Layer"
 msgstr ""
 
-#: ../ui/main.glade:273
+#: ../ui/main.glade:320
 msgid "_Two Pages"
 msgstr ""
 
-#: ../ui/main.glade:823
+#: ../ui/main.glade:893
 msgid "_Vertical Space"
 msgstr ""
 
-#: ../ui/main.glade:263
+#: ../ui/main.glade:310
 msgid "_View"
 msgstr ""
 
-#: ../ui/main.glade:1001
+#: ../ui/main.glade:1132
 msgid "_delete strokes"
 msgstr ""
 
-#: ../ui/main.glade:878 ../ui/main.glade:950 ../ui/main.glade:1024
+#: ../ui/main.glade:952 ../ui/main.glade:1076 ../ui/main.glade:1156
 msgid "_fine"
 msgstr ""
 
-#: ../ui/main.glade:887 ../ui/main.glade:959 ../ui/main.glade:1033
+#: ../ui/main.glade:962 ../ui/main.glade:1086 ../ui/main.glade:1166
 msgid "_medium"
 msgstr ""
 
-#: ../ui/main.glade:983
+#: ../ui/main.glade:1112
 msgid "_standard"
 msgstr ""
 
-#: ../ui/main.glade:896 ../ui/main.glade:968 ../ui/main.glade:1042
+#: ../ui/main.glade:972 ../ui/main.glade:1096 ../ui/main.glade:1176
 msgid "_thick"
 msgstr ""
 
-#: ../ui/main.glade:869
+#: ../ui/main.glade:942
 msgid "_very fine"
 msgstr ""
 
-#: ../ui/main.glade:992
+#: ../ui/main.glade:1122
 msgid "_whiteout"
 msgstr ""
 
@@ -2162,7 +2223,7 @@ msgstr ""
 msgid "load from file"
 msgstr ""
 
-#: ../ui/settings.glade:1212
+#: ../ui/settings.glade:1269
 msgid "s"
 msgstr ""
 
@@ -2170,6 +2231,6 @@ msgstr ""
 msgid "save to file"
 msgstr ""
 
-#: ../ui/main.glade:905
+#: ../ui/main.glade:982
 msgid "ver_y thick"
 msgstr ""

--- a/po/zh.po
+++ b/po/zh.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: xournalpp 1.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-12-30 12:21+0100\n"
+"POT-Creation-Date: 2019-01-23 10:36+0100\n"
 "PO-Revision-Date: 2018-11-14 19:55+0100\n"
 "Last-Translator: Andreas Butti <andreasbutti at gmail dot com>\n"
 "Language-Team: Xournal++ team\n"
@@ -16,41 +16,41 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.7.1\n"
 
-#: ../src/undo/DeleteUndoAction.cpp:113 ../src/undo/AddUndoAction.cpp:119
+#: ../src/undo/AddUndoAction.cpp:119 ../src/undo/DeleteUndoAction.cpp:113
 msgid " elements"
 msgstr "元素"
 
-#: ../src/undo/DeleteUndoAction.cpp:128 ../src/undo/AddUndoAction.cpp:134
+#: ../src/undo/AddUndoAction.cpp:134 ../src/undo/DeleteUndoAction.cpp:128
 msgid " image"
 msgstr "图片"
 
-#: ../src/undo/DeleteUndoAction.cpp:132 ../src/undo/AddUndoAction.cpp:138
+#: ../src/undo/AddUndoAction.cpp:138 ../src/undo/DeleteUndoAction.cpp:132
 msgid " latex"
 msgstr "LaTeX"
 
-#: ../src/gui/MainWindow.cpp:734
+#: ../src/gui/MainWindow.cpp:818
 msgctxt "Page {pagenumber} \"of {pagecount}\""
 msgid " of {1}{2}"
 msgstr "页，共{1}页"
 
-#: ../src/undo/DeleteUndoAction.cpp:120 ../src/undo/AddUndoAction.cpp:126
+#: ../src/undo/AddUndoAction.cpp:126 ../src/undo/DeleteUndoAction.cpp:120
 msgid " stroke"
 msgstr "笔划"
 
-#: ../src/undo/DeleteUndoAction.cpp:124 ../src/undo/AddUndoAction.cpp:130
+#: ../src/undo/AddUndoAction.cpp:130 ../src/undo/DeleteUndoAction.cpp:124
 msgid " text"
 msgstr "文本"
 
-#: ../src/control/settings/Settings.cpp:79
+#: ../src/control/settings/Settings.cpp:90
 #, fuzzy
 msgid "%F-Note-%H-%M"
 msgstr "%F-Note-%H-%M.xoj"
 
-#: ../ui/settings.glade:590
+#: ../ui/settings.glade:604
 msgid "%F-Note-%H-%M.xoj"
 msgstr "%F-Note-%H-%M.xoj"
 
-#: ../ui/settings.glade:613
+#: ../ui/settings.glade:627
 msgid ""
 "%a\tAbbreviated weekday name \t(e.g. Thu)\n"
 "%A\tFull weekday name (e.g. Thursday)\n"
@@ -80,19 +80,19 @@ msgstr ""
 msgid "<b>... or select already used Image:</b>"
 msgstr "<b>...或者选择已用图片：</b>"
 
-#: ../ui/settings.glade:271
+#: ../ui/settings.glade:285
 msgid "<b>Add horizontal space</b>"
 msgstr "<b>增加水平间距</b>"
 
-#: ../ui/settings.glade:248
+#: ../ui/settings.glade:262
 msgid "<b>Add vertical space</b>"
 msgstr "<b>增加垂直间距</b>"
 
-#: ../ui/settings.glade:704
+#: ../ui/settings.glade:718
 msgid "<b>Autoload .pdf.xoj</b>"
 msgstr "<b>自动加载.pdf.xoj</b>"
 
-#: ../ui/settings.glade:488
+#: ../ui/settings.glade:502
 msgid ""
 "<b>Autosave Folder</b>\n"
 "<i>If the document already was saved you can find it in the same folder\n"
@@ -104,7 +104,7 @@ msgstr ""
 "<i>如果文档已经保存，您可以在同一目录中使用扩展名.autosave.xoj找到该文档。\n"
 "如果文件没有保存，您可以在目录~/.xournalpp/autosave中找到。</i>"
 
-#: ../ui/settings.glade:428
+#: ../ui/settings.glade:442
 msgid "<b>Autosave</b>"
 msgstr "<b>自动保存</b>"
 
@@ -122,7 +122,7 @@ msgstr "背景"
 msgid "<b>Color</b>"
 msgstr "<b>颜色</b>"
 
-#: ../ui/settings.glade:1464
+#: ../ui/settings.glade:1521
 #, fuzzy
 msgid "<b>Colors</b>"
 msgstr "<b>颜色</b>"
@@ -140,7 +140,7 @@ msgid ""
 "for the fist Page"
 msgstr ""
 
-#: ../ui/settings.glade:1835
+#: ../ui/settings.glade:1907
 msgid "<b>Cursor</b>"
 msgstr "<b>光标</b>"
 
@@ -148,15 +148,15 @@ msgstr "<b>光标</b>"
 msgid "<b>Default Tools</b>"
 msgstr "<b>缺省工具</b>"
 
-#: ../ui/settings.glade:577
+#: ../ui/settings.glade:591
 msgid "<b>Default name:</b>"
 msgstr "<b>缺省名：</b>"
 
-#: ../ui/settings.glade:524
+#: ../ui/settings.glade:538
 msgid "<b>Default save name</b>"
 msgstr "<b>缺省保存名</b>"
 
-#: ../ui/settings.glade:1943
+#: ../ui/settings.glade:2030
 msgid "<b>Default</b>"
 msgstr "<b>缺省</b>"
 
@@ -166,11 +166,11 @@ msgid ""
 "Select pages to export"
 msgstr ""
 
-#: ../ui/settings.glade:1002
+#: ../ui/settings.glade:1016
 msgid "<b>Eraser</b>"
 msgstr "<b>橡皮</b>"
 
-#: ../ui/settings.glade:110
+#: ../ui/settings.glade:124
 msgid "<b>Extended Input</b>"
 msgstr "<b>扩展输入</b>"
 
@@ -180,19 +180,19 @@ msgid ""
 "Select transparency for fill color"
 msgstr ""
 
-#: ../ui/settings.glade:1661
+#: ../ui/settings.glade:1733
 msgid "<b>Fullscreen</b>"
 msgstr "<b>全屏模式</b>"
 
-#: ../ui/settings.glade:658
+#: ../ui/settings.glade:672
 msgid "<b>Help</b> (Placeholders)"
 msgstr "<b>帮助</b> "
 
-#: ../ui/settings.glade:1390
+#: ../ui/settings.glade:1447
 msgid "<b>Left / Right</b>"
 msgstr "<b>左/右</b>"
 
-#: ../ui/settings.glade:819
+#: ../ui/settings.glade:833
 msgid "<b>Middle Mouse Button</b>"
 msgstr "<b>鼠标中键</b>"
 
@@ -205,24 +205,24 @@ msgstr "<b>页面尺寸</b>"
 msgid "<b>Pagesize</b>"
 msgstr "<b>页面尺寸</b>"
 
-#: ../ui/settings.glade:1731
+#: ../ui/settings.glade:1803
 msgid "<b>Presentation</b> Another Fullscreen Mode, <i>Start with F5</i>"
 msgstr "<b>演讲模式</b> (备选全屏模式 <i>使用F5激活</i>)"
 
-#: ../ui/settings.glade:155
+#: ../ui/settings.glade:169
 msgid "<b>Pressure sensitivity</b>"
 msgstr "<b>压力敏感</b>"
 
-#: ../ui/settings.glade:849
+#: ../ui/settings.glade:863
 msgid "<b>Right Mouse Button</b>"
 msgstr "<b>鼠标右键</b>"
 
-#: ../ui/settings.glade:1584
+#: ../ui/settings.glade:1656
 #, fuzzy
 msgid "<b>Scrollbars</b>"
 msgstr "<b>颜色</b>"
 
-#: ../ui/settings.glade:200
+#: ../ui/settings.glade:214
 msgid "<b>Scrolling outside the page</b>"
 msgstr "<b>卷出页面</b>"
 
@@ -230,15 +230,15 @@ msgstr "<b>卷出页面</b>"
 msgid "<b>Separator</b>"
 msgstr "<b>分割线</b>"
 
-#: ../ui/settings.glade:944
+#: ../ui/settings.glade:958
 msgid "<b>Stylus Button 1</b> Action if the pen button is pressed"
 msgstr ""
 
-#: ../ui/settings.glade:973
+#: ../ui/settings.glade:987
 msgid "<b>Stylus Button 2</b> Action if the pen button is pressed"
 msgstr ""
 
-#: ../ui/settings.glade:1031
+#: ../ui/settings.glade:1045
 msgid ""
 "<b>Touch Screen</b> <i>You can also configure other devices like mice</i>"
 msgstr "<b>触屏</b> <i>鼠标以外的其他设备也可以进行配置</i>"
@@ -247,7 +247,7 @@ msgstr "<b>触屏</b> <i>鼠标以外的其他设备也可以进行配置</i>"
 msgid "<i>Example:</i> 1-3 or 1,3,5-7 etc."
 msgstr "<i>比如：</i> 1-3 或者 1,3,5-7 等。"
 
-#: ../ui/settings.glade:929
+#: ../ui/settings.glade:943
 msgid ""
 "<i>Here you can define which tools will be selected If you\n"
 "use the eraser or other device.\n"
@@ -256,7 +256,7 @@ msgstr ""
 "<i>如果需使用橡皮或者其他设备，此处可以对用到的工具可以进行配置。\n"
 "此处可以关闭触屏功能。</i>"
 
-#: ../ui/settings.glade:804
+#: ../ui/settings.glade:818
 msgid ""
 "<i>Here you can define which tools will be selected if you press\n"
 "a button; after you release the button the previously selected\n"
@@ -265,14 +265,14 @@ msgstr ""
 "<i>此处可以设定如果按键就会选择的工具；\n"
 "该键被松开时原先的工具将会被选择</i>"
 
-#: ../ui/settings.glade:2030
+#: ../ui/settings.glade:2188
 msgid ""
 "<i>If audio recording is running, the time stamps are stored to the "
 "handwritten Text and can be replayed.\n"
 "The Audio track is recorded to a separate folder, and liked to there.</i>"
 msgstr ""
 
-#: ../ui/settings.glade:224
+#: ../ui/settings.glade:238
 msgid ""
 "<i>If you add <b>additional space</b> beside the pages\n"
 "you can choose the area of the screen you would\n"
@@ -281,11 +281,11 @@ msgstr ""
 "<i>如果在页面之间加入了<b>额外的空隙</b>\n"
 "则可以选择屏幕上额外的操作区域</i>"
 
-#: ../ui/settings.glade:170
+#: ../ui/settings.glade:184
 msgid "<i>If you have a tablet pen you can get different line widths</i>"
 msgstr "<i>如果您有Tablet笔则可以获得不同的线宽。</i>"
 
-#: ../ui/settings.glade:728
+#: ../ui/settings.glade:742
 msgid ""
 "<i>If you open a PDF and there is a\n"
 "Xournal file with the same name it will open the xoj file.</i>"
@@ -293,7 +293,7 @@ msgstr ""
 "<i>如果您打开一个PDF文件，但是此处有一个有同样的文件名的xoj文件，\n"
 "则Xournal文件将会被打开。</i>"
 
-#: ../ui/settings.glade:324
+#: ../ui/settings.glade:338
 msgid ""
 "<i>Put a ruler on your screen to calibrate the zoom level to fit your "
 "screen. Takes effect after restarting xournalpp.\n"
@@ -303,17 +303,17 @@ msgstr ""
 "在Xournal++重启时将会发挥作用。\n"
 "标尺的长度单位是厘米，游标的单位是dpi。</i>"
 
-#: ../ui/settings.glade:133
+#: ../ui/settings.glade:147
 msgid "<i>Select some advanced input options</i>"
 msgstr ""
 
-#: ../ui/settings.glade:1339
+#: ../ui/settings.glade:1396
 msgid ""
 "<i>The commands will be executed in the UI Thread, make sure\n"
 "they are not blocking!</i>"
 msgstr ""
 
-#: ../ui/settings.glade:548
+#: ../ui/settings.glade:562
 msgid "<i>This name will be proposed if you save a new document</i>"
 msgstr "这个名字是在文件保存时候的建议名。"
 
@@ -329,15 +329,15 @@ msgstr ""
 msgid "About Xournal++"
 msgstr "关于Xournal++"
 
-#: ../src/control/XournalMain.cpp:245
+#: ../src/control/XournalMain.cpp:250
 msgid "Absolute path for the audio files playback"
 msgstr ""
 
-#: ../ui/main.glade:1086
+#: ../ui/main.glade:1233
 msgid "Add/Edit Tex"
 msgstr "插入/编辑TeX"
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:48
+#: ../src/control/stockdlg/XojOpenDlg.cpp:51
 msgid "All files"
 msgstr "所有文件"
 
@@ -356,7 +356,7 @@ msgid "Apply to current page"
 msgstr "删除当前页"
 
 #: ../src/control/stockdlg/ImageOpenDlg.cpp:30
-#: ../src/control/stockdlg/XojOpenDlg.cpp:147
+#: ../src/control/stockdlg/XojOpenDlg.cpp:152
 msgid "Attach file to the journal"
 msgstr "将文件附加到日记"
 
@@ -381,15 +381,15 @@ msgstr "变量\"{1\"}不能为整数，其值为NULL"
 msgid "Attribute color not set!"
 msgstr "颜色未设置"
 
-#: ../ui/settings.glade:2051
+#: ../ui/settings.glade:2209
 msgid "Audio Folder"
 msgstr ""
 
-#: ../ui/settings.glade:2088
+#: ../ui/settings.glade:2246
 msgid "Audio Recording"
 msgstr ""
 
-#: ../src/control/AudioController.cpp:100
+#: ../src/control/AudioController.cpp:98
 msgid ""
 "Audio folder not set! Recording won't work!\n"
 "Please set the recording folder under \"Preferences > Audio recording\""
@@ -400,16 +400,16 @@ msgstr ""
 msgid "Authors:"
 msgstr "<b>作者：</b>"
 
-#: ../ui/settings.glade:1170
+#: ../ui/settings.glade:1227
 msgid "Autodetect"
 msgstr ""
 
-#: ../ui/settings.glade:456
+#: ../ui/settings.glade:470
 #, fuzzy
 msgid "Autosave every ... minutes:"
 msgstr "自动保存间隔分钟数："
 
-#: ../src/control/Control.cpp:254
+#: ../src/control/Control.cpp:256
 #, fuzzy
 msgid "Autosave failed with an error: {1}"
 msgstr "打开文件出错：{1}"
@@ -418,8 +418,7 @@ msgstr "打开文件出错：{1}"
 msgid "Autosave: {1}"
 msgstr "自动保存：{1}"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:333
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:336
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:429
 msgid "Back"
 msgstr "后退"
 
@@ -429,11 +428,11 @@ msgstr "后退"
 msgid "Background"
 msgstr "背景"
 
-#: ../ui/settings.glade:1520
+#: ../ui/settings.glade:1577
 msgid "Background color for window Background"
 msgstr ""
 
-#: ../ui/settings.glade:1857
+#: ../ui/settings.glade:1929
 msgid "Big cursor for pen"
 msgstr "画笔使用大光标"
 
@@ -447,11 +446,11 @@ msgstr "黑色"
 msgid "Blue"
 msgstr "蓝色"
 
-#: ../ui/settings.glade:1509
+#: ../ui/settings.glade:1566
 msgid "Border color"
 msgstr "边界颜色"
 
-#: ../ui/settings.glade:1495
+#: ../ui/settings.glade:1552
 #, fuzzy
 msgid "Border color for current page and other selections"
 msgstr "當前頁和選中項目的邊界顏色"
@@ -460,8 +459,8 @@ msgstr "當前頁和選中項目的邊界顏色"
 msgid "Built on:"
 msgstr ""
 
-#: ../src/control/Control.cpp:2022 ../src/control/Control.cpp:2534
-#: ../src/control/Control.cpp:2570 ../src/control/XournalMain.cpp:124
+#: ../src/control/Control.cpp:2058 ../src/control/Control.cpp:2581
+#: ../src/control/Control.cpp:2619 ../src/control/XournalMain.cpp:128
 msgid "Cancel"
 msgstr "取消"
 
@@ -478,7 +477,7 @@ msgstr "改变字体"
 msgid "Change stroke fill"
 msgstr "改变笔划粗细"
 
-#: ../src/undo/SizeUndoAction.cpp:145
+#: ../src/undo/SizeUndoAction.cpp:139
 msgid "Change stroke width"
 msgstr "改变笔划粗细"
 
@@ -486,7 +485,7 @@ msgstr "改变笔划粗细"
 msgid "Color \"{1}\" unknown (not defined in default color list)!"
 msgstr "色彩\"{1}\"未定义！"
 
-#: ../ui/main.glade:588
+#: ../ui/main.glade:633
 msgid "Configure Page Template"
 msgstr ""
 
@@ -494,8 +493,8 @@ msgstr ""
 msgid "Contents"
 msgstr "内容"
 
-#: ../src/control/Control.cpp:1036 ../src/control/Control.cpp:1044
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:321
+#: ../src/control/Control.cpp:1047 ../src/control/Control.cpp:1055
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:402
 msgid "Copy"
 msgstr "拷贝"
 
@@ -516,37 +515,51 @@ msgstr "末页"
 msgid "Copy page"
 msgstr "拷贝一页"
 
+#: ../src/control/LatexController.cpp:103
+msgid "Could not convert tex to PDF: {1} (exit code: {2})"
+msgstr ""
+
 #: ../src/control/jobs/SaveJob.cpp:137
 msgid ""
 "Could not create backup! (The file was created from an older Xournal version)"
 msgstr "未能产生备份文件！(此文件应为老版本Xournal所建)"
 
-#: ../src/util/Util.cpp:97
+#: ../src/util/Util.cpp:94
 #, fuzzy
 msgid "Could not create folder: {1}"
 msgstr "不能打开文件\"{1}\""
 
-#: ../src/control/Control.cpp:218 ../src/control/Control.cpp:235
+#: ../src/control/Control.cpp:220 ../src/control/Control.cpp:237
 #, fuzzy
 msgid "Could not delete old autosave file \"{1}\""
 msgstr "不能打开文件\"{1}\""
 
-#: ../src/control/LatexController.cpp:381
+#: ../src/control/LatexController.cpp:428
 msgid ""
-"Could not find Xournal++ LaTeX executable relative or in Path.\n"
-"Searched for: mathtex-xournalpp.cgi"
+"Could not find pdflatex in Path.\n"
+"Please install pdflatex first and make sure it's in the Path."
 msgstr ""
+
+#: ../src/control/LatexController.cpp:299
+#, fuzzy
+msgid "Could not load LaTeX PDF file, URL-Error: {1}"
+msgstr "未能提取LaTeX图像文件{1}"
+
+#: ../src/control/LatexController.cpp:307
+#, fuzzy
+msgid "Could not load LaTeX PDF file: {1}"
+msgstr "不能打开文件\"{1}\""
 
 #: ../src/control/pagetype/PageTypeHandler.cpp:18
 #, fuzzy
 msgid "Could not load pagetemplates.ini file"
 msgstr "不能打开文件\"{1}\""
 
-#: ../src/control/xojfile/LoadHandler.cpp:123
+#: ../src/control/xojfile/LoadHandler.cpp:124
 msgid "Could not open file: \"{1}\""
 msgstr "不能打开文件\"{1}\""
 
-#: ../src/gui/MainWindow.cpp:93
+#: ../src/gui/MainWindow.cpp:86
 msgid ""
 "Could not parse custom toolbar.ini file: {1}\n"
 "Toolbars will not be available"
@@ -554,7 +567,7 @@ msgstr ""
 "未能解析配置文件toolbar.ini: {1}\n"
 "工具条将不可用"
 
-#: ../src/gui/MainWindow.cpp:83
+#: ../src/gui/MainWindow.cpp:76
 msgid ""
 "Could not parse general toolbar.ini file: {1}\n"
 "No Toolbars will be available"
@@ -562,7 +575,7 @@ msgstr ""
 "未能解析一般文件toolbar.ini: {1}\n"
 "工具条将不可用"
 
-#: ../src/control/xojfile/LoadHandler.cpp:328
+#: ../src/control/xojfile/LoadHandler.cpp:347
 msgid "Could not read image: {1}. Error message: {2}"
 msgstr "未能读入图像：{1}。错误提示为：{2}"
 
@@ -574,22 +587,23 @@ msgstr ""
 "未能重复操作\"{1}\"\n"
 "有错误发生***请提交一个错误报告***"
 
-#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:214
+#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:210
 msgid "Could not remove tool item from Toolbar {1} on position {2}"
 msgstr ""
 
-#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:209
+#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:205
 msgid "Could not remove tool item {1} from Toolbar {2} on position {3}"
 msgstr ""
 
-#: ../src/control/Control.cpp:228 ../src/control/Control.cpp:247
+#: ../src/control/Control.cpp:230 ../src/control/Control.cpp:249
 #, fuzzy
 msgid "Could not rename autosave file from \"{1}\" to \"{2}\""
 msgstr "未能写入外来数据文件：{1} ({2})"
 
-#: ../src/control/LatexController.cpp:310
-msgid "Could not retrieve LaTeX image file: {1}"
-msgstr "未能提取LaTeX图像文件{1}"
+#: ../src/control/LatexController.cpp:89
+#, fuzzy
+msgid "Could not save .tex file: {1}"
+msgstr "不能打开文件\"{1}\""
 
 #: ../src/undo/UndoRedoHandler.cpp:144
 msgid ""
@@ -599,11 +613,11 @@ msgstr ""
 "未能撤销操作\"{1}\"\n"
 "有错误发生***请提交一个错误报告***"
 
-#: ../src/control/xojfile/SaveHandler.cpp:294
+#: ../src/control/xojfile/SaveHandler.cpp:290
 msgid "Could not write background \"{1}\", {2}"
 msgstr "未能写上背景\"{1}\", {2}"
 
-#: ../src/control/xojfile/SaveHandler.cpp:419
+#: ../src/control/xojfile/SaveHandler.cpp:415
 msgid "Could not write background \"{1}\". Continuing anyway."
 msgstr "未能写上背景\"{1}\"，不管啦继续哦..."
 
@@ -620,7 +634,7 @@ msgstr "当前页"
 msgid "Custom"
 msgstr "设置"
 
-#: ../ui/settings.glade:1231
+#: ../ui/settings.glade:1288
 msgid "Custom Commands (for Method \"Custom\")"
 msgstr ""
 
@@ -633,35 +647,40 @@ msgstr "设置"
 msgid "Customized"
 msgstr "设置过"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:320
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:401
 msgid "Cut"
 msgstr "剪切"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:442
+#: ../ui/settings.glade:1621
+msgid "Dark Theme (restart needed)"
+msgstr ""
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:460
 msgid "Default Tool"
 msgstr "缺省工具"
 
-#: ../ui/settings.glade:1997
+#: ../ui/settings.glade:2155
 msgid "Defaults"
 msgstr "缺省"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:407
 #: ../src/undo/DeleteUndoAction.cpp:102
 msgid "Delete"
 msgstr "删除"
 
-#: ../ui/main.glade:620
+#: ../ui/main.glade:668
 msgid "Delete Layer"
 msgstr "删除层"
 
-#: ../src/control/XournalMain.cpp:123
+#: ../src/control/XournalMain.cpp:127
 msgid "Delete Logfile"
 msgstr "删除日志文件"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:387
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:447
 msgid "Delete current page"
 msgstr "删除当前页"
 
-#: ../src/control/XournalMain.cpp:173
+#: ../src/control/XournalMain.cpp:177
 #, fuzzy
 msgid "Delete file"
 msgstr "删除日志文件"
@@ -674,7 +693,7 @@ msgstr "删除层"
 msgid "Delete stroke"
 msgstr "删除笔划"
 
-#: ../ui/main.glade:1297
+#: ../ui/main.glade:1447
 #, fuzzy
 msgid "Delete this page"
 msgstr "刪除當前頁"
@@ -683,7 +702,7 @@ msgstr "刪除當前頁"
 msgid "Device"
 msgstr "设备"
 
-#: ../ui/settings.glade:1261
+#: ../ui/settings.glade:1318
 msgid "Disable"
 msgstr ""
 
@@ -691,19 +710,19 @@ msgstr ""
 msgid "Disable drawing for this device"
 msgstr "取消此设备绘制"
 
-#: ../ui/settings.glade:1134
+#: ../ui/settings.glade:1191
 msgid "Disable touch if pen is near screen"
 msgstr ""
 
-#: ../ui/settings.glade:1156
+#: ../ui/settings.glade:1213
 msgid "Disabling Method"
 msgstr ""
 
-#: ../src/control/Control.cpp:2533 ../src/control/Control.cpp:2569
+#: ../src/control/Control.cpp:2577 ../src/control/Control.cpp:2618
 msgid "Discard"
 msgstr "丢弃"
 
-#: ../src/control/Control.cpp:1952
+#: ../src/control/Control.cpp:1988
 msgid ""
 "Do not open Autosave files. They may will be overwritten!\n"
 "Copy the files to another folder.\n"
@@ -714,21 +733,17 @@ msgstr ""
 msgid "Do not overwrite the background PDF! This will cause errors!"
 msgstr ""
 
-#: ../src/control/Control.cpp:2566
+#: ../src/control/Control.cpp:2615
 msgid "Document file was removed."
 msgstr "文档已删除。"
 
-#: ../src/control/xojfile/LoadHandler.cpp:202
+#: ../src/control/xojfile/LoadHandler.cpp:203
 msgid "Document is not complete (maybe the end is cut off?)"
 msgstr "文档文件不完整"
 
 #: ../src/model/Document.cpp:393
 msgid "Document not loaded! ({1}), {2}"
 msgstr "文档未加载！({1}), {2}"
-
-#: ../src/control/XournalMain.cpp:242
-msgid "Don't compress PDF files (for debugging)"
-msgstr "勿压缩PDF文件(调试用)"
 
 #: ../src/control/pagetype/PageTypeHandler.cpp:26
 msgid "Dotted"
@@ -740,13 +755,13 @@ msgstr "在这里和工具条之间可以来回拖动条目。"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:99
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:40
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:420
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:465
 msgid "Draw Arrow"
 msgstr "绘制箭头"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:97
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:39
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:416
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:464
 msgid "Draw Circle"
 msgstr "绘制圆形"
 
@@ -758,20 +773,20 @@ msgstr "绘制直线"
 #: ../src/gui/dialog/ButtonConfigGui.cpp:95
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:29
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:38
-#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:120
-#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:123
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:418
+#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:122
+#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:125
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:463
 msgid "Draw Rectangle"
 msgstr "绘制矩形"
 
-#: ../ui/main.glade:778
+#: ../ui/main.glade:844
 #, fuzzy
 msgid "Draw _Line"
 msgstr "绘制直线"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:101
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:42
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:422
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:466
 msgid "Draw coordinate system"
 msgstr ""
 
@@ -788,26 +803,35 @@ msgstr "勿作修改"
 msgid "Edit text"
 msgstr "编辑文本"
 
-#: ../ui/settings.glade:1249
+#: ../src/undo/EmergencySaveRestore.cpp:35
+#, fuzzy
+msgid "Emergency saved document"
+msgstr "未保存文档"
+
+#: ../ui/settings.glade:1306
 #, fuzzy
 msgid "Enable"
 msgstr "激活标尺"
+
+#: ../ui/settings.glade:1176
+msgid "Enable zoom gestures (needs restart)"
+msgstr ""
 
 #: ../ui/texdialog.glade:66
 msgid "Enter / edit LaTeX Text"
 msgstr ""
 
-#: ../src/undo/EraseUndoAction.cpp:130 ../src/undo/DeleteUndoAction.cpp:99
-#: ../src/undo/AddUndoAction.cpp:104
+#: ../src/undo/AddUndoAction.cpp:104 ../src/undo/DeleteUndoAction.cpp:99
+#: ../src/undo/EraseUndoAction.cpp:130
 msgid "Erase stroke"
 msgstr "擦除笔划"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:56
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:282
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:308
 msgid "Eraser"
 msgstr "橡皮"
 
-#: ../ui/main.glade:940
+#: ../ui/main.glade:1066
 msgid "Eraser Optio_ns"
 msgstr "橡皮选项(_n)"
 
@@ -815,7 +839,7 @@ msgstr "橡皮选项(_n)"
 msgid "Eraser Type - don't change"
 msgstr ""
 
-#: ../src/control/Control.cpp:2232
+#: ../src/control/Control.cpp:2268
 msgid ""
 "Error annotate PDF file \"{1}\"\n"
 "{2}"
@@ -828,11 +852,11 @@ msgstr ""
 msgid "Error export PDF Page"
 msgstr "输出为PDF"
 
-#: ../src/gui/GladeGui.cpp:25
+#: ../src/gui/GladeGui.cpp:26
 msgid "Error loading glade file \"{1}\" (try to load \"{2}\")"
 msgstr "加载glade文件\"{1}\"出错(尝试加载\"{2}\")"
 
-#: ../src/control/Control.cpp:2047
+#: ../src/control/Control.cpp:2083
 msgid "Error opening file \"{1}\""
 msgstr "打开文件\"{1}\"出错"
 
@@ -840,11 +864,11 @@ msgstr "打开文件\"{1}\"出错"
 msgid "Error opening file: \"{1}\""
 msgstr "打开文件\"{1}\"出错"
 
-#: ../src/control/xojfile/LoadHandler.cpp:428
+#: ../src/control/xojfile/LoadHandler.cpp:447
 msgid "Error reading PDF: {1}"
 msgstr "读入PDF出错：{1}"
 
-#: ../src/control/xojfile/LoadHandler.cpp:499
+#: ../src/control/xojfile/LoadHandler.cpp:518
 msgid "Error reading width of a stroke: {1}"
 msgstr "读入笔划粗细出错：{1}"
 
@@ -852,7 +876,7 @@ msgstr "读入笔划粗细出错：{1}"
 msgid "Error: {1}"
 msgstr "错误：{1}"
 
-#: ../src/control/XournalMain.cpp:147
+#: ../src/control/XournalMain.cpp:151
 msgid ""
 "Errorlog cannot be deleted. You have to do it manually.\n"
 "Logfile: {1}"
@@ -868,19 +892,19 @@ msgstr "输出"
 msgid "Export PDF"
 msgstr "输出为PDF"
 
-#: ../ui/main.glade:113
+#: ../ui/main.glade:119
 msgid "Export as..."
 msgstr "输出为..."
 
-#: ../src/control/LatexController.cpp:398
+#: ../src/control/LatexController.cpp:445
 msgid "Failed to generate LaTeX image!"
 msgstr ""
 
-#: ../ui/main.glade:920 ../ui/main.glade:1057
+#: ../ui/main.glade:1044 ../ui/main.glade:1192
 msgid "Fi_ll"
 msgstr ""
 
-#: ../src/util/Util.cpp:127 ../src/util/Util.cpp:148
+#: ../src/util/Util.cpp:123 ../src/util/Util.cpp:143
 msgid ""
 "File couldn't be opened. You have to do it manually:\n"
 "URL: {1}"
@@ -888,23 +912,23 @@ msgstr ""
 "未能打开文件，请手动操作：\n"
 "URL: {1}"
 
-#: ../src/control/Control.cpp:1982
+#: ../src/control/Control.cpp:2018
 msgid "Filename: {1}"
 msgstr "文件名：{1}"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:445
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:500
 msgid "Fill"
 msgstr ""
 
-#: ../ui/main.glade:928 ../ui/main.glade:1065
+#: ../ui/main.glade:1053 ../ui/main.glade:1201
 msgid "Fill transparency"
 msgstr ""
 
-#: ../ui/main.glade:1492
+#: ../ui/main.glade:1634
 msgid "Find next occurrence of the search string"
 msgstr ""
 
-#: ../ui/main.glade:1471
+#: ../ui/main.glade:1613
 msgid "Find previous occurrence of the search string"
 msgstr ""
 
@@ -912,37 +936,43 @@ msgstr ""
 msgid "Font"
 msgstr "字体"
 
-#: ../ui/main.glade:289
+#: ../ui/main.glade:338
 msgid "Fullscreen"
 msgstr "全屏"
 
-#: ../ui/about.glade:233
+#: ../ui/about.glade:234
 msgid "GNU GPLv2 or later"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:331
+#: ../ui/settings.glade:1072
+msgid ""
+"GTK Touch / Scrolling workaround. Change Scroll / Touch behavoir. Enabled "
+"touch drawing. Needs restart."
+msgstr ""
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:428
 msgid "Go to first page"
 msgstr "首页"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:344
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:432
 msgid "Go to last page"
 msgstr "末页"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:349
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:435
 #, fuzzy
 msgid "Go to next layer"
 msgstr "末页"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:339
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:430
 msgid "Go to page"
 msgstr "跳转到页面"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:347
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:434
 #, fuzzy
 msgid "Go to previous layer"
 msgstr "首页"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:351
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:436
 #, fuzzy
 msgid "Go to top layer"
 msgstr "跳转到页面"
@@ -966,16 +996,20 @@ msgstr "灰色"
 msgid "Green"
 msgstr "绿色"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:378
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:411
 msgid "Grid Snapping"
 msgstr ""
 
-#: ../ui/main.glade:843
+#: ../ui/settings.glade:2113
+msgid "Grid snapping tolerance:"
+msgstr ""
+
+#: ../ui/main.glade:915
 msgid "H_and Tool"
 msgstr "手形工具(_a)"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:63
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:426
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:474
 msgid "Hand"
 msgstr "手形工具"
 
@@ -983,16 +1017,16 @@ msgstr "手形工具"
 msgid "Height:"
 msgstr "高度："
 
-#: ../ui/main.glade:379
+#: ../ui/main.glade:407
 #, fuzzy
 msgid "Hide Menu"
 msgstr "隐藏菜单条"
 
-#: ../ui/settings.glade:1683 ../ui/settings.glade:1753
+#: ../ui/settings.glade:1755 ../ui/settings.glade:1825
 msgid "Hide Menubar"
 msgstr "隐藏菜单条"
 
-#: ../ui/settings.glade:1698 ../ui/settings.glade:1768
+#: ../ui/settings.glade:1770 ../ui/settings.glade:1840
 msgid "Hide Sidebar"
 msgstr "隐藏侧边栏"
 
@@ -1001,26 +1035,31 @@ msgstr "隐藏侧边栏"
 msgid "Hide all"
 msgstr "隐藏菜单条"
 
-#: ../ui/settings.glade:1613
+#: ../ui/settings.glade:1685
 msgid "Hide the horizontal scrollbar"
 msgstr ""
 
-#: ../ui/settings.glade:1628
+#: ../ui/settings.glade:1700
 msgid "Hide the vertical scrollbar"
 msgstr ""
 
+#: ../ui/settings.glade:1944
+#, fuzzy
+msgid "Highlight cursor position"
+msgstr "高亮选项(_i)"
+
 #: ../src/gui/dialog/ButtonConfigGui.cpp:57
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:399
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:457
 msgid "Highlighter"
 msgstr "高亮"
 
-#: ../ui/main.glade:1014
+#: ../ui/main.glade:1146
 #, fuzzy
 msgid "Highlighter Opti_ons"
 msgstr "高亮选项(_i)"
 
 #: ../src/control/pagetype/PageTypeHandler.cpp:32
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:403
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:459
 msgid "Image"
 msgstr "图片"
 
@@ -1028,11 +1067,11 @@ msgstr "图片"
 msgid "Images"
 msgstr "图片"
 
-#: ../ui/settings.glade:390
+#: ../ui/settings.glade:404
 msgid "Input"
 msgstr "输入"
 
-#: ../ui/settings.glade:1090
+#: ../ui/settings.glade:1119
 msgid "Input Device"
 msgstr "输入设备"
 
@@ -1040,7 +1079,7 @@ msgstr "输入设备"
 msgid "Insert Latex"
 msgstr "插入LaTeX"
 
-#: ../ui/main.glade:1277
+#: ../ui/main.glade:1427
 msgid "Insert a copy of the current page below"
 msgstr ""
 
@@ -1048,7 +1087,7 @@ msgstr ""
 msgid "Insert elements"
 msgstr "插入元素"
 
-#: ../src/undo/InsertUndoAction.cpp:47 ../src/gui/dialog/ButtonConfigGui.cpp:59
+#: ../src/gui/dialog/ButtonConfigGui.cpp:59 ../src/undo/InsertUndoAction.cpp:47
 msgid "Insert image"
 msgstr "插入图片"
 
@@ -1060,11 +1099,11 @@ msgstr "插入LaTeX"
 msgid "Insert layer"
 msgstr "插入层"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:394
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:443
 msgid "Insert page"
 msgstr "插入页面"
 
-#: ../src/control/XournalMain.cpp:244
+#: ../src/control/XournalMain.cpp:249
 msgid "Jump to Page (first Page: 1)"
 msgstr "跳到页面(第一页:1)"
 
@@ -1086,7 +1125,7 @@ msgstr "选择图层"
 msgid "Layer {1}"
 msgstr "{1}图层"
 
-#: ../ui/about.glade:217
+#: ../ui/about.glade:218
 msgid "License"
 msgstr ""
 
@@ -1104,7 +1143,7 @@ msgstr "浅绿"
 msgid "Lined"
 msgstr "画线的"
 
-#: ../ui/settings.glade:772
+#: ../ui/settings.glade:786
 msgid "Load / Save"
 msgstr "加载/保存"
 
@@ -1112,13 +1151,13 @@ msgstr "加载/保存"
 msgid "Load file"
 msgstr "加载文件"
 
-#: ../src/gui/PageView.cpp:738
+#: ../src/gui/PageView.cpp:739
 #: ../src/gui/sidebar/previews/base/SidebarPreviewBaseEntry.cpp:105
 #: ../src/gui/toolbarMenubar/ToolPageLayer.cpp:20
 msgid "Loading..."
 msgstr "加载中..."
 
-#: ../ui/toolbarManageDialog.glade:8 ../ui/toolbarCustomizeDialog.glade:10
+#: ../ui/toolbarCustomizeDialog.glade:10 ../ui/toolbarManageDialog.glade:8
 msgid "Manage Toolbar"
 msgstr "定制工具条"
 
@@ -1128,11 +1167,17 @@ msgid "Mangenta"
 msgstr "品红"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:81
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:437
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:514
 msgid "Medium"
 msgstr "中"
 
-#: ../src/control/XournalMain.cpp:462
+#: ../src/control/XournalMain.cpp:460
+msgid ""
+"Missing the needed UI file! .app corrupted?\n"
+"Path: {1}"
+msgstr ""
+
+#: ../src/control/XournalMain.cpp:474
 msgid ""
 "Missing the needed UI file, could not find them at any location.\n"
 "Not relative\n"
@@ -1140,7 +1185,7 @@ msgid ""
 "Not in {1}"
 msgstr ""
 
-#: ../ui/settings.glade:883
+#: ../ui/settings.glade:897
 msgid "Mouse Button"
 msgstr "鼠标按钮"
 
@@ -1161,7 +1206,7 @@ msgstr "向后移动页面"
 msgid "Move page upwards"
 msgstr "向前移动页面"
 
-#: ../ui/main.glade:531
+#: ../ui/main.glade:571
 msgid "N_ext annotated page"
 msgstr "下一个标注页(_e)"
 
@@ -1169,31 +1214,31 @@ msgstr "下一个标注页(_e)"
 msgid "New"
 msgstr "新建"
 
-#: ../ui/main.glade:571
+#: ../ui/main.glade:614
 msgid "New Page _After"
 msgstr "新建后页(_A)"
 
-#: ../ui/main.glade:563
+#: ../ui/main.glade:605
 msgid "New Page _Before"
 msgstr "新建前页(_B)"
 
-#: ../ui/main.glade:580
+#: ../ui/main.glade:624
 msgid "New Page at _End"
 msgstr "新建尾页(_E)"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:316
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:388
 msgid "New Xournal"
 msgstr "新建日记"
 
-#: ../ui/main.glade:611
+#: ../ui/main.glade:658
 msgid "New _Layer"
 msgstr "新建图层(_L)"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:342
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:431
 msgid "Next"
 msgstr "下一个"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:355
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:438
 msgid "Next annotated page"
 msgstr "下一个标注页面"
 
@@ -1220,20 +1265,20 @@ msgstr ""
 msgid "Open Image"
 msgstr "打开图片"
 
-#: ../src/control/XournalMain.cpp:121
+#: ../src/control/XournalMain.cpp:125
 msgid "Open Logfile"
 msgstr "打开日志文件"
 
-#: ../src/control/XournalMain.cpp:122
+#: ../src/control/XournalMain.cpp:126
 msgid "Open Logfile directory"
 msgstr "打开日志文件目录"
 
 #: ../src/control/stockdlg/XojOpenDlg.cpp:16
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:318
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:389
 msgid "Open file"
 msgstr "打开文件"
 
-#: ../src/control/RecentManager.cpp:241
+#: ../src/control/RecentManager.cpp:244
 msgctxt "{1} is a URI"
 msgid "Open {1}"
 msgstr "打开{1}"
@@ -1247,7 +1292,7 @@ msgstr "橙色"
 msgid "PDF Export"
 msgstr "输出为PDF"
 
-#: ../src/gui/MainWindow.cpp:732
+#: ../src/gui/MainWindow.cpp:816
 msgid "PDF Page {1}"
 msgstr "PDF页码{1}"
 
@@ -1255,17 +1300,17 @@ msgstr "PDF页码{1}"
 msgid "PDF background missing"
 msgstr "PDF背景丢失"
 
-#: ../src/control/XournalMain.cpp:223
+#: ../src/control/XournalMain.cpp:230
 msgid "PDF file successfully created"
 msgstr "PDF文件成功建立"
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:58
-#: ../src/control/jobs/PdfExportJob.cpp:23
 #: ../src/control/jobs/CustomExportJob.cpp:27
+#: ../src/control/jobs/PdfExportJob.cpp:23
+#: ../src/control/stockdlg/XojOpenDlg.cpp:61
 msgid "PDF files"
 msgstr "PDF文件"
 
-#: ../src/control/XournalMain.cpp:243
+#: ../src/control/XournalMain.cpp:248
 msgid "PDF output filename"
 msgstr "PDF输出文件名"
 
@@ -1283,7 +1328,7 @@ msgstr ""
 msgid "PNG with transparent background"
 msgstr "纸张背景(_a)"
 
-#: ../ui/main.glade:540
+#: ../ui/main.glade:581
 #, fuzzy
 msgid "P_revious annotated Page"
 msgstr "前一個標註頁(_r)"
@@ -1325,35 +1370,35 @@ msgstr "页码："
 msgid "Paper Format"
 msgstr "纸张样式"
 
-#: ../ui/main.glade:643
+#: ../ui/main.glade:693
 msgid "Paper _Color"
 msgstr "纸张颜色(_C)"
 
-#: ../ui/main.glade:635
+#: ../ui/main.glade:684
 msgid "Paper _Format"
 msgstr "纸张样式(_F)"
 
-#: ../ui/main.glade:651
+#: ../ui/main.glade:702
 msgid "Paper b_ackground"
 msgstr "纸张背景(_a)"
 
-#: ../ui/about.glade:201
+#: ../ui/about.glade:202
 msgid ""
 "Partial based on Xournal\n"
 "by Denis Auroux"
 msgstr ""
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:403
 #: ../src/undo/AddUndoAction.cpp:108
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:322
 msgid "Paste"
 msgstr "粘贴"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:55
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:382
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:286
 msgid "Pen"
 msgstr "画笔"
 
-#: ../ui/main.glade:859
+#: ../ui/main.glade:932
 msgid "Pen _Options"
 msgstr "画笔选项(_O)"
 
@@ -1361,9 +1406,9 @@ msgstr "画笔选项(_O)"
 msgid "Plain"
 msgstr "空白"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:473
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:32
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:106
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:413
 #, fuzzy
 msgid "Play Object"
 msgstr "选择对象"
@@ -1372,11 +1417,11 @@ msgstr "选择对象"
 msgid "Predefined"
 msgstr "预定"
 
-#: ../ui/main.glade:251
+#: ../ui/main.glade:297
 msgid "Preferences"
 msgstr "偏好设置"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:461
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:417
 msgid "Presentation mode"
 msgstr "演讲模式"
 
@@ -1384,15 +1429,15 @@ msgstr "演讲模式"
 msgid "Range"
 msgstr "范围"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:371
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:479
 msgid "Rec / Stop"
 msgstr ""
 
-#: ../ui/main.glade:299
+#: ../ui/main.glade:1225
 msgid "Rec-Stop"
 msgstr ""
 
-#: ../ui/main.glade:61
+#: ../ui/main.glade:63
 msgid "Recent _Documents"
 msgstr "最近文档(_D)"
 
@@ -1401,8 +1446,8 @@ msgstr "最近文档(_D)"
 msgid "Red"
 msgstr "红色"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:397
 #: ../src/undo/UndoRedoHandler.cpp:293
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:327
 msgid "Redo"
 msgstr "重复"
 
@@ -1410,15 +1455,15 @@ msgstr "重复"
 msgid "Redo: "
 msgstr "重复："
 
-#: ../src/control/Control.cpp:2021
+#: ../src/control/Control.cpp:2057
 msgid "Remove PDF Background"
 msgstr "去掉PDF背景"
 
-#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:202
+#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:198
 msgid "Removed tool item from Toolbar {1} ID {2}"
 msgstr ""
 
-#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:198
+#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:194
 msgid "Removed tool item {1} from Toolbar {2} ID {3}"
 msgstr ""
 
@@ -1431,7 +1476,7 @@ msgstr ""
 msgid "Resolution"
 msgstr "解析度："
 
-#: ../src/control/XournalMain.cpp:174
+#: ../src/control/XournalMain.cpp:178
 #, fuzzy
 msgid "Restore file"
 msgstr "保存文件"
@@ -1441,33 +1486,37 @@ msgstr "保存文件"
 msgid "Rotation"
 msgstr "解析度："
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:375
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:410
 msgid "Rotation Snapping"
+msgstr ""
+
+#: ../ui/settings.glade:2083
+msgid "Rotation snapping tolerance:"
 msgstr ""
 
 #: ../src/control/pagetype/PageTypeHandler.cpp:24
 msgid "Ruled"
 msgstr "定标"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:432
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:467
 msgid "Ruler"
 msgstr "标尺"
 
-#: ../src/control/jobs/SaveJob.cpp:13 ../src/control/Control.cpp:2532
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:315
+#: ../src/control/Control.cpp:2576 ../src/control/jobs/SaveJob.cpp:13
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:390
 msgid "Save"
 msgstr "保存"
 
-#: ../src/control/Control.cpp:2568
+#: ../src/control/Control.cpp:2617
 msgid "Save As"
 msgstr "保存为"
 
-#: ../src/control/Control.cpp:2352 ../src/gui/dialog/PageTemplateDialog.cpp:112
+#: ../src/control/Control.cpp:2388 ../src/gui/dialog/PageTemplateDialog.cpp:112
 msgid "Save File"
 msgstr "保存文件"
 
-#: ../src/control/jobs/SaveJob.cpp:151
 #: ../src/control/jobs/CustomExportJob.cpp:276
+#: ../src/control/jobs/SaveJob.cpp:151
 #, fuzzy
 msgid "Save file error: {1}"
 msgstr "打开文件出错：{1}"
@@ -1476,7 +1525,7 @@ msgstr "打开文件出错：{1}"
 msgid "Scale"
 msgstr "缩放"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:324
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:405
 msgid "Search"
 msgstr "搜索"
 
@@ -1485,12 +1534,12 @@ msgstr "搜索"
 msgid "Select Background Color"
 msgstr "选色"
 
-#: ../ui/settings.glade:2065
+#: ../ui/settings.glade:2223
 #, fuzzy
 msgid "Select Folder"
 msgstr "选色"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:447
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:476
 msgid "Select Font"
 msgstr "选择字体"
 
@@ -1498,9 +1547,9 @@ msgstr "选择字体"
 msgid "Select Image"
 msgstr "选择图片"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:471
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:31
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:99
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:410
 msgid "Select Object"
 msgstr "选择对象"
 
@@ -1508,21 +1557,21 @@ msgstr "选择对象"
 msgid "Select PDF Page"
 msgstr "选择PDF页面"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:470
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:10
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:29
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:85
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:125
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:408
 msgid "Select Rectangle"
 msgstr "选择矩形"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:469
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:30
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:92
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:406
 msgid "Select Region"
 msgstr "选择区域"
 
-#: ../src/control/Control.cpp:2020
+#: ../src/control/Control.cpp:2056
 msgid "Select another PDF"
 msgstr "选择其他PDF"
 
@@ -1549,19 +1598,19 @@ msgstr "选择矩形"
 msgid "Select region"
 msgstr "选择区域"
 
-#: ../ui/settings.glade:1964
+#: ../ui/settings.glade:2051
 msgid "Select the tool and Settings if you press the Default Button"
 msgstr "按下缺省按钮，此工具及其设置将会生效"
 
-#: ../ui/settings.glade:1789
+#: ../ui/settings.glade:1861
 msgid "Select toolbar:"
 msgstr "选择工具条："
 
-#: ../ui/settings.glade:1543
+#: ../ui/settings.glade:1600
 msgid "Selection Color (Text, Stroke Selection etc.)"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:120
+#: ../src/control/XournalMain.cpp:124
 msgid "Send Bugreport"
 msgstr "选择错误报告"
 
@@ -1569,11 +1618,15 @@ msgstr "选择错误报告"
 msgid "Separator"
 msgstr "分割线"
 
-#: ../ui/settings.glade:1123
+#: ../ui/settings.glade:1165
+msgid "Settings for Touch devices"
+msgstr ""
+
+#: ../ui/settings.glade:1152
 msgid "Settings for Touch devices which are detected by GTK."
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:430
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:462
 msgid "Shape Recognizer"
 msgstr "识别形状"
 
@@ -1596,19 +1649,19 @@ msgstr "只显示未使用页面(一个未使用页面)"
 msgid "Show only not used pages ({1} unused pages)"
 msgstr "只显示未使用页面({1}个未使用页面)"
 
-#: ../ui/main.glade:322
+#: ../ui/main.glade:348
 msgid "Show sidebar"
 msgstr "显示侧边栏"
 
-#: ../ui/settings.glade:1412
+#: ../ui/settings.glade:1469
 msgid "Show sidebar on the right side"
 msgstr "侧边栏右置"
 
-#: ../ui/settings.glade:1427
+#: ../ui/settings.glade:1484
 msgid "Show vertical scrollbar on the left side"
 msgstr "垂直滚动条左置"
 
-#: ../src/control/XournalMain.cpp:309
+#: ../src/control/XournalMain.cpp:308
 #, fuzzy
 msgid ""
 "Sorry, Xournal++ can only open one file at once.\n"
@@ -1617,7 +1670,7 @@ msgstr ""
 "Xournal只能打開一個命令行檔案。\n"
 "其他的會被忽略。"
 
-#: ../src/control/XournalMain.cpp:324
+#: ../src/control/XournalMain.cpp:323
 #, fuzzy
 msgid ""
 "Sorry, Xournal++ cannot open remote files at the moment.\n"
@@ -1630,13 +1683,13 @@ msgstr ""
 msgid "Standard"
 msgstr "标准"
 
-#: ../ui/main.glade:1610
+#: ../ui/main.glade:1752
 msgid "State PLACEHOLDER"
 msgstr ""
 
-#: ../src/undo/RecognizerUndoAction.cpp:101
 #: ../src/gui/dialog/ButtonConfigGui.cpp:103
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:43
+#: ../src/undo/RecognizerUndoAction.cpp:101
 msgid "Stroke recognizer"
 msgstr "笔划识别"
 
@@ -1644,19 +1697,19 @@ msgstr "笔划识别"
 msgid "Successfully saved document to \"{1}\""
 msgstr "文档已经保存为\"{1}\""
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:128
+#: ../src/control/stockdlg/XojOpenDlg.cpp:132
 msgid "Supported files"
 msgstr "支撑文件"
 
-#: ../ui/main.glade:1236
+#: ../ui/main.glade:1386
 msgid "Swap the current page with the one above"
 msgstr ""
 
-#: ../ui/main.glade:1257
+#: ../ui/main.glade:1407
 msgid "Swap the current page with the one below"
 msgstr ""
 
-#: ../ui/main.glade:337
+#: ../ui/main.glade:363
 msgid "T_oolbars"
 msgstr "工具条(_o)"
 
@@ -1664,16 +1717,16 @@ msgstr "工具条(_o)"
 msgid "Template:"
 msgstr "模板："
 
-#: ../ui/settings.glade:1317
+#: ../ui/settings.glade:1374
 msgid "Test disable"
 msgstr ""
 
-#: ../ui/settings.glade:1304
+#: ../ui/settings.glade:1361
 msgid "Test enable"
 msgstr ""
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:58
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:401
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:458
 msgid "Text"
 msgstr "文本"
 
@@ -1682,7 +1735,7 @@ msgstr "文本"
 msgid "Text %i times found on this page"
 msgstr "文本在本页面出现%i次"
 
-#: ../ui/main.glade:1077
+#: ../ui/main.glade:1214
 msgid "Text Font..."
 msgstr "文本字体..."
 
@@ -1710,35 +1763,35 @@ msgstr "文本未找到"
 msgid "Text not found, searched on all pages"
 msgstr "找遍所有页面未找到文本"
 
-#: ../src/control/Control.cpp:1006
+#: ../src/control/Control.cpp:1017
 msgid ""
 "The Toolbarconfiguration \"{1}\" is predefined, would you create a copy to "
 "edit?"
 msgstr "工具条配置\"{1}\"是预置的，要产生一个拷贝到编辑?"
 
-#: ../src/control/Control.cpp:2017
+#: ../src/control/Control.cpp:2053
 msgid "The attached background PDF could not be found."
 msgstr "附加的背景PDF未找到。"
 
-#: ../src/control/Control.cpp:2018
+#: ../src/control/Control.cpp:2054
 msgid "The background PDF could not be found."
 msgstr "背景PDF未找到。"
 
-#: ../src/control/XournalMain.cpp:115
+#: ../src/control/XournalMain.cpp:119
 msgid "The most recent log file name: {1}"
 msgstr "最近的日志文件名：{1}"
 
-#: ../ui/settings.glade:369
+#: ../ui/settings.glade:383
 msgid "The unit of the ruler is cm"
 msgstr "标尺的单位是厘米"
 
-#: ../src/control/XournalMain.cpp:108
+#: ../src/control/XournalMain.cpp:112
 msgid ""
 "There are errorlogfiles from Xournal++. Please send a Bugreport, so the bug "
 "may be fixed."
 msgstr "发现Xournal++的错误日志文件，请发送一个错误报告，将会被修正。"
 
-#: ../src/control/XournalMain.cpp:107
+#: ../src/control/XournalMain.cpp:111
 msgid ""
 "There is an errorlogfile from Xournal++. Please send a Bugreport, so the bug "
 "may be fixed."
@@ -1749,7 +1802,7 @@ msgid "There was an error displaying help: {1}"
 msgstr ""
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:82
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:439
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:515
 msgid "Thick"
 msgstr "粗"
 
@@ -1759,25 +1812,25 @@ msgid "Thickness - don't change"
 msgstr "勿作修改"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:80
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:435
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:513
 msgid "Thin"
 msgstr "细"
 
-#: ../src/control/Control.cpp:2530
+#: ../src/control/Control.cpp:2574
 msgid "This document is not saved yet."
 msgstr ""
 
-#: ../src/control/tools/ImageHandler.cpp:56
 #: ../src/control/PageBackgroundChangeController.cpp:177
+#: ../src/control/tools/ImageHandler.cpp:56
 msgid "This image could not be loaded. Error message: {1}"
 msgstr ""
 
-#: ../ui/settings.glade:1185
+#: ../ui/settings.glade:1242
 #, fuzzy
 msgid "Timeout"
 msgstr "涂白"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:368
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:418
 msgid "Toggle fullscreen"
 msgstr "全屏"
 
@@ -1786,7 +1839,7 @@ msgstr "全屏"
 msgid "Tool - don't change"
 msgstr "勿作修改"
 
-#: ../src/gui/toolbarMenubar/model/ToolbarData.cpp:156
+#: ../src/gui/toolbarMenubar/model/ToolbarData.cpp:152
 msgid "Toolbar found: {1}"
 msgstr "发现工具条：{1}"
 
@@ -1794,11 +1847,11 @@ msgstr "发现工具条：{1}"
 msgid "Toolbars"
 msgstr "工具条"
 
-#: ../ui/settings.glade:1358
+#: ../ui/settings.glade:1415
 msgid "Touch"
 msgstr ""
 
-#: ../ui/settings.glade:1046
+#: ../ui/settings.glade:1060
 msgid ""
 "Touch Screens which are detected by GTK are handled specially, and don't "
 "need to be configured here."
@@ -1812,12 +1865,12 @@ msgstr ""
 msgid "Trying to emergency save the current open document…"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:458
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:416
 msgid "Two pages"
 msgstr "双页"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:396
 #: ../src/undo/UndoRedoHandler.cpp:274
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:326
 msgid "Undo"
 msgstr "撤销"
 
@@ -1825,15 +1878,15 @@ msgstr "撤销"
 msgid "Undo: "
 msgstr "撤销："
 
-#: ../src/control/xojfile/LoadHandler.cpp:241
+#: ../src/control/xojfile/LoadHandler.cpp:260
 msgid "Unexpected root tag: {1}"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:270
+#: ../src/control/xojfile/LoadHandler.cpp:289
 msgid "Unexpected tag in document: \"{1}\""
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:475
+#: ../src/control/xojfile/LoadHandler.cpp:494
 msgid "Unknown background type: {1}"
 msgstr ""
 
@@ -1841,23 +1894,23 @@ msgstr ""
 msgid "Unknown color value \"{1}\""
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:410
+#: ../src/control/xojfile/LoadHandler.cpp:429
 msgid "Unknown domain type: {1}"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:193
+#: ../src/control/xojfile/LoadHandler.cpp:194
 msgid "Unknown parser error"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:345
+#: ../src/control/xojfile/LoadHandler.cpp:364
 msgid "Unknown pixmap::domain type: {1}"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:558
+#: ../src/control/xojfile/LoadHandler.cpp:591
 msgid "Unknown stroke type: \"{1}\", assuming pen"
 msgstr ""
 
-#: ../src/control/Control.cpp:2424
+#: ../src/control/Control.cpp:2460
 msgid "Unsaved Document"
 msgstr "未保存文档"
 
@@ -1866,7 +1919,7 @@ msgstr "未保存文档"
 msgid "Version"
 msgstr "扩展"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:425
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:472
 msgid "Vertical Space"
 msgstr "垂直间距"
 
@@ -1874,7 +1927,7 @@ msgstr "垂直间距"
 msgid "Vertical space"
 msgstr "垂直间距"
 
-#: ../ui/settings.glade:1895
+#: ../ui/settings.glade:1982
 msgid "View"
 msgstr "视图"
 
@@ -1895,7 +1948,7 @@ msgstr "宽度："
 msgid "With PDF background"
 msgstr "使用PDF背景"
 
-#: ../ui/about.glade:187
+#: ../ui/about.glade:188
 msgid "With help from the community"
 msgstr ""
 
@@ -1903,19 +1956,19 @@ msgstr ""
 msgid "Write text"
 msgstr "写文本"
 
-#: ../src/control/xojfile/LoadHandler.cpp:821
+#: ../src/control/xojfile/LoadHandler.cpp:852
 msgid "Wrong count of points ({1})"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:836
+#: ../src/control/xojfile/LoadHandler.cpp:866
 msgid "Wrong number of points, got {1}, expected {2}"
 msgstr ""
 
-#: ../ui/settings.glade:1171
+#: ../ui/settings.glade:1228
 msgid "X11"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:188
+#: ../src/control/xojfile/LoadHandler.cpp:189
 msgid "XML Parser error: {1}"
 msgstr ""
 
@@ -1923,24 +1976,24 @@ msgstr ""
 msgid "Xournal (Compatibility)"
 msgstr ""
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:69
+#: ../src/control/stockdlg/XojOpenDlg.cpp:72
 msgid "Xournal files"
 msgstr "Xournal文件"
 
-#: ../ui/settings.glade:28
+#: ../ui/settings.glade:42
 msgid "Xournal++ Preferences"
 msgstr "Xournal++偏好设置"
 
-#: ../src/control/XournalMain.cpp:168
+#: ../src/control/XournalMain.cpp:172
 msgid "Xournal++ crashed last time. Would you restore it?"
 msgstr ""
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:79 ../src/control/Control.cpp:2359
+#: ../src/control/Control.cpp:2395 ../src/control/stockdlg/XojOpenDlg.cpp:82
 #, fuzzy
 msgid "Xournal++ files"
 msgstr "Xournal文件"
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:89
+#: ../src/control/stockdlg/XojOpenDlg.cpp:92
 #: ../src/gui/dialog/PageTemplateDialog.cpp:119
 #, fuzzy
 msgid "Xournal++ template"
@@ -1958,7 +2011,7 @@ msgid ""
 "Template\"."
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:111
+#: ../src/control/XournalMain.cpp:115
 msgid ""
 "You're using {1}/{2} branch. Send Bugreport will direct you to this repo's "
 "issue tracker."
@@ -1973,19 +2026,19 @@ msgid ""
 "PDF page."
 msgstr ""
 
-#: ../ui/settings.glade:302
+#: ../ui/settings.glade:316
 msgid "Zoom"
 msgstr "缩放"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:362
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:422
 msgid "Zoom fit to screen"
 msgstr "适合屏幕"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:360
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:421
 msgid "Zoom in"
 msgstr "放大"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:358
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:420
 msgid "Zoom out"
 msgstr "缩小"
 
@@ -1993,44 +2046,44 @@ msgstr "缩小"
 msgid "Zoom slider"
 msgstr "缩放游标"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:364
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:423
 msgid "Zoom to 100%"
 msgstr "原始尺寸"
 
-#: ../ui/main.glade:69
+#: ../ui/main.glade:71
 msgid "_Annotate PDF"
 msgstr "标注PDF(_A)"
 
+#: ../src/control/Control.cpp:2389 ../src/control/jobs/BaseExportJob.cpp:26
 #: ../src/control/stockdlg/ImageOpenDlg.cpp:12
 #: ../src/control/stockdlg/XojOpenDlg.cpp:17
-#: ../src/control/jobs/BaseExportJob.cpp:26 ../src/control/Control.cpp:2353
 #: ../src/gui/dialog/PageTemplateDialog.cpp:113
 #, fuzzy
 msgid "_Cancel"
 msgstr "取消"
 
-#: ../ui/main.glade:361
+#: ../ui/main.glade:388
 msgid "_Customize"
 msgstr "设置(_C)"
 
-#: ../ui/main.glade:723
+#: ../ui/main.glade:779
 #, fuzzy
 msgid "_Default Tools"
 msgstr "<b>預設工具</b>"
 
-#: ../ui/main.glade:596
+#: ../ui/main.glade:642
 msgid "_Delete Page"
 msgstr "删除页面(_D)"
 
-#: ../ui/main.glade:153
+#: ../ui/main.glade:162
 msgid "_Edit"
 msgstr "编辑(_E)"
 
-#: ../ui/main.glade:683
+#: ../ui/main.glade:735
 msgid "_Eraser"
 msgstr "橡皮(_E)"
 
-#: ../ui/main.glade:104
+#: ../ui/main.glade:109
 msgid "_Export as PDF"
 msgstr "输出为PDF(_E)"
 
@@ -2038,49 +2091,49 @@ msgstr "输出为PDF(_E)"
 msgid "_File"
 msgstr "文件(_F)"
 
-#: ../ui/main.glade:448
+#: ../ui/main.glade:480
 msgid "_First Page"
 msgstr "首页(_F)"
 
-#: ../ui/main.glade:466
+#: ../ui/main.glade:500
 #, fuzzy
 msgid "_Goto Page"
 msgstr "頁面跳轉(_G)"
 
-#: ../ui/main.glade:1099
+#: ../ui/main.glade:1247
 msgid "_Help"
 msgstr "帮助(_H)"
 
-#: ../ui/main.glade:693
+#: ../ui/main.glade:746
 msgid "_Highlighter"
 msgstr "高亮(_H)"
 
-#: ../ui/main.glade:713
+#: ../ui/main.glade:768
 msgid "_Image"
 msgstr "图片(_I)"
 
-#: ../ui/main.glade:553
+#: ../ui/main.glade:595
 msgid "_Journal"
 msgstr "日志(_J)"
 
-#: ../ui/main.glade:484
+#: ../ui/main.glade:520
 msgid "_Last Page"
 msgstr "末页(_L)"
 
-#: ../ui/main.glade:353
+#: ../ui/main.glade:379
 msgid "_Manage"
 msgstr "管理(_M)"
 
-#: ../ui/main.glade:438
+#: ../ui/main.glade:470
 msgid "_Navigation"
 msgstr "导航(_N)"
 
-#: ../ui/main.glade:508
+#: ../ui/main.glade:546
 #, fuzzy
 msgid "_Next Layer"
 msgstr "下一页(_N)"
 
-#: ../ui/main.glade:475
+#: ../ui/main.glade:510
 msgid "_Next Page"
 msgstr "下一页(_N)"
 
@@ -2090,83 +2143,83 @@ msgstr "下一页(_N)"
 msgid "_Open"
 msgstr "打开{1}"
 
-#: ../ui/main.glade:673
+#: ../ui/main.glade:724
 msgid "_Pen"
 msgstr "画笔(_P)"
 
-#: ../ui/main.glade:281
+#: ../ui/main.glade:329
 msgid "_Presentation Mode"
 msgstr "演讲模式(_P)"
 
-#: ../ui/main.glade:499
+#: ../ui/main.glade:536
 #, fuzzy
 msgid "_Previous Layer"
 msgstr "前一页(_P)"
 
-#: ../ui/main.glade:457
+#: ../ui/main.glade:490
 msgid "_Previous Page"
 msgstr "前一页(_P)"
 
-#: ../src/control/jobs/BaseExportJob.cpp:27 ../src/control/Control.cpp:2354
+#: ../src/control/Control.cpp:2390 ../src/control/jobs/BaseExportJob.cpp:27
 #: ../src/gui/dialog/PageTemplateDialog.cpp:114
 #, fuzzy
 msgid "_Save"
 msgstr "保存"
 
-#: ../ui/main.glade:737
+#: ../ui/main.glade:794
 msgid "_Shape Recognizer"
 msgstr "形状识别(_S)"
 
-#: ../ui/main.glade:703
+#: ../ui/main.glade:757
 msgid "_Text"
 msgstr "文本(_T)"
 
-#: ../ui/main.glade:663
+#: ../ui/main.glade:714
 msgid "_Tools"
 msgstr "工具(_T)"
 
-#: ../ui/main.glade:517
+#: ../ui/main.glade:556
 #, fuzzy
 msgid "_Top Layer"
 msgstr "图层"
 
-#: ../ui/main.glade:273
+#: ../ui/main.glade:320
 msgid "_Two Pages"
 msgstr "双页(_T)"
 
-#: ../ui/main.glade:823
+#: ../ui/main.glade:893
 msgid "_Vertical Space"
 msgstr "垂直间距(_V)"
 
-#: ../ui/main.glade:263
+#: ../ui/main.glade:310
 msgid "_View"
 msgstr "视图(_V)"
 
-#: ../ui/main.glade:1001
+#: ../ui/main.glade:1132
 msgid "_delete strokes"
 msgstr "删除笔划(_d)"
 
-#: ../ui/main.glade:878 ../ui/main.glade:950 ../ui/main.glade:1024
+#: ../ui/main.glade:952 ../ui/main.glade:1076 ../ui/main.glade:1156
 msgid "_fine"
 msgstr "细(_f)"
 
-#: ../ui/main.glade:887 ../ui/main.glade:959 ../ui/main.glade:1033
+#: ../ui/main.glade:962 ../ui/main.glade:1086 ../ui/main.glade:1166
 msgid "_medium"
 msgstr "中(_m)"
 
-#: ../ui/main.glade:983
+#: ../ui/main.glade:1112
 msgid "_standard"
 msgstr "标准(_s)"
 
-#: ../ui/main.glade:896 ../ui/main.glade:968 ../ui/main.glade:1042
+#: ../ui/main.glade:972 ../ui/main.glade:1096 ../ui/main.glade:1176
 msgid "_thick"
 msgstr "粗(_t)"
 
-#: ../ui/main.glade:869
+#: ../ui/main.glade:942
 msgid "_very fine"
 msgstr "极细(_v)"
 
-#: ../ui/main.glade:992
+#: ../ui/main.glade:1122
 msgid "_whiteout"
 msgstr "涂白(_w)"
 
@@ -2179,9 +2232,21 @@ msgstr "范围"
 msgid "cursor"
 msgstr "光标"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:299
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:294
+msgid "dash-/ doted"
+msgstr ""
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:291
+msgid "dashed"
+msgstr ""
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:312
 msgid "delete stroke"
 msgstr "删除笔划"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:297
+msgid "dotted"
+msgstr ""
 
 #: ../ui/exportSettings.glade:213
 msgid "dpi"
@@ -2208,7 +2273,7 @@ msgstr "鼠标"
 msgid "pen"
 msgstr "画笔"
 
-#: ../ui/settings.glade:1212
+#: ../ui/settings.glade:1269
 msgid "s"
 msgstr ""
 
@@ -2221,7 +2286,8 @@ msgstr "保存文件"
 msgid "show"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:285
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:288
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:310
 msgid "standard"
 msgstr "标准"
 
@@ -2234,15 +2300,15 @@ msgstr ""
 msgid "touchscreen"
 msgstr "全屏"
 
-#: ../ui/main.glade:905
+#: ../ui/main.glade:982
 msgid "ver_y thick"
 msgstr "极粗(_y)"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:292
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:311
 msgid "whiteout"
 msgstr "涂白"
 
-#: ../src/control/xojfile/LoadHandler.cpp:835
+#: ../src/control/xojfile/LoadHandler.cpp:865
 msgid "xoj-File: {1}"
 msgstr ""
 
@@ -2338,6 +2404,9 @@ msgstr ""
 
 #~ msgid "Disable Ruler & Stroke Recognizer"
 #~ msgstr "取消标尺和笔划识别"
+
+#~ msgid "Don't compress PDF files (for debugging)"
+#~ msgstr "勿压缩PDF文件(调试用)"
 
 #, fuzzy
 #~ msgid "Drawing type"

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: xournalpp 1.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-12-30 12:21+0100\n"
+"POT-Creation-Date: 2019-01-23 10:36+0100\n"
 "PO-Revision-Date: 2018-11-14 20:04+0100\n"
 "Last-Translator: Andreas Butti <andreasbutti at gmail dot com>\n"
 "Language-Team: Xournal++ team\n"
@@ -16,41 +16,41 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.7.1\n"
 
-#: ../src/undo/DeleteUndoAction.cpp:113 ../src/undo/AddUndoAction.cpp:119
+#: ../src/undo/AddUndoAction.cpp:119 ../src/undo/DeleteUndoAction.cpp:113
 msgid " elements"
 msgstr "元素"
 
-#: ../src/undo/DeleteUndoAction.cpp:128 ../src/undo/AddUndoAction.cpp:134
+#: ../src/undo/AddUndoAction.cpp:134 ../src/undo/DeleteUndoAction.cpp:128
 msgid " image"
 msgstr "圖片"
 
-#: ../src/undo/DeleteUndoAction.cpp:132 ../src/undo/AddUndoAction.cpp:138
+#: ../src/undo/AddUndoAction.cpp:138 ../src/undo/DeleteUndoAction.cpp:132
 msgid " latex"
 msgstr "LaTeX"
 
-#: ../src/gui/MainWindow.cpp:734
+#: ../src/gui/MainWindow.cpp:818
 msgctxt "Page {pagenumber} \"of {pagecount}\""
 msgid " of {1}{2}"
 msgstr "頁，共{1}頁"
 
-#: ../src/undo/DeleteUndoAction.cpp:120 ../src/undo/AddUndoAction.cpp:126
+#: ../src/undo/AddUndoAction.cpp:126 ../src/undo/DeleteUndoAction.cpp:120
 msgid " stroke"
 msgstr "筆劃"
 
-#: ../src/undo/DeleteUndoAction.cpp:124 ../src/undo/AddUndoAction.cpp:130
+#: ../src/undo/AddUndoAction.cpp:130 ../src/undo/DeleteUndoAction.cpp:124
 msgid " text"
 msgstr "文本"
 
-#: ../src/control/settings/Settings.cpp:79
+#: ../src/control/settings/Settings.cpp:90
 #, fuzzy
 msgid "%F-Note-%H-%M"
 msgstr "%F-Note-%H-%M.xoj"
 
-#: ../ui/settings.glade:590
+#: ../ui/settings.glade:604
 msgid "%F-Note-%H-%M.xoj"
 msgstr "%F-Note-%H-%M.xoj"
 
-#: ../ui/settings.glade:613
+#: ../ui/settings.glade:627
 msgid ""
 "%a\tAbbreviated weekday name \t(e.g. Thu)\n"
 "%A\tFull weekday name (e.g. Thursday)\n"
@@ -80,19 +80,19 @@ msgstr ""
 msgid "<b>... or select already used Image:</b>"
 msgstr "<b>...或者選擇已用圖片：</b>"
 
-#: ../ui/settings.glade:271
+#: ../ui/settings.glade:285
 msgid "<b>Add horizontal space</b>"
 msgstr "<b>增加水平間距</b>"
 
-#: ../ui/settings.glade:248
+#: ../ui/settings.glade:262
 msgid "<b>Add vertical space</b>"
 msgstr "<b>增加垂直間距</b>"
 
-#: ../ui/settings.glade:704
+#: ../ui/settings.glade:718
 msgid "<b>Autoload .pdf.xoj</b>"
 msgstr "<b>自動加載.pdf.xoj</b>"
 
-#: ../ui/settings.glade:488
+#: ../ui/settings.glade:502
 msgid ""
 "<b>Autosave Folder</b>\n"
 "<i>If the document already was saved you can find it in the same folder\n"
@@ -104,7 +104,7 @@ msgstr ""
 "<i>如果文檔已經保存，您可以在同一目錄中使用副檔名.autosave.xoj找到該文檔。\n"
 "如果檔案沒有保存，您可以在目錄~/.xournalpp/autosave中找到。</i>"
 
-#: ../ui/settings.glade:428
+#: ../ui/settings.glade:442
 msgid "<b>Autosave</b>"
 msgstr "<b>自動保存</b>"
 
@@ -122,7 +122,7 @@ msgstr "背景"
 msgid "<b>Color</b>"
 msgstr "<b>顏色</b>"
 
-#: ../ui/settings.glade:1464
+#: ../ui/settings.glade:1521
 #, fuzzy
 msgid "<b>Colors</b>"
 msgstr "<b>顏色</b>"
@@ -140,7 +140,7 @@ msgid ""
 "for the fist Page"
 msgstr ""
 
-#: ../ui/settings.glade:1835
+#: ../ui/settings.glade:1907
 msgid "<b>Cursor</b>"
 msgstr "<b>光標</b>"
 
@@ -148,15 +148,15 @@ msgstr "<b>光標</b>"
 msgid "<b>Default Tools</b>"
 msgstr "<b>預設工具</b>"
 
-#: ../ui/settings.glade:577
+#: ../ui/settings.glade:591
 msgid "<b>Default name:</b>"
 msgstr "<b>預設名：</b>"
 
-#: ../ui/settings.glade:524
+#: ../ui/settings.glade:538
 msgid "<b>Default save name</b>"
 msgstr "<b>預設保存名</b>"
 
-#: ../ui/settings.glade:1943
+#: ../ui/settings.glade:2030
 msgid "<b>Default</b>"
 msgstr "<b>預設</b>"
 
@@ -166,11 +166,11 @@ msgid ""
 "Select pages to export"
 msgstr ""
 
-#: ../ui/settings.glade:1002
+#: ../ui/settings.glade:1016
 msgid "<b>Eraser</b>"
 msgstr "<b>橡皮</b>"
 
-#: ../ui/settings.glade:110
+#: ../ui/settings.glade:124
 msgid "<b>Extended Input</b>"
 msgstr "<b>擴展輸入</b>"
 
@@ -180,19 +180,19 @@ msgid ""
 "Select transparency for fill color"
 msgstr ""
 
-#: ../ui/settings.glade:1661
+#: ../ui/settings.glade:1733
 msgid "<b>Fullscreen</b>"
 msgstr "<b>全屏模式</b>"
 
-#: ../ui/settings.glade:658
+#: ../ui/settings.glade:672
 msgid "<b>Help</b> (Placeholders)"
 msgstr "<b>幫助</b> "
 
-#: ../ui/settings.glade:1390
+#: ../ui/settings.glade:1447
 msgid "<b>Left / Right</b>"
 msgstr "<b>左/右</b>"
 
-#: ../ui/settings.glade:819
+#: ../ui/settings.glade:833
 msgid "<b>Middle Mouse Button</b>"
 msgstr "<b>滑鼠中鍵</b>"
 
@@ -205,24 +205,24 @@ msgstr "<b>頁面尺寸</b>"
 msgid "<b>Pagesize</b>"
 msgstr "<b>頁面尺寸</b>"
 
-#: ../ui/settings.glade:1731
+#: ../ui/settings.glade:1803
 msgid "<b>Presentation</b> Another Fullscreen Mode, <i>Start with F5</i>"
 msgstr "<b>演講模式</b> (備選全屏模式 <i>使用F5激活</i>)"
 
-#: ../ui/settings.glade:155
+#: ../ui/settings.glade:169
 msgid "<b>Pressure sensitivity</b>"
 msgstr "<b>壓力敏感</b>"
 
-#: ../ui/settings.glade:849
+#: ../ui/settings.glade:863
 msgid "<b>Right Mouse Button</b>"
 msgstr "<b>滑鼠右鍵</b>"
 
-#: ../ui/settings.glade:1584
+#: ../ui/settings.glade:1656
 #, fuzzy
 msgid "<b>Scrollbars</b>"
 msgstr "<b>顏色</b>"
 
-#: ../ui/settings.glade:200
+#: ../ui/settings.glade:214
 msgid "<b>Scrolling outside the page</b>"
 msgstr "<b>捲出頁面</b>"
 
@@ -230,15 +230,15 @@ msgstr "<b>捲出頁面</b>"
 msgid "<b>Separator</b>"
 msgstr "<b>分割線</b>"
 
-#: ../ui/settings.glade:944
+#: ../ui/settings.glade:958
 msgid "<b>Stylus Button 1</b> Action if the pen button is pressed"
 msgstr ""
 
-#: ../ui/settings.glade:973
+#: ../ui/settings.glade:987
 msgid "<b>Stylus Button 2</b> Action if the pen button is pressed"
 msgstr ""
 
-#: ../ui/settings.glade:1031
+#: ../ui/settings.glade:1045
 msgid ""
 "<b>Touch Screen</b> <i>You can also configure other devices like mice</i>"
 msgstr "<b>觸屏</b> <i>滑鼠以外的其他設備也可以進行配置</i>"
@@ -247,7 +247,7 @@ msgstr "<b>觸屏</b> <i>滑鼠以外的其他設備也可以進行配置</i>"
 msgid "<i>Example:</i> 1-3 or 1,3,5-7 etc."
 msgstr "<i>比如：</i> 1-3 或者 1,3,5-7 等。"
 
-#: ../ui/settings.glade:929
+#: ../ui/settings.glade:943
 msgid ""
 "<i>Here you can define which tools will be selected If you\n"
 "use the eraser or other device.\n"
@@ -256,7 +256,7 @@ msgstr ""
 "<i>如果需使用橡皮或者其他設備，此處可以對用到的工具可以進行配置。\n"
 "此處可以關閉觸屏功能。</i>"
 
-#: ../ui/settings.glade:804
+#: ../ui/settings.glade:818
 msgid ""
 "<i>Here you can define which tools will be selected if you press\n"
 "a button; after you release the button the previously selected\n"
@@ -265,14 +265,14 @@ msgstr ""
 "<i>此處可以設定如果按鍵就會選擇的工具；\n"
 "該鍵被鬆開時原先的工具將會被選擇</i>"
 
-#: ../ui/settings.glade:2030
+#: ../ui/settings.glade:2188
 msgid ""
 "<i>If audio recording is running, the time stamps are stored to the "
 "handwritten Text and can be replayed.\n"
 "The Audio track is recorded to a separate folder, and liked to there.</i>"
 msgstr ""
 
-#: ../ui/settings.glade:224
+#: ../ui/settings.glade:238
 msgid ""
 "<i>If you add <b>additional space</b> beside the pages\n"
 "you can choose the area of the screen you would\n"
@@ -281,11 +281,11 @@ msgstr ""
 "<i>如果在頁面之間加入了<b>額外的空隙</b>\n"
 "則可以選擇屏幕上額外的操作區域</i>"
 
-#: ../ui/settings.glade:170
+#: ../ui/settings.glade:184
 msgid "<i>If you have a tablet pen you can get different line widths</i>"
 msgstr "<i>如果您有Tablet筆則可以獲得不同的綫寬。</i>"
 
-#: ../ui/settings.glade:728
+#: ../ui/settings.glade:742
 msgid ""
 "<i>If you open a PDF and there is a\n"
 "Xournal file with the same name it will open the xoj file.</i>"
@@ -293,7 +293,7 @@ msgstr ""
 "<i>如果您打開一個PDF檔案，但是此處有一個有同樣的檔案名的xoj檔案，\n"
 "則Xournal檔案將會被打開。</i>"
 
-#: ../ui/settings.glade:324
+#: ../ui/settings.glade:338
 msgid ""
 "<i>Put a ruler on your screen to calibrate the zoom level to fit your "
 "screen. Takes effect after restarting xournalpp.\n"
@@ -303,17 +303,17 @@ msgstr ""
 "在Xournal++重啟時將會發揮作用。\n"
 "標尺的長度單位是釐米，游標的單位是dpi。</i>"
 
-#: ../ui/settings.glade:133
+#: ../ui/settings.glade:147
 msgid "<i>Select some advanced input options</i>"
 msgstr ""
 
-#: ../ui/settings.glade:1339
+#: ../ui/settings.glade:1396
 msgid ""
 "<i>The commands will be executed in the UI Thread, make sure\n"
 "they are not blocking!</i>"
 msgstr ""
 
-#: ../ui/settings.glade:548
+#: ../ui/settings.glade:562
 msgid "<i>This name will be proposed if you save a new document</i>"
 msgstr "這個名字是在檔案保存時候的建議名。"
 
@@ -329,15 +329,15 @@ msgstr ""
 msgid "About Xournal++"
 msgstr "關於Xournal++"
 
-#: ../src/control/XournalMain.cpp:245
+#: ../src/control/XournalMain.cpp:250
 msgid "Absolute path for the audio files playback"
 msgstr ""
 
-#: ../ui/main.glade:1086
+#: ../ui/main.glade:1233
 msgid "Add/Edit Tex"
 msgstr "插入/編輯TeX"
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:48
+#: ../src/control/stockdlg/XojOpenDlg.cpp:51
 msgid "All files"
 msgstr "所有檔案"
 
@@ -356,7 +356,7 @@ msgid "Apply to current page"
 msgstr "刪除當前頁"
 
 #: ../src/control/stockdlg/ImageOpenDlg.cpp:30
-#: ../src/control/stockdlg/XojOpenDlg.cpp:147
+#: ../src/control/stockdlg/XojOpenDlg.cpp:152
 msgid "Attach file to the journal"
 msgstr "將檔案附加到日記"
 
@@ -381,15 +381,15 @@ msgstr "變數\"{1\"}不能為整數，其值為NULL"
 msgid "Attribute color not set!"
 msgstr "顏色未設置"
 
-#: ../ui/settings.glade:2051
+#: ../ui/settings.glade:2209
 msgid "Audio Folder"
 msgstr ""
 
-#: ../ui/settings.glade:2088
+#: ../ui/settings.glade:2246
 msgid "Audio Recording"
 msgstr ""
 
-#: ../src/control/AudioController.cpp:100
+#: ../src/control/AudioController.cpp:98
 msgid ""
 "Audio folder not set! Recording won't work!\n"
 "Please set the recording folder under \"Preferences > Audio recording\""
@@ -400,16 +400,16 @@ msgstr ""
 msgid "Authors:"
 msgstr "<b>作者：</b>"
 
-#: ../ui/settings.glade:1170
+#: ../ui/settings.glade:1227
 msgid "Autodetect"
 msgstr ""
 
-#: ../ui/settings.glade:456
+#: ../ui/settings.glade:470
 #, fuzzy
 msgid "Autosave every ... minutes:"
 msgstr "自動保存間隔分鐘數："
 
-#: ../src/control/Control.cpp:254
+#: ../src/control/Control.cpp:256
 #, fuzzy
 msgid "Autosave failed with an error: {1}"
 msgstr "打開檔案出錯：{1}"
@@ -418,8 +418,7 @@ msgstr "打開檔案出錯：{1}"
 msgid "Autosave: {1}"
 msgstr "自動保存：{1}"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:333
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:336
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:429
 msgid "Back"
 msgstr "後退"
 
@@ -429,11 +428,11 @@ msgstr "後退"
 msgid "Background"
 msgstr "背景"
 
-#: ../ui/settings.glade:1520
+#: ../ui/settings.glade:1577
 msgid "Background color for window Background"
 msgstr ""
 
-#: ../ui/settings.glade:1857
+#: ../ui/settings.glade:1929
 msgid "Big cursor for pen"
 msgstr "畫筆使用大光標"
 
@@ -447,11 +446,11 @@ msgstr "黑色"
 msgid "Blue"
 msgstr "藍色"
 
-#: ../ui/settings.glade:1509
+#: ../ui/settings.glade:1566
 msgid "Border color"
 msgstr "邊界顏色"
 
-#: ../ui/settings.glade:1495
+#: ../ui/settings.glade:1552
 #, fuzzy
 msgid "Border color for current page and other selections"
 msgstr "當前頁和選中項目的邊界顏色"
@@ -460,8 +459,8 @@ msgstr "當前頁和選中項目的邊界顏色"
 msgid "Built on:"
 msgstr ""
 
-#: ../src/control/Control.cpp:2022 ../src/control/Control.cpp:2534
-#: ../src/control/Control.cpp:2570 ../src/control/XournalMain.cpp:124
+#: ../src/control/Control.cpp:2058 ../src/control/Control.cpp:2581
+#: ../src/control/Control.cpp:2619 ../src/control/XournalMain.cpp:128
 msgid "Cancel"
 msgstr "取消"
 
@@ -478,7 +477,7 @@ msgstr "改變字型"
 msgid "Change stroke fill"
 msgstr "改變筆劃粗細"
 
-#: ../src/undo/SizeUndoAction.cpp:145
+#: ../src/undo/SizeUndoAction.cpp:139
 msgid "Change stroke width"
 msgstr "改變筆劃粗細"
 
@@ -486,7 +485,7 @@ msgstr "改變筆劃粗細"
 msgid "Color \"{1}\" unknown (not defined in default color list)!"
 msgstr "色彩\"{1}\"未定義！"
 
-#: ../ui/main.glade:588
+#: ../ui/main.glade:633
 msgid "Configure Page Template"
 msgstr ""
 
@@ -494,8 +493,8 @@ msgstr ""
 msgid "Contents"
 msgstr "內容"
 
-#: ../src/control/Control.cpp:1036 ../src/control/Control.cpp:1044
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:321
+#: ../src/control/Control.cpp:1047 ../src/control/Control.cpp:1055
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:402
 msgid "Copy"
 msgstr "拷貝"
 
@@ -516,37 +515,51 @@ msgstr "末頁"
 msgid "Copy page"
 msgstr "拷貝一頁"
 
+#: ../src/control/LatexController.cpp:103
+msgid "Could not convert tex to PDF: {1} (exit code: {2})"
+msgstr ""
+
 #: ../src/control/jobs/SaveJob.cpp:137
 msgid ""
 "Could not create backup! (The file was created from an older Xournal version)"
 msgstr "未能產生備份檔案！(此檔案應為老版本Xournal所建)"
 
-#: ../src/util/Util.cpp:97
+#: ../src/util/Util.cpp:94
 #, fuzzy
 msgid "Could not create folder: {1}"
 msgstr "不能打開檔案\"{1}\""
 
-#: ../src/control/Control.cpp:218 ../src/control/Control.cpp:235
+#: ../src/control/Control.cpp:220 ../src/control/Control.cpp:237
 #, fuzzy
 msgid "Could not delete old autosave file \"{1}\""
 msgstr "不能打開檔案\"{1}\""
 
-#: ../src/control/LatexController.cpp:381
+#: ../src/control/LatexController.cpp:428
 msgid ""
-"Could not find Xournal++ LaTeX executable relative or in Path.\n"
-"Searched for: mathtex-xournalpp.cgi"
+"Could not find pdflatex in Path.\n"
+"Please install pdflatex first and make sure it's in the Path."
 msgstr ""
+
+#: ../src/control/LatexController.cpp:299
+#, fuzzy
+msgid "Could not load LaTeX PDF file, URL-Error: {1}"
+msgstr "未能提取LaTeX圖像檔案{1}"
+
+#: ../src/control/LatexController.cpp:307
+#, fuzzy
+msgid "Could not load LaTeX PDF file: {1}"
+msgstr "不能打開檔案\"{1}\""
 
 #: ../src/control/pagetype/PageTypeHandler.cpp:18
 #, fuzzy
 msgid "Could not load pagetemplates.ini file"
 msgstr "不能打開檔案\"{1}\""
 
-#: ../src/control/xojfile/LoadHandler.cpp:123
+#: ../src/control/xojfile/LoadHandler.cpp:124
 msgid "Could not open file: \"{1}\""
 msgstr "不能打開檔案\"{1}\""
 
-#: ../src/gui/MainWindow.cpp:93
+#: ../src/gui/MainWindow.cpp:86
 msgid ""
 "Could not parse custom toolbar.ini file: {1}\n"
 "Toolbars will not be available"
@@ -554,7 +567,7 @@ msgstr ""
 "未能解析配置檔案toolbar.ini: {1}\n"
 "工具條將不可用"
 
-#: ../src/gui/MainWindow.cpp:83
+#: ../src/gui/MainWindow.cpp:76
 msgid ""
 "Could not parse general toolbar.ini file: {1}\n"
 "No Toolbars will be available"
@@ -562,7 +575,7 @@ msgstr ""
 "未能解析一般檔案toolbar.ini: {1}\n"
 "工具條將不可用"
 
-#: ../src/control/xojfile/LoadHandler.cpp:328
+#: ../src/control/xojfile/LoadHandler.cpp:347
 msgid "Could not read image: {1}. Error message: {2}"
 msgstr "未能讀入圖像：{1}。錯誤提示為：{2}"
 
@@ -574,22 +587,23 @@ msgstr ""
 "未能重複操作\"{1}\"\n"
 "有錯誤發生***請提交一個錯誤報告***"
 
-#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:214
+#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:210
 msgid "Could not remove tool item from Toolbar {1} on position {2}"
 msgstr ""
 
-#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:209
+#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:205
 msgid "Could not remove tool item {1} from Toolbar {2} on position {3}"
 msgstr ""
 
-#: ../src/control/Control.cpp:228 ../src/control/Control.cpp:247
+#: ../src/control/Control.cpp:230 ../src/control/Control.cpp:249
 #, fuzzy
 msgid "Could not rename autosave file from \"{1}\" to \"{2}\""
 msgstr "未能寫入外來數據檔案：{1} ({2})"
 
-#: ../src/control/LatexController.cpp:310
-msgid "Could not retrieve LaTeX image file: {1}"
-msgstr "未能提取LaTeX圖像檔案{1}"
+#: ../src/control/LatexController.cpp:89
+#, fuzzy
+msgid "Could not save .tex file: {1}"
+msgstr "不能打開檔案\"{1}\""
 
 #: ../src/undo/UndoRedoHandler.cpp:144
 msgid ""
@@ -599,11 +613,11 @@ msgstr ""
 "未能撤銷操作\"{1}\"\n"
 "有錯誤發生***請提交一個錯誤報告***"
 
-#: ../src/control/xojfile/SaveHandler.cpp:294
+#: ../src/control/xojfile/SaveHandler.cpp:290
 msgid "Could not write background \"{1}\", {2}"
 msgstr "未能寫上背景\"{1}\", {2}"
 
-#: ../src/control/xojfile/SaveHandler.cpp:419
+#: ../src/control/xojfile/SaveHandler.cpp:415
 msgid "Could not write background \"{1}\". Continuing anyway."
 msgstr "未能寫上背景\"{1}\"，不管啦繼續哦..."
 
@@ -620,7 +634,7 @@ msgstr "當前頁"
 msgid "Custom"
 msgstr "設置"
 
-#: ../ui/settings.glade:1231
+#: ../ui/settings.glade:1288
 msgid "Custom Commands (for Method \"Custom\")"
 msgstr ""
 
@@ -633,35 +647,40 @@ msgstr "設置"
 msgid "Customized"
 msgstr "設置過"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:320
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:401
 msgid "Cut"
 msgstr "剪切"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:442
+#: ../ui/settings.glade:1621
+msgid "Dark Theme (restart needed)"
+msgstr ""
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:460
 msgid "Default Tool"
 msgstr "預設工具"
 
-#: ../ui/settings.glade:1997
+#: ../ui/settings.glade:2155
 msgid "Defaults"
 msgstr "預設"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:407
 #: ../src/undo/DeleteUndoAction.cpp:102
 msgid "Delete"
 msgstr "刪除"
 
-#: ../ui/main.glade:620
+#: ../ui/main.glade:668
 msgid "Delete Layer"
 msgstr "刪除層"
 
-#: ../src/control/XournalMain.cpp:123
+#: ../src/control/XournalMain.cpp:127
 msgid "Delete Logfile"
 msgstr "刪除日誌檔案"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:387
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:447
 msgid "Delete current page"
 msgstr "刪除當前頁"
 
-#: ../src/control/XournalMain.cpp:173
+#: ../src/control/XournalMain.cpp:177
 #, fuzzy
 msgid "Delete file"
 msgstr "刪除日誌檔案"
@@ -674,7 +693,7 @@ msgstr "刪除層"
 msgid "Delete stroke"
 msgstr "刪除筆劃"
 
-#: ../ui/main.glade:1297
+#: ../ui/main.glade:1447
 #, fuzzy
 msgid "Delete this page"
 msgstr "刪除當前頁"
@@ -683,7 +702,7 @@ msgstr "刪除當前頁"
 msgid "Device"
 msgstr "設備"
 
-#: ../ui/settings.glade:1261
+#: ../ui/settings.glade:1318
 msgid "Disable"
 msgstr ""
 
@@ -691,19 +710,19 @@ msgstr ""
 msgid "Disable drawing for this device"
 msgstr "取消此設備繪製"
 
-#: ../ui/settings.glade:1134
+#: ../ui/settings.glade:1191
 msgid "Disable touch if pen is near screen"
 msgstr ""
 
-#: ../ui/settings.glade:1156
+#: ../ui/settings.glade:1213
 msgid "Disabling Method"
 msgstr ""
 
-#: ../src/control/Control.cpp:2533 ../src/control/Control.cpp:2569
+#: ../src/control/Control.cpp:2577 ../src/control/Control.cpp:2618
 msgid "Discard"
 msgstr "丟棄"
 
-#: ../src/control/Control.cpp:1952
+#: ../src/control/Control.cpp:1988
 msgid ""
 "Do not open Autosave files. They may will be overwritten!\n"
 "Copy the files to another folder.\n"
@@ -714,21 +733,17 @@ msgstr ""
 msgid "Do not overwrite the background PDF! This will cause errors!"
 msgstr ""
 
-#: ../src/control/Control.cpp:2566
+#: ../src/control/Control.cpp:2615
 msgid "Document file was removed."
 msgstr "文檔已刪除。"
 
-#: ../src/control/xojfile/LoadHandler.cpp:202
+#: ../src/control/xojfile/LoadHandler.cpp:203
 msgid "Document is not complete (maybe the end is cut off?)"
 msgstr "文檔檔案不完整"
 
 #: ../src/model/Document.cpp:393
 msgid "Document not loaded! ({1}), {2}"
 msgstr "文檔未加載！({1}), {2}"
-
-#: ../src/control/XournalMain.cpp:242
-msgid "Don't compress PDF files (for debugging)"
-msgstr "勿壓縮PDF檔案(調試用)"
 
 #: ../src/control/pagetype/PageTypeHandler.cpp:26
 msgid "Dotted"
@@ -740,13 +755,13 @@ msgstr "在這裡和工具條之間可以來回拖動條目。"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:99
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:40
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:420
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:465
 msgid "Draw Arrow"
 msgstr "繪製箭頭"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:97
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:39
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:416
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:464
 msgid "Draw Circle"
 msgstr "繪製圓形"
 
@@ -758,20 +773,20 @@ msgstr "繪製直線"
 #: ../src/gui/dialog/ButtonConfigGui.cpp:95
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:29
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:38
-#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:120
-#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:123
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:418
+#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:122
+#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:125
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:463
 msgid "Draw Rectangle"
 msgstr "繪製矩形"
 
-#: ../ui/main.glade:778
+#: ../ui/main.glade:844
 #, fuzzy
 msgid "Draw _Line"
 msgstr "繪製直線"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:101
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:42
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:422
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:466
 msgid "Draw coordinate system"
 msgstr ""
 
@@ -788,26 +803,35 @@ msgstr "勿作修改"
 msgid "Edit text"
 msgstr "編輯文本"
 
-#: ../ui/settings.glade:1249
+#: ../src/undo/EmergencySaveRestore.cpp:35
+#, fuzzy
+msgid "Emergency saved document"
+msgstr "未保存文檔"
+
+#: ../ui/settings.glade:1306
 #, fuzzy
 msgid "Enable"
 msgstr "激活標尺"
+
+#: ../ui/settings.glade:1176
+msgid "Enable zoom gestures (needs restart)"
+msgstr ""
 
 #: ../ui/texdialog.glade:66
 msgid "Enter / edit LaTeX Text"
 msgstr ""
 
-#: ../src/undo/EraseUndoAction.cpp:130 ../src/undo/DeleteUndoAction.cpp:99
-#: ../src/undo/AddUndoAction.cpp:104
+#: ../src/undo/AddUndoAction.cpp:104 ../src/undo/DeleteUndoAction.cpp:99
+#: ../src/undo/EraseUndoAction.cpp:130
 msgid "Erase stroke"
 msgstr "擦除筆劃"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:56
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:282
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:308
 msgid "Eraser"
 msgstr "橡皮"
 
-#: ../ui/main.glade:940
+#: ../ui/main.glade:1066
 msgid "Eraser Optio_ns"
 msgstr "橡皮選項(_n)"
 
@@ -815,7 +839,7 @@ msgstr "橡皮選項(_n)"
 msgid "Eraser Type - don't change"
 msgstr ""
 
-#: ../src/control/Control.cpp:2232
+#: ../src/control/Control.cpp:2268
 msgid ""
 "Error annotate PDF file \"{1}\"\n"
 "{2}"
@@ -828,11 +852,11 @@ msgstr ""
 msgid "Error export PDF Page"
 msgstr "輸出為PDF"
 
-#: ../src/gui/GladeGui.cpp:25
+#: ../src/gui/GladeGui.cpp:26
 msgid "Error loading glade file \"{1}\" (try to load \"{2}\")"
 msgstr "加載glade檔案\"{1}\"出錯(嘗試加載\"{2}\")"
 
-#: ../src/control/Control.cpp:2047
+#: ../src/control/Control.cpp:2083
 msgid "Error opening file \"{1}\""
 msgstr "打開檔案\"{1}\"出錯"
 
@@ -840,11 +864,11 @@ msgstr "打開檔案\"{1}\"出錯"
 msgid "Error opening file: \"{1}\""
 msgstr "打開檔案\"{1}\"出錯"
 
-#: ../src/control/xojfile/LoadHandler.cpp:428
+#: ../src/control/xojfile/LoadHandler.cpp:447
 msgid "Error reading PDF: {1}"
 msgstr "讀入PDF出錯：{1}"
 
-#: ../src/control/xojfile/LoadHandler.cpp:499
+#: ../src/control/xojfile/LoadHandler.cpp:518
 msgid "Error reading width of a stroke: {1}"
 msgstr "讀入筆劃粗細出錯：{1}"
 
@@ -852,7 +876,7 @@ msgstr "讀入筆劃粗細出錯：{1}"
 msgid "Error: {1}"
 msgstr "錯誤：{1}"
 
-#: ../src/control/XournalMain.cpp:147
+#: ../src/control/XournalMain.cpp:151
 msgid ""
 "Errorlog cannot be deleted. You have to do it manually.\n"
 "Logfile: {1}"
@@ -868,19 +892,19 @@ msgstr "輸出"
 msgid "Export PDF"
 msgstr "輸出為PDF"
 
-#: ../ui/main.glade:113
+#: ../ui/main.glade:119
 msgid "Export as..."
 msgstr "輸出為..."
 
-#: ../src/control/LatexController.cpp:398
+#: ../src/control/LatexController.cpp:445
 msgid "Failed to generate LaTeX image!"
 msgstr ""
 
-#: ../ui/main.glade:920 ../ui/main.glade:1057
+#: ../ui/main.glade:1044 ../ui/main.glade:1192
 msgid "Fi_ll"
 msgstr ""
 
-#: ../src/util/Util.cpp:127 ../src/util/Util.cpp:148
+#: ../src/util/Util.cpp:123 ../src/util/Util.cpp:143
 msgid ""
 "File couldn't be opened. You have to do it manually:\n"
 "URL: {1}"
@@ -888,23 +912,23 @@ msgstr ""
 "未能打開檔案，請手動操作：\n"
 "URL: {1}"
 
-#: ../src/control/Control.cpp:1982
+#: ../src/control/Control.cpp:2018
 msgid "Filename: {1}"
 msgstr "檔案名：{1}"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:445
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:500
 msgid "Fill"
 msgstr ""
 
-#: ../ui/main.glade:928 ../ui/main.glade:1065
+#: ../ui/main.glade:1053 ../ui/main.glade:1201
 msgid "Fill transparency"
 msgstr ""
 
-#: ../ui/main.glade:1492
+#: ../ui/main.glade:1634
 msgid "Find next occurrence of the search string"
 msgstr ""
 
-#: ../ui/main.glade:1471
+#: ../ui/main.glade:1613
 msgid "Find previous occurrence of the search string"
 msgstr ""
 
@@ -912,37 +936,43 @@ msgstr ""
 msgid "Font"
 msgstr "字型"
 
-#: ../ui/main.glade:289
+#: ../ui/main.glade:338
 msgid "Fullscreen"
 msgstr "全屏"
 
-#: ../ui/about.glade:233
+#: ../ui/about.glade:234
 msgid "GNU GPLv2 or later"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:331
+#: ../ui/settings.glade:1072
+msgid ""
+"GTK Touch / Scrolling workaround. Change Scroll / Touch behavoir. Enabled "
+"touch drawing. Needs restart."
+msgstr ""
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:428
 msgid "Go to first page"
 msgstr "首頁"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:344
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:432
 msgid "Go to last page"
 msgstr "末頁"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:349
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:435
 #, fuzzy
 msgid "Go to next layer"
 msgstr "末頁"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:339
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:430
 msgid "Go to page"
 msgstr "跳轉到頁面"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:347
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:434
 #, fuzzy
 msgid "Go to previous layer"
 msgstr "首頁"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:351
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:436
 #, fuzzy
 msgid "Go to top layer"
 msgstr "跳轉到頁面"
@@ -966,16 +996,20 @@ msgstr "灰色"
 msgid "Green"
 msgstr "綠色"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:378
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:411
 msgid "Grid Snapping"
 msgstr ""
 
-#: ../ui/main.glade:843
+#: ../ui/settings.glade:2113
+msgid "Grid snapping tolerance:"
+msgstr ""
+
+#: ../ui/main.glade:915
 msgid "H_and Tool"
 msgstr "手形工具(_a)"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:63
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:426
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:474
 msgid "Hand"
 msgstr "手形工具"
 
@@ -983,16 +1017,16 @@ msgstr "手形工具"
 msgid "Height:"
 msgstr "高度："
 
-#: ../ui/main.glade:379
+#: ../ui/main.glade:407
 #, fuzzy
 msgid "Hide Menu"
 msgstr "隱藏菜單條"
 
-#: ../ui/settings.glade:1683 ../ui/settings.glade:1753
+#: ../ui/settings.glade:1755 ../ui/settings.glade:1825
 msgid "Hide Menubar"
 msgstr "隱藏菜單條"
 
-#: ../ui/settings.glade:1698 ../ui/settings.glade:1768
+#: ../ui/settings.glade:1770 ../ui/settings.glade:1840
 msgid "Hide Sidebar"
 msgstr "隱藏側邊欄"
 
@@ -1001,27 +1035,32 @@ msgstr "隱藏側邊欄"
 msgid "Hide all"
 msgstr "隱藏菜單條"
 
-#: ../ui/settings.glade:1613
+#: ../ui/settings.glade:1685
 msgid "Hide the horizontal scrollbar"
 msgstr ""
 
-#: ../ui/settings.glade:1628
+#: ../ui/settings.glade:1700
 msgid "Hide the vertical scrollbar"
 msgstr ""
 
+#: ../ui/settings.glade:1944
+#, fuzzy
+msgid "Highlight cursor position"
+msgstr "高亮選項(_i)"
+
 #: ../src/gui/dialog/ButtonConfigGui.cpp:57
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:399
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:457
 #, fuzzy
 msgid "Highlighter"
 msgstr "高亮"
 
-#: ../ui/main.glade:1014
+#: ../ui/main.glade:1146
 #, fuzzy
 msgid "Highlighter Opti_ons"
 msgstr "高亮選項(_i)"
 
 #: ../src/control/pagetype/PageTypeHandler.cpp:32
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:403
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:459
 msgid "Image"
 msgstr "圖片"
 
@@ -1029,11 +1068,11 @@ msgstr "圖片"
 msgid "Images"
 msgstr "圖片"
 
-#: ../ui/settings.glade:390
+#: ../ui/settings.glade:404
 msgid "Input"
 msgstr "輸入"
 
-#: ../ui/settings.glade:1090
+#: ../ui/settings.glade:1119
 msgid "Input Device"
 msgstr "輸入設備"
 
@@ -1041,7 +1080,7 @@ msgstr "輸入設備"
 msgid "Insert Latex"
 msgstr "插入LaTeX"
 
-#: ../ui/main.glade:1277
+#: ../ui/main.glade:1427
 msgid "Insert a copy of the current page below"
 msgstr ""
 
@@ -1049,7 +1088,7 @@ msgstr ""
 msgid "Insert elements"
 msgstr "插入元素"
 
-#: ../src/undo/InsertUndoAction.cpp:47 ../src/gui/dialog/ButtonConfigGui.cpp:59
+#: ../src/gui/dialog/ButtonConfigGui.cpp:59 ../src/undo/InsertUndoAction.cpp:47
 msgid "Insert image"
 msgstr "插入圖片"
 
@@ -1061,11 +1100,11 @@ msgstr "插入LaTeX"
 msgid "Insert layer"
 msgstr "插入層"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:394
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:443
 msgid "Insert page"
 msgstr "插入頁面"
 
-#: ../src/control/XournalMain.cpp:244
+#: ../src/control/XournalMain.cpp:249
 msgid "Jump to Page (first Page: 1)"
 msgstr "跳到頁面(第一頁:1)"
 
@@ -1087,7 +1126,7 @@ msgstr "選擇圖層"
 msgid "Layer {1}"
 msgstr "{1}圖層"
 
-#: ../ui/about.glade:217
+#: ../ui/about.glade:218
 msgid "License"
 msgstr ""
 
@@ -1105,7 +1144,7 @@ msgstr "淺綠"
 msgid "Lined"
 msgstr "畫綫的"
 
-#: ../ui/settings.glade:772
+#: ../ui/settings.glade:786
 msgid "Load / Save"
 msgstr "加載/保存"
 
@@ -1113,13 +1152,13 @@ msgstr "加載/保存"
 msgid "Load file"
 msgstr "加載檔案"
 
-#: ../src/gui/PageView.cpp:738
+#: ../src/gui/PageView.cpp:739
 #: ../src/gui/sidebar/previews/base/SidebarPreviewBaseEntry.cpp:105
 #: ../src/gui/toolbarMenubar/ToolPageLayer.cpp:20
 msgid "Loading..."
 msgstr "加載中..."
 
-#: ../ui/toolbarManageDialog.glade:8 ../ui/toolbarCustomizeDialog.glade:10
+#: ../ui/toolbarCustomizeDialog.glade:10 ../ui/toolbarManageDialog.glade:8
 msgid "Manage Toolbar"
 msgstr "定製工具條"
 
@@ -1129,11 +1168,17 @@ msgid "Mangenta"
 msgstr "品紅"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:81
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:437
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:514
 msgid "Medium"
 msgstr "中"
 
-#: ../src/control/XournalMain.cpp:462
+#: ../src/control/XournalMain.cpp:460
+msgid ""
+"Missing the needed UI file! .app corrupted?\n"
+"Path: {1}"
+msgstr ""
+
+#: ../src/control/XournalMain.cpp:474
 msgid ""
 "Missing the needed UI file, could not find them at any location.\n"
 "Not relative\n"
@@ -1141,7 +1186,7 @@ msgid ""
 "Not in {1}"
 msgstr ""
 
-#: ../ui/settings.glade:883
+#: ../ui/settings.glade:897
 msgid "Mouse Button"
 msgstr "滑鼠按鈕"
 
@@ -1162,7 +1207,7 @@ msgstr "向後移動頁面"
 msgid "Move page upwards"
 msgstr "向前移動頁面"
 
-#: ../ui/main.glade:531
+#: ../ui/main.glade:571
 msgid "N_ext annotated page"
 msgstr "下一個標註頁(_e)"
 
@@ -1170,31 +1215,31 @@ msgstr "下一個標註頁(_e)"
 msgid "New"
 msgstr "新建"
 
-#: ../ui/main.glade:571
+#: ../ui/main.glade:614
 msgid "New Page _After"
 msgstr "新建後頁(_A)"
 
-#: ../ui/main.glade:563
+#: ../ui/main.glade:605
 msgid "New Page _Before"
 msgstr "新建前頁(_B)"
 
-#: ../ui/main.glade:580
+#: ../ui/main.glade:624
 msgid "New Page at _End"
 msgstr "新建尾頁(_E)"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:316
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:388
 msgid "New Xournal"
 msgstr "新建日記"
 
-#: ../ui/main.glade:611
+#: ../ui/main.glade:658
 msgid "New _Layer"
 msgstr "新建圖層(_L)"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:342
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:431
 msgid "Next"
 msgstr "下一個"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:355
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:438
 msgid "Next annotated page"
 msgstr "下一個標註頁面"
 
@@ -1221,20 +1266,20 @@ msgstr ""
 msgid "Open Image"
 msgstr "打開圖片"
 
-#: ../src/control/XournalMain.cpp:121
+#: ../src/control/XournalMain.cpp:125
 msgid "Open Logfile"
 msgstr "打開日誌檔案"
 
-#: ../src/control/XournalMain.cpp:122
+#: ../src/control/XournalMain.cpp:126
 msgid "Open Logfile directory"
 msgstr "打開日誌檔案目錄"
 
 #: ../src/control/stockdlg/XojOpenDlg.cpp:16
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:318
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:389
 msgid "Open file"
 msgstr "打開檔案"
 
-#: ../src/control/RecentManager.cpp:241
+#: ../src/control/RecentManager.cpp:244
 msgctxt "{1} is a URI"
 msgid "Open {1}"
 msgstr "打開{1}"
@@ -1248,7 +1293,7 @@ msgstr "橙色"
 msgid "PDF Export"
 msgstr "輸出為PDF"
 
-#: ../src/gui/MainWindow.cpp:732
+#: ../src/gui/MainWindow.cpp:816
 msgid "PDF Page {1}"
 msgstr "PDF頁碼{1}"
 
@@ -1256,17 +1301,17 @@ msgstr "PDF頁碼{1}"
 msgid "PDF background missing"
 msgstr "PDF背景丟失"
 
-#: ../src/control/XournalMain.cpp:223
+#: ../src/control/XournalMain.cpp:230
 msgid "PDF file successfully created"
 msgstr "PDF檔案成功建立"
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:58
-#: ../src/control/jobs/PdfExportJob.cpp:23
 #: ../src/control/jobs/CustomExportJob.cpp:27
+#: ../src/control/jobs/PdfExportJob.cpp:23
+#: ../src/control/stockdlg/XojOpenDlg.cpp:61
 msgid "PDF files"
 msgstr "PDF檔案"
 
-#: ../src/control/XournalMain.cpp:243
+#: ../src/control/XournalMain.cpp:248
 msgid "PDF output filename"
 msgstr "PDF輸出檔案名"
 
@@ -1284,7 +1329,7 @@ msgstr ""
 msgid "PNG with transparent background"
 msgstr "紙張背景(_a)"
 
-#: ../ui/main.glade:540
+#: ../ui/main.glade:581
 #, fuzzy
 msgid "P_revious annotated Page"
 msgstr "前一個標註頁(_r)"
@@ -1326,35 +1371,35 @@ msgstr "頁碼："
 msgid "Paper Format"
 msgstr "紙張樣式"
 
-#: ../ui/main.glade:643
+#: ../ui/main.glade:693
 msgid "Paper _Color"
 msgstr "紙張顏色(_C)"
 
-#: ../ui/main.glade:635
+#: ../ui/main.glade:684
 msgid "Paper _Format"
 msgstr "紙張樣式(_F)"
 
-#: ../ui/main.glade:651
+#: ../ui/main.glade:702
 msgid "Paper b_ackground"
 msgstr "紙張背景(_a)"
 
-#: ../ui/about.glade:201
+#: ../ui/about.glade:202
 msgid ""
 "Partial based on Xournal\n"
 "by Denis Auroux"
 msgstr ""
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:403
 #: ../src/undo/AddUndoAction.cpp:108
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:322
 msgid "Paste"
 msgstr "粘貼"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:55
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:382
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:286
 msgid "Pen"
 msgstr "畫筆"
 
-#: ../ui/main.glade:859
+#: ../ui/main.glade:932
 msgid "Pen _Options"
 msgstr "畫筆選項(_O)"
 
@@ -1362,9 +1407,9 @@ msgstr "畫筆選項(_O)"
 msgid "Plain"
 msgstr "空白"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:473
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:32
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:106
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:413
 #, fuzzy
 msgid "Play Object"
 msgstr "選擇對象"
@@ -1373,11 +1418,11 @@ msgstr "選擇對象"
 msgid "Predefined"
 msgstr "預定"
 
-#: ../ui/main.glade:251
+#: ../ui/main.glade:297
 msgid "Preferences"
 msgstr "偏好設置"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:461
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:417
 msgid "Presentation mode"
 msgstr "演講模式"
 
@@ -1385,15 +1430,15 @@ msgstr "演講模式"
 msgid "Range"
 msgstr "範圍"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:371
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:479
 msgid "Rec / Stop"
 msgstr ""
 
-#: ../ui/main.glade:299
+#: ../ui/main.glade:1225
 msgid "Rec-Stop"
 msgstr ""
 
-#: ../ui/main.glade:61
+#: ../ui/main.glade:63
 msgid "Recent _Documents"
 msgstr "最近文檔(_D)"
 
@@ -1402,8 +1447,8 @@ msgstr "最近文檔(_D)"
 msgid "Red"
 msgstr "紅色"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:397
 #: ../src/undo/UndoRedoHandler.cpp:293
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:327
 msgid "Redo"
 msgstr "重複"
 
@@ -1411,15 +1456,15 @@ msgstr "重複"
 msgid "Redo: "
 msgstr "重複："
 
-#: ../src/control/Control.cpp:2021
+#: ../src/control/Control.cpp:2057
 msgid "Remove PDF Background"
 msgstr "去掉PDF背景"
 
-#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:202
+#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:198
 msgid "Removed tool item from Toolbar {1} ID {2}"
 msgstr ""
 
-#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:198
+#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:194
 msgid "Removed tool item {1} from Toolbar {2} ID {3}"
 msgstr ""
 
@@ -1432,7 +1477,7 @@ msgstr ""
 msgid "Resolution"
 msgstr "解析度："
 
-#: ../src/control/XournalMain.cpp:174
+#: ../src/control/XournalMain.cpp:178
 #, fuzzy
 msgid "Restore file"
 msgstr "保存檔案"
@@ -1442,33 +1487,37 @@ msgstr "保存檔案"
 msgid "Rotation"
 msgstr "解析度："
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:375
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:410
 msgid "Rotation Snapping"
+msgstr ""
+
+#: ../ui/settings.glade:2083
+msgid "Rotation snapping tolerance:"
 msgstr ""
 
 #: ../src/control/pagetype/PageTypeHandler.cpp:24
 msgid "Ruled"
 msgstr "定標"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:432
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:467
 msgid "Ruler"
 msgstr "標尺"
 
-#: ../src/control/jobs/SaveJob.cpp:13 ../src/control/Control.cpp:2532
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:315
+#: ../src/control/Control.cpp:2576 ../src/control/jobs/SaveJob.cpp:13
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:390
 msgid "Save"
 msgstr "保存"
 
-#: ../src/control/Control.cpp:2568
+#: ../src/control/Control.cpp:2617
 msgid "Save As"
 msgstr "保存為"
 
-#: ../src/control/Control.cpp:2352 ../src/gui/dialog/PageTemplateDialog.cpp:112
+#: ../src/control/Control.cpp:2388 ../src/gui/dialog/PageTemplateDialog.cpp:112
 msgid "Save File"
 msgstr "保存檔案"
 
-#: ../src/control/jobs/SaveJob.cpp:151
 #: ../src/control/jobs/CustomExportJob.cpp:276
+#: ../src/control/jobs/SaveJob.cpp:151
 #, fuzzy
 msgid "Save file error: {1}"
 msgstr "打開檔案出錯：{1}"
@@ -1477,7 +1526,7 @@ msgstr "打開檔案出錯：{1}"
 msgid "Scale"
 msgstr "縮放"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:324
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:405
 msgid "Search"
 msgstr "搜索"
 
@@ -1486,12 +1535,12 @@ msgstr "搜索"
 msgid "Select Background Color"
 msgstr "選色"
 
-#: ../ui/settings.glade:2065
+#: ../ui/settings.glade:2223
 #, fuzzy
 msgid "Select Folder"
 msgstr "選色"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:447
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:476
 msgid "Select Font"
 msgstr "選擇字型"
 
@@ -1499,9 +1548,9 @@ msgstr "選擇字型"
 msgid "Select Image"
 msgstr "選擇圖片"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:471
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:31
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:99
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:410
 msgid "Select Object"
 msgstr "選擇對象"
 
@@ -1509,21 +1558,21 @@ msgstr "選擇對象"
 msgid "Select PDF Page"
 msgstr "選擇PDF頁面"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:470
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:10
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:29
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:85
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:125
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:408
 msgid "Select Rectangle"
 msgstr "選擇矩形"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:469
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:30
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:92
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:406
 msgid "Select Region"
 msgstr "選擇區域"
 
-#: ../src/control/Control.cpp:2020
+#: ../src/control/Control.cpp:2056
 msgid "Select another PDF"
 msgstr "選擇其他PDF"
 
@@ -1550,19 +1599,19 @@ msgstr "選擇矩形"
 msgid "Select region"
 msgstr "選擇區域"
 
-#: ../ui/settings.glade:1964
+#: ../ui/settings.glade:2051
 msgid "Select the tool and Settings if you press the Default Button"
 msgstr "按下預設按鈕，此工具及其設置將會生效"
 
-#: ../ui/settings.glade:1789
+#: ../ui/settings.glade:1861
 msgid "Select toolbar:"
 msgstr "選擇工具條："
 
-#: ../ui/settings.glade:1543
+#: ../ui/settings.glade:1600
 msgid "Selection Color (Text, Stroke Selection etc.)"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:120
+#: ../src/control/XournalMain.cpp:124
 msgid "Send Bugreport"
 msgstr "選擇錯誤報告"
 
@@ -1570,11 +1619,15 @@ msgstr "選擇錯誤報告"
 msgid "Separator"
 msgstr "分割線"
 
-#: ../ui/settings.glade:1123
+#: ../ui/settings.glade:1165
+msgid "Settings for Touch devices"
+msgstr ""
+
+#: ../ui/settings.glade:1152
 msgid "Settings for Touch devices which are detected by GTK."
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:430
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:462
 msgid "Shape Recognizer"
 msgstr "識別形狀"
 
@@ -1597,19 +1650,19 @@ msgstr "只顯示未使用頁面(一個未使用頁面)"
 msgid "Show only not used pages ({1} unused pages)"
 msgstr "只顯示未使用頁面({1}個未使用頁面)"
 
-#: ../ui/main.glade:322
+#: ../ui/main.glade:348
 msgid "Show sidebar"
 msgstr "顯示側邊欄"
 
-#: ../ui/settings.glade:1412
+#: ../ui/settings.glade:1469
 msgid "Show sidebar on the right side"
 msgstr "側邊欄右置"
 
-#: ../ui/settings.glade:1427
+#: ../ui/settings.glade:1484
 msgid "Show vertical scrollbar on the left side"
 msgstr "垂直捲動條左置"
 
-#: ../src/control/XournalMain.cpp:309
+#: ../src/control/XournalMain.cpp:308
 #, fuzzy
 msgid ""
 "Sorry, Xournal++ can only open one file at once.\n"
@@ -1618,7 +1671,7 @@ msgstr ""
 "Xournal只能打開一個命令行檔案。\n"
 "其他的會被忽略。"
 
-#: ../src/control/XournalMain.cpp:324
+#: ../src/control/XournalMain.cpp:323
 #, fuzzy
 msgid ""
 "Sorry, Xournal++ cannot open remote files at the moment.\n"
@@ -1631,13 +1684,13 @@ msgstr ""
 msgid "Standard"
 msgstr "標準"
 
-#: ../ui/main.glade:1610
+#: ../ui/main.glade:1752
 msgid "State PLACEHOLDER"
 msgstr ""
 
-#: ../src/undo/RecognizerUndoAction.cpp:101
 #: ../src/gui/dialog/ButtonConfigGui.cpp:103
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:43
+#: ../src/undo/RecognizerUndoAction.cpp:101
 msgid "Stroke recognizer"
 msgstr "筆劃識別"
 
@@ -1645,19 +1698,19 @@ msgstr "筆劃識別"
 msgid "Successfully saved document to \"{1}\""
 msgstr "文檔已經保存為\"{1}\""
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:128
+#: ../src/control/stockdlg/XojOpenDlg.cpp:132
 msgid "Supported files"
 msgstr "支撐檔案"
 
-#: ../ui/main.glade:1236
+#: ../ui/main.glade:1386
 msgid "Swap the current page with the one above"
 msgstr ""
 
-#: ../ui/main.glade:1257
+#: ../ui/main.glade:1407
 msgid "Swap the current page with the one below"
 msgstr ""
 
-#: ../ui/main.glade:337
+#: ../ui/main.glade:363
 msgid "T_oolbars"
 msgstr "工具條(_o)"
 
@@ -1665,16 +1718,16 @@ msgstr "工具條(_o)"
 msgid "Template:"
 msgstr "模板："
 
-#: ../ui/settings.glade:1317
+#: ../ui/settings.glade:1374
 msgid "Test disable"
 msgstr ""
 
-#: ../ui/settings.glade:1304
+#: ../ui/settings.glade:1361
 msgid "Test enable"
 msgstr ""
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:58
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:401
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:458
 msgid "Text"
 msgstr "文本"
 
@@ -1683,7 +1736,7 @@ msgstr "文本"
 msgid "Text %i times found on this page"
 msgstr "文本在本頁面出現%i次"
 
-#: ../ui/main.glade:1077
+#: ../ui/main.glade:1214
 msgid "Text Font..."
 msgstr "文本字型..."
 
@@ -1711,35 +1764,35 @@ msgstr "文本未找到"
 msgid "Text not found, searched on all pages"
 msgstr "找遍所有頁面未找到文本"
 
-#: ../src/control/Control.cpp:1006
+#: ../src/control/Control.cpp:1017
 msgid ""
 "The Toolbarconfiguration \"{1}\" is predefined, would you create a copy to "
 "edit?"
 msgstr "工具條配置\"{1}\"是預置的，要產生一個拷貝到編輯?"
 
-#: ../src/control/Control.cpp:2017
+#: ../src/control/Control.cpp:2053
 msgid "The attached background PDF could not be found."
 msgstr "附加的背景PDF未找到。"
 
-#: ../src/control/Control.cpp:2018
+#: ../src/control/Control.cpp:2054
 msgid "The background PDF could not be found."
 msgstr "背景PDF未找到。"
 
-#: ../src/control/XournalMain.cpp:115
+#: ../src/control/XournalMain.cpp:119
 msgid "The most recent log file name: {1}"
 msgstr "最近的日誌檔案名：{1}"
 
-#: ../ui/settings.glade:369
+#: ../ui/settings.glade:383
 msgid "The unit of the ruler is cm"
 msgstr "標尺的單位是釐米"
 
-#: ../src/control/XournalMain.cpp:108
+#: ../src/control/XournalMain.cpp:112
 msgid ""
 "There are errorlogfiles from Xournal++. Please send a Bugreport, so the bug "
 "may be fixed."
 msgstr "發現Xournal++的錯誤日誌檔案，請發送一個錯誤報告，將會被修正。"
 
-#: ../src/control/XournalMain.cpp:107
+#: ../src/control/XournalMain.cpp:111
 msgid ""
 "There is an errorlogfile from Xournal++. Please send a Bugreport, so the bug "
 "may be fixed."
@@ -1750,7 +1803,7 @@ msgid "There was an error displaying help: {1}"
 msgstr ""
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:82
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:439
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:515
 msgid "Thick"
 msgstr "粗"
 
@@ -1760,25 +1813,25 @@ msgid "Thickness - don't change"
 msgstr "勿作修改"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:80
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:435
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:513
 msgid "Thin"
 msgstr "細"
 
-#: ../src/control/Control.cpp:2530
+#: ../src/control/Control.cpp:2574
 msgid "This document is not saved yet."
 msgstr ""
 
-#: ../src/control/tools/ImageHandler.cpp:56
 #: ../src/control/PageBackgroundChangeController.cpp:177
+#: ../src/control/tools/ImageHandler.cpp:56
 msgid "This image could not be loaded. Error message: {1}"
 msgstr ""
 
-#: ../ui/settings.glade:1185
+#: ../ui/settings.glade:1242
 #, fuzzy
 msgid "Timeout"
 msgstr "涂白"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:368
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:418
 msgid "Toggle fullscreen"
 msgstr "全屏"
 
@@ -1787,7 +1840,7 @@ msgstr "全屏"
 msgid "Tool - don't change"
 msgstr "勿作修改"
 
-#: ../src/gui/toolbarMenubar/model/ToolbarData.cpp:156
+#: ../src/gui/toolbarMenubar/model/ToolbarData.cpp:152
 msgid "Toolbar found: {1}"
 msgstr "發現工具條：{1}"
 
@@ -1795,11 +1848,11 @@ msgstr "發現工具條：{1}"
 msgid "Toolbars"
 msgstr "工具條"
 
-#: ../ui/settings.glade:1358
+#: ../ui/settings.glade:1415
 msgid "Touch"
 msgstr ""
 
-#: ../ui/settings.glade:1046
+#: ../ui/settings.glade:1060
 msgid ""
 "Touch Screens which are detected by GTK are handled specially, and don't "
 "need to be configured here."
@@ -1813,12 +1866,12 @@ msgstr ""
 msgid "Trying to emergency save the current open document…"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:458
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:416
 msgid "Two pages"
 msgstr "雙頁"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:396
 #: ../src/undo/UndoRedoHandler.cpp:274
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:326
 msgid "Undo"
 msgstr "撤銷"
 
@@ -1826,15 +1879,15 @@ msgstr "撤銷"
 msgid "Undo: "
 msgstr "撤銷："
 
-#: ../src/control/xojfile/LoadHandler.cpp:241
+#: ../src/control/xojfile/LoadHandler.cpp:260
 msgid "Unexpected root tag: {1}"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:270
+#: ../src/control/xojfile/LoadHandler.cpp:289
 msgid "Unexpected tag in document: \"{1}\""
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:475
+#: ../src/control/xojfile/LoadHandler.cpp:494
 msgid "Unknown background type: {1}"
 msgstr ""
 
@@ -1842,23 +1895,23 @@ msgstr ""
 msgid "Unknown color value \"{1}\""
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:410
+#: ../src/control/xojfile/LoadHandler.cpp:429
 msgid "Unknown domain type: {1}"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:193
+#: ../src/control/xojfile/LoadHandler.cpp:194
 msgid "Unknown parser error"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:345
+#: ../src/control/xojfile/LoadHandler.cpp:364
 msgid "Unknown pixmap::domain type: {1}"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:558
+#: ../src/control/xojfile/LoadHandler.cpp:591
 msgid "Unknown stroke type: \"{1}\", assuming pen"
 msgstr ""
 
-#: ../src/control/Control.cpp:2424
+#: ../src/control/Control.cpp:2460
 msgid "Unsaved Document"
 msgstr "未保存文檔"
 
@@ -1867,7 +1920,7 @@ msgstr "未保存文檔"
 msgid "Version"
 msgstr "擴展"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:425
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:472
 msgid "Vertical Space"
 msgstr "垂直間距"
 
@@ -1875,7 +1928,7 @@ msgstr "垂直間距"
 msgid "Vertical space"
 msgstr "垂直間距"
 
-#: ../ui/settings.glade:1895
+#: ../ui/settings.glade:1982
 msgid "View"
 msgstr "視圖"
 
@@ -1896,7 +1949,7 @@ msgstr "寬度："
 msgid "With PDF background"
 msgstr "使用PDF背景"
 
-#: ../ui/about.glade:187
+#: ../ui/about.glade:188
 msgid "With help from the community"
 msgstr ""
 
@@ -1904,19 +1957,19 @@ msgstr ""
 msgid "Write text"
 msgstr "寫文本"
 
-#: ../src/control/xojfile/LoadHandler.cpp:821
+#: ../src/control/xojfile/LoadHandler.cpp:852
 msgid "Wrong count of points ({1})"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:836
+#: ../src/control/xojfile/LoadHandler.cpp:866
 msgid "Wrong number of points, got {1}, expected {2}"
 msgstr ""
 
-#: ../ui/settings.glade:1171
+#: ../ui/settings.glade:1228
 msgid "X11"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:188
+#: ../src/control/xojfile/LoadHandler.cpp:189
 msgid "XML Parser error: {1}"
 msgstr ""
 
@@ -1924,24 +1977,24 @@ msgstr ""
 msgid "Xournal (Compatibility)"
 msgstr ""
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:69
+#: ../src/control/stockdlg/XojOpenDlg.cpp:72
 msgid "Xournal files"
 msgstr "Xournal檔案"
 
-#: ../ui/settings.glade:28
+#: ../ui/settings.glade:42
 msgid "Xournal++ Preferences"
 msgstr "Xournal++偏好設置"
 
-#: ../src/control/XournalMain.cpp:168
+#: ../src/control/XournalMain.cpp:172
 msgid "Xournal++ crashed last time. Would you restore it?"
 msgstr ""
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:79 ../src/control/Control.cpp:2359
+#: ../src/control/Control.cpp:2395 ../src/control/stockdlg/XojOpenDlg.cpp:82
 #, fuzzy
 msgid "Xournal++ files"
 msgstr "Xournal檔案"
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:89
+#: ../src/control/stockdlg/XojOpenDlg.cpp:92
 #: ../src/gui/dialog/PageTemplateDialog.cpp:119
 #, fuzzy
 msgid "Xournal++ template"
@@ -1959,7 +2012,7 @@ msgid ""
 "Template\"."
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:111
+#: ../src/control/XournalMain.cpp:115
 msgid ""
 "You're using {1}/{2} branch. Send Bugreport will direct you to this repo's "
 "issue tracker."
@@ -1974,19 +2027,19 @@ msgid ""
 "PDF page."
 msgstr ""
 
-#: ../ui/settings.glade:302
+#: ../ui/settings.glade:316
 msgid "Zoom"
 msgstr "縮放"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:362
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:422
 msgid "Zoom fit to screen"
 msgstr "適合屏幕"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:360
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:421
 msgid "Zoom in"
 msgstr "放大"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:358
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:420
 msgid "Zoom out"
 msgstr "縮小"
 
@@ -1994,44 +2047,44 @@ msgstr "縮小"
 msgid "Zoom slider"
 msgstr "縮放游標"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:364
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:423
 msgid "Zoom to 100%"
 msgstr "原始尺寸"
 
-#: ../ui/main.glade:69
+#: ../ui/main.glade:71
 msgid "_Annotate PDF"
 msgstr "標註PDF(_A)"
 
+#: ../src/control/Control.cpp:2389 ../src/control/jobs/BaseExportJob.cpp:26
 #: ../src/control/stockdlg/ImageOpenDlg.cpp:12
 #: ../src/control/stockdlg/XojOpenDlg.cpp:17
-#: ../src/control/jobs/BaseExportJob.cpp:26 ../src/control/Control.cpp:2353
 #: ../src/gui/dialog/PageTemplateDialog.cpp:113
 #, fuzzy
 msgid "_Cancel"
 msgstr "取消"
 
-#: ../ui/main.glade:361
+#: ../ui/main.glade:388
 msgid "_Customize"
 msgstr "設置(_C)"
 
-#: ../ui/main.glade:723
+#: ../ui/main.glade:779
 #, fuzzy
 msgid "_Default Tools"
 msgstr "<b>預設工具</b>"
 
-#: ../ui/main.glade:596
+#: ../ui/main.glade:642
 msgid "_Delete Page"
 msgstr "刪除頁面(_D)"
 
-#: ../ui/main.glade:153
+#: ../ui/main.glade:162
 msgid "_Edit"
 msgstr "編輯(_E)"
 
-#: ../ui/main.glade:683
+#: ../ui/main.glade:735
 msgid "_Eraser"
 msgstr "橡皮(_E)"
 
-#: ../ui/main.glade:104
+#: ../ui/main.glade:109
 msgid "_Export as PDF"
 msgstr "輸出為PDF(_E)"
 
@@ -2039,49 +2092,49 @@ msgstr "輸出為PDF(_E)"
 msgid "_File"
 msgstr "檔案(_F)"
 
-#: ../ui/main.glade:448
+#: ../ui/main.glade:480
 msgid "_First Page"
 msgstr "首頁(_F)"
 
-#: ../ui/main.glade:466
+#: ../ui/main.glade:500
 #, fuzzy
 msgid "_Goto Page"
 msgstr "頁面跳轉(_G)"
 
-#: ../ui/main.glade:1099
+#: ../ui/main.glade:1247
 msgid "_Help"
 msgstr "幫助(_H)"
 
-#: ../ui/main.glade:693
+#: ../ui/main.glade:746
 msgid "_Highlighter"
 msgstr "高亮(_H)"
 
-#: ../ui/main.glade:713
+#: ../ui/main.glade:768
 msgid "_Image"
 msgstr "圖片(_I)"
 
-#: ../ui/main.glade:553
+#: ../ui/main.glade:595
 msgid "_Journal"
 msgstr "日誌(_J)"
 
-#: ../ui/main.glade:484
+#: ../ui/main.glade:520
 msgid "_Last Page"
 msgstr "末頁(_L)"
 
-#: ../ui/main.glade:353
+#: ../ui/main.glade:379
 msgid "_Manage"
 msgstr "管理(_M)"
 
-#: ../ui/main.glade:438
+#: ../ui/main.glade:470
 msgid "_Navigation"
 msgstr "導航(_N)"
 
-#: ../ui/main.glade:508
+#: ../ui/main.glade:546
 #, fuzzy
 msgid "_Next Layer"
 msgstr "下一頁(_N)"
 
-#: ../ui/main.glade:475
+#: ../ui/main.glade:510
 msgid "_Next Page"
 msgstr "下一頁(_N)"
 
@@ -2091,83 +2144,83 @@ msgstr "下一頁(_N)"
 msgid "_Open"
 msgstr "打開{1}"
 
-#: ../ui/main.glade:673
+#: ../ui/main.glade:724
 msgid "_Pen"
 msgstr "畫筆(_P)"
 
-#: ../ui/main.glade:281
+#: ../ui/main.glade:329
 msgid "_Presentation Mode"
 msgstr "演講模式(_P)"
 
-#: ../ui/main.glade:499
+#: ../ui/main.glade:536
 #, fuzzy
 msgid "_Previous Layer"
 msgstr "前一頁(_P)"
 
-#: ../ui/main.glade:457
+#: ../ui/main.glade:490
 msgid "_Previous Page"
 msgstr "前一頁(_P)"
 
-#: ../src/control/jobs/BaseExportJob.cpp:27 ../src/control/Control.cpp:2354
+#: ../src/control/Control.cpp:2390 ../src/control/jobs/BaseExportJob.cpp:27
 #: ../src/gui/dialog/PageTemplateDialog.cpp:114
 #, fuzzy
 msgid "_Save"
 msgstr "保存"
 
-#: ../ui/main.glade:737
+#: ../ui/main.glade:794
 msgid "_Shape Recognizer"
 msgstr "形狀識別(_S)"
 
-#: ../ui/main.glade:703
+#: ../ui/main.glade:757
 msgid "_Text"
 msgstr "文本(_T)"
 
-#: ../ui/main.glade:663
+#: ../ui/main.glade:714
 msgid "_Tools"
 msgstr "工具(_T)"
 
-#: ../ui/main.glade:517
+#: ../ui/main.glade:556
 #, fuzzy
 msgid "_Top Layer"
 msgstr "圖層"
 
-#: ../ui/main.glade:273
+#: ../ui/main.glade:320
 msgid "_Two Pages"
 msgstr "雙頁(_T)"
 
-#: ../ui/main.glade:823
+#: ../ui/main.glade:893
 msgid "_Vertical Space"
 msgstr "垂直間距(_V)"
 
-#: ../ui/main.glade:263
+#: ../ui/main.glade:310
 msgid "_View"
 msgstr "視圖(_V)"
 
-#: ../ui/main.glade:1001
+#: ../ui/main.glade:1132
 msgid "_delete strokes"
 msgstr "刪除筆劃(_d)"
 
-#: ../ui/main.glade:878 ../ui/main.glade:950 ../ui/main.glade:1024
+#: ../ui/main.glade:952 ../ui/main.glade:1076 ../ui/main.glade:1156
 msgid "_fine"
 msgstr "細(_f)"
 
-#: ../ui/main.glade:887 ../ui/main.glade:959 ../ui/main.glade:1033
+#: ../ui/main.glade:962 ../ui/main.glade:1086 ../ui/main.glade:1166
 msgid "_medium"
 msgstr "中(_m)"
 
-#: ../ui/main.glade:983
+#: ../ui/main.glade:1112
 msgid "_standard"
 msgstr "標準(_s)"
 
-#: ../ui/main.glade:896 ../ui/main.glade:968 ../ui/main.glade:1042
+#: ../ui/main.glade:972 ../ui/main.glade:1096 ../ui/main.glade:1176
 msgid "_thick"
 msgstr "粗(_t)"
 
-#: ../ui/main.glade:869
+#: ../ui/main.glade:942
 msgid "_very fine"
 msgstr "極細(_v)"
 
-#: ../ui/main.glade:992
+#: ../ui/main.glade:1122
 msgid "_whiteout"
 msgstr "涂白(_w)"
 
@@ -2180,9 +2233,21 @@ msgstr "範圍"
 msgid "cursor"
 msgstr "光標"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:299
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:294
+msgid "dash-/ doted"
+msgstr ""
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:291
+msgid "dashed"
+msgstr ""
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:312
 msgid "delete stroke"
 msgstr "刪除筆劃"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:297
+msgid "dotted"
+msgstr ""
 
 #: ../ui/exportSettings.glade:213
 msgid "dpi"
@@ -2209,7 +2274,7 @@ msgstr "滑鼠"
 msgid "pen"
 msgstr "畫筆"
 
-#: ../ui/settings.glade:1212
+#: ../ui/settings.glade:1269
 msgid "s"
 msgstr ""
 
@@ -2222,7 +2287,8 @@ msgstr "保存檔案"
 msgid "show"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:285
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:288
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:310
 msgid "standard"
 msgstr "標準"
 
@@ -2235,15 +2301,15 @@ msgstr ""
 msgid "touchscreen"
 msgstr "全屏"
 
-#: ../ui/main.glade:905
+#: ../ui/main.glade:982
 msgid "ver_y thick"
 msgstr "極粗(_y)"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:292
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:311
 msgid "whiteout"
 msgstr "涂白"
 
-#: ../src/control/xojfile/LoadHandler.cpp:835
+#: ../src/control/xojfile/LoadHandler.cpp:865
 msgid "xoj-File: {1}"
 msgstr ""
 
@@ -2339,6 +2405,9 @@ msgstr ""
 
 #~ msgid "Disable Ruler & Stroke Recognizer"
 #~ msgstr "取消標尺和筆劃識別"
+
+#~ msgid "Don't compress PDF files (for debugging)"
+#~ msgstr "勿壓縮PDF檔案(調試用)"
 
 #, fuzzy
 #~ msgid "Drawing type"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: xournalpp 1.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-12-30 12:21+0100\n"
+"POT-Creation-Date: 2019-01-23 10:36+0100\n"
 "PO-Revision-Date: 2018-11-14 19:57+0100\n"
 "Last-Translator: Andreas Butti <andreasbutti at gmail dot com>\n"
 "Language-Team: Xournal++ team\n"
@@ -16,41 +16,41 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.7.1\n"
 
-#: ../src/undo/DeleteUndoAction.cpp:113 ../src/undo/AddUndoAction.cpp:119
+#: ../src/undo/AddUndoAction.cpp:119 ../src/undo/DeleteUndoAction.cpp:113
 msgid " elements"
 msgstr "元素"
 
-#: ../src/undo/DeleteUndoAction.cpp:128 ../src/undo/AddUndoAction.cpp:134
+#: ../src/undo/AddUndoAction.cpp:134 ../src/undo/DeleteUndoAction.cpp:128
 msgid " image"
 msgstr "圖片"
 
-#: ../src/undo/DeleteUndoAction.cpp:132 ../src/undo/AddUndoAction.cpp:138
+#: ../src/undo/AddUndoAction.cpp:138 ../src/undo/DeleteUndoAction.cpp:132
 msgid " latex"
 msgstr "LaTeX"
 
-#: ../src/gui/MainWindow.cpp:734
+#: ../src/gui/MainWindow.cpp:818
 msgctxt "Page {pagenumber} \"of {pagecount}\""
 msgid " of {1}{2}"
 msgstr "頁，共{1}頁"
 
-#: ../src/undo/DeleteUndoAction.cpp:120 ../src/undo/AddUndoAction.cpp:126
+#: ../src/undo/AddUndoAction.cpp:126 ../src/undo/DeleteUndoAction.cpp:120
 msgid " stroke"
 msgstr "筆劃"
 
-#: ../src/undo/DeleteUndoAction.cpp:124 ../src/undo/AddUndoAction.cpp:130
+#: ../src/undo/AddUndoAction.cpp:130 ../src/undo/DeleteUndoAction.cpp:124
 msgid " text"
 msgstr "文本"
 
-#: ../src/control/settings/Settings.cpp:79
+#: ../src/control/settings/Settings.cpp:90
 #, fuzzy
 msgid "%F-Note-%H-%M"
 msgstr "%F-Note-%H-%M.xoj"
 
-#: ../ui/settings.glade:590
+#: ../ui/settings.glade:604
 msgid "%F-Note-%H-%M.xoj"
 msgstr "%F-Note-%H-%M.xoj"
 
-#: ../ui/settings.glade:613
+#: ../ui/settings.glade:627
 msgid ""
 "%a\tAbbreviated weekday name \t(e.g. Thu)\n"
 "%A\tFull weekday name (e.g. Thursday)\n"
@@ -80,19 +80,19 @@ msgstr ""
 msgid "<b>... or select already used Image:</b>"
 msgstr "<b>...或者選擇已用圖片：</b>"
 
-#: ../ui/settings.glade:271
+#: ../ui/settings.glade:285
 msgid "<b>Add horizontal space</b>"
 msgstr "<b>增加水平間距</b>"
 
-#: ../ui/settings.glade:248
+#: ../ui/settings.glade:262
 msgid "<b>Add vertical space</b>"
 msgstr "<b>增加垂直間距</b>"
 
-#: ../ui/settings.glade:704
+#: ../ui/settings.glade:718
 msgid "<b>Autoload .pdf.xoj</b>"
 msgstr "<b>自動加載.pdf.xoj</b>"
 
-#: ../ui/settings.glade:488
+#: ../ui/settings.glade:502
 msgid ""
 "<b>Autosave Folder</b>\n"
 "<i>If the document already was saved you can find it in the same folder\n"
@@ -104,7 +104,7 @@ msgstr ""
 "<i>如果文檔已經保存，您可以在同一目錄中使用副檔名.autosave.xoj找到該文檔。\n"
 "如果檔案沒有保存，您可以在目錄~/.xournalpp/autosave中找到。</i>"
 
-#: ../ui/settings.glade:428
+#: ../ui/settings.glade:442
 msgid "<b>Autosave</b>"
 msgstr "<b>自動保存</b>"
 
@@ -122,7 +122,7 @@ msgstr "背景"
 msgid "<b>Color</b>"
 msgstr "<b>顏色</b>"
 
-#: ../ui/settings.glade:1464
+#: ../ui/settings.glade:1521
 #, fuzzy
 msgid "<b>Colors</b>"
 msgstr "<b>顏色</b>"
@@ -140,7 +140,7 @@ msgid ""
 "for the fist Page"
 msgstr ""
 
-#: ../ui/settings.glade:1835
+#: ../ui/settings.glade:1907
 msgid "<b>Cursor</b>"
 msgstr "<b>光標</b>"
 
@@ -148,15 +148,15 @@ msgstr "<b>光標</b>"
 msgid "<b>Default Tools</b>"
 msgstr "<b>預設工具</b>"
 
-#: ../ui/settings.glade:577
+#: ../ui/settings.glade:591
 msgid "<b>Default name:</b>"
 msgstr "<b>預設名：</b>"
 
-#: ../ui/settings.glade:524
+#: ../ui/settings.glade:538
 msgid "<b>Default save name</b>"
 msgstr "<b>預設保存名</b>"
 
-#: ../ui/settings.glade:1943
+#: ../ui/settings.glade:2030
 msgid "<b>Default</b>"
 msgstr "<b>預設</b>"
 
@@ -166,11 +166,11 @@ msgid ""
 "Select pages to export"
 msgstr ""
 
-#: ../ui/settings.glade:1002
+#: ../ui/settings.glade:1016
 msgid "<b>Eraser</b>"
 msgstr "<b>橡皮</b>"
 
-#: ../ui/settings.glade:110
+#: ../ui/settings.glade:124
 msgid "<b>Extended Input</b>"
 msgstr "<b>擴展輸入</b>"
 
@@ -180,19 +180,19 @@ msgid ""
 "Select transparency for fill color"
 msgstr ""
 
-#: ../ui/settings.glade:1661
+#: ../ui/settings.glade:1733
 msgid "<b>Fullscreen</b>"
 msgstr "<b>全屏模式</b>"
 
-#: ../ui/settings.glade:658
+#: ../ui/settings.glade:672
 msgid "<b>Help</b> (Placeholders)"
 msgstr "<b>幫助</b> "
 
-#: ../ui/settings.glade:1390
+#: ../ui/settings.glade:1447
 msgid "<b>Left / Right</b>"
 msgstr "<b>左/右</b>"
 
-#: ../ui/settings.glade:819
+#: ../ui/settings.glade:833
 msgid "<b>Middle Mouse Button</b>"
 msgstr "<b>滑鼠中鍵</b>"
 
@@ -205,24 +205,24 @@ msgstr "<b>頁面尺寸</b>"
 msgid "<b>Pagesize</b>"
 msgstr "<b>頁面尺寸</b>"
 
-#: ../ui/settings.glade:1731
+#: ../ui/settings.glade:1803
 msgid "<b>Presentation</b> Another Fullscreen Mode, <i>Start with F5</i>"
 msgstr "<b>演講模式</b> (備選全屏模式 <i>使用F5激活</i>)"
 
-#: ../ui/settings.glade:155
+#: ../ui/settings.glade:169
 msgid "<b>Pressure sensitivity</b>"
 msgstr "<b>壓力敏感</b>"
 
-#: ../ui/settings.glade:849
+#: ../ui/settings.glade:863
 msgid "<b>Right Mouse Button</b>"
 msgstr "<b>滑鼠右鍵</b>"
 
-#: ../ui/settings.glade:1584
+#: ../ui/settings.glade:1656
 #, fuzzy
 msgid "<b>Scrollbars</b>"
 msgstr "<b>顏色</b>"
 
-#: ../ui/settings.glade:200
+#: ../ui/settings.glade:214
 msgid "<b>Scrolling outside the page</b>"
 msgstr "<b>捲出頁面</b>"
 
@@ -230,15 +230,15 @@ msgstr "<b>捲出頁面</b>"
 msgid "<b>Separator</b>"
 msgstr "<b>分割線</b>"
 
-#: ../ui/settings.glade:944
+#: ../ui/settings.glade:958
 msgid "<b>Stylus Button 1</b> Action if the pen button is pressed"
 msgstr ""
 
-#: ../ui/settings.glade:973
+#: ../ui/settings.glade:987
 msgid "<b>Stylus Button 2</b> Action if the pen button is pressed"
 msgstr ""
 
-#: ../ui/settings.glade:1031
+#: ../ui/settings.glade:1045
 msgid ""
 "<b>Touch Screen</b> <i>You can also configure other devices like mice</i>"
 msgstr "<b>觸屏</b> <i>滑鼠以外的其他設備也可以進行配置</i>"
@@ -247,7 +247,7 @@ msgstr "<b>觸屏</b> <i>滑鼠以外的其他設備也可以進行配置</i>"
 msgid "<i>Example:</i> 1-3 or 1,3,5-7 etc."
 msgstr "<i>比如：</i> 1-3 或者 1,3,5-7 等。"
 
-#: ../ui/settings.glade:929
+#: ../ui/settings.glade:943
 msgid ""
 "<i>Here you can define which tools will be selected If you\n"
 "use the eraser or other device.\n"
@@ -256,7 +256,7 @@ msgstr ""
 "<i>如果需使用橡皮或者其他設備，此處可以對用到的工具可以進行配置。\n"
 "此處可以關閉觸屏功能。</i>"
 
-#: ../ui/settings.glade:804
+#: ../ui/settings.glade:818
 msgid ""
 "<i>Here you can define which tools will be selected if you press\n"
 "a button; after you release the button the previously selected\n"
@@ -265,14 +265,14 @@ msgstr ""
 "<i>此處可以設定如果按鍵就會選擇的工具；\n"
 "該鍵被鬆開時原先的工具將會被選擇</i>"
 
-#: ../ui/settings.glade:2030
+#: ../ui/settings.glade:2188
 msgid ""
 "<i>If audio recording is running, the time stamps are stored to the "
 "handwritten Text and can be replayed.\n"
 "The Audio track is recorded to a separate folder, and liked to there.</i>"
 msgstr ""
 
-#: ../ui/settings.glade:224
+#: ../ui/settings.glade:238
 msgid ""
 "<i>If you add <b>additional space</b> beside the pages\n"
 "you can choose the area of the screen you would\n"
@@ -281,11 +281,11 @@ msgstr ""
 "<i>如果在頁面之間加入了<b>額外的空隙</b>\n"
 "則可以選擇屏幕上額外的操作區域</i>"
 
-#: ../ui/settings.glade:170
+#: ../ui/settings.glade:184
 msgid "<i>If you have a tablet pen you can get different line widths</i>"
 msgstr "<i>如果您有Tablet筆則可以獲得不同的綫寬。</i>"
 
-#: ../ui/settings.glade:728
+#: ../ui/settings.glade:742
 msgid ""
 "<i>If you open a PDF and there is a\n"
 "Xournal file with the same name it will open the xoj file.</i>"
@@ -293,7 +293,7 @@ msgstr ""
 "<i>如果您打開一個PDF檔案，但是此處有一個有同樣的檔案名的xoj檔案，\n"
 "則Xournal檔案將會被打開。</i>"
 
-#: ../ui/settings.glade:324
+#: ../ui/settings.glade:338
 msgid ""
 "<i>Put a ruler on your screen to calibrate the zoom level to fit your "
 "screen. Takes effect after restarting xournalpp.\n"
@@ -303,17 +303,17 @@ msgstr ""
 "在Xournal++重啟時將會發揮作用。\n"
 "標尺的長度單位是釐米，游標的單位是dpi。</i>"
 
-#: ../ui/settings.glade:133
+#: ../ui/settings.glade:147
 msgid "<i>Select some advanced input options</i>"
 msgstr ""
 
-#: ../ui/settings.glade:1339
+#: ../ui/settings.glade:1396
 msgid ""
 "<i>The commands will be executed in the UI Thread, make sure\n"
 "they are not blocking!</i>"
 msgstr ""
 
-#: ../ui/settings.glade:548
+#: ../ui/settings.glade:562
 msgid "<i>This name will be proposed if you save a new document</i>"
 msgstr "這個名字是在檔案保存時候的建議名。"
 
@@ -329,15 +329,15 @@ msgstr ""
 msgid "About Xournal++"
 msgstr "關於Xournal++"
 
-#: ../src/control/XournalMain.cpp:245
+#: ../src/control/XournalMain.cpp:250
 msgid "Absolute path for the audio files playback"
 msgstr ""
 
-#: ../ui/main.glade:1086
+#: ../ui/main.glade:1233
 msgid "Add/Edit Tex"
 msgstr "插入/編輯TeX"
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:48
+#: ../src/control/stockdlg/XojOpenDlg.cpp:51
 msgid "All files"
 msgstr "所有檔案"
 
@@ -356,7 +356,7 @@ msgid "Apply to current page"
 msgstr "刪除當前頁"
 
 #: ../src/control/stockdlg/ImageOpenDlg.cpp:30
-#: ../src/control/stockdlg/XojOpenDlg.cpp:147
+#: ../src/control/stockdlg/XojOpenDlg.cpp:152
 msgid "Attach file to the journal"
 msgstr "將檔案附加到日記"
 
@@ -381,15 +381,15 @@ msgstr "變數\"{1\"}不能為整數，其值為NULL"
 msgid "Attribute color not set!"
 msgstr "顏色未設置"
 
-#: ../ui/settings.glade:2051
+#: ../ui/settings.glade:2209
 msgid "Audio Folder"
 msgstr ""
 
-#: ../ui/settings.glade:2088
+#: ../ui/settings.glade:2246
 msgid "Audio Recording"
 msgstr ""
 
-#: ../src/control/AudioController.cpp:100
+#: ../src/control/AudioController.cpp:98
 msgid ""
 "Audio folder not set! Recording won't work!\n"
 "Please set the recording folder under \"Preferences > Audio recording\""
@@ -400,16 +400,16 @@ msgstr ""
 msgid "Authors:"
 msgstr "<b>作者：</b>"
 
-#: ../ui/settings.glade:1170
+#: ../ui/settings.glade:1227
 msgid "Autodetect"
 msgstr ""
 
-#: ../ui/settings.glade:456
+#: ../ui/settings.glade:470
 #, fuzzy
 msgid "Autosave every ... minutes:"
 msgstr "自動保存間隔分鐘數："
 
-#: ../src/control/Control.cpp:254
+#: ../src/control/Control.cpp:256
 #, fuzzy
 msgid "Autosave failed with an error: {1}"
 msgstr "打開檔案出錯：{1}"
@@ -418,8 +418,7 @@ msgstr "打開檔案出錯：{1}"
 msgid "Autosave: {1}"
 msgstr "自動保存：{1}"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:333
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:336
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:429
 msgid "Back"
 msgstr "後退"
 
@@ -429,11 +428,11 @@ msgstr "後退"
 msgid "Background"
 msgstr "背景"
 
-#: ../ui/settings.glade:1520
+#: ../ui/settings.glade:1577
 msgid "Background color for window Background"
 msgstr ""
 
-#: ../ui/settings.glade:1857
+#: ../ui/settings.glade:1929
 msgid "Big cursor for pen"
 msgstr "畫筆使用大光標"
 
@@ -447,11 +446,11 @@ msgstr "黑色"
 msgid "Blue"
 msgstr "藍色"
 
-#: ../ui/settings.glade:1509
+#: ../ui/settings.glade:1566
 msgid "Border color"
 msgstr "邊界顏色"
 
-#: ../ui/settings.glade:1495
+#: ../ui/settings.glade:1552
 #, fuzzy
 msgid "Border color for current page and other selections"
 msgstr "當前頁和選中項目的邊界顏色"
@@ -460,8 +459,8 @@ msgstr "當前頁和選中項目的邊界顏色"
 msgid "Built on:"
 msgstr ""
 
-#: ../src/control/Control.cpp:2022 ../src/control/Control.cpp:2534
-#: ../src/control/Control.cpp:2570 ../src/control/XournalMain.cpp:124
+#: ../src/control/Control.cpp:2058 ../src/control/Control.cpp:2581
+#: ../src/control/Control.cpp:2619 ../src/control/XournalMain.cpp:128
 msgid "Cancel"
 msgstr "取消"
 
@@ -478,7 +477,7 @@ msgstr "改變字型"
 msgid "Change stroke fill"
 msgstr "改變筆劃粗細"
 
-#: ../src/undo/SizeUndoAction.cpp:145
+#: ../src/undo/SizeUndoAction.cpp:139
 msgid "Change stroke width"
 msgstr "改變筆劃粗細"
 
@@ -486,7 +485,7 @@ msgstr "改變筆劃粗細"
 msgid "Color \"{1}\" unknown (not defined in default color list)!"
 msgstr "色彩\"{1}\"未定義！"
 
-#: ../ui/main.glade:588
+#: ../ui/main.glade:633
 msgid "Configure Page Template"
 msgstr ""
 
@@ -494,8 +493,8 @@ msgstr ""
 msgid "Contents"
 msgstr "內容"
 
-#: ../src/control/Control.cpp:1036 ../src/control/Control.cpp:1044
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:321
+#: ../src/control/Control.cpp:1047 ../src/control/Control.cpp:1055
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:402
 msgid "Copy"
 msgstr "拷貝"
 
@@ -516,37 +515,51 @@ msgstr "末頁"
 msgid "Copy page"
 msgstr "拷貝一頁"
 
+#: ../src/control/LatexController.cpp:103
+msgid "Could not convert tex to PDF: {1} (exit code: {2})"
+msgstr ""
+
 #: ../src/control/jobs/SaveJob.cpp:137
 msgid ""
 "Could not create backup! (The file was created from an older Xournal version)"
 msgstr "未能產生備份檔案！(此檔案應為老版本Xournal所建)"
 
-#: ../src/util/Util.cpp:97
+#: ../src/util/Util.cpp:94
 #, fuzzy
 msgid "Could not create folder: {1}"
 msgstr "不能打開檔案\"{1}\""
 
-#: ../src/control/Control.cpp:218 ../src/control/Control.cpp:235
+#: ../src/control/Control.cpp:220 ../src/control/Control.cpp:237
 #, fuzzy
 msgid "Could not delete old autosave file \"{1}\""
 msgstr "不能打開檔案\"{1}\""
 
-#: ../src/control/LatexController.cpp:381
+#: ../src/control/LatexController.cpp:428
 msgid ""
-"Could not find Xournal++ LaTeX executable relative or in Path.\n"
-"Searched for: mathtex-xournalpp.cgi"
+"Could not find pdflatex in Path.\n"
+"Please install pdflatex first and make sure it's in the Path."
 msgstr ""
+
+#: ../src/control/LatexController.cpp:299
+#, fuzzy
+msgid "Could not load LaTeX PDF file, URL-Error: {1}"
+msgstr "未能提取LaTeX圖像檔案{1}"
+
+#: ../src/control/LatexController.cpp:307
+#, fuzzy
+msgid "Could not load LaTeX PDF file: {1}"
+msgstr "不能打開檔案\"{1}\""
 
 #: ../src/control/pagetype/PageTypeHandler.cpp:18
 #, fuzzy
 msgid "Could not load pagetemplates.ini file"
 msgstr "不能打開檔案\"{1}\""
 
-#: ../src/control/xojfile/LoadHandler.cpp:123
+#: ../src/control/xojfile/LoadHandler.cpp:124
 msgid "Could not open file: \"{1}\""
 msgstr "不能打開檔案\"{1}\""
 
-#: ../src/gui/MainWindow.cpp:93
+#: ../src/gui/MainWindow.cpp:86
 msgid ""
 "Could not parse custom toolbar.ini file: {1}\n"
 "Toolbars will not be available"
@@ -554,7 +567,7 @@ msgstr ""
 "未能解析配置檔案toolbar.ini: {1}\n"
 "工具條將不可用"
 
-#: ../src/gui/MainWindow.cpp:83
+#: ../src/gui/MainWindow.cpp:76
 msgid ""
 "Could not parse general toolbar.ini file: {1}\n"
 "No Toolbars will be available"
@@ -562,7 +575,7 @@ msgstr ""
 "未能解析一般檔案toolbar.ini: {1}\n"
 "工具條將不可用"
 
-#: ../src/control/xojfile/LoadHandler.cpp:328
+#: ../src/control/xojfile/LoadHandler.cpp:347
 msgid "Could not read image: {1}. Error message: {2}"
 msgstr "未能讀入圖像：{1}。錯誤提示為：{2}"
 
@@ -574,22 +587,23 @@ msgstr ""
 "未能重複操作\"{1}\"\n"
 "有錯誤發生***請提交一個錯誤報告***"
 
-#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:214
+#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:210
 msgid "Could not remove tool item from Toolbar {1} on position {2}"
 msgstr ""
 
-#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:209
+#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:205
 msgid "Could not remove tool item {1} from Toolbar {2} on position {3}"
 msgstr ""
 
-#: ../src/control/Control.cpp:228 ../src/control/Control.cpp:247
+#: ../src/control/Control.cpp:230 ../src/control/Control.cpp:249
 #, fuzzy
 msgid "Could not rename autosave file from \"{1}\" to \"{2}\""
 msgstr "未能寫入外來數據檔案：{1} ({2})"
 
-#: ../src/control/LatexController.cpp:310
-msgid "Could not retrieve LaTeX image file: {1}"
-msgstr "未能提取LaTeX圖像檔案{1}"
+#: ../src/control/LatexController.cpp:89
+#, fuzzy
+msgid "Could not save .tex file: {1}"
+msgstr "不能打開檔案\"{1}\""
 
 #: ../src/undo/UndoRedoHandler.cpp:144
 msgid ""
@@ -599,11 +613,11 @@ msgstr ""
 "未能撤銷操作\"{1}\"\n"
 "有錯誤發生***請提交一個錯誤報告***"
 
-#: ../src/control/xojfile/SaveHandler.cpp:294
+#: ../src/control/xojfile/SaveHandler.cpp:290
 msgid "Could not write background \"{1}\", {2}"
 msgstr "未能寫上背景\"{1}\", {2}"
 
-#: ../src/control/xojfile/SaveHandler.cpp:419
+#: ../src/control/xojfile/SaveHandler.cpp:415
 msgid "Could not write background \"{1}\". Continuing anyway."
 msgstr "未能寫上背景\"{1}\"，不管啦繼續哦..."
 
@@ -620,7 +634,7 @@ msgstr "當前頁"
 msgid "Custom"
 msgstr "設置"
 
-#: ../ui/settings.glade:1231
+#: ../ui/settings.glade:1288
 msgid "Custom Commands (for Method \"Custom\")"
 msgstr ""
 
@@ -633,35 +647,40 @@ msgstr "設置"
 msgid "Customized"
 msgstr "設置過"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:320
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:401
 msgid "Cut"
 msgstr "剪切"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:442
+#: ../ui/settings.glade:1621
+msgid "Dark Theme (restart needed)"
+msgstr ""
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:460
 msgid "Default Tool"
 msgstr "預設工具"
 
-#: ../ui/settings.glade:1997
+#: ../ui/settings.glade:2155
 msgid "Defaults"
 msgstr "預設"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:407
 #: ../src/undo/DeleteUndoAction.cpp:102
 msgid "Delete"
 msgstr "刪除"
 
-#: ../ui/main.glade:620
+#: ../ui/main.glade:668
 msgid "Delete Layer"
 msgstr "刪除層"
 
-#: ../src/control/XournalMain.cpp:123
+#: ../src/control/XournalMain.cpp:127
 msgid "Delete Logfile"
 msgstr "刪除日誌檔案"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:387
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:447
 msgid "Delete current page"
 msgstr "刪除當前頁"
 
-#: ../src/control/XournalMain.cpp:173
+#: ../src/control/XournalMain.cpp:177
 #, fuzzy
 msgid "Delete file"
 msgstr "刪除日誌檔案"
@@ -674,7 +693,7 @@ msgstr "刪除層"
 msgid "Delete stroke"
 msgstr "刪除筆劃"
 
-#: ../ui/main.glade:1297
+#: ../ui/main.glade:1447
 #, fuzzy
 msgid "Delete this page"
 msgstr "删除当前页"
@@ -683,7 +702,7 @@ msgstr "删除当前页"
 msgid "Device"
 msgstr "設備"
 
-#: ../ui/settings.glade:1261
+#: ../ui/settings.glade:1318
 msgid "Disable"
 msgstr ""
 
@@ -691,19 +710,19 @@ msgstr ""
 msgid "Disable drawing for this device"
 msgstr "取消此設備繪製"
 
-#: ../ui/settings.glade:1134
+#: ../ui/settings.glade:1191
 msgid "Disable touch if pen is near screen"
 msgstr ""
 
-#: ../ui/settings.glade:1156
+#: ../ui/settings.glade:1213
 msgid "Disabling Method"
 msgstr ""
 
-#: ../src/control/Control.cpp:2533 ../src/control/Control.cpp:2569
+#: ../src/control/Control.cpp:2577 ../src/control/Control.cpp:2618
 msgid "Discard"
 msgstr "丟棄"
 
-#: ../src/control/Control.cpp:1952
+#: ../src/control/Control.cpp:1988
 msgid ""
 "Do not open Autosave files. They may will be overwritten!\n"
 "Copy the files to another folder.\n"
@@ -714,21 +733,17 @@ msgstr ""
 msgid "Do not overwrite the background PDF! This will cause errors!"
 msgstr ""
 
-#: ../src/control/Control.cpp:2566
+#: ../src/control/Control.cpp:2615
 msgid "Document file was removed."
 msgstr "文檔已刪除。"
 
-#: ../src/control/xojfile/LoadHandler.cpp:202
+#: ../src/control/xojfile/LoadHandler.cpp:203
 msgid "Document is not complete (maybe the end is cut off?)"
 msgstr "文檔檔案不完整"
 
 #: ../src/model/Document.cpp:393
 msgid "Document not loaded! ({1}), {2}"
 msgstr "文檔未加載！({1}), {2}"
-
-#: ../src/control/XournalMain.cpp:242
-msgid "Don't compress PDF files (for debugging)"
-msgstr "勿壓縮PDF檔案(調試用)"
 
 #: ../src/control/pagetype/PageTypeHandler.cpp:26
 msgid "Dotted"
@@ -740,13 +755,13 @@ msgstr "在這裡和工具條之間可以來回拖動條目。"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:99
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:40
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:420
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:465
 msgid "Draw Arrow"
 msgstr "繪製箭頭"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:97
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:39
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:416
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:464
 msgid "Draw Circle"
 msgstr "繪製圓形"
 
@@ -758,20 +773,20 @@ msgstr "繪製直線"
 #: ../src/gui/dialog/ButtonConfigGui.cpp:95
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:29
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:38
-#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:120
-#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:123
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:418
+#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:122
+#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:125
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:463
 msgid "Draw Rectangle"
 msgstr "繪製矩形"
 
-#: ../ui/main.glade:778
+#: ../ui/main.glade:844
 #, fuzzy
 msgid "Draw _Line"
 msgstr "繪製直線"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:101
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:42
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:422
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:466
 msgid "Draw coordinate system"
 msgstr ""
 
@@ -788,26 +803,35 @@ msgstr "勿作修改"
 msgid "Edit text"
 msgstr "編輯文本"
 
-#: ../ui/settings.glade:1249
+#: ../src/undo/EmergencySaveRestore.cpp:35
+#, fuzzy
+msgid "Emergency saved document"
+msgstr "未保存文檔"
+
+#: ../ui/settings.glade:1306
 #, fuzzy
 msgid "Enable"
 msgstr "激活標尺"
+
+#: ../ui/settings.glade:1176
+msgid "Enable zoom gestures (needs restart)"
+msgstr ""
 
 #: ../ui/texdialog.glade:66
 msgid "Enter / edit LaTeX Text"
 msgstr ""
 
-#: ../src/undo/EraseUndoAction.cpp:130 ../src/undo/DeleteUndoAction.cpp:99
-#: ../src/undo/AddUndoAction.cpp:104
+#: ../src/undo/AddUndoAction.cpp:104 ../src/undo/DeleteUndoAction.cpp:99
+#: ../src/undo/EraseUndoAction.cpp:130
 msgid "Erase stroke"
 msgstr "擦除筆劃"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:56
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:282
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:308
 msgid "Eraser"
 msgstr "橡皮"
 
-#: ../ui/main.glade:940
+#: ../ui/main.glade:1066
 msgid "Eraser Optio_ns"
 msgstr "橡皮選項(_n)"
 
@@ -815,7 +839,7 @@ msgstr "橡皮選項(_n)"
 msgid "Eraser Type - don't change"
 msgstr ""
 
-#: ../src/control/Control.cpp:2232
+#: ../src/control/Control.cpp:2268
 msgid ""
 "Error annotate PDF file \"{1}\"\n"
 "{2}"
@@ -828,11 +852,11 @@ msgstr ""
 msgid "Error export PDF Page"
 msgstr "輸出為PDF"
 
-#: ../src/gui/GladeGui.cpp:25
+#: ../src/gui/GladeGui.cpp:26
 msgid "Error loading glade file \"{1}\" (try to load \"{2}\")"
 msgstr "加載glade檔案\"{1}\"出錯(嘗試加載\"{2}\")"
 
-#: ../src/control/Control.cpp:2047
+#: ../src/control/Control.cpp:2083
 msgid "Error opening file \"{1}\""
 msgstr "打開檔案\"{1}\"出錯"
 
@@ -840,11 +864,11 @@ msgstr "打開檔案\"{1}\"出錯"
 msgid "Error opening file: \"{1}\""
 msgstr "打開檔案\"{1}\"出錯"
 
-#: ../src/control/xojfile/LoadHandler.cpp:428
+#: ../src/control/xojfile/LoadHandler.cpp:447
 msgid "Error reading PDF: {1}"
 msgstr "讀入PDF出錯：{1}"
 
-#: ../src/control/xojfile/LoadHandler.cpp:499
+#: ../src/control/xojfile/LoadHandler.cpp:518
 msgid "Error reading width of a stroke: {1}"
 msgstr "讀入筆劃粗細出錯：{1}"
 
@@ -852,7 +876,7 @@ msgstr "讀入筆劃粗細出錯：{1}"
 msgid "Error: {1}"
 msgstr "錯誤：{1}"
 
-#: ../src/control/XournalMain.cpp:147
+#: ../src/control/XournalMain.cpp:151
 msgid ""
 "Errorlog cannot be deleted. You have to do it manually.\n"
 "Logfile: {1}"
@@ -868,19 +892,19 @@ msgstr "輸出"
 msgid "Export PDF"
 msgstr "輸出為PDF"
 
-#: ../ui/main.glade:113
+#: ../ui/main.glade:119
 msgid "Export as..."
 msgstr "輸出為..."
 
-#: ../src/control/LatexController.cpp:398
+#: ../src/control/LatexController.cpp:445
 msgid "Failed to generate LaTeX image!"
 msgstr ""
 
-#: ../ui/main.glade:920 ../ui/main.glade:1057
+#: ../ui/main.glade:1044 ../ui/main.glade:1192
 msgid "Fi_ll"
 msgstr ""
 
-#: ../src/util/Util.cpp:127 ../src/util/Util.cpp:148
+#: ../src/util/Util.cpp:123 ../src/util/Util.cpp:143
 msgid ""
 "File couldn't be opened. You have to do it manually:\n"
 "URL: {1}"
@@ -888,23 +912,23 @@ msgstr ""
 "未能打開檔案，請手動操作：\n"
 "URL: {1}"
 
-#: ../src/control/Control.cpp:1982
+#: ../src/control/Control.cpp:2018
 msgid "Filename: {1}"
 msgstr "檔案名：{1}"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:445
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:500
 msgid "Fill"
 msgstr ""
 
-#: ../ui/main.glade:928 ../ui/main.glade:1065
+#: ../ui/main.glade:1053 ../ui/main.glade:1201
 msgid "Fill transparency"
 msgstr ""
 
-#: ../ui/main.glade:1492
+#: ../ui/main.glade:1634
 msgid "Find next occurrence of the search string"
 msgstr ""
 
-#: ../ui/main.glade:1471
+#: ../ui/main.glade:1613
 msgid "Find previous occurrence of the search string"
 msgstr ""
 
@@ -912,37 +936,43 @@ msgstr ""
 msgid "Font"
 msgstr "字型"
 
-#: ../ui/main.glade:289
+#: ../ui/main.glade:338
 msgid "Fullscreen"
 msgstr "全屏"
 
-#: ../ui/about.glade:233
+#: ../ui/about.glade:234
 msgid "GNU GPLv2 or later"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:331
+#: ../ui/settings.glade:1072
+msgid ""
+"GTK Touch / Scrolling workaround. Change Scroll / Touch behavoir. Enabled "
+"touch drawing. Needs restart."
+msgstr ""
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:428
 msgid "Go to first page"
 msgstr "首頁"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:344
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:432
 msgid "Go to last page"
 msgstr "末頁"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:349
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:435
 #, fuzzy
 msgid "Go to next layer"
 msgstr "末頁"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:339
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:430
 msgid "Go to page"
 msgstr "跳轉到頁面"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:347
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:434
 #, fuzzy
 msgid "Go to previous layer"
 msgstr "首頁"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:351
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:436
 #, fuzzy
 msgid "Go to top layer"
 msgstr "跳轉到頁面"
@@ -966,16 +996,20 @@ msgstr "灰色"
 msgid "Green"
 msgstr "綠色"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:378
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:411
 msgid "Grid Snapping"
 msgstr ""
 
-#: ../ui/main.glade:843
+#: ../ui/settings.glade:2113
+msgid "Grid snapping tolerance:"
+msgstr ""
+
+#: ../ui/main.glade:915
 msgid "H_and Tool"
 msgstr "手形工具(_a)"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:63
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:426
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:474
 msgid "Hand"
 msgstr "手形工具"
 
@@ -983,16 +1017,16 @@ msgstr "手形工具"
 msgid "Height:"
 msgstr "高度："
 
-#: ../ui/main.glade:379
+#: ../ui/main.glade:407
 #, fuzzy
 msgid "Hide Menu"
 msgstr "隱藏菜單條"
 
-#: ../ui/settings.glade:1683 ../ui/settings.glade:1753
+#: ../ui/settings.glade:1755 ../ui/settings.glade:1825
 msgid "Hide Menubar"
 msgstr "隱藏菜單條"
 
-#: ../ui/settings.glade:1698 ../ui/settings.glade:1768
+#: ../ui/settings.glade:1770 ../ui/settings.glade:1840
 msgid "Hide Sidebar"
 msgstr "隱藏側邊欄"
 
@@ -1001,26 +1035,31 @@ msgstr "隱藏側邊欄"
 msgid "Hide all"
 msgstr "隱藏菜單條"
 
-#: ../ui/settings.glade:1613
+#: ../ui/settings.glade:1685
 msgid "Hide the horizontal scrollbar"
 msgstr ""
 
-#: ../ui/settings.glade:1628
+#: ../ui/settings.glade:1700
 msgid "Hide the vertical scrollbar"
 msgstr ""
 
+#: ../ui/settings.glade:1944
+#, fuzzy
+msgid "Highlight cursor position"
+msgstr "高亮選項(_i)"
+
 #: ../src/gui/dialog/ButtonConfigGui.cpp:57
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:399
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:457
 msgid "Highlighter"
 msgstr "高亮"
 
-#: ../ui/main.glade:1014
+#: ../ui/main.glade:1146
 #, fuzzy
 msgid "Highlighter Opti_ons"
 msgstr "高亮選項(_i)"
 
 #: ../src/control/pagetype/PageTypeHandler.cpp:32
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:403
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:459
 msgid "Image"
 msgstr "圖片"
 
@@ -1028,11 +1067,11 @@ msgstr "圖片"
 msgid "Images"
 msgstr "圖片"
 
-#: ../ui/settings.glade:390
+#: ../ui/settings.glade:404
 msgid "Input"
 msgstr "輸入"
 
-#: ../ui/settings.glade:1090
+#: ../ui/settings.glade:1119
 msgid "Input Device"
 msgstr "輸入設備"
 
@@ -1040,7 +1079,7 @@ msgstr "輸入設備"
 msgid "Insert Latex"
 msgstr "插入LaTeX"
 
-#: ../ui/main.glade:1277
+#: ../ui/main.glade:1427
 msgid "Insert a copy of the current page below"
 msgstr ""
 
@@ -1048,7 +1087,7 @@ msgstr ""
 msgid "Insert elements"
 msgstr "插入元素"
 
-#: ../src/undo/InsertUndoAction.cpp:47 ../src/gui/dialog/ButtonConfigGui.cpp:59
+#: ../src/gui/dialog/ButtonConfigGui.cpp:59 ../src/undo/InsertUndoAction.cpp:47
 msgid "Insert image"
 msgstr "插入圖片"
 
@@ -1060,11 +1099,11 @@ msgstr "插入LaTeX"
 msgid "Insert layer"
 msgstr "插入層"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:394
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:443
 msgid "Insert page"
 msgstr "插入頁面"
 
-#: ../src/control/XournalMain.cpp:244
+#: ../src/control/XournalMain.cpp:249
 msgid "Jump to Page (first Page: 1)"
 msgstr "跳到頁面(第一頁:1)"
 
@@ -1086,7 +1125,7 @@ msgstr "選擇圖層"
 msgid "Layer {1}"
 msgstr "{1}圖層"
 
-#: ../ui/about.glade:217
+#: ../ui/about.glade:218
 msgid "License"
 msgstr ""
 
@@ -1104,7 +1143,7 @@ msgstr "淺綠"
 msgid "Lined"
 msgstr "畫綫的"
 
-#: ../ui/settings.glade:772
+#: ../ui/settings.glade:786
 msgid "Load / Save"
 msgstr "加載/保存"
 
@@ -1112,13 +1151,13 @@ msgstr "加載/保存"
 msgid "Load file"
 msgstr "加載檔案"
 
-#: ../src/gui/PageView.cpp:738
+#: ../src/gui/PageView.cpp:739
 #: ../src/gui/sidebar/previews/base/SidebarPreviewBaseEntry.cpp:105
 #: ../src/gui/toolbarMenubar/ToolPageLayer.cpp:20
 msgid "Loading..."
 msgstr "加載中..."
 
-#: ../ui/toolbarManageDialog.glade:8 ../ui/toolbarCustomizeDialog.glade:10
+#: ../ui/toolbarCustomizeDialog.glade:10 ../ui/toolbarManageDialog.glade:8
 msgid "Manage Toolbar"
 msgstr "定製工具條"
 
@@ -1128,11 +1167,17 @@ msgid "Mangenta"
 msgstr "品紅"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:81
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:437
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:514
 msgid "Medium"
 msgstr "中"
 
-#: ../src/control/XournalMain.cpp:462
+#: ../src/control/XournalMain.cpp:460
+msgid ""
+"Missing the needed UI file! .app corrupted?\n"
+"Path: {1}"
+msgstr ""
+
+#: ../src/control/XournalMain.cpp:474
 msgid ""
 "Missing the needed UI file, could not find them at any location.\n"
 "Not relative\n"
@@ -1140,7 +1185,7 @@ msgid ""
 "Not in {1}"
 msgstr ""
 
-#: ../ui/settings.glade:883
+#: ../ui/settings.glade:897
 msgid "Mouse Button"
 msgstr "滑鼠按鈕"
 
@@ -1161,7 +1206,7 @@ msgstr "向後移動頁面"
 msgid "Move page upwards"
 msgstr "向前移動頁面"
 
-#: ../ui/main.glade:531
+#: ../ui/main.glade:571
 msgid "N_ext annotated page"
 msgstr "下一個標註頁(_e)"
 
@@ -1169,31 +1214,31 @@ msgstr "下一個標註頁(_e)"
 msgid "New"
 msgstr "新建"
 
-#: ../ui/main.glade:571
+#: ../ui/main.glade:614
 msgid "New Page _After"
 msgstr "新建後頁(_A)"
 
-#: ../ui/main.glade:563
+#: ../ui/main.glade:605
 msgid "New Page _Before"
 msgstr "新建前頁(_B)"
 
-#: ../ui/main.glade:580
+#: ../ui/main.glade:624
 msgid "New Page at _End"
 msgstr "新建尾頁(_E)"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:316
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:388
 msgid "New Xournal"
 msgstr "新建日記"
 
-#: ../ui/main.glade:611
+#: ../ui/main.glade:658
 msgid "New _Layer"
 msgstr "新建圖層(_L)"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:342
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:431
 msgid "Next"
 msgstr "下一個"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:355
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:438
 msgid "Next annotated page"
 msgstr "下一個標註頁面"
 
@@ -1220,20 +1265,20 @@ msgstr ""
 msgid "Open Image"
 msgstr "打開圖片"
 
-#: ../src/control/XournalMain.cpp:121
+#: ../src/control/XournalMain.cpp:125
 msgid "Open Logfile"
 msgstr "打開日誌檔案"
 
-#: ../src/control/XournalMain.cpp:122
+#: ../src/control/XournalMain.cpp:126
 msgid "Open Logfile directory"
 msgstr "打開日誌檔案目錄"
 
 #: ../src/control/stockdlg/XojOpenDlg.cpp:16
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:318
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:389
 msgid "Open file"
 msgstr "打開檔案"
 
-#: ../src/control/RecentManager.cpp:241
+#: ../src/control/RecentManager.cpp:244
 msgctxt "{1} is a URI"
 msgid "Open {1}"
 msgstr "打開{1}"
@@ -1247,7 +1292,7 @@ msgstr "橙色"
 msgid "PDF Export"
 msgstr "輸出為PDF"
 
-#: ../src/gui/MainWindow.cpp:732
+#: ../src/gui/MainWindow.cpp:816
 msgid "PDF Page {1}"
 msgstr "PDF頁碼{1}"
 
@@ -1255,17 +1300,17 @@ msgstr "PDF頁碼{1}"
 msgid "PDF background missing"
 msgstr "PDF背景丟失"
 
-#: ../src/control/XournalMain.cpp:223
+#: ../src/control/XournalMain.cpp:230
 msgid "PDF file successfully created"
 msgstr "PDF檔案成功建立"
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:58
-#: ../src/control/jobs/PdfExportJob.cpp:23
 #: ../src/control/jobs/CustomExportJob.cpp:27
+#: ../src/control/jobs/PdfExportJob.cpp:23
+#: ../src/control/stockdlg/XojOpenDlg.cpp:61
 msgid "PDF files"
 msgstr "PDF檔案"
 
-#: ../src/control/XournalMain.cpp:243
+#: ../src/control/XournalMain.cpp:248
 msgid "PDF output filename"
 msgstr "PDF輸出檔案名"
 
@@ -1283,7 +1328,7 @@ msgstr ""
 msgid "PNG with transparent background"
 msgstr "紙張背景(_a)"
 
-#: ../ui/main.glade:540
+#: ../ui/main.glade:581
 #, fuzzy
 msgid "P_revious annotated Page"
 msgstr "前一個標註頁(_r)"
@@ -1325,35 +1370,35 @@ msgstr "頁碼："
 msgid "Paper Format"
 msgstr "紙張樣式"
 
-#: ../ui/main.glade:643
+#: ../ui/main.glade:693
 msgid "Paper _Color"
 msgstr "紙張顏色(_C)"
 
-#: ../ui/main.glade:635
+#: ../ui/main.glade:684
 msgid "Paper _Format"
 msgstr "紙張樣式(_F)"
 
-#: ../ui/main.glade:651
+#: ../ui/main.glade:702
 msgid "Paper b_ackground"
 msgstr "紙張背景(_a)"
 
-#: ../ui/about.glade:201
+#: ../ui/about.glade:202
 msgid ""
 "Partial based on Xournal\n"
 "by Denis Auroux"
 msgstr ""
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:403
 #: ../src/undo/AddUndoAction.cpp:108
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:322
 msgid "Paste"
 msgstr "粘貼"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:55
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:382
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:286
 msgid "Pen"
 msgstr "畫筆"
 
-#: ../ui/main.glade:859
+#: ../ui/main.glade:932
 msgid "Pen _Options"
 msgstr "畫筆選項(_O)"
 
@@ -1361,9 +1406,9 @@ msgstr "畫筆選項(_O)"
 msgid "Plain"
 msgstr "空白"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:473
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:32
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:106
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:413
 #, fuzzy
 msgid "Play Object"
 msgstr "選擇對象"
@@ -1372,11 +1417,11 @@ msgstr "選擇對象"
 msgid "Predefined"
 msgstr "預定"
 
-#: ../ui/main.glade:251
+#: ../ui/main.glade:297
 msgid "Preferences"
 msgstr "偏好設置"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:461
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:417
 msgid "Presentation mode"
 msgstr "演講模式"
 
@@ -1384,15 +1429,15 @@ msgstr "演講模式"
 msgid "Range"
 msgstr "範圍"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:371
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:479
 msgid "Rec / Stop"
 msgstr ""
 
-#: ../ui/main.glade:299
+#: ../ui/main.glade:1225
 msgid "Rec-Stop"
 msgstr ""
 
-#: ../ui/main.glade:61
+#: ../ui/main.glade:63
 msgid "Recent _Documents"
 msgstr "最近文檔(_D)"
 
@@ -1401,8 +1446,8 @@ msgstr "最近文檔(_D)"
 msgid "Red"
 msgstr "紅色"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:397
 #: ../src/undo/UndoRedoHandler.cpp:293
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:327
 msgid "Redo"
 msgstr "重複"
 
@@ -1410,15 +1455,15 @@ msgstr "重複"
 msgid "Redo: "
 msgstr "重複："
 
-#: ../src/control/Control.cpp:2021
+#: ../src/control/Control.cpp:2057
 msgid "Remove PDF Background"
 msgstr "去掉PDF背景"
 
-#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:202
+#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:198
 msgid "Removed tool item from Toolbar {1} ID {2}"
 msgstr ""
 
-#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:198
+#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:194
 msgid "Removed tool item {1} from Toolbar {2} ID {3}"
 msgstr ""
 
@@ -1431,7 +1476,7 @@ msgstr ""
 msgid "Resolution"
 msgstr "解析度："
 
-#: ../src/control/XournalMain.cpp:174
+#: ../src/control/XournalMain.cpp:178
 #, fuzzy
 msgid "Restore file"
 msgstr "保存檔案"
@@ -1441,33 +1486,37 @@ msgstr "保存檔案"
 msgid "Rotation"
 msgstr "解析度："
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:375
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:410
 msgid "Rotation Snapping"
+msgstr ""
+
+#: ../ui/settings.glade:2083
+msgid "Rotation snapping tolerance:"
 msgstr ""
 
 #: ../src/control/pagetype/PageTypeHandler.cpp:24
 msgid "Ruled"
 msgstr "定標"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:432
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:467
 msgid "Ruler"
 msgstr "標尺"
 
-#: ../src/control/jobs/SaveJob.cpp:13 ../src/control/Control.cpp:2532
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:315
+#: ../src/control/Control.cpp:2576 ../src/control/jobs/SaveJob.cpp:13
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:390
 msgid "Save"
 msgstr "保存"
 
-#: ../src/control/Control.cpp:2568
+#: ../src/control/Control.cpp:2617
 msgid "Save As"
 msgstr "保存為"
 
-#: ../src/control/Control.cpp:2352 ../src/gui/dialog/PageTemplateDialog.cpp:112
+#: ../src/control/Control.cpp:2388 ../src/gui/dialog/PageTemplateDialog.cpp:112
 msgid "Save File"
 msgstr "保存檔案"
 
-#: ../src/control/jobs/SaveJob.cpp:151
 #: ../src/control/jobs/CustomExportJob.cpp:276
+#: ../src/control/jobs/SaveJob.cpp:151
 #, fuzzy
 msgid "Save file error: {1}"
 msgstr "打開檔案出錯：{1}"
@@ -1476,7 +1525,7 @@ msgstr "打開檔案出錯：{1}"
 msgid "Scale"
 msgstr "縮放"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:324
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:405
 msgid "Search"
 msgstr "搜索"
 
@@ -1485,12 +1534,12 @@ msgstr "搜索"
 msgid "Select Background Color"
 msgstr "選色"
 
-#: ../ui/settings.glade:2065
+#: ../ui/settings.glade:2223
 #, fuzzy
 msgid "Select Folder"
 msgstr "選色"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:447
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:476
 msgid "Select Font"
 msgstr "選擇字型"
 
@@ -1498,9 +1547,9 @@ msgstr "選擇字型"
 msgid "Select Image"
 msgstr "選擇圖片"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:471
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:31
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:99
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:410
 msgid "Select Object"
 msgstr "選擇對象"
 
@@ -1508,21 +1557,21 @@ msgstr "選擇對象"
 msgid "Select PDF Page"
 msgstr "選擇PDF頁面"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:470
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:10
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:29
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:85
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:125
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:408
 msgid "Select Rectangle"
 msgstr "選擇矩形"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:469
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:30
 #: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:92
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:406
 msgid "Select Region"
 msgstr "選擇區域"
 
-#: ../src/control/Control.cpp:2020
+#: ../src/control/Control.cpp:2056
 msgid "Select another PDF"
 msgstr "選擇其他PDF"
 
@@ -1549,19 +1598,19 @@ msgstr "選擇矩形"
 msgid "Select region"
 msgstr "選擇區域"
 
-#: ../ui/settings.glade:1964
+#: ../ui/settings.glade:2051
 msgid "Select the tool and Settings if you press the Default Button"
 msgstr "按下預設按鈕，此工具及其設置將會生效"
 
-#: ../ui/settings.glade:1789
+#: ../ui/settings.glade:1861
 msgid "Select toolbar:"
 msgstr "選擇工具條："
 
-#: ../ui/settings.glade:1543
+#: ../ui/settings.glade:1600
 msgid "Selection Color (Text, Stroke Selection etc.)"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:120
+#: ../src/control/XournalMain.cpp:124
 msgid "Send Bugreport"
 msgstr "選擇錯誤報告"
 
@@ -1569,11 +1618,15 @@ msgstr "選擇錯誤報告"
 msgid "Separator"
 msgstr "分割線"
 
-#: ../ui/settings.glade:1123
+#: ../ui/settings.glade:1165
+msgid "Settings for Touch devices"
+msgstr ""
+
+#: ../ui/settings.glade:1152
 msgid "Settings for Touch devices which are detected by GTK."
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:430
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:462
 msgid "Shape Recognizer"
 msgstr "識別形狀"
 
@@ -1596,19 +1649,19 @@ msgstr "只顯示未使用頁面(一個未使用頁面)"
 msgid "Show only not used pages ({1} unused pages)"
 msgstr "只顯示未使用頁面({1}個未使用頁面)"
 
-#: ../ui/main.glade:322
+#: ../ui/main.glade:348
 msgid "Show sidebar"
 msgstr "顯示側邊欄"
 
-#: ../ui/settings.glade:1412
+#: ../ui/settings.glade:1469
 msgid "Show sidebar on the right side"
 msgstr "側邊欄右置"
 
-#: ../ui/settings.glade:1427
+#: ../ui/settings.glade:1484
 msgid "Show vertical scrollbar on the left side"
 msgstr "垂直捲動條左置"
 
-#: ../src/control/XournalMain.cpp:309
+#: ../src/control/XournalMain.cpp:308
 #, fuzzy
 msgid ""
 "Sorry, Xournal++ can only open one file at once.\n"
@@ -1617,7 +1670,7 @@ msgstr ""
 "Xournal只能打開一個命令行檔案。\n"
 "其他的會被忽略。"
 
-#: ../src/control/XournalMain.cpp:324
+#: ../src/control/XournalMain.cpp:323
 #, fuzzy
 msgid ""
 "Sorry, Xournal++ cannot open remote files at the moment.\n"
@@ -1630,13 +1683,13 @@ msgstr ""
 msgid "Standard"
 msgstr "標準"
 
-#: ../ui/main.glade:1610
+#: ../ui/main.glade:1752
 msgid "State PLACEHOLDER"
 msgstr ""
 
-#: ../src/undo/RecognizerUndoAction.cpp:101
 #: ../src/gui/dialog/ButtonConfigGui.cpp:103
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:43
+#: ../src/undo/RecognizerUndoAction.cpp:101
 msgid "Stroke recognizer"
 msgstr "筆劃識別"
 
@@ -1644,19 +1697,19 @@ msgstr "筆劃識別"
 msgid "Successfully saved document to \"{1}\""
 msgstr "文檔已經保存為\"{1}\""
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:128
+#: ../src/control/stockdlg/XojOpenDlg.cpp:132
 msgid "Supported files"
 msgstr "支撐檔案"
 
-#: ../ui/main.glade:1236
+#: ../ui/main.glade:1386
 msgid "Swap the current page with the one above"
 msgstr ""
 
-#: ../ui/main.glade:1257
+#: ../ui/main.glade:1407
 msgid "Swap the current page with the one below"
 msgstr ""
 
-#: ../ui/main.glade:337
+#: ../ui/main.glade:363
 msgid "T_oolbars"
 msgstr "工具條(_o)"
 
@@ -1664,16 +1717,16 @@ msgstr "工具條(_o)"
 msgid "Template:"
 msgstr "模板："
 
-#: ../ui/settings.glade:1317
+#: ../ui/settings.glade:1374
 msgid "Test disable"
 msgstr ""
 
-#: ../ui/settings.glade:1304
+#: ../ui/settings.glade:1361
 msgid "Test enable"
 msgstr ""
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:58
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:401
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:458
 msgid "Text"
 msgstr "文本"
 
@@ -1682,7 +1735,7 @@ msgstr "文本"
 msgid "Text %i times found on this page"
 msgstr "文本在本頁面出現%i次"
 
-#: ../ui/main.glade:1077
+#: ../ui/main.glade:1214
 msgid "Text Font..."
 msgstr "文本字型..."
 
@@ -1710,35 +1763,35 @@ msgstr "文本未找到"
 msgid "Text not found, searched on all pages"
 msgstr "找遍所有頁面未找到文本"
 
-#: ../src/control/Control.cpp:1006
+#: ../src/control/Control.cpp:1017
 msgid ""
 "The Toolbarconfiguration \"{1}\" is predefined, would you create a copy to "
 "edit?"
 msgstr "工具條配置\"{1}\"是預置的，要產生一個拷貝到編輯?"
 
-#: ../src/control/Control.cpp:2017
+#: ../src/control/Control.cpp:2053
 msgid "The attached background PDF could not be found."
 msgstr "附加的背景PDF未找到。"
 
-#: ../src/control/Control.cpp:2018
+#: ../src/control/Control.cpp:2054
 msgid "The background PDF could not be found."
 msgstr "背景PDF未找到。"
 
-#: ../src/control/XournalMain.cpp:115
+#: ../src/control/XournalMain.cpp:119
 msgid "The most recent log file name: {1}"
 msgstr "最近的日誌檔案名：{1}"
 
-#: ../ui/settings.glade:369
+#: ../ui/settings.glade:383
 msgid "The unit of the ruler is cm"
 msgstr "標尺的單位是釐米"
 
-#: ../src/control/XournalMain.cpp:108
+#: ../src/control/XournalMain.cpp:112
 msgid ""
 "There are errorlogfiles from Xournal++. Please send a Bugreport, so the bug "
 "may be fixed."
 msgstr "發現Xournal++的錯誤日誌檔案，請發送一個錯誤報告，將會被修正。"
 
-#: ../src/control/XournalMain.cpp:107
+#: ../src/control/XournalMain.cpp:111
 msgid ""
 "There is an errorlogfile from Xournal++. Please send a Bugreport, so the bug "
 "may be fixed."
@@ -1749,7 +1802,7 @@ msgid "There was an error displaying help: {1}"
 msgstr ""
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:82
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:439
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:515
 msgid "Thick"
 msgstr "粗"
 
@@ -1759,25 +1812,25 @@ msgid "Thickness - don't change"
 msgstr "勿作修改"
 
 #: ../src/gui/dialog/ButtonConfigGui.cpp:80
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:435
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:513
 msgid "Thin"
 msgstr "細"
 
-#: ../src/control/Control.cpp:2530
+#: ../src/control/Control.cpp:2574
 msgid "This document is not saved yet."
 msgstr ""
 
-#: ../src/control/tools/ImageHandler.cpp:56
 #: ../src/control/PageBackgroundChangeController.cpp:177
+#: ../src/control/tools/ImageHandler.cpp:56
 msgid "This image could not be loaded. Error message: {1}"
 msgstr ""
 
-#: ../ui/settings.glade:1185
+#: ../ui/settings.glade:1242
 #, fuzzy
 msgid "Timeout"
 msgstr "涂白"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:368
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:418
 msgid "Toggle fullscreen"
 msgstr "全屏"
 
@@ -1786,7 +1839,7 @@ msgstr "全屏"
 msgid "Tool - don't change"
 msgstr "勿作修改"
 
-#: ../src/gui/toolbarMenubar/model/ToolbarData.cpp:156
+#: ../src/gui/toolbarMenubar/model/ToolbarData.cpp:152
 msgid "Toolbar found: {1}"
 msgstr "發現工具條：{1}"
 
@@ -1794,11 +1847,11 @@ msgstr "發現工具條：{1}"
 msgid "Toolbars"
 msgstr "工具條"
 
-#: ../ui/settings.glade:1358
+#: ../ui/settings.glade:1415
 msgid "Touch"
 msgstr ""
 
-#: ../ui/settings.glade:1046
+#: ../ui/settings.glade:1060
 msgid ""
 "Touch Screens which are detected by GTK are handled specially, and don't "
 "need to be configured here."
@@ -1812,12 +1865,12 @@ msgstr ""
 msgid "Trying to emergency save the current open document…"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:458
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:416
 msgid "Two pages"
 msgstr "雙頁"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:396
 #: ../src/undo/UndoRedoHandler.cpp:274
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:326
 msgid "Undo"
 msgstr "撤銷"
 
@@ -1825,15 +1878,15 @@ msgstr "撤銷"
 msgid "Undo: "
 msgstr "撤銷："
 
-#: ../src/control/xojfile/LoadHandler.cpp:241
+#: ../src/control/xojfile/LoadHandler.cpp:260
 msgid "Unexpected root tag: {1}"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:270
+#: ../src/control/xojfile/LoadHandler.cpp:289
 msgid "Unexpected tag in document: \"{1}\""
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:475
+#: ../src/control/xojfile/LoadHandler.cpp:494
 msgid "Unknown background type: {1}"
 msgstr ""
 
@@ -1841,23 +1894,23 @@ msgstr ""
 msgid "Unknown color value \"{1}\""
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:410
+#: ../src/control/xojfile/LoadHandler.cpp:429
 msgid "Unknown domain type: {1}"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:193
+#: ../src/control/xojfile/LoadHandler.cpp:194
 msgid "Unknown parser error"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:345
+#: ../src/control/xojfile/LoadHandler.cpp:364
 msgid "Unknown pixmap::domain type: {1}"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:558
+#: ../src/control/xojfile/LoadHandler.cpp:591
 msgid "Unknown stroke type: \"{1}\", assuming pen"
 msgstr ""
 
-#: ../src/control/Control.cpp:2424
+#: ../src/control/Control.cpp:2460
 msgid "Unsaved Document"
 msgstr "未保存文檔"
 
@@ -1866,7 +1919,7 @@ msgstr "未保存文檔"
 msgid "Version"
 msgstr "擴展"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:425
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:472
 msgid "Vertical Space"
 msgstr "垂直間距"
 
@@ -1874,7 +1927,7 @@ msgstr "垂直間距"
 msgid "Vertical space"
 msgstr "垂直間距"
 
-#: ../ui/settings.glade:1895
+#: ../ui/settings.glade:1982
 msgid "View"
 msgstr "視圖"
 
@@ -1895,7 +1948,7 @@ msgstr "寬度："
 msgid "With PDF background"
 msgstr "使用PDF背景"
 
-#: ../ui/about.glade:187
+#: ../ui/about.glade:188
 msgid "With help from the community"
 msgstr ""
 
@@ -1903,19 +1956,19 @@ msgstr ""
 msgid "Write text"
 msgstr "寫文本"
 
-#: ../src/control/xojfile/LoadHandler.cpp:821
+#: ../src/control/xojfile/LoadHandler.cpp:852
 msgid "Wrong count of points ({1})"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:836
+#: ../src/control/xojfile/LoadHandler.cpp:866
 msgid "Wrong number of points, got {1}, expected {2}"
 msgstr ""
 
-#: ../ui/settings.glade:1171
+#: ../ui/settings.glade:1228
 msgid "X11"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:188
+#: ../src/control/xojfile/LoadHandler.cpp:189
 msgid "XML Parser error: {1}"
 msgstr ""
 
@@ -1923,24 +1976,24 @@ msgstr ""
 msgid "Xournal (Compatibility)"
 msgstr ""
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:69
+#: ../src/control/stockdlg/XojOpenDlg.cpp:72
 msgid "Xournal files"
 msgstr "Xournal檔案"
 
-#: ../ui/settings.glade:28
+#: ../ui/settings.glade:42
 msgid "Xournal++ Preferences"
 msgstr "Xournal++偏好設置"
 
-#: ../src/control/XournalMain.cpp:168
+#: ../src/control/XournalMain.cpp:172
 msgid "Xournal++ crashed last time. Would you restore it?"
 msgstr ""
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:79 ../src/control/Control.cpp:2359
+#: ../src/control/Control.cpp:2395 ../src/control/stockdlg/XojOpenDlg.cpp:82
 #, fuzzy
 msgid "Xournal++ files"
 msgstr "Xournal檔案"
 
-#: ../src/control/stockdlg/XojOpenDlg.cpp:89
+#: ../src/control/stockdlg/XojOpenDlg.cpp:92
 #: ../src/gui/dialog/PageTemplateDialog.cpp:119
 #, fuzzy
 msgid "Xournal++ template"
@@ -1958,7 +2011,7 @@ msgid ""
 "Template\"."
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:111
+#: ../src/control/XournalMain.cpp:115
 msgid ""
 "You're using {1}/{2} branch. Send Bugreport will direct you to this repo's "
 "issue tracker."
@@ -1973,19 +2026,19 @@ msgid ""
 "PDF page."
 msgstr ""
 
-#: ../ui/settings.glade:302
+#: ../ui/settings.glade:316
 msgid "Zoom"
 msgstr "縮放"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:362
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:422
 msgid "Zoom fit to screen"
 msgstr "適合屏幕"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:360
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:421
 msgid "Zoom in"
 msgstr "放大"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:358
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:420
 msgid "Zoom out"
 msgstr "縮小"
 
@@ -1993,44 +2046,44 @@ msgstr "縮小"
 msgid "Zoom slider"
 msgstr "縮放游標"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:364
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:423
 msgid "Zoom to 100%"
 msgstr "原始尺寸"
 
-#: ../ui/main.glade:69
+#: ../ui/main.glade:71
 msgid "_Annotate PDF"
 msgstr "標註PDF(_A)"
 
+#: ../src/control/Control.cpp:2389 ../src/control/jobs/BaseExportJob.cpp:26
 #: ../src/control/stockdlg/ImageOpenDlg.cpp:12
 #: ../src/control/stockdlg/XojOpenDlg.cpp:17
-#: ../src/control/jobs/BaseExportJob.cpp:26 ../src/control/Control.cpp:2353
 #: ../src/gui/dialog/PageTemplateDialog.cpp:113
 #, fuzzy
 msgid "_Cancel"
 msgstr "取消"
 
-#: ../ui/main.glade:361
+#: ../ui/main.glade:388
 msgid "_Customize"
 msgstr "設置(_C)"
 
-#: ../ui/main.glade:723
+#: ../ui/main.glade:779
 #, fuzzy
 msgid "_Default Tools"
 msgstr "<b>缺省工具</b>"
 
-#: ../ui/main.glade:596
+#: ../ui/main.glade:642
 msgid "_Delete Page"
 msgstr "刪除頁面(_D)"
 
-#: ../ui/main.glade:153
+#: ../ui/main.glade:162
 msgid "_Edit"
 msgstr "編輯(_E)"
 
-#: ../ui/main.glade:683
+#: ../ui/main.glade:735
 msgid "_Eraser"
 msgstr "橡皮(_E)"
 
-#: ../ui/main.glade:104
+#: ../ui/main.glade:109
 msgid "_Export as PDF"
 msgstr "輸出為PDF(_E)"
 
@@ -2038,49 +2091,49 @@ msgstr "輸出為PDF(_E)"
 msgid "_File"
 msgstr "檔案(_F)"
 
-#: ../ui/main.glade:448
+#: ../ui/main.glade:480
 msgid "_First Page"
 msgstr "首頁(_F)"
 
-#: ../ui/main.glade:466
+#: ../ui/main.glade:500
 #, fuzzy
 msgid "_Goto Page"
 msgstr "頁面跳轉(_G)"
 
-#: ../ui/main.glade:1099
+#: ../ui/main.glade:1247
 msgid "_Help"
 msgstr "幫助(_H)"
 
-#: ../ui/main.glade:693
+#: ../ui/main.glade:746
 msgid "_Highlighter"
 msgstr "高亮(_H)"
 
-#: ../ui/main.glade:713
+#: ../ui/main.glade:768
 msgid "_Image"
 msgstr "圖片(_I)"
 
-#: ../ui/main.glade:553
+#: ../ui/main.glade:595
 msgid "_Journal"
 msgstr "日誌(_J)"
 
-#: ../ui/main.glade:484
+#: ../ui/main.glade:520
 msgid "_Last Page"
 msgstr "末頁(_L)"
 
-#: ../ui/main.glade:353
+#: ../ui/main.glade:379
 msgid "_Manage"
 msgstr "管理(_M)"
 
-#: ../ui/main.glade:438
+#: ../ui/main.glade:470
 msgid "_Navigation"
 msgstr "導航(_N)"
 
-#: ../ui/main.glade:508
+#: ../ui/main.glade:546
 #, fuzzy
 msgid "_Next Layer"
 msgstr "下一頁(_N)"
 
-#: ../ui/main.glade:475
+#: ../ui/main.glade:510
 msgid "_Next Page"
 msgstr "下一頁(_N)"
 
@@ -2090,83 +2143,83 @@ msgstr "下一頁(_N)"
 msgid "_Open"
 msgstr "打開{1}"
 
-#: ../ui/main.glade:673
+#: ../ui/main.glade:724
 msgid "_Pen"
 msgstr "畫筆(_P)"
 
-#: ../ui/main.glade:281
+#: ../ui/main.glade:329
 msgid "_Presentation Mode"
 msgstr "演講模式(_P)"
 
-#: ../ui/main.glade:499
+#: ../ui/main.glade:536
 #, fuzzy
 msgid "_Previous Layer"
 msgstr "前一頁(_P)"
 
-#: ../ui/main.glade:457
+#: ../ui/main.glade:490
 msgid "_Previous Page"
 msgstr "前一頁(_P)"
 
-#: ../src/control/jobs/BaseExportJob.cpp:27 ../src/control/Control.cpp:2354
+#: ../src/control/Control.cpp:2390 ../src/control/jobs/BaseExportJob.cpp:27
 #: ../src/gui/dialog/PageTemplateDialog.cpp:114
 #, fuzzy
 msgid "_Save"
 msgstr "保存"
 
-#: ../ui/main.glade:737
+#: ../ui/main.glade:794
 msgid "_Shape Recognizer"
 msgstr "形狀識別(_S)"
 
-#: ../ui/main.glade:703
+#: ../ui/main.glade:757
 msgid "_Text"
 msgstr "文本(_T)"
 
-#: ../ui/main.glade:663
+#: ../ui/main.glade:714
 msgid "_Tools"
 msgstr "工具(_T)"
 
-#: ../ui/main.glade:517
+#: ../ui/main.glade:556
 #, fuzzy
 msgid "_Top Layer"
 msgstr "圖層"
 
-#: ../ui/main.glade:273
+#: ../ui/main.glade:320
 msgid "_Two Pages"
 msgstr "雙頁(_T)"
 
-#: ../ui/main.glade:823
+#: ../ui/main.glade:893
 msgid "_Vertical Space"
 msgstr "垂直間距(_V)"
 
-#: ../ui/main.glade:263
+#: ../ui/main.glade:310
 msgid "_View"
 msgstr "視圖(_V)"
 
-#: ../ui/main.glade:1001
+#: ../ui/main.glade:1132
 msgid "_delete strokes"
 msgstr "刪除筆劃(_d)"
 
-#: ../ui/main.glade:878 ../ui/main.glade:950 ../ui/main.glade:1024
+#: ../ui/main.glade:952 ../ui/main.glade:1076 ../ui/main.glade:1156
 msgid "_fine"
 msgstr "細(_f)"
 
-#: ../ui/main.glade:887 ../ui/main.glade:959 ../ui/main.glade:1033
+#: ../ui/main.glade:962 ../ui/main.glade:1086 ../ui/main.glade:1166
 msgid "_medium"
 msgstr "中(_m)"
 
-#: ../ui/main.glade:983
+#: ../ui/main.glade:1112
 msgid "_standard"
 msgstr "標準(_s)"
 
-#: ../ui/main.glade:896 ../ui/main.glade:968 ../ui/main.glade:1042
+#: ../ui/main.glade:972 ../ui/main.glade:1096 ../ui/main.glade:1176
 msgid "_thick"
 msgstr "粗(_t)"
 
-#: ../ui/main.glade:869
+#: ../ui/main.glade:942
 msgid "_very fine"
 msgstr "極細(_v)"
 
-#: ../ui/main.glade:992
+#: ../ui/main.glade:1122
 msgid "_whiteout"
 msgstr "涂白(_w)"
 
@@ -2179,9 +2232,21 @@ msgstr "範圍"
 msgid "cursor"
 msgstr "光標"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:299
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:294
+msgid "dash-/ doted"
+msgstr ""
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:291
+msgid "dashed"
+msgstr ""
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:312
 msgid "delete stroke"
 msgstr "刪除筆劃"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:297
+msgid "dotted"
+msgstr ""
 
 #: ../ui/exportSettings.glade:213
 #, fuzzy
@@ -2212,7 +2277,7 @@ msgstr "滑鼠"
 msgid "pen"
 msgstr "畫筆"
 
-#: ../ui/settings.glade:1212
+#: ../ui/settings.glade:1269
 msgid "s"
 msgstr ""
 
@@ -2225,7 +2290,8 @@ msgstr "保存檔案"
 msgid "show"
 msgstr ""
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:285
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:288
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:310
 msgid "standard"
 msgstr "標準"
 
@@ -2238,15 +2304,15 @@ msgstr ""
 msgid "touchscreen"
 msgstr "全屏"
 
-#: ../ui/main.glade:905
+#: ../ui/main.glade:982
 msgid "ver_y thick"
 msgstr "極粗(_y)"
 
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:292
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:311
 msgid "whiteout"
 msgstr "涂白"
 
-#: ../src/control/xojfile/LoadHandler.cpp:835
+#: ../src/control/xojfile/LoadHandler.cpp:865
 msgid "xoj-File: {1}"
 msgstr ""
 
@@ -2342,6 +2408,9 @@ msgstr ""
 
 #~ msgid "Disable Ruler & Stroke Recognizer"
 #~ msgstr "取消標尺和筆劃識別"
+
+#~ msgid "Don't compress PDF files (for debugging)"
+#~ msgstr "勿壓縮PDF檔案(調試用)"
 
 #, fuzzy
 #~ msgid "Drawing type"

--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -68,6 +68,7 @@ void Settings::loadDefault()
 
 	this->autoloadPdfXoj = true;
 	this->showBigCursor = false;
+	this->highlightPosition = false;
 	this->darkTheme = false;
 	this->scrollbarHideType = SCROLLBAR_HIDE_NONE;
 
@@ -335,6 +336,10 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur)
 	else if (xmlStrcmp(name, (const xmlChar*) "showBigCursor") == 0)
 	{
 		this->showBigCursor = xmlStrcmp(value, (const xmlChar*) "true") ? false : true;
+	}
+	else if (xmlStrcmp(name, (const xmlChar*) "highlightPosition") == 0)
+	{
+		this->highlightPosition = xmlStrcmp(value, (const xmlChar*) "true") ? false : true;
 	}
 	else if (xmlStrcmp(name, (const xmlChar*) "darkTheme") == 0)
 	{
@@ -725,6 +730,7 @@ void Settings::save()
 	WRITE_COMMENT("Which gui elements are hidden if you are in Presentation mode, separated by a colon (,)");
 
 	WRITE_BOOL_PROP(showBigCursor);
+	WRITE_BOOL_PROP(highlightPosition);
 	WRITE_BOOL_PROP(darkTheme);
 
 	if (this->scrollbarHideType == SCROLLBAR_HIDE_BOTH)
@@ -1039,6 +1045,27 @@ void Settings::setShowBigCursor(bool b)
 	}
 
 	this->showBigCursor = b;
+	save();
+}
+
+bool Settings::isHighlightPosition()
+{
+	XOJ_CHECK_TYPE(Settings);
+
+	return this->highlightPosition;
+
+}
+
+void Settings::setHighlightPosition(bool highlight)
+{
+	XOJ_CHECK_TYPE(Settings);
+
+	if (this->highlightPosition == highlight)
+	{
+		return;
+	}
+
+	this->highlightPosition = highlight;
 	save();
 }
 

--- a/src/control/settings/Settings.h
+++ b/src/control/settings/Settings.h
@@ -251,6 +251,9 @@ public:
 	bool isShowBigCursor();
 	void setShowBigCursor(bool b);
 
+	bool isHighlightPosition();
+	void setHighlightPosition(bool highlight);
+
 	ScrollbarHideType getScrollbarHideType();
 	void setScrollbarHideType(ScrollbarHideType type);
 
@@ -387,6 +390,11 @@ private:
 	 *  Show a better visible cursor for pen
 	 */
 	bool showBigCursor;
+
+	/**
+	 * Show a yellow circle around the cursor
+	 */
+	bool highlightPosition;
 
 	/**
 	 * If the user uses a dark-themed DE, he should enable this 

--- a/src/gui/dialog/SettingsDialog.cpp
+++ b/src/gui/dialog/SettingsDialog.cpp
@@ -164,6 +164,7 @@ void SettingsDialog::load()
 	loadCheckbox("cbAddVerticalSpace", settings->getAddVerticalSpace());
 	loadCheckbox("cbAddHorizontalSpace", settings->getAddHorizontalSpace());
 	loadCheckbox("cbBigCursor", settings->isShowBigCursor());
+	loadCheckbox("cbHighlightPosition", settings->isHighlightPosition());
 	loadCheckbox("cbDarkTheme", settings->isDarkTheme());
 	loadCheckbox("cbHideHorizontalScrollbar", settings->getScrollbarHideType() & SCROLLBAR_HIDE_HORIZONTAL);
 	loadCheckbox("cbHideVerticalScrollbar", settings->getScrollbarHideType() & SCROLLBAR_HIDE_VERTICAL);
@@ -344,6 +345,7 @@ void SettingsDialog::save()
 	settings->setAddVerticalSpace(getCheckbox("cbAddVerticalSpace"));
 	settings->setAddHorizontalSpace(getCheckbox("cbAddHorizontalSpace"));
 	settings->setShowBigCursor(getCheckbox("cbBigCursor"));
+	settings->setHighlightPosition(getCheckbox("cbHighlightPosition"));
 	settings->setDarkTheme(getCheckbox("cbDarkTheme"));
 	settings->setTouchWorkaround(getCheckbox("cbTouchWorkaround"));
 

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -1939,6 +1939,21 @@ they are not blocking!&lt;/i&gt;</property>
                             <property name="position">0</property>
                           </packing>
                         </child>
+                        <child>
+                          <object class="GtkCheckButton" id="cbHighlightPosition">
+                            <property name="label" translatable="yes">Highlight cursor position</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="xalign">0</property>
+                            <property name="draw_indicator">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
                       </object>
                       <packing>
                         <property name="expand">True</property>


### PR DESCRIPTION
Hi! I added the feature requested in #786 .
Now under Preferences -> View you can enable the highlighting option.
Right now I made it available only when in "Big Cursor" mode, but if you think that it should be available without that mode too, no problem, we only need to move one if outside a block ;)
Fixes #786 