### PR TITLE
Simplify and refactor latex tool code

### DIFF
--- a/src/control/LatexController.cpp
+++ b/src/control/LatexController.cpp
@@ -41,11 +41,12 @@ const char* LATEX_TEMPLATE_2 =
 
 LatexController::LatexController(Control* control)
 	: control(control),
+	  dlg(control->getGladeSearchPath()),
 	  doc(control->getDocument()),
-	  texTmp(Util::getTmpDirSubfolder("tex"))
+	  texTmpDir(Util::getTmpDirSubfolder("tex"))
 {
 	XOJ_INIT_TYPE(LatexController);
-	Util::ensureFolderExists(this->texTmp);
+	Util::ensureFolderExists(this->texTmpDir);
 }
 
 LatexController::~LatexController()
@@ -70,22 +71,22 @@ bool LatexController::findTexExecutable()
 		return false;
 	}
 
-	binTex = pdflatex;
+	this->pdflatexPath = pdflatex;
 	g_free(pdflatex);
 
 	return true;
 }
 
-std::unique_ptr<GPid> LatexController::runCommandAsync()
+std::unique_ptr<GPid> LatexController::runCommandAsync(string texString)
 {
 	XOJ_CHECK_TYPE(LatexController);
 	g_assert(!this->isUpdating);
 
 	string texContents = LATEX_TEMPLATE_1;
-	texContents += this->currentTex;
+	texContents += texString;
 	texContents += LATEX_TEMPLATE_2;
 
-	Path texFile = texTmp / "tex.tex";
+	Path texFile = this->texTmpDir / "tex.tex";
 
 	GError* err = NULL;
 	if (!g_file_set_contents(texFile.c_str(), texContents.c_str(), texContents.length(), &err))
@@ -96,16 +97,18 @@ std::unique_ptr<GPid> LatexController::runCommandAsync()
 	}
 
 	char* texFileEscaped = g_strescape(texFile.c_str(), NULL);
-	char* cmd = g_strdup(binTex.c_str());
+	char* cmd = g_strdup(this->pdflatexPath.c_str());
 
 	static char* texFlag = g_strdup("-interaction=nonstopmode");
 	char* argv[] = { cmd, texFlag, texFileEscaped, NULL };
 
-	std::unique_ptr<GPid> pdflatex_pid(new GPid);
+	std::unique_ptr<GPid> pdflatexPid(new GPid);
 	GSpawnFlags flags = GSpawnFlags(G_SPAWN_STDOUT_TO_DEV_NULL | G_SPAWN_STDERR_TO_DEV_NULL | G_SPAWN_DO_NOT_REAP_CHILD);
+
 	this->setUpdating(true);
-	this->lastPreviewedTex = this->currentTex;
-	bool success = g_spawn_async(texTmp.c_str(), argv, nullptr, flags, nullptr, nullptr, pdflatex_pid.get(), &err);
+	this->lastPreviewedTex = texString;
+
+	bool success = g_spawn_async(texTmpDir.c_str(), argv, nullptr, flags, nullptr, nullptr, pdflatexPid.get(), &err);
 	if (!success)
 	{
 		string message = FS(_F("Could not start pdflatex: {1} (exit code: {2})") % err->message % err->code);
@@ -114,13 +117,13 @@ std::unique_ptr<GPid> LatexController::runCommandAsync()
 
 		g_error_free(err);
 		this->setUpdating(false);
-		pdflatex_pid.reset();
+		pdflatexPid.reset();
 	}
 
 	g_free(texFileEscaped);
 	g_free(cmd);
 
