### PR TITLE
keep text dark when highlighting

### DIFF
--- a/src/control/tools/StrokeHandler.cpp
+++ b/src/control/tools/StrokeHandler.cpp
@@ -43,7 +43,14 @@ void StrokeHandler::draw(cairo_t* cr)
 	}
 
 	view.applyColor(cr, stroke);
-	cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
+
+	if (stroke->getToolType() == STROKE_TOOL_HIGHLIGHTER) {
+	  cairo_set_operator(cr, CAIRO_OPERATOR_MULTIPLY);
+	}
+	else {
+	  cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
+	}
+
 	cairo_mask_surface(cr, surfMask, 0, 0);
 }
 
@@ -94,7 +101,7 @@ bool StrokeHandler::onMotionNotifyEvent(const PositionInputData& pos)
 	else
 	{
 		if (pointCount > 0)
-		{			
+		{
 			Point prevPoint(stroke->getPoint(pointCount - 1));
 
 			Stroke lastSegment;

--- a/src/view/StrokeView.cpp
+++ b/src/view/StrokeView.cpp
@@ -84,7 +84,13 @@ void StrokeView::changeCairoSource(bool markAudioStroke)
 	if (s->getToolType() == STROKE_TOOL_HIGHLIGHTER ||
 		(s->getAudioFilename().length() == 0 && markAudioStroke))
 	{
-		cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
+		if (s->getToolType() == STROKE_TOOL_HIGHLIGHTER) {
+			cairo_set_operator(cr, CAIRO_OPERATOR_MULTIPLY);
+		}
+		else {
+			cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
+		}
+
 		// Set the color
 		DocumentView::applyColor(cr, s, 120);
 	}


### PR DESCRIPTION
Currently, highlighting text with the highlighter tool covers it with transparent strokes, so it looks like this (on the right side, I highlighted several times to emphasize the point):

![over](https://user-images.githubusercontent.com/7050984/54699737-d522a480-4aee-11e9-8378-56bc3d693fbe.png)

This pull request changes the compositing operator for the highlighter tool to MULTIPLY, so that instead the text stays dark:

![multiply](https://user-images.githubusercontent.com/7050984/54699783-ef5c8280-4aee-11e9-8976-fd8358f9efd6.png)

I think I changed it everywhere that is appropriate, but those more familiar with the source should probably check.