### PR TITLE
Tap select/filtering improvements

### DIFF
--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -151,6 +151,7 @@ void Settings::loadDefault()
 	this->strokeFilterSuccessiveTime = 500;
 	this->strokeFilterEnabled = false;
 	this->doActionOnStrokeFiltered = false;
+	this->trySelectOnStrokeFiltered = false;
 
 	this->inTransaction = false;
 
@@ -601,6 +602,10 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur)
 	{
 		this->doActionOnStrokeFiltered = xmlStrcmp(value, (const xmlChar*) "true") ? false : true;
 	}
+	else if (xmlStrcmp(name, (const xmlChar*) "trySelectOnStrokeFiltered") == 0)
+	{
+		this->trySelectOnStrokeFiltered = xmlStrcmp(value, (const xmlChar*) "true") ? false : true;
+	}
 
 	xmlFree(name);
 	xmlFree(value);
@@ -975,6 +980,7 @@ void Settings::save()
 
 	WRITE_BOOL_PROP(strokeFilterEnabled);
 	WRITE_BOOL_PROP(doActionOnStrokeFiltered);
+	WRITE_BOOL_PROP(trySelectOnStrokeFiltered);
 
 	WRITE_BOOL_PROP(experimentalInputSystemEnabled);
 	WRITE_BOOL_PROP(inputSystemTPCButton);
@@ -2371,6 +2377,18 @@ bool Settings::getDoActionOnStrokeFiltered()
 {
 	XOJ_CHECK_TYPE(Settings);
 	return this->doActionOnStrokeFiltered;
+}
+
+void Settings::setTrySelectOnStrokeFiltered(bool enabled)
+{
+	XOJ_CHECK_TYPE(Settings);
+	this->trySelectOnStrokeFiltered = enabled;
+}
+
+bool Settings::getTrySelectOnStrokeFiltered()
+{
+	XOJ_CHECK_TYPE(Settings);
+	return this->trySelectOnStrokeFiltered;
 }
 
 

--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -146,8 +146,8 @@ void Settings::loadDefault()
 	this->inputSystemTPCButton = false;
 	this->inputSystemDrawOutsideWindow = true;
 
-	this->strokeFilterIgnoreTime = 200;
-	this->strokeFilterIgnorePoints = 8;
+	this->strokeFilterIgnoreTime = 150;
+	this->strokeFilterIgnoreLength = 1;
 	this->strokeFilterSuccessiveTime = 500;
 	this->strokeFilterEnabled = false;
 	this->doActionOnStrokeFiltered = false;
@@ -585,9 +585,9 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur)
 	{
 		this->strokeFilterIgnoreTime = g_ascii_strtoll((const char*) value, NULL, 10);
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "strokeFilterIgnorePoints") == 0)
+	else if (xmlStrcmp(name, (const xmlChar*) "strokeFilterIgnoreLength") == 0)
 	{
-		this->strokeFilterIgnorePoints = g_ascii_strtoll((const char*) value, NULL, 10);
+		this->strokeFilterIgnoreLength = g_ascii_strtoll((const char*) value, NULL, 10);
 	}
 	else if (xmlStrcmp(name, (const xmlChar*) "strokeFilterSuccessiveTime") == 0)
 	{
@@ -970,7 +970,7 @@ void Settings::save()
 	WRITE_STRING_PROP(pluginDisabled);
 
 	WRITE_INT_PROP(strokeFilterIgnoreTime);
-	WRITE_INT_PROP(strokeFilterIgnorePoints);
+	WRITE_INT_PROP(strokeFilterIgnoreLength);
 	WRITE_INT_PROP(strokeFilterSuccessiveTime);
 
 	WRITE_BOOL_PROP(strokeFilterEnabled);
@@ -2330,20 +2330,20 @@ void Settings::setPluginDisabled(string pluginEnabled)
 }
 
 
-void Settings::getStrokeFilter( int* ignoreTime, int* ignorePoints, int* successiveTime)
+void Settings::getStrokeFilter( int* ignoreTime, int* ignoreLength, int* successiveTime)
 {
 	XOJ_CHECK_TYPE(Settings);
 	*ignoreTime = this->strokeFilterIgnoreTime;
-	*ignorePoints = this->strokeFilterIgnorePoints;
+	*ignoreLength = this->strokeFilterIgnoreLength;
 	*successiveTime = this->strokeFilterSuccessiveTime;
 
 }
 
-void Settings::setStrokeFilter( int ignoreTime, int ignorePoints, int successiveTime)
+void Settings::setStrokeFilter( int ignoreTime, int ignoreLength, int successiveTime)
 {
 	XOJ_CHECK_TYPE(Settings);
 	this->strokeFilterIgnoreTime = ignoreTime;
-	this->strokeFilterIgnorePoints = ignorePoints;
+	this->strokeFilterIgnoreLength = ignoreLength;
 	this->strokeFilterSuccessiveTime = successiveTime;
 
 }

