### PR TITLE
fix various problems with zoom-fit-mode

### DIFF
--- a/src/control/Control.h
+++ b/src/control/Control.h
@@ -127,6 +127,7 @@ public:
 
 	void updateWindowTitle();
 	void calcZoomFitSize();
+	void setZoomFitButton(bool enabled);
 	void setViewPairedPages(bool continous);
 	void setViewPresentationMode(bool continous);
 	void setPairsOffset(int numOffset);
@@ -263,8 +264,7 @@ protected:
 	 * On slower machine this feels more fluent, therefore this will not
 	 * be removed
 	 */
-	void zoomCallback(ActionType type);
-	void zoomFit();
+	void zoomCallback(ActionType type, bool enabled);
 
 	void rotationSnappingToggle();
 	void gridSnappingToggle();

--- a/src/control/zoom/ZoomControl.cpp
+++ b/src/control/zoom/ZoomControl.cpp
@@ -1,5 +1,6 @@
 #include "ZoomControl.h"
 
+#include "control/Control.h"
 #include "gui/Layout.h"
 #include "gui/PageView.h"
 #include "gui/widgets/XournalWidget.h"
@@ -28,7 +29,10 @@ void ZoomControl::zoomOneStep(bool zoomIn, double x, double y)
 
 	startZoomSequence(x, y);
 
