### PR TITLE
Layout relative page navigation

### DIFF
--- a/src/gui/Layout.cpp
+++ b/src/gui/Layout.cpp
@@ -271,6 +271,7 @@ void Layout::layoutPages()
 			{
 
 				XojPageView* v = this->view->viewPages[pageAtRowCol];
+				v->setMappedRowCol( r,c );  					//store row and column for e.g. proper arrow key navigation
 				int vDisplayWidth = v->getDisplayWidth();
 				{
 					int paddingLeft;
@@ -483,5 +484,12 @@ XojPageView* Layout::getViewAt(int x, int y)
 	
 	return NULL;
 	
+	
+}
+
+
+int Layout::getIndexAtGridMap(int row, int col)
+{
+	return this->mapper.map( col, row); //watch out.. x,y --> c,r
 	
 }

--- a/src/gui/Layout.h
+++ b/src/gui/Layout.h
@@ -95,6 +95,12 @@ public:
 	 */	
 	XojPageView* getViewAt(int x, int y);
 
+	/**
+	 * Return the page index found ( or -1 if not found) at layout grid row,col
+	 * 
+	 */	
+	int getIndexAtGridMap(int row, int col);
+	
 	
 private:
 	void checkScroll(GtkAdjustment* adjustment, double& lastScroll);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -532,32 +532,6 @@ bool MainWindow::onKeyPressCallback(GtkWidget* widget, GdkEventKey* event, MainW
 		//editing text - give that control
 		return false;
 	}
-	else if (event->keyval == GDK_KEY_Down)
-	{
-		if (win->getControl()->getSettings()->isPresentationMode())
-		{
-			win->getControl()->getScrollHandler()->goToNextPage();
-			return true;
-		}
-		else
-		{
-			win->getLayout()->scrollRelativ(0, 30);
-			return true;
-		}
-	}
-	else if (event->keyval == GDK_KEY_Up)
-	{
-		if (win->getControl()->getSettings()->isPresentationMode())
-		{
-			win->getControl()->getScrollHandler()->goToPreviousPage();
-			return true;
-		}
-		else
-		{
-			win->getLayout()->scrollRelativ(0, -30);
-			return true;
-		}
-	}
 	else if (event->keyval == GDK_KEY_Escape)
 	{
 		win->getControl()->getSearchBar()->showSearchBar(false);

--- a/src/gui/PageView.cpp
+++ b/src/gui/PageView.cpp
@@ -934,6 +934,31 @@ void XojPageView::setY( int y )
 	this->dispY = y;
 }
 
+void XojPageView::setMappedRowCol(int row, int col )
+{
+	XOJ_CHECK_TYPE(XojPageView);
+	
+	this->mappedRow = row;
+	this->mappedCol = col;
+}
+
+
+int XojPageView::getMappedRow()
+{
+	XOJ_CHECK_TYPE(XojPageView);
+	
+	return this->mappedRow;
+}
+	
+
+int XojPageView::getMappedCol()
+{
+	XOJ_CHECK_TYPE(XojPageView);
+	
+	return this->mappedCol;
+}	
+	
+
 PageRef XojPageView::getPage()
 {
 	XOJ_CHECK_TYPE(XojPageView);

--- a/src/gui/PageView.h
+++ b/src/gui/PageView.h
@@ -77,6 +77,17 @@ public:
 	 */
 	bool containsPoint(int x, int y, bool local = false);
 	bool containsY(int y);
+	
+	/**
+	 * Returns Row assigned in current layout
+	 */ 
+	int getMappedRow();
+	
+	/**
+	 * Returns Column assigned in current layout
+	 */ 
+	int getMappedCol();
+	
 
 	GtkColorWrapper getSelectionColor();
 	int getBufferPixels();
@@ -169,6 +180,11 @@ private:
 	void setX(int x);
 	void setY(int y);
 
+	void setMappedRowCol(int row, int col );	//row, column assigned by mapper during layout.
+
+	
+
+
 private:
 	XOJ_TYPE_ATTRIB;
 
@@ -223,10 +239,19 @@ private:
 	int dispX;	//position on display - set in Layout::layoutPages
 	int dispY;
 
+
+	int mappedRow;
+	int mappedCol;
+
+
 	friend class RenderJob;
 	friend class InputHandler;
 	friend class BaseSelectObject;
 	friend class SelectObject;
 	friend class PlayObject;
+<<<<<<< HEAD
 	friend void Layout::layoutPages();	//only function allowed to setX(), setY()
+=======
+	friend void Layout::layoutPages();	//only function allowed to setMappedRowCol()
+>>>>>>> d0560ff... Store Mapper assigned row,col in PageView and expose mapper function to allow easy directional navigation of pages.
 };

--- a/src/gui/PageView.h
+++ b/src/gui/PageView.h
@@ -249,9 +249,5 @@ private:
 	friend class BaseSelectObject;
 	friend class SelectObject;
 	friend class PlayObject;
-<<<<<<< HEAD
-	friend void Layout::layoutPages();	//only function allowed to setX(), setY()
-=======
-	friend void Layout::layoutPages();	//only function allowed to setMappedRowCol()
->>>>>>> d0560ff... Store Mapper assigned row,col in PageView and expose mapper function to allow easy directional navigation of pages.
+	friend void Layout::layoutPages();	//only function allowed to setX(), setY(), setMappedRowCol()
 };

