### PR TITLE
fixes #1217 - Corrupted drawing after Search - missing cairo save/restore

### DIFF
--- a/src/gui/PageView.cpp
+++ b/src/gui/PageView.cpp
@@ -972,8 +972,10 @@ void XojPageView::paintPageSync(cairo_t* cr, GdkRectangle* rect)
 
 	if (this->search)
 	{
+		cairo_save(cr);
 		cairo_scale(cr, zoom, zoom);
 		this->search->paint(cr, rect, zoom, getSelectionColor());
+		cairo_restore(cr);
 	}
 
 	if (this->inputHandler)


### PR DESCRIPTION
 Needed to save and restore cairo drawing context around scale+search->paint in Pageview:paintPageSync().