### PR TITLE
Improve file dialog history handling

### DIFF
--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -2653,6 +2653,7 @@ bool Control::showSaveDialog()
 
 	gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(dialog), suggested_folder.c_str());
 	gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(dialog), suggested_name.c_str());
+	gtk_file_chooser_add_shortcut_folder(GTK_FILE_CHOOSER(dialog), this->settings->getLastOpenPath().c_str(), nullptr);
 
 	gtk_file_chooser_set_do_overwrite_confirmation(GTK_FILE_CHOOSER(dialog), false); //handled below
 

--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -838,9 +838,13 @@ void Settings::save()
 	WRITE_BOOL_PROP(zoomGesturesEnabled);
 
 	WRITE_STRING_PROP(selectedToolbar);
-	WRITE_STRING_PROP(lastSavePath.str());
-	WRITE_STRING_PROP(lastOpenPath.str());
-	WRITE_STRING_PROP(lastImagePath.str());
+
+	auto lastSavePath = this->lastSavePath.str();
+	auto lastOpenPath = this->lastOpenPath.str();
+	auto lastImagePath = this->lastImagePath.str();
+	WRITE_STRING_PROP(lastSavePath);
+	WRITE_STRING_PROP(lastOpenPath);
+	WRITE_STRING_PROP(lastImagePath);
 
 	WRITE_DOUBLE_PROP(zoomStep);
 	WRITE_DOUBLE_PROP(zoomStepScroll);

--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -310,6 +310,10 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur)
 	{
 		this->lastSavePath = (const char*) value;
 	}
+	else if (xmlStrcmp(name, (const xmlChar*) "lastOpenPath") == 0)
+	{
+		this->lastOpenPath = (const char*) value;
+	}
 	else if (xmlStrcmp(name, (const xmlChar*) "lastImagePath") == 0)
 	{
 		this->lastImagePath = (const char*) value;
@@ -835,6 +839,7 @@ void Settings::save()
 
 	WRITE_STRING_PROP(selectedToolbar);
 	WRITE_STRING_PROP(lastSavePath.str());
+	WRITE_STRING_PROP(lastOpenPath.str());
 	WRITE_STRING_PROP(lastImagePath.str());
 
 	WRITE_DOUBLE_PROP(zoomStep);
@@ -1771,6 +1776,21 @@ Path Settings::getLastSavePath()
 	XOJ_CHECK_TYPE(Settings);
 
 	return this->lastSavePath;
+}
+
+void Settings::setLastOpenPath(Path p)
+{
+	XOJ_CHECK_TYPE(Settings);
+
+	this->lastOpenPath = p;
+	save();
+}
+
+Path Settings::getLastOpenPath()
+{
+	XOJ_CHECK_TYPE(Settings);
+
+	return this->lastOpenPath;
 }
 
 void Settings::setLastImagePath(Path path)

--- a/src/control/settings/Settings.h
+++ b/src/control/settings/Settings.h
@@ -204,6 +204,12 @@ public:
 	void setLastSavePath(Path p);
 	Path getLastSavePath();
 
+    /**
+     * The last open path
+     */
+    void setLastOpenPath(Path p);
+	Path getLastOpenPath();
+
 	void setLastImagePath(Path p);
 	Path getLastImagePath();
 
@@ -514,6 +520,11 @@ private:
 	 *  The last saved folder
 	 */
 	Path lastSavePath;
+
+    /**
+	 *  The last opened folder
+	 */
+	Path lastOpenPath;
 
 	/**
 	 *  The last "insert image" folder

--- a/src/control/settings/Settings.h
+++ b/src/control/settings/Settings.h
@@ -204,10 +204,10 @@ public:
 	void setLastSavePath(Path p);
 	Path getLastSavePath();
 
-    /**
-     * The last open path
-     */
-    void setLastOpenPath(Path p);
+	/**
+	 * The last open path
+	 */
+	void setLastOpenPath(Path p);
 	Path getLastOpenPath();
 
 	void setLastImagePath(Path p);
@@ -242,26 +242,26 @@ public:
 
 	void setPairsOffset(int numPairsOffset);
 	int getPairsOffset();
-	
+
 	void setViewColumns(int numColumns);
 	int getViewColumns();
 
 	void setViewRows(int numRows);
 	int getViewRows();
-	
+
 	void setViewFixedRows(bool viewFixedRows);
 	bool isViewFixedRows();
-	
+
 	void setViewLayoutVert(bool vert);
 	bool getViewLayoutVert();
-	
+
 	void setViewLayoutR2L(bool r2l);
 	bool getViewLayoutR2L();
 
 	void setViewLayoutB2T(bool b2t);
 	bool getViewLayoutB2T();
-	
-	
+
+
 	bool isAutloadPdfXoj();
 	void setAutoloadPdfXoj(bool load);
 
