### PR TITLE
Fix the Draw Arrow/Draw Coordinate System issue/inconsistency in the Tools menu

### DIFF
--- a/po/cs.po
+++ b/po/cs.po
@@ -921,6 +921,7 @@ msgstr "Kreslit čáru"
 #: ../src/gui/dialog/ButtonConfigGui.cpp:108
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:34
 #: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:470
+#: ../ui/main.glade:1128
 msgid "Draw coordinate system"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -939,6 +939,7 @@ msgstr "Strecke _zeichnen"
 #: ../src/gui/dialog/ButtonConfigGui.cpp:108
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:34
 #: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:470
+#: ../ui/main.glade:1128
 msgid "Draw coordinate system"
 msgstr "Koordinatensystem zeichnen"
 

--- a/po/it.po
+++ b/po/it.po
@@ -937,6 +937,7 @@ msgstr "Disegna _Linea"
 #: ../src/gui/dialog/ButtonConfigGui.cpp:108
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:34
 #: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:470
+#: ../ui/main.glade:1128
 msgid "Draw coordinate system"
 msgstr "Disegna il sistema di coordinate"
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -922,6 +922,7 @@ msgstr "Rysuj linię"
 #: ../src/gui/dialog/ButtonConfigGui.cpp:108
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:34
 #: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:470
+#: ../ui/main.glade:1128
 msgid "Draw coordinate system"
 msgstr ""
 

--- a/po/xournalpp.pot
+++ b/po/xournalpp.pot
@@ -397,6 +397,7 @@ msgstr ""
 #: ../src/gui/dialog/ButtonConfigGui.cpp:108
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:34
 #: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:470
+#: ../ui/main.glade:1128
 msgid "Draw coordinate system"
 msgstr ""
 

--- a/po/zh.po
+++ b/po/zh.po
@@ -890,6 +890,7 @@ msgstr "绘制直线"
 #: ../src/gui/dialog/ButtonConfigGui.cpp:108
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:34
 #: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:470
+#: ../ui/main.glade:1128
 msgid "Draw coordinate system"
 msgstr ""
 

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -890,6 +890,7 @@ msgstr "繪製直線"
 #: ../src/gui/dialog/ButtonConfigGui.cpp:108
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:34
 #: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:470
+#: ../ui/main.glade:1128
 msgid "Draw coordinate system"
 msgstr ""
 

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -890,6 +890,7 @@ msgstr "繪製直線"
 #: ../src/gui/dialog/ButtonConfigGui.cpp:108
 #: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:34
 #: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:470
+#: ../ui/main.glade:1128
 msgid "Draw coordinate system"
 msgstr ""
 

--- a/ui/main.glade
+++ b/ui/main.glade
@@ -1125,7 +1125,7 @@
                       <object class="GtkCheckMenuItem" id="menuToolsDrawCoordinateSystem">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Draw Arrow</property>
+                        <property name="label" translatable="yes">Draw coordinate system</property>
                         <property name="use_underline">True</property>
                         <signal name="toggled" handler="ACTION_TOOL_DRAW_COORDINATE_SYSTEM" swapped="no"/>
                         <accelerator key="5" signal="activate" modifiers="GDK_CONTROL_MASK"/>


### PR DESCRIPTION
Minor bug: Under the Tools menu, the "Draw Arrow" is duplicated (the bottom one does "Draw Coordinate System")
I built the latest version from the `xournalpp-git` AUR package.

Screenshot of bug:
![xournalpp-minor-naming-bug-20190403](https://user-images.githubusercontent.com/29907828/55518291-79edc780-5641-11e9-95b6-76c9a39f0474.png)

This time, I was able to find the source of the issue! :) The PR contains the fix. I tested it by building from source. Tested on Arch Linux, built manually with this tutorial: https://github.com/xournalpp/xournalpp/blob/master/readme/LinuxBuild.md
I also edited the translation files to make sure that it was consistently recognizing it across all languages (some of them had "" in msgstr, would that mean it would replace with nothing, or would it replace it with the default string? I'm not very familiar with potfiles. I kept the name lowercase to make it consistent with other places where we have "Draw coordinate system" (in the arrow/dropdown near the shape tool button))
Feel free to edit (I checked "allow edits from maintainers") if you see any inconsistencies or things you want changed.

Here is a screenshot of the fix:
![Screenshot_20190403_191656](https://user-images.githubusercontent.com/29907828/55519364-7d834d80-5645-11e9-8d34-8ca8d32ade12.png)

Thank you!
- siliconninja