### PR TITLE
Update eraser's cursor's size on zoom change

### DIFF
--- a/src/.vscode/c_cpp_properties.json
+++ b/src/.vscode/c_cpp_properties.json
@@ -6,7 +6,8 @@
                 "${workspaceFolder}/**",
                 "/usr/include/libglade-2.0",
                 "/usr/include/glib-2.0",
-                "/usr/include/gtk-2.0"
+                "/usr/include/gtk-2.0",
+                "/usr/include/gtk-3.0"
             ],
             "defines": [],
             "compilerPath": "/usr/bin/gcc",

--- a/src/gui/Cursor.cpp
+++ b/src/gui/Cursor.cpp
@@ -269,7 +269,7 @@ void Cursor::updateCursor()
 GdkCursor* Cursor::getEraserCursor()
 {
 	// Eraser's size follow a quadratic increment, so the cursor will do the same
-	double cursorSize = control->getToolHandler()->getThickness() * 7;
+	double cursorSize = control->getToolHandler()->getThickness() * 2 * control->getZoomControl()->getZoom();
 
 	cairo_surface_t* surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32,
 	                                                      cursorSize,

--- a/src/gui/XournalView.cpp
+++ b/src/gui/XournalView.cpp
@@ -638,6 +638,9 @@ void XournalView::zoomChanged()
 
 	control->getMetadataManager()->storeMetadata(file.str(), getCurrentPage(), getZoom());
 
+	// Updates the Eraser's cursor icon in order to make it as big as the erasing area
+	control->getCursor()->updateCursor();
+
 	this->control->getScheduler()->blockRerenderZoom();
 }
 


### PR DESCRIPTION
Hi!
This should fix #894 
I think I'm going to implement the stuff we we're saying about "saving a pre-rendered icon" for some tools and use it when needed instead of re-draw them every time. At least I'd like to see if this could be less "resources extensive", not that it is right now but... why not?