-	return pdflatex_pid;
+	return pdflatexPid;
 }
 
 /**
@@ -174,49 +177,43 @@ void LatexController::findSelectedTexElement()
 		}
 	}
 	this->doc->unlock();
-	this->currentTex = this->initialTex;
-	if (this->initialTex.empty())
-	{
-		this->currentTex = "x^2";
-	}
 
 	// need to do this otherwise we can't remove the image for its replacement
 	this->control->clearSelectionEndText();
 }
 
-void LatexController::showTexEditDialog()
+string LatexController::showTexEditDialog()
 {
 	XOJ_CHECK_TYPE(LatexController);
 
-	this->dlg.reset(new LatexDialog(control->getGladeSearchPath()));
-
-	// preselect default text so user can overwrite it easily
-	this->dlg->setTex(currentTex, this->initialTex.empty());
-
-	g_signal_connect(dlg->getTextBuffer(), "changed", G_CALLBACK(handleTexChanged), this);
+	// Attach the signal handler before setting the buffer text so that the
+	// callback is triggered
+	gulong signalHandler = g_signal_connect(dlg.getTextBuffer(), "changed", G_CALLBACK(handleTexChanged), this);
+	bool isNewFormula = this->initialTex.empty();
+	this->dlg.setFinalTex(isNewFormula ? "x^2" : this->initialTex);
 
 	if (this->temporaryRender != nullptr)
 	{
-		this->dlg->setTempRender(this->temporaryRender->getPdf());
+		this->dlg.setTempRender(this->temporaryRender->getPdf());
 	}
 
-	this->dlg->show(GTK_WINDOW(control->getWindow()->getWindow()));
+	this->dlg.show(GTK_WINDOW(control->getWindow()->getWindow()), isNewFormula);
+	g_signal_handler_disconnect(dlg.getTextBuffer(), signalHandler);
 
-	this->currentTex = this->dlg->getTex();
+	string result = this->dlg.getFinalTex();
 	// If the user cancelled, there is no change in the latex string.
-	this->currentTex = this->currentTex == "" ? initialTex : this->currentTex;
-
-	this->dlg.reset();
+	result = result == "" ? initialTex : result;
+	return result;
 }
 
-void LatexController::triggerImageUpdate()
+void LatexController::triggerImageUpdate(string texString)
 {
 	if (this->isUpdating)
 	{
 		return;
 	}
 
-	std::unique_ptr<GPid> pid = this->runCommandAsync();
+	std::unique_ptr<GPid> pid = this->runCommandAsync(texString);
 	if (pid != nullptr)
 	{
 		g_assert(this->isUpdating);
@@ -226,23 +223,16 @@ void LatexController::triggerImageUpdate()
 
 /**
  * Text-changed handler: when the Buffer in the dialog changes, this handler
- * updates currentTex, removes the previous existing render and creates a new
- * one. We need to do it through 'self' because signal handlers cannot directly
- * access non-static methods and non-static fields such as 'dlg' so we need to
- * wrap all the dlg method inside small methods in 'self'. To improve
- * performance, we render the text asynchronously.
+ * removes the previous existing render and creates a new one. We need to do it
+ * through 'self' because signal handlers cannot directly access non-static
+ * methods and non-static fields such as 'dlg' so we need to wrap all the dlg
+ * method inside small methods in 'self'. To improve performance, we render the
+ * text asynchronously.
  */
 void LatexController::handleTexChanged(GtkTextBuffer* buffer, LatexController* self)
 {
 	XOJ_CHECK_TYPE_OBJ(self, LatexController);
-
-	GtkTextIter start;
-	GtkTextIter end;
-	gtk_text_buffer_get_start_iter(buffer, &start);
-	gtk_text_buffer_get_end_iter(buffer, &end);
-	self->setCurrentTex(gtk_text_buffer_get_text(buffer, &start, &end, true));
-
-	self->triggerImageUpdate();
+	self->triggerImageUpdate(self->dlg.getBufferContents());
 }
 
 void LatexController::onPdfRenderComplete(GPid pid, gint returnCode, LatexController* self)