--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -588,7 +588,7 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur)
 	}
 	else if (xmlStrcmp(name, (const xmlChar*) "strokeFilterIgnoreLength") == 0)
 	{
-		this->strokeFilterIgnoreLength = g_ascii_strtoll((const char*) value, NULL, 10);
+		this->strokeFilterIgnoreLength = tempg_ascii_strtod((const char*) value, NULL);
 	}
 	else if (xmlStrcmp(name, (const xmlChar*) "strokeFilterSuccessiveTime") == 0)
 	{
@@ -975,7 +975,7 @@ void Settings::save()
 	WRITE_STRING_PROP(pluginDisabled);
 
 	WRITE_INT_PROP(strokeFilterIgnoreTime);
-	WRITE_INT_PROP(strokeFilterIgnoreLength);
+	WRITE_DOUBLE_PROP(strokeFilterIgnoreLength);
 	WRITE_INT_PROP(strokeFilterSuccessiveTime);
 
 	WRITE_BOOL_PROP(strokeFilterEnabled);
@@ -2336,7 +2336,7 @@ void Settings::setPluginDisabled(string pluginEnabled)
 }
 
 
-void Settings::getStrokeFilter( int* ignoreTime, int* ignoreLength, int* successiveTime)
+void Settings::getStrokeFilter( int* ignoreTime, double* ignoreLength, int* successiveTime)
 {
 	XOJ_CHECK_TYPE(Settings);
 	*ignoreTime = this->strokeFilterIgnoreTime;
@@ -2345,7 +2345,7 @@ void Settings::getStrokeFilter( int* ignoreTime, int* ignoreLength, int* success
 
 }
 
-void Settings::setStrokeFilter( int ignoreTime, int ignoreLength, int successiveTime)
+void Settings::setStrokeFilter( int ignoreTime, double ignoreLength, int successiveTime)
 {
 	XOJ_CHECK_TYPE(Settings);
 	this->strokeFilterIgnoreTime = ignoreTime;

--- a/src/control/settings/Settings.h
+++ b/src/control/settings/Settings.h
@@ -413,15 +413,25 @@ public:
 	void setStrokeFilter( int strokeFilterIgnoreTime, int strokeFilterIgnoreLength, int strokeFilterSuccessiveTime);
 
 	/**
-	 * Set StrokeFilter enabled
+	 * Set DoActionOnStrokeFilter enabled
 	 */
 	void setDoActionOnStrokeFiltered(bool enabled);
 
 	/**
-	 * Get StrokeFilter enabled
+	 * Get DoActionOnStrokeFilter enabled
 	 */
 	bool getDoActionOnStrokeFiltered();
 
+		/**
+	 * Set TrySelectOnStrokeFilter enabled
+	 */
+	void setTrySelectOnStrokeFiltered(bool enabled);
+
+	/**
+	 * Get TrySelectOnStrokeFilter enabled
+	 */
+	bool getTrySelectOnStrokeFiltered();
+	
 public:
 	// Custom settings
 	SElement& getCustomElement(string name);
@@ -790,7 +800,7 @@ private:
 
 
 	/**
-	 * Used to filter strokes of short time and length unless successive
+	 * Used to filter strokes of short time and length unless successive in order to do something else ( i.e. select object, float Toolbox menu ).
 	 * strokeFilterIgnoreLength			this many points
 	 * strokeFilterIgnoreTime 			within this time (ms)  will be ignored..
 	 * strokeFilterSuccessiveTime		...unless successive within this time.
@@ -800,6 +810,7 @@ private:
 	int strokeFilterSuccessiveTime;
 	bool strokeFilterEnabled;
 	bool doActionOnStrokeFiltered;
+	bool trySelectOnStrokeFiltered;
 
 	/**
 	 * Whether the new experimental input system is activated

--- a/src/control/settings/Settings.h
+++ b/src/control/settings/Settings.h
@@ -405,12 +405,12 @@ public:
 	/**
 	 * get strokeFilter settings
 	 */
-	void getStrokeFilter( int* strokeFilterIgnoreTime, int* strokeFilterIgnorePoints, int* strokeFilterSuccessiveTime);
+	void getStrokeFilter( int* strokeFilterIgnoreTime, int* strokeFilterIgnoreLength, int* strokeFilterSuccessiveTime);
 
 	/**
 	 * configure stroke filter
 	 */
-	void setStrokeFilter( int strokeFilterIgnoreTime, int strokeFilterIgnorePoints, int strokeFilterSuccessiveTime);
+	void setStrokeFilter( int strokeFilterIgnoreTime, int strokeFilterIgnoreLength, int strokeFilterSuccessiveTime);
 
 	/**
 	 * Set StrokeFilter enabled
@@ -791,12 +791,12 @@ private:
 
 	/**
 	 * Used to filter strokes of short time and length unless successive
-	 * strokeFilterIgnorePoints			this many points
+	 * strokeFilterIgnoreLength			this many points
 	 * strokeFilterIgnoreTime 			within this time (ms)  will be ignored..
 	 * strokeFilterSuccessiveTime		...unless successive within this time.
 	 */
 	int strokeFilterIgnoreTime;
-	int strokeFilterIgnorePoints;
+	int strokeFilterIgnoreLength;
 	int strokeFilterSuccessiveTime;
 	bool strokeFilterEnabled;
 	bool doActionOnStrokeFiltered;

--- a/src/control/settings/Settings.h
+++ b/src/control/settings/Settings.h
@@ -405,12 +405,12 @@ public:
 	/**
 	 * get strokeFilter settings
 	 */
-	void getStrokeFilter( int* strokeFilterIgnoreTime, int* strokeFilterIgnoreLength, int* strokeFilterSuccessiveTime);
+	void getStrokeFilter( int* strokeFilterIgnoreTime, double* strokeFilterIgnoreLength, int* strokeFilterSuccessiveTime);
 
 	/**
 	 * configure stroke filter
 	 */
-	void setStrokeFilter( int strokeFilterIgnoreTime, int strokeFilterIgnoreLength, int strokeFilterSuccessiveTime);
+	void setStrokeFilter( int strokeFilterIgnoreTime, double strokeFilterIgnoreLength, int strokeFilterSuccessiveTime);
 
 	/**
 	 * Set DoActionOnStrokeFilter enabled
@@ -801,12 +801,12 @@ private:
 
 	/**
 	 * Used to filter strokes of short time and length unless successive in order to do something else ( i.e. select object, float Toolbox menu ).
-	 * strokeFilterIgnoreLength			this many points
+	 * strokeFilterIgnoreLength			this many mm ( double )
 	 * strokeFilterIgnoreTime 			within this time (ms)  will be ignored..
 	 * strokeFilterSuccessiveTime		...unless successive within this time.
 	 */
 	int strokeFilterIgnoreTime;
-	int strokeFilterIgnoreLength;
+	double strokeFilterIgnoreLength;
 	int strokeFilterSuccessiveTime;
 	bool strokeFilterEnabled;
 	bool doActionOnStrokeFiltered;

--- a/src/control/tools/BaseStrokeHandler.cpp
+++ b/src/control/tools/BaseStrokeHandler.cpp
@@ -193,7 +193,8 @@ void BaseStrokeHandler::onButtonReleaseEvent(const PositionInputData& pos)
 	
 	if ( settings->getStrokeFilterEnabled() )		// Note: For simple strokes see StrokeHandler which has a slightly different version of this filter.  See //!
 	{	
-		int strokeFilterIgnoreTime,strokeFilterIgnoreLength,strokeFilterSuccessiveTime;
+		int strokeFilterIgnoreTime,strokeFilterSuccessiveTime;
+		double strokeFilterIgnoreLength;
 		
 		settings->getStrokeFilter( &strokeFilterIgnoreTime, &strokeFilterIgnoreLength, &strokeFilterSuccessiveTime  );
 		double dpmm = settings->getDisplayDpi()/25.4;

--- a/src/control/tools/BaseStrokeHandler.cpp
+++ b/src/control/tools/BaseStrokeHandler.cpp
@@ -193,23 +193,23 @@ void BaseStrokeHandler::onButtonReleaseEvent(const PositionInputData& pos)
 	
 	if ( settings->getStrokeFilterEnabled() )		// Note: For simple strokes see StrokeHandler which has a slightly different version of this filter.  See //!
 	{	
-		int strokeFilterIgnoreTime,strokeFilterIgnorePoints,strokeFilterSuccessiveTime;
+		int strokeFilterIgnoreTime,strokeFilterIgnoreLength,strokeFilterSuccessiveTime;
 		
-		settings->getStrokeFilter( &strokeFilterIgnoreTime, &strokeFilterIgnorePoints, &strokeFilterSuccessiveTime  );
+		settings->getStrokeFilter( &strokeFilterIgnoreTime, &strokeFilterIgnoreLength, &strokeFilterSuccessiveTime  );
 		double dpmm = settings->getDisplayDpi()/25.4;
 		
 		double zoom = xournal->getZoom();
 		double lengthSqrd =  ( pow(   ((pos.x / zoom) - (this->buttonDownPoint.x))  ,2) 
 					+ pow(   ((pos.y / zoom) - (this->buttonDownPoint.y))  ,2) ) * pow(xournal->getZoom(),2);
 								    
-		if (   lengthSqrd < pow((strokeFilterIgnorePoints*dpmm),2) && pos.timestamp - this->startStrokeTime < strokeFilterIgnoreTime) 
+		if (   lengthSqrd < pow((strokeFilterIgnoreLength*dpmm),2) && pos.timestamp - this->startStrokeTime < strokeFilterIgnoreTime) 
 		{
 			if ( pos.timestamp - this->lastStrokeTime  > strokeFilterSuccessiveTime )
 			{
 				//stroke not being added to layer... delete here.
 				delete stroke;
 				stroke = NULL;
-				this->trySelect = true;
+				this->userTapped = true;
 				
 				this->lastStrokeTime = pos.timestamp;
 				

--- a/src/control/tools/BaseStrokeHandler.h
+++ b/src/control/tools/BaseStrokeHandler.h
@@ -63,6 +63,7 @@ protected:
 
 	DocumentView view;
 	Point currPoint;
+	Point buttonDownPoint;	// used for tapSelect and filtering - never snapped to grid. See startPoint defined in derived classes such as CircleHandler.
 	bool modShift = false;
 	bool modControl = false;
 };

--- a/src/control/tools/InputHandler.h
+++ b/src/control/tools/InputHandler.h
@@ -89,9 +89,9 @@ public:
 	virtual void resetShapeRecognizer();
 	
 	/**
-	 * trySelect - experimental feature to try select on filtered draw. See cbDoActionOnStrokeFilter
+	 * userTapped - experimental feature to take action on filtered draw. See cbDoActionOnStrokeFilter
 	 */
-	bool trySelect = false;	
+	bool userTapped = false;	
 
 protected:
 

--- a/src/control/tools/StrokeHandler.cpp
+++ b/src/control/tools/StrokeHandler.cpp
@@ -154,7 +154,8 @@ void StrokeHandler::onButtonReleaseEvent(const PositionInputData& pos)
 	
 	if ( settings->getStrokeFilterEnabled() )		// Note: For shape tools see BaseStrokeHandler which has a slightly different version of this filter. See //!
 	{	
-		int strokeFilterIgnoreTime,strokeFilterIgnoreLength,strokeFilterSuccessiveTime;
+		int strokeFilterIgnoreTime,strokeFilterSuccessiveTime;
+		double strokeFilterIgnoreLength;
 		
 		settings->getStrokeFilter( &strokeFilterIgnoreTime, &strokeFilterIgnoreLength, &strokeFilterSuccessiveTime  );
 		double dpmm = settings->getDisplayDpi()/25.4;

--- a/src/control/tools/StrokeHandler.cpp
+++ b/src/control/tools/StrokeHandler.cpp
@@ -154,16 +154,16 @@ void StrokeHandler::onButtonReleaseEvent(const PositionInputData& pos)
 	
 	if ( settings->getStrokeFilterEnabled() )		// Note: For shape tools see BaseStrokeHandler which has a slightly different version of this filter. See //!
 	{	
-		int strokeFilterIgnoreTime,strokeFilterIgnorePoints,strokeFilterSuccessiveTime;
+		int strokeFilterIgnoreTime,strokeFilterIgnoreLength,strokeFilterSuccessiveTime;
 		
-		settings->getStrokeFilter( &strokeFilterIgnoreTime, &strokeFilterIgnorePoints, &strokeFilterSuccessiveTime  );
+		settings->getStrokeFilter( &strokeFilterIgnoreTime, &strokeFilterIgnoreLength, &strokeFilterSuccessiveTime  );
 		double dpmm = settings->getDisplayDpi()/25.4;
 		
 		double zoom = xournal->getZoom();
 		double lengthSqrd =  ( pow(   ((pos.x / zoom) - (this->buttonDownPoint.x))  ,2) 
 					+ pow(   ((pos.y / zoom) - (this->buttonDownPoint.y))  ,2) ) * pow(xournal->getZoom(),2);
 								    
-		if ( lengthSqrd < pow((strokeFilterIgnorePoints*dpmm),2) && pos.timestamp - this->startStrokeTime < strokeFilterIgnoreTime) 
+		if ( lengthSqrd < pow((strokeFilterIgnoreLength*dpmm),2) && pos.timestamp - this->startStrokeTime < strokeFilterIgnoreTime) 
 		{
 			if ( pos.timestamp - this->lastStrokeTime  > strokeFilterSuccessiveTime )
 			{
@@ -173,7 +173,7 @@ void StrokeHandler::onButtonReleaseEvent(const PositionInputData& pos)
 				
 				delete stroke;
 				stroke = NULL;
-				this->trySelect = true;
+				this->userTapped = true;
 				
 				this->lastStrokeTime = pos.timestamp;
 

--- a/src/control/tools/StrokeHandler.h
+++ b/src/control/tools/StrokeHandler.h
@@ -48,6 +48,8 @@ protected:
 	void strokeRecognizerDetected(ShapeRecognizerResult* result, Layer* layer);
 	void destroySurface();
 
+protected:
+		Point buttonDownPoint;	// used for tapSelect and filtering - never snapped to grid.
 private:
 	XOJ_TYPE_ATTRIB;
 

--- a/src/gui/PageView.cpp
+++ b/src/gui/PageView.cpp
@@ -503,7 +503,7 @@ bool XojPageView::onButtonReleaseEvent(const PositionInputData& pos)
 	{
 		this->inputHandler->onButtonReleaseEvent(pos);
 		
-		if( control->getSettings()->getDoActionOnStrokeFiltered() && this->inputHandler->trySelect){  //experimental feature
+		if( control->getSettings()->getDoActionOnStrokeFiltered() && this->inputHandler->userTapped){  //experimental feature
 			double zoom = xournal->getZoom();
 			SelectObject select(this);
 			select.at(pos.x/zoom, pos.y/zoom);

--- a/src/gui/PageView.cpp
+++ b/src/gui/PageView.cpp
@@ -503,7 +503,7 @@ bool XojPageView::onButtonReleaseEvent(const PositionInputData& pos)
 	{
 		this->inputHandler->onButtonReleaseEvent(pos);
 		
-		if( control->getSettings()->getDoActionOnStrokeFiltered() && this->inputHandler->userTapped){  //experimental feature
+		if( control->getSettings()->getTrySelectOnStrokeFiltered() && this->inputHandler->userTapped){  //experimental feature
 			double zoom = xournal->getZoom();
 			SelectObject select(this);
 			select.at(pos.x/zoom, pos.y/zoom);

--- a/src/gui/dialog/SettingsDialog.cpp
+++ b/src/gui/dialog/SettingsDialog.cpp
@@ -78,7 +78,7 @@ SettingsDialog::SettingsDialog(GladeSearchpath* gladeSearchPath, Settings* setti
 			{
 				XOJ_CHECK_TYPE_OBJ(self, SettingsDialog);
 				self->enableWithCheckbox("cbStrokeFilterEnabled", "spStrokeIgnoreTime");
-				self->enableWithCheckbox("cbStrokeFilterEnabled", "spStrokeIgnorePoints");
+				self->enableWithCheckbox("cbStrokeFilterEnabled", "spStrokeIgnoreLength");
 				self->enableWithCheckbox("cbStrokeFilterEnabled", "spStrokeSuccessiveTime");
 				self->enableWithCheckbox("cbStrokeFilterEnabled", "cbdoActionOnStrokeFiltered");
 			}), this);	
@@ -275,8 +275,8 @@ void SettingsDialog::load()
 		
 		GtkWidget* spStrokeIgnoreTime = get("spStrokeIgnoreTime");
 		gtk_spin_button_set_value(GTK_SPIN_BUTTON(spStrokeIgnoreTime), time);
-		GtkWidget* spStrokeIgnorePoints = get("spStrokeIgnorePoints");
-		gtk_spin_button_set_value(GTK_SPIN_BUTTON(spStrokeIgnorePoints), points);
+		GtkWidget* spStrokeIgnoreLength = get("spStrokeIgnoreLength");
+		gtk_spin_button_set_value(GTK_SPIN_BUTTON(spStrokeIgnoreLength), points);
 		GtkWidget* spStrokeSuccessiveTime = get("spStrokeSuccessiveTime");
 		gtk_spin_button_set_value(GTK_SPIN_BUTTON(spStrokeSuccessiveTime), successive);
 	}
@@ -338,7 +338,7 @@ void SettingsDialog::load()
 	enableWithCheckbox("cbAddHorizontalSpace", "spAddHorizontalSpace");
 	enableWithCheckbox("cbDrawDirModsEnabled", "spDrawDirModsRadius");
 	enableWithCheckbox("cbStrokeFilterEnabled", "spStrokeIgnoreTime");
-	enableWithCheckbox("cbStrokeFilterEnabled", "spStrokeIgnorePoints");
+	enableWithCheckbox("cbStrokeFilterEnabled", "spStrokeIgnoreLength");
 	enableWithCheckbox("cbStrokeFilterEnabled", "spStrokeSuccessiveTime");
 	enableWithCheckbox("cbStrokeFilterEnabled", "cbdoActionOnStrokeFiltered");
 	enableWithCheckbox("cbDisableTouchOnPenNear", "boxInternalHandRecognition");
@@ -583,11 +583,11 @@ void SettingsDialog::save()
 
 	GtkWidget* spStrokeIgnoreTime = get("spStrokeIgnoreTime");
 	int strokeIgnoreTime = gtk_spin_button_get_value(GTK_SPIN_BUTTON(spStrokeIgnoreTime));
-	GtkWidget* spStrokeIgnorePoints = get("spStrokeIgnorePoints");
-	int strokeIgnorePoints = gtk_spin_button_get_value(GTK_SPIN_BUTTON(spStrokeIgnorePoints));
+	GtkWidget* spStrokeIgnoreLength = get("spStrokeIgnoreLength");
+	int strokeIgnoreLength = gtk_spin_button_get_value(GTK_SPIN_BUTTON(spStrokeIgnoreLength));
 	GtkWidget* spStrokeSuccessiveTime = get("spStrokeSuccessiveTime");
 	int strokeSuccessiveTime = gtk_spin_button_get_value(GTK_SPIN_BUTTON(spStrokeSuccessiveTime));
-	settings->setStrokeFilter( strokeIgnoreTime, strokeIgnorePoints, strokeSuccessiveTime);
+	settings->setStrokeFilter( strokeIgnoreTime, strokeIgnoreLength, strokeSuccessiveTime);
 
 	
 

--- a/src/gui/dialog/SettingsDialog.cpp
+++ b/src/gui/dialog/SettingsDialog.cpp
@@ -271,14 +271,14 @@ void SettingsDialog::load()
 
 	{
 		int time = 0;
-		int points = 0;
+		double length = 0;
 		int successive = 0;
-		settings->getStrokeFilter( &time, & points, & successive);
+		settings->getStrokeFilter( &time, &length, &successive);
 		
 		GtkWidget* spStrokeIgnoreTime = get("spStrokeIgnoreTime");
 		gtk_spin_button_set_value(GTK_SPIN_BUTTON(spStrokeIgnoreTime), time);
 		GtkWidget* spStrokeIgnoreLength = get("spStrokeIgnoreLength");
-		gtk_spin_button_set_value(GTK_SPIN_BUTTON(spStrokeIgnoreLength), points);
+		gtk_spin_button_set_value(GTK_SPIN_BUTTON(spStrokeIgnoreLength), length);
 		GtkWidget* spStrokeSuccessiveTime = get("spStrokeSuccessiveTime");
 		gtk_spin_button_set_value(GTK_SPIN_BUTTON(spStrokeSuccessiveTime), successive);
 	}
@@ -588,7 +588,7 @@ void SettingsDialog::save()
 	GtkWidget* spStrokeIgnoreTime = get("spStrokeIgnoreTime");
 	int strokeIgnoreTime = gtk_spin_button_get_value(GTK_SPIN_BUTTON(spStrokeIgnoreTime));
 	GtkWidget* spStrokeIgnoreLength = get("spStrokeIgnoreLength");
-	int strokeIgnoreLength = gtk_spin_button_get_value(GTK_SPIN_BUTTON(spStrokeIgnoreLength));
+	double strokeIgnoreLength = gtk_spin_button_get_value(GTK_SPIN_BUTTON(spStrokeIgnoreLength));
 	GtkWidget* spStrokeSuccessiveTime = get("spStrokeSuccessiveTime");
 	int strokeSuccessiveTime = gtk_spin_button_get_value(GTK_SPIN_BUTTON(spStrokeSuccessiveTime));
 	settings->setStrokeFilter( strokeIgnoreTime, strokeIgnoreLength, strokeSuccessiveTime);

--- a/src/gui/dialog/SettingsDialog.cpp
+++ b/src/gui/dialog/SettingsDialog.cpp
@@ -80,7 +80,8 @@ SettingsDialog::SettingsDialog(GladeSearchpath* gladeSearchPath, Settings* setti
 				self->enableWithCheckbox("cbStrokeFilterEnabled", "spStrokeIgnoreTime");
 				self->enableWithCheckbox("cbStrokeFilterEnabled", "spStrokeIgnoreLength");
 				self->enableWithCheckbox("cbStrokeFilterEnabled", "spStrokeSuccessiveTime");
-				self->enableWithCheckbox("cbStrokeFilterEnabled", "cbdoActionOnStrokeFiltered");
+//				self->enableWithCheckbox("cbStrokeFilterEnabled", "cbDoActionOnStrokeFiltered");
+				self->enableWithCheckbox("cbStrokeFilterEnabled", "cbTrySelectOnStrokeFiltered");
 			}), this);	
 	
 	g_signal_connect(get("cbDisableTouchOnPenNear"), "toggled", G_CALLBACK(
@@ -221,7 +222,8 @@ void SettingsDialog::load()
 	loadCheckbox("cbAddHorizontalSpace", settings->getAddHorizontalSpace());
 	loadCheckbox("cbDrawDirModsEnabled", settings->getDrawDirModsEnabled());
 	loadCheckbox("cbStrokeFilterEnabled", settings->getStrokeFilterEnabled());
-	loadCheckbox("cbdoActionOnStrokeFiltered", settings->getDoActionOnStrokeFiltered());	
+	loadCheckbox("cbDoActionOnStrokeFiltered", settings->getDoActionOnStrokeFiltered());	
+	loadCheckbox("cbTrySelectOnStrokeFiltered", settings->getTrySelectOnStrokeFiltered());	
 	loadCheckbox("cbBigCursor", settings->isShowBigCursor());
 	loadCheckbox("cbHighlightPosition", settings->isHighlightPosition());
 	loadCheckbox("cbDarkTheme", settings->isDarkTheme());
@@ -340,7 +342,8 @@ void SettingsDialog::load()
 	enableWithCheckbox("cbStrokeFilterEnabled", "spStrokeIgnoreTime");
 	enableWithCheckbox("cbStrokeFilterEnabled", "spStrokeIgnoreLength");
 	enableWithCheckbox("cbStrokeFilterEnabled", "spStrokeSuccessiveTime");
-	enableWithCheckbox("cbStrokeFilterEnabled", "cbdoActionOnStrokeFiltered");
+//	enableWithCheckbox("cbStrokeFilterEnabled", "cbDoActionOnStrokeFiltered");
+	enableWithCheckbox("cbStrokeFilterEnabled", "cbTrySelectOnStrokeFiltered");
 	enableWithCheckbox("cbDisableTouchOnPenNear", "boxInternalHandRecognition");
 	customHandRecognitionToggled();
 
@@ -498,7 +501,8 @@ void SettingsDialog::save()
 	settings->setAddHorizontalSpace(getCheckbox("cbAddHorizontalSpace"));
 	settings->setDrawDirModsEnabled(getCheckbox("cbDrawDirModsEnabled"));
 	settings->setStrokeFilterEnabled(getCheckbox("cbStrokeFilterEnabled"));
-	settings->setDoActionOnStrokeFiltered(getCheckbox("cbdoActionOnStrokeFiltered"));
+	settings->setDoActionOnStrokeFiltered(getCheckbox("cbDoActionOnStrokeFiltered"));
+	settings->setTrySelectOnStrokeFiltered(getCheckbox("cbTrySelectOnStrokeFiltered"));
 	settings->setShowBigCursor(getCheckbox("cbBigCursor"));
 	settings->setHighlightPosition(getCheckbox("cbHighlightPosition"));
 	settings->setDarkTheme(getCheckbox("cbDarkTheme"));

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -40,14 +40,15 @@
     <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentStrokeIgnoreLength">
+    <property name="lower">0.010000000000000011</property>
     <property name="upper">100</property>
-    <property name="value">30</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">5</property>
+    <property name="value">1</property>
+    <property name="step_increment">0.10000000000000001</property>
+    <property name="page_increment">2</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentStrokeIgnoreTime">
     <property name="upper">1000</property>
-    <property name="value">300</property>
+    <property name="value">150</property>
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
   </object>
@@ -3182,6 +3183,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                             <property name="max_width_chars">0</property>
                                             <property name="text" translatable="yes">8</property>
                                             <property name="adjustment">adjustmentStrokeIgnoreLength</property>
+                                            <property name="digits">2</property>
                                             <property name="numeric">True</property>
                                             <property name="update_policy">if-valid</property>
                                             <property name="value">1</property>

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -39,9 +39,9 @@
     <property name="step_increment">0.05000000000000001</property>
     <property name="page_increment">10</property>
   </object>
-  <object class="GtkAdjustment" id="adjustmentStrokeIgnorePoints">
+  <object class="GtkAdjustment" id="adjustmentStrokeIgnoreLength">
     <property name="upper">100</property>
-    <property name="value">8</property>
+    <property name="value">30</property>
     <property name="step_increment">1</property>
     <property name="page_increment">5</property>
   </object>
@@ -3145,7 +3145,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                           <object class="GtkLabel" id="sid156">
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Ignore Time ( ms)</property>
+                                            <property name="label" translatable="yes">Ignore Time (ms)</property>
                                             <property name="angle">0.029999999999999999</property>
                                           </object>
                                           <packing>
@@ -3174,16 +3174,16 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkSpinButton" id="spStrokeIgnorePoints">
+                                          <object class="GtkSpinButton" id="spStrokeIgnoreLength">
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
-                                            <property name="tooltip_markup" translatable="yes">How short (length in screen mm)  of the stroke  AND...
+                                            <property name="tooltip_markup" translatable="yes">How short (screen mm)  of the stroke  AND...
 
 &lt;i&gt;Recommended: 1 mm&lt;/i&gt;</property>
                                             <property name="valign">start</property>
                                             <property name="max_width_chars">0</property>
                                             <property name="text" translatable="yes">8</property>
-                                            <property name="adjustment">adjustmentStrokeIgnorePoints</property>
+                                            <property name="adjustment">adjustmentStrokeIgnoreLength</property>
                                             <property name="numeric">True</property>
                                             <property name="update_policy">if-valid</property>
                                             <property name="value">1</property>

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -3159,14 +3159,14 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                             <property name="can_focus">True</property>
                                             <property name="tooltip_markup" translatable="yes">How short (time)  AND...
 
-&lt;i&gt;Recommended: 200ms&lt;/i&gt;</property>
+&lt;i&gt;Recommended: 150ms&lt;/i&gt;</property>
                                             <property name="valign">start</property>
                                             <property name="max_width_chars">0</property>
-                                            <property name="text" translatable="yes">50</property>
+                                            <property name="text" translatable="yes">8</property>
                                             <property name="adjustment">adjustmentStrokeIgnoreTime</property>
                                             <property name="numeric">True</property>
                                             <property name="update_policy">if-valid</property>
-                                            <property name="value">50</property>
+                                            <property name="value">150</property>
                                           </object>
                                           <packing>
                                             <property name="left_attach">2</property>
@@ -3177,16 +3177,16 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                           <object class="GtkSpinButton" id="spStrokeIgnorePoints">
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
-                                            <property name="tooltip_markup" translatable="yes">How short (length in points)  of the stroke  AND...
+                                            <property name="tooltip_markup" translatable="yes">How short (length in screen mm)  of the stroke  AND...
 
-&lt;i&gt;Recommended: 8 points&lt;/i&gt;</property>
+&lt;i&gt;Recommended: 1 mm&lt;/i&gt;</property>
                                             <property name="valign">start</property>
                                             <property name="max_width_chars">0</property>
                                             <property name="text" translatable="yes">8</property>
                                             <property name="adjustment">adjustmentStrokeIgnorePoints</property>
                                             <property name="numeric">True</property>
                                             <property name="update_policy">if-valid</property>
-                                            <property name="value">8</property>
+                                            <property name="value">1</property>
                                           </object>
                                           <packing>
                                             <property name="left_attach">3</property>
@@ -3197,7 +3197,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                           <object class="GtkLabel" id="sid157">
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Max Length (points)</property>
+                                            <property name="label" translatable="yes">Max Length (mm)</property>
                                           </object>
                                           <packing>
                                             <property name="left_attach">3</property>

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.18.3 -->
 <interface>
   <requires lib="gtk+" version="3.0"/>
   <object class="GtkAdjustment" id="adjustmentAudioGain">
@@ -106,9 +106,6 @@
     <property name="type_hint">normal</property>
     <property name="gravity">center</property>
     <signal name="close" handler="gtk_widget_hide" swapped="no"/>
-    <child>
-      <placeholder/>
-    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox3">
         <property name="visible">True</property>
@@ -726,6 +723,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">False</property>
+                                <property name="xalign">0.5</property>
                                 <property name="draw_indicator">True</property>
                                 <child>
                                   <object class="GtkLabel" id="sid92">
@@ -3128,11 +3126,11 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                         <property name="column_spacing">5</property>
                                         <child>
                                           <object class="GtkCheckButton" id="cbStrokeFilterEnabled">
-                                            <property name="label" translatable="yes">Enable  Stroke Filter</property>
+                                            <property name="label" translatable="yes">Enable Tap action.</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
                                             <property name="receives_default">False</property>
-                                            <property name="tooltip_markup" translatable="yes">Ignore inputs of short time and length unless it comes in short succession.</property>
+                                            <property name="tooltip_markup" translatable="yes">Do not draw for inputs of short time and length unless it comes in short succession. Instead, show floating toolbox.</property>
                                             <property name="xalign">0</property>
                                             <property name="draw_indicator">True</property>
                                           </object>
@@ -3236,13 +3234,14 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkCheckButton" id="cbdoActionOnStrokeFiltered">
-                                            <property name="label" translatable="yes">Select on quick tap.</property>
+                                          <object class="GtkCheckButton" id="cbTrySelectOnStrokeFiltered">
+                                            <property name="label" translatable="yes">Try to select object first.</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
                                             <property name="receives_default">False</property>
-                                            <property name="tooltip_markup" translatable="yes">On quick tap select object.</property>
+                                            <property name="tooltip_markup" translatable="yes">Try to select object first; if nothing selected then show floating toolbox if enabled.</property>
                                             <property name="xalign">0</property>
+                                            <property name="yalign">0.43999999761581421</property>
                                             <property name="draw_indicator">True</property>
                                           </object>
                                           <packing>
@@ -3264,7 +3263,21 @@ It must be short in time and length and we can't have ignored another stroke rec
                                           </packing>
                                         </child>
                                         <child>
-                                          <placeholder/>
+                                          <object class="GtkCheckButton" id="cbDoActionOnStrokeFiltered">
+                                            <property name="label" translatable="yes">Show Floating Toolbox</property>
+                                            <property name="visible">True</property>
+                                            <property name="sensitive">False</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="tooltip_markup" translatable="yes">Try to select object first; if nothing selected then show floating toolbox if enabled.</property>
+                                            <property name="xalign">0</property>
+                                            <property name="yalign">0.43000000715255737</property>
+                                            <property name="draw_indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">1</property>
+                                            <property name="top_attach">1</property>
+                                          </packing>
                                         </child>
                                       </object>
                                     </child>
@@ -3274,7 +3287,8 @@ It must be short in time and length and we can't have ignored another stroke rec
                                   <object class="GtkLabel" id="sid159">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="label" translatable="yes">Stroke Filter - w/ try quick Select ( Experimental )</property>
+                                    <property name="label" translatable="yes">Action on Tool Tap</property>
+                                    <property name="angle">0.040000000000000001</property>
                                   </object>
                                 </child>
                               </object>


### PR DESCRIPTION
In preparation for use with a popup/floatingToolbox. Changed tapSelect/scratch filtering to use screen length and distance from buttondown to buttonup independent of stroke points.  Settings and variable name changes to better reflect new implementation.