### PR TITLE
Flatpak: Initial manifest proposal

### DIFF
--- a/org.github.xournalpp.xournalpp.yaml
+++ b/org.github.xournalpp.xournalpp.yaml
@@ -1,0 +1,88 @@
+---
+app-id: com.github.xournalpp.xournalpp
+runtime: org.gnome.Platform
+runtime-version: '3.30'
+sdk: org.gnome.Sdk
+command: xournalpp
+rename-icon: xournalpp
+rename-desktop-file: xournalpp.desktop
+rename-appdata-file: xournalpp.xml
+finish-args:
+  # X11 + XShm access
+  - "--share=ipc"
+  - "--socket=x11"
+  # Wayland access
+  - "--socket=wayland"
+  # Needs to save files locally
+  - "--filesystem=xdg-documents"
+  - "--socket=pulseaudio"
+  # Allow dconf
+  - "--filesystem=xdg-run/dconf"
+  - "--filesystem=~/.config/dconf:ro"
+  - "--talk-name=ca.desrt.dconf"
+  - "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
+build-options:
+cleanup:
+  - "/include"
+  - "/lib/pkgconfig"
+  - "/man"
+  - "/share/doc"
+  - "/share/gtk-doc"
+  - "/share/man"
+  - "/share/pkgconfig"
+  - "*.la"
+  - "*.a"
+modules:
+  - name: poppler
+    buildsystem: cmake-ninja
+    config-opts:
+      - "-DCMAKE_INSTALL_LIBDIR=/app/lib"
+      - "-DCMAKE_INSTALL_INCLUDEDIR=/app/include"
+      - "-DENABLE_LIBOPENJPEG=none"
+    cleanup:
+      - "/bin"
+    sources:
+      - type: archive
+        url: https://poppler.freedesktop.org/poppler-0.69.0.tar.xz
+        sha256: 637ff943f805f304ff1da77ba2e7f1cbd675f474941fd8ae1e0fc01a5b45a3f9
+  - name: libportaudiocpp
+    buildsystem: autotools
+    config-opts:
+      - "--enable-cxx" # compile with c++ headers!!!
+    sources:
+      - type: git
+        url: https://git.assembla.com/portaudio.git
+        commit: 396fe4b6699ae929d3a685b3ef8a7e97396139a4
+    cleanup:
+      - "/include"
+      - "/lib/*.a"
+      - "/lib/*.la"
+      - "/lib/pkgconfig"
+      - "/man"
+      - "/share/aclocal"
+      - "/share/doc"
+      - "/share/gtk-doc"
+      - "/share/man"
+      - "/share/pkgconfig"
+  - name: libsndfile
+    buildsystem: autotools
+    sources:
+      - type: archive
+        url: http://www.mega-nerd.com/libsndfile/files/libsndfile-1.0.27.tar.gz
+        sha256: a391952f27f4a92ceb2b4c06493ac107896ed6c76be9a613a4731f076d30fac0
+  # Tried git, but failed to get the autogen script to run.
+  #     - type: git
+  #       url: https://github.com/erikd/libsndfile
+  #       commit: 1d928bffdb65e827c3e7d17ece0e123b4a70ec6c
+  #       tag: 1.0.28
+
+  - name: xournallpp
+    buildsystem: cmake-ninja
+    config-opts: []
+    sources:
+      - type: git
+        path: .
+        #url: https://github.com/xournalpp/xournalpp
+        commit: 4d28632b023c7efd17eb85e520cefbd681e7b8c7
+        tag: 1.0.7
+


### PR DESCRIPTION
This a flatpak manifest i came up with. It is working for me, but as this is the very first app i wrote a flatpak  manifest for, this might be totally buggy. I'm also new to Xournalpp so i might not even notice if something is not working what should work. 

In #857 i posted a json manifest which i converted to yaml as it supports comments properly. I also dumped the sox dependecie and added libsndfile instead. 

To create a flatpak file the following to commands are needed.  ./flatpak-build and ./repo are arbitrary
folder names.
```
flatpak-builder ./flatpak-build org.github.xournalpp.xournalpp.yaml --force-clean --repo=./repo 
flatpak build-bundle ./repo  xournalpp.flatpak com.github.xournalpp.xournalpp
```