### PR TITLE
Cursor cleanup - part 1

### DIFF
--- a/src/control/tools/BaseStrokeHandler.cpp
+++ b/src/control/tools/BaseStrokeHandler.cpp
@@ -182,6 +182,8 @@ void BaseStrokeHandler::onButtonReleaseEvent(const PositionInputData& pos)
 {
 	XOJ_CHECK_TYPE(BaseStrokeHandler);
 
+	xournal->getCursor()->activateDrawDirCursor(false);	//in case released within  fixate_Dir_Mods_Dist
+	
 	if (stroke == NULL)
 	{
 		return;
@@ -293,23 +295,17 @@ void BaseStrokeHandler::modifyModifiersByDrawDir(double width, double height,  b
 			this->drawModifierFixed = (DIRSET_MODIFIERS)(SET |
 				(gestureShift? SHIFT:NONE) |
 				(gestureControl? CONTROL:NONE) );
-			if(changeCursor)
-			{
-				xournal->getCursor()->updateCursor();
-			}
+ 			if(changeCursor)
+ 			{
+				xournal->getCursor()->activateDrawDirCursor(false);
+ 			}
 		}
 		else
 		{
-			if (changeCursor)
-			{
-				int corner = ( this->modShift?0:1 ) + ( this->modControl?2:0);
-				
-				if( corner != this-> lastCursor)
-				{
-					xournal->getCursor()->setTempDrawDirCursor(  this->modShift, this->modControl);
-					this->lastCursor = corner;
-				}
-			}
+ 			if (changeCursor)
+ 			{
+				xournal->getCursor()->activateDrawDirCursor( true,  this->modShift, this->modControl);
+ 			}
 		}
 	}
 	else

--- a/src/gui/XournalppCursor.cpp
+++ b/src/gui/XournalppCursor.cpp
@@ -132,10 +132,11 @@ void XournalppCursor::updateCursor()
 	GdkWindow* window = gtk_widget_get_window(win->getWindow());
 
 	GdkCursor* cursor = NULL;
+	bool useDefault = false;
 
 	if (this->busy)
 	{
-		cursor = gdk_cursor_new_for_display(gdk_window_get_display(window), GDK_WATCH);
+		setStockCursor(GDK_WATCH);
 	}
 	else
 	{
@@ -146,49 +147,50 @@ void XournalppCursor::updateCursor()
 		{
 			if (this->mouseDown)
 			{
-				cursor = gdk_cursor_new_for_display(gdk_window_get_display(window), GDK_FLEUR);
+	
+				setStockCursor(GDK_FLEUR);
 			}
 			else
 			{
-				cursor = gdk_cursor_new_for_display(gdk_window_get_display(window), GDK_HAND1);
+				setStockCursor(GDK_HAND1);
 			}
 		}
 		else if (!this->insidePage)
 		{
-			// not inside page: so use default cursor
+			useDefault = true; // not inside page: so use default cursor
 		}
 		else if (this->selectionType)
 		{
 			switch (this->selectionType)
 			{
 			case CURSOR_SELECTION_MOVE:
-				cursor = gdk_cursor_new_for_display(gdk_window_get_display(window), GDK_FLEUR);
+				setStockCursor(GDK_FLEUR);
 				break;
 			case CURSOR_SELECTION_TOP_LEFT:
-				cursor = gdk_cursor_new_for_display(gdk_window_get_display(window), GDK_TOP_LEFT_CORNER);
+				setStockCursor(GDK_TOP_LEFT_CORNER);
 				break;
 			case CURSOR_SELECTION_TOP_RIGHT:
-				cursor = gdk_cursor_new_for_display(gdk_window_get_display(window), GDK_TOP_RIGHT_CORNER);
+				setStockCursor(GDK_TOP_RIGHT_CORNER);
 				break;
 			case CURSOR_SELECTION_BOTTOM_LEFT:
-				cursor = gdk_cursor_new_for_display(gdk_window_get_display(window), GDK_BOTTOM_LEFT_CORNER);
+				setStockCursor(GDK_BOTTOM_LEFT_CORNER);
 				break;
 			case CURSOR_SELECTION_BOTTOM_RIGHT:
-				cursor = gdk_cursor_new_for_display(gdk_window_get_display(window), GDK_BOTTOM_RIGHT_CORNER);
+				setStockCursor(GDK_BOTTOM_RIGHT_CORNER);
 				break;
 			case CURSOR_SELECTION_LEFT:
 			case CURSOR_SELECTION_RIGHT:
-				cursor = gdk_cursor_new_for_display(gdk_window_get_display(window), GDK_SB_H_DOUBLE_ARROW);
+				setStockCursor(GDK_SB_H_DOUBLE_ARROW);
 				break;
 			case CURSOR_SELECTION_ROTATE:
-				cursor = gdk_cursor_new_for_display(gdk_window_get_display(window), GDK_EXCHANGE);
+				setStockCursor(GDK_EXCHANGE);
 				break;
 			case CURSOR_SELECTION_DELETE:
-				cursor = gdk_cursor_new_for_display(gdk_window_get_display(window), GDK_PIRATE);
+				setStockCursor(GDK_PIRATE);
 				break;				
 			case CURSOR_SELECTION_TOP:
 			case CURSOR_SELECTION_BOTTOM:
-				cursor = gdk_cursor_new_for_display(gdk_window_get_display(window), GDK_SB_V_DOUBLE_ARROW);
+				setStockCursor(GDK_SB_V_DOUBLE_ARROW);
 				break;
 			default:
 				break;
@@ -211,26 +213,26 @@ void XournalppCursor::updateCursor()
 		{
 			if (this->invisible)
 			{
-				cursor = gdk_cursor_new_for_display(gdk_window_get_display(window), GDK_BLANK_CURSOR);
+				setStockCursor(GDK_BLANK_CURSOR);
 			}
 			else
 			{
-				cursor = gdk_cursor_new_for_display(gdk_window_get_display(window), GDK_XTERM);
+				setStockCursor(GDK_XTERM);
 			}
 		}
 		else if (type == TOOL_IMAGE)
 		{
-			// No special cursor needed
+			useDefault = true; // No special cursor needed
 		}
 		else if (type == TOOL_FLOATING_TOOLBOX)
 		{
-			// No special cursor needed
+			useDefault = true; // No special cursor needed
 		}
 		else if (type == TOOL_VERTICAL_SPACE)
 		{
 			if (this->mouseDown)
 			{
-				cursor = gdk_cursor_new_for_display(gdk_window_get_display(window), GDK_SB_V_DOUBLE_ARROW);
+				setStockCursor(GDK_SB_V_DOUBLE_ARROW);
 			}
 		}
 		else if (type == TOOL_SELECT_OBJECT)
@@ -239,12 +241,13 @@ void XournalppCursor::updateCursor()
 		}
 		else if (type == TOOL_PLAY_OBJECT) 
 		{
-			cursor = gdk_cursor_new_for_display(gdk_window_get_display(window), GDK_HAND2);
+			setStockCursor(GDK_HAND2);
 		}
 		else // other selections are handled before anyway, because you can move a selection with every tool
 		{
-			cursor = gdk_cursor_new_for_display(gdk_window_get_display(window), GDK_TCROSS);
+			setStockCursor(GDK_TCROSS);
 		}
+		
 
 	}
 
@@ -254,8 +257,12 @@ void XournalppCursor::updateCursor()
 		{
 			gdk_window_set_cursor(gtk_widget_get_window(xournal->getWidget()), cursor);
 		}
-
-		gtk_widget_set_sensitive(xournal->getWidget(), !this->busy);
+		else if(useDefault)
+		{
+			
+			
+			gtk_widget_set_sensitive(xournal->getWidget(), !this->busy);
+		}
 	}
 
 	gdk_display_sync(gdk_display_get_default());
@@ -406,11 +413,14 @@ GdkCursor* XournalppCursor::createHighlighterOrPenCursor(int size, double alpha)
 
 
 
-void XournalppCursor::setTempCursor(GdkCursorType type)
+void XournalppCursor::setStockCursor(GdkCursorType type)
 {
 	XOJ_CHECK_TYPE(XournalppCursor);
 	
+	
+	
 	MainWindow* win = control->getWindow();
+	
 	
 	if( !win) return;
 	
@@ -419,14 +429,25 @@ void XournalppCursor::setTempCursor(GdkCursorType type)
 	if(!xournal) return;
 	
 	GdkWindow* window = gtk_widget_get_window(xournal->getWidget());
-	
+		
 	if( !window ) return;
+	
+	GdkCursor *currentcursor =gdk_window_get_cursor(window);
+	
+	if ( type == gdk_cursor_get_cursor_type (currentcursor))
+	{
+		return;
+	}
+	
 	
 	GdkCursor* cursor = gdk_cursor_new_for_display(gdk_window_get_display(window), type);
 	gdk_window_set_cursor(gtk_widget_get_window(xournal->getWidget()), cursor);
 	gdk_window_set_cursor(window, cursor);
 	g_object_unref(cursor);
 }
+
+
+
 
 void XournalppCursor::setTempDrawDirCursor(bool shift, bool ctrl)
 {

--- a/src/gui/XournalppCursor.h
+++ b/src/gui/XournalppCursor.h
@@ -15,6 +15,7 @@
 #include <XournalType.h>
 
 #include <gtk/gtk.h>
+#include <gui/inputdevices/InputEvents.h>
 
 class Control;
 
@@ -33,7 +34,8 @@ public:
 	void setInvisible(bool invisible);
 	void setInsidePage(bool insidePage);
 	void setStockCursor(GdkCursorType type);
-	void setTempDrawDirCursor(bool shift, bool ctrl);
+	void activateDrawDirCursor(bool enable, bool shift=false, bool ctrl=false);
+	void setInputDeviceClass(InputDeviceClass inputDevice);
 	
 
 
@@ -46,9 +48,13 @@ private:
 	GdkCursor* createHighlighterOrPenCursor(int size, double alpha);
 	GdkCursor* createCustomDrawDirCursor(int size, bool shift, bool ctrl);
 	
+	void doDrawDirCursor();
+
+	
 private:
 	XOJ_TYPE_ATTRIB;
 
+	InputDeviceClass inputDevice = INPUT_DEVICE_MOUSE;
 
 	Control* control = NULL;
 	bool busy = false;
@@ -57,6 +63,11 @@ private:
 
 	bool mouseDown = false;
 	bool invisible = false;
+	
+	// One shot drawDir custom cursor -drawn instead of pen/stylus then cleared.
+	bool drawDirActive = false;
+	bool drawDirShift = false;
+	bool drawDirCtrl = false;	
 	
 	
 	//combination to avoid making same cursor

--- a/src/gui/XournalppCursor.h
+++ b/src/gui/XournalppCursor.h
@@ -32,7 +32,7 @@ public:
 	void setMouseDown(bool mouseDown);
 	void setInvisible(bool invisible);
 	void setInsidePage(bool insidePage);
-	void setTempCursor(GdkCursorType type);
+	void setStockCursor(GdkCursorType type);
 	void setTempDrawDirCursor(bool shift, bool ctrl);
 	
 
@@ -57,4 +57,9 @@ private:
 
 	bool mouseDown = false;
 	bool invisible = false;
+	
+	
+	//combination to avoid making same cursor
+	void* lastCustomCursorAddress = NULL;	//for comparison only
+	int lastCustomCursorType = 0;	//our own id
 };

--- a/src/gui/inputdevices/AbstractInputHandler.cpp
+++ b/src/gui/inputdevices/AbstractInputHandler.cpp
@@ -4,6 +4,7 @@
 
 #include "AbstractInputHandler.h"
 #include "InputContext.h"
+#include <gui/XournalppCursor.h>
 
 AbstractInputHandler::AbstractInputHandler(InputContext* inputContext)
 {
@@ -41,6 +42,7 @@ bool AbstractInputHandler::handle(InputEvent* event)
 
 	if (!this->blocked)
 	{
+		this->inputContext->getXournal()->view->getCursor()->setInputDeviceClass(event->deviceClass);
 		return this->handleImpl(event);
 	} else {
 		return true;

--- a/src/gui/inputdevices/MouseInputHandler.cpp
+++ b/src/gui/inputdevices/MouseInputHandler.cpp
@@ -54,19 +54,12 @@ bool MouseInputHandler::handleImpl(InputEvent* event)
 	 * Trigger motion actions
 	 */
 	// Trigger motion action when pen/mouse is pressed and moved
-	if (event->type == MOTION_EVENT) //mouse or pen moved
+	if ( event->type == MOTION_EVENT) //mouse or pen moved
 	{
-		if (this->deviceClassPressed)
-		{
-			this->actionMotion(event);
-		}
-		else
-		{
-			XournalppCursor* cursor = xournal->view->getCursor();
-			cursor->setStockCursor(GDK_ARROW);
-		}
-		// Update cursor visibility
-		xournal->view->getCursor()->setInvisible(false);
+		this->actionMotion(event);
+		XournalppCursor* cursor = xournal->view->getCursor();
+		cursor->setInvisible(false);
+		cursor->updateCursor();
 	}
 
 	// Notify if mouse enters/leaves widget

--- a/src/gui/inputdevices/MouseInputHandler.cpp
+++ b/src/gui/inputdevices/MouseInputHandler.cpp
@@ -63,7 +63,7 @@ bool MouseInputHandler::handleImpl(InputEvent* event)
 		else
 		{
 			XournalppCursor* cursor = xournal->view->getCursor();
-			cursor->setTempCursor(GDK_ARROW);
+			cursor->setStockCursor(GDK_ARROW);
 		}
 		// Update cursor visibility
 		xournal->view->getCursor()->setInvisible(false);

--- a/src/gui/inputdevices/PenInputHandler.cpp
+++ b/src/gui/inputdevices/PenInputHandler.cpp
@@ -259,7 +259,7 @@ bool PenInputHandler::actionMotion(InputEvent* event)
 		 * Only trigger once the new page was entered to ensure that an input device can leave the page temporarily.
 		 * For these events we need to fake an end point in the old page and a start point in the new page.
 		 */
-		if (currentPage && !lastEventPage && lastHitEventPage)
+		if (this->deviceClassPressed && currentPage && !lastEventPage && lastHitEventPage)
 		{
 #ifdef DEBUG_INPUT
 			g_message("PenInputHandler: Start new input on switching page...");
@@ -275,7 +275,7 @@ bool PenInputHandler::actionMotion(InputEvent* event)
 		 * Get all events where the input sequence started outside of a page and moved into one.
 		 * For these events we need to fake a start point in the current page.
 		 */
-		if (currentPage && !lastEventPage && !lastHitEventPage)
+		if (this->deviceClassPressed && currentPage && !lastEventPage && !lastHitEventPage)
 		{
 #ifdef DEBUG_INPUT
 			g_message("PenInputHandler: Start new input on entering page...");

--- a/src/gui/inputdevices/StylusInputHandler.cpp
+++ b/src/gui/inputdevices/StylusInputHandler.cpp
@@ -67,17 +67,10 @@ bool StylusInputHandler::handleImpl(InputEvent* event)
 	// Trigger motion action when pen/mouse is pressed and moved
 	if (event->type == MOTION_EVENT) //mouse or pen moved
 	{
-		if (this->deviceClassPressed)
-		{
-			this->actionMotion(event);
-		}
-		else
-		{
-			XournalppCursor* cursor = xournal->view->getCursor();
-			cursor->updateCursor();
-		}
-		// Update cursor visibility
-		xournal->view->getCursor()->setInvisible(false);
+		this->actionMotion(event);
+		XournalppCursor* cursor = xournal->view->getCursor();
+		cursor->setInvisible(false);
+		cursor->updateCursor();
 	}
 
 

--- a/src/gui/inputdevices/TouchDrawingInputHandler.cpp
+++ b/src/gui/inputdevices/TouchDrawingInputHandler.cpp
@@ -6,6 +6,7 @@
 #include "InputContext.h"
 
 #include <gui/widgets/XournalWidget.h>
+#include <gui/XournalppCursor.h>
 
 TouchDrawingInputHandler::TouchDrawingInputHandler(InputContext* inputContext) : PenInputHandler(inputContext)
 {
@@ -56,6 +57,8 @@ bool TouchDrawingInputHandler::handleImpl(InputEvent* event)
 	if (this->deviceClassPressed && event->type == MOTION_EVENT)
 	{
 		this->actionMotion(event);
+		XournalppCursor* cursor = xournal->view->getCursor();
+		cursor->updateCursor();
 	}
 
 	// Notify if finger enters/leaves widget

--- a/src/gui/inputdevices/TouchInputHandler.cpp
+++ b/src/gui/inputdevices/TouchInputHandler.cpp
@@ -4,7 +4,6 @@
 
 #include "TouchInputHandler.h"
 #include "InputContext.h"
-#include "../XournalppCursor.h"
 
 TouchInputHandler::TouchInputHandler(InputContext* inputContext) : AbstractInputHandler(inputContext)
 {
@@ -37,8 +36,6 @@ bool TouchInputHandler::handleImpl(InputEvent* event)
 	if (event->type == MOTION_EVENT)
 	{
 		actionMotion(event);
-		XournalppCursor* cursor = inputContext->getXournal()->view->getCursor();
-		cursor->updateCursor();
 	}
 
 	if (event->type == BUTTON_RELEASE_EVENT)

--- a/src/gui/inputdevices/old/NewGtkInputDevice.cpp
+++ b/src/gui/inputdevices/old/NewGtkInputDevice.cpp
@@ -320,6 +320,7 @@ bool NewGtkInputDevice::eventHandler(GdkEvent* event)
 
 		XournalppCursor* cursor = view->getControl()->getWindow()->getXournal()->getCursor();
 		cursor->setInvisible(false);
+		cursor->updateCursor();
 
 		view->getHandRecognition()->event(sourceDevice);
 	}


### PR DESCRIPTION
Recent cursor changes revealed growing pains related to the new input system.
This keeps the new cursor behaviour ( but consolidates the responsibility in XournalpppCursor ) and re-enables functionality that hadn't yet carried over to the new input system.
It also retains new and old functionality in the old input system.