### PR TITLE
Improve/fix Latex tool usability

### DIFF
--- a/src/control/LatexController.cpp
+++ b/src/control/LatexController.cpp
@@ -41,7 +41,6 @@ const char* LATEX_TEMPLATE_2 =
 LatexController::LatexController(Control* control)
 	: control(control),
 	  doc(control->getDocument()),
-	  // NOTE: Could get a race condition if multiple Xournal++ processes are running
 	  texTmp(Util::getTmpDirSubfolder("tex"))
 {
 	XOJ_INIT_TYPE(LatexController);

--- a/src/control/LatexController.cpp
+++ b/src/control/LatexController.cpp
@@ -318,6 +318,9 @@ void LatexController::setUpdating(bool newValue)
 	// needed.
 	gtk_widget_set_sensitive(okButton, this->isValidTex);
 
+	GtkLabel* errorLabel = GTK_LABEL(this->dlg->get("texErrorLabel"));
+	gtk_label_set_text(errorLabel, this->isValidTex ? "" : "The formula is empty when rendered or invalid.");
+
 	this->isUpdating = newValue;
 }
 

--- a/src/control/LatexController.cpp
+++ b/src/control/LatexController.cpp
@@ -14,15 +14,29 @@
 
 #include "pixbuf-utils.h"
 
+/**
+ * First half of the LaTeX template used to generate preview PDFs. User-supplied
+ * formulas will be inserted between the two halves.
+ *
+ * This template is necessarily complicated because we need to cause an error if
+ * the rendered formula is blank. Otherwise, a completely blank, sizeless PDF
+ * will be generated, which Poppler will be unable to load.
+ */
 const char* LATEX_TEMPLATE_1 =
-"\\documentclass[border=5pt]{standalone}\n"
-"\\usepackage{amsmath}\n"
-"\\begin{document}\n"
-"\\(\\displaystyle\n";
+	R"(\documentclass[crop, border=5pt]{standalone})" "\n"
+	R"(\usepackage{amsmath})" "\n"
+	R"(\usepackage{ifthen})" "\n"
+	R"(\begin{document})" "\n"
+	R"(\def\preview{\(\displaystyle)" "\n";
 
 const char* LATEX_TEMPLATE_2 =
-"\n\\)\n"
-"\\end{document}\n";
+	"\n\\)}\n"
+	R"(\newlength{\pheight})" "\n"
+	R"(\settoheight{\pheight}{\hbox{\preview}})" "\n"
+	R"(\ifthenelse{\pheight=0.0pt})" "\n"
+	R"({\GenericError{}{xournalpp: blank formula}{}{}})" "\n"
+	R"({\preview})" "\n"
+	R"(\end{document})" "\n";
 
 LatexController::LatexController(Control* control)
 	: control(control),

--- a/src/control/LatexController.cpp
+++ b/src/control/LatexController.cpp
@@ -25,6 +25,7 @@
 const char* LATEX_TEMPLATE_1 =
 	R"(\documentclass[crop, border=5pt]{standalone})" "\n"
 	R"(\usepackage{amsmath})" "\n"
+	R"(\usepackage{amssymb})" "\n"
 	R"(\usepackage{ifthen})" "\n"
 	R"(\newlength{\pheight})" "\n"
 	R"(\def\preview{\(\displaystyle)" "\n";

--- a/src/control/LatexController.h
+++ b/src/control/LatexController.h
@@ -133,12 +133,14 @@ private:
 	Path binTex;
 
 	/**
-	 * Orignal TeX, if editing
+	 * The original TeX string when the dialog was opened, or the empty string
+	 * if creating a new LaTeX element.
 	 */
 	string initialTex;
 
 	/**
-	 * Updated TeX string
+	 * The TeX string that the LaTeX element should display after editing
+	 * finishes.
 	 */
 	string currentTex;
 
@@ -213,7 +215,7 @@ private:
 	/**
 	 * LaTex editor dialog
 	 */
-	LatexDialog* dlg = nullptr;
+	std::unique_ptr<LatexDialog> dlg = nullptr;
 
 	/**
 	 * The controller owns the rendered preview in order to be able to delete it

--- a/src/control/LatexController.h
+++ b/src/control/LatexController.h
@@ -135,7 +135,7 @@ private:
 	/**
 	 * Orignal TeX, if editing
 	 */
-	string initalTex;
+	string initialTex;
 
 	/**
 	 * Updated TeX string
@@ -216,8 +216,8 @@ private:
 	LatexDialog* dlg = nullptr;
 
 	/**
-	 * The controller holds the 'on-the-go' render in order
-	 * to be able to delete it when a new render is created
+	 * The controller owns the rendered preview in order to be able to delete it
+	 * when a new render is created
 	 */
 	std::unique_ptr<TexImage> temporaryRender;
 };

--- a/src/control/LatexController.h
+++ b/src/control/LatexController.h
@@ -71,7 +71,7 @@ private:
 	 * Asynchronously runs the LaTeX command and then updates the TeX image. If
 	 * the preview is already being updated, then this method will be a no-op.
 	 */
-	void triggerPreviewUpdate(bool hasTexImage);
+	void triggerImageUpdate(bool isPreview);
 
 	/**
 	 * Show the LaTex Editor dialog
@@ -90,13 +90,14 @@ private:
 	/**
 	 * Updates the display once the PDF file is generated. The data pair
 	 * contains a pointer to the LatexController from which it is called, as
-	 * well as a flag that indicates whether the TexImage element has been
-	 * inserted yet.
+	 * well as a flag that indicates whether this render is for a preview.
 	 *
 	 * If the Latex text has changed since the last update, triggerPreviewUpdate
 	 * will be called again.
 	 */
 	static void onPdfRenderComplete(GPid pid, gint returnCode, PdfRenderCallbackData* data);
+
+	void setUpdating(bool newValue);
 
 	/*******/
 	//Wrappers for signal handler who can't access non-static fields 

--- a/src/control/LatexController.h
+++ b/src/control/LatexController.h
@@ -198,9 +198,10 @@ private:
 	Layer* layer = NULL;
 
 	/**
-	 * Text tmp directory in configuration folder
+	 * The directory in which the LaTeX files will be generated. Note that this
+	 * should be within a system temporary directory.
 	 */
-	string texTmp;
+	Path texTmp;
 
 	/**
 	 * Previously existing TexImage

--- a/src/control/LatexController.h
+++ b/src/control/LatexController.h
@@ -53,7 +53,7 @@ private:
 	void findSelectedTexElement();
 
 	/**
-	 * If a previous image/text is selected, delete it 
+	 * If a previous image/text is selected, delete it
 	 */
 	void deleteOldImage();
 
@@ -154,6 +154,11 @@ private:
 	 * Whether a preview is currently being generated.
 	 */
 	bool isUpdating = false;
+
+	/**
+	 * Whether the current TeX string is valid.
+	 */
+	bool isValidTex = false;
 
 	/**
 	 * X-Position

--- a/src/gui/dialog/LatexDialog.cpp
+++ b/src/gui/dialog/LatexDialog.cpp
@@ -88,8 +88,6 @@ void LatexDialog::save()
 {
 	XOJ_CHECK_TYPE(LatexDialog);
 
-	//I don't understand why this doesn't works 
-	//if start and end are declared as pointers
 	GtkTextIter start, end;
 	gtk_text_buffer_get_bounds(this->textBuffer, &start, &end);
 	this->theLatex = gtk_text_buffer_get_slice(this->textBuffer, &start, &end, FALSE);
@@ -103,7 +101,7 @@ void LatexDialog::load()
 	{
 		theLatex = "x^2";
 	}
-	
+
 	gtk_text_buffer_set_text(this->textBuffer, this->theLatex.c_str(), -1);
 }
 
@@ -113,7 +111,7 @@ void LatexDialog::show(GtkWindow *parent)
 	this->load();
 	gtk_window_set_transient_for(GTK_WINDOW(this->window), parent);
 	int res = gtk_dialog_run(GTK_DIALOG(this->window));
-	if (res == 1)
+	if (res == GTK_RESPONSE_OK)
 	{
 		this->save();
 	}

--- a/src/gui/dialog/LatexDialog.cpp
+++ b/src/gui/dialog/LatexDialog.cpp
@@ -36,7 +36,7 @@ string LatexDialog::getTex()
 	return this->theLatex;
 }
 
-void LatexDialog::setTempRender(PopplerDocument* pdf, size_t length)
+void LatexDialog::setTempRender(PopplerDocument* pdf)
 {
 	XOJ_CHECK_TYPE(LatexDialog);
 
@@ -96,12 +96,6 @@ void LatexDialog::save()
 void LatexDialog::load()
 {
 	XOJ_CHECK_TYPE(LatexDialog);
-
-	if (theLatex.empty())
-	{
-		theLatex = "x^2";
-	}
-
 	gtk_text_buffer_set_text(this->textBuffer, this->theLatex.c_str(), -1);
 }
 

--- a/src/gui/dialog/LatexDialog.h
+++ b/src/gui/dialog/LatexDialog.h
@@ -31,9 +31,9 @@ class LatexDialog : public GladeGui
 	// Set and retrieve text from text box
 	void setTex(string texString);
 	string getTex();
-	
+
 	//Set and retrieve temporary Tex render
-	void setTempRender(PopplerDocument* pdf, size_t length);
+	void setTempRender(PopplerDocument* pdf);
 
 	// Necessary for the controller in order to connect the 'text-changed'
 	// signal handler
@@ -41,12 +41,12 @@ class LatexDialog : public GladeGui
 
   private:
 	XOJ_TYPE_ATTRIB;
-	
+
 	// Temporary render
 	GtkWidget* texTempRender;
 	cairo_surface_t* scaledRender = NULL;
 	GtkCssProvider* cssProvider;
-	
+
 	// Text field
 	GtkWidget* texBox;
 	GtkTextBuffer* textBuffer;

--- a/src/util/Path.cpp
+++ b/src/util/Path.cpp
@@ -198,6 +198,23 @@ void Path::operator /=(const char* p)
 	*this /= string(p);
 }
 
+Path Path::operator /(Path p)
+{
+	return *this / p.c_str();
+}
+
+Path Path::operator /(string p)
+{
+	return *this / p.c_str();
+}
+
+Path Path::operator /(const char* p)
+{
+	Path ret(*this);
+	ret /= p;
+	return ret;
+}
+
 void Path::operator +=(Path p)
 {
 	path += p.str();

--- a/src/util/Path.h
+++ b/src/util/Path.h
@@ -121,14 +121,26 @@ public:
 
 	// Append operations
 public:
+	/**
+	 * Modifies this path by appending the other path.
+	 */
 	void operator /=(Path p);
 	void operator /=(string p);
 	void operator /=(const char* p);
 
+	/**
+	 * Creates a copy of this path with the other path appended.
+	 *
+	 * If this method is going to be used multiple times, instead use /= to
+	 * avoid making multiple copies.
+	 */
+	Path operator /(Path p);
+	Path operator /(string p);
+	Path operator /(const char* p);
+
 	void operator +=(Path p);
 	void operator +=(string p);
 	void operator +=(const char* p);
-
 
 public:
 	/**

--- a/src/util/Util.cpp
+++ b/src/util/Util.cpp
@@ -99,7 +99,7 @@ Path Util::getConfigFile(Path relativeFileName)
 Path Util::getTmpDirSubfolder(Path subfolder)
 {
 	Path p(g_get_tmp_dir());
-	p /= "xournalpp";
+	p /= FS(_F("xournalpp-{1}") % Util::getPid());
 	p /= subfolder;
 	return Util::ensureFolderExists(p);
 }

--- a/src/util/Util.cpp
+++ b/src/util/Util.cpp
@@ -86,24 +86,34 @@ Path Util::getConfigSubfolder(Path subfolder)
 	p /= CONFIG_DIR;
 	p /= subfolder;
 
-	if (!p.exists())
-	{
-		if (g_mkdir_with_parents(p.c_str(), 0700))
-		{
-			Util::execInUiThread([=]() {
-				string msg = FS(_F("Could not create folder: {1}") % p.str());
-				XojMsgBox::showErrorToUser(NULL, msg);
-			});
-		}
-	}
-
-	return p;
+	return Util::ensureFolderExists(p);
 }
 
 Path Util::getConfigFile(Path relativeFileName)
 {
 	Path p = getConfigSubfolder(relativeFileName.getParentPath());
 	p /= relativeFileName.getFilename();
+	return p;
+}
+
+Path Util::getTmpDirSubfolder(Path subfolder)
+{
+	Path p(g_get_tmp_dir());
+	p /= "xournalpp";
+	p /= subfolder;
+	return Util::ensureFolderExists(p);
+}
+
+Path Util::ensureFolderExists(Path p)
+{
+	if (g_mkdir_with_parents(p.c_str(), 0700) == -1)
+	{
+		Util::execInUiThread([=]() {
+			string msg = FS(_F("Could not create folder: {1}") % p.str());
+			g_warning(msg.c_str());
+			XojMsgBox::showErrorToUser(nullptr, msg);
+		});
+	}
 	return p;
 }
 

--- a/src/util/Util.h
+++ b/src/util/Util.h
@@ -39,9 +39,13 @@ public:
 
 	static void openFileWithDefaultApplicaion(Path filename);
 	static void openFileWithFilebrowser(Path filename);
-	
+
 	static Path getConfigSubfolder(Path subfolder = "");
 	static Path getConfigFile(Path relativeFileName = "");
+
+	static Path getTmpDirSubfolder(Path subfolder = "");
+
+	static Path ensureFolderExists(Path p);
 
 	/**
 	 * Execute the callback in the UI Thread.

--- a/test/util/PathTest.cpp
+++ b/test/util/PathTest.cpp
@@ -117,6 +117,19 @@ public:
 		b.clearExtensions();
 		CPPUNIT_ASSERT_EQUAL(string("/test/asdf"), b.str());
 	}
+
+	void testOperators()
+	{
+		Path a = Path("/test/a");
+		Path b = a / "foo.pdf";
+		CPPUNIT_ASSERT_EQUAL(string("/test/a"), a.str());
+		CPPUNIT_ASSERT_EQUAL(string("/test/foo.pdf"), b.str());
+
+		a /= "bar.pdf";
+		CPPUNIT_ASSERT_EQUAL(string("/test/a/bar.pdf"), a.str());
+		// b should not be affected by a
+		CPPUNIT_ASSERT_EQUAL(string("/test/foo.pdf"), b.str());
+	}
 };
 
 // Registers the fixture into the 'registry'

--- a/ui/texdialog.glade
+++ b/ui/texdialog.glade
@@ -26,7 +26,6 @@
             <child>
               <object class="GtkButton" id="texcancelbutton">
                 <property name="label">gtk-cancel</property>
-                <property name="use_action_appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>
@@ -41,7 +40,6 @@
             <child>
               <object class="GtkButton" id="texokbutton">
                 <property name="label">gtk-ok</property>
-                <property name="use_action_appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
@@ -116,8 +114,8 @@
       </object>
     </child>
     <action-widgets>
-      <action-widget response="2">texcancelbutton</action-widget>
-      <action-widget response="1">texokbutton</action-widget>
+      <action-widget response="-6">texcancelbutton</action-widget>
+      <action-widget response="-5">texokbutton</action-widget>
     </action-widgets>
   </object>
 </interface>

--- a/ui/texdialog.glade
+++ b/ui/texdialog.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.0"/>
   <object class="GtkDialog" id="texDialog">
@@ -10,6 +10,9 @@
     <property name="window_position">center</property>
     <property name="icon_name">dialog-information</property>
     <property name="type_hint">dialog</property>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox2">
         <property name="visible">True</property>
@@ -75,18 +78,6 @@
           </packing>
         </child>
         <child>
-          <object class="GtkTextView" id="texView">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">3</property>
-
-          </packing>
-        </child>
-        <child>
           <object class="GtkImage" id="texImage">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
@@ -96,6 +87,30 @@
             <property name="fill">True</property>
             <property name="padding">12</property>
             <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="texErrorLabel">
+            <property name="visible">True</property>
+            <property name="sensitive">False</property>
+            <property name="can_focus">False</property>
+            <property name="justify">right</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkTextView" id="texView">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">4</property>
           </packing>
         </child>
       </object>


### PR DESCRIPTION
* [x] Improve error handling (Fixes #1095 somewhat. Possibly prevents #1100).
* [x] ~Set the rendered font color to the currently selected color in the toolbar~ (should be brought up in a separate issue)
* [x] Render asynchronously to avoid the noticeable pauses on keypresses (~100ms on my computer) 
* [x] ~Since pdflatex is relatively slow, delay rendering until 200ms have passed since the last key was entered~ (doesn't bring a noticeable improvement to the user experience)
* [x] ~Make LaTeX tool selectable, with click to bring up the dialog instead of instantly bringing up the dialog and placing the formula in the top left corner~ (too many changes; will bring up in another issue)
* [x] Disable OK button when the entered formula is invalid
* [x] Display a message that explains why the OK button is disabled
* [x] Generate Latex previews in a temporary directory instead of in the config directory
* [x] Include `amssymb` (#1128)