### PR TITLE
spelling fix, po/de.po

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -20,6 +20,10 @@ msgstr ""
 "X-Generator: Poedit 2.2.1\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+#: ../ui/settings.glade:3259
+msgid "         Settings:     "
+msgstr "\tEinstellungen:\t"
+
 #: ../src/undo/AddUndoAction.cpp:119 ../src/undo/DeleteUndoAction.cpp:113
 msgid " elements"
 msgstr "Elemente"
@@ -45,1475 +49,13 @@ msgstr " Linie"
 msgid " text"
 msgstr " Text"
 
-#: ../src/control/settings/Settings.cpp:108
-msgid "%F-Note-%H-%M"
-msgstr "%F-Notiz-%H-%M"
-
-#: ../src/control/XournalMain.cpp:316
-msgid "Absolute path for the audio files playback"
-msgstr "Absoluter Pfad für die Audiodateien"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:463
-msgid "Add/Edit Tex"
-msgstr "LaTeX  editieren/hinzufügen"
-
-#: ../src/control/stockdlg/XojOpenDlg.cpp:53
-msgid "All files"
-msgstr "Alle Dateien"
-
-#: ../src/control/pagetype/PageTypeMenu.cpp:257
-msgid "Apply to all pages"
-msgstr "Auf alle Seiten anwenden"
-
-#: ../src/control/pagetype/PageTypeMenu.cpp:246
-msgid "Apply to current page"
-msgstr "Auf aktuelle Seite anwenden"
-
-#: ../src/control/stockdlg/ImageOpenDlg.cpp:30
-#: ../src/control/stockdlg/XojOpenDlg.cpp:154
-msgid "Attach file to the journal"
-msgstr "Datei ans .xoj anhängen"
-
-#: ../src/control/xojfile/LoadHandlerHelper.cpp:140
-msgid "Attribute \"{1}\" could not be parsed as double, the value is \"{2}\""
-msgstr ""
-"Attribut \"{1}\" konnte nicht als Fließkommazahl ausgelesen werden, der Wert "
-"ist \"{2}\""
-
-#: ../src/control/xojfile/LoadHandlerHelper.cpp:132
-msgid "Attribute \"{1}\" could not be parsed as double, the value is NULL"
-msgstr ""
-"Attribut \"{1}\" konnte nicht als Fließkommazahl ausgelesen werden, der Wert "
-"ist NULL"
-
-#: ../src/control/xojfile/LoadHandlerHelper.cpp:160
-#: ../src/control/xojfile/LoadHandlerHelper.cpp:183
-msgid "Attribute \"{1}\" could not be parsed as int, the value is \"{2}\""
-msgstr ""
-"Attribut \"{1}\" konnte nicht als Ganzzahl ausgelesen werden, der Wert ist "
-"\"{1}\""
-
-#: ../src/control/xojfile/LoadHandlerHelper.cpp:152
-msgid "Attribute \"{1}\" could not be parsed as int, the value is NULL"
-msgstr ""
-"Attribut \"{1}\" konnte nicht als Ganzzahl ausgelesen werden, der Wert ist "
-"NULL"
-
-#: ../src/control/xojfile/LoadHandlerHelper.cpp:205
-#: ../src/control/xojfile/LoadHandlerHelper.cpp:228
-msgid "Attribute \"{1}\" could not be parsed as size_t, the value is \"{2}\""
-msgstr ""
-"Attribut \"{1}\" konnte nicht als size_t ausgelesen werden, der Wert ist "
-"\"{2}\""
-
-#: ../src/control/xojfile/LoadHandlerHelper.cpp:197
-msgid "Attribute \"{1}\" could not be parsed as size_t, the value is NULL"
-msgstr ""
-"Attribut \"{1}\" konnte nicht als size_t ausgelesen werden, der Wert ist NULL"
-
-#: ../src/control/xojfile/LoadHandlerHelper.cpp:70
-msgid "Attribute color not set!"
-msgstr "Attribut Farbe ist nicht gesetzt!"
-
-#: ../src/control/AudioController.cpp:152
-msgid ""
-"Audio folder not set! Recording won't work!\n"
-"Please set the recording folder under \"Preferences > Audio recording\""
-msgstr ""
-"Audio Ordner nicht gesetzt! Aufzeichnung wird nicht funktionieren!\n"
-"Bitte den Ordner festlegen unter \"Einstellungen > Audioaufzeichnung\""
-
-#: ../src/control/Control.cpp:251
-msgid "Autosave failed with an error: {1}"
-msgstr "Autospeichern fehlgeschlagen mit Fehler: {1}"
-
-#: ../src/control/jobs/AutosaveJob.cpp:25
-msgid "Autosave: {1}"
-msgstr "Autospeichern: {1}"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:432
-msgid "Back"
-msgstr "Zurück"
-
-#: ../src/gui/sidebar/previews/layer/SidebarPreviewLayerEntry.cpp:22
-#: ../src/gui/toolbarMenubar/ToolPageLayer.cpp:270
-#: ../src/gui/toolbarMenubar/ToolPageLayer.cpp:322
-msgid "Background"
-msgstr "Hintergrund"
-
-#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:10
-#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:136
-msgid "Black"
-msgstr "Schwarz"
-
-#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:14
-#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:140
-msgid "Blue"
-msgstr "Blau"
-
-#: ../src/control/Control.cpp:2293 ../src/control/Control.cpp:2832
-#: ../src/control/Control.cpp:2874 ../src/control/XournalMain.cpp:138
-msgid "Cancel"
-msgstr "Abbrechen"
-
-#: ../src/undo/ColorUndoAction.cpp:119
-msgid "Change color"
-msgstr "Farbe ändern"
-
-#: ../src/undo/FontUndoAction.cpp:134
-msgid "Change font"
-msgstr "Schriftart ändern"
-
-#: ../src/undo/FillUndoAction.cpp:117
-msgid "Change stroke fill"
-msgstr "Figurenfüllung ändern"
-
-#: ../src/undo/SizeUndoAction.cpp:139
-msgid "Change stroke width"
-msgstr "Liniendicke ändern"
-
-#: ../src/control/xojfile/LoadHandlerHelper.cpp:98
-msgid "Color \"{1}\" unknown (not defined in default color list)!"
-msgstr "Farbe \"{1}\" unbekannt (nicht in der Farbliste)"
-
-#: ../src/gui/sidebar/indextree/SidebarIndexPage.cpp:276
-msgid "Contents"
-msgstr "Inhalt"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:405
-#: ../src/gui/toolbarMenubar/model/ToolbarModel.cpp:114
-#: ../src/gui/toolbarMenubar/model/ToolbarModel.cpp:122
-msgid "Copy"
-msgstr "Kopieren"
-
-#: ../src/control/pagetype/PageTypeHandler.cpp:30
-msgid "Copy current"
-msgstr "Aktuellen Hintergrund kopieren"
-
-#: ../src/undo/CopyUndoAction.cpp:81
-msgid "Copy page"
-msgstr "Kopiere Seite"
-
-#: ../src/control/LatexController.cpp:93
-msgid "Could not convert tex to PDF: {1} (exit code: {2})"
-msgstr "Konnte TeX nicht nach PDF Konvertieren: {1} (exit code: {2})"
-
-#: ../src/control/jobs/SaveJob.cpp:137
-msgid ""
-"Could not create backup! (The file was created from an older Xournal version)"
-msgstr ""
-"Konnte kein Backup erstellen! (Diese Datei wurde mit einer alten Version von "
-"Xournal erstellt.)"
-
-#: ../src/util/Util.cpp:94
-msgid "Could not create folder: {1}"
-msgstr "Konnte den Ordner \"{1}\" nicht erstellen"
-
-#: ../src/control/LatexController.cpp:400
-msgid ""
-"Could not find pdflatex in Path.\n"
-"Please install pdflatex first and make sure it's in the Path."
-msgstr ""
-"Konnte pdflatex nicht im Pfad finden.\n"
-"Bitte installieren Sie pdflatex und stellen sicher, das es im Pfad "
-"eingetragen ist."
-
-#: ../src/control/LatexController.cpp:356
-msgid "Could not load LaTeX PDF file"
-msgstr "Konnte LaTeX PDF Datei nicht öffnen: \"{1}\""
-
-#: ../src/control/LatexController.cpp:341
-msgid "Could not load LaTeX PDF file, File Error: {1}"
-msgstr "Die LaTeX-PDF Datei konnte nicht geladen werden, Datei Fehler: {1}"
-
-#: ../src/control/LatexController.cpp:349
-msgid "Could not load LaTeX PDF file: {1}"
-msgstr "Konnte LaTeX PDF Datei nicht öffnen: \"{1}\""
-
-#: ../src/control/pagetype/PageTypeHandler.cpp:18
-msgid "Could not load pagetemplates.ini file"
-msgstr "Konnte die Datei pagetemplates.ini nicht öffnen"
-
-#: ../src/control/xojfile/LoadHandler.cpp:984
-msgid "Could not open attachment: {1}. Error message: Could not read file"
-msgstr ""
-"Der Anhang {1} konnte nicht geladen werden. Fehlermeldung: Konnte Datei "
-"nicht lesen"
-
-#: ../src/control/xojfile/LoadHandler.cpp:993
-msgid "Could not open attachment: {1}. Error message: Could not write file"
-msgstr ""
-"Der Anhang {1} konnte nicht geladen werden. Fehlermeldung: Konnte Datei "
-"nicht schreiben"
-
-#: ../src/control/xojfile/LoadHandler.cpp:963
-#: ../src/control/xojfile/LoadHandler.cpp:1291
-#: ../src/control/xojfile/LoadHandler.cpp:1311
-msgid ""
-"Could not open attachment: {1}. Error message: No valid file size provided"
-msgstr ""
-"Der Anhang {1} konnte nicht geladen werden. Fehlermeldung: Keine gültige "
-"Größe angegeben"
-
-#: ../src/control/xojfile/LoadHandler.cpp:953
-#: ../src/control/xojfile/LoadHandler.cpp:971
-#: ../src/control/xojfile/LoadHandler.cpp:1282
-#: ../src/control/xojfile/LoadHandler.cpp:1299
-msgid "Could not open attachment: {1}. Error message: {2}"
-msgstr "Der Anhang {1} konnte nicht geladen werden. Fehlermeldung: {2}"
-
-#: ../src/control/xojfile/LoadHandler.cpp:193
-msgid "Could not open file: \"{1}\""
-msgstr "Konnte die Datei nicht öffnen: \"{1}\""
-
-#: ../src/gui/MainWindow.cpp:82
-msgid ""
-"Could not parse custom toolbar.ini file: {1}\n"
-"Toolbars will not be available"
-msgstr ""
-"Konnte die benutzerdefinierte Datei toolbar.ini nicht lesen: {1}\n"
-"Es werden keine Werkzeugleisten zur Verfügung stehen"
-
-#: ../src/gui/MainWindow.cpp:72
-msgid ""
-"Could not parse general toolbar.ini file: {1}\n"
-"No Toolbars will be available"
-msgstr ""
-"Konnte die globale Datei toolbar.ini nicht lesen: {1}\n"
-"Es werden keine Werkzeugleisten zur Verfügung stehen"
-
-#: ../src/control/xojfile/LoadHandler.cpp:437
-#: ../src/control/xojfile/LoadHandler.cpp:465
-msgid "Could not read image: {1}. Error message: {2}"
-msgstr "Das Bild {1} konnte nicht geladen werden. Fehlermeldung: {2}"
-
-#: ../src/undo/UndoRedoHandler.cpp:175
-msgid ""
-"Could not redo \"{1}\"\n"
-"Something went wrong… Please write a bug report…"
-msgstr ""
-"Konnte '{1}' nicht wiederherstellen\n"
-"Etwas ist schief gelaufen… Bitte erstellen Sie einen Fehlerbericht…"
-
-#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:210
-msgid "Could not remove tool item from Toolbar {1} on position {2}"
-msgstr ""
-"Konnte Werkzeug von der Werkzeugleiste {1} Position {2} nicht entfernen"
-
-#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:205
-msgid "Could not remove tool item {1} from Toolbar {2} on position {3}"
-msgstr ""
-"Konnte Werkzeug {1} von der Werkzeugleiste {2} Position {3} nicht entfernen"
-
-#: ../src/control/Control.cpp:238
-msgid "Could not rename autosave file from \"{1}\" to \"{2}\": {3}"
-msgstr "Konnte Datei \"{1}\" nicht umbenennen zu \"{2}\""
-
-#: ../src/control/LatexController.cpp:79
-msgid "Could not save .tex file: {1}"
-msgstr "Konnte .tex Datei \"{1}\" nicht speichern:"
-
-#: ../src/undo/UndoRedoHandler.cpp:138
-msgid ""
-"Could not undo \"{1}\"\n"
-"Something went wrong… Please write a bug report…"
-msgstr ""
-"Konnte '{1}' nicht rückgängig machen\n"
-"Etwas ist schief gelaufen... Bitte erstellen Sie einen Fehlerbericht…"
-
-#: ../src/control/xojfile/SaveHandler.cpp:290
-msgid "Could not write background \"{1}\", {2}"
-msgstr "Konnte Hintergrund \"{1}\" nicht speichern, {2}"
-
-#: ../src/control/xojfile/SaveHandler.cpp:410
-msgid "Could not write background \"{1}\". Continuing anyway."
-msgstr "Konnte Hintergrund nicht speichern \"{1}\". Fahre trotzdem fort."
-
-#: ../src/gui/toolbarMenubar/ToolPageLayer.cpp:109
-msgid "Create new layer"
-msgstr "Neue Ebene erstellen"
-
-#: ../src/gui/dialog/FormatDialog.cpp:72
-msgid "Custom"
-msgstr "Benutzerdefiniert"
-
-#: ../src/control/jobs/CustomExportJob.cpp:18
-msgid "Custom Export"
-msgstr "Benutzerdefinierter Export"
-
-#: ../src/gui/dialog/ToolbarManageDialog.cpp:38
-msgid "Customized"
-msgstr "Anpassen"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:404
-msgid "Cut"
-msgstr "Ausschneiden"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:465
-msgid "Default Tool"
-msgstr "Standard Werkzeug"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:410
-#: ../src/undo/DeleteUndoAction.cpp:102
-msgid "Delete"
-msgstr "Löschen"
-
-#: ../src/control/XournalMain.cpp:137
-msgid "Delete Logfile"
-msgstr "Logdatei löschen"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:450
-msgid "Delete current page"
-msgstr "Aktuelle Seite löschen"
-
-#: ../src/control/XournalMain.cpp:187
-msgid "Delete file"
-msgstr "Datei löschen"
-
-#: ../src/undo/RemoveLayerUndoAction.cpp:41
-msgid "Delete layer"
-msgstr "Ebene löschen"
-
-#: ../src/control/Control.cpp:2828 ../src/control/Control.cpp:2873
-msgid "Discard"
-msgstr "Verwerfen"
-
-#: ../src/control/Control.cpp:2223
-msgid ""
-"Do not open Autosave files. They may will be overwritten!\n"
-"Copy the files to another folder.\n"
-"Files from Folder {1} cannot be opened."
-msgstr ""
-"Öffnen sie keine automatisch gespeicherten Dateien. Diese werden ansonsten "
-"überschrieben!\n"
-"Kopieren Sie diese Dateien an einen anderen Ort.\n"
-"Dateien aus dem Ordner {1} können nicht geöffnet werden."
-
-#: ../src/control/jobs/BaseExportJob.cpp:46
-msgid "Do not overwrite the background PDF! This will cause errors!"
-msgstr ""
-"Das Hintergrund PDF darf nicht überschrieben werden! Dies verursacht Fehler!"
-
-#: ../src/control/Control.cpp:2870
-msgid "Document file was removed."
-msgstr "Datei des Dokuments wurde entfernt."
-
-#: ../src/control/xojfile/LoadHandler.cpp:293
-msgid "Document is not complete (maybe the end is cut off?)"
-msgstr "Dokument ist nicht vollständig (z.B. nicht komplett übertragen?)"
-
-#: ../src/model/Document.cpp:389 ../src/model/Document.cpp:399
-msgid "Document not loaded! ({1}), {2}"
-msgstr "Dokument nicht geladen! ({1}), {2}"
-
-#: ../src/control/pagetype/PageTypeHandler.cpp:26
-msgid "Dotted"
-msgstr "Gepunktet"
-
-#: ../src/gui/dialog/ButtonConfigGui.cpp:106
-#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:32
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:470
-msgid "Draw Arrow"
-msgstr "Pfeil zeichnen"
-
-#: ../src/gui/dialog/ButtonConfigGui.cpp:104
-#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:31
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:469
-msgid "Draw Circle"
-msgstr "Kreis zeichnen"
-
-#: ../src/gui/dialog/ButtonConfigGui.cpp:100
-#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:33
-msgid "Draw Line"
-msgstr "Strecke zeichnen"
-
-#: ../src/gui/dialog/ButtonConfigGui.cpp:102
-#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:23
-#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:30
-#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:112
-#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:115
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:468
-msgid "Draw Rectangle"
-msgstr "Rechteck Zeichnen"
-
-#: ../src/gui/dialog/ButtonConfigGui.cpp:108
-#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:34
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:471
-msgid "Draw coordinate system"
-msgstr "Koordinatensystem zeichnen"
-
-#: ../src/undo/InsertUndoAction.cpp:40
-msgid "Draw stroke"
-msgstr "Linie zeichen"
-
-#: ../src/gui/dialog/ButtonConfigGui.cpp:96
-msgid "Drawing Type - don't change"
-msgstr "Zeichnungstyp - nicht ändern"
-
-#: ../src/undo/TextBoxUndoAction.cpp:52
-msgid "Edit text"
-msgstr "Text schreiben"
-
-#: ../src/undo/EmergencySaveRestore.cpp:36
-msgid "Emergency saved document"
-msgstr "Notfall gespeichertes Dokument"
-
-#: ../src/undo/AddUndoAction.cpp:104 ../src/undo/DeleteUndoAction.cpp:99
-#: ../src/undo/EraseUndoAction.cpp:129
-msgid "Erase stroke"
-msgstr "Linie löschen"
-
-#: ../src/gui/dialog/ButtonConfigGui.cpp:64
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:311
-msgid "Eraser"
-msgstr "Radierer"
-
-#: ../src/control/Control.cpp:2518
-msgid ""
-"Error annotate PDF file \"{1}\"\n"
-"{2}"
-msgstr ""
-"Fehler beim Öffnen des PDFs \"{1}\"\n"
-"{2}"
-
-#: ../src/gui/GladeGui.cpp:24
-msgid "Error loading glade file \"{1}\" (try to load \"{2}\")"
-msgstr "Fehler beim Laden der Glade-Datei \"{1}\" (Datei \"{2}\")"
-
-#: ../src/control/Control.cpp:2318
-msgid "Error opening file \"{1}\""
-msgstr "Fehler beim Öffnen der Datei '{1}'"
-
-#: ../src/util/OutputStream.cpp:35
-msgid "Error opening file: \"{1}\""
-msgstr "Fehler beim Öffnen der Datei '{1}'"
-
-#: ../src/control/xojfile/LoadHandler.cpp:560
-#: ../src/control/xojfile/LoadHandler.cpp:587
-msgid "Error reading PDF: {1}"
-msgstr "Fehler beim Lesen des PDFs: {1}"
-
-#: ../src/control/xojfile/LoadHandler.cpp:658
-msgid "Error reading width of a stroke: {1}"
-msgstr "Fehler beim Lesen der Dicke einer Linie: {1}"
-
-#: ../src/control/jobs/ImageExport.cpp:143
-msgid "Error save image #1"
-msgstr "Fehler beim Speichern des Bildes #1"
-
-#: ../src/control/jobs/ImageExport.cpp:160
-msgid "Error save image #2"
-msgstr "Fehler beim Speichern des Bildes #2"
-
-#: ../src/util/CrashHandler.cpp:47
-msgid "Error: {1}"
-msgstr "Fehler: {1}"
-
-#: ../src/control/XournalMain.cpp:161
-msgid ""
-"Errorlog cannot be deleted. You have to do it manually.\n"
-"Logfile: {1}"
-msgstr ""
-"Fehlerlog konnte nicht gelöscht werden. Sie müssen die Datei manuell "
-"löschen.\n"
-"Logdatei: {1}"
-
-#: ../src/control/jobs/BaseExportJob.cpp:24
-msgid "Export PDF"
-msgstr "Exportieren als PDF"
-
-#: ../src/control/LatexController.cpp:417
-msgid "Failed to generate LaTeX image!"
-msgstr "Fehler beim erstellen des LaTeX Bildes!"
-
-#: ../src/util/Util.cpp:123 ../src/util/Util.cpp:143
-msgid ""
-"File couldn't be opened. You have to do it manually:\n"
-"URL: {1}"
-msgstr ""
-"Datei konnte nicht geöffnet werden, Sie müssen sie manuell öffnen\n"
-":URL: {1}"
-
-#: ../src/control/Control.cpp:2253
-msgid "Filename: {1}"
-msgstr "Dateiname: {1}"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:509
-msgid "Fill"
-msgstr "Füllung"
-
-#: ../src/gui/toolbarMenubar/FontButton.cpp:71
-msgid "Font"
-msgstr "Schriftart"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:431
-msgid "Go to first page"
-msgstr "Gehe zur ersten Seite"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:435
-msgid "Go to last page"
-msgstr "Gehe zur letzten Seite"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:438
-msgid "Go to next layer"
-msgstr "Zur nächsten Ebene springen"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:433
-msgid "Go to page"
-msgstr "Gehe zur Seite"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:437
-msgid "Go to previous layer"
-msgstr "Zur vorherigen Ebene springen"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:439
-msgid "Go to top layer"
-msgstr "Zur obersten Ebene springen"
-
-#: ../src/control/pagetype/PageTypeHandler.cpp:25
-msgid "Graph"
-msgstr "Kariert"
-
-#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:15
-#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:141
-msgid "Gray"
-msgstr "Grau"
-
-#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:11
-#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:137
-msgid "Green"
-msgstr "Grün"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:414
-msgid "Grid Snapping"
-msgstr "Am Raster einrasten"
-
-#: ../src/gui/dialog/ButtonConfigGui.cpp:71
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:479
-msgid "Hand"
-msgstr "Hand"
-
-#: ../src/gui/toolbarMenubar/ToolPageLayer.cpp:99
-msgid "Hide all"
-msgstr "Alle ausblenden"
-
-#: ../src/gui/dialog/ButtonConfigGui.cpp:65
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:460
-msgid "Highlighter"
-msgstr "Textmarker"
-
-#: ../src/control/pagetype/PageTypeHandler.cpp:32
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:464
-msgid "Image"
-msgstr "Bild"
-
-#: ../src/control/XournalMain.cpp:259
-msgid "Image file successfully created"
-msgstr "Bild erfolgreich erstellt"
-
-#: ../src/control/XournalMain.cpp:314
-msgid "Image output filename (.png / .svg)"
-msgstr "Dateiname der Bild-Ausgabe (.png / .svg)"
-
-#: ../src/control/stockdlg/ImageOpenDlg.cpp:18
-msgid "Images"
-msgstr "Bilddateien"
-
-#: ../src/undo/InsertUndoAction.cpp:116
-msgid "Insert elements"
-msgstr "Elemente einfügen"
-
-#: ../src/gui/dialog/ButtonConfigGui.cpp:67 ../src/undo/InsertUndoAction.cpp:48
-msgid "Insert image"
-msgstr "Bild einfügen"
-
-#: ../src/undo/InsertUndoAction.cpp:52
-msgid "Insert latex"
-msgstr "LaTeX einfügen"
-
-#: ../src/undo/InsertLayerUndoAction.cpp:40
-msgid "Insert layer"
-msgstr "Ebene einfügen"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:446
-msgid "Insert page"
-msgstr "Seite einfügen"
-
-#: ../src/control/XournalMain.cpp:315
-msgid "Jump to Page (first Page: 1)"
-msgstr "Springe zur Seite (erste Seite: 1)"
-
-#: ../src/gui/toolbarMenubar/ToolPageLayer.cpp:348
-msgid "Layer"
-msgstr "Ebene"
-
-#: ../src/gui/sidebar/previews/layer/SidebarPreviewLayers.cpp:79
-msgid "Layer Preview"
-msgstr "Ebenen-Vorschau"
-
-#: ../src/gui/toolbarMenubar/ToolPageLayer.cpp:331
-msgid "Layer selection"
-msgstr "Ebenenauswahl"
-
-#: ../src/gui/sidebar/previews/layer/SidebarPreviewLayerEntry.cpp:26
-#: ../src/gui/toolbarMenubar/ToolPageLayer.cpp:260
-#: ../src/gui/toolbarMenubar/ToolPageLayer.cpp:318
-msgid "Layer {1}"
-msgstr "Ebene {1}"
-
-#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:12
-#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:138
-msgid "Light Blue"
-msgstr "Hellblau"
-
-#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:13
-#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:139
-msgid "Light Green"
-msgstr "Hellgrün"
-
-#: ../src/control/pagetype/PageTypeHandler.cpp:23
-msgid "Lined"
-msgstr "Liniert mit Rand"
-
-#: ../src/gui/PageView.cpp:747
-#: ../src/gui/sidebar/previews/base/SidebarPreviewBaseEntry.cpp:103
-#: ../src/gui/toolbarMenubar/ToolPageLayer.cpp:18
-msgid "Loading..."
-msgstr "Laden..."
-
-#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:17
-#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:143
-msgid "Mangenta"
-msgstr "Magenta"
-
-#: ../src/gui/dialog/ButtonConfigGui.cpp:88
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:523
-msgid "Medium"
-msgstr "Mittel"
-
-#: ../src/control/XournalMain.cpp:540
-msgid ""
-"Missing the needed UI file! .app corrupted?\n"
-"Path: {1}"
-msgstr ""
-"Fehlende UI Datei! .app Fehlerhaft?\n"
-"Pfad: {1}"
-
-#: ../src/control/XournalMain.cpp:554
-msgid ""
-"Missing the needed UI file, could not find them at any location.\n"
-"Not relative\n"
-"Not in the Working Path\n"
-"Not in {1}"
-msgstr ""
-"Konnte die nötigen UI Dateien nicht finden!\n"
-"Nicht relativ\n"
-"Nicht im Arbeitspfad\n"
-"Nicht in {1}"
-
-#: ../src/undo/MoveUndoAction.cpp:20
-msgid "Move"
-msgstr "Verschieben"
-
-#: ../src/undo/MoveLayerUndoAction.cpp:38
-msgid "Move layer"
-msgstr "Ebene verschieben"
-
-#: ../src/undo/SwapUndoAction.cpp:88
-msgid "Move page downwards"
-msgstr "Verschiebe Seite nach unten"
-
-#: ../src/undo/SwapUndoAction.cpp:88
-msgid "Move page upwards"
-msgstr "Verschiebe Seite nach oben"
-
-#: ../src/gui/dialog/ToolbarManageDialog.cpp:90
-msgid "New"
-msgstr "Neu"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:391
-msgid "New Xournal"
-msgstr "Neues Xournal"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:434
-msgid "Next"
-msgstr "Nächste Seite"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:441
-msgid "Next annotated page"
-msgstr "Nächste beschriftete Seite"
-
-#: ../src/gui/dialog/ButtonConfigGui.cpp:44
-msgid "No device"
-msgstr "Kein Gerät"
-
-#: ../src/pdf/base/XojCairoPdfExport.cpp:93
-#: ../src/pdf/base/XojCairoPdfExport.cpp:142
-msgid "No pages to export!"
-msgstr "Keine Seite zu exportieren!"
-
-#: ../src/gui/dialog/ButtonConfigGui.cpp:98
-msgid "Normal drawing"
-msgstr "Normal zeichnen"
-
-#: ../src/plugin/Plugin.cpp:417 ../src/plugin/Plugin.cpp:438
-msgid "OK"
-msgstr "OK"
-
-#: ../src/control/jobs/BaseExportJob.cpp:113
-msgid ""
-"Only local files are supported\n"
-"Path: {1}"
-msgstr ""
-"Es werden nur lokale Dateien unterstützt\n"
-"Pfad: {1}"
-
-#: ../src/control/stockdlg/ImageOpenDlg.cpp:11
-msgid "Open Image"
-msgstr "Öffne Bild"
-
-#: ../src/control/XournalMain.cpp:135
-msgid "Open Logfile"
-msgstr "Öffne Logdatei"
-
-#: ../src/control/XournalMain.cpp:136
-msgid "Open Logfile directory"
-msgstr "Öffne Verzeichnis der Logdateien"
-
-#: ../src/control/stockdlg/XojOpenDlg.cpp:16
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:392
-msgid "Open file"
-msgstr "Öffne Datei"
-
-#: ../src/control/RecentManager.cpp:249
-msgctxt "{1} is a URI"
-msgid "Open {1}"
-msgstr "Öffne {1}"
-
-#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:18
-#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:144
-msgid "Orange"
-msgstr "Orange"
-
-#: ../src/control/jobs/PdfExportJob.cpp:9
-msgid "PDF Export"
-msgstr "PDF Exportieren"
-
-#: ../src/gui/MainWindow.cpp:802
-msgid "PDF Page {1}"
-msgstr "PDF-Seite {1}"
-
-#: ../src/view/PdfView.cpp:40
-msgid "PDF background missing"
-msgstr "PDF-Hintergrund fehlt"
-
-#: ../src/control/XournalMain.cpp:294
-msgid "PDF file successfully created"
-msgstr "PDF-Datei erfolgreich erstellt"
-
-#: ../src/control/jobs/CustomExportJob.cpp:23
-#: ../src/control/jobs/PdfExportJob.cpp:23
-#: ../src/control/stockdlg/XojOpenDlg.cpp:63
-msgid "PDF files"
-msgstr "PDF Dateien"
-
-#: ../src/control/XournalMain.cpp:313
-msgid "PDF output filename"
-msgstr "Dateiname der PDF-Ausgabe"
-
-#: ../src/control/jobs/CustomExportJob.cpp:24
-msgid "PDF with plain background"
-msgstr "PDF mit leerem Hintergrund"
-
-#: ../src/control/jobs/CustomExportJob.cpp:25
-msgid "PNG graphics"
-msgstr "PNG Bild"
-
-#: ../src/control/jobs/CustomExportJob.cpp:26
-msgid "PNG with transparent background"
-msgstr "PNG mit transparentem Hintergrund"
-
-#: ../src/gui/toolbarMenubar/ToolPageSpinner.cpp:67
-msgid "Page"
-msgstr "Seite"
-
-#: ../src/gui/sidebar/previews/page/SidebarPreviewPages.cpp:28
-msgid "Page Preview"
-msgstr "Seitenvorschau"
-
-#: ../src/undo/PageBackgroundChangedUndoAction.cpp:106
-msgid "Page background changed"
-msgstr "Seitenhintergrund geändert"
-
-#: ../src/undo/InsertDeletePageUndoAction.cpp:129
-msgid "Page deleted"
-msgstr "Seite gelöscht"
-
-#: ../src/undo/InsertDeletePageUndoAction.cpp:125
-msgid "Page inserted"
-msgstr "Seite hinzugefügt"
-
-#: ../src/gui/toolbarMenubar/ToolPageSpinner.cpp:49
-msgid "Page number"
-msgstr "Seitennummer"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:419
-msgid "Paired pages"
-msgstr "Mehrspaltig"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:406
-#: ../src/undo/AddUndoAction.cpp:108
-msgid "Paste"
-msgstr "Einfügen"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:485
-msgid "Pause / Play"
-msgstr "Pause / Play"
-
-#: ../src/gui/dialog/ButtonConfigGui.cpp:63
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:290
-msgid "Pen"
-msgstr "Stift"
-
-#: ../src/control/pagetype/PageTypeHandler.cpp:22
-msgid "Plain"
-msgstr "Einfarbig"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:478
-#: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:20
-#: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:89
-msgid "Play Object"
-msgstr "Objekt abspielen"
-
-#: ../src/gui/dialog/ToolbarManageDialog.cpp:23
-msgid "Predefined"
-msgstr "Vordefiniert"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:420
-msgid "Presentation mode"
-msgstr "Präsentationsmodus"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:484
-msgid "Record Audio / Stop Recording"
-msgstr "Aufzeichnung starten / stoppen"
-
-#: ../src/control/Control.cpp:970
-msgid "Recorder could not be started."
-msgstr "Aufzeichnung konnte nicht gestartet werden."
-
-#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:16
-#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:142
-msgid "Red"
-msgstr "Rot"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:400
-#: ../src/undo/UndoRedoHandler.cpp:287
-msgid "Redo"
-msgstr "Wiederherstellen"
-
-#: ../src/undo/UndoRedoHandler.cpp:281
-msgid "Redo: "
-msgstr "Wiederherstellen: "
-
-#: ../src/control/Control.cpp:2292
-msgid "Remove PDF Background"
-msgstr "PDF-Hintergrund entfernen"
-
-#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:198
-msgid "Removed tool item from Toolbar {1} ID {2}"
-msgstr "Entferne Werkzeug von der Werkzeugleiste {1} ID {2}"
-
-#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:194
-msgid "Removed tool item {1} from Toolbar {2} ID {3}"
-msgstr "Entferne Werkzeug {1} von der Werkzeugleiste {2} ID {3}"
-
-#: ../src/util/XojMsgBox.cpp:74
-msgid "Replace"
-msgstr "Ersetzen"
-
-#: ../src/control/xojfile/LoadHandler.cpp:1331
-msgid "Requested temporary file was not found for attachment {1}"
-msgstr "Angefragte temporäre Datei für Anhang {1} nicht gefunden"
-
-#: ../src/control/XournalMain.cpp:188
-msgid "Restore file"
-msgstr "Datei widerherstellen"
-
-#: ../src/undo/RotateUndoAction.cpp:74
-msgid "Rotation"
-msgstr "Drehung"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:413
-msgid "Rotation Snapping"
-msgstr "Drehung einrasten"
-
-#: ../src/control/pagetype/PageTypeHandler.cpp:24
-msgid "Ruled"
-msgstr "Liniert"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:472
-msgid "Ruler"
-msgstr "Lineal"
-
-#: ../src/control/jobs/CustomExportJob.cpp:27
-msgid "SVG graphics"
-msgstr "SVG Bild"
-
-#: ../src/control/jobs/CustomExportJob.cpp:28
-msgid "SVG with transparent background"
-msgstr "SVG mit transparentem Hintergrund"
-
-#: ../src/control/Control.cpp:2827 ../src/control/jobs/SaveJob.cpp:13
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:393
-msgid "Save"
-msgstr "Speichern"
-
-#: ../src/control/Control.cpp:2872
-msgid "Save As"
-msgstr "Speichern als…"
-
-#: ../src/control/Control.cpp:2638 ../src/gui/dialog/PageTemplateDialog.cpp:111
-msgid "Save File"
-msgstr "Speichere Datei"
-
-#: ../src/control/jobs/CustomExportJob.cpp:162
-#: ../src/control/jobs/SaveJob.cpp:151
-msgid "Save file error: {1}"
-msgstr "Fehler beim Speichern der Datei: {1}"
-
-#: ../src/undo/ScaleUndoAction.cpp:73
-msgid "Scale"
-msgstr "Skalieren"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:408
-msgid "Search"
-msgstr "Suchen"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:481
-msgid "Select Font"
-msgstr "Schriftart auswählen"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:476
-#: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:19
-#: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:82
-msgid "Select Object"
-msgstr "Objekt auswählen"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:475
-#: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:10
-#: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:17
-#: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:68
-#: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:108
-msgid "Select Rectangle"
-msgstr "Rechteck auswählen"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:474
-#: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:18
-#: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:75
-msgid "Select Region"
-msgstr "Bereich auswählen"
-
-#: ../src/control/Control.cpp:2291
-msgid "Select another PDF"
-msgstr "Andere PDF-Datei auswählen"
-
-#: ../src/util/XojMsgBox.cpp:73
-msgid "Select another name"
-msgstr "Anderen Namen wählen"
-
-#: ../src/gui/dialog/SelectBackgroundColorDialog.cpp:143
-msgid "Select background color"
-msgstr "Hintergrundfarbe wählen"
-
-#: ../src/gui/toolbarMenubar/ColorToolItem.cpp:59
-#: ../src/gui/toolbarMenubar/ColorToolItem.cpp:175
-msgid "Select color"
-msgstr "Farbe auswählen"
-
-#: ../src/gui/dialog/ButtonConfigGui.cpp:70
-msgid "Select rectangle"
-msgstr "Rechteck auswählen"
-
-#: ../src/gui/dialog/ButtonConfigGui.cpp:69
-msgid "Select region"
-msgstr "Bereich auswählen"
-
-#: ../src/control/XournalMain.cpp:134
-msgid "Send Bugreport"
-msgstr "Fehlerbericht senden"
-
-#: ../src/gui/dialog/toolbarCustomize/ToolbarCustomizeDialog.cpp:53
-msgid "Separator"
-msgstr "Trenner"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:467
-msgid "Shape Recognizer"
-msgstr "Figurenerkennung"
-
-#: ../src/gui/toolbarMenubar/ToolPageLayer.cpp:90
-msgid "Show all"
-msgstr "Alle anzeigen"
-
-#: ../src/gui/dialog/backgroundSelect/PdfPagesDialog.cpp:134
-msgid "Show only not used pages (one unused page)"
-msgstr "Nur nicht benutzte Seiten anzeigen (eine nicht benutzte Seiten)"
-
-#: ../src/gui/dialog/backgroundSelect/PdfPagesDialog.cpp:135
-msgid "Show only not used pages ({1} unused pages)"
-msgstr "Nur nicht benutzte Seiten anzeigen ({1} nicht benutzte Seiten)"
-
-#: ../src/control/XournalMain.cpp:388
-msgid ""
-"Sorry, Xournal++ can only open one file at once.\n"
-"Others are ignored."
-msgstr ""
-"Entschuldigung, Xournal++ kann nur eine Datei aufs mal öffnen.\n"
-"Alle weiteren werden ignoriert."
-
-#: ../src/control/XournalMain.cpp:403
-msgid ""
-"Sorry, Xournal++ cannot open remote files at the moment.\n"
-"You have to copy the file to a local directory."
-msgstr ""
-"Entschuldigung, Xournal++ kann derzeit keine entfernten Dateien öffnen.\n"
-"Kopieren Sie die Datei in einen lokalen Ordner."
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:487
-msgid "Stop"
-msgstr "Aufnahme stoppen"
-
-#: ../src/gui/dialog/ButtonConfigGui.cpp:110
-#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:35
-#: ../src/undo/RecognizerUndoAction.cpp:101
-msgid "Stroke recognizer"
-msgstr "Figurenerkennung"
-
-#: ../src/util/CrashHandler.cpp:51
-msgid "Successfully saved document to \"{1}\""
-msgstr "Dokument erfolgreich nach \"{1}\" gespeichert."
-
-#: ../src/control/stockdlg/XojOpenDlg.cpp:134
-msgid "Supported files"
-msgstr "Unterstützte Dateiformate"
-
-#: ../src/gui/dialog/ButtonConfigGui.cpp:66
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:462
-msgid "Text"
-msgstr "Text"
-
-#: ../src/gui/SearchBar.cpp:70
-#, c-format
-msgid "Text %i times found on this page"
-msgstr "Text auf dieser Seite %i mal gefunden"
-
-#: ../src/undo/TextUndoAction.cpp:47
-msgid "Text changes"
-msgstr "Text geändert"
-
-#: ../src/gui/SearchBar.cpp:66
-msgid "Text found on this page"
-msgstr "Text auf dieser Seite gefunden"
-
-#: ../src/gui/SearchBar.cpp:150 ../src/gui/SearchBar.cpp:206
-msgid "Text found once on page {1}"
-msgstr "Text einmal auf Seite {1} gefunden"
-
-#: ../src/gui/SearchBar.cpp:151 ../src/gui/SearchBar.cpp:207
-msgid "Text found {1} times on page {2}"
-msgstr "Text {1}-mal auf Seite {2} gefunden"
-
-#: ../src/gui/SearchBar.cpp:77
-msgid "Text not found"
-msgstr "Text nicht gefunden"
-
-#: ../src/gui/SearchBar.cpp:164 ../src/gui/SearchBar.cpp:220
-msgid "Text not found, searched on all pages"
-msgstr "Text nicht gefunden, auf allen Seiten gesucht"
-
-#: ../src/control/Control.cpp:1163
-msgid ""
-"The Toolbarconfiguration \"{1}\" is predefined, would you create a copy to "
-"edit?"
-msgstr ""
-"Die Werkzeugleistenkonfiguration \"{1}\" ist vordefiniert, möchten Sie eine "
-"Kopie erstellen?"
-
-#: ../src/control/Control.cpp:2288
-msgid "The attached background PDF could not be found."
-msgstr "Der angehängte PDF-Hintergrund konnte nicht gefunden werden."
-
-#: ../src/control/Control.cpp:2289
-msgid "The background PDF could not be found."
-msgstr "Der PDF-Hintergrund konnte nicht gefunden werden."
-
-#: ../src/control/xojfile/LoadHandler.cpp:150
-msgid "The file is no valid .xopp file (Mimetype missing): \"{1}\""
-msgstr "Die Datei ist keine gültige .xopp-Datei (Mimetype fehlt): \"{1}\""
-
-#: ../src/control/xojfile/LoadHandler.cpp:158
-msgid "The file is no valid .xopp file (Mimetype wrong): \"{1}\""
-msgstr "Die Datei ist keine gültige .xopp-Datei (Mimetype falsch): \"{1}\""
-
-#: ../src/control/xojfile/LoadHandler.cpp:167
-msgid "The file is no valid .xopp file (Version missing): \"{1}\""
-msgstr "Die Datei ist keine gültige .xopp-Datei (Version fehlt): \"{1}\""
-
-#: ../src/control/xojfile/LoadHandler.cpp:181
-msgid "The file is not a valid .xopp file (Version string corrupted): \"{1}\""
-msgstr ""
-"Die Datei ist keine gültige .xopp-Datei (Versionsdaten ungültig): \"{1}\""
-
-#: ../src/control/XournalMain.cpp:129
-msgid "The most recent log file name: {1}"
-msgstr "Der aktuelleste Logdateiname: {1}"
-
-#: ../src/control/XournalMain.cpp:122
-msgid ""
-"There are errorlogfiles from Xournal++. Please send a Bugreport, so the bug "
-"may be fixed."
-msgstr ""
-"Es ist ein Xournal++ Fehlerlog vorhanden. Bitte senden Sie einen "
-"Fehlerbericht (auf Englisch wenn möglich), damit der Fehler korrigiert "
-"werden kann."
-
-#: ../src/control/XournalMain.cpp:121
-msgid ""
-"There is an errorlogfile from Xournal++. Please send a Bugreport, so the bug "
-"may be fixed."
-msgstr ""
-"Es ist ein Xournal++ Fehlerlog vorhanden. Bitte senden Sie einen "
-"Fehlerbericht (auf Englisch wenn möglich), damit der Fehler korrigiert "
-"werden kann."
-
-#: ../src/util/XojMsgBox.cpp:89
-msgid "There was an error displaying help: {1}"
-msgstr "Es ist ein Fehler aufgetreten beim Anzeigen der Hilfe: {1}"
-
-#: ../src/gui/dialog/ButtonConfigGui.cpp:89
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:524
-msgid "Thick"
-msgstr "Dick"
-
-#: ../src/gui/dialog/ButtonConfigGui.cpp:86
-msgid "Thickness - don't change"
-msgstr "Dicke - nicht ändern"
-
-#: ../src/gui/dialog/ButtonConfigGui.cpp:87
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:522
-msgid "Thin"
-msgstr "Dünn"
-
-#: ../src/control/Control.cpp:2825
-msgid "This document is not saved yet."
-msgstr "Dieses Dokument wurde noch nicht gespeichert."
-
-#: ../src/control/PageBackgroundChangeController.cpp:183
-#: ../src/control/tools/ImageHandler.cpp:56
-msgid "This image could not be loaded. Error message: {1}"
-msgstr "Das Bild konnte nicht geladen werden. Fehlermeldung: {1}"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:421
-msgid "Toggle fullscreen"
-msgstr "Vollbild umschalten"
-
-#: ../src/gui/dialog/ButtonConfigGui.cpp:62
-msgid "Tool - don't change"
-msgstr "Werkzeug - nicht ändern"
-
-#: ../src/gui/toolbarMenubar/model/ToolbarData.cpp:166
-msgid "Toolbar found: {1}"
-msgstr "Werkzeugleiste gefunden: {1}"
-
-#: ../src/gui/dialog/ToolbarManageDialog.cpp:55
-msgid "Toolbars"
-msgstr "Werkzeugleisten"
-
-#: ../src/util/CrashHandler.cpp:37
-msgid "Trying to emergency save the current open document…"
-msgstr "Versuche ein Notfall-Speichern des aktuell geöffneten Dokuments…"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:399
-#: ../src/undo/UndoRedoHandler.cpp:268
-msgid "Undo"
-msgstr "Rückgängig"
-
-#: ../src/undo/UndoRedoHandler.cpp:263
-msgid "Undo: "
-msgstr "Rückgängig: "
-
-#: ../src/control/xojfile/LoadHandler.cpp:350
-msgid "Unexpected root tag: {1}"
-msgstr "Unerwarteter Root Tag: {1}"
-
-#: ../src/control/xojfile/LoadHandler.cpp:383
-msgid "Unexpected tag in document: \"{1}\""
-msgstr "Unerwarteter Tag im Dokument: \"{1}\""
-
-#: ../src/control/xojfile/LoadHandler.cpp:634
-msgid "Unknown background type: {1}"
-msgstr "Unbekannter Hintergrundtyp: {1}"
-
-#: ../src/control/xojfile/LoadHandlerHelper.cpp:80
-msgid "Unknown color value \"{1}\""
-msgstr "Unbekannter Farbwert \"{1}\""
-
-#: ../src/control/xojfile/LoadHandler.cpp:569
-msgid "Unknown domain type: {1}"
-msgstr "Unbekannter Domänentyp: {1}"
-
-#: ../src/control/xojfile/LoadHandler.cpp:284
-msgid "Unknown parser error"
-msgstr "Unbekannter Lesefehler"
-
-#: ../src/control/xojfile/LoadHandler.cpp:482
-msgid "Unknown pixmap::domain type: {1}"
-msgstr "Unbekannter pixmap::domain Typ: {1}"
-
-#: ../src/control/xojfile/LoadHandler.cpp:753
-msgid "Unknown stroke type: \"{1}\", assuming pen"
-msgstr "Unbekannter Linientyp: \"{1}\", verwende Stift"
-
-#: ../src/control/Control.cpp:2711
-msgid "Unsaved Document"
-msgstr "Ungespeichertes Dokument"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:477
-msgid "Vertical Space"
-msgstr "Vertikaler Platz"
-
-#: ../src/gui/dialog/ButtonConfigGui.cpp:68
-msgid "Vertical space"
-msgstr "Vertikaler Platz"
-
-#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:20
-#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:146
-msgid "White"
-msgstr "Weiß"
-
-#: ../src/control/pagetype/PageTypeHandler.cpp:31
-msgid "With PDF background"
-msgstr "Mit PDF-Hintergrund"
-
-#: ../src/undo/InsertUndoAction.cpp:44
-msgid "Write text"
-msgstr "Text schreiben"
-
-#: ../src/control/xojfile/LoadHandler.cpp:1153
-msgid "Wrong count of points ({1})"
-msgstr "Falsche Punktanzahl ({1})"
-
-#: ../src/control/xojfile/LoadHandler.cpp:1167
-msgid "Wrong number of points, got {1}, expected {2}"
-msgstr "Falsche Punktzahl {1}, erwartet wurde {2}"
-
-#: ../src/control/xojfile/LoadHandler.cpp:279
-msgid "XML Parser error: {1}"
-msgstr "XML Parser Fehler: {1}"
-
-#: ../src/control/jobs/CustomExportJob.cpp:29
-msgid "Xournal (Compatibility)"
-msgstr "Xournal (Kompatibilitätsmodus)"
-
-#: ../src/control/stockdlg/XojOpenDlg.cpp:74
-msgid "Xournal files"
-msgstr "Xournal Dateien"
-
-#: ../src/control/XournalMain.cpp:182
-msgid "Xournal++ crashed last time. Would you restore it?"
-msgstr ""
-"Xournal++ ist das letzte mal abgestürzt. Soll die Datei widerhergestellt "
-"werden?"
-
-#: ../src/control/Control.cpp:2645 ../src/control/stockdlg/XojOpenDlg.cpp:84
-msgid "Xournal++ files"
-msgstr "Xournal++ Dateien"
-
-#: ../src/control/stockdlg/XojOpenDlg.cpp:94
-#: ../src/gui/dialog/PageTemplateDialog.cpp:118
-msgid "Xournal++ template"
-msgstr "Xournal++ Vorlage"
-
-#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:19
-#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:145
-msgid "Yellow"
-msgstr "Gelb"
-
-#: ../src/control/PageBackgroundChangeController.cpp:225
-msgid ""
-"You don't have any PDF pages to select from. Cancel operation.\n"
-"Please select another background type: Menu \"Journal\" → \"Configure Page "
-"Template\"."
-msgstr ""
-"Es gibt keine PDF Seiten zum Auswählen. Abbruch.\n"
-"Bitte wählen Sie einen anderen Hintergrundtyp: Menü \"Journal\" / "
-"\"Seitenvorlage konfigurieren\"."
-
-#: ../src/control/XournalMain.cpp:125
-msgid ""
-"You're using {1}/{2} branch. Send Bugreport will direct you to this repo's "
-"issue tracker."
-msgstr ""
-"Sie benutzen den {1}/{2} Zweig. Das Senden eines Fehlerberichts wird Sie zum "
-"Issue-Tracker dieses Repositoriums führen."
-
-#: ../src/gui/sidebar/indextree/SidebarIndexPage.cpp:93
-msgid ""
-"Your current document does not contain PDF Page no {1}\n"
-"Would you like to insert this page?\n"
-"\n"
-"Tip: You can select Journal → Paper Background → PDF Background to insert a "
-"PDF page."
-msgstr ""
-"Ihr aktuelles Dokument beinhaltet die PDF Seite {1} nicht\n"
-"Möchten Sie diese Seite einfügen?\n"
-"\n"
-"Tipp: Sie können im Menü Journal / Seitenhintergrund / PDF-Hintergrund eine "
-"beliebige PDF Seite einfügen."
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:425
-msgid "Zoom fit to screen"
-msgstr "Passend zoomen"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:424
-msgid "Zoom in"
-msgstr "Hereinzoomen"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:423
-msgid "Zoom out"
-msgstr "Herauszoomen"
-
-#: ../src/gui/toolbarMenubar/ToolZoomSlider.cpp:106
-msgid "Zoom slider"
-msgstr "Zoomregler"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:426
-msgid "Zoom to 100%"
-msgstr "Zoom auf 100%"
-
-#: ../src/control/Control.cpp:2639 ../src/control/jobs/BaseExportJob.cpp:25
-#: ../src/control/stockdlg/ImageOpenDlg.cpp:12
-#: ../src/control/stockdlg/XojOpenDlg.cpp:17
-#: ../src/gui/dialog/PageTemplateDialog.cpp:112
-msgid "_Cancel"
-msgstr "_Abbrechen"
-
-#: ../src/control/stockdlg/ImageOpenDlg.cpp:13
-#: ../src/control/stockdlg/XojOpenDlg.cpp:18
-msgid "_Open"
-msgstr "Ö_ffnen"
-
-#: ../src/control/Control.cpp:2640 ../src/control/jobs/BaseExportJob.cpp:26
-#: ../src/gui/dialog/PageTemplateDialog.cpp:113
-msgid "_Save"
-msgstr "_Speichern"
-
-#: ../src/util/DeviceListHelper.cpp:92
-msgid "cursor"
-msgstr "XournalppCursor"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:298
-msgid "dash-/ doted"
-msgstr "gepunkted / gestrichelt"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:295
-msgid "dashed"
-msgstr "gestichelt"
-
-#: ../src/gui/dialog/PluginDialogEntry.cpp:38
-msgid "default disabled"
-msgstr "Standard deaktivieren"
-
-#: ../src/gui/dialog/PluginDialogEntry.cpp:38
-msgid "default enabled"
-msgstr "Standard aktivieren"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:315
-msgid "delete stroke"
-msgstr "Linie löschen"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:301
-msgid "dotted"
-msgstr "Gepunktet"
-
-#: ../src/util/DeviceListHelper.cpp:88
-msgid "eraser"
-msgstr "Radierer"
-
-#: ../src/util/DeviceListHelper.cpp:97
-msgid "keyboard"
-msgstr "Tastatur"
-
-#: ../src/util/DeviceListHelper.cpp:80
-msgid "mouse"
-msgstr "Maus"
-
-#: ../src/util/DeviceListHelper.cpp:84
-msgid "pen"
-msgstr "Stift"
-
-#: ../src/gui/toolbarMenubar/ToolPageLayer.cpp:222
-msgid "show"
-msgstr "anzeigen"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:292
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:313
-msgid "standard"
-msgstr "standard"
-
-#: ../src/util/DeviceListHelper.cpp:105
-msgid "touchpad"
-msgstr "Touchpad"
-
-#: ../src/util/DeviceListHelper.cpp:101
-msgid "touchscreen"
-msgstr "Touchscreen"
-
-#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:314
-msgid "whiteout"
-msgstr "weiß übermalen"
-
-#: ../src/control/xojfile/LoadHandler.cpp:1166
-msgid "xoj-File: {1}"
-msgstr "xoj-Datei: {1}"
-
-#: ../src/xoj-preview-extractor/xournal-thumbnailer.cpp:75
-msgid "xoj-preview-extractor: call with INPUT.xoj OUTPUT.png"
-msgstr "xoj-Vorschau-Extraktor: rufe auf mit INPUT.xoj OUTPUT.png"
-
-#: ../src/xoj-preview-extractor/xournal-thumbnailer.cpp:97
-msgid "xoj-preview-extractor: file \"{1}\" contains no preview"
-msgstr "xoj-Vorschau-Extraktor: Datei \"{1}\" enthält keine Vorschau"
-
-#: ../src/xoj-preview-extractor/xournal-thumbnailer.cpp:89
-msgid "xoj-preview-extractor: file \"{1}\" is not .xoj file"
-msgstr "xoj-Vorschau-Extraktor: Datei \"{1}\" ist keine xoj-Datei"
-
-#: ../src/xoj-preview-extractor/xournal-thumbnailer.cpp:102
-msgid ""
-"xoj-preview-extractor: no preview and page found, maybe an invalid file?"
-msgstr ""
-"xoj-Vorschau-Extraktor: keine Vorschau und keine Seite gefunden: ungültige "
-"Datei?"
-
-#: ../src/xoj-preview-extractor/xournal-thumbnailer.cpp:93
-msgid "xoj-preview-extractor: opening input file \"{1}\" failed"
-msgstr "xoj-Vorschau-Extraktor: Öffnen der Datei \"{1}\" fehlgeschlagen"
-
-#: ../src/xoj-preview-extractor/xournal-thumbnailer.cpp:109
-msgid "xoj-preview-extractor: opening output file \"{1}\" failed"
-msgstr "xoj-Vorschau-Extraktor: Öffnen der Ausgabedatei \"{1}\" fehlgeschlagen"
-
-#: ../src/xoj-preview-extractor/xournal-thumbnailer.cpp:118
-msgid "xoj-preview-extractor: successfully extracted"
-msgstr "xoj-Vorschau-Extraktor: erfolgreich extrahiert"
-
-#: ../ui/settings.glade:3259
-msgid "         Settings:     "
-msgstr "\tEinstellungen:\t"
-
 #: ../ui/settings.glade:2512 ../ui/settings.glade:2523
 msgid "%"
 msgstr "%"
