### PR TITLE
Tap select

### DIFF
--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -142,7 +142,7 @@ void Settings::loadDefault()
 	this->pluginEnabled = "";
 	this->pluginDisabled = "";
 	
-	this->strokeFilterIgnoreTime = 300;
+	this->strokeFilterIgnoreTime = 200;
 	this->strokeFilterIgnorePoints = 8;
 	this->strokeFilterSuccessiveTime = 500;
 	this->strokeFilterEnabled = false;

--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -142,7 +142,12 @@ void Settings::loadDefault()
 	this->pluginEnabled = "";
 	this->pluginDisabled = "";
 	
-	inTransaction = false;
+	this->strokeFilterIgnoreTime = 300;
+	this->strokeFilterIgnorePoints = 8;
+	this->strokeFilterSuccessiveTime = 500;
+	
+	this->inTransaction = false;
+	
 }
 
 void Settings::parseData(xmlNodePtr cur, SElement& elem)
@@ -542,7 +547,19 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur)
 	{
 		this->audioOutputDevice = g_ascii_strtoll((const char *) value, NULL, 10);
 	}
-
+	else if (xmlStrcmp(name, (const xmlChar*) "strokeFilterIgnoreTime") == 0)
+	{
+		this->strokeFilterIgnoreTime = g_ascii_strtoll((const char*) value, NULL, 10);
+	}	
+	else if (xmlStrcmp(name, (const xmlChar*) "strokeFilterIgnorePoints") == 0)
+	{
+		this->strokeFilterIgnorePoints = g_ascii_strtoll((const char*) value, NULL, 10);
+	}	
+	else if (xmlStrcmp(name, (const xmlChar*) "strokeFilterSuccessiveTime") == 0)
+	{
+		this->strokeFilterSuccessiveTime = g_ascii_strtoll((const char*) value, NULL, 10);
+	}
+	
 	xmlFree(name);
 	xmlFree(value);
 }
@@ -903,6 +920,11 @@ void Settings::save()
 
 	WRITE_STRING_PROP(pluginEnabled);
 	WRITE_STRING_PROP(pluginDisabled);
+	
+	WRITE_INT_PROP(strokeFilterIgnoreTime);
+	WRITE_INT_PROP(strokeFilterIgnorePoints);
+	WRITE_INT_PROP(strokeFilterSuccessiveTime);
+	
 
 	xmlNodePtr xmlFont;
 	xmlFont = xmlNewChild(root, NULL, (const xmlChar*) "property", NULL);
@@ -2236,6 +2258,26 @@ void Settings::setPluginDisabled(string pluginEnabled)
 	save();
 }
 
+
+void Settings::getStrokeFilter( int* ignoreTime, int* ignorePoints, int* successiveTime)
+{
+	XOJ_CHECK_TYPE(Settings);
+	*ignoreTime = this->strokeFilterIgnoreTime;
+	*ignorePoints = this->strokeFilterIgnorePoints;
+	*successiveTime = this->strokeFilterSuccessiveTime;
+	
+}
+
+void Settings::setStrokeFilter( int ignoreTime, int ignorePoints, int successiveTime)
+{
+	XOJ_CHECK_TYPE(Settings);
+	this->strokeFilterIgnoreTime = ignoreTime;
+	this->strokeFilterIgnorePoints = ignorePoints;
+	this->strokeFilterSuccessiveTime = successiveTime;
+	
+}
+	
+	
 //////////////////////////////////////////////////
 
 SAttribute::SAttribute()

--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -145,6 +145,8 @@ void Settings::loadDefault()
 	this->strokeFilterIgnoreTime = 300;
 	this->strokeFilterIgnorePoints = 8;
 	this->strokeFilterSuccessiveTime = 500;
+	this->strokeFilterEnabled = false;
+	this->doActionOnStrokeFiltered = false;
 	
 	this->inTransaction = false;
 	
@@ -559,6 +561,16 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur)
 	{
 		this->strokeFilterSuccessiveTime = g_ascii_strtoll((const char*) value, NULL, 10);
 	}
+	else if (xmlStrcmp(name, (const xmlChar*) "strokeFilterEnabled") == 0)
+	{
+		this->strokeFilterEnabled = xmlStrcmp(value, (const xmlChar*) "true") ? false : true;
+	}
+	else if (xmlStrcmp(name, (const xmlChar*) "doActionOnStrokeFiltered") == 0)
+	{
+		this->doActionOnStrokeFiltered = xmlStrcmp(value, (const xmlChar*) "true") ? false : true;
+	}
+	
+	
 	
 	xmlFree(name);
 	xmlFree(value);
@@ -925,6 +937,9 @@ void Settings::save()
 	WRITE_INT_PROP(strokeFilterIgnorePoints);
 	WRITE_INT_PROP(strokeFilterSuccessiveTime);
 	
+	WRITE_BOOL_PROP(strokeFilterEnabled);
+	WRITE_BOOL_PROP(doActionOnStrokeFiltered);
+
 
 	xmlNodePtr xmlFont;
 	xmlFont = xmlNewChild(root, NULL, (const xmlChar*) "property", NULL);
@@ -2277,6 +2292,31 @@ void Settings::setStrokeFilter( int ignoreTime, int ignorePoints, int successive
 	
 }
 	
