### PR TITLE
Fix support for relocatable installations

### DIFF
--- a/src/control/XournalMain.cpp
+++ b/src/control/XournalMain.cpp
@@ -509,6 +509,19 @@ string XournalMain::findResourcePath(string searchFile)
 		return relative5.getParentPath().str();
 	}
 
+	// -----------------------------------------------------------------------
+
+	// Check for .../share resources directory relative to binary to support
+	// relocatable installations (such as e.g., AppImages)
+	Path relative6 = executableDir;
+	relative6 /= "../share/xournalpp/";
+	relative6 /= searchFile;
+
+	if (relative6.exists())
+	{
+		return relative6.getParentPath().str();
+	}
+
 	// Not found
 	return "";
 }


### PR DESCRIPTION
Had to amend my commit 3 times, since you use tabs. But it should be alright now.

This PR implements support for relocatable installations, such as AppImages. Paths such as in `/usr` should never be hardcoded to `/`, not even if you respect the install prefix (you seem to do, the header responsible for that data is auto-generated). Instead, it's much better to detect paths relative to the currently running binary directory. Since this is `.../usr/bin` and the data is installed into `.../usr/share/xournalpp`, it's quite simple to deduce the relative path from the executable dir. Your code already provides that directory as a variable, so it was quite simple to fix this.

More information: https://docs.appimage.org/reference/best-practices.html#binaries-must-not-use-compiled-in-absolute-paths

This is most useful to the AppImage #944 and #1182. This PR makes that usable, otherwise loading of the about dialog's resources fails.
![screenshot_2019-06-03_22-43-31](https://user-images.githubusercontent.com/4503202/58833307-07a15f80-8651-11e9-95ee-99347517bf6c.png)

It'd be quite simple to improve the function in question a bit to contain less redundant code and be easier to debug by using a loop to iterate over all options. I'd like to send another PR for that, if you approve this idea.