+
+#: ../src/control/settings/Settings.cpp:108
+msgid "%F-Note-%H-%M"
+msgstr "%F-Notiz-%H-%M"
 
 #: ../ui/settings.glade:402
 msgid ""
@@ -1858,6 +400,10 @@ msgstr ""
 msgid "About Xournal++"
 msgstr "Über Xournal++"
 
+#: ../src/control/XournalMain.cpp:316
+msgid "Absolute path for the audio files playback"
+msgstr "Absoluter Pfad für die Audiodateien"
+
 #: ../ui/settings.glade:2792
 msgid "Add additional horizontal space of"
 msgstr "Füge Horizontalen Platz von"
@@ -1865,6 +411,14 @@ msgstr "Füge Horizontalen Platz von"
 #: ../ui/settings.glade:2771
 msgid "Add additional vertical space of"
 msgstr "Füge Vertikalen Platz von"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:463
+msgid "Add/Edit Tex"
+msgstr "LaTeX  editieren/hinzufügen"
+
+#: ../src/control/stockdlg/XojOpenDlg.cpp:53
+msgid "All files"
+msgstr "Alle Dateien"
 
 #: ../ui/exportSettings.glade:136
 msgid "All pages"
@@ -1880,6 +434,60 @@ msgstr ""
 "Er muss, gemessen an der Zeit und der Länge, kurz sein und es darf kein "
 "Strich vor kurzem ignoriert worden sein."
 