+void Settings::setStrokeFilterEnabled(bool enabled)
+{
+	XOJ_CHECK_TYPE(Settings);
+	this->strokeFilterEnabled = enabled;
+}
+
+bool Settings::getStrokeFilterEnabled()
+{
+	XOJ_CHECK_TYPE(Settings);
+
+	return this->strokeFilterEnabled;
+}
+
+void Settings::setDoActionOnStrokeFiltered(bool enabled)
+{
+	XOJ_CHECK_TYPE(Settings);
+	this->doActionOnStrokeFiltered = enabled;
+}
+
+bool Settings::getDoActionOnStrokeFiltered()
+{
+	XOJ_CHECK_TYPE(Settings);
+	return this->doActionOnStrokeFiltered;
+}
+
 	
 //////////////////////////////////////////////////
 

--- a/src/control/settings/Settings.h
+++ b/src/control/settings/Settings.h
@@ -375,6 +375,17 @@ public:
 	 * Set size index in XOJ_UNITS
 	 */
 	void setSizeUnitIndex(int sizeUnitId);
+
+	/**
+	 * Set StrokeFilter enabled
+	 */
+	void setStrokeFilterEnabled(bool enabled);	
+
+	/**
+	 * Get StrokeFilter enabled
+	 */
+	bool getStrokeFilterEnabled();		
+
 	
 	/**
 	 * get strokeFilter settings
@@ -386,6 +397,16 @@ public:
 	 */
 	void setStrokeFilter( int strokeFilterIgnoreTime, int strokeFilterIgnorePoints, int strokeFilterSuccessiveTime);
 
+	/**
+	 * Set StrokeFilter enabled
+	 */
+	void setDoActionOnStrokeFiltered(bool enabled);	
+
+	/**
+	 * Get StrokeFilter enabled
+	 */
+	bool getDoActionOnStrokeFiltered();		
+	
 public:
 	// Custom settings
 	SElement& getCustomElement(string name);
@@ -757,7 +778,8 @@ private:
 	int strokeFilterIgnoreTime;
 	int strokeFilterIgnorePoints;
 	int strokeFilterSuccessiveTime;
-	
+	bool strokeFilterEnabled;
+	bool doActionOnStrokeFiltered;
 	
 	/**
 	 * "Transaction" running, do not save until the end is reached

--- a/src/control/settings/Settings.h
+++ b/src/control/settings/Settings.h
@@ -375,6 +375,16 @@ public:
 	 * Set size index in XOJ_UNITS
 	 */
 	void setSizeUnitIndex(int sizeUnitId);
+	
+	/**
+	 * get strokeFilter settings
+	 */
+	void getStrokeFilter( int* strokeFilterIgnoreTime, int* strokeFilterIgnorePoints, int* strokeFilterSuccessiveTime);
+
+	/**
+	 * configure stroke filter
+	 */
+	void setStrokeFilter( int strokeFilterIgnoreTime, int strokeFilterIgnorePoints, int strokeFilterSuccessiveTime);
 
 public:
 	// Custom settings
@@ -737,8 +747,22 @@ private:
 	 */
 	string pluginDisabled;
 
+	
+	/**
+	 * Used to filter strokes of short time and length unless successive
+	 * strokeFilterIgnorePoints			this many points 
+	 * strokeFilterIgnoreTime 			within this time (ms)  will be ignored..
+	 * strokeFilterSuccessiveTime		...unless successive within this time.
+	 */
+	int strokeFilterIgnoreTime;
+	int strokeFilterIgnorePoints;
+	int strokeFilterSuccessiveTime;
+	
+	
 	/**
 	 * "Transaction" running, do not save until the end is reached
 	 */
 	bool inTransaction;
+	
+	
 };

--- a/src/control/tools/BaseStrokeHandler.cpp
+++ b/src/control/tools/BaseStrokeHandler.cpp
@@ -190,7 +190,6 @@ void BaseStrokeHandler::onButtonReleaseEvent(const PositionInputData& pos)
 	
 	Control* control = xournal->getControl();
 	Settings* settings = control->getSettings();
