### PR TITLE
Fixed #764

### DIFF
--- a/src/gui/dialog/ButtonConfigGui.cpp
+++ b/src/gui/dialog/ButtonConfigGui.cpp
@@ -34,8 +34,8 @@ ButtonConfigGui::ButtonConfigGui(SettingsDialog* dlg, GladeSearchpath* gladeSear
 	{
 		gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(this->cbDevice), _("No device"));
 
-		DeviceListHelper devList;
-		for (InputDevice& dev : devList.getDeviceList())
+		this->deviceList = new DeviceListHelper(true);
+		for (InputDevice& dev : this->deviceList->getDeviceList())
 		{
 			string txt = dev.getName()  + " (" + dev.getType() + ")";
 			gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(this->cbDevice), txt.c_str());
@@ -111,6 +111,11 @@ ButtonConfigGui::ButtonConfigGui(SettingsDialog* dlg, GladeSearchpath* gladeSear
 
 ButtonConfigGui::~ButtonConfigGui()
 {
+	XOJ_CHECK_TYPE(ButtonConfigGui);
+
+	delete this->deviceList;
+	this->deviceList = NULL;
+
 	XOJ_RELEASE_TYPE(ButtonConfigGui);
 }
 
@@ -198,8 +203,7 @@ void ButtonConfigGui::loadSettings()
 		int i = 0;
 
 
-		DeviceListHelper devList;
-		for (InputDevice& dev : devList.getDeviceList())
+		for (InputDevice& dev : this->deviceList->getDeviceList())
 		{
 			if (cfg->device == dev.getName())
 			{
@@ -283,8 +287,7 @@ void ButtonConfigGui::saveSettings()
 
 	if (this->withDevice)
 	{
-		DeviceListHelper devList;
-		std::vector<InputDevice>& devices = devList.getDeviceList();
+		std::vector<InputDevice>& devices = this->deviceList->getDeviceList();
 		int dev = gtk_combo_box_get_active(GTK_COMBO_BOX(cbDevice)) - 1;
 
 		if (dev < 0 || (int)devices.size() <= dev)

--- a/src/gui/dialog/ButtonConfigGui.h
+++ b/src/gui/dialog/ButtonConfigGui.h
@@ -16,6 +16,7 @@
 
 #include <gdk/gdk.h>
 
+class DeviceListHelper;
 class Settings;
 class SettingsDialog;
 
@@ -43,6 +44,8 @@ private:
 	Settings* settings;
 	int button;
 	bool withDevice;
+
+	DeviceListHelper* deviceList = NULL;
 
 	GtkWidget* cbDevice;
 	GtkWidget* cbDisableDrawing;

--- a/src/gui/dialog/SettingsDialog.cpp
+++ b/src/gui/dialog/SettingsDialog.cpp
@@ -75,7 +75,7 @@ void SettingsDialog::initMouseButtonEvents(const char* hbox, int button, bool wi
 {
 	XOJ_CHECK_TYPE(SettingsDialog);
 
-	this->buttonConfigs.push_back(new ButtonConfigGui(this, getGladeSearchPath(), get(hbox),settings, button, withDevice));
+	this->buttonConfigs.push_back(new ButtonConfigGui(this, getGladeSearchPath(), get(hbox), settings, button, withDevice));
 }
 
 void SettingsDialog::initMouseButtonEvents()

--- a/src/util/DeviceListHelper.cpp
+++ b/src/util/DeviceListHelper.cpp
@@ -3,7 +3,8 @@
 #include <i18n.h>
 
 
-DeviceListHelper::DeviceListHelper()
+DeviceListHelper::DeviceListHelper(bool ignoreTouchDevices)
+ : ignoreTouchDevices(ignoreTouchDevices)
 {
 	// For never GTK versions, see example here:
 	// https://cvs.gnucash.org/docs/MASTER/gnc-cell-renderer-popup_8c_source.html
@@ -30,6 +31,11 @@ void DeviceListHelper::addDevicesToList(GList* devList)
 		if (GDK_SOURCE_KEYBOARD == gdk_device_get_source(dev))
 		{
 			// Skip keyboard
+			devList = devList->next;
+			continue;
+		}
+		if (ignoreTouchDevices && GDK_SOURCE_TOUCHSCREEN == gdk_device_get_source(dev))
+		{
 			devList = devList->next;
 			continue;
 		}

--- a/src/util/DeviceListHelper.h
+++ b/src/util/DeviceListHelper.h
@@ -40,7 +40,7 @@ private:
 class DeviceListHelper
 {
 public:
-	DeviceListHelper();
+	DeviceListHelper(bool ignoreTouchDevices = false);
 	virtual ~DeviceListHelper();
 
 public:
@@ -50,5 +50,7 @@ private:
 	void addDevicesToList(GList* devList);
 
 private:
+	bool ignoreTouchDevices;
+
 	vector<InputDevice> deviceList;
 };


### PR DESCRIPTION
Do not allow to configure GTK Touch Screen - there is a separated tab
for this, and this causes crashes on some devices