### PR TITLE
Make cursor visible on general movement after typing in text field

### DIFF
--- a/src/gui/inputdevices/MouseInputHandler.cpp
+++ b/src/gui/inputdevices/MouseInputHandler.cpp
@@ -59,11 +59,14 @@ bool MouseInputHandler::handleImpl(InputEvent* event)
 		if (this->deviceClassPressed)
 		{
 			this->actionMotion(event);
-		} else
+		}
+		else
 		{
 			XournalppCursor* cursor = xournal->view->getCursor();
 			cursor->setTempCursor(GDK_ARROW);
 		}
+		// Update cursor visibility
+		xournal->view->getCursor()->setInvisible(false);
 	}
 
 	// Notify if mouse enters/leaves widget

--- a/src/gui/inputdevices/PenInputHandler.cpp
+++ b/src/gui/inputdevices/PenInputHandler.cpp
@@ -283,7 +283,6 @@ bool PenInputHandler::actionMotion(InputEvent* event)
 
 	// Update the cursor
 	xournal->view->getCursor()->setInsidePage(currentPage != nullptr);
-	xournal->view->getCursor()->setInvisible(false);
 
 	// Selections and single-page elements will always work on one page so we need to handle them differently
 	if (this->sequenceStartPage && toolHandler->isSinglePageTool())

--- a/src/gui/inputdevices/StylusInputHandler.cpp
+++ b/src/gui/inputdevices/StylusInputHandler.cpp
@@ -70,11 +70,14 @@ bool StylusInputHandler::handleImpl(InputEvent* event)
 		if (this->deviceClassPressed)
 		{
 			this->actionMotion(event);
-		} else
+		}
+		else
 		{
 			XournalppCursor* cursor = xournal->view->getCursor();
 			cursor->updateCursor();
 		}
+		// Update cursor visibility
+		xournal->view->getCursor()->setInvisible(false);
 	}
 
 


### PR DESCRIPTION
Previously, #1164 fixed the cursor becoming invisible after editing a text field, but it seems to only work when the cursor is pressed and moved. This PR makes the cursor visibile when the cursor moves in general, not just when the mouse/stylus is pressed.