-	int pointCount = stroke->getPointCount();
 	
 	if ( settings->getStrokeFilterEnabled() )		// Note: For simple strokes see StrokeHandler which has a slightly different version of this filter.  See //!
 	{	
@@ -200,19 +199,16 @@ void BaseStrokeHandler::onButtonReleaseEvent(const PositionInputData& pos)
 		
 		if (  pos.time - this->startStrokeTime < strokeFilterIgnoreTime)  // don't filter on points as shapes have fixed or minimum. //!
 		{
-			if ( pos.time - this->lastStrokeTime  < strokeFilterSuccessiveTime )
+			if ( pos.time - this->lastStrokeTime  > strokeFilterSuccessiveTime )
 			{
-				g_print("NOT_IGNORED: %d\n",pos.time - startStrokeTime);
-			}
-			else
-			{
-				g_print("IGNORED: %d\tlength:%d\n",pos.time - startStrokeTime, pointCount);
 				//stroke not being added to layer... delete here.
 				delete stroke;
 				stroke = NULL;
 				this->trySelect = true; 	//!
 				this->lastStrokeTime = pos.time;
+				
 				xournal->getCursor()->updateCursor();
+				
 				return;
 			}
 

--- a/src/control/tools/BaseStrokeHandler.h
+++ b/src/control/tools/BaseStrokeHandler.h
@@ -48,7 +48,7 @@ private:
 	
 	// to filter out short strokes (usually the user tapping on the page to select it)
 	guint32 startStrokeTime;
-	static guint32 lastIgnorePointTime;	//persist across strokes - allow us to not ignore persistent dotting.
+	static guint32 lastStrokeTime;	//persist across strokes - allow us to not ignore persistent dotting.
 	
 protected:
 	void snapToGrid(double& x, double& y);

--- a/src/control/tools/BaseStrokeHandler.h
+++ b/src/control/tools/BaseStrokeHandler.h
@@ -46,6 +46,10 @@ private:
 	bool flipShift = false;	//use to reverse Shift key modifier action. i.e.  for separate Rectangle and Square Tool buttons.
 	bool flipControl = false; //use to reverse Control key modifier action.
 	
+	// to filter out short strokes (usually the user tapping on the page to select it)
+	guint32 startStrokeTime;
+	static guint32 lastIgnorePointTime;	//persist across strokes - allow us to not ignore persistent dotting.
+	
 protected:
 	void snapToGrid(double& x, double& y);
 	/**

--- a/src/control/tools/InputHandler.h
+++ b/src/control/tools/InputHandler.h
@@ -87,7 +87,11 @@ public:
 	 * but needs to be in the base interface.
 	 */
 	virtual void resetShapeRecognizer();
-
+	
+	/**
+	 * trySelect - experimental feature to try select on filtered draw. See cbDoActionOnStrokeFilter
+	 */
+	bool trySelect = false;	
 
 protected:
 

--- a/src/control/tools/StrokeHandler.cpp
+++ b/src/control/tools/StrokeHandler.cpp
@@ -174,6 +174,7 @@ void StrokeHandler::onButtonReleaseEvent(const PositionInputData& pos)
 				//stroke not being added to layer... delete here.
 				delete stroke;
 				stroke = NULL;
+				this->trySelect = true;
 				return;
 			}
 		}

--- a/src/control/tools/StrokeHandler.cpp
+++ b/src/control/tools/StrokeHandler.cpp
@@ -153,29 +153,31 @@ void StrokeHandler::onButtonReleaseEvent(const PositionInputData& pos)
 	Control* control = xournal->getControl();
 	Settings* settings = control->getSettings();
 	int pointCount = stroke->getPointCount();
-	int strokeFilterIgnoreTime,strokeFilterIgnorePoints,strokeFilterSuccessiveTime;
 	
-	settings->getStrokeFilter( &strokeFilterIgnoreTime, &strokeFilterIgnorePoints, &strokeFilterSuccessiveTime  );
-	
-	if ( pointCount < strokeFilterIgnorePoints && pos.time - this->startStrokeTime < strokeFilterIgnoreTime)
-	{
-		if ( pos.time - this->lastIgnorePointTime  < strokeFilterSuccessiveTime )
+	if ( settings->getStrokeFilterEnabled() )
+	{	
+		int strokeFilterIgnoreTime,strokeFilterIgnorePoints,strokeFilterSuccessiveTime;
+		
+		settings->getStrokeFilter( &strokeFilterIgnoreTime, &strokeFilterIgnorePoints, &strokeFilterSuccessiveTime  );
+		
+		if ( pointCount < strokeFilterIgnorePoints && pos.time - this->startStrokeTime < strokeFilterIgnoreTime)
 		{
-			this->lastIgnorePointTime = pos.time;
-			g_print("NOT_IGNORED: %d\n",pos.time - startStrokeTime);
-		}
-		else
-		{
-			this->lastIgnorePointTime = pos.time;
-			g_print("IGNORED: %d\tlength:%d\n",pos.time - startStrokeTime, pointCount);
-			//stroke not being added to layer... delete here.
-			delete stroke;
-			stroke = NULL;
-			return;
+			if ( pos.time - this->lastIgnorePointTime  < strokeFilterSuccessiveTime )
+			{
+				this->lastIgnorePointTime = pos.time;
+				g_print("NOT_IGNORED: %d\n",pos.time - startStrokeTime);
+			}
+			else
+			{
+				this->lastIgnorePointTime = pos.time;
+				g_print("IGNORED: %d\tlength:%d\n",pos.time - startStrokeTime, pointCount);
+				//stroke not being added to layer... delete here.
+				delete stroke;
+				stroke = NULL;
+				return;
+			}
 		}
 	}
-	
-	
 	
 	// Backward compatibility and also easier to handle for me;-)
 	// I cannot draw a line with one point, to draw a visible line I need two points,

--- a/src/control/tools/StrokeHandler.cpp
+++ b/src/control/tools/StrokeHandler.cpp
@@ -16,7 +16,7 @@
 
 
 
-guint32 StrokeHandler::lastIgnorePointTime;		//persist for next stroke
+guint32 StrokeHandler::lastStrokeTime;		//persist for next stroke
 
 
 
@@ -154,30 +154,34 @@ void StrokeHandler::onButtonReleaseEvent(const PositionInputData& pos)
 	Settings* settings = control->getSettings();
 	int pointCount = stroke->getPointCount();
 	
-	if ( settings->getStrokeFilterEnabled() )
+	if ( settings->getStrokeFilterEnabled() )		// Note: For shape tools see BaseStrokeHandler which has a slightly different version of this filter. See //!
 	{	
 		int strokeFilterIgnoreTime,strokeFilterIgnorePoints,strokeFilterSuccessiveTime;
 		
 		settings->getStrokeFilter( &strokeFilterIgnoreTime, &strokeFilterIgnorePoints, &strokeFilterSuccessiveTime  );
 		
-		if ( pointCount < strokeFilterIgnorePoints && pos.time - this->startStrokeTime < strokeFilterIgnoreTime)
+		if ( pointCount < strokeFilterIgnorePoints && pos.time - this->startStrokeTime < strokeFilterIgnoreTime) 	//!
 		{
-			if ( pos.time - this->lastIgnorePointTime  < strokeFilterSuccessiveTime )
+			if ( pos.time - this->lastStrokeTime  < strokeFilterSuccessiveTime )
 			{
-				this->lastIgnorePointTime = pos.time;
 				g_print("NOT_IGNORED: %d\n",pos.time - startStrokeTime);
 			}
 			else
 			{
-				this->lastIgnorePointTime = pos.time;
 				g_print("IGNORED: %d\tlength:%d\n",pos.time - startStrokeTime, pointCount);
 				//stroke not being added to layer... delete here.
 				delete stroke;
 				stroke = NULL;
-				this->trySelect = true;
+				if( pointCount <4) //limit to filtered 'dots' only.  //!
+				{
+					this->trySelect = true;
+				}
+				this->lastStrokeTime = pos.time;
+				//! xournal->getCursor()->updateCursor();
 				return;
 			}
 		}
+		this->lastStrokeTime = pos.time;
 	}
 	
 	// Backward compatibility and also easier to handle for me;-)

--- a/src/control/tools/StrokeHandler.cpp
+++ b/src/control/tools/StrokeHandler.cpp
@@ -162,15 +162,11 @@ void StrokeHandler::onButtonReleaseEvent(const PositionInputData& pos)
 		
 		if ( pointCount < strokeFilterIgnorePoints && pos.time - this->startStrokeTime < strokeFilterIgnoreTime) 	//!
 		{
-			if ( pos.time - this->lastStrokeTime  < strokeFilterSuccessiveTime )
+			if ( pos.time - this->lastStrokeTime  > strokeFilterSuccessiveTime )
 			{
-				g_print("NOT_IGNORED: %d\n",pos.time - startStrokeTime);
-			}
-			else
-			{
-				this->redrawable->rerenderRect(stroke->getX(), stroke->getY(), stroke->getElementWidth(), stroke->getElementHeight() ); // Remove intermediate drawing //!
-				g_print("IGNORED: %d\tlength:%d\n",pos.time - startStrokeTime, pointCount);
 				//stroke not being added to layer... delete here.
+				this->redrawable->rerenderRect(stroke->getX(), stroke->getY(), stroke->getElementWidth(), stroke->getElementHeight() ); // clear onMotionNotifyEvent drawing //!
+
 				delete stroke;
 				stroke = NULL;
 				if( pointCount <4) //limit to filtered 'dots' only.  //!
@@ -178,7 +174,7 @@ void StrokeHandler::onButtonReleaseEvent(const PositionInputData& pos)
 					this->trySelect = true;
 				}
 				this->lastStrokeTime = pos.time;
-				//! xournal->getCursor()->updateCursor();
+
 				return;
 			}
 		}

