### PR TITLE
fixes 1042: Mouse grab: Can't move page up slowly

### DIFF
--- a/src/gui/Layout.cpp
+++ b/src/gui/Layout.cpp
@@ -368,7 +368,7 @@ void Layout::setSize(int widgetWidth, int widgetHeight)
 	this->view->getControl()->calcZoomFitSize();
 }
 
-void Layout::scrollRelativ(int x, int y)
+void Layout::scrollRelativ(double x, double y)
 {
 	XOJ_CHECK_TYPE(Layout);
 

--- a/src/gui/Layout.h
+++ b/src/gui/Layout.h
@@ -44,7 +44,7 @@ public:
 	/**
 	 * Increases the adjustments by the given amounts
 	 */
-	void scrollRelativ(int x, int y);
+	void scrollRelativ(double x, double y);
 
 	/**
 	 * Changes the adjustments by absolute amounts (for pinch-to-zoom)

--- a/src/gui/inputdevices/InputSequence.cpp
+++ b/src/gui/inputdevices/InputSequence.cpp
@@ -152,10 +152,6 @@ void InputSequence::handleScrollEvent()
 	// use root coordinates as reference point because
 	// scrolling changes window relative coordinates
 	// see github Gnome/evince@1adce5486b10e763bed869
-	if (lastMousePositionX  == (int)rootX && lastMousePositionY == (int)rootY)
-	{
-		return;
-	}
 
 	if (scrollOffsetX == 0 && scrollOffsetY == 0)
 	{

--- a/src/gui/inputdevices/InputSequence.h
+++ b/src/gui/inputdevices/InputSequence.h
@@ -208,12 +208,12 @@ private:
 	/**
 	 * Last mouse position for Scrolling
 	 */
-	int lastMousePositionX = 0;
+	double lastMousePositionX = 0;
 
 	/**
 	 * Last mouse position for Scrolling
 	 */
-	int lastMousePositionY = 0;
+	double lastMousePositionY = 0;
 
 	/**
 	 * Currently scrolling active
@@ -223,10 +223,10 @@ private:
 	/**
 	 * The last Mouse Position, for scrolling
 	 */
-	int scrollOffsetX = 0;
+	double scrollOffsetX = 0;
 
 	/**
 	 * The last Mouse Position, for scrolling
 	 */
-	int scrollOffsetY = 0;
+	double scrollOffsetY = 0;
 };


### PR DESCRIPTION
The hand tool was scrolling with int but the scrolling works with doubles. The result was that you couldn't move the page up nor to the left slowly using the grab tool.