### PR TITLE
Allow double clicks on selected objects to begin editing

### DIFF
--- a/src/control/tools/EditSelection.cpp
+++ b/src/control/tools/EditSelection.cpp
@@ -223,6 +223,18 @@ double EditSelection::getYOnView()
 	return this->y;
 }
 
+double EditSelection::getOriginalXOnView()
+{
+	XOJ_CHECK_TYPE(EditSelection);
+	return this->contents->getOriginalX();
+}
+
+double EditSelection::getOriginalYOnView()
+{
+	XOJ_CHECK_TYPE(EditSelection);
+	return this->contents->getOriginalY();
+}
+
 /**
  * get the width in document coordinates (multiple with zoom)
  */

--- a/src/control/tools/EditSelection.h
+++ b/src/control/tools/EditSelection.h
@@ -66,6 +66,18 @@ public:
 	double getYOnView();
 
 	/**
+	 * @return The original X coordinates of the provided view in document
+	 * coordinates.
+	 */
+	double getOriginalXOnView();
+
+	/**
+	 * @return The original Y coordinates of the provided view in document
+	 * coordinates.
+	 */
+	double getOriginalYOnView();
+
+	/**
 	 * Get the width in document coordinates (multiple with zoom)
 	 */
 	double getWidth();

--- a/src/gui/inputdevices/MouseInputHandler.cpp
+++ b/src/gui/inputdevices/MouseInputHandler.cpp
@@ -47,6 +47,14 @@ bool MouseInputHandler::handleImpl(GdkEvent* event)
 		return true;
 	}
 
+	if (event->type == GDK_DOUBLE_BUTTON_PRESS)
+	{
+		guint button;
+		gdk_event_get_button(event, &button);
+		this->actionPerform(event);
+		return true;
+	}
+
 	/*
 	 * Trigger motion actions
 	 */

--- a/src/gui/inputdevices/MouseInputHandler.cpp
+++ b/src/gui/inputdevices/MouseInputHandler.cpp
@@ -49,8 +49,6 @@ bool MouseInputHandler::handleImpl(GdkEvent* event)
 
 	if (event->type == GDK_DOUBLE_BUTTON_PRESS)
 	{
-		guint button;
-		gdk_event_get_button(event, &button);
 		this->actionPerform(event);
 		return true;
 	}

--- a/src/gui/inputdevices/PenInputHandler.cpp
+++ b/src/gui/inputdevices/PenInputHandler.cpp
@@ -390,7 +390,10 @@ void PenInputHandler::actionPerform(GdkEvent* event)
 	ToolHandler* toolHandler = this->inputContext->getToolHandler();
 	ToolType toolType = toolHandler->getToolType();
 	bool isSelectTool = toolType == TOOL_SELECT_OBJECT || TOOL_SELECT_RECT || TOOL_SELECT_REGION;
-	if (isSelectTool && selection != nullptr)
+
+	// Double click selection to edit;
+	// Only applies to double left clicks / taps
+	if (!this->modifier2 && !this->modifier3 && isSelectTool && selection != nullptr)
 	{
 		XojPageView* currentPage = this->getPageAtCurrentPosition(event);
 		PositionInputData pos = getInputDataRelativeToCurrentPage(currentPage, event);
@@ -409,6 +412,8 @@ void PenInputHandler::actionPerform(GdkEvent* event)
 			{
 				xournal->view->clearSelection();
 				toolHandler->selectTool(TOOL_TEXT);
+				// Simulate a button press; there's too many things that we
+				// could forget to do if we manually call XojPageView::startText
 				currentPage->onButtonPressEvent(pos);
 			}
 			else if (elemType == ELEMENT_TEXIMAGE)

--- a/src/gui/inputdevices/PenInputHandler.h
+++ b/src/gui/inputdevices/PenInputHandler.h
@@ -87,6 +87,11 @@ protected:
 	 */
 	bool actionMotion(GdkEvent* event);
 
+	/**
+	 * Action for a discrete input.
+	 */
+	void actionPerform(GdkEvent* event);
+
 	void actionLeaveWindow(GdkEvent* event);
 	void actionEnterWindow(GdkEvent* event);
 

--- a/src/gui/inputdevices/StylusInputHandler.cpp
+++ b/src/gui/inputdevices/StylusInputHandler.cpp
@@ -54,6 +54,15 @@ bool StylusInputHandler::handleImpl(GdkEvent* event)
 		}
 	}
 
+	// Trigger discrete action on double tap
+	if (event->type == GDK_DOUBLE_BUTTON_PRESS)
+	{
+		guint button;
+		gdk_event_get_button(event, &button);
+		this->actionPerform(event);
+		return true;
+	}
+
 	// Trigger motion action when pen/mouse is pressed and moved
 	if (this->deviceClassPressed && event->type == GDK_MOTION_NOTIFY) //mouse or pen moved
 	{

--- a/src/gui/inputdevices/StylusInputHandler.cpp
+++ b/src/gui/inputdevices/StylusInputHandler.cpp
@@ -57,8 +57,6 @@ bool StylusInputHandler::handleImpl(GdkEvent* event)
 	// Trigger discrete action on double tap
 	if (event->type == GDK_DOUBLE_BUTTON_PRESS)
 	{
-		guint button;
-		gdk_event_get_button(event, &button);
 		this->actionPerform(event);
 		return true;
 	}


### PR DESCRIPTION
Implements #1137 for the new input system only.
- [x] Handle double clicks for both mouse and stylus
- [x] Only catch double taps/left clicks