+#: ../src/control/pagetype/PageTypeMenu.cpp:257
+msgid "Apply to all pages"
+msgstr "Auf alle Seiten anwenden"
+
+#: ../src/control/pagetype/PageTypeMenu.cpp:246
+msgid "Apply to current page"
+msgstr "Auf aktuelle Seite anwenden"
+
+#: ../src/control/stockdlg/ImageOpenDlg.cpp:30
+#: ../src/control/stockdlg/XojOpenDlg.cpp:154
+msgid "Attach file to the journal"
+msgstr "Datei ans .xoj anhängen"
+
+#: ../src/control/xojfile/LoadHandlerHelper.cpp:140
+msgid "Attribute \"{1}\" could not be parsed as double, the value is \"{2}\""
+msgstr ""
+"Attribut \"{1}\" konnte nicht als Fließkommazahl ausgelesen werden, der Wert "
+"ist \"{2}\""
+
+#: ../src/control/xojfile/LoadHandlerHelper.cpp:132
+msgid "Attribute \"{1}\" could not be parsed as double, the value is NULL"
+msgstr ""
+"Attribut \"{1}\" konnte nicht als Fließkommazahl ausgelesen werden, der Wert "
+"ist NULL"
+
+#: ../src/control/xojfile/LoadHandlerHelper.cpp:160
+#: ../src/control/xojfile/LoadHandlerHelper.cpp:183
+msgid "Attribute \"{1}\" could not be parsed as int, the value is \"{2}\""
+msgstr ""
+"Attribut \"{1}\" konnte nicht als Ganzzahl ausgelesen werden, der Wert ist "
+"\"{1}\""
+
+#: ../src/control/xojfile/LoadHandlerHelper.cpp:152
+msgid "Attribute \"{1}\" could not be parsed as int, the value is NULL"
+msgstr ""
+"Attribut \"{1}\" konnte nicht als Ganzzahl ausgelesen werden, der Wert ist "
+"NULL"
+
+#: ../src/control/xojfile/LoadHandlerHelper.cpp:205
+#: ../src/control/xojfile/LoadHandlerHelper.cpp:228
+msgid "Attribute \"{1}\" could not be parsed as size_t, the value is \"{2}\""
+msgstr ""
+"Attribut \"{1}\" konnte nicht als size_t ausgelesen werden, der Wert ist "
+"\"{2}\""
+
+#: ../src/control/xojfile/LoadHandlerHelper.cpp:197
+msgid "Attribute \"{1}\" could not be parsed as size_t, the value is NULL"
+msgstr ""
+"Attribut \"{1}\" konnte nicht als size_t ausgelesen werden, der Wert ist NULL"
+
+#: ../src/control/xojfile/LoadHandlerHelper.cpp:70
+msgid "Attribute color not set!"
+msgstr "Attribut Farbe ist nicht gesetzt!"
+
 #: ../ui/settings.glade:3668
 msgid "Audio Devices"
 msgstr "Audiogeräte"
