### PR TITLE
save/read settings with fixed locale

### DIFF
--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -179,7 +179,7 @@ void Settings::parseData(xmlNodePtr cur, SElement& elem)
 			}
 			else if (sType == "double")
 			{
-				double d = atof((const char*) value);
+				double d = g_ascii_strtod((const char*) value, NULL);	//g_ascii_strtod ignores locale setting.
 				elem.setDouble((const char*) name, d);
 			}
 			else if (sType == "hex")
@@ -316,11 +316,11 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur)
 	}
 	else if (xmlStrcmp(name, (const xmlChar*) "zoomStep") == 0)
 	{
-		this->zoomStep = g_strtod((const char*) value, NULL);
+		this->zoomStep = g_ascii_strtod((const char*) value, NULL);
 	}
 	else if (xmlStrcmp(name, (const xmlChar*) "zoomStepScroll") == 0)
 	{
-		this->zoomStepScroll = g_strtod((const char*) value, NULL);
+		this->zoomStepScroll = g_ascii_strtod((const char*) value, NULL);
 	}
 	else if (xmlStrcmp(name, (const xmlChar*) "displayDpi") == 0)
 	{
@@ -496,7 +496,7 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur)
 	}
 	else if (xmlStrcmp(name, (const xmlChar*) "snapRotationTolerance") == 0)
 	{
-		this->snapRotationTolerance = g_strtod((const char*) value, NULL);
+		this->snapRotationTolerance = g_ascii_strtod((const char*) value, NULL);
 	}
 	else if (xmlStrcmp(name, (const xmlChar*) "snapGrid") == 0)
 	{
@@ -508,7 +508,7 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur)
 	}
 	else if (xmlStrcmp(name, (const xmlChar*) "snapGridTolerance") == 0)
 	{
-		this->snapGridTolerance = g_strtod((const char*) value, NULL);
+		this->snapGridTolerance = g_ascii_strtod((const char*) value, NULL);
 	}
 	else if (xmlStrcmp(name, (const xmlChar*) "touchWorkaround") == 0)
 	{
@@ -539,7 +539,7 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur)
 	}
 	else if (xmlStrcmp(name, (const xmlChar*) "audioGain") == 0)
 	{
-		this->audioGain = g_strtod((const char *) value, NULL);
+		this->audioGain = g_ascii_strtod((const char *) value, NULL);
 	}
 	else if (xmlStrcmp(name, (const xmlChar*) "audioInputDevice") == 0)
 	{
@@ -708,9 +708,9 @@ xmlNodePtr Settings::savePropertyDouble(const gchar* key, double value, xmlNodeP
 {
 	XOJ_CHECK_TYPE(Settings);
 
-	char* text = g_strdup_printf("%0.3lf", value);
+	char text[G_ASCII_DTOSTR_BUF_SIZE];
+	g_ascii_dtostr( text, G_ASCII_DTOSTR_BUF_SIZE, value);	//  g_ascii_ version uses C locale always.
 	xmlNodePtr xmlNode = saveProperty(key, text, parent);
-	g_free(text);
 	return xmlNode;
 }
 
@@ -945,9 +945,11 @@ void Settings::save()
 	xmlFont = xmlNewChild(root, NULL, (const xmlChar*) "property", NULL);
 	xmlSetProp(xmlFont, (const xmlChar*) "name", (const xmlChar*) "font");
 	xmlSetProp(xmlFont, (const xmlChar*) "font", (const xmlChar*) this->font.getName().c_str());
-	gchar* sSize = g_strdup_printf("%0.1lf", this->font.getSize());
+
+	char sSize[G_ASCII_DTOSTR_BUF_SIZE];
+	g_ascii_dtostr( sSize, G_ASCII_DTOSTR_BUF_SIZE, this->font.getSize());	//no locale
 	xmlSetProp(xmlFont, (const xmlChar*) "size", (const xmlChar*) sSize);
-	g_free(sSize);
+
 
 	for (std::map<string, SElement>::value_type p: data)
 	{
@@ -1001,9 +1003,9 @@ void Settings::saveData(xmlNodePtr root, string name, SElement& elem)
 		{
 			type = "double";
 
-			char* tmp = g_strdup_printf("%lf", attrib.dValue);
+			char tmp[G_ASCII_DTOSTR_BUF_SIZE];
+			g_ascii_dtostr( tmp, G_ASCII_DTOSTR_BUF_SIZE, attrib.dValue);
 			value = tmp;
-			g_free(tmp);
 		}
 		else if (attrib.type == ATTRIBUTE_TYPE_INT_HEX)
 		{

--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -152,6 +152,18 @@ void Settings::loadDefault()
 	
 }
 
+/**
+ * tempg_ascii_strtod
+* 	Transition to using g_ascii_strtod to minimize disruption. May, 2019. 
+*  Delete this and replace calls to this function with calls to g_ascii_strtod() in 2020.
+* 	See: https://developer.gnome.org/glib/stable/glib-String-Utility-Functions.html#g-strtod
+*/
+double tempg_ascii_strtod( const gchar* txt, gchar ** endptr )
+{
+	return g_strtod ( txt, endptr  );		//  makes best guess between locale formatted and C formatted numbers. See link above.
+}
+
+
 void Settings::parseData(xmlNodePtr cur, SElement& elem)
 {
 	XOJ_CHECK_TYPE(Settings);
@@ -179,7 +191,7 @@ void Settings::parseData(xmlNodePtr cur, SElement& elem)
 			}
 			else if (sType == "double")
 			{
-				double d = g_ascii_strtod((const char*) value, NULL);	//g_ascii_strtod ignores locale setting.
+				double d = tempg_ascii_strtod((const char*) value, NULL);	//g_ascii_strtod ignores locale setting.
 				elem.setDouble((const char*) name, d);
 			}
 			else if (sType == "hex")
@@ -316,11 +328,11 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur)
 	}
 	else if (xmlStrcmp(name, (const xmlChar*) "zoomStep") == 0)
 	{
-		this->zoomStep = g_ascii_strtod((const char*) value, NULL);
+		this->zoomStep = tempg_ascii_strtod((const char*) value, NULL);
 	}
 	else if (xmlStrcmp(name, (const xmlChar*) "zoomStepScroll") == 0)
 	{
-		this->zoomStepScroll = g_ascii_strtod((const char*) value, NULL);
+		this->zoomStepScroll = tempg_ascii_strtod((const char*) value, NULL);
 	}
 	else if (xmlStrcmp(name, (const xmlChar*) "displayDpi") == 0)
 	{
@@ -496,7 +508,7 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur)
 	}
 	else if (xmlStrcmp(name, (const xmlChar*) "snapRotationTolerance") == 0)
 	{
-		this->snapRotationTolerance = g_ascii_strtod((const char*) value, NULL);
+		this->snapRotationTolerance = tempg_ascii_strtod((const char*) value, NULL);
 	}
 	else if (xmlStrcmp(name, (const xmlChar*) "snapGrid") == 0)
 	{
@@ -508,7 +520,7 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur)
 	}
 	else if (xmlStrcmp(name, (const xmlChar*) "snapGridTolerance") == 0)
 	{
-		this->snapGridTolerance = g_ascii_strtod((const char*) value, NULL);
+		this->snapGridTolerance = tempg_ascii_strtod((const char*) value, NULL);
 	}
 	else if (xmlStrcmp(name, (const xmlChar*) "touchWorkaround") == 0)
 	{
@@ -535,11 +547,11 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur)
 	}
 	else if (xmlStrcmp(name, (const xmlChar*) "audioSampleRate") == 0)
 	{
-		this->audioSampleRate = g_ascii_strtod((const char *) value, NULL);
+		this->audioSampleRate = tempg_ascii_strtod((const char *) value, NULL);
 	}
 	else if (xmlStrcmp(name, (const xmlChar*) "audioGain") == 0)
 	{
-		this->audioGain = g_ascii_strtod((const char *) value, NULL);
+		this->audioGain = tempg_ascii_strtod((const char *) value, NULL);
 	}
 	else if (xmlStrcmp(name, (const xmlChar*) "audioInputDevice") == 0)
 	{
@@ -652,6 +664,7 @@ void Settings::loadButtonConfig()
 
 bool Settings::load()
 {
+	
 	XOJ_CHECK_TYPE(Settings);
 
 	xmlKeepBlanksDefault(0);

--- a/src/control/xml/DoubleArrayAttribute.cpp
+++ b/src/control/xml/DoubleArrayAttribute.cpp
@@ -24,15 +24,15 @@ void DoubleArrayAttribute::writeOut(OutputStream* out)
 
 	if (this->count > 0)
 	{
-		char* str = g_strdup_printf("%0.2lf", this->values[0]);
+		char str[G_ASCII_DTOSTR_BUF_SIZE];
+		g_ascii_dtostr( str, G_ASCII_DTOSTR_BUF_SIZE, this->values[0]);	//  g_ascii_ version uses C locale always.
 		out->write(str);
-		g_free(str);
 	}
 
 	for (int i = 1; i < this->count; i++)
 	{
-		char* str = g_strdup_printf(" %0.2lf", this->values[i]);
+		char str[G_ASCII_DTOSTR_BUF_SIZE];
+		g_ascii_dtostr( str, G_ASCII_DTOSTR_BUF_SIZE, this->values[i]);
 		out->write(str);
-		g_free(str);
 	}
 }

--- a/src/control/xml/DoubleAttribute.cpp
+++ b/src/control/xml/DoubleAttribute.cpp
@@ -16,7 +16,8 @@ void DoubleAttribute::writeOut(OutputStream* out)
 {
 	XOJ_CHECK_TYPE(DoubleAttribute);
 
-	char* str = g_strdup_printf("%0.2lf", value);
+	char str[G_ASCII_DTOSTR_BUF_SIZE];
+	g_ascii_dtostr( str, G_ASCII_DTOSTR_BUF_SIZE, value);	//  g_ascii_ version uses C locale always.
 	out->write(str);
-	g_free(str);
+
 }

--- a/src/control/xml/XmlPointNode.cpp
+++ b/src/control/xml/XmlPointNode.cpp
@@ -47,9 +47,15 @@ void XmlPointNode::writeOut(OutputStream* out)
 		{
 			out->write(" ");
 		}
-		char* tmp = g_strdup_printf("%0.2lf %0.2lf", p->x, p->y);
+		char tmpX[G_ASCII_DTOSTR_BUF_SIZE];
+		g_ascii_dtostr( tmpX, G_ASCII_DTOSTR_BUF_SIZE, p->x);
+		char tmpY[G_ASCII_DTOSTR_BUF_SIZE];
+		g_ascii_dtostr( tmpY, G_ASCII_DTOSTR_BUF_SIZE, p->y);
+
+		char* tmp = g_strdup_printf("%s %s", tmpX, tmpY);
 		out->write(tmp);
 		g_free(tmp);
+		
 	}
 
 	out->write("</");

