### PR TITLE
fix that zoom with slider maliciously scrolls

### DIFF
--- a/src/control/zoom/ZoomControl.cpp
+++ b/src/control/zoom/ZoomControl.cpp
@@ -45,19 +45,17 @@ void ZoomControl::startZoomSequence(double centerX, double centerY)
 {
 	XOJ_CHECK_TYPE(ZoomControl);
 
+	Rectangle rect = getVisibleRect();
 	if (centerX == -1 || centerY == -1)
 	{
-		GtkWidget* widget = view->getWidget();
-		this->zoomWidgetPosX = gtk_widget_get_allocated_width(widget) / 2;
-		this->zoomWidgetPosY = gtk_widget_get_allocated_height(widget) / 2;
+		this->zoomWidgetPosX = rect.width/2;
+		this->zoomWidgetPosY = rect.height/2;
 	}
 	else
 	{
 		this->zoomWidgetPosX = centerX;
 		this->zoomWidgetPosY = centerY;
 	}
-
-	Rectangle rect = getVisibleRect();
 
 	this->scrollPositionX = (rect.x + this->zoomWidgetPosX) / this->zoom;
 	this->scrollPositionY = (rect.y + this->zoomWidgetPosY) / this->zoom;


### PR DESCRIPTION
relates #416 

Can you maybe check, wether zoom with slider or button still work properly?
gtk_widget_get_allocated_width/height gives for me the width and height of the whole scrollable widget, not the visible rect.
I'm sorry, that I didn't reopened #416. The problem was still, there and I forgot to write.