--- a/src/control/tools/StrokeHandler.cpp
+++ b/src/control/tools/StrokeHandler.cpp
@@ -168,6 +168,7 @@ void StrokeHandler::onButtonReleaseEvent(const PositionInputData& pos)
 			}
 			else
 			{
+				this->redrawable->rerenderRect(stroke->getX(), stroke->getY(), stroke->getElementWidth(), stroke->getElementHeight() ); // Remove intermediate drawing //!
 				g_print("IGNORED: %d\tlength:%d\n",pos.time - startStrokeTime, pointCount);
 				//stroke not being added to layer... delete here.
 				delete stroke;
@@ -246,7 +247,7 @@ void StrokeHandler::onButtonReleaseEvent(const PositionInputData& pos)
 	//Manually force the rendering of the stroke, if no motion event occurred inbetween, that would rerender the page.
 	if (stroke->getPointCount() == 2)
 	{
-		this->redrawable->rerenderElement(stroke);
+		this->redrawable->rerenderElement(stroke); 
 	}
 
 	stroke = NULL;

--- a/src/control/tools/StrokeHandler.h
+++ b/src/control/tools/StrokeHandler.h
@@ -64,5 +64,10 @@ private:
 	DocumentView view;
 
 	ShapeRecognizer* reco;
+
+	guint32 startStrokeTime;
+	
+	static guint32 lastIgnorePointTime;	//persist across strokes - allow us to not ignore persistent dotting.
+	
 };
 

--- a/src/control/tools/StrokeHandler.h
+++ b/src/control/tools/StrokeHandler.h
@@ -68,7 +68,7 @@ private:
 	
 	// to filter out short strokes (usually the user tapping on the page to select it)
 	guint32 startStrokeTime;
-	static guint32 lastIgnorePointTime;	//persist across strokes - allow us to not ignore persistent dotting.
+	static guint32 lastStrokeTime;	//persist across strokes - allow us to not ignore persistent dotting.
 	
 
 };

--- a/src/control/tools/StrokeHandler.h
+++ b/src/control/tools/StrokeHandler.h
@@ -65,9 +65,11 @@ private:
 
 	ShapeRecognizer* reco;
 
-	guint32 startStrokeTime;
 	
+	// to filter out short strokes (usually the user tapping on the page to select it)
+	guint32 startStrokeTime;
 	static guint32 lastIgnorePointTime;	//persist across strokes - allow us to not ignore persistent dotting.
 	