@@ -1887,6 +495,14 @@ msgstr "Audiogeräte"
 #: ../ui/settings.glade:3805
 msgid "Audio Recording"
 msgstr "Audioaufzeichnung"
+
+#: ../src/control/AudioController.cpp:152
+msgid ""
+"Audio folder not set! Recording won't work!\n"
+"Please set the recording folder under \"Preferences > Audio recording\""
+msgstr ""
+"Audio Ordner nicht gesetzt! Aufzeichnung wird nicht funktionieren!\n"
+"Bitte den Ordner festlegen unter \"Einstellungen > Audioaufzeichnung\""
 
 #: ../ui/pluginEntry.glade:65
 msgid "Author"
@@ -1908,6 +524,14 @@ msgstr "Automatisch"
 msgid "Autoloading Journals"
 msgstr "Automatisches Laden von Dokumenten"
 
+#: ../src/control/Control.cpp:251
+msgid "Autosave failed with an error: {1}"
+msgstr "Autospeichern fehlgeschlagen mit Fehler: {1}"
+
+#: ../src/control/jobs/AutosaveJob.cpp:25
+msgid "Autosave: {1}"
+msgstr "Autospeichern: {1}"
+
 #: ../ui/settings.glade:303
 msgid "Autosaving"
 msgstr "Automatisches Speichern"
@@ -1916,6 +540,16 @@ msgstr "Automatisches Speichern"
 msgid "Available Placeholders"
 msgstr "Verfügbare Platzhalter"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:432
+msgid "Back"
+msgstr "Zurück"
+
+#: ../src/gui/sidebar/previews/layer/SidebarPreviewLayerEntry.cpp:22
+#: ../src/gui/toolbarMenubar/ToolPageLayer.cpp:270
+#: ../src/gui/toolbarMenubar/ToolPageLayer.cpp:322
+msgid "Background"
+msgstr "Hintergrund"
+
 #: ../ui/settings.glade:1933
 msgid "Background color for window Background"
 msgstr "Hintergrundfarbe des Fensters"
@@ -1923,6 +557,16 @@ msgstr "Hintergrundfarbe des Fensters"
 #: ../ui/settings.glade:2063
 msgid "Big cursor for pen"
 msgstr "Großer XournalppCursor für den Stift"
+
+#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:10
+#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:136
+msgid "Black"
+msgstr "Schwarz"
+
+#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:14
+#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:140
+msgid "Blue"
+msgstr "Blau"
 
 #: ../ui/settings.glade:1922
 msgid "Border color"
@@ -1944,6 +588,31 @@ msgstr "Taste 1"
 msgid "Button 2"
 msgstr "Taste 2"
 
+#: ../src/control/Control.cpp:2293 ../src/control/Control.cpp:2832
+#: ../src/control/Control.cpp:2874 ../src/control/XournalMain.cpp:138
+msgid "Cancel"
+msgstr "Abbrechen"
+
+#: ../src/undo/ColorUndoAction.cpp:119
+msgid "Change color"
+msgstr "Farbe ändern"
+
+#: ../src/undo/FontUndoAction.cpp:134
+msgid "Change font"
+msgstr "Schriftart ändern"
+
+#: ../src/undo/FillUndoAction.cpp:117
+msgid "Change stroke fill"
+msgstr "Figurenfüllung ändern"
+
+#: ../src/undo/SizeUndoAction.cpp:139
+msgid "Change stroke width"
+msgstr "Liniendicke ändern"
+
+#: ../src/control/xojfile/LoadHandlerHelper.cpp:98
+msgid "Color \"{1}\" unknown (not defined in default color list)!"
+msgstr "Farbe \"{1}\" unbekannt (nicht in der Farbliste)"
+
 #: ../ui/settings.glade:2000
 msgid "Colors"
 msgstr "Farben"
@@ -1951,6 +620,20 @@ msgstr "Farben"
 #: ../ui/main.glade:927
 msgid "Configure Page Template"
 msgstr "Seitenvorlage konfigurieren"
+
+#: ../src/gui/sidebar/indextree/SidebarIndexPage.cpp:276
+msgid "Contents"
+msgstr "Inhalt"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:405
+#: ../src/gui/toolbarMenubar/model/ToolbarModel.cpp:114
+#: ../src/gui/toolbarMenubar/model/ToolbarModel.cpp:122
+msgid "Copy"
+msgstr "Kopieren"
+
+#: ../src/control/pagetype/PageTypeHandler.cpp:30
+msgid "Copy current"
+msgstr "Aktuellen Hintergrund kopieren"
 
 #: ../ui/pageTemplate.glade:175
 msgid "Copy last page settings"
@@ -1960,6 +643,149 @@ msgstr "Einstellungen der letzten Seite kopieren"
 msgid "Copy last page size"
 msgstr "Größe der letzten Seite kopieren"
 
+#: ../src/undo/CopyUndoAction.cpp:81
+msgid "Copy page"
+msgstr "Kopiere Seite"
+
+#: ../src/control/LatexController.cpp:93
+msgid "Could not convert tex to PDF: {1} (exit code: {2})"
+msgstr "Konnte TeX nicht nach PDF Konvertieren: {1} (exit code: {2})"
+
+#: ../src/control/jobs/SaveJob.cpp:137
+msgid ""
+"Could not create backup! (The file was created from an older Xournal version)"
+msgstr ""
+"Konnte kein Backup erstellen! (Diese Datei wurde mit einer alten Version von "
+"Xournal erstellt.)"
+
+#: ../src/util/Util.cpp:94
+msgid "Could not create folder: {1}"
+msgstr "Konnte den Ordner \"{1}\" nicht erstellen"
+
+#: ../src/control/LatexController.cpp:400
+msgid ""
+"Could not find pdflatex in Path.\n"
+"Please install pdflatex first and make sure it's in the Path."
+msgstr ""
+"Konnte pdflatex nicht im Pfad finden.\n"
+"Bitte installieren Sie pdflatex und stellen sicher, das es im Pfad "
+"eingetragen ist."
+
+#: ../src/control/LatexController.cpp:356
+msgid "Could not load LaTeX PDF file"
+msgstr "Konnte LaTeX PDF Datei nicht öffnen: \"{1}\""
+
+#: ../src/control/LatexController.cpp:341
+msgid "Could not load LaTeX PDF file, File Error: {1}"
+msgstr "Die LaTeX-PDF Datei konnte nicht geladen werden, Datei Fehler: {1}"
+
+#: ../src/control/LatexController.cpp:349
+msgid "Could not load LaTeX PDF file: {1}"
+msgstr "Konnte LaTeX PDF Datei nicht öffnen: \"{1}\""
+
+#: ../src/control/pagetype/PageTypeHandler.cpp:18
+msgid "Could not load pagetemplates.ini file"
+msgstr "Konnte die Datei pagetemplates.ini nicht öffnen"
+
+#: ../src/control/xojfile/LoadHandler.cpp:984
+msgid "Could not open attachment: {1}. Error message: Could not read file"
+msgstr ""
+"Der Anhang {1} konnte nicht geladen werden. Fehlermeldung: Konnte Datei "
+"nicht lesen"
+
+#: ../src/control/xojfile/LoadHandler.cpp:993
+msgid "Could not open attachment: {1}. Error message: Could not write file"
+msgstr ""
+"Der Anhang {1} konnte nicht geladen werden. Fehlermeldung: Konnte Datei "
+"nicht schreiben"
+
+#: ../src/control/xojfile/LoadHandler.cpp:963
+#: ../src/control/xojfile/LoadHandler.cpp:1291
+#: ../src/control/xojfile/LoadHandler.cpp:1311
+msgid ""
+"Could not open attachment: {1}. Error message: No valid file size provided"
+msgstr ""
+"Der Anhang {1} konnte nicht geladen werden. Fehlermeldung: Keine gültige "
+"Größe angegeben"
+
+#: ../src/control/xojfile/LoadHandler.cpp:953
+#: ../src/control/xojfile/LoadHandler.cpp:971
+#: ../src/control/xojfile/LoadHandler.cpp:1282
+#: ../src/control/xojfile/LoadHandler.cpp:1299
+msgid "Could not open attachment: {1}. Error message: {2}"
+msgstr "Der Anhang {1} konnte nicht geladen werden. Fehlermeldung: {2}"
+
+#: ../src/control/xojfile/LoadHandler.cpp:193
+msgid "Could not open file: \"{1}\""
+msgstr "Konnte die Datei nicht öffnen: \"{1}\""
+
+#: ../src/gui/MainWindow.cpp:82
+msgid ""
+"Could not parse custom toolbar.ini file: {1}\n"
+"Toolbars will not be available"
+msgstr ""
+"Konnte die benutzerdefinierte Datei toolbar.ini nicht lesen: {1}\n"
+"Es werden keine Werkzeugleisten zur Verfügung stehen"
+
+#: ../src/gui/MainWindow.cpp:72
+msgid ""
+"Could not parse general toolbar.ini file: {1}\n"
+"No Toolbars will be available"
+msgstr ""
+"Konnte die globale Datei toolbar.ini nicht lesen: {1}\n"
+"Es werden keine Werkzeugleisten zur Verfügung stehen"
+
+#: ../src/control/xojfile/LoadHandler.cpp:437
+#: ../src/control/xojfile/LoadHandler.cpp:465
+msgid "Could not read image: {1}. Error message: {2}"
+msgstr "Das Bild {1} konnte nicht geladen werden. Fehlermeldung: {2}"
+
+#: ../src/undo/UndoRedoHandler.cpp:175
+msgid ""
+"Could not redo \"{1}\"\n"
+"Something went wrong… Please write a bug report…"
+msgstr ""
+"Konnte '{1}' nicht wiederherstellen\n"
+"Etwas ist schief gelaufen… Bitte erstellen Sie einen Fehlerbericht…"
+
+#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:210
+msgid "Could not remove tool item from Toolbar {1} on position {2}"
+msgstr ""
+"Konnte Werkzeug von der Werkzeugleiste {1} Position {2} nicht entfernen"
+
+#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:205
+msgid "Could not remove tool item {1} from Toolbar {2} on position {3}"
+msgstr ""
+"Konnte Werkzeug {1} von der Werkzeugleiste {2} Position {3} nicht entfernen"
+
+#: ../src/control/Control.cpp:238
+msgid "Could not rename autosave file from \"{1}\" to \"{2}\": {3}"
+msgstr "Konnte Datei \"{1}\" nicht umbenennen zu \"{2}\""
+
+#: ../src/control/LatexController.cpp:79
+msgid "Could not save .tex file: {1}"
+msgstr "Konnte .tex Datei \"{1}\" nicht speichern:"
+
+#: ../src/undo/UndoRedoHandler.cpp:138
+msgid ""
+"Could not undo \"{1}\"\n"
+"Something went wrong… Please write a bug report…"
+msgstr ""
+"Konnte '{1}' nicht rückgängig machen\n"
+"Etwas ist schief gelaufen... Bitte erstellen Sie einen Fehlerbericht…"
+
+#: ../src/control/xojfile/SaveHandler.cpp:290
+msgid "Could not write background \"{1}\", {2}"
+msgstr "Konnte Hintergrund \"{1}\" nicht speichern, {2}"
+
+#: ../src/control/xojfile/SaveHandler.cpp:410
+msgid "Could not write background \"{1}\". Continuing anyway."
+msgstr "Konnte Hintergrund nicht speichern \"{1}\". Fahre trotzdem fort."
+
+#: ../src/gui/toolbarMenubar/ToolPageLayer.cpp:109
+msgid "Create new layer"
+msgstr "Neue Ebene erstellen"
+
 #: ../ui/exportSettings.glade:151
 msgid "Current page"
 msgstr "Aktuelle Seite"