-	this->zoomFitMode = false;
+	if (this->zoomFitMode)
+	{
+		this->setZoomFitMode(false);
+	}
 	double newZoom;
 	if (zoomIn)
 	{
@@ -47,6 +51,11 @@ void ZoomControl::zoomScroll(bool zoomIn, double x, double y)
 {
 	XOJ_CHECK_TYPE(ZoomControl);
 
+	if (this->zoomFitMode)
+	{
+		this->setZoomFitMode(false);
+	}
+
 	if (this->zoomSequenceStart == -1 || scrollCursorPositionX != x || scrollCursorPositionY != y)
 	{
 		scrollCursorPositionX = x;
@@ -54,7 +63,6 @@ void ZoomControl::zoomScroll(bool zoomIn, double x, double y)
 		startZoomSequence(x, y);
 	}
 
-	this->zoomFitMode = false;
 	double newZoom;
 	if (zoomIn)
 	{
@@ -232,11 +240,10 @@ void ZoomControl::setZoom(double zoom)
 	XOJ_CHECK_TYPE(ZoomControl);
 
 	this->zoom = zoom;
-	this->zoomFitMode = false;
 	fireZoomChanged();
 }
 
-void ZoomControl::setZoom100(double zoom)
+void ZoomControl::setZoom100Value(double zoom)
 {
 	XOJ_CHECK_TYPE(ZoomControl);
 
@@ -248,27 +255,22 @@ void ZoomControl::setZoom100(double zoom)
 	fireZoomRangeValueChanged();
 }
 
-void ZoomControl::setZoomFit(double zoom)
+void ZoomControl::setZoomFitValue(double zoom)
 {
 	XOJ_CHECK_TYPE(ZoomControl);
 
 	this->zoomFitValue = zoom;
 	fireZoomRangeValueChanged();
-
-	if (this->zoomFitMode)
-	{
-		zoomFit();
-	}
 }
 
-double ZoomControl::getZoomFit()
+double ZoomControl::getZoomFitValue()
 {
 	XOJ_CHECK_TYPE(ZoomControl);
 
 	return this->zoomFitValue;
 }
 
-double ZoomControl::getZoom100()
+double ZoomControl::getZoom100Value()
 {
 	XOJ_CHECK_TYPE(ZoomControl);
 
@@ -279,21 +281,33 @@ void ZoomControl::zoom100()
 {
 	XOJ_CHECK_TYPE(ZoomControl);
 
-	this->zoomFitMode = false;
+	if(this->zoomFitMode)
+	{
+		this->setZoomFitMode(false);
+	}
 
 	startZoomSequence(-1, -1);
 	this->zoomSequnceChange(this->zoom100Value, false);
 	endZoomSequence();
 }
 
-void ZoomControl::zoomFit()
+void ZoomControl::setZoomFitMode(bool isZoomFitMode)
 {
 	XOJ_CHECK_TYPE(ZoomControl);
 
-	this->zoomFitMode = true;
-	startZoomSequence(-1, -1);
-	this->zoomSequnceChange(this->zoomFitValue, false);
-	endZoomSequence();
+	this->zoomFitMode = isZoomFitMode;
+	if(isZoomFitMode)
+	{
+		startZoomSequence(-1, -1);
+		this->zoomSequnceChange(this->zoomFitValue, false);
+		endZoomSequence();
+	}
+	this->view->getControl()->setZoomFitButton(isZoomFitMode);
+}
+
+bool ZoomControl::isZoomFitMode()
+{
+	return this->zoomFitMode;
 }
 
 double ZoomControl::getZoomStep()

--- a/src/control/zoom/ZoomControl.h
+++ b/src/control/zoom/ZoomControl.h
@@ -55,8 +55,8 @@ public:
 	/**
 	 * Zoom so that the page fits the current size of the window
 	 */
-	void zoomFit();
-
+	void setZoomFitMode(bool isZoomFitMode);
+	bool isZoomFitMode();
 	/**
 	 * Zoom so that the displayed page on the screen has the same size as the real size
 	 * The dpi has to be set correctly
@@ -88,11 +88,11 @@ public:
 	 *
 	 * @param zoom zoom value depending zoom100Value
 	 */
-	void setZoom100(double zoom);
-	void setZoomFit(double zoom);
+	void setZoom100Value(double zoom);
+	void setZoomFitValue(double zoom);
 
-	double getZoomFit();
-	double getZoom100();
+	double getZoomFitValue();
+	double getZoom100Value();
 
 	void addZoomListener(ZoomListener* listener);
 

--- a/src/control/zoom/ZoomGesture.cpp
+++ b/src/control/zoom/ZoomGesture.cpp
@@ -62,6 +62,10 @@ void ZoomGesture::zoomBegin()
 
 	Rectangle zoomSequenceRectangle = zoomControl->getVisibleRect();
 
+	if(zoomControl->isZoomFitMode())
+	{
+		zoomControl->setZoomFitMode(false);
+	}
 	zoomControl->startZoomSequence(x - zoomSequenceRectangle.x, y - zoomSequenceRectangle.y);
 }
 

--- a/src/enums/ActionGroup.enum.h
+++ b/src/enums/ActionGroup.enum.h
@@ -65,6 +65,8 @@ enum ActionGroup
 	GROUP_LAYOUT_LR,
 	
 	GROUP_LAYOUT_TB,
+
+	GROUP_ZOOM_FIT,
 };
 
 ActionGroup ActionGroup_fromString(string value);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -53,6 +53,7 @@ MainWindow::MainWindow(GladeSearchpath* gladeSearchPath, Control* control)
 
 	// Window handler
 	g_signal_connect(this->window, "delete-event", G_CALLBACK(deleteEventCallback), this->control);
+	g_signal_connect(this->window, "configure-event", G_CALLBACK(configureEventCallback), this->control);
 	g_signal_connect(this->window, "window_state_event", G_CALLBACK(windowStateEventCallback), this);
 
 	g_signal_connect(get("buttonCloseSidebar"), "clicked", G_CALLBACK(buttonCloseSidebarClicked), this);
@@ -566,6 +567,17 @@ bool MainWindow::deleteEventCallback(GtkWidget* widget, GdkEvent* event, Control
 	control->quit();
 
 	return true;
+}
+
+bool MainWindow::configureEventCallback(GtkWidget* widget, GdkEventConfigure* event, Control* control)
+{
+	control->calcZoomFitSize();
+	ZoomControl *zoom = control->getZoomControl();
+	if(zoom->isZoomFitMode())
+	{
+		zoom->setZoomFitMode(true);
+	}
+	return false;
 }
 
 void MainWindow::setSidebarVisible(bool visible)

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -117,6 +117,11 @@ private:
 	static bool deleteEventCallback(GtkWidget* widget, GdkEvent* event, Control* control);
 
 	/**
+	 * Window has been moved or resized. Needed for Zoomfit
+	 */
+	static bool configureEventCallback(GtkWidget* widget, GdkEventConfigure* event, Control* control);
+
+	/**
 	 * Key is pressed
 	 */
 	static bool onKeyPressCallback(GtkWidget* widget, GdkEventKey* event, MainWindow* win);

--- a/src/gui/toolbarMenubar/ToolMenuHandler.cpp
+++ b/src/gui/toolbarMenubar/ToolMenuHandler.cpp
@@ -422,7 +422,7 @@ void ToolMenuHandler::initToolItems()
 
 	ADD_STOCK_ITEM("ZOOM_OUT", ACTION_ZOOM_OUT, "zoom-out", _("Zoom out"));
 	ADD_STOCK_ITEM("ZOOM_IN", ACTION_ZOOM_IN, "zoom-in", _("Zoom in"));
-	ADD_STOCK_ITEM("ZOOM_FIT", ACTION_ZOOM_FIT, "zoom-fit-best", _("Zoom fit to screen"));
+	ADD_CUSTOM_ITEM_TGL("ZOOM_FIT", ACTION_ZOOM_FIT,  GROUP_ZOOM_FIT, false, "zoom-fit-best", _("Zoom fit to screen"));
 	ADD_STOCK_ITEM("ZOOM_100", ACTION_ZOOM_100, "zoom-original", _("Zoom to 100%"));
 
 	// Menu Navigation

--- a/src/gui/toolbarMenubar/ToolZoomSlider.cpp
+++ b/src/gui/toolbarMenubar/ToolZoomSlider.cpp
@@ -30,7 +30,7 @@ void ToolZoomSlider::sliderChanged(GtkRange* range, ToolZoomSlider* self)
 		return;
 	}
 