--- a/src/control/xml/XmlStrokeNode.cpp
+++ b/src/control/xml/XmlStrokeNode.cpp
@@ -65,15 +65,16 @@ void XmlStrokeNode::writeOut(OutputStream* out)
 	writeAttributes(out);
 
 	out->write(" width=\"");
-	char* tmp = g_strdup_printf("%1.2lf", width);
+	
+	char tmp[G_ASCII_DTOSTR_BUF_SIZE];
+	g_ascii_dtostr( tmp, G_ASCII_DTOSTR_BUF_SIZE,width);	//  g_ascii_ version uses C locale always.
 	out->write(tmp);
-	g_free(tmp);
 
 	for (int i = 0; i < widthsLength; i++)
 	{
-		char* tmp = g_strdup_printf(" %1.2lf", widths[i]);
+		char tmp[G_ASCII_DTOSTR_BUF_SIZE];
+		g_ascii_dtostr( tmp, G_ASCII_DTOSTR_BUF_SIZE,widths[i]);
 		out->write(tmp);
-		g_free(tmp);
 	}
 
 	out->write("\"");
@@ -86,13 +87,23 @@ void XmlStrokeNode::writeOut(OutputStream* out)
 	{
 		out->write(">");
 
-		char* tmp = g_strdup_printf("%1.2lf %1.2lf", points[0].x, points[0].y);
+		char tmpX[G_ASCII_DTOSTR_BUF_SIZE];
+		g_ascii_dtostr( tmpX, G_ASCII_DTOSTR_BUF_SIZE, points[0].x);
+		char tmpY[G_ASCII_DTOSTR_BUF_SIZE];
+		g_ascii_dtostr( tmpY, G_ASCII_DTOSTR_BUF_SIZE, points[0].y);
+
+		char* tmp = g_strdup_printf("%s %s", tmpX, tmpY);
 		out->write(tmp);
 		g_free(tmp);
 
 		for (int i = 1; i < this->pointsLength; i++)
 		{
-			char* tmp = g_strdup_printf(" %1.2lf %1.2lf", points[i].x, points[i].y);
+			char tmpX[G_ASCII_DTOSTR_BUF_SIZE];
+			g_ascii_dtostr( tmpX, G_ASCII_DTOSTR_BUF_SIZE, points[i].x);
+			char tmpY[G_ASCII_DTOSTR_BUF_SIZE];
+			g_ascii_dtostr( tmpY, G_ASCII_DTOSTR_BUF_SIZE, points[i].y);
+
+			char* tmp = g_strdup_printf("%s %s", tmpX, tmpY);
 			out->write(tmp);
 			g_free(tmp);
 		}

--- a/src/control/xojfile/SaveHandler.cpp
+++ b/src/control/xojfile/SaveHandler.cpp
@@ -390,12 +390,7 @@ void SaveHandler::saveTo(OutputStream* out, Path filename, ProgressListener* lis
 {
 	XOJ_CHECK_TYPE(SaveHandler);
 
-	char* old_locale, *saved_locale;
-
-	old_locale = setlocale(LC_NUMERIC, NULL);
-	saved_locale = g_strdup(old_locale);
-
-	setlocale(LC_NUMERIC, "C");
+	// XMLNode should be locale-safe ( store doubles using Locale 'C' format
 
 	out->write("<?xml version=\"1.0\" standalone=\"no\"?>\n");
 	root->writeOut(out, listener);
@@ -416,8 +411,6 @@ void SaveHandler::saveTo(OutputStream* out, Path filename, ProgressListener* lis
 		}
 	}
 
-	setlocale(LC_NUMERIC, saved_locale);
-	g_free(saved_locale);
 }
 
 string SaveHandler::getErrorMessage()


### PR DESCRIPTION
This was the only thing that came to mind regarding #1074.
If the user changed his locale then xournalpp would have problems loading floating point settings the next time around.

This PR changes all of the settings double conversion to use 
g_ascii_dtostr instead of g_dtostr   
and g_ascii_strtoll instead of atof.  

The ascii variants always use locale 'C'.

We were already mainly using g_ascii_strtoll for settings.