@@ -252,7 +242,8 @@ void LatexController::onPdfRenderComplete(GPid pid, gint returnCode, LatexContro
 	GError* err = nullptr;
 	g_spawn_check_exit_status(returnCode, &err);
 	g_spawn_close_pid(pid);
-	bool shouldUpdate = self->lastPreviewedTex != self->currentTex;
+	string currentTex = self->dlg.getBufferContents();
+	bool shouldUpdate = self->lastPreviewedTex != currentTex;
 	if (err != nullptr)
 	{
 		self->isValidTex = false;
@@ -263,7 +254,7 @@ void LatexController::onPdfRenderComplete(GPid pid, gint returnCode, LatexContro
 			g_warning("%s", message.c_str());
 			XojMsgBox::showErrorToUser(self->control->getGtkWindow(), message);
 		}
-		Path pdfPath = self->texTmp / "tex.pdf";
+		Path pdfPath = self->texTmpDir / "tex.pdf";
 		if (pdfPath.exists())
 		{
 			// Delete the pdf to prevent more errors
@@ -274,24 +265,24 @@ void LatexController::onPdfRenderComplete(GPid pid, gint returnCode, LatexContro
 	else
 	{
 		self->isValidTex = true;
-		self->temporaryRender = self->loadRendered();
+		self->temporaryRender = self->loadRendered(currentTex);
 		if (self->temporaryRender != nullptr)
 		{
-			self->setImageInDialog(self->temporaryRender->getPdf());
+			self->dlg.setTempRender(self->temporaryRender->getPdf());
 		}
 
 	}
 	self->setUpdating(false);
 	if (shouldUpdate)
 	{
-		self->triggerImageUpdate();
+		self->triggerImageUpdate(currentTex);
 	}
 }
 
 void LatexController::setUpdating(bool newValue)
 {
 	XOJ_CHECK_TYPE(LatexController);
-	GtkWidget* okButton = this->dlg->get("texokbutton");
+	GtkWidget* okButton = this->dlg.get("texokbutton");
 	bool buttonEnabled = true;
 	if ((!this->isUpdating && newValue) || (this->isUpdating && !newValue))
 	{
@@ -306,26 +297,14 @@ void LatexController::setUpdating(bool newValue)
 
 	// Invalid LaTeX will generate an invalid PDF, so disable the OK button if
 	// needed.
-	buttonEnabled = buttonEnabled ? this->isValidTex : buttonEnabled;
+	buttonEnabled = buttonEnabled && this->isValidTex;
 
 	gtk_widget_set_sensitive(okButton, buttonEnabled);
 
-	GtkLabel* errorLabel = GTK_LABEL(this->dlg->get("texErrorLabel"));
-	gtk_label_set_text(errorLabel, this->isValidTex ? "" : "The formula is empty when rendered or invalid.");
+	GtkLabel* errorLabel = GTK_LABEL(this->dlg.get("texErrorLabel"));
+	gtk_label_set_text(errorLabel, this->isValidTex ? "" : N_("The formula is empty when rendered or invalid."));
 
 	this->isUpdating = newValue;
-}
-
-void LatexController::setImageInDialog(PopplerDocument* pdf)
-{
-	XOJ_CHECK_TYPE(LatexController);
-	this->dlg->setTempRender(pdf);
-}
-
-void LatexController::setCurrentTex(string currentTex)
-{
-	XOJ_CHECK_TYPE(LatexController);
-	this->currentTex = currentTex;
 }
 
 void LatexController::deleteOldImage()
@@ -348,7 +327,7 @@ void LatexController::deleteOldImage()
 	}
 }
 
-std::unique_ptr<TexImage> LatexController::convertDocumentToImage(PopplerDocument* doc)
+std::unique_ptr<TexImage> LatexController::convertDocumentToImage(PopplerDocument* doc, string formula)
 {
 	XOJ_CHECK_TYPE(LatexController);
 
@@ -367,21 +346,14 @@ std::unique_ptr<TexImage> LatexController::convertDocumentToImage(PopplerDocumen
 	std::unique_ptr<TexImage> img(new TexImage());
 	img->setX(posx);
 	img->setY(posy);
-	img->setText(currentTex);
+	img->setText(formula);
 
 	if (imgheight)
 	{
 		double ratio = pageWidth / pageHeight;
 		if (ratio == 0)
 		{
-			if (imgwidth == 0)
-			{
-				img->setWidth(10);
-			}
-			else
-			{
-				img->setWidth(imgwidth);
-			}
+			img->setWidth(imgwidth == 0 ? 10 : imgwidth);
 		}
 		else
 		{
@@ -398,10 +370,7 @@ std::unique_ptr<TexImage> LatexController::convertDocumentToImage(PopplerDocumen
 	return img;
 }
 
-/**
- * Load PDF as TexImage
- */
-std::unique_ptr<TexImage> LatexController::loadRendered()
+std::unique_ptr<TexImage> LatexController::loadRendered(string renderedTex)
 {
 	XOJ_CHECK_TYPE(LatexController);
 
@@ -410,7 +379,7 @@ std::unique_ptr<TexImage> LatexController::loadRendered()
 		return nullptr;
 	}
 
-	Path pdfPath = texTmp / "tex.pdf";
+	Path pdfPath = texTmpDir / "tex.pdf";
 	GError* err = NULL;
 
 	gchar* fileContents = NULL;
@@ -439,7 +408,7 @@ std::unique_ptr<TexImage> LatexController::loadRendered()
 		return NULL;
 	}
 
-	std::unique_ptr<TexImage> img = convertDocumentToImage(pdf);
+	std::unique_ptr<TexImage> img = convertDocumentToImage(pdf, renderedTex);
 	g_object_unref(pdf);
 
 	// Do not assign the PDF, theoretical it should work, but it gets a Poppler PDF error
@@ -455,8 +424,8 @@ void LatexController::insertTexImage()
 {
 	XOJ_CHECK_TYPE(LatexController);
 
-	TexImage* img = this->loadRendered().release();
-	g_assert(img != nullptr);
+	g_assert(this->temporaryRender != nullptr);
+	TexImage* img = this->temporaryRender.release();
 
 	this->deleteOldImage();
 
@@ -484,9 +453,9 @@ void LatexController::run()
 	}
 
 	this->findSelectedTexElement();
-	this->showTexEditDialog();
+	string newTex = this->showTexEditDialog();
 
-	if (this->initialTex != this->currentTex)
+	if (this->initialTex != newTex)
 	{
 		g_assert(this->isValidTex);
 		this->insertTexImage();

--- a/src/control/LatexController.h
+++ b/src/control/LatexController.h
@@ -35,6 +35,9 @@ class Layer;
 class LatexController
 {
 public:
+	LatexController() = delete;
+	LatexController(const LatexController& other) = delete;
+	LatexController& operator=(const LatexController& other) = delete;
 	LatexController(Control* control);
 	virtual ~LatexController();
 
@@ -63,24 +66,28 @@ private:
 	void deleteOldImage();
 
 	/**
-	 * Run the LaTeX command asynchronously. Note that this method can only be
-	 * called when the preview is not updating.
+	 * Run the LaTeX command asynchronously to generate a preview for the given
+	 * LaTeX string. Note that this method can only be called when the preview
+	 * is not updating.
 	 *
 	 * @return The PID of the spawned process, or nullptr if the .tex file could
 	 * not be written or the command failed to start.
 	 */
-	std::unique_ptr<GPid> runCommandAsync();
+	std::unique_ptr<GPid> runCommandAsync(string texString);
 
 	/**
-	 * Asynchronously runs the LaTeX command and then updates the TeX image. If
-	 * the preview is already being updated, then this method will be a no-op.
+	 * Asynchronously runs the LaTeX command and then updates the TeX image with
+	 * the given LaTeX string. If the preview is already being updated, then
+	 * this method will be a no-op.
 	 */
-	void triggerImageUpdate();
+	void triggerImageUpdate(string texString);
 
 	/**
-	 * Show the LaTex Editor dialog
+	 * Show the LaTex Editor dialog, returning the final formula input by the
+	 * user. If the input was cancelled, the resulting string will be the same
+	 * as the initial formula.
 	 */
-	void showTexEditDialog();
+	string showTexEditDialog();
 
 	/**
 	 * Signal handler, updates the rendered image when the text in the editor
@@ -98,27 +105,19 @@ private:
 
 	void setUpdating(bool newValue);
 
-	/*******/
-	//Wrappers for signal handler who can't access non-static fields 
-	//(see implementation for further explanation)
-	void setImageInDialog(PopplerDocument* pdf);
-	void setCurrentTex(string currentTex);
-	GtkTextIter* getStartIterator(GtkTextBuffer* buffer);
-	GtkTextIter* getEndIterator(GtkTextBuffer* buffer);
-	/*******/
-
 	/**
-	 * Convert PDF Document to TexImage
+	 * Convert the given PDF Document to a TexImage and set the formula to the
+	 * given formula.
 	 */
-	std::unique_ptr<TexImage> convertDocumentToImage(PopplerDocument* doc);
+	std::unique_ptr<TexImage> convertDocumentToImage(PopplerDocument* doc, string formula);
 
 	/**
-	 * Load PDF as TexImage
+	 * Load the preview PDF from disk and create a TexImage object.
 	 */
-	std::unique_ptr<TexImage> loadRendered();
+	std::unique_ptr<TexImage> loadRendered(string renderedTex);
 
 	/**
-	 * Actual image creation
+	 * Insert the generated preview TexImage into the current page.
 	 */
 	void insertTexImage();
 
@@ -128,21 +127,20 @@ private:
 	Control* control = NULL;
 
 	/**
+	 * LaTex editor dialog
+	 */
+	LatexDialog dlg;
+
+	/**
 	 * Tex binary full path
 	 */
-	Path binTex;
+	Path pdflatexPath;
 
 	/**
 	 * The original TeX string when the dialog was opened, or the empty string
 	 * if creating a new LaTeX element.
 	 */
 	string initialTex;
-
-	/**
-	 * The TeX string that the LaTeX element should display after editing
-	 * finishes.
-	 */
-	string currentTex;
 
 	/**
 	 * The last TeX string shown in the preview.
@@ -203,7 +201,7 @@ private:
 	 * The directory in which the LaTeX files will be generated. Note that this
 	 * should be within a system temporary directory.
 	 */
-	Path texTmp;
+	Path texTmpDir;
 
 	/**
 	 * Previously existing TexImage
@@ -211,11 +209,6 @@ private:
 	TexImage* selectedTexImage = NULL;
 
 	Text* selectedText = NULL;
-
-	/**
-	 * LaTex editor dialog
-	 */
-	std::unique_ptr<LatexDialog> dlg = nullptr;
 
 	/**
 	 * The controller owns the rendered preview in order to be able to delete it

--- a/src/gui/dialog/LatexDialog.cpp
+++ b/src/gui/dialog/LatexDialog.cpp
@@ -1,6 +1,6 @@
 #include "LatexDialog.h"
 
-LatexDialog::LatexDialog(GladeSearchpath *gladeSearchPath)
+LatexDialog::LatexDialog(GladeSearchpath* gladeSearchPath)
  : GladeGui(gladeSearchPath, "texdialog.glade", "texDialog")
 {
 	XOJ_INIT_TYPE(LatexDialog);
@@ -24,17 +24,16 @@ LatexDialog::~LatexDialog()
 	XOJ_RELEASE_TYPE(LatexDialog);
 }
 
-void LatexDialog::setTex(string texString, bool preselect)
+void LatexDialog::setFinalTex(string texString)
 {
 	XOJ_CHECK_TYPE(LatexDialog);
-	this->theLatex = texString;
-	this->preselect = preselect;
+	this->finalLatex = texString;
 }
 
-string LatexDialog::getTex()
+string LatexDialog::getFinalTex()
 {
 	XOJ_CHECK_TYPE(LatexDialog);
-	return this->theLatex;
+	return this->finalLatex;
 }
 
 void LatexDialog::setTempRender(PopplerDocument* pdf)
@@ -84,44 +83,35 @@ GtkTextBuffer* LatexDialog::getTextBuffer()
 	return this->textBuffer;
 }
 
-
-void LatexDialog::save()
-{
-	XOJ_CHECK_TYPE(LatexDialog);
-
+string LatexDialog::getBufferContents() {
 	GtkTextIter start, end;
 	gtk_text_buffer_get_bounds(this->textBuffer, &start, &end);
-	this->theLatex = gtk_text_buffer_get_slice(this->textBuffer, &start, &end, FALSE);
-}
-
-void LatexDialog::load()
-{
-	XOJ_CHECK_TYPE(LatexDialog);
-	gtk_text_buffer_set_text(this->textBuffer, this->theLatex.c_str(), -1);
-
-	// preselect all text in the box if desired
-	if (this->preselect) {
-		GtkTextIter start, end;
-		gtk_text_buffer_get_start_iter(this->textBuffer, &start);
-		gtk_text_buffer_get_end_iter(this->textBuffer, &end);
-		gtk_text_buffer_select_range(this->textBuffer, &start, &end);
-	}
+	gchar* chars = gtk_text_buffer_get_text(this->textBuffer, &start, &end, false);
+	string s = chars;
+	g_free(chars);
+	return s;
 }
 
 void LatexDialog::show(GtkWindow *parent)
 {
+	this->show(parent, false);
+}
+
+void LatexDialog::show(GtkWindow *parent, bool selectText)
+{
 	XOJ_CHECK_TYPE(LatexDialog);
-	this->load();
+
+	gtk_text_buffer_set_text(this->textBuffer, this->finalLatex.c_str(), -1);
+	if (selectText)
+	{
+		GtkTextIter start, end;
+		gtk_text_buffer_get_bounds(this->textBuffer, &start, &end);
+		gtk_text_buffer_select_range(this->textBuffer, &start, &end);
+	}
+
 	gtk_window_set_transient_for(GTK_WINDOW(this->window), parent);
 	int res = gtk_dialog_run(GTK_DIALOG(this->window));
-	if (res == GTK_RESPONSE_OK)
-	{
-		this->save();
-	}
-	else
-	{
-		this->theLatex = "";
-	}
+	this->finalLatex = res == GTK_RESPONSE_OK ? this->getBufferContents() : "";
 
 	gtk_widget_hide(this->window);
 }

--- a/src/gui/dialog/LatexDialog.h
+++ b/src/gui/dialog/LatexDialog.h
@@ -20,17 +20,26 @@
 class LatexDialog : public GladeGui
 {
   public:
+	LatexDialog() = delete;
+	LatexDialog(const LatexDialog& other) = delete;
+	LatexDialog& operator=(const LatexDialog& other) = delete;
 	LatexDialog(GladeSearchpath* gladeSearchPath);
 	virtual ~LatexDialog();
 
   public:
+	/**
+	 * Show the dialog.
+	 */
 	virtual void show(GtkWindow* parent);
-	void save();
-	void load();
+
+	/**
+	 * Show the dialog, optionally selecting the text field contents by default.
+	 */
+	void show(GtkWindow* parent, bool selectTex);
 
 	// Set and retrieve text from text box
-	void setTex(string texString, bool preselect = false);
-	string getTex();
+	void setFinalTex(string texString);
+	string getFinalTex();
 
 	//Set and retrieve temporary Tex render
 	void setTempRender(PopplerDocument* pdf);
@@ -38,6 +47,11 @@ class LatexDialog : public GladeGui
 	// Necessary for the controller in order to connect the 'text-changed'
 	// signal handler
 	GtkTextBuffer* getTextBuffer();
+
+	/**
+	 * @return The contents of the formula input text buffer.
+	 */
+	string getBufferContents();
 
   private:
 	XOJ_TYPE_ATTRIB;
@@ -51,6 +65,8 @@ class LatexDialog : public GladeGui
 	GtkWidget* texBox;
 	GtkTextBuffer* textBuffer;
 
-	string theLatex;
-	bool preselect = false;
+	/**
+	 * The final LaTeX string to save once the dialog is closed.
+	 */
+	string finalLatex;
 };


### PR DESCRIPTION
This PR refactors the LaTeX tool code to be simpler, purely for maintenance purposes.

- Removed redundant variables
- Made data flow of the latex string explicit
- Marked the "invalid latex" message for localization
- Renamed some variables/methods for clarity
- Minor code cleanup
- Added documentation

Let me know if there are any regressions. If not, I will be merging this in three days.