### PR TITLE
Update version number in CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required (VERSION 2.8.8)
 project ("Xournal++" CXX C)
 
 ## Also update changelog in debian folder!
-set (PROJECT_VERSION "1.0.11")
+set (PROJECT_VERSION "1.0.13")
 set (PROJECT_PACKAGE "xournalpp")
 set (PROJECT_STRING "${PROJECT_NAME} ${PROJECT_VERSION}")
 set (PROJECT_URL "https://github.com/xournalpp/xournalpp")


### PR DESCRIPTION
We forgot to update the version number to `1.0.13` after we released `1.0.12`, so we'll should at least remember to do it now.