### PR TITLE
Preserve line style when erasing partial strokes

### DIFF
--- a/src/model/eraser/EraseableStroke.cpp
+++ b/src/model/eraser/EraseableStroke.cpp
@@ -385,6 +385,7 @@ GList* EraseableStroke::getStroke(Stroke* original)
 			s = new Stroke();
 			s->setColor(original->getColor());
 			s->setToolType(original->getToolType());
+			s->setLineStyle(original->getLineStyle());
 			s->setWidth(original->getWidth());
 			list = g_list_append(list, s);
 		}


### PR DESCRIPTION
Fixes #1043.

This is my first ever pull request, so please let me know if I'm doing anything wrong.