### PR TITLE
Multiple clicks in text editor

### DIFF
--- a/src/gui/PageView.cpp
+++ b/src/gui/PageView.cpp
@@ -502,7 +502,7 @@ bool XojPageView::onButtonDoublePressEvent(const PositionInputData& pos)
 	else if (toolHandler->getToolType() == TOOL_TEXT)
 	{
 		this->startText(x, y);
-		this->textEditor->selectWord();
+		this->textEditor->selectAtCursor(TextEditor::SelectType::word);
 	}
 
 	return true;

--- a/src/gui/PageView.cpp
+++ b/src/gui/PageView.cpp
@@ -45,6 +45,7 @@
 #include <gdk/gdk.h>
 
 #include <stdlib.h>
+#include <algorithm>
 
 XojPageView::XojPageView(XournalView* xournal, PageRef page)
 {
@@ -438,6 +439,65 @@ bool XojPageView::onButtonPressEvent(const PositionInputData& pos)
 	{
 		ImageHandler imgHandler(xournal->getControl(), this);
 		imgHandler.insertImage(x, y);
+	}
+
+	return true;
+}
+
+bool XojPageView::onButtonDoublePressEvent(const PositionInputData& pos)
+{
+	// This method assumes that it is called after onButtonPressEvent but before
+	// onButtonReleaseEvent
+	double x = pos.x;
+	double y = pos.y;
+	if (x < 0 || y < 0)
+	{
+		return false;
+	}
+
+	double zoom = this->xournal->getZoom();
+	x /= zoom;
+	y /= zoom;
+	ToolHandler* toolHandler = this->xournal->getControl()->getToolHandler();
+	ToolType toolType = toolHandler->getToolType();
+	bool isSelectTool = toolType == TOOL_SELECT_OBJECT || TOOL_SELECT_RECT || TOOL_SELECT_REGION;
+
+	EditSelection* selection = xournal->getSelection();
+	bool hasNoModifiers = !pos.isShiftDown() && !pos.isControlDown();
+
+	if (hasNoModifiers && isSelectTool && selection != nullptr)
+	{
+		// Find a selected object under the cursor, if possible. The selection doesn't change the
+		// element coordinates until it is finalized, so we need to use position relative to the
+		// original coordinates of the selection.
+		double origx = x - (selection->getXOnView() - selection->getOriginalXOnView()) / zoom;
+		double origy = y - (selection->getYOnView() - selection->getOriginalYOnView()) / zoom;
+		std::vector<Element*>* elems = selection->getElements();
+		auto it = std::find_if(elems->begin(), elems->end(), [&](Element*& elem) {
+			return elem->intersectsArea(origx - 5, origy - 5, 5, 5);
+		});
+		if (it != elems->end())
+		{
+			// Enter editing mode on the selected object
+			Element* object = *it;
+			ElementType elemType = object->getType();
+			if (elemType == ELEMENT_TEXT)
+			{
+				this->xournal->clearSelection();
+				toolHandler->selectTool(TOOL_TEXT);
+				// Simulate a button press; there's too many things that we
+				// could forget to do if we manually call startText
+				this->onButtonPressEvent(pos);
+			}
+			else if (elemType == ELEMENT_TEXIMAGE)
+			{
+				Control* control = this->xournal->getControl();
+				this->xournal->clearSelection();
+				EditSelection* sel = new EditSelection(control->getUndoRedoHandler(), object, this, this->getPage());
+				this->xournal->setSelection(sel);
+				control->runLatex();
+			}
+		}
 	}
 
 	return true;

--- a/src/gui/PageView.cpp
+++ b/src/gui/PageView.cpp
@@ -499,6 +499,11 @@ bool XojPageView::onButtonDoublePressEvent(const PositionInputData& pos)
 			}
 		}
 	}
+	else if (toolHandler->getToolType() == TOOL_TEXT)
+	{
+		this->startText(x, y);
+		this->textEditor->selectWord();
+	}
 
 	return true;
 }

