### PR TITLE
Edit selection movement between and going off page

### DIFF
--- a/src/control/tools/EditSelection.cpp
+++ b/src/control/tools/EditSelection.cpp
@@ -163,7 +163,7 @@ void EditSelection::finalizeSelection()
 {
 	XOJ_CHECK_TYPE(EditSelection);
 
-	XojPageView* v = getBestMatchingPageView();
+	XojPageView* v = getPageViewUnderCursor();
 	if (v == NULL)
 	{	// Not on any page - move back to original page and position
 		this->x = this->contents->getOriginalX();
@@ -546,7 +546,7 @@ void EditSelection::mouseMove(double x, double y)
 
 	this->view->getXournal()->repaintSelection();
 
-	XojPageView* v = getBestMatchingPageView();
+	XojPageView* v = getPageViewUnderCursor();
 
 	if (v && v != this->view)
 	{
@@ -559,7 +559,7 @@ void EditSelection::mouseMove(double x, double y)
 	}
 }
 
-XojPageView* EditSelection::getBestMatchingPageView()
+XojPageView* EditSelection::getPageViewUnderCursor()
 {
 	XOJ_CHECK_TYPE(EditSelection);
 

--- a/src/control/tools/EditSelection.cpp
+++ b/src/control/tools/EditSelection.cpp
@@ -562,9 +562,16 @@ XojPageView* EditSelection::getBestMatchingPageView()
 	XOJ_CHECK_TYPE(EditSelection);
 
 	PagePositionHandler* pp = this->view->getXournal()->getPagePositionHandler();
-	int rx = this->getXOnViewAbsolute();
-	int ry = this->getYOnViewAbsolute();
-	XojPageView* v = pp->getBestMatchingView(rx, ry, this->getViewWidth(), this->getViewHeight());
+	
+	double zoom = view->getXournal()->getZoom();
+	
+	
+	//get grabbing hand position
+	double hx = this->view->getX() + (this->x + this->relMousePosX)*zoom;
+	double hy = this->view->getY() + (this->y + this->relMousePosY)*zoom;
+	
+	XojPageView* v = pp->getViewAt(hx,hy);
+
 	return v;
 }
 

--- a/src/control/tools/EditSelection.cpp
+++ b/src/control/tools/EditSelection.cpp
@@ -165,23 +165,25 @@ void EditSelection::finalizeSelection()
 
 	XojPageView* v = getBestMatchingPageView();
 	if (v == NULL)
-	{
-		this->view->getXournal()->deleteSelection(this);
+	{	// Not on any page - move back to original page and position
+		this->x = this->contents->getOriginalX();
+		this->y = this->contents->getOriginalY();
+		v = this->contents->getSourceView();
 	}
-	else
-	{
-		this->view = v;
+	
 
-		PageRef page = this->view->getPage();
-		Layer* layer = page->getSelectedLayer();
-		this->contents->finalizeSelection(this->x, this->y, this->width, this->height,
-										  this->aspectRatio, layer, page, this->view, this->undo);
+	this->view = v;
 
-		this->view->rerenderRect(this->x, this->y, this->width, this->height);
+	PageRef page = this->view->getPage();
+	Layer* layer = page->getSelectedLayer();
+	this->contents->finalizeSelection(this->x, this->y, this->width, this->height,
+										this->aspectRatio, layer, page, this->view, this->undo);
 
-		// This is needed if the selection not was 100% on a page
-		this->view->getXournal()->repaintSelection(true);
-	}
+	this->view->rerenderRect(this->x, this->y, this->width, this->height);
+
+	// This is needed if the selection not was 100% on a page
+	this->view->getXournal()->repaintSelection(true);
+
 }
 
 /**

--- a/src/control/tools/EditSelection.h
+++ b/src/control/tools/EditSelection.h
@@ -219,9 +219,9 @@ private:
 	void finalizeSelection();
 
 	/**
-	 * Gets the PageView where the selection is located on
+	 * Gets the PageView under the cursor
 	 */
-	XojPageView* getBestMatchingPageView();
+	XojPageView* getPageViewUnderCursor();
 
 	/**
 	 * Translate all coordinates which are relative to the current view to the new view,

--- a/src/control/tools/EditSelectionContents.cpp
+++ b/src/control/tools/EditSelectionContents.cpp
@@ -429,6 +429,22 @@ void EditSelectionContents::finalizeSelection(double x, double y, double width, 
 
 }
 
+double EditSelectionContents::getOriginalX()
+{
+	return this->originalX;
+}
+
+double EditSelectionContents::getOriginalY()
+{
+	return this->originalY;
+}
+
+XojPageView* EditSelectionContents::getSourceView()
+{
+	return this->sourceView;
+}
+
+
 void EditSelectionContents::updateContent(double x, double y, double rotation, double width, double height, bool aspectRatio,
 										  Layer* layer, PageRef targetPage, XojPageView* targetView,
 										  UndoRedoHandler* undo, CursorSelectionType type)

--- a/src/control/tools/EditSelectionContents.h
+++ b/src/control/tools/EditSelectionContents.h
@@ -108,6 +108,24 @@ private:
 	static bool repaintSelection(EditSelectionContents* selection);
 
 public:
+	
+	/**
+	 * Gets the original view of the contents
+	 */
+	XojPageView * getSourceView();
+	
+	
+	/**
+	 * Gets the original X of the contents
+	 */
+	double getOriginalX();
+
+	/**
+	 * Gets the original Y of the contents
+	 */
+	double getOriginalY();
+
+	
 	/**
 	 * Gets the original width of the contents
 	 */

--- a/src/gui/pageposition/PagePositionHandler.cpp
+++ b/src/gui/pageposition/PagePositionHandler.cpp
@@ -50,14 +50,6 @@ void PagePositionHandler::update(XojPageView** viewPages, int viewPagesLen, int 
 
 }
 
-XojPageView* PagePositionHandler::getBestMatchingView(int x, int y, int width, int height)
-{
-	XOJ_CHECK_TYPE(PagePositionHandler);
-
-	// Does this simplification result in expected behaviour? 
-	return this->getViewAt(x + width / 2, y + height / 2);
-}
-
 XojPageView* PagePositionHandler::getViewAt(int x, int y, PagePositionCache* cache)
 {
 	XOJ_CHECK_TYPE(PagePositionHandler);

--- a/src/gui/pageposition/PagePositionHandler.h
+++ b/src/gui/pageposition/PagePositionHandler.h
@@ -3,7 +3,7 @@
  *
  * Knows the positions of pages in the view
  *
- * @author Xournal++ Team, Justin Jones
+ * @author Xournal++ Team
  * https://github.com/xournalpp/xournalpp
  *
  * @license GNU GPLv2 or later
@@ -36,7 +36,6 @@ public:
 	 * Returns the XojPageView with the given coordinates
 	 */
 	XojPageView* getViewAt(int x, int y, PagePositionCache* cache = NULL);
-	XojPageView* getBestMatchingView(int x, int y, int width, int height);
 
 private:
 	void addData(PagePosition* p);


### PR DESCRIPTION
This is in regard to the movement of selected objects between pages after selection.
 
This functionality was broken in the multilayout code changes.
This is a slightly different implementation to consider:
  It uses the page found under the cursor ( instead of the one with the biggest overlap );
  It doesn't delete the item if finalized off-page but instead resets to original page and position.