+
 };
 

--- a/src/gui/PageView.cpp
+++ b/src/gui/PageView.cpp
@@ -502,6 +502,12 @@ bool XojPageView::onButtonReleaseEvent(const PositionInputData& pos)
 	if (this->inputHandler)
 	{
 		this->inputHandler->onButtonReleaseEvent(pos);
+		
+		if( control->getSettings()->getDoActionOnStrokeFiltered() && this->inputHandler->trySelect){  //experimental feature
+			double zoom = xournal->getZoom();
+			SelectObject select(this);
+			select.at(pos.x/zoom, pos.y/zoom);
+		}
 		delete this->inputHandler;
 		this->inputHandler = NULL;
 	}

--- a/src/gui/dialog/SettingsDialog.cpp
+++ b/src/gui/dialog/SettingsDialog.cpp
@@ -72,7 +72,16 @@ SettingsDialog::SettingsDialog(GladeSearchpath* gladeSearchPath, Settings* setti
 				XOJ_CHECK_TYPE_OBJ(self, SettingsDialog);
 				self->enableWithCheckbox("cbDrawDirModsEnabled", "spDrawDirModsRadius");
 			}), this);
-	
+
+	g_signal_connect(get("cbStrokeFilterEnabled"), "toggled", G_CALLBACK(
+			+[](GtkToggleButton* togglebutton, SettingsDialog* self)
+			{
+				XOJ_CHECK_TYPE_OBJ(self, SettingsDialog);
+				self->enableWithCheckbox("cbStrokeFilterEnabled", "spStrokeIgnoreTime");
+				self->enableWithCheckbox("cbStrokeFilterEnabled", "spStrokeIgnorePoints");
+				self->enableWithCheckbox("cbStrokeFilterEnabled", "spStrokeSuccessiveTime");
+				self->enableWithCheckbox("cbStrokeFilterEnabled", "cbdoActionOnStrokeFiltered");
+			}), this);	
 	
 	g_signal_connect(get("cbDisableTouchOnPenNear"), "toggled", G_CALLBACK(
 			+[](GtkToggleButton* togglebutton, SettingsDialog* self)
@@ -211,6 +220,8 @@ void SettingsDialog::load()
 	loadCheckbox("cbAddVerticalSpace", settings->getAddVerticalSpace());
 	loadCheckbox("cbAddHorizontalSpace", settings->getAddHorizontalSpace());
 	loadCheckbox("cbDrawDirModsEnabled", settings->getDrawDirModsEnabled());
+	loadCheckbox("cbStrokeFilterEnabled", settings->getStrokeFilterEnabled());
+	loadCheckbox("cbdoActionOnStrokeFiltered", settings->getDoActionOnStrokeFiltered());	
 	loadCheckbox("cbBigCursor", settings->isShowBigCursor());
 	loadCheckbox("cbHighlightPosition", settings->isHighlightPosition());
 	loadCheckbox("cbDarkTheme", settings->isDarkTheme());
@@ -252,6 +263,20 @@ void SettingsDialog::load()
 	GtkWidget* spDrawDirModsRadius = get("spDrawDirModsRadius");
 	gtk_spin_button_set_value(GTK_SPIN_BUTTON(spDrawDirModsRadius), settings->getDrawDirModsRadius());
 
+	{
+		int time = 0;
+		int points = 0;
+		int successive = 0;
+		settings->getStrokeFilter( &time, & points, & successive);
+		
+		GtkWidget* spStrokeIgnoreTime = get("spStrokeIgnoreTime");
+		gtk_spin_button_set_value(GTK_SPIN_BUTTON(spStrokeIgnoreTime), time);
+		GtkWidget* spStrokeIgnorePoints = get("spStrokeIgnorePoints");
+		gtk_spin_button_set_value(GTK_SPIN_BUTTON(spStrokeIgnorePoints), points);
+		GtkWidget* spStrokeSuccessiveTime = get("spStrokeSuccessiveTime");
+		gtk_spin_button_set_value(GTK_SPIN_BUTTON(spStrokeSuccessiveTime), successive);
+	}
+	
 	GtkWidget* slider = get("zoomCallibSlider");
 
 	this->setDpi(settings->getDisplayDpi());
@@ -308,10 +333,14 @@ void SettingsDialog::load()
 	enableWithCheckbox("cbAddVerticalSpace", "spAddVerticalSpace");
 	enableWithCheckbox("cbAddHorizontalSpace", "spAddHorizontalSpace");
 	enableWithCheckbox("cbDrawDirModsEnabled", "spDrawDirModsRadius");
+	enableWithCheckbox("cbStrokeFilterEnabled", "spStrokeIgnoreTime");
+	enableWithCheckbox("cbStrokeFilterEnabled", "spStrokeIgnorePoints");
+	enableWithCheckbox("cbStrokeFilterEnabled", "spStrokeSuccessiveTime");
+	enableWithCheckbox("cbStrokeFilterEnabled", "cbdoActionOnStrokeFiltered");
 	enableWithCheckbox("cbDisableTouchOnPenNear", "boxInternalHandRecognition");
 	customHandRecognitionToggled();
 
-
+	
 	SElement& touch = settings->getCustomElement("touch");
 	bool disablePen = false;
 	touch.getBool("disableTouch", disablePen);
@@ -464,6 +493,8 @@ void SettingsDialog::save()
 	settings->setAddVerticalSpace(getCheckbox("cbAddVerticalSpace"));
 	settings->setAddHorizontalSpace(getCheckbox("cbAddHorizontalSpace"));
 	settings->setDrawDirModsEnabled(getCheckbox("cbDrawDirModsEnabled"));
+	settings->setStrokeFilterEnabled(getCheckbox("cbStrokeFilterEnabled"));
+	settings->setDoActionOnStrokeFiltered(getCheckbox("cbdoActionOnStrokeFiltered"));
 	settings->setShowBigCursor(getCheckbox("cbBigCursor"));
 	settings->setHighlightPosition(getCheckbox("cbHighlightPosition"));
 	settings->setDarkTheme(getCheckbox("cbDarkTheme"));
@@ -543,6 +574,15 @@ void SettingsDialog::save()
 	int drawDirModsRadius = gtk_spin_button_get_value(GTK_SPIN_BUTTON(spDrawDirModsRadius));
 	settings->setDrawDirModsRadius(drawDirModsRadius);
 
+	GtkWidget* spStrokeIgnoreTime = get("spStrokeIgnoreTime");
+	int strokeIgnoreTime = gtk_spin_button_get_value(GTK_SPIN_BUTTON(spStrokeIgnoreTime));
+	GtkWidget* spStrokeIgnorePoints = get("spStrokeIgnorePoints");
+	int strokeIgnorePoints = gtk_spin_button_get_value(GTK_SPIN_BUTTON(spStrokeIgnorePoints));
+	GtkWidget* spStrokeSuccessiveTime = get("spStrokeSuccessiveTime");
+	int strokeSuccessiveTime = gtk_spin_button_get_value(GTK_SPIN_BUTTON(spStrokeSuccessiveTime));
+	settings->setStrokeFilter( strokeIgnoreTime, strokeIgnorePoints, strokeSuccessiveTime);
+
+	
 
 	settings->setDisplayDpi(dpi);
 

--- a/src/gui/inputdevices/InputSequence.cpp
+++ b/src/gui/inputdevices/InputSequence.cpp
@@ -30,7 +30,7 @@ InputSequence::~InputSequence()
 
 	if (inputRunning)
 	{
-		actionEnd();
+		actionEnd(__UINT32_MAX__);
 	}
 	clearAxes();
 
@@ -109,11 +109,12 @@ void InputSequence::setCurrentRootPosition(double x, double y)
 /**
  * Set (mouse)button
  */
-void InputSequence::setButton(guint button)
+void InputSequence::setButton(guint button, guint time)
 {
 	XOJ_CHECK_TYPE(InputSequence);
 
 	this->button = button;
+	this->eventTime = time;
 }
 
 /**
@@ -182,13 +183,15 @@ void InputSequence::handleScrollEvent()
 /**
  * Mouse / Pen / Touch move
  */
-bool InputSequence::actionMoved()
+bool InputSequence::actionMoved(guint32 time)
 {
 	XOJ_CHECK_TYPE(InputSequence);
 
 	GtkXournal* xournal = inputHandler->getXournal();
 	ToolHandler* h = inputHandler->getToolHandler();
 
+	this->eventTime = time;
+	
 	changeTool();
 
 	if (penDevice)
@@ -258,10 +261,12 @@ bool InputSequence::actionMoved()
 /**
  * Mouse / Pen down / touch start
  */
-bool InputSequence::actionStart()
+bool InputSequence::actionStart(guint32 time)
 {
 	XOJ_CHECK_TYPE(InputSequence);
 
+	this->eventTime = time;
+	
 	inputHandler->focusWidget();
 
 	checkCanStartInput();
@@ -379,7 +384,7 @@ bool InputSequence::checkStillRunning()
 
 	// Button is not down, stop input now!
 	// So the new input can start
-	actionEnd();
+	actionEnd(__UINT32_MAX__);
 
 	return true;
 }
@@ -387,7 +392,7 @@ bool InputSequence::checkStillRunning()
 /**
  * Mouse / Pen up / touch end
  */
-void InputSequence::actionEnd()
+void InputSequence::actionEnd(guint32 time)
 {
 	XOJ_CHECK_TYPE(InputSequence);
 
@@ -396,6 +401,8 @@ void InputSequence::actionEnd()
 		return;
 	}
 
+	this->eventTime = time;
+	
 	// Mouse button not pressed anymore
 	this->button = 0;
 
@@ -452,9 +459,10 @@ PositionInputData InputSequence::getInputDataRelativeToCurrentPage(XojPageView* 
 	GtkXournal* xournal = inputHandler->getXournal();
 
 	PositionInputData pos;
-	pos.x = x - page->getX() - xournal->x;
-	pos.y = y - page->getY() - xournal->y;
+	pos.x = this->x - page->getX() - xournal->x;
+	pos.y = this->y - page->getY() - xournal->y;
 	pos.pressure = Point::NO_PRESURE;
+	pos.time = this->eventTime;
 
 	if (presureSensitivity)
 	{

--- a/src/gui/inputdevices/InputSequence.h
+++ b/src/gui/inputdevices/InputSequence.h
@@ -31,17 +31,17 @@ public:
 	/**
 	 * Mouse / Pen / Touch move
 	 */
-	bool actionMoved();
+	bool actionMoved(guint32 time);
 
 	/**
 	 * Mouse / Pen down / touch start
 	 */
-	bool actionStart();
+	bool actionStart(guint32 time);
 
 	/**
 	 * Mouse / Pen up / touch end
 	 */
-	void actionEnd();
+	void actionEnd(guint32 time);
 
 	/**
 	 * Check if input is still running, or if there an event was missed
@@ -85,7 +85,7 @@ public:
 	/**
 	 * Set (mouse)button
 	 */
-	void setButton(guint button);
+	void setButton(guint button, guint time);
 
 	/**
 	 * Set state flags from GDKevent (Shift down etc.)
@@ -229,4 +229,12 @@ private:
 	 * The last Mouse Position, for scrolling
 	 */
 	double scrollOffsetY = 0;
+
+	
+	/**
+	 * event time
+	 */
+	guint32 eventTime;
+	
+	
 };

--- a/src/gui/inputdevices/NewGtkInputDevice.cpp
+++ b/src/gui/inputdevices/NewGtkInputDevice.cpp
@@ -247,7 +247,7 @@ bool NewGtkInputDevice::eventHandler(GdkEvent* event)
 
 		if (input != NULL)
 		{
-			input->actionEnd();
+			input->actionEnd(((GdkEventTouch *)event)->time);
 		}
 
 		g_hash_table_remove(touchInputList, sequence);
@@ -301,7 +301,7 @@ bool NewGtkInputDevice::eventHandler(GdkEvent* event)
 	guint button = 0;
 	if (gdk_event_get_button(event, &button))
 	{
-		input->setButton(button);
+		input->setButton(button, gdk_event_get_time(event) );
 	}
 
 	GdkModifierType state = (GdkModifierType)0;
@@ -313,7 +313,8 @@ bool NewGtkInputDevice::eventHandler(GdkEvent* event)
 	if (event->type == GDK_MOTION_NOTIFY || event->type == GDK_TOUCH_UPDATE)
 	{
 		input->copyAxes(event);
-		input->actionMoved();
+		guint32 time = event->type == GDK_MOTION_NOTIFY ? ((GdkEventMotion *)event)->time : ((GdkEventTouch *)event)->time;	// or call gdk_event_get_time(event)
+		input->actionMoved(time);
 
 		Cursor* cursor = view->getControl()->getWindow()->getXournal()->getCursor();
 		cursor->setInvisible(false);
@@ -323,12 +324,13 @@ bool NewGtkInputDevice::eventHandler(GdkEvent* event)
 	else if (event->type == GDK_BUTTON_PRESS || event->type == GDK_TOUCH_BEGIN)
 	{
 		input->copyAxes(event);
-		input->actionStart();
+		guint32 time = event->type == GDK_BUTTON_PRESS ? ((GdkEventButton *)event)->time : ((GdkEventTouch *)event)->time;  //or call gdk_event_get_time()
+		input->actionStart(time);
 	}
 	else if (event->type == GDK_BUTTON_RELEASE)
 	{
 		input->copyAxes(event);
-		input->actionEnd();
+		input->actionEnd( ((GdkEventButton *)event)->time );
 	}
 
 	return true;

--- a/src/gui/inputdevices/PositionInputData.h
+++ b/src/gui/inputdevices/PositionInputData.h
@@ -24,9 +24,9 @@ public:
 	double x;
 	double y;
 	double pressure;
-	
 	guint32 time;	//event time
 
+	
 	/**
 	 * State flags from GDKevent (Shift down etc.)
 	 */

--- a/src/gui/inputdevices/PositionInputData.h
+++ b/src/gui/inputdevices/PositionInputData.h
@@ -24,6 +24,8 @@ public:
 	double x;
 	double y;
 	double pressure;
+	
+	guint32 time;	//event time
 
 	/**
 	 * State flags from GDKevent (Shift down etc.)

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -3000,7 +3000,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                         </child>
                                         <child>
                                           <object class="GtkCheckButton" id="cbdoActionOnStrokeFiltered">
-                                            <property name="label" translatable="yes">  </property>
+                                            <property name="label" translatable="yes">Try select instead</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
                                             <property name="receives_default">False</property>

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -2982,7 +2982,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                           <object class="GtkSpinButton" id="spStrokeSuccessiveTime">
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
-                                            <property name="tooltip_markup" translatable="yes">... AND How much time must have passed since last ignore.
+                                            <property name="tooltip_markup" translatable="yes">... AND How much time must have passed since last stroke.
 
 &lt;i&gt;Recommended: 500ms&lt;/i&gt;</property>
                                             <property name="valign">start</property>

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -2922,7 +2922,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                             <property name="can_focus">True</property>
                                             <property name="tooltip_markup" translatable="yes">How short (time)  AND...
 
-&lt;i&gt;Recommended: 300ms&lt;/i&gt;</property>
+&lt;i&gt;Recommended: 200ms&lt;/i&gt;</property>
                                             <property name="valign">start</property>
                                             <property name="max_width_chars">0</property>
                                             <property name="text" translatable="yes">50</property>
@@ -3000,11 +3000,11 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                         </child>
                                         <child>
                                           <object class="GtkCheckButton" id="cbdoActionOnStrokeFiltered">
-                                            <property name="label" translatable="yes">Try select instead</property>
+                                            <property name="label" translatable="yes">Select on quick tap.</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
                                             <property name="receives_default">False</property>
-                                            <property name="tooltip_markup" translatable="yes">If the stroke is filtered out try selecting instead.</property>
+                                            <property name="tooltip_markup" translatable="yes">On quick tap select object.</property>
                                             <property name="xalign">0</property>
                                             <property name="draw_indicator">True</property>
                                           </object>

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -39,6 +39,24 @@
     <property name="step_increment">0.05000000000000001</property>
     <property name="page_increment">10</property>
   </object>
+  <object class="GtkAdjustment" id="adjustmentStrokeIgnorePoints">
+    <property name="upper">100</property>
+    <property name="value">8</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">5</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustmentStrokeIgnoreTime">
+    <property name="upper">1000</property>
+    <property name="value">300</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustmentStrokeSuccessiveTime">
+    <property name="upper">1000</property>
+    <property name="value">500</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
   <object class="GtkAdjustment" id="adjustmentTimeout">
     <property name="lower">1</property>
     <property name="upper">100</property>
@@ -2844,7 +2862,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                   <object class="GtkLabel" id="sid3">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="label" translatable="yes">Drawing Tools - Set Modifiers by Draw Direction ( Experimental)</property>
+                                    <property name="label" translatable="yes">Drawing Tools - Set Modifiers by Draw Direction ( Experimental )</property>
                                   </object>
                                 </child>
                               </object>
@@ -2852,6 +2870,181 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
                                 <property name="position">5</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkFrame" id="sid5">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
+                                <child>
+                                  <object class="GtkAlignment" id="sid6">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="bottom_padding">8</property>
+                                    <property name="left_padding">12</property>
+                                    <property name="right_padding">12</property>
+                                    <child>
+                                      <object class="GtkGrid" id="grid7">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="column_spacing">5</property>
+                                        <child>
+                                          <object class="GtkCheckButton" id="cbStrokeFilterEnabled">
+                                            <property name="label" translatable="yes">Enable  Stroke Filter</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="tooltip_markup" translatable="yes">Ignore inputs of short time and length unless it comes in short succession.</property>
+                                            <property name="xalign">0</property>
+                                            <property name="draw_indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">0</property>
+                                            <property name="top_attach">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="sid7">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="label" translatable="yes">Ignore Time ( ms)</property>
+                                            <property name="angle">0.029999999999999999</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">2</property>
+                                            <property name="top_attach">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSpinButton" id="spStrokeIgnoreTime">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="tooltip_markup" translatable="yes">How short (time)  AND...
+
+&lt;i&gt;Recommended: 300ms&lt;/i&gt;</property>
+                                            <property name="valign">start</property>
+                                            <property name="max_width_chars">0</property>
+                                            <property name="text" translatable="yes">50</property>
+                                            <property name="adjustment">adjustmentStrokeIgnoreTime</property>
+                                            <property name="numeric">True</property>
+                                            <property name="update_policy">if-valid</property>
+                                            <property name="value">50</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">2</property>
+                                            <property name="top_attach">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSpinButton" id="spStrokeIgnorePoints">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="tooltip_markup" translatable="yes">How short (length in points)  of the stroke  AND...
+
+&lt;i&gt;Recommended: 8 points&lt;/i&gt;</property>
+                                            <property name="valign">start</property>
+                                            <property name="max_width_chars">0</property>
+                                            <property name="text" translatable="yes">8</property>
+                                            <property name="adjustment">adjustmentStrokeIgnorePoints</property>
+                                            <property name="numeric">True</property>
+                                            <property name="update_policy">if-valid</property>
+                                            <property name="value">8</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">3</property>
+                                            <property name="top_attach">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="sid9">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="label" translatable="yes">Max Length (points)</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">3</property>
+                                            <property name="top_attach">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="sid157">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="label" translatable="yes">Successive (ms)</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">4</property>
+                                            <property name="top_attach">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSpinButton" id="spStrokeSuccessiveTime">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="tooltip_markup" translatable="yes">... AND How much time must have passed since last ignore.
+
+&lt;i&gt;Recommended: 500ms&lt;/i&gt;</property>
+                                            <property name="valign">start</property>
+                                            <property name="max_width_chars">0</property>
+                                            <property name="text" translatable="yes">8</property>
+                                            <property name="adjustment">adjustmentStrokeSuccessiveTime</property>
+                                            <property name="numeric">True</property>
+                                            <property name="update_policy">if-valid</property>
+                                            <property name="value">500</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">4</property>
+                                            <property name="top_attach">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="cbdoActionOnStrokeFiltered">
+                                            <property name="label" translatable="yes">  </property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="tooltip_markup" translatable="yes">If the stroke is filtered out try selecting instead.</property>
+                                            <property name="xalign">0</property>
+                                            <property name="draw_indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">0</property>
+                                            <property name="top_attach">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="label1">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="tooltip_text" translatable="yes">All three conditions must be met before stroke is ignored.
+It must be short in time and length and we can't have ignored another stroke recently.</property>
+                                            <property name="label" translatable="yes">         Settings:     </property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">1</property>
+                                            <property name="top_attach">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label">
+                                  <object class="GtkLabel" id="sid8">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="label" translatable="yes">Stroke Filter - w/ try quick Select ( Experimental )</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">6</property>
                               </packing>
                             </child>
                           </object>


### PR DESCRIPTION
Adds experimental feature to ignore short scratches which in turn allow the user to select items without changing from the drawing tool. 
![tapSelect](https://user-images.githubusercontent.com/2329541/56862189-6a724d80-6965-11e9-892b-37fd5468139d.gif)