@@ -284,7 +284,7 @@ public:
 	void setDrawDirModsEnabled(bool enable);
 	int  getDrawDirModsRadius();
 	void setDrawDirModsRadius(int pixels);
-		
+
 	bool isTouchWorkaround();
 	void setTouchWorkaround(bool b);
 
@@ -385,14 +385,14 @@ public:
 	/**
 	 * Set StrokeFilter enabled
 	 */
-	void setStrokeFilterEnabled(bool enabled);	
+	void setStrokeFilterEnabled(bool enabled);
 
 	/**
 	 * Get StrokeFilter enabled
 	 */
-	bool getStrokeFilterEnabled();		
+	bool getStrokeFilterEnabled();
 
-	
+
 	/**
 	 * get strokeFilter settings
 	 */
@@ -406,13 +406,13 @@ public:
 	/**
 	 * Set StrokeFilter enabled
 	 */
-	void setDoActionOnStrokeFiltered(bool enabled);	
+	void setDoActionOnStrokeFiltered(bool enabled);
 
 	/**
 	 * Get StrokeFilter enabled
 	 */
-	bool getDoActionOnStrokeFiltered();		
-	
+	bool getDoActionOnStrokeFiltered();
+
 public:
 	// Custom settings
 	SElement& getCustomElement(string name);
@@ -496,7 +496,7 @@ private:
 	bool highlightPosition;
 
 	/**
-	 * If the user uses a dark-themed DE, he should enable this 
+	 * If the user uses a dark-themed DE, he should enable this
 	 * (white icons)
 	 */
 	bool darkTheme;
@@ -521,7 +521,7 @@ private:
 	 */
 	Path lastSavePath;
 
-    /**
+	/**
 	 *  The last opened folder
 	 */
 	Path lastOpenPath;
@@ -584,41 +584,41 @@ private:
 	/**
 	 *  Offsets first page ( to align pairing )
 	 */
-	int numPairsOffset;	
-	
+	int numPairsOffset;
+
 	/**
 	 *  Use when fixed number of columns
 	 */
-	int numColumns;	
+	int numColumns;
 
 	/**
 	 *  Use when fixed number of rows
 	 */
-	int numRows;	
+	int numRows;
 
 	/**
 	 *  USE  fixed rows, otherwise fixed columns
 	 */
-	bool viewFixedRows;	
-	
+	bool viewFixedRows;
+
 	/**
-	 *  Layout Vertical then Horizontal 
+	 *  Layout Vertical then Horizontal
 	 */
-	bool layoutVertical;	
-	
+	bool layoutVertical;
+
 	/**
 	 *  Layout pages right to left
 	 */
-	bool layoutRightToLeft;	
-	
+	bool layoutRightToLeft;
+
 	/**
 	 *  Layout Bottom to Top
 	 */
-	bool layoutBottomToTop;	
-	
-	
-	
-	
+	bool layoutBottomToTop;
+
+
+
+
 	/**
 	 * Automatically load filename.pdf.xoj / .pdf.xopp instead of filename.pdf (true/false)
 	 */
@@ -660,9 +660,9 @@ private:
 
 	/**
 	 * Radius at which emulated modifiers are locked on for the rest of drawing operation
-	 */	
+	 */
 	int drawDirModsRadius;
-	
+
 	/**
 	 * Rotation snapping enabled by default
 	 */
@@ -779,10 +779,10 @@ private:
 	 */
 	string pluginDisabled;
 
-	
+
 	/**
 	 * Used to filter strokes of short time and length unless successive
-	 * strokeFilterIgnorePoints			this many points 
+	 * strokeFilterIgnorePoints			this many points
 	 * strokeFilterIgnoreTime 			within this time (ms)  will be ignored..
 	 * strokeFilterSuccessiveTime		...unless successive within this time.
 	 */
@@ -791,11 +791,11 @@ private:
 	int strokeFilterSuccessiveTime;
 	bool strokeFilterEnabled;
 	bool doActionOnStrokeFiltered;
-	
+
 	/**
 	 * "Transaction" running, do not save until the end is reached
 	 */
 	bool inTransaction;
-	
-	
+
+
 };

--- a/src/control/stockdlg/XojOpenDlg.cpp
+++ b/src/control/stockdlg/XojOpenDlg.cpp
@@ -19,25 +19,17 @@ XojOpenDlg::XojOpenDlg(GtkWindow* win, Settings* settings)
 
 	gtk_file_chooser_set_local_only(GTK_FILE_CHOOSER(dialog), true);
 