--- a/src/gui/PageView.cpp
+++ b/src/gui/PageView.cpp
@@ -470,8 +470,8 @@ bool XojPageView::onButtonDoublePressEvent(const PositionInputData& pos)
 		// Find a selected object under the cursor, if possible. The selection doesn't change the
 		// element coordinates until it is finalized, so we need to use position relative to the
 		// original coordinates of the selection.
-		double origx = x - (selection->getXOnView() - selection->getOriginalXOnView()) / zoom;
-		double origy = y - (selection->getYOnView() - selection->getOriginalYOnView()) / zoom;
+		double origx = x - (selection->getXOnView() - selection->getOriginalXOnView());
+		double origy = y - (selection->getYOnView() - selection->getOriginalYOnView());
 		std::vector<Element*>* elems = selection->getElements();
 		auto it = std::find_if(elems->begin(), elems->end(), [&](Element*& elem) {
 			return elem->intersectsArea(origx - 5, origy - 5, 5, 5);

--- a/src/gui/PageView.cpp
+++ b/src/gui/PageView.cpp
@@ -448,16 +448,14 @@ bool XojPageView::onButtonDoublePressEvent(const PositionInputData& pos)
 {
 	// This method assumes that it is called after onButtonPressEvent but before
 	// onButtonReleaseEvent
-	double x = pos.x;
-	double y = pos.y;
+	double zoom = this->xournal->getZoom();
+	double x = pos.x / zoom;
+	double y = pos.y / zoom;
 	if (x < 0 || y < 0)
 	{
 		return false;
 	}
 
-	double zoom = this->xournal->getZoom();
-	x /= zoom;
-	y /= zoom;
 	ToolHandler* toolHandler = this->xournal->getControl()->getToolHandler();
 	ToolType toolType = toolHandler->getToolType();
 	bool isSelectTool = toolType == TOOL_SELECT_OBJECT || TOOL_SELECT_RECT || TOOL_SELECT_REGION;
@@ -499,12 +497,34 @@ bool XojPageView::onButtonDoublePressEvent(const PositionInputData& pos)
 			}
 		}
 	}
-	else if (toolHandler->getToolType() == TOOL_TEXT)
+	else if (toolType == TOOL_TEXT)
 	{
 		this->startText(x, y);
 		this->textEditor->selectAtCursor(TextEditor::SelectType::word);
 	}
 
+	return true;
+}
+
+bool XojPageView::onButtonTriplePressEvent(const PositionInputData& pos)
+{
+	// This method assumes that it is called after onButtonDoubleEvent but before
+	// onButtonReleaseEvent
+	double zoom = this->xournal->getZoom();
+	double x = pos.x / zoom;
+	double y = pos.y / zoom;
+	if (x < 0 || y < 0)
+	{
+		return false;
+	}
+
+	ToolHandler* toolHandler = this->xournal->getControl()->getToolHandler();
+
+	if (toolHandler->getToolType() == TOOL_TEXT)
+	{
+		this->startText(x, y);
+		this->textEditor->selectAtCursor(TextEditor::SelectType::paragraph);
+	}
 	return true;
 }
 

--- a/src/gui/PageView.h
+++ b/src/gui/PageView.h
@@ -150,6 +150,7 @@ public: // event handler
 	bool onButtonPressEvent(const PositionInputData& pos);
 	bool onButtonReleaseEvent(const PositionInputData& pos);
 	bool onButtonDoublePressEvent(const PositionInputData& pos);
