### PR TITLE
Make latex tool check for latex package dependencies

### DIFF
--- a/src/control/LatexController.h
+++ b/src/control/LatexController.h
@@ -50,10 +50,21 @@ public:
 	void run();
 
 private:
+
 	/**
-	 * Find the tex executable, return false if not found
+	 * Provides information about whether a particular dependency was found or not.
 	 */
-	bool findTexExecutable();
+	class FindDependencyStatus {
+	public:
+		FindDependencyStatus(bool success, string errorMsg) : success(success), errorMsg(errorMsg) {};
+		bool success;
+		string errorMsg;
+	};
+
+	/**
+	 * Set the required LaTeX files, returning false if at least one of them is not found.
+	 */
+	LatexController::FindDependencyStatus findTexDependencies();
 
 	/**
 	 * Find a selected tex element, and load it


### PR DESCRIPTION
Fixes #1178. In particular:

* Now requires `kpsewhich` to be installed (provided by most latex distributions)
* Uses `kpsewhich` to check for `standalone`.
