### PR TITLE
Fix autosave file name for new unsaved documents

### DIFF
--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -207,7 +207,19 @@ void Control::renameLastAutosaveFile()
 	Path filename = this->lastAutosaveFilename;
 	Path renamed = Util::getAutosaveFilename();
 	renamed.clearExtensions();
-	renamed += filename.getFilename();
+	if (filename.str().find_first_of(".") != 0)
+	{
+		// This file must be a fresh, unsaved document. Since this file is
+		// already in ~/.xournalpp/autosave/, we need to change the renamed filename.
+		renamed += ".old.autosave.xopp";
+	}
+	else
+	{
+		// The file is a saved document with the form ".<filename>.autosave.xopp"
+		renamed += filename.getFilename();
+	}
+
+	g_message(FS(_F("Autosave renamed from {1} to {2}") % this->lastAutosaveFilename.str() % renamed.str()).c_str());
 
 	if (!filename.exists())
 	{

--- a/src/control/jobs/AutosaveJob.cpp
+++ b/src/control/jobs/AutosaveJob.cpp
@@ -22,7 +22,8 @@ void AutosaveJob::afterRun()
 {
 	XOJ_CHECK_TYPE(AutosaveJob);
 
-	string msg = FS(_F("Autosave: {1}") % this->error);
+	string msg = FS(_F("Error while autosaving: {1}") % this->error);
+	g_warning(msg.c_str());
 	XojMsgBox::showErrorToUser(control->getGtkWindow(), msg);
 }
 
@@ -50,11 +51,13 @@ void AutosaveJob::run()
 		string file = filename.getFilename();
 		filename = filename.getParentPath();
 		filename /= string(".") + file;
-		filename.clearExtensions();
-		filename += ".autosave.xopp";
 	}
+	filename.clearExtensions();
+	filename += ".autosave.xopp";
 
 	control->renameLastAutosaveFile();
+
+	g_message(FS(_F("Autosaving to {1}") % filename.str()).c_str());
 
 	handler.saveTo(filename);
 


### PR DESCRIPTION
Fixes #1142. In particular:

* Changes how autosaves of new unsaved documents are renamed. Before, they were renamed from `~/.xournalpp/autosave/<pid>.autosave.xopp` to `~/.xournalpp/autosave/<pid><pid>.xopp`. Now, they are renamed to `~/.xournalpp/autosave/<pid>.old.autosave.xopp`.
* Adds additional diagnostic information messages (on stdout) about autosaving

Feedback is welcome, but this PR is immediately ready for merge (the fix has been confirmed to work and doesn't seem to break any behavior).