+	bool onButtonTriplePressEvent(const PositionInputData& pos);
 	bool onMotionNotifyEvent(const PositionInputData& pos);
 
 	/**

--- a/src/gui/PageView.h
+++ b/src/gui/PageView.h
@@ -149,6 +149,7 @@ public:
 public: // event handler
 	bool onButtonPressEvent(const PositionInputData& pos);
 	bool onButtonReleaseEvent(const PositionInputData& pos);
+	bool onButtonDoublePressEvent(const PositionInputData& pos);
 	bool onMotionNotifyEvent(const PositionInputData& pos);
 
 	/**

--- a/src/gui/TextEditor.cpp
+++ b/src/gui/TextEditor.cpp
@@ -449,6 +449,36 @@ void TextEditor::toggleBold()
 	//this->repaintEditor();
 }
 
+void TextEditor::selectWord()
+{
+	XOJ_CHECK_TYPE(TextEditor);
+
+	GtkTextMark* mark = gtk_text_buffer_get_insert(this->buffer);
+	GtkTextIter currentPos;
+	gtk_text_buffer_get_iter_at_mark(this->buffer, &currentPos, mark);
+
+	// Only process double click
+	if (!gtk_text_iter_inside_word(&currentPos))
+	{
+		return;
+	}
+
+	GtkTextIter startPos = currentPos;
+	GtkTextIter endPos = currentPos;
+	if (!gtk_text_iter_starts_word(&currentPos))
+	{
+		gtk_text_iter_backward_word_start(&startPos);
+	}
+	if (!gtk_text_iter_ends_word(&currentPos))
+	{
+		gtk_text_iter_forward_word_end(&endPos);
+	}
+
+	gtk_text_buffer_select_range(this->buffer, &startPos, &endPos);
+
+	this->repaintEditor();
+}
+
 void TextEditor::selectAll()
 {
 	XOJ_CHECK_TYPE(TextEditor);

--- a/src/gui/TextEditor.cpp
+++ b/src/gui/TextEditor.cpp
@@ -449,7 +449,7 @@ void TextEditor::toggleBold()
 	//this->repaintEditor();
 }
 
-void TextEditor::selectWord()
+void TextEditor::selectAtCursor(TextEditor::SelectType ty)
 {
 	XOJ_CHECK_TYPE(TextEditor);
 
@@ -465,28 +465,34 @@ void TextEditor::selectWord()
 
 	GtkTextIter startPos = currentPos;
 	GtkTextIter endPos = currentPos;
-	if (!gtk_text_iter_starts_word(&currentPos))
-	{
-		gtk_text_iter_backward_word_start(&startPos);
-	}
-	if (!gtk_text_iter_ends_word(&currentPos))
-	{
-		gtk_text_iter_forward_word_end(&endPos);
+
+	switch(ty) {
+	case TextEditor::SelectType::word:
+		if (!gtk_text_iter_starts_word(&currentPos))
+		{
+			gtk_text_iter_backward_word_start(&startPos);
+		}
+		if (!gtk_text_iter_ends_word(&currentPos))
+		{
+			gtk_text_iter_forward_word_end(&endPos);
+		}
+		break;
+	case TextEditor::SelectType::paragraph:
+		if (!gtk_text_iter_starts_line(&currentPos))
+		{
+			gtk_text_iter_backward_line(&startPos);
+		}
+		if (!gtk_text_iter_ends_line(&currentPos))
+		{
+			gtk_text_iter_forward_to_line_end(&endPos);
+		}
+		break;
+	case TextEditor::SelectType::all:
+		gtk_text_buffer_get_bounds(this->buffer, &startPos, &endPos);
+		break;
 	}
 
 	gtk_text_buffer_select_range(this->buffer, &startPos, &endPos);
-
-	this->repaintEditor();
-}
-
-void TextEditor::selectAll()
-{
-	XOJ_CHECK_TYPE(TextEditor);
-
-	GtkTextIter start_iter, end_iter;
-
-	gtk_text_buffer_get_bounds(buffer, &start_iter, &end_iter);
-	gtk_text_buffer_select_range(buffer, &start_iter, &end_iter);
 
 	this->repaintEditor();
 }

--- a/src/gui/TextEditor.h
+++ b/src/gui/TextEditor.h
@@ -32,6 +32,7 @@ public:
 	bool onKeyReleaseEvent(GdkEventKey* event);
 
 	void toggleOverwrite();
+	void selectWord();
 	void selectAll();
 	void toggleBold();
 	void incSize();

--- a/src/gui/TextEditor.h
+++ b/src/gui/TextEditor.h
@@ -26,14 +26,16 @@ public:
 	TextEditor(XojPageView* gui, GtkWidget* widget, Text* text, bool ownText);
 	virtual ~TextEditor();
 
+	/** Represents the different kinds of text selection */
+	enum class SelectType { word, paragraph, all };
+
 	void paint(cairo_t* cr, GdkRectangle* rect, double zoom);
 
 	bool onKeyPressEvent(GdkEventKey* event);
 	bool onKeyReleaseEvent(GdkEventKey* event);
 
 	void toggleOverwrite();