-	double back = self->zoom->getZoom100() * scaleFuncInv(gtk_range_get_value(range));
+	double back = self->zoom->getZoom100Value() * scaleFuncInv(gtk_range_get_value(range));
 	self->zoom->zoomSequnceChange(back, false);
 }
 
@@ -41,6 +41,7 @@ bool ToolZoomSlider::sliderButtonPress(GtkRange* range, GdkEvent *event, ToolZoo
 	if(!self->sliderChangingByUser)
 	{
 		self->sliderChangingByUser = true;
+		self->zoom->setZoomFitMode(false);
 		self->zoom->startZoomSequence(-1, -1);
 	}
 	return false;
@@ -110,8 +111,8 @@ void ToolZoomSlider::updateScaleMarks()
 	}
 
 	gtk_scale_clear_marks(GTK_SCALE(this->slider));
-	gtk_scale_add_mark(GTK_SCALE(this->slider), zoom->getZoom100(), horizontal ? GTK_POS_BOTTOM : GTK_POS_RIGHT, NULL);
-	gtk_scale_add_mark(GTK_SCALE(this->slider), zoom->getZoomFit(), horizontal ? GTK_POS_BOTTOM : GTK_POS_RIGHT, NULL);
+	gtk_scale_add_mark(GTK_SCALE(this->slider), scaleFunc(zoom->getZoom100Value()), horizontal ? GTK_POS_BOTTOM : GTK_POS_RIGHT, NULL);
+	gtk_scale_add_mark(GTK_SCALE(this->slider), scaleFunc(zoom->getZoomFitValue()), horizontal ? GTK_POS_BOTTOM : GTK_POS_RIGHT, NULL);
 }
 
 GtkToolItem* ToolZoomSlider::createItem(bool horizontal)


### PR DESCRIPTION
I fixed various problems with the zoom fit mode.
- Calculation of zoomFitValue after zooming in and out
- Make the zoom fit Button indicate, zoomFitMode is active
- recalculate and zoom, when Window is resized
- recalculate and zoom, when loading new file
At some places, I'm not sure wether its the way to do this. And I kind of fear calling calcZoomFitSize bit too often.
I would request others to test the behavior, before merging. For me everything works well now. 