--- a/src/gui/XournalView.cpp
+++ b/src/gui/XournalView.cpp
@@ -207,12 +207,12 @@ bool XournalView::onKeyPressEvent(GdkEventKey* event)
 	}
 	else
 	{
-		if (event->keyval == GDK_KEY_Page_Down)
+		if (event->keyval == GDK_KEY_Page_Down || event->keyval == GDK_KEY_KP_Page_Down)
 		{
 			control->getScrollHandler()->goToNextPage();
 			return true;
 		}
-		if (event->keyval == GDK_KEY_Page_Up)
+		if (event->keyval == GDK_KEY_Page_Up || event->keyval == GDK_KEY_KP_Page_Up)
 		{
 			control->getScrollHandler()->goToPreviousPage();
 			return true;
@@ -228,6 +228,32 @@ bool XournalView::onKeyPressEvent(GdkEventKey* event)
 		return true;
 	}
 
+	//Numeric keypad always navigates by page
+	if (event->keyval == GDK_KEY_KP_Up)
+	{
+		this->pageRelativeXY(0,-1);
+		return true;
+	}
+
+	if (event->keyval == GDK_KEY_KP_Down)
+	{
+		this->pageRelativeXY(0,1);
+		return true;
+	}
+
+	if (event->keyval == GDK_KEY_KP_Left)
+	{
+		this->pageRelativeXY(-1, 0);
+		return true;
+	}
+
+	if (event->keyval == GDK_KEY_KP_Right)
+	{
+		this->pageRelativeXY(1,0);
+		return true;
+	}
+
+	
 	if (event->keyval == GDK_KEY_Up)
 	{
 		if (control->getSettings()->isPresentationMode())
@@ -237,7 +263,14 @@ bool XournalView::onKeyPressEvent(GdkEventKey* event)
 		}
 		else
 		{
-			layout->scrollRelativ(0, -scrollKeySize);
+			if (state & GDK_SHIFT_MASK)
+			{
+				this->pageRelativeXY(0,-1);
+			}
+			else
+			{
+				layout->scrollRelativ(0, -scrollKeySize);
+			}
 			return true;
 		}
 	}
@@ -251,30 +284,51 @@ bool XournalView::onKeyPressEvent(GdkEventKey* event)
 		}
 		else
 		{
-			layout->scrollRelativ(0, scrollKeySize);
+			if (state & GDK_SHIFT_MASK)
+			{
+				this->pageRelativeXY(0,1);
+			}
+			else
+			{
+				layout->scrollRelativ(0, scrollKeySize);
+			}
 			return true;
 		}
 	}
 
 	if (event->keyval == GDK_KEY_Left)
 	{
-		control->getScrollHandler()->goToPreviousPage();
+		if (state & GDK_SHIFT_MASK)
+		{
+			this->pageRelativeXY(-1,0);
+		}
+		else
+		{
+			layout->scrollRelativ(-scrollKeySize, 0);
+		}
 		return true;
 	}
 
 	if (event->keyval == GDK_KEY_Right)
 	{
-		control->getScrollHandler()->goToNextPage();
+		if (state & GDK_SHIFT_MASK)
+		{
+			this->pageRelativeXY(1,0);
+		}
+		else
+		{
+			layout->scrollRelativ(scrollKeySize, 0);
+		}
 		return true;
 	}
 
-	if (event->keyval == GDK_KEY_End)
+	if (event->keyval == GDK_KEY_End || event->keyval == GDK_KEY_KP_End)
 	{
 		control->getScrollHandler()->goToLastPage();
 		return true;
 	}
 
-	if (event->keyval == GDK_KEY_Home)
+	if (event->keyval == GDK_KEY_Home || event->keyval == GDK_KEY_KP_Home)
 	{
 		control->getScrollHandler()->goToFirstPage();
 		return true;
@@ -456,6 +510,27 @@ void XournalView::scrollTo(size_t pageNo, double yDocument)
 	control->firePageSelected(pageNo);
 }
 
+	
+void XournalView::pageRelativeXY(int offCol, int offRow)
+{
+	XOJ_CHECK_TYPE(XournalView);
+
+	int currPage = getCurrentPage();
+
+    XojPageView* view = getViewFor(currPage );
+	int row = view->getMappedRow();
+	int col = view->getMappedCol();
+				
+	Layout* layout = gtk_xournal_get_layout(this->widget);
+	int page = layout->getIndexAtGridMap(row +offRow  ,col + offCol);
+	if( page >=0)
+	{
+		this-> scrollTo(page, 0);
+	}
+
+}
+
+	
 void XournalView::endTextAllPages(XojPageView* except)
 {
 	XOJ_CHECK_TYPE(XournalView);

--- a/src/gui/XournalView.h
+++ b/src/gui/XournalView.h
@@ -51,6 +51,9 @@ public:
 	void layoutPages();
 
 	void scrollTo(size_t pageNo, double y);
+	
+	//Relative navigation in current layout:
+	void pageRelativeXY(int offCol, int offRow );
 
 	size_t getCurrentPage();
 

--- a/src/gui/toolbarMenubar/ToolZoomSlider.cpp
+++ b/src/gui/toolbarMenubar/ToolZoomSlider.cpp
@@ -199,6 +199,8 @@ GtkToolItem* ToolZoomSlider::newItem()
 	g_signal_connect(this->slider, "format-value", G_CALLBACK(sliderFormatValue), this);
 	gtk_scale_set_draw_value(GTK_SCALE(this->slider), true);
 
+	gtk_widget_set_can_focus(this->slider, false);
+	
 	if (this->horizontal)
 	{
 		gtk_widget_set_size_request(GTK_WIDGET(this->slider), 120, 16);


### PR DESCRIPTION
This PR adds page navigation with respect to the position of the pages as laid out.

Explores  keymappings as below:

Arrow Keys:  
   no modifier - as before, scrolls view
   shifted arrow and
   numeric keypad arrow keys - - selects page found in given direction.

Note: removes ability for zoom control to have focus so that keys don't mysteriously stop working after you adjust zoom with the mouse.