-	void selectWord();
-	void selectAll();
+	void selectAtCursor(TextEditor::SelectType ty);
 	void toggleBold();
 	void incSize();
 	void decSize();

--- a/src/gui/TextEditorWidget.h
+++ b/src/gui/TextEditorWidget.h
@@ -65,7 +65,7 @@ static guint signals[LAST_SIGNAL] = {0};
 static void gtk_xoj_int_txt_select_all(GtkWidget* widget)
 {
 	GtkXojIntTxt* txt = GTK_XOJ_INT_TXT(widget);
-	txt->te->selectAll();
+	txt->te->selectAtCursor(TextEditor::SelectType::all);
 }
 
 static void gtk_xoj_int_txt_move_cursor(GtkWidget* widget, gint step, gint bitmask)

--- a/src/gui/inputdevices/MouseInputHandler.cpp
+++ b/src/gui/inputdevices/MouseInputHandler.cpp
@@ -47,7 +47,7 @@ bool MouseInputHandler::handleImpl(GdkEvent* event)
 		return true;
 	}
 
-	if (event->type == GDK_DOUBLE_BUTTON_PRESS)
+	if (event->type == GDK_DOUBLE_BUTTON_PRESS || event->type == GDK_TRIPLE_BUTTON_PRESS)
 	{
 		this->actionPerform(event);
 		return true;

--- a/src/gui/inputdevices/PenInputHandler.cpp
+++ b/src/gui/inputdevices/PenInputHandler.cpp
@@ -392,7 +392,14 @@ void PenInputHandler::actionPerform(GdkEvent* event)
 
 	XojPageView* currentPage = this->getPageAtCurrentPosition(event);
 	PositionInputData pos = this->getInputDataRelativeToCurrentPage(currentPage, event);
-	currentPage->onButtonDoublePressEvent(pos);
+	if (event->type == GDK_DOUBLE_BUTTON_PRESS)
+	{
+		currentPage->onButtonDoublePressEvent(pos);
+	}
+	else if (event->type == GDK_TRIPLE_BUTTON_PRESS)
+	{
+		currentPage->onButtonTriplePressEvent(pos);
+	}
 }
 
 void PenInputHandler::actionLeaveWindow(GdkEvent* event)

--- a/src/gui/inputdevices/StylusInputHandler.cpp
+++ b/src/gui/inputdevices/StylusInputHandler.cpp
@@ -55,7 +55,7 @@ bool StylusInputHandler::handleImpl(GdkEvent* event)
 	}
 
 	// Trigger discrete action on double tap
-	if (event->type == GDK_DOUBLE_BUTTON_PRESS)
+	if (event->type == GDK_DOUBLE_BUTTON_PRESS || event->type == GDK_TRIPLE_BUTTON_PRESS)
 	{
 		this->actionPerform(event);
 		return true;


### PR DESCRIPTION
Makes multiple clicks on during text editors select words and lines. This will implement and close #841. In particular:

* [x] Double clicking in a text field will select that word
* [x] Fix a zoom issue when double clicking a selected object to begin editing
* [x] Triple click in a text field will select a paragraph