-	if (!settings->getLastSavePath().isEmpty())
-	{
-		gtk_file_chooser_set_current_folder_uri(GTK_FILE_CHOOSER(dialog), settings->getLastSavePath().c_str());
-	}
-	else
-	{
-		g_warning("lastSavePath is not set!");
-		gtk_file_chooser_set_current_folder_uri(GTK_FILE_CHOOSER(dialog), g_get_home_dir());
-	}
-
+	const gchar* currentFolder = nullptr;
 	if (!settings->getLastOpenPath().isEmpty())
 	{
-		gtk_file_chooser_set_current_folder_uri(GTK_FILE_CHOOSER(dialog), settings->getLastOpenPath().c_str());
+		currentFolder = settings->getLastOpenPath().c_str();
 	}
 	else
 	{
 		g_warning("lastOpenPath is not set!");
-		gtk_file_chooser_set_current_folder_uri(GTK_FILE_CHOOSER(dialog), g_get_home_dir());
+		currentFolder = g_get_home_dir();
 	}
+	gtk_file_chooser_set_current_folder_uri(GTK_FILE_CHOOSER(dialog), currentFolder);
 }
 
 XojOpenDlg::~XojOpenDlg()
@@ -117,7 +109,7 @@ Path XojOpenDlg::runDialog()
 	}
 
 	Path file(gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog)));
-	settings->setLastSavePath(file.getParentPath().str());
+	settings->setLastOpenPath(file.getParentPath().str());
 
 	return file;
 }
@@ -169,13 +161,16 @@ Path XojOpenDlg::showOpenDialog(bool pdf, bool& attachPdf)
 	gtk_file_chooser_set_preview_widget(GTK_FILE_CHOOSER(dialog), image);
 	g_signal_connect(dialog, "update-preview", G_CALLBACK(updatePreviewCallback), NULL);
 
-	auto lastPath = this->settings->getLastOpenPath();
-	if (!lastPath.isEmpty())
+	auto lastOpenPath = this->settings->getLastOpenPath();
+	if (!lastOpenPath.isEmpty())
 	{
-		// TODO: Can either set current folder or add as a shortcut
-		// gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(this->dialog), lastPath.c_str());
-		//
-		gtk_file_chooser_add_shortcut_folder(GTK_FILE_CHOOSER(this->dialog), lastPath.c_str(), nullptr);
+		gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(this->dialog), lastOpenPath.c_str());
+	}
+
+	auto lastSavePath = this->settings->getLastSavePath();
+	if (!lastSavePath.isEmpty())
+	{
+		gtk_file_chooser_add_shortcut_folder(GTK_FILE_CHOOSER(this->dialog), lastSavePath.c_str(), nullptr);
 	}
 
 	Path file = runDialog();

--- a/src/control/stockdlg/XojOpenDlg.cpp
+++ b/src/control/stockdlg/XojOpenDlg.cpp
@@ -28,6 +28,16 @@ XojOpenDlg::XojOpenDlg(GtkWindow* win, Settings* settings)
 		g_warning("lastSavePath is not set!");
 		gtk_file_chooser_set_current_folder_uri(GTK_FILE_CHOOSER(dialog), g_get_home_dir());
 	}
+
+	if (!settings->getLastOpenPath().isEmpty())
+	{
+		gtk_file_chooser_set_current_folder_uri(GTK_FILE_CHOOSER(dialog), settings->getLastOpenPath().c_str());
+	}
+	else
+	{
+		g_warning("lastOpenPath is not set!");
+		gtk_file_chooser_set_current_folder_uri(GTK_FILE_CHOOSER(dialog), g_get_home_dir());
+	}
 }
 
 XojOpenDlg::~XojOpenDlg()
@@ -159,12 +169,27 @@ Path XojOpenDlg::showOpenDialog(bool pdf, bool& attachPdf)
 	gtk_file_chooser_set_preview_widget(GTK_FILE_CHOOSER(dialog), image);
 	g_signal_connect(dialog, "update-preview", G_CALLBACK(updatePreviewCallback), NULL);
 
+	auto lastPath = this->settings->getLastOpenPath();
+	if (!lastPath.isEmpty())
+	{
+		// TODO: Can either set current folder or add as a shortcut
+		// gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(this->dialog), lastPath.c_str());
+		//
+		gtk_file_chooser_add_shortcut_folder(GTK_FILE_CHOOSER(this->dialog), lastPath.c_str(), nullptr);
+	}
+
 	Path file = runDialog();
 
 	if (attachOpt)
 	{
 		attachPdf = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(attachOpt));
 		g_object_unref(attachOpt);
+	}
+
+	if (!file.isEmpty())
+	{
+		g_message("lastOpenPath set");
+		this->settings->setLastOpenPath(file.getParentPath().str());
 	}
 
 	return file;


### PR DESCRIPTION
Fixes #1108 and fixes #1056. In particular:
* Adds a new setting that stores the last opened file.
* Fixes `lastSaveFile` and `lastImageFile` being incorrectly saved in the settings.
* The file open dialog now displays the folder of the last opened file by default.
* When opening a file, the folder of the last saved file is added as a shortcut on the left sidebar. When saving, the folder of the last opened file is added.
