### PR TITLE
Try Alternate Toolbar Menu Ordering

### DIFF
--- a/src/gui/MainWindowToolbarMenu.cpp
+++ b/src/gui/MainWindowToolbarMenu.cpp
@@ -174,7 +174,7 @@ void MainWindowToolbarMenu::updateToolbarMenu(GtkMenuShell* menubar, Settings* s
 
 	inPredefinedSection = true;
 
-	int menuPos = 0;
+	int menuPos = 3;
 	for (ToolbarData* d : *toolbar->getModel()->getToolbars())
 	{
 		addToolbarMenuEntry(d, menubar, menuPos);

--- a/ui/main.glade
+++ b/ui/main.glade
@@ -289,43 +289,6 @@
                       </object>
                     </child>
                     <child>
-                      <object class="GtkMenuItem" id="menuitemEditToolbar">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">T_oolbars</property>
-                        <property name="use_underline">True</property>
-                        <child type="submenu">
-                          <object class="GtkMenu" id="menuEditToolbar">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <child>
-                              <object class="GtkMenuItem" id="menuEditToolbarManage">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">_Manage</property>
-                                <property name="use_underline">True</property>
-                                <signal name="activate" handler="ACTION_MANAGE_TOOLBAR" swapped="no"/>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkMenuItem" id="menuEditToolbarCustomize">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">_Customize</property>
-                                <property name="use_underline">True</property>
-                                <signal name="activate" handler="ACTION_CUSTOMIZE_TOOLBAR" swapped="no"/>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                     </child>                    
-                     <child>
-                      <object class="GtkSeparatorMenuItem" id="menuitem4B">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                      </object>
-                    </child>                   <child>
                       <object class="GtkMenuItem" id="menuEditSettings">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>

--- a/ui/main.glade
+++ b/ui/main.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.18.3 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
   <object class="GtkAdjustment" id="adjHorizontal">
@@ -92,8 +92,8 @@
                         <property name="use_underline">True</property>
                         <property name="use_stock">True</property>
                         <signal name="activate" handler="ACTION_SAVE_AS" swapped="no"/>
-                        <accelerator key="s" signal="activate" modifiers="GDK_SHIFT_MASK | GDK_CONTROL_MASK"/>
                         <accelerator key="u" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                        <accelerator key="s" signal="activate" modifiers="GDK_SHIFT_MASK | GDK_CONTROL_MASK"/>
                       </object>
                     </child>
                     <child>
@@ -289,6 +289,43 @@
                       </object>
                     </child>
                     <child>
+                      <object class="GtkMenuItem" id="menuitemEditToolbar">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">T_oolbars</property>
+                        <property name="use_underline">True</property>
+                        <child type="submenu">
+                          <object class="GtkMenu" id="menuEditToolbar">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <child>
+                              <object class="GtkMenuItem" id="menuEditToolbarManage">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">_Manage</property>
+                                <property name="use_underline">True</property>
+                                <signal name="activate" handler="ACTION_MANAGE_TOOLBAR" swapped="no"/>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkMenuItem" id="menuEditToolbarCustomize">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">_Customize</property>
+                                <property name="use_underline">True</property>
+                                <signal name="activate" handler="ACTION_CUSTOMIZE_TOOLBAR" swapped="no"/>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                     </child>                    
+                     <child>
+                      <object class="GtkSeparatorMenuItem" id="menuitem4B">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                      </object>
+                    </child>                   <child>
                       <object class="GtkMenuItem" id="menuEditSettings">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
@@ -661,12 +698,6 @@
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <child>
-                              <object class="GtkSeparatorMenuItem" id="separatormenuitem16">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                              </object>
-                            </child>
-                            <child>
                               <object class="GtkMenuItem" id="menuViewToolbarManage">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
@@ -684,7 +715,13 @@
                                 <signal name="activate" handler="ACTION_CUSTOMIZE_TOOLBAR" swapped="no"/>
                               </object>
                             </child>
-                          </object>
+                             <child>
+                              <object class="GtkSeparatorMenuItem" id="separatormenuitem16">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                              </object>
+                            </child>
+                         </object>
                         </child>
                       </object>
                     </child>
@@ -717,8 +754,8 @@
                         <property name="use_underline">True</property>
                         <property name="use_stock">True</property>
                         <signal name="activate" handler="ACTION_ZOOM_IN" swapped="no"/>
-                        <accelerator key="plus" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                         <accelerator key="KP_Add" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                        <accelerator key="plus" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                       </object>
                     </child>
                     <child>
@@ -729,8 +766,8 @@
                         <property name="use_underline">True</property>
                         <property name="use_stock">True</property>
                         <signal name="activate" handler="ACTION_ZOOM_OUT" swapped="no"/>
-                        <accelerator key="minus" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                         <accelerator key="KP_Subtract" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                        <accelerator key="minus" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                       </object>
                     </child>
                     <child>


### PR DESCRIPTION
fixes #1187 - positions the Manage and Customize options at the top of the Toolbar submenu instead of the bottom.
This is just a suggestion... might be my preference and no one else's?
The initial commit also tries a Toolbar submenu under the Edit menu - which is where I've naturally looked for the Toolbar customization in the past but doesn't quite feel right now?