@@ -1968,9 +794,25 @@ msgstr "Aktuelle Seite"
 msgid "Cursor"
 msgstr "Mauszeiger"
 
+#: ../src/gui/dialog/FormatDialog.cpp:72
+msgid "Custom"
+msgstr "Benutzerdefiniert"
+
 #: ../ui/settings.glade:1613
 msgid "Custom Commands (for Method \"Custom\")"
 msgstr "Kommandos (für die Methode \"Benutzerdefiniert\")"
+
+#: ../src/control/jobs/CustomExportJob.cpp:18
+msgid "Custom Export"
+msgstr "Benutzerdefinierter Export"
+
+#: ../src/gui/dialog/ToolbarManageDialog.cpp:38
+msgid "Customized"
+msgstr "Anpassen"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:404
+msgid "Cut"
+msgstr "Ausschneiden"
 
 #: ../ui/settings.glade:1979
 msgid "Dark Theme (requires restart)"
@@ -1980,6 +822,10 @@ msgstr "Dunkles Thema (benötigt Neustart)"
 msgid "Default Save Name"
 msgstr "Standard Dateiname"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:465
+msgid "Default Tool"
+msgstr "Standard Werkzeug"
+
 #: ../ui/settings.glade:365
 msgid "Default name: "
 msgstr "Standard Name: "
@@ -1988,8 +834,29 @@ msgstr "Standard Name: "
 msgid "Defaults"
 msgstr "Standards"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:410
+#: ../src/undo/DeleteUndoAction.cpp:102
+msgid "Delete"
+msgstr "Löschen"
+
 #: ../ui/main.glade:962
 msgid "Delete Layer"
+msgstr "Ebene löschen"
+
+#: ../src/control/XournalMain.cpp:137
+msgid "Delete Logfile"
+msgstr "Logdatei löschen"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:450
+msgid "Delete current page"
+msgstr "Aktuelle Seite löschen"
+
+#: ../src/control/XournalMain.cpp:187
+msgid "Delete file"
+msgstr "Datei löschen"
+
+#: ../src/undo/RemoveLayerUndoAction.cpp:41
+msgid "Delete layer"
 msgstr "Ebene löschen"
 
 #: ../ui/settingsButtonConfig.glade:122
@@ -2020,9 +887,45 @@ msgstr "Zeichnen mit diesem Gerät deaktivieren"
 msgid "Disabling Method"
 msgstr "Deaktivierungsmethode"
 
+#: ../src/control/Control.cpp:2828 ../src/control/Control.cpp:2873
+msgid "Discard"
+msgstr "Verwerfen"
+
 #: ../ui/settings.glade:2661
 msgid "Display DPI Calibration"
 msgstr "Bildschirm DPI-Kalibrierung"
+
+#: ../src/control/Control.cpp:2223
+msgid ""
+"Do not open Autosave files. They may will be overwritten!\n"
+"Copy the files to another folder.\n"
+"Files from Folder {1} cannot be opened."
+msgstr ""
+"Öffnen sie keine automatisch gespeicherten Dateien. Diese werden ansonsten "
+"überschrieben!\n"
+"Kopieren Sie diese Dateien an einen anderen Ort.\n"
+"Dateien aus dem Ordner {1} können nicht geöffnet werden."
+
+#: ../src/control/jobs/BaseExportJob.cpp:46
+msgid "Do not overwrite the background PDF! This will cause errors!"
+msgstr ""
+"Das Hintergrund PDF darf nicht überschrieben werden! Dies verursacht Fehler!"
+
+#: ../src/control/Control.cpp:2870
+msgid "Document file was removed."
+msgstr "Datei des Dokuments wurde entfernt."
+
+#: ../src/control/xojfile/LoadHandler.cpp:293
+msgid "Document is not complete (maybe the end is cut off?)"
+msgstr "Dokument ist nicht vollständig (z.B. nicht komplett übertragen?)"
+
+#: ../src/model/Document.cpp:389 ../src/model/Document.cpp:399
+msgid "Document not loaded! ({1}), {2}"
+msgstr "Dokument nicht geladen! ({1}), {2}"
+
+#: ../src/control/pagetype/PageTypeHandler.cpp:26
+msgid "Dotted"
+msgstr "Gepunktet"
 
 #: ../ui/settings.glade:620 ../ui/settings.glade:752 ../ui/settings.glade:3049
 msgid ""
@@ -2047,9 +950,45 @@ msgstr ""
 msgid "Drag and drop Components fom here to the toolbars and back."
 msgstr "Ziehen Sie Objekte von hier in die Werkzeugleiste und zurück."
 
+#: ../src/gui/dialog/ButtonConfigGui.cpp:106
+#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:32
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:470
+msgid "Draw Arrow"
+msgstr "Pfeil zeichnen"
+
+#: ../src/gui/dialog/ButtonConfigGui.cpp:104
+#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:31
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:469
+msgid "Draw Circle"
+msgstr "Kreis zeichnen"
+
+#: ../src/gui/dialog/ButtonConfigGui.cpp:100
+#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:33
+msgid "Draw Line"
+msgstr "Strecke zeichnen"
+
+#: ../src/gui/dialog/ButtonConfigGui.cpp:102
+#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:23
+#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:30
+#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:112
+#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:115
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:468
+msgid "Draw Rectangle"
+msgstr "Rechteck Zeichnen"
+
 #: ../ui/main.glade:1138
 msgid "Draw _Line"
 msgstr "Strecke _zeichnen"
+
+#: ../src/gui/dialog/ButtonConfigGui.cpp:108
+#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:34
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:471
+msgid "Draw coordinate system"
+msgstr "Koordinatensystem zeichnen"
+
+#: ../src/undo/InsertUndoAction.cpp:40
+msgid "Draw stroke"
+msgstr "Linie zeichen"
 
 #: ../ui/settings.glade:3307
 msgid "Drawing Area"
@@ -2058,6 +997,18 @@ msgstr "Zeichenbereich"
 #: ../ui/settings.glade:3099
 msgid "Drawing Tools - Set Modifiers by Draw Direction (Experimental)"
 msgstr "Zeichenwerkzeuge - Setze Optionen via Zeichenrichtung (experimentell)"
+
+#: ../src/gui/dialog/ButtonConfigGui.cpp:96
+msgid "Drawing Type - don't change"
+msgstr "Zeichnungstyp - nicht ändern"
+
+#: ../src/undo/TextBoxUndoAction.cpp:52
+msgid "Edit text"
+msgstr "Text schreiben"
+
+#: ../src/undo/EmergencySaveRestore.cpp:36
+msgid "Emergency saved document"
+msgstr "Notfall gespeichertes Dokument"
 
 #: ../ui/settings.glade:1533
 msgid "Enable"
@@ -2111,6 +1062,16 @@ msgstr "Zoom-Gesten aktivieren (erfordert Neustart)"
 msgid "Enter / edit LaTeX Text"
 msgstr "Bearbeite- / editiere LaTeX Text"
 
+#: ../src/undo/AddUndoAction.cpp:104 ../src/undo/DeleteUndoAction.cpp:99
+#: ../src/undo/EraseUndoAction.cpp:129
+msgid "Erase stroke"
+msgstr "Linie löschen"
+
+#: ../src/gui/dialog/ButtonConfigGui.cpp:64
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:311
+msgid "Eraser"
+msgstr "Radierer"
+
 #: ../ui/main.glade:1360
 msgid "Eraser Optio_ns"
 msgstr "Radierer Optionen"
@@ -2118,6 +1079,56 @@ msgstr "Radierer Optionen"
 #: ../ui/settingsButtonConfig.glade:119
 msgid "Eraser Type - don't change"
 msgstr "Radierer - nicht ändern"
+
+#: ../src/control/Control.cpp:2518
+msgid ""
+"Error annotate PDF file \"{1}\"\n"
+"{2}"
+msgstr ""
+"Fehler beim Öffnen des PDFs \"{1}\"\n"
+"{2}"
+
+#: ../src/gui/GladeGui.cpp:24
+msgid "Error loading glade file \"{1}\" (try to load \"{2}\")"
+msgstr "Fehler beim Laden der Glade-Datei \"{1}\" (Datei \"{2}\")"
+
+#: ../src/control/Control.cpp:2318
+msgid "Error opening file \"{1}\""
+msgstr "Fehler beim Öffnen der Datei '{1}'"
+
+#: ../src/util/OutputStream.cpp:35
+msgid "Error opening file: \"{1}\""
+msgstr "Fehler beim Öffnen der Datei '{1}'"
+
+#: ../src/control/xojfile/LoadHandler.cpp:560
+#: ../src/control/xojfile/LoadHandler.cpp:587
+msgid "Error reading PDF: {1}"
+msgstr "Fehler beim Lesen des PDFs: {1}"
+
+#: ../src/control/xojfile/LoadHandler.cpp:658
+msgid "Error reading width of a stroke: {1}"
+msgstr "Fehler beim Lesen der Dicke einer Linie: {1}"
+
+#: ../src/control/jobs/ImageExport.cpp:143
+msgid "Error save image #1"
+msgstr "Fehler beim Speichern des Bildes #1"
+
+#: ../src/control/jobs/ImageExport.cpp:160
+msgid "Error save image #2"
+msgstr "Fehler beim Speichern des Bildes #2"
+
+#: ../src/util/CrashHandler.cpp:47
+msgid "Error: {1}"
+msgstr "Fehler: {1}"
+
+#: ../src/control/XournalMain.cpp:161
+msgid ""
+"Errorlog cannot be deleted. You have to do it manually.\n"
+"Logfile: {1}"
+msgstr ""
+"Fehlerlog konnte nicht gelöscht werden. Sie müssen die Datei manuell "
+"löschen.\n"
+"Logdatei: {1}"
 
 #: ../ui/settings.glade:649
 msgid "Experimental Input System"
@@ -2127,13 +1138,37 @@ msgstr "Experimentelles Eingabesystem"
 msgid "Export"
 msgstr "Exportieren"
 
+#: ../src/control/jobs/BaseExportJob.cpp:24
+msgid "Export PDF"
+msgstr "Exportieren als PDF"
+
 #: ../ui/main.glade:118
 msgid "Export as..."
 msgstr "Exportieren als..."
 
+#: ../src/control/LatexController.cpp:417
+msgid "Failed to generate LaTeX image!"
+msgstr "Fehler beim erstellen des LaTeX Bildes!"
+
 #: ../ui/main.glade:1338 ../ui/main.glade:1486
 msgid "Fi_ll"
 msgstr "Ausfü_llen"
+
+#: ../src/util/Util.cpp:123 ../src/util/Util.cpp:143
+msgid ""
+"File couldn't be opened. You have to do it manually:\n"
+"URL: {1}"
+msgstr ""
+"Datei konnte nicht geöffnet werden, Sie müssen sie manuell öffnen\n"
+":URL: {1}"
+
+#: ../src/control/Control.cpp:2253
+msgid "Filename: {1}"
+msgstr "Dateiname: {1}"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:509
+msgid "Fill"
+msgstr "Füllung"
 
 #: ../ui/main.glade:1347 ../ui/main.glade:1495
 msgid "Fill transparency"
@@ -2151,6 +1186,10 @@ msgstr "Vorheriges Vorkommen des Textes suchen"
 msgid "First Page Offset "
 msgstr "Verschiebung der ersten Seite "
 
+#: ../src/gui/toolbarMenubar/FontButton.cpp:71
+msgid "Font"
+msgstr "Schriftart"
+
 #: ../ui/main.glade:336 ../ui/settings.glade:2279
 msgid "Fullscreen"
 msgstr "Vollbild"
@@ -2167,9 +1206,51 @@ msgstr "Gain"
 msgid "Global"
 msgstr "Global"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:431
+msgid "Go to first page"
+msgstr "Gehe zur ersten Seite"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:435
+msgid "Go to last page"
+msgstr "Gehe zur letzten Seite"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:438
+msgid "Go to next layer"
+msgstr "Zur nächsten Ebene springen"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:433
+msgid "Go to page"
+msgstr "Gehe zur Seite"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:437
+msgid "Go to previous layer"
+msgstr "Zur vorherigen Ebene springen"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:439
+msgid "Go to top layer"
+msgstr "Zur obersten Ebene springen"
+
 #: ../ui/goto.glade:13
 msgid "Goto Page"
 msgstr "_Gehe zur Seite"
+
+#: ../src/control/pagetype/PageTypeHandler.cpp:25
+msgid "Graph"
+msgstr "Kariert"
+
+#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:15
+#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:141
+msgid "Gray"
+msgstr "Grau"
+
+#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:11
+#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:137
+msgid "Green"
+msgstr "Grün"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:414
+msgid "Grid Snapping"
+msgstr "Am Raster einrasten"
 
 #: ../ui/settings.glade:2970
 msgid "Grid snapping tolerance"
@@ -2178,6 +1259,11 @@ msgstr "Toleranz um in Gitter einzurasten"
 #: ../ui/main.glade:1209
 msgid "H_and Tool"
 msgstr "Hand-Werkzeug"
+
+#: ../src/gui/dialog/ButtonConfigGui.cpp:71
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:479
+msgid "Hand"
+msgstr "Hand"
 
 #: ../ui/settings.glade:1638
 msgid "Hand Recognition"
@@ -2199,6 +1285,10 @@ msgstr "Menüleiste ausblenden"
 msgid "Hide Sidebar"
 msgstr "Seitenleiste ausblenden"
 
+#: ../src/gui/toolbarMenubar/ToolPageLayer.cpp:99
+msgid "Hide all"
+msgstr "Alle ausblenden"
+
 #: ../ui/settings.glade:2178
 msgid "Hide the horizontal scrollbar"
 msgstr "Horizontale Bildlaufleiste ausblenden"
@@ -2210,6 +1300,11 @@ msgstr "Vertikale Bildlaufleiste ausblenden"
 #: ../ui/settings.glade:2048
 msgid "Highlight cursor position"
 msgstr "Markierungscursor Position"
+
+#: ../src/gui/dialog/ButtonConfigGui.cpp:65
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:460
+msgid "Highlighter"
+msgstr "Textmarker"
 
 #: ../ui/main.glade:1440
 msgid "Highlighter Opti_ons"
@@ -2246,6 +1341,23 @@ msgstr ""
 "Ignoriere Eingaben mit kurzer Länge (zeitlich und räumlich), sofern sie "
 "nicht in kurzer Folge auftreten."
 
+#: ../src/control/pagetype/PageTypeHandler.cpp:32
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:464
+msgid "Image"
+msgstr "Bild"
+
+#: ../src/control/XournalMain.cpp:259
+msgid "Image file successfully created"
+msgstr "Bild erfolgreich erstellt"
+
+#: ../src/control/XournalMain.cpp:314
+msgid "Image output filename (.png / .svg)"
+msgstr "Dateiname der Bild-Ausgabe (.png / .svg)"
+
+#: ../src/control/stockdlg/ImageOpenDlg.cpp:18
+msgid "Images"
+msgstr "Bilddateien"
+
 #: ../ui/settings.glade:3613
 msgid "Input Device"
 msgstr "Eingabegerät"
