### PR TITLE
Fix backward compatibility for toolbar.ini loading

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,7 +117,7 @@ if (MacIntegration_FOUND)
 endif ()
 
 # Plugins / scripting
-pkg_check_modules (Lua "lua5.3")
+pkg_check_modules (Lua "lua >= 5.3")
 if (Lua_FOUND)
 	message("Enable Xournal++ Plugins")
 	add_includes_ldflags ("${Lua_LDFLAGS}" "${Lua_INCLUDE_DIRS}")

--- a/src/plugin/Plugin.cpp
+++ b/src/plugin/Plugin.cpp
@@ -5,10 +5,12 @@
 
 #ifdef ENABLE_PLUGINS
 
+extern "C" {
 #include <lua.h>
 #include <lauxlib.h>
 #include <lualib.h>
 #include <lauxlib.h>
+}
 
 #include "luapi_application.h"
 

--- a/src/plugin/Plugin.h
+++ b/src/plugin/Plugin.h
@@ -18,7 +18,9 @@
 #include <config-features.h>
 
 #ifdef ENABLE_PLUGINS
+extern "C" {
 #include <lua.h>
+}
 
 class Plugin;
 class Control;


### PR DESCRIPTION
@andreasb242 please check if this does break your build or the changes are transparent for you. I require those to build on Arch.

This does not fix the build problems when lua is not present.