### PR TITLE
Eraser's cursor's size now matches the actual eraser size

### DIFF
--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -1828,6 +1828,7 @@ void Control::showSettings()
 	bool verticalSpace = settings->getAddVerticalSpace();
 	bool horizontalSpace = settings->getAddHorizontalSpace();
 	bool bigCursor = settings->isShowBigCursor();
+	bool highlightPosition = settings->isHighlightPosition();
 
 	SettingsDialog* dlg = new SettingsDialog(this->gladeSearchPath, settings, this);
 	dlg->show(GTK_WINDOW(this->win->getWindow()));
@@ -1844,7 +1845,7 @@ void Control::showSettings()
 		scrollHandler->scrollToPage(currentPage);
 	}
 
-	if (bigCursor != settings->isShowBigCursor())
+	if (bigCursor != settings->isShowBigCursor() || highlightPosition != settings->isHighlightPosition())
 	{
 		getCursor()->updateCursor();
 	}

--- a/src/gui/Cursor.cpp
+++ b/src/gui/Cursor.cpp
@@ -205,11 +205,11 @@ void Cursor::updateCursor()
 		}
 		else if (type == TOOL_ERASER)
 		{
-			cursor = eraserCursor();
+			cursor = getEraserCursor();
 		}
 		else if (type == TOOL_HILIGHTER)
 		{
-			cursor = highlighterCursor();
+			cursor = getHighlighterCursor();
 		}
 		else if (type == TOOL_TEXT)
 		{
@@ -266,9 +266,11 @@ void Cursor::updateCursor()
 	}
 }
 
-GdkCursor* Cursor::eraserCursor()
+GdkCursor* Cursor::getEraserCursor()
 {
-	const double cursorSize = 8;
+	// Eraser's size follow a quadratic increment, so the cursor will do the same
+	double cursorSize = control->getToolHandler()->getSize();
+	cursorSize *= cursorSize * 7;
 
 	cairo_surface_t* surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32,
 	                                                      cursorSize,
@@ -298,7 +300,7 @@ GdkCursor* Cursor::eraserCursor()
 	return cursor;
 }
 
-GdkCursor* Cursor::highlighterCursor()
+GdkCursor* Cursor::getHighlighterCursor()
 {
 	XOJ_CHECK_TYPE(Cursor);
 

--- a/src/gui/Cursor.h
+++ b/src/gui/Cursor.h
@@ -36,8 +36,8 @@ public:
 private:
 	GdkCursor* getPenCursor();
 
-	GdkCursor* eraserCursor();
-	GdkCursor* highlighterCursor();
+	GdkCursor* getEraserCursor();
+	GdkCursor* getHighlighterCursor();
 
 	GdkCursor* createHighlighterOrPenCursor(int size, double alpha);
 


### PR DESCRIPTION
Hi! 
This should  fix #856 
I thought one thing tho, right now we re-draw the cursor every time the cursor goes off and on the paper, even if it's not a really big issue, I think we could speed up things a little more by creating the cursor's image file in the .xournalpp folder only once, and then we could just load them when needed.
I'm saying this because we would only need 6 small pngs, 3 for the eraser's size, and 3 for the pen (big cursor, highlight position, both of them combined)
What do you think?