@@ -2266,6 +1378,48 @@ msgstr "LaTeX einfügen"
 msgid "Insert a copy of the current page below"
 msgstr "Eine Kopie der aktuellen Seite unten einfügen"
 
+#: ../src/undo/InsertUndoAction.cpp:116
+msgid "Insert elements"
+msgstr "Elemente einfügen"
+
+#: ../src/gui/dialog/ButtonConfigGui.cpp:67 ../src/undo/InsertUndoAction.cpp:48
+msgid "Insert image"
+msgstr "Bild einfügen"
+
+#: ../src/undo/InsertUndoAction.cpp:52
+msgid "Insert latex"
+msgstr "LaTeX einfügen"
+
+#: ../src/undo/InsertLayerUndoAction.cpp:40
+msgid "Insert layer"
+msgstr "Ebene einfügen"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:446
+msgid "Insert page"
+msgstr "Seite einfügen"
+
+#: ../src/control/XournalMain.cpp:315
+msgid "Jump to Page (first Page: 1)"
+msgstr "Springe zur Seite (erste Seite: 1)"
+
+#: ../src/gui/toolbarMenubar/ToolPageLayer.cpp:348
+msgid "Layer"
+msgstr "Ebene"
+
+#: ../src/gui/sidebar/previews/layer/SidebarPreviewLayers.cpp:79
+msgid "Layer Preview"
+msgstr "Ebenen-Vorschau"
+
+#: ../src/gui/toolbarMenubar/ToolPageLayer.cpp:331
+msgid "Layer selection"
+msgstr "Ebenenauswahl"
+
+#: ../src/gui/sidebar/previews/layer/SidebarPreviewLayerEntry.cpp:26
+#: ../src/gui/toolbarMenubar/ToolPageLayer.cpp:260
+#: ../src/gui/toolbarMenubar/ToolPageLayer.cpp:318
+msgid "Layer {1}"
+msgstr "Ebene {1}"
+
 #: ../ui/main.glade:361
 msgid "Layout"
 msgstr "Layout"
@@ -2278,6 +1432,20 @@ msgstr "Links / Rechtshändig"
 msgid "License"
 msgstr "Lizenz"
 
+#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:12
+#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:138
+msgid "Light Blue"
+msgstr "Hellblau"
+
+#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:13
+#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:139
+msgid "Light Green"
+msgstr "Hellgrün"
+
+#: ../src/control/pagetype/PageTypeHandler.cpp:23
+msgid "Lined"
+msgstr "Liniert mit Rand"
+
 #: ../ui/settings.glade:569
 msgid "Load / Save"
 msgstr "Laden / Speichern"
@@ -2286,13 +1454,29 @@ msgstr "Laden / Speichern"
 msgid "Load file"
 msgstr "Datei laden"
 
+#: ../src/gui/PageView.cpp:747
+#: ../src/gui/sidebar/previews/base/SidebarPreviewBaseEntry.cpp:103
+#: ../src/gui/toolbarMenubar/ToolPageLayer.cpp:18
+msgid "Loading..."
+msgstr "Laden..."
+
 #: ../ui/toolbarCustomizeDialog.glade:10 ../ui/toolbarManageDialog.glade:8
 msgid "Manage Toolbar"
 msgstr "Werkzeugleisten verwalten"
 
+#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:17
+#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:143
+msgid "Mangenta"
+msgstr "Magenta"
+
 #: ../ui/settings.glade:3200
 msgid "Max Length (points)"
 msgstr "Maximale Länge (Punkte)"
+
+#: ../src/gui/dialog/ButtonConfigGui.cpp:88
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:523
+msgid "Medium"
+msgstr "Mittel"
 
 #: ../ui/settings.glade:764
 msgid ""
@@ -2308,6 +1492,26 @@ msgstr ""
 msgid "Middle Mouse Button"
 msgstr "Mittlere Maustaste"
 
+#: ../src/control/XournalMain.cpp:540
+msgid ""
+"Missing the needed UI file! .app corrupted?\n"
+"Path: {1}"
+msgstr ""
+"Fehlende UI Datei! .app Fehlerhaft?\n"
+"Pfad: {1}"
+
+#: ../src/control/XournalMain.cpp:554
+msgid ""
+"Missing the needed UI file, could not find them at any location.\n"
+"Not relative\n"
+"Not in the Working Path\n"
+"Not in {1}"
+msgstr ""
+"Konnte die nötigen UI Dateien nicht finden!\n"
+"Nicht relativ\n"
+"Nicht im Arbeitspfad\n"
+"Nicht in {1}"
+
 #: ../ui/settings.glade:979
 msgid "Mouse"
 msgstr "Maus"
@@ -2316,9 +1520,29 @@ msgstr "Maus"
 msgid "Mouse Buttons"
 msgstr "Maustasten"
 
+#: ../src/undo/MoveUndoAction.cpp:20
+msgid "Move"
+msgstr "Verschieben"
+
+#: ../src/undo/MoveLayerUndoAction.cpp:38
+msgid "Move layer"
+msgstr "Ebene verschieben"
+
+#: ../src/undo/SwapUndoAction.cpp:88
+msgid "Move page downwards"
+msgstr "Verschiebe Seite nach unten"
+
+#: ../src/undo/SwapUndoAction.cpp:88
+msgid "Move page upwards"
+msgstr "Verschiebe Seite nach oben"
+
 #: ../ui/main.glade:865
 msgid "N_ext annotated page"
 msgstr "Nächste beschriftete Seite"
+
+#: ../src/gui/dialog/ToolbarManageDialog.cpp:90
+msgid "New"
+msgstr "Neu"
 
 #: ../ui/main.glade:908
 msgid "New Page _After"
@@ -2332,9 +1556,38 @@ msgstr "Neue Seite davor"
 msgid "New Page at _End"
 msgstr "Neue Seite am Ende"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:391
+msgid "New Xournal"
+msgstr "Neues Xournal"
+
 #: ../ui/main.glade:952
 msgid "New _Layer"
 msgstr "Neue Ebene"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:434
+msgid "Next"
+msgstr "Nächste Seite"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:441
+msgid "Next annotated page"
+msgstr "Nächste beschriftete Seite"
+
+#: ../src/gui/dialog/ButtonConfigGui.cpp:44
+msgid "No device"
+msgstr "Kein Gerät"
+
+#: ../src/pdf/base/XojCairoPdfExport.cpp:93
+#: ../src/pdf/base/XojCairoPdfExport.cpp:142
+msgid "No pages to export!"
+msgstr "Keine Seite zu exportieren!"
+
+#: ../src/gui/dialog/ButtonConfigGui.cpp:98
+msgid "Normal drawing"
+msgstr "Normal zeichnen"
+
+#: ../src/plugin/Plugin.cpp:417 ../src/plugin/Plugin.cpp:438
+msgid "OK"
+msgstr "OK"
 
 #: ../ui/settings.glade:2893
 msgid "Offset first page this many pages when <b>Pair Pages</b> enabled"
@@ -2346,21 +1599,118 @@ msgstr ""
 msgid "On quick tap select object."
 msgstr "Bei schnellem Tippen auswählen."
 
+#: ../src/control/jobs/BaseExportJob.cpp:113
+msgid ""
+"Only local files are supported\n"
+"Path: {1}"
+msgstr ""
+"Es werden nur lokale Dateien unterstützt\n"
+"Pfad: {1}"
+
+#: ../src/control/stockdlg/ImageOpenDlg.cpp:11
+msgid "Open Image"
+msgstr "Öffne Bild"
+
+#: ../src/control/XournalMain.cpp:135
+msgid "Open Logfile"
+msgstr "Öffne Logdatei"
+
+#: ../src/control/XournalMain.cpp:136
+msgid "Open Logfile directory"
+msgstr "Öffne Verzeichnis der Logdateien"
+
+#: ../src/control/stockdlg/XojOpenDlg.cpp:16
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:392
+msgid "Open file"
+msgstr "Öffne Datei"
+
+#: ../src/control/RecentManager.cpp:249
+msgctxt "{1} is a URI"
+msgid "Open {1}"
+msgstr "Öffne {1}"
+
 #: ../ui/settings.glade:786
 msgid "Options"
 msgstr "Optionen"
+
+#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:18
+#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:144
+msgid "Orange"
+msgstr "Orange"
 
 #: ../ui/settings.glade:3635
 msgid "Output Device"
 msgstr "Ausgabegerät"
 
+#: ../src/control/jobs/PdfExportJob.cpp:9
+msgid "PDF Export"
+msgstr "PDF Exportieren"
+
+#: ../src/gui/MainWindow.cpp:802
+msgid "PDF Page {1}"
+msgstr "PDF-Seite {1}"
+
+#: ../src/view/PdfView.cpp:40
+msgid "PDF background missing"
+msgstr "PDF-Hintergrund fehlt"
+
+#: ../src/control/XournalMain.cpp:294
+msgid "PDF file successfully created"
+msgstr "PDF-Datei erfolgreich erstellt"
+
+#: ../src/control/jobs/CustomExportJob.cpp:23
+#: ../src/control/jobs/PdfExportJob.cpp:23
+#: ../src/control/stockdlg/XojOpenDlg.cpp:63
+msgid "PDF files"
+msgstr "PDF Dateien"
+
+#: ../src/control/XournalMain.cpp:313
+msgid "PDF output filename"
+msgstr "Dateiname der PDF-Ausgabe"
+
+#: ../src/control/jobs/CustomExportJob.cpp:24
+msgid "PDF with plain background"
+msgstr "PDF mit leerem Hintergrund"
+
+#: ../src/control/jobs/CustomExportJob.cpp:25
+msgid "PNG graphics"
+msgstr "PNG Bild"
+
+#: ../src/control/jobs/CustomExportJob.cpp:26
+msgid "PNG with transparent background"
+msgstr "PNG mit transparentem Hintergrund"
+
 #: ../ui/main.glade:875
 msgid "P_revious annotated Page"
 msgstr "Vorherige beschriftete Seite"
 
+#: ../src/gui/toolbarMenubar/ToolPageSpinner.cpp:67
+msgid "Page"
+msgstr "Seite"
+
+#: ../src/gui/sidebar/previews/page/SidebarPreviewPages.cpp:28
+msgid "Page Preview"
+msgstr "Seitenvorschau"
+
 #: ../ui/pageTemplate.glade:17
 msgid "Page Template"
 msgstr "Seitenvorlage"
+
+#: ../src/undo/PageBackgroundChangedUndoAction.cpp:106
+msgid "Page background changed"
+msgstr "Seitenhintergrund geändert"
+
+#: ../src/undo/InsertDeletePageUndoAction.cpp:129
+msgid "Page deleted"
+msgstr "Seite gelöscht"
+
+#: ../src/undo/InsertDeletePageUndoAction.cpp:125
+msgid "Page inserted"
+msgstr "Seite hinzugefügt"
+
+#: ../src/gui/toolbarMenubar/ToolPageSpinner.cpp:49
+msgid "Page number"
+msgstr "Seitennummer"
 
 #: ../ui/exportSettings.glade:167
 msgid "Pages:"
@@ -2369,6 +1719,10 @@ msgstr "Seiten:"
 #: ../ui/settings.glade:2926
 msgid "Paired Pages"
 msgstr "Mehrseitiges Layout"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:419
+msgid "Paired pages"
+msgstr "Mehrspaltig"
 
 #: ../ui/pagesize.glade:17
 msgid "Paper Format"
@@ -2394,13 +1748,37 @@ msgstr ""
 "Teilweise basierend auf Xounal\n"
 "von Denis Auroux"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:406
+#: ../src/undo/AddUndoAction.cpp:108
+msgid "Paste"
+msgstr "Einfügen"
+
 #: ../ui/main.glade:1528
 msgid "Pause"
 msgstr "Pause"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:485
+msgid "Pause / Play"
+msgstr "Pause / Play"
+
+#: ../src/gui/dialog/ButtonConfigGui.cpp:63
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:290
+msgid "Pen"
+msgstr "Stift"
+
 #: ../ui/main.glade:1226
 msgid "Pen _Options"
 msgstr "Stift Optionen"
+
+#: ../src/control/pagetype/PageTypeHandler.cpp:22
+msgid "Plain"
+msgstr "Einfarbig"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:478
+#: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:20
+#: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:89
+msgid "Play Object"
+msgstr "Objekt abspielen"
 
 #: ../ui/plugin.glade:13
 msgid "Plugin Manager"
@@ -2415,12 +1793,20 @@ msgid "Plugin changes are only applied after Xournal++ restart"
 msgstr ""
 "Änderungen an den Plugins werden erst nach einem Neustart von Xournal++ aktiv"
 
+#: ../src/gui/dialog/ToolbarManageDialog.cpp:23
+msgid "Predefined"
+msgstr "Vordefiniert"
+
 #: ../ui/main.glade:295
 msgid "Preferences"
 msgstr "Einstellungen"
 
 #: ../ui/settings.glade:2377
 msgid "Presentation Mode"
+msgstr "Präsentationsmodus"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:420
+msgid "Presentation mode"
 msgstr "Präsentationsmodus"
 
 #: ../ui/settings.glade:1065
@@ -2439,25 +1825,117 @@ msgstr "Zuletzt geöffnete _Dokumente"
 msgid "Record / Stop"
 msgstr "Aufnahme / Stop"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:484
+msgid "Record Audio / Stop Recording"
+msgstr "Aufzeichnung starten / stoppen"
+
+#: ../src/control/Control.cpp:970
+msgid "Recorder could not be started."
+msgstr "Aufzeichnung konnte nicht gestartet werden."
+
 #: ../ui/settings.glade:3759
 msgid "Recording Quality"
 msgstr "Aufnahmequalität"
+
+#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:16
+#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:142
+msgid "Red"
+msgstr "Rot"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:400
+#: ../src/undo/UndoRedoHandler.cpp:287
+msgid "Redo"
+msgstr "Wiederherstellen"
+
+#: ../src/undo/UndoRedoHandler.cpp:281
+msgid "Redo: "
+msgstr "Wiederherstellen: "
+
+#: ../src/control/Control.cpp:2292
+msgid "Remove PDF Background"
+msgstr "PDF-Hintergrund entfernen"
+
+#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:198
+msgid "Removed tool item from Toolbar {1} ID {2}"
+msgstr "Entferne Werkzeug von der Werkzeugleiste {1} ID {2}"
+
+#: ../src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:194
+msgid "Removed tool item {1} from Toolbar {2} ID {3}"
+msgstr "Entferne Werkzeug {1} von der Werkzeugleiste {2} ID {3}"
+
+#: ../src/util/XojMsgBox.cpp:74
+msgid "Replace"
+msgstr "Ersetzen"
+
+#: ../src/control/xojfile/LoadHandler.cpp:1331
+msgid "Requested temporary file was not found for attachment {1}"
+msgstr "Angefragte temporäre Datei für Anhang {1} nicht gefunden"
 
 #: ../ui/exportSettings.glade:107
 msgid "Resolution"
 msgstr "Auflösung"
 
+#: ../src/control/XournalMain.cpp:188
+msgid "Restore file"
+msgstr "Datei widerherstellen"
+
 #: ../ui/settings.glade:931
 msgid "Right Mouse Button"
 msgstr "Rechte Maustaste"
+
+#: ../src/undo/RotateUndoAction.cpp:74
+msgid "Rotation"
+msgstr "Drehung"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:413
+msgid "Rotation Snapping"
+msgstr "Drehung einrasten"
 
 #: ../ui/settings.glade:2958
 msgid "Rotation snapping tolerance"
 msgstr "Drehungsraster Toleranz"
 
+#: ../src/control/pagetype/PageTypeHandler.cpp:24
+msgid "Ruled"
+msgstr "Liniert"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:472
+msgid "Ruler"
+msgstr "Lineal"
+
+#: ../src/control/jobs/CustomExportJob.cpp:27
+msgid "SVG graphics"
+msgstr "SVG Bild"
+
+#: ../src/control/jobs/CustomExportJob.cpp:28
+msgid "SVG with transparent background"
+msgstr "SVG mit transparentem Hintergrund"
+
 #: ../ui/settings.glade:3700
 msgid "Sample Rate"
 msgstr "Abtastrate"
+
+#: ../src/control/Control.cpp:2827 ../src/control/jobs/SaveJob.cpp:13
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:393
+msgid "Save"
+msgstr "Speichern"
+
+#: ../src/control/Control.cpp:2872
+msgid "Save As"
+msgstr "Speichern als…"
+
+#: ../src/control/Control.cpp:2638 ../src/gui/dialog/PageTemplateDialog.cpp:111
+msgid "Save File"
+msgstr "Speichere Datei"
+
+#: ../src/control/jobs/CustomExportJob.cpp:162
+#: ../src/control/jobs/SaveJob.cpp:151
+msgid "Save file error: {1}"
+msgstr "Fehler beim Speichern der Datei: {1}"
+
+#: ../src/undo/ScaleUndoAction.cpp:73
+msgid "Scale"
+msgstr "Skalieren"
 
 #: ../ui/settings.glade:2214
 msgid "Scrollbars"
