### PR TITLE
Preselect default text in LaTeX input dialog

### DIFF
--- a/src/control/LatexController.cpp
+++ b/src/control/LatexController.cpp
@@ -189,7 +189,10 @@ void LatexController::showTexEditDialog()
 	XOJ_CHECK_TYPE(LatexController);
 
 	this->dlg.reset(new LatexDialog(control->getGladeSearchPath()));
-	this->dlg->setTex(currentTex);
+
+	// preselect default text so user can overwrite it easily
+	this->dlg->setTex(currentTex, this->initialTex.empty());
+
 	g_signal_connect(dlg->getTextBuffer(), "changed", G_CALLBACK(handleTexChanged), this);
 
 	if (this->temporaryRender != nullptr)

--- a/src/gui/dialog/LatexDialog.cpp
+++ b/src/gui/dialog/LatexDialog.cpp
@@ -24,10 +24,11 @@ LatexDialog::~LatexDialog()
 	XOJ_RELEASE_TYPE(LatexDialog);
 }
 
-void LatexDialog::setTex(string texString)
+void LatexDialog::setTex(string texString, bool preselect)
 {
 	XOJ_CHECK_TYPE(LatexDialog);
 	this->theLatex = texString;
+	this->preselect = preselect;
 }
 
 string LatexDialog::getTex()
@@ -97,6 +98,14 @@ void LatexDialog::load()
 {
 	XOJ_CHECK_TYPE(LatexDialog);
 	gtk_text_buffer_set_text(this->textBuffer, this->theLatex.c_str(), -1);
+
+	// preselect all text in the box if desired
+	if (this->preselect) {
+		GtkTextIter start, end;
+		gtk_text_buffer_get_start_iter(this->textBuffer, &start);
+		gtk_text_buffer_get_end_iter(this->textBuffer, &end);
+		gtk_text_buffer_select_range(this->textBuffer, &start, &end);
+	}
 }
 
 void LatexDialog::show(GtkWindow *parent)

--- a/src/gui/dialog/LatexDialog.h
+++ b/src/gui/dialog/LatexDialog.h
@@ -29,7 +29,7 @@ class LatexDialog : public GladeGui
 	void load();
 
 	// Set and retrieve text from text box
-	void setTex(string texString);
+	void setTex(string texString, bool preselect = false);
 	string getTex();
 
 	//Set and retrieve temporary Tex render
@@ -52,4 +52,5 @@ class LatexDialog : public GladeGui
 	GtkTextBuffer* textBuffer;
 
 	string theLatex;
+	bool preselect = false;
 };


### PR DESCRIPTION
With this change, users won't have to delete the default x^2 LaTeX
formula before adding their own. The x^2 is selected so upon typing it
will vanish.

Fixes: #1140