### PR TITLE
Fix issue #1026

### DIFF
--- a/src/gui/TextEditor.cpp
+++ b/src/gui/TextEditor.cpp
@@ -984,7 +984,7 @@ void TextEditor::copyToCliboard()
 {
 	XOJ_CHECK_TYPE(TextEditor);
 
-	GtkClipboard* clipboard = gtk_widget_get_clipboard(this->widget, GDK_SELECTION_PRIMARY);
+	GtkClipboard* clipboard = gtk_widget_get_clipboard(this->widget, GDK_SELECTION_CLIPBOARD);
 	gtk_text_buffer_copy_clipboard(this->buffer, clipboard);
 }
 
@@ -992,7 +992,7 @@ void TextEditor::cutToClipboard()
 {
 	XOJ_CHECK_TYPE(TextEditor);
 
-	GtkClipboard* clipboard = gtk_widget_get_clipboard(this->widget, GDK_SELECTION_PRIMARY);
+	GtkClipboard* clipboard = gtk_widget_get_clipboard(this->widget, GDK_SELECTION_CLIPBOARD);
 	gtk_text_buffer_cut_clipboard(this->buffer, clipboard, true);
 
 	this->repaintEditor();
@@ -1003,7 +1003,7 @@ void TextEditor::pasteFromClipboard()
 {
 	XOJ_CHECK_TYPE(TextEditor);
 
-	GtkClipboard* clipboard = gtk_widget_get_clipboard(this->widget, GDK_SELECTION_PRIMARY);
+	GtkClipboard* clipboard = gtk_widget_get_clipboard(this->widget, GDK_SELECTION_CLIPBOARD);
 	gtk_text_buffer_paste_clipboard(this->buffer, clipboard, NULL, true);
 
 	this->repaintEditor();


### PR DESCRIPTION
This fixes the issue (#1026) with the text editor copying to the PRIMARY selection instead of the CLIPBOARD selection.