@@ -2467,6 +1945,10 @@ msgstr "Bildlaufleisten"
 msgid "Scrolling outside the page"
 msgstr "Scrollen über die Seitenränder hinaus"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:408
+msgid "Search"
+msgstr "Suchen"
+
 #: ../ui/pageTemplate.glade:165
 msgid "Select Background Color"
 msgstr "Hintergrundfarbe wählen"
@@ -2475,17 +1957,66 @@ msgstr "Hintergrundfarbe wählen"
 msgid "Select Folder"
 msgstr "Ordner auswählen"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:481
+msgid "Select Font"
+msgstr "Schriftart auswählen"
+
 #: ../ui/images.glade:7
 msgid "Select Image"
 msgstr "Bild auswählen"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:476
+#: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:19
+#: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:82
+msgid "Select Object"
+msgstr "Objekt auswählen"
 
 #: ../ui/pdfpages.glade:7
 msgid "Select PDF Page"
 msgstr "PDF-Seite auswählen"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:475
+#: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:10
+#: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:17
+#: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:68
+#: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:108
+msgid "Select Rectangle"
+msgstr "Rechteck auswählen"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:474
+#: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:18
+#: ../src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:75
+msgid "Select Region"
+msgstr "Bereich auswählen"
+
+#: ../src/control/Control.cpp:2291
+msgid "Select another PDF"
+msgstr "Andere PDF-Datei auswählen"
+
+#: ../src/util/XojMsgBox.cpp:73
+msgid "Select another name"
+msgstr "Anderen Namen wählen"
+
+#: ../src/gui/dialog/SelectBackgroundColorDialog.cpp:143
+msgid "Select background color"
+msgstr "Hintergrundfarbe wählen"
+
+#: ../src/gui/toolbarMenubar/ColorToolItem.cpp:59
+#: ../src/gui/toolbarMenubar/ColorToolItem.cpp:175
+msgid "Select color"
+msgstr "Farbe auswählen"
+
 #: ../ui/settings.glade:3240
 msgid "Select on quick tap."
 msgstr "Bei schnellem Tippen auswählen."
+
+#: ../src/gui/dialog/ButtonConfigGui.cpp:70
+msgid "Select rectangle"
+msgstr "Rechteck auswählen"
+
+#: ../src/gui/dialog/ButtonConfigGui.cpp:69
+msgid "Select region"
+msgstr "Bereich auswählen"
 
 #: ../ui/settings.glade:2343
 msgid "Select toolbar:"
@@ -2495,6 +2026,14 @@ msgstr "Wähle Werkzeugleiste:"
 msgid "Selection Color (Text, Stroke Selection etc.)"
 msgstr "Auswahlfarbe (Text-, Figuren Selektion etc.)"
 
+#: ../src/control/XournalMain.cpp:134
+msgid "Send Bugreport"
+msgstr "Fehlerbericht senden"
+
+#: ../src/gui/dialog/toolbarCustomize/ToolbarCustomizeDialog.cpp:53
+msgid "Separator"
+msgstr "Trenner"
+
 #: ../ui/main.glade:458
 msgid "Set Columns"
 msgstr "Spalten setzen"
@@ -2503,9 +2042,17 @@ msgstr "Spalten setzen"
 msgid "Set Rows"
 msgstr "Zeilen setzen"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:467
+msgid "Shape Recognizer"
+msgstr "Figurenerkennung"
+
 #: ../ui/settings.glade:1853
 msgid "Show Menubar on Startup"
 msgstr "Menüleiste beim Start zeigen"
+
+#: ../src/gui/toolbarMenubar/ToolPageLayer.cpp:90
+msgid "Show all"
+msgstr "Alle anzeigen"
 
 #: ../ui/pdfpages.glade:67
 msgid ""
@@ -2514,6 +2061,14 @@ msgid ""
 msgstr ""
 "Zeige nur nicht benutzte Seiten\n"
 "DIESER TEXT IST EIN PLATZHALTER!"
+
+#: ../src/gui/dialog/backgroundSelect/PdfPagesDialog.cpp:134
+msgid "Show only not used pages (one unused page)"
+msgstr "Nur nicht benutzte Seiten anzeigen (eine nicht benutzte Seiten)"
+
+#: ../src/gui/dialog/backgroundSelect/PdfPagesDialog.cpp:135
+msgid "Show only not used pages ({1} unused pages)"
+msgstr "Nur nicht benutzte Seiten anzeigen ({1} nicht benutzte Seiten)"
 
 #: ../ui/main.glade:346
 msgid "Show sidebar"
@@ -2531,6 +2086,22 @@ msgstr "Vertikale Bildlaufleiste auf der linken Seite anzeigen"
 msgid "Snapping"
 msgstr "Raster"
 
+#: ../src/control/XournalMain.cpp:388
+msgid ""
+"Sorry, Xournal++ can only open one file at once.\n"
+"Others are ignored."
+msgstr ""
+"Entschuldigung, Xournal++ kann nur eine Datei aufs mal öffnen.\n"
+"Alle weiteren werden ignoriert."
+
+#: ../src/control/XournalMain.cpp:403
+msgid ""
+"Sorry, Xournal++ cannot open remote files at the moment.\n"
+"You have to copy the file to a local directory."
+msgstr ""
+"Entschuldigung, Xournal++ kann derzeit keine entfernten Dateien öffnen.\n"
+"Kopieren Sie die Datei in einen lokalen Ordner."
+
 #: ../ui/settings.glade:2457
 msgid "Speed for Ctrl + Scroll"
 msgstr "Geschwindigkeit für Strg + Scroll"
@@ -2547,6 +2118,10 @@ msgstr "Standard"
 msgid "State PLACEHOLDER"
 msgstr "Zustand PLATZHALTER"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:487
+msgid "Stop"
+msgstr "Aufnahme stoppen"
+
 #: ../ui/settings.glade:3522 ../ui/settings.glade:3558
 msgid "Storage Folder"
 msgstr "Speicherplatz"
@@ -2554,6 +2129,12 @@ msgstr "Speicherplatz"
 #: ../ui/settings.glade:3277
 msgid "Stroke Filter - w/ try quick Select ( Experimental )"
 msgstr "Strichfilter - mit/ohne Schnellauswahl (experimentell)"
+
+#: ../src/gui/dialog/ButtonConfigGui.cpp:110
+#: ../src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp:35
+#: ../src/undo/RecognizerUndoAction.cpp:101
+msgid "Stroke recognizer"
+msgstr "Figurenerkennung"
 
 #: ../ui/settings.glade:1258
 msgid "Stylus"
@@ -2563,9 +2144,17 @@ msgstr "Stift"
 msgid "Stylus Buttons"
 msgstr "Stifttasten"
 
+#: ../src/util/CrashHandler.cpp:51
+msgid "Successfully saved document to \"{1}\""
+msgstr "Dokument erfolgreich nach \"{1}\" gespeichert."
+
 #: ../ui/settings.glade:3211
 msgid "Successive (ms)"
 msgstr "Aufeinander folgend (ms)"
+
+#: ../src/control/stockdlg/XojOpenDlg.cpp:134
+msgid "Supported files"
+msgstr "Unterstützte Dateiformate"
 
 #: ../ui/main.glade:1721
 msgid "Swap the current page with the one above"
@@ -2587,13 +2176,106 @@ msgstr "Vorlage:"
 msgid "Test"
 msgstr "Test"
 
+#: ../src/gui/dialog/ButtonConfigGui.cpp:66
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:462
+msgid "Text"
+msgstr "Text"
+
+#: ../src/gui/SearchBar.cpp:70
+#, c-format
+msgid "Text %i times found on this page"
+msgstr "Text auf dieser Seite %i mal gefunden"
+
 #: ../ui/main.glade:1508
 msgid "Text Font..."
 msgstr "Schriftart..."
 
+#: ../src/undo/TextUndoAction.cpp:47
+msgid "Text changes"
+msgstr "Text geändert"
+
+#: ../src/gui/SearchBar.cpp:66
+msgid "Text found on this page"
+msgstr "Text auf dieser Seite gefunden"
+
+#: ../src/gui/SearchBar.cpp:150 ../src/gui/SearchBar.cpp:206
+msgid "Text found once on page {1}"
+msgstr "Text einmal auf Seite {1} gefunden"
+
+#: ../src/gui/SearchBar.cpp:151 ../src/gui/SearchBar.cpp:207
+msgid "Text found {1} times on page {2}"
+msgstr "Text {1}-mal auf Seite {2} gefunden"
+
+#: ../src/gui/SearchBar.cpp:77
+msgid "Text not found"
+msgstr "Text nicht gefunden"
+
+#: ../src/gui/SearchBar.cpp:164 ../src/gui/SearchBar.cpp:220
+msgid "Text not found, searched on all pages"
+msgstr "Text nicht gefunden, auf allen Seiten gesucht"
+
+#: ../src/control/Control.cpp:1163
+msgid ""
+"The Toolbarconfiguration \"{1}\" is predefined, would you create a copy to "
+"edit?"
+msgstr ""
+"Die Werkzeugleistenkonfiguration \"{1}\" ist vordefiniert, möchten Sie eine "
+"Kopie erstellen?"
+
+#: ../src/control/Control.cpp:2288
+msgid "The attached background PDF could not be found."
+msgstr "Der angehängte PDF-Hintergrund konnte nicht gefunden werden."
+
+#: ../src/control/Control.cpp:2289
+msgid "The background PDF could not be found."
+msgstr "Der PDF-Hintergrund konnte nicht gefunden werden."
+
+#: ../src/control/xojfile/LoadHandler.cpp:150
+msgid "The file is no valid .xopp file (Mimetype missing): \"{1}\""
+msgstr "Die Datei ist keine gültige .xopp-Datei (Mimetype fehlt): \"{1}\""
+
+#: ../src/control/xojfile/LoadHandler.cpp:158
+msgid "The file is no valid .xopp file (Mimetype wrong): \"{1}\""
+msgstr "Die Datei ist keine gültige .xopp-Datei (Mimetype falsch): \"{1}\""
+
+#: ../src/control/xojfile/LoadHandler.cpp:167
+msgid "The file is no valid .xopp file (Version missing): \"{1}\""
+msgstr "Die Datei ist keine gültige .xopp-Datei (Version fehlt): \"{1}\""
+
+#: ../src/control/xojfile/LoadHandler.cpp:181
+msgid "The file is not a valid .xopp file (Version string corrupted): \"{1}\""
+msgstr ""
+"Die Datei ist keine gültige .xopp-Datei (Versionsdaten ungültig): \"{1}\""
+
+#: ../src/control/XournalMain.cpp:129
+msgid "The most recent log file name: {1}"
+msgstr "Der aktuelleste Logdateiname: {1}"
+
 #: ../ui/settings.glade:2638
 msgid "The unit of the ruler is cm"
 msgstr "Die Einheit des Maßstabes ist cm"
+
+#: ../src/control/XournalMain.cpp:122
+msgid ""
+"There are errorlogfiles from Xournal++. Please send a Bugreport, so the bug "
+"may be fixed."
+msgstr ""
+"Es ist ein Xournal++ Fehlerlog vorhanden. Bitte senden Sie einen "
+"Fehlerbericht (auf Englisch wenn möglich), damit der Fehler korrigiert "
+"werden kann."
+
+#: ../src/control/XournalMain.cpp:121
+msgid ""
+"There is an errorlogfile from Xournal++. Please send a Bugreport, so the bug "
+"may be fixed."
+msgstr ""
+"Es ist ein Xournal++ Fehlerlog vorhanden. Bitte senden Sie einen "
+"Fehlerbericht (auf Englisch wenn möglich), damit der Fehler korrigiert "
+"werden kann."
+
+#: ../src/util/XojMsgBox.cpp:89
+msgid "There was an error displaying help: {1}"
+msgstr "Es ist ein Fehler aufgetreten beim Anzeigen der Hilfe: {1}"
 
 #: ../ui/settings.glade:715
 msgid ""
@@ -2602,9 +2284,32 @@ msgstr ""
 "Die folgenden Einstellungen zeigen nur Wirkung wenn das experimentelle "
 "Eingabesystem aktiviert ist"
 
+#: ../src/gui/dialog/ButtonConfigGui.cpp:89
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:524
+msgid "Thick"
+msgstr "Dick"
+
+#: ../src/gui/dialog/ButtonConfigGui.cpp:86
+msgid "Thickness - don't change"
+msgstr "Dicke - nicht ändern"
+
+#: ../src/gui/dialog/ButtonConfigGui.cpp:87
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:522
+msgid "Thin"
+msgstr "Dünn"
+
+#: ../src/control/Control.cpp:2825
+msgid "This document is not saved yet."
+msgstr "Dieses Dokument wurde noch nicht gespeichert."
+
 #: ../ui/settings.glade:675
 msgid "This feature is not yet implemented - this is only a placeholder"
 msgstr "Diese Funktion ist noch nicht implementiert - dies ist ein Platzhalter"
+
+#: ../src/control/PageBackgroundChangeController.cpp:183
+#: ../src/control/tools/ImageHandler.cpp:56
+msgid "This image could not be loaded. Error message: {1}"
+msgstr "Das Bild konnte nicht geladen werden. Fehlermeldung: {1}"
 
 #: ../ui/settings.glade:601
 msgid "This is an experimental feature! Use it with care. "
@@ -2614,6 +2319,22 @@ msgstr "Dies ist eine experimentelle Funktion! Benutze sie mit Vorsicht."
 msgid "Timeout"
 msgstr "Wartezeit"
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:421
+msgid "Toggle fullscreen"
+msgstr "Vollbild umschalten"
+
+#: ../src/gui/dialog/ButtonConfigGui.cpp:62
+msgid "Tool - don't change"
+msgstr "Werkzeug - nicht ändern"
+
+#: ../src/gui/toolbarMenubar/model/ToolbarData.cpp:166
+msgid "Toolbar found: {1}"
+msgstr "Werkzeugleiste gefunden: {1}"
+
+#: ../src/gui/dialog/ToolbarManageDialog.cpp:55
+msgid "Toolbars"
+msgstr "Werkzeugleisten"
+
 #: ../ui/settings.glade:1343 ../ui/settings.glade:1800
 msgid "Touchscreen"
 msgstr "Touchscreen"
@@ -2621,6 +2342,55 @@ msgstr "Touchscreen"
 #: ../ui/fillTransparency.glade:13
 msgid "Transparency settings"
 msgstr "Tranzparenz Einstellungen"
+
+#: ../src/util/CrashHandler.cpp:37
+msgid "Trying to emergency save the current open document…"
+msgstr "Versuche ein Notfall-Speichern des aktuell geöffneten Dokuments…"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:399
+#: ../src/undo/UndoRedoHandler.cpp:268
+msgid "Undo"
+msgstr "Rückgängig"
+
+#: ../src/undo/UndoRedoHandler.cpp:263
+msgid "Undo: "
+msgstr "Rückgängig: "
+
+#: ../src/control/xojfile/LoadHandler.cpp:350
+msgid "Unexpected root tag: {1}"
+msgstr "Unerwarteter Root Tag: {1}"
+
+#: ../src/control/xojfile/LoadHandler.cpp:383
+msgid "Unexpected tag in document: \"{1}\""
+msgstr "Unerwarteter Tag im Dokument: \"{1}\""
+
+#: ../src/control/xojfile/LoadHandler.cpp:634
+msgid "Unknown background type: {1}"
+msgstr "Unbekannter Hintergrundtyp: {1}"
+
+#: ../src/control/xojfile/LoadHandlerHelper.cpp:80
+msgid "Unknown color value \"{1}\""
+msgstr "Unbekannter Farbwert \"{1}\""
+
+#: ../src/control/xojfile/LoadHandler.cpp:569
+msgid "Unknown domain type: {1}"
+msgstr "Unbekannter Domänentyp: {1}"
+
+#: ../src/control/xojfile/LoadHandler.cpp:284
+msgid "Unknown parser error"
+msgstr "Unbekannter Lesefehler"
+
+#: ../src/control/xojfile/LoadHandler.cpp:482
+msgid "Unknown pixmap::domain type: {1}"
+msgstr "Unbekannter pixmap::domain Typ: {1}"
+
+#: ../src/control/xojfile/LoadHandler.cpp:753
+msgid "Unknown stroke type: \"{1}\", assuming pen"
+msgstr "Unbekannter Linientyp: \"{1}\", verwende Stift"
+
+#: ../src/control/Control.cpp:2711
+msgid "Unsaved Document"
+msgstr "Ungespeichertes Dokument"
 
 #: ../ui/settings.glade:2905
 msgid "Usually 0 or 1"
@@ -2634,9 +2404,22 @@ msgstr "Version"
 msgid "Version: "
 msgstr "Version: "
 
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:477
+msgid "Vertical Space"
+msgstr "Vertikaler Platz"
+
+#: ../src/gui/dialog/ButtonConfigGui.cpp:68
+msgid "Vertical space"
+msgstr "Vertikaler Platz"
+
 #: ../ui/settings.glade:2407
 msgid "View"
 msgstr "Ansicht"
+
+#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:20
+#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:146
+msgid "White"
+msgstr "Weiß"
 
 #: ../ui/settingsButtonConfig.glade:121
 msgid "Whiteout"
@@ -2646,6 +2429,10 @@ msgstr "Weiß übermalen"
 msgid "Width:"
 msgstr "Breite:"
 
+#: ../src/control/pagetype/PageTypeHandler.cpp:31
+msgid "With PDF background"
+msgstr "Mit PDF-Hintergrund"
+
 #: ../ui/about.glade:193
 msgid "With help from the community"
 msgstr "Mit Hilfe der Community"
