### PR TITLE
Place newly created latex objects in the center of the screen/page

### DIFF
--- a/src/control/LatexController.cpp
+++ b/src/control/LatexController.cpp
@@ -196,6 +196,30 @@ void LatexController::findSelectedTexElement()
 			this->imgheight = this->selectedText->getElementHeight();
 		}
 	}
+	else
+	{
+		// This is a new latex object, so here we pick a convenient initial location
+		const double zoom = this->control->getWindow()->getXournal()->getZoom();
+		Layout* const layout = this->control->getWindow()->getLayout();
+
+		// Calculate coordinates (screen) of the center of the visible area
+		const auto visibleBounds = layout->getVisibleRect();
+		const double centerX = visibleBounds.x + 0.5 * visibleBounds.width;
+		const double centerY = visibleBounds.y + 0.5 * visibleBounds.height;
+
+		if (layout->getViewAt(centerX, centerY) == this->view)
+		{
+			// Pick the center of the visible area (converting from screen to page coordinates)
+			this->posx = (centerX - this->view->getX()) / zoom;
+			this->posy = (centerY - this->view->getY()) / zoom;
+		}
+		else
+		{
+			// No better location, so just center it on the page (possibly out of viewport)
+			this->posx = 0.5 * this->page->getWidth();
+			this->posy = 0.5 * this->page->getHeight();
+		}
+	}
 	this->doc->unlock();
 
 	// need to do this otherwise we can't remove the image for its replacement


### PR DESCRIPTION
By default, newly created latex objects are placed in the top left corner of the current page. This PR now sets convenient default locations:

* If the center of the viewport is on the current page, then place the new latex in the center of the viewport.
* Otherwise, place the new latex in the center of the current page (which may possibly be out of the viewport).

The default placement can obviously be improved, so feedback is welcome.

(There's also the option of turning the LaTeX tool into a real selectable tool, but that would require some work.)

I will be merging this in three days if there are no objections.