### PR TITLE
Do not crash when system default locale could not be found

### DIFF
--- a/src/control/XournalMain.cpp
+++ b/src/control/XournalMain.cpp
@@ -68,7 +68,14 @@ void XournalMain::initLocalisation()
 
 	// Not working on Windows! Working on Linux, but not sure if it's needed
 #ifndef WIN32
+try
+{
 	std::locale::global(std::locale("")); // "" - system default locale
+}
+catch (std::runtime_error &e)
+{
+	g_warning("XournalMain: System default locale could not be set.\nCaused by: %s", e.what());
+}
 #endif
 	std::cout.imbue(std::locale());
 }


### PR DESCRIPTION
Fix for issue #859 
Do not crash if system default locale cannot be set but log a warning.