@@ -2654,13 +2441,89 @@ msgstr "Mit Hilfe der Community"
 msgid "Workaround"
 msgstr "Abhilfe"
 
+#: ../src/undo/InsertUndoAction.cpp:44
+msgid "Write text"
+msgstr "Text schreiben"
+
+#: ../src/control/xojfile/LoadHandler.cpp:1153
+msgid "Wrong count of points ({1})"
+msgstr "Falsche Punktanzahl ({1})"
+
+#: ../src/control/xojfile/LoadHandler.cpp:1167
+msgid "Wrong number of points, got {1}, expected {2}"
+msgstr "Falsche Punktzahl {1}, erwartet wurde {2}"
+
 #: ../ui/settings.glade:1443
 msgid "X11"
 msgstr "X11"
 
+#: ../src/control/xojfile/LoadHandler.cpp:279
+msgid "XML Parser error: {1}"
+msgstr "XML Parser Fehler: {1}"
+
+#: ../src/control/jobs/CustomExportJob.cpp:29
+msgid "Xournal (Compatibility)"
+msgstr "Xournal (Kompatibilitätsmodus)"
+
+#: ../src/control/stockdlg/XojOpenDlg.cpp:74
+msgid "Xournal files"
+msgstr "Xournal Dateien"
+
 #: ../ui/settings.glade:103
 msgid "Xournal++ Preferences"
 msgstr "Xournal++ Einstellungen"
+
+#: ../src/control/XournalMain.cpp:182
+msgid "Xournal++ crashed last time. Would you restore it?"
+msgstr ""
+"Xournal++ ist das letzte mal abgestürzt. Soll die Datei widerhergestellt "
+"werden?"
+
+#: ../src/control/Control.cpp:2645 ../src/control/stockdlg/XojOpenDlg.cpp:84
+msgid "Xournal++ files"
+msgstr "Xournal++ Dateien"
+
+#: ../src/control/stockdlg/XojOpenDlg.cpp:94
+#: ../src/gui/dialog/PageTemplateDialog.cpp:118
+msgid "Xournal++ template"
+msgstr "Xournal++ Vorlage"
+
+#: ../src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp:19
+#: ../src/gui/toolbarMenubar/model/ToolbarColorNames.cpp:145
+msgid "Yellow"
+msgstr "Gelb"
+
+#: ../src/control/PageBackgroundChangeController.cpp:225
+msgid ""
+"You don't have any PDF pages to select from. Cancel operation.\n"
+"Please select another background type: Menu \"Journal\" → \"Configure Page "
+"Template\"."
+msgstr ""
+"Es gibt keine PDF Seiten zum Auswählen. Abbruch.\n"
+"Bitte wählen Sie einen anderen Hintergrundtyp: Menü \"Journal\" / "
+"\"Seitenvorlage konfigurieren\"."
+
+#: ../src/control/XournalMain.cpp:125
+msgid ""
+"You're using {1}/{2} branch. Send Bugreport will direct you to this repo's "
+"issue tracker."
+msgstr ""
+"Sie benutzen den {1}/{2} Zweig. Das Senden eines Fehlerberichts wird Sie zum "
+"Issue-Tracker dieses Repositoriums führen."
+
+#: ../src/gui/sidebar/indextree/SidebarIndexPage.cpp:93
+msgid ""
+"Your current document does not contain PDF Page no {1}\n"
+"Would you like to insert this page?\n"
+"\n"
+"Tip: You can select Journal → Paper Background → PDF Background to insert a "
+"PDF page."
+msgstr ""
+"Ihr aktuelles Dokument beinhaltet die PDF Seite {1} nicht\n"
+"Möchten Sie diese Seite einfügen?\n"
+"\n"
+"Tipp: Sie können im Menü Journal / Seitenhintergrund / PDF-Hintergrund eine "
+"beliebige PDF Seite einfügen."
 
 #: ../ui/settings.glade:2691
 msgid "Zoom"
@@ -2673,6 +2536,26 @@ msgstr "Zoom-Gesten"
 #: ../ui/settings.glade:2538
 msgid "Zoom Speed"
 msgstr "Zoomgeschwindigkeit"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:425
+msgid "Zoom fit to screen"
+msgstr "Passend zoomen"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:424
+msgid "Zoom in"
+msgstr "Hereinzoomen"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:423
+msgid "Zoom out"
+msgstr "Herauszoomen"
+
+#: ../src/gui/toolbarMenubar/ToolZoomSlider.cpp:106
+msgid "Zoom slider"
+msgstr "Zoomregler"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:426
+msgid "Zoom to 100%"
+msgstr "Zoom auf 100%"
 
 #: ../ui/main.glade:468 ../ui/main.glade:563
 msgid "_1"
@@ -2701,6 +2584,13 @@ msgstr "_PDF beschriften"
 #: ../ui/main.glade:433
 msgid "_Bottom to Top"
 msgstr "_Unten nach Oben"
+
+#: ../src/control/Control.cpp:2639 ../src/control/jobs/BaseExportJob.cpp:25
+#: ../src/control/stockdlg/ImageOpenDlg.cpp:12
+#: ../src/control/stockdlg/XojOpenDlg.cpp:17
+#: ../src/gui/dialog/PageTemplateDialog.cpp:112
+msgid "_Cancel"
+msgstr "_Abbrechen"
 
 #: ../ui/main.glade:447
 msgid "_Cols/Rows"
@@ -2786,6 +2676,11 @@ msgstr "_Nächste Ebene"
 msgid "_Next Page"
 msgstr "_Nächste Seite"
 
+#: ../src/control/stockdlg/ImageOpenDlg.cpp:13
+#: ../src/control/stockdlg/XojOpenDlg.cpp:18
+msgid "_Open"
+msgstr "Ö_ffnen"
+
 #: ../ui/main.glade:318
 msgid "_Pair Pages"
 msgstr "_Mehrseitiges Layout"
@@ -2813,6 +2708,11 @@ msgstr "_Vorherige Seite"
 #: ../ui/main.glade:407
 msgid "_Right To Left"
 msgstr "_Rechts nach Links"
+
+#: ../src/control/Control.cpp:2640 ../src/control/jobs/BaseExportJob.cpp:26
+#: ../src/gui/dialog/PageTemplateDialog.cpp:113
+msgid "_Save"
+msgstr "_Speichern"
 
 #: ../ui/main.glade:1088
 msgid "_Shape Recognizer"
@@ -2878,9 +2778,37 @@ msgstr "_weiß übermalen"
 msgid "change"
 msgstr "ändern"
 
+#: ../src/util/DeviceListHelper.cpp:92
+msgid "cursor"
+msgstr "XournalppCursor"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:298
+msgid "dash-/ doted"
+msgstr "gepunkted / gestrichelt"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:295
+msgid "dashed"
+msgstr "gestichelt"
+
+#: ../src/gui/dialog/PluginDialogEntry.cpp:38
+msgid "default disabled"
+msgstr "Standard deaktivieren"
+
+#: ../src/gui/dialog/PluginDialogEntry.cpp:38
+msgid "default enabled"
+msgstr "Standard aktivieren"
+
 #: ../ui/pluginEntry.glade:140
 msgid "default enabled / disabled"
 msgstr "Standard aktiviert / deaktiviert"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:315
+msgid "delete stroke"
+msgstr "Linie löschen"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:301
+msgid "dotted"
+msgstr "Gepunktet"
 
 #: ../ui/exportSettings.glade:213
 msgid "dpi"
@@ -2890,9 +2818,17 @@ msgstr "dpi"
 msgid "enabled,"
 msgstr "aktiviert,"
 
+#: ../src/util/DeviceListHelper.cpp:88
+msgid "eraser"
+msgstr "Radierer"
+
 #: ../ui/settings.glade:248
 msgid "every"
 msgstr "alle"
+
+#: ../src/util/DeviceListHelper.cpp:97
+msgid "keyboard"
+msgstr "Tastatur"
 
 #: ../ui/pageTemplate.glade:47
 msgid "load from file"
@@ -2901,6 +2837,14 @@ msgstr "Von Datei laden"
 #: ../ui/settings.glade:273
 msgid "minutes"
 msgstr "Minuten"
+
+#: ../src/util/DeviceListHelper.cpp:80
+msgid "mouse"
+msgstr "Maus"
+
+#: ../src/util/DeviceListHelper.cpp:84
+msgid "pen"
+msgstr "Stift"
 
 # Übersetzung unterscheidet sich wegen Satzbau
 #: ../ui/settings.glade:2829 ../ui/settings.glade:2840
@@ -2920,9 +2864,65 @@ msgstr "s <i>(nach denen der Touchscreen reaktiviert wird)</i>"
 msgid "save to file"
 msgstr "Speichere in Datei"
 
+#: ../src/gui/toolbarMenubar/ToolPageLayer.cpp:222
+msgid "show"
+msgstr "anzeigen"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:292
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:313
+msgid "standard"
+msgstr "standard"
+
+#: ../src/util/DeviceListHelper.cpp:105
+msgid "touchpad"
+msgstr "Touchpad"
+
+#: ../src/util/DeviceListHelper.cpp:101
+msgid "touchscreen"
+msgstr "Touchscreen"
+
 #: ../ui/main.glade:1276
 msgid "ver_y thick"
 msgstr "sehr dick"
+
+#: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:314
+msgid "whiteout"
+msgstr "weiß übermalen"
+
+#: ../src/control/xojfile/LoadHandler.cpp:1166
+msgid "xoj-File: {1}"
+msgstr "xoj-Datei: {1}"
+
+#: ../src/xoj-preview-extractor/xournal-thumbnailer.cpp:75
+msgid "xoj-preview-extractor: call with INPUT.xoj OUTPUT.png"
+msgstr "xoj-Vorschau-Extraktor: rufe auf mit INPUT.xoj OUTPUT.png"
+
+#: ../src/xoj-preview-extractor/xournal-thumbnailer.cpp:97
+msgid "xoj-preview-extractor: file \"{1}\" contains no preview"
+msgstr "xoj-Vorschau-Extraktor: Datei \"{1}\" enthält keine Vorschau"
+
+#: ../src/xoj-preview-extractor/xournal-thumbnailer.cpp:89
+msgid "xoj-preview-extractor: file \"{1}\" is not .xoj file"
+msgstr "xoj-Vorschau-Extraktor: Datei \"{1}\" ist keine xoj-Datei"
+
+#: ../src/xoj-preview-extractor/xournal-thumbnailer.cpp:102
+msgid ""
+"xoj-preview-extractor: no preview and page found, maybe an invalid file?"
+msgstr ""
+"xoj-Vorschau-Extraktor: keine Vorschau und keine Seite gefunden: ungültige "
+"Datei?"
+
+#: ../src/xoj-preview-extractor/xournal-thumbnailer.cpp:93
+msgid "xoj-preview-extractor: opening input file \"{1}\" failed"
+msgstr "xoj-Vorschau-Extraktor: Öffnen der Datei \"{1}\" fehlgeschlagen"
+
+#: ../src/xoj-preview-extractor/xournal-thumbnailer.cpp:109
+msgid "xoj-preview-extractor: opening output file \"{1}\" failed"
+msgstr "xoj-Vorschau-Extraktor: Öffnen der Ausgabedatei \"{1}\" fehlgeschlagen"
+
+#: ../src/xoj-preview-extractor/xournal-thumbnailer.cpp:118
+msgid "xoj-preview-extractor: successfully extracted"
+msgstr "xoj-Vorschau-Extraktor: erfolgreich extrahiert"
 
 #~ msgid "Could not delete old autosave file \"{1}\""
 #~ msgstr ""

--- a/src/gui/Redrawable.h
+++ b/src/gui/Redrawable.h
@@ -26,7 +26,7 @@ public:
 
 	/**
 	 * Call this if you only need to repaint the view, this means the buffer will be painted again,
-	 * and all selections, text edtiors etc. are drawed again, but the view buffer is not refreshed.
+	 * and all selections, text editors etc. are drawn again, but the view buffer is not refreshed.
 	 *
 	 * for refreshing the view buffer (if you have changed the document) call rerender.
 	 */
@@ -37,7 +37,7 @@ public:
 
 	/**
 	 * Call this if you only need to readraw the view, this means the buffer will be painted again,
-	 * and all selections, text edtiors etc. are drawed again, but the view buffer is not refreshed.
+	 * and all selections, text edtiors etc. are drawn again, but the view buffer is not refreshed.
 	 *
 	 * for refreshing the view buffer (if you have changed the document) call repaint.
 	 */

--- a/src/gui/toolbarMenubar/icon/ColorSelectImage.cpp
+++ b/src/gui/toolbarMenubar/icon/ColorSelectImage.cpp
@@ -48,7 +48,7 @@ void ColorSelectImage::drawWidget(cairo_t* cr)
 }
 
 /**
- * @return The widget which is drawed
+ * @return The widget which is drawn
  */
 GtkWidget* ColorSelectImage::getWidget()
 {

--- a/src/gui/toolbarMenubar/icon/ColorSelectImage.h
+++ b/src/gui/toolbarMenubar/icon/ColorSelectImage.h
@@ -73,7 +73,7 @@ public:
 
 public:
 	/**
-	 * @return The widget which is drawed
+	 * @return The widget which is drawn
 	 */
 	GtkWidget* getWidget();
 
@@ -117,7 +117,7 @@ private:
 	XOJ_TYPE_ATTRIB;
 
 	/**
-	 * The widget which is drawed
+	 * The widget which is drawn
 	 */
 	GtkWidget* widget = NULL;
 

--- a/src/model/Stroke.cpp
+++ b/src/model/Stroke.cpp
@@ -449,7 +449,7 @@ void Stroke::setPressure(const vector<double>& pressure)
 {
 	XOJ_CHECK_TYPE(Stroke);
 
-	// The last pressure is not used - as there is no line drawed from this point
+	// The last pressure is not used - as there is no line drawn from this point
 	if (this->pointCount - 1 > (int)pressure.size())
 	{
 		g_warning("invalid pressure point count: %i, expected %i", (int)pressure.size(), (int)this->pointCount - 1);

--- a/src/view/DocumentView.cpp
+++ b/src/view/DocumentView.cpp
@@ -216,8 +216,8 @@ void DocumentView::drawLayer(cairo_t* cr, Layer* l)
 	cairo_set_operator(cr, CAIRO_OPERATOR_SOURCE);
 
 #ifdef DEBUG_SHOW_REPAINT_BOUNDS
-	int drawed = 0;
-	int notDrawed = 0;
+	int drawn = 0;
+	int notDrawn = 0;
 #endif // DEBUG_SHOW_REPAINT_BOUNDS
 	for (Element* e : *l->getElements())
 	{
@@ -235,13 +235,13 @@ void DocumentView::drawLayer(cairo_t* cr, Layer* l)
 			{
 				drawElement(cr, e);
 #ifdef DEBUG_SHOW_REPAINT_BOUNDS
-				drawed++;
+				drawn++;
 #endif // DEBUG_SHOW_REPAINT_BOUNDS
 			}
 #ifdef DEBUG_SHOW_REPAINT_BOUNDS
 			else
 			{
-				notDrawed++;
+				notDrawn++;
 			}
 #endif // DEBUG_SHOW_REPAINT_BOUNDS
 
@@ -249,14 +249,14 @@ void DocumentView::drawLayer(cairo_t* cr, Layer* l)
 		else
 		{
 #ifdef DEBUG_SHOW_REPAINT_BOUNDS
-			drawed++;
+			drawn++;
 #endif // DEBUG_SHOW_REPAINT_BOUNDS
 			drawElement(cr, e);
 		}
 	}
 
 #ifdef DEBUG_SHOW_REPAINT_BOUNDS
-	g_message("DBG:DocumentView: draw %i / not draw %i", drawed, notDrawed);
+	g_message("DBG:DocumentView: draw %i / not draw %i", drawn, notDrawn);
 #endif // DEBUG_SHOW_REPAINT_BOUNDS
 }
 

--- a/src/view/StrokeView.cpp
+++ b/src/view/StrokeView.cpp
@@ -103,7 +103,7 @@ void StrokeView::changeCairoSource(bool markAudioStroke)
 }
 
 /**
- * No pressure sensitivity, one line is drawed
+ * No pressure sensitivity, one line is drawn
  */
 void StrokeView::drawNoPressure()
 {
@@ -165,7 +165,7 @@ void StrokeView::drawNoPressure()
 
 /**
  * Draw a stroke with pressure, for this multiple
- * lines with different widths needs to be drawed
+ * lines with different widths needs to be drawn
  */
 void StrokeView::drawWithPressuire()
 {

--- a/src/view/StrokeView.h
+++ b/src/view/StrokeView.h
@@ -36,13 +36,13 @@ private:
 	void drawEraseableStroke(cairo_t* cr, Stroke* s);
 
 	/**
-	 * No pressure sensitivity, one line is drawed
+	 * No pressure sensitivity, one line is drawn
 	 */
 	void drawNoPressure();
 
 	/**
 	 * Draw a stroke with pressure, for this multiple
-	 * lines with different widths needs to be drawed
+	 * lines with different widths needs to be drawn
 	 */
 	void drawWithPressuire();
 


### PR DESCRIPTION
Spelling fix
po.de.po   <- should I be checking this in  - updated by cmake and constantly getting in the way of other checkins. Did someone forget to check it in?