### PR TITLE
Allow "*.pdf.xopp" as a filename

### DIFF
--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -2348,14 +2348,14 @@ bool Control::loadPdf(Path filename, int scrollToPage)
 	{
 		Path f = filename;
 		f.clearExtensions();
-		f += ".pdf.xopp";
+		f += ".xopp";
 		Document* tmp = loadHandler.loadDocument(f.str());
 
 		if (tmp == NULL)
 		{
 			f = filename;
 			f.clearExtensions();
-			f += ".pdf.xoj";
+			f += ".xoj";
 			tmp = loadHandler.loadDocument(f.str());
 		}
 

--- a/src/util/Path.cpp
+++ b/src/util/Path.cpp
@@ -138,11 +138,11 @@ void Path::clearExtensions()
 {
 	string plower = StringUtils::toLowerCase(path);
 
-	REMOVE_EXTENSION(".pdf.xoj");
-	REMOVE_EXTENSION(".pdf.xopp");
+	//REMOVE_EXTENSION(".pdf.xoj");
+	//REMOVE_EXTENSION(".pdf.xopp");
 	REMOVE_EXTENSION(".xoj");
 	REMOVE_EXTENSION(".xopp");
-	REMOVE_EXTENSION(".pdf");
+	//REMOVE_EXTENSION(".pdf");
 }
 
 /**

--- a/src/util/Path.cpp
+++ b/src/util/Path.cpp
@@ -137,12 +137,9 @@ bool Path::hasExtension(string ext)
 void Path::clearExtensions()
 {
 	string plower = StringUtils::toLowerCase(path);
-
-	//REMOVE_EXTENSION(".pdf.xoj");
-	//REMOVE_EXTENSION(".pdf.xopp");
+	
 	REMOVE_EXTENSION(".xoj");
 	REMOVE_EXTENSION(".xopp");
-	//REMOVE_EXTENSION(".pdf");
 }
 
 /**

--- a/test/util/PathTest.cpp
+++ b/test/util/PathTest.cpp
@@ -103,19 +103,27 @@ public:
 
 		b = Path("/test/asdf.PDF");
 		b.clearExtensions();
-		CPPUNIT_ASSERT_EQUAL(string("/test/asdf"), b.str());
+		CPPUNIT_ASSERT_EQUAL(string("/test/asdf.PDF"), b.str());
 
 		b = Path("/test/asdf.PDF.xoj");
 		b.clearExtensions();
-		CPPUNIT_ASSERT_EQUAL(string("/test/asdf"), b.str());
+		CPPUNIT_ASSERT_EQUAL(string("/test/asdf.PDF"), b.str());
+        
+        	b = Path("/test/asdf.PDF.xopp");
+		b.clearExtensions();
+		CPPUNIT_ASSERT_EQUAL(string("/test/asdf.PDF"), b.str());
 
 		b = Path("/test/asdf.xoj");
+		b.clearExtensions();
+		CPPUNIT_ASSERT_EQUAL(string("/test/asdf"), b.str());
+        
+        	b = Path("/test/asdf.xopp");
 		b.clearExtensions();
 		CPPUNIT_ASSERT_EQUAL(string("/test/asdf"), b.str());
 
 		b = Path("/test/asdf.pdf");
 		b.clearExtensions();
-		CPPUNIT_ASSERT_EQUAL(string("/test/asdf"), b.str());
+		CPPUNIT_ASSERT_EQUAL(string("/test/asdf.pdf"), b.str());
 	}
 };
 


### PR DESCRIPTION
Fixes https://github.com/xournalpp/xournalpp/issues/962
as well as it fixes an issue where the AutoloadPdfXoj feature would only look for *.pdf.xopp which however couldn't exist.

If it is preferred not to keep the .pdf part of the filename only line 2351 of Control.cpp should be changed, as this will fix the autoload issue.
This might be a good behavior once the background is saved in the file itself.