### PR TITLE
Fix TextEditor not updating correctly after text is pasted

### DIFF
--- a/src/gui/TextEditor.cpp
+++ b/src/gui/TextEditor.cpp
@@ -29,6 +29,8 @@ TextEditor::TextEditor(XojPageView* gui, GtkWidget* widget, Text* text, bool own
 	string txt = this->text->getText();
 	gtk_text_buffer_set_text(this->buffer, txt.c_str(), -1);
 
+	g_signal_connect(this->buffer, "paste-done", G_CALLBACK(bufferPasteDoneCallback), this);
+
 	GtkTextIter first = { 0 };
 	gtk_text_buffer_get_iter_at_offset(this->buffer, &first, 0);
 	gtk_text_buffer_place_cursor(this->buffer, &first);
@@ -1005,9 +1007,12 @@ void TextEditor::pasteFromClipboard()
 
 	GtkClipboard* clipboard = gtk_widget_get_clipboard(this->widget, GDK_SELECTION_PRIMARY);
 	gtk_text_buffer_paste_clipboard(this->buffer, clipboard, NULL, true);
+}
 
-	this->repaintEditor();
-	this->contentsChanged(true);
+void TextEditor::bufferPasteDoneCallback(GtkTextBuffer* buffer, GtkClipboard* clipboard, TextEditor* te)
+{
+	te->repaintEditor();
+	te->contentsChanged(true);
 }
 
 void TextEditor::resetImContext()

--- a/src/gui/TextEditor.h
+++ b/src/gui/TextEditor.h
@@ -66,6 +66,8 @@ private:
 	int getByteOffset(int charOffset);
 	int getCharOffset(int byteOffset);
 
+	static void bufferPasteDoneCallback(GtkTextBuffer* buffer, GtkClipboard* clipboard, TextEditor* te);
+
 	static void iMCommitCallback(GtkIMContext* context, const gchar* str,
 								 TextEditor* te);
 	static void iMPreeditChangedCallback(GtkIMContext* context, TextEditor* te);


### PR DESCRIPTION
Since text pasting is asynchronous according to https://developer.gnome.org/gtk3/stable/GtkTextBuffer.html#gtk-text-buffer-paste-clipboard, the repaint calls are
triggered before the text is actually pasted. This commit attaches the repaint
calls to the `paste-done` signal that is fired by the text buffer once the
pasting completes.

This fixes #1103.