### PR TITLE
Let's Do CSS

### DIFF
--- a/src/control/XournalMain.cpp
+++ b/src/control/XournalMain.cpp
@@ -358,7 +358,8 @@ int XournalMain::run(int argc, char* argv[])
 	gtk_init(&argc, &argv);
 
 	GladeSearchpath* gladePath = new GladeSearchpath();
-	initResourcePath(gladePath);
+	initResourcePath(gladePath, "ui/about.glade");
+	initResourcePath(gladePath, "ui/xournalpp.css",  false); 	//will notify user if file not present. Path ui/ already added above.
 
 	// init singleton
 	string colorNameFile = Util::getConfigFile("colornames.ini").str();
@@ -526,11 +527,11 @@ string XournalMain::findResourcePath(string searchFile)
 	return "";
 }
 
-void XournalMain::initResourcePath(GladeSearchpath* gladePath)
+void XournalMain::initResourcePath(GladeSearchpath* gladePath, const gchar* relativePathAndFile, bool failIfNotFound)
 {
 	XOJ_CHECK_TYPE(XournalMain);
 
-	string uiPath = findResourcePath("ui/about.glade");
+	string uiPath = findResourcePath(relativePathAndFile);	//i.e.  relativePathAndFile = "ui/about.glade"
 
 	if (uiPath != "")
 	{
@@ -542,7 +543,8 @@ void XournalMain::initResourcePath(GladeSearchpath* gladePath)
 
 #ifdef __APPLE__
 	Path p = Stacktrace::getExePath();
-	p /= "../Resources/ui/about.glade";
+	p /= "../Resources";
+	p /= relativePathAndFile;
 
 	if (p.exists())
 	{
@@ -550,13 +552,18 @@ void XournalMain::initResourcePath(GladeSearchpath* gladePath)
 		return;
 	}
 
-	string msg = FS(_F("Missing the needed UI file! .app corrupted?\nPath: {1}") % p.str());
+	string msg = FS(_F("Missing the needed UI file:\n{1}\n .app corrupted?\nPath: {2}") % relativePathAndFile % p.str());
+	
+	if (!failIfNotFound)
+	{
+		msg += _("\nWill now attempt to run without this file.");
+	}
 	XojMsgBox::showErrorToUser(NULL, msg);
 #else
 	// Check at the target installation directory
 	Path absolute = PACKAGE_DATA_DIR;
 	absolute /= PROJECT_PACKAGE;
-	absolute /= "ui/about.glade";
+	absolute /= relativePathAndFile;
 
 	if (absolute.exists())
 	{
@@ -564,9 +571,18 @@ void XournalMain::initResourcePath(GladeSearchpath* gladePath)
 		return;
 	}
 
-	string msg = FS(_F("Missing the needed UI file, could not find them at any location.\nNot relative\nNot in the Working Path\nNot in {1}") % PACKAGE_DATA_DIR);
+	
+	string msg = FS(_F("<span foreground='red' size='x-large'>Missing the needed UI file:\n<b>{1}</b></span>\nCould not find them at any location.\n  Not relative\n  Not in the Working Path\n  Not in {2}") % relativePathAndFile % PACKAGE_DATA_DIR);
+	
+	if (!failIfNotFound)
+	{
+		msg += _("\n\nWill now attempt to run without this file.");
+	}
 	XojMsgBox::showErrorToUser(NULL, msg);
 #endif
 
-	exit(12);
+	if (failIfNotFound)
+	{
+		exit(12);
+	}
 }

--- a/src/control/XournalMain.h
+++ b/src/control/XournalMain.h
@@ -37,6 +37,7 @@ private:
 
 	void initSettingsPath();
 	void initResourcePath(GladeSearchpath* gladePath);
+	void initResourcePath(GladeSearchpath* gladePath, const gchar* relativePathAndFile, bool failIfNotFound = true);
 	string findResourcePath(string searchFile);
 
 private:

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -42,7 +42,7 @@ MainWindow::MainWindow(GladeSearchpath* gladeSearchPath, Control* control)
 	this->toolbarWidgets = new GtkWidget*[TOOLBAR_DEFINITIONS_LEN];
 	this->toolbarSelectMenu = new MainWindowToolbarMenu(this);
 
-	
+	loadMainCSS(gladeSearchPath,"xournalpp.css");
 	
 	GtkOverlay *overlay = GTK_OVERLAY (get("mainOverlay"));
 	this->floatingToolbox = new FloatingToolbox (this, overlay);  
@@ -935,3 +935,15 @@ void MainWindow::setAudioPlaybackPaused(bool paused)
 	this->getToolMenuHandler()->setAudioPlaybackPaused(paused);
 }
 
+void MainWindow::loadMainCSS(GladeSearchpath* gladeSearchPath, const gchar* cssFilename)
+{
+	XOJ_CHECK_TYPE(MainWindow);
+
+	string filename = gladeSearchPath->findFile("", cssFilename);
+	GtkCssProvider *provider = gtk_css_provider_new ();
+	gtk_css_provider_load_from_path (provider, filename.c_str(), NULL);
+	gtk_style_context_add_provider_for_screen(gdk_screen_get_default(), GTK_STYLE_PROVIDER(provider),
+											  GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+	g_object_unref(provider);
+}
+	

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -144,7 +144,10 @@ private:
 	static void dragDataRecived(GtkWidget* widget, GdkDragContext* dragContext, gint x, gint y,
 								GtkSelectionData* data, guint info, guint time, MainWindow* win);
 
-
+	/**
+	 * Load Overall CSS file with custom icons, other styling and potentially, user changes
+	 */
+	void loadMainCSS(GladeSearchpath* gladeSearchPath, const gchar* cssFilename);
 	
 private:
 	XOJ_TYPE_ATTRIB;

--- a/src/util/XojMsgBox.cpp
+++ b/src/util/XojMsgBox.cpp
@@ -20,8 +20,9 @@ void XojMsgBox::showErrorToUser(GtkWindow* win, string msg)
 		win = defaultWindow;
 	}
 
-	GtkWidget* dialog = gtk_message_dialog_new(win, GTK_DIALOG_MODAL, GTK_MESSAGE_ERROR, GTK_BUTTONS_OK,
-											   "%s", msg.c_str());
+	GtkWidget* dialog = gtk_message_dialog_new_with_markup(win, GTK_DIALOG_MODAL, GTK_MESSAGE_ERROR, GTK_BUTTONS_OK,
+											   NULL);
+	gtk_message_dialog_set_markup( GTK_MESSAGE_DIALOG (dialog), msg.c_str());
 	if (win != NULL)
 	{
 		gtk_window_set_transient_for(GTK_WINDOW(dialog), win);
@@ -36,11 +37,13 @@ int XojMsgBox::showPluginMessage(string pluginName, string msg, map<int, string>
 
 	if (error)
 	{
-		header = "Error in " + header;
+		header = "<b>Error in </b>" + header;
 	}
 
-	GtkWidget* dialog = gtk_message_dialog_new(defaultWindow, GTK_DIALOG_MODAL, GTK_MESSAGE_ERROR, GTK_BUTTONS_NONE,
-											   "%s", header.c_str());
+	GtkWidget* dialog = gtk_message_dialog_new_with_markup(defaultWindow, GTK_DIALOG_MODAL, GTK_MESSAGE_ERROR, GTK_BUTTONS_NONE,
+											   NULL);
+	gtk_message_dialog_set_markup( GTK_MESSAGE_DIALOG (dialog), header.c_str());
+	
 	if (defaultWindow != NULL)
 	{
 		gtk_window_set_transient_for(GTK_WINDOW(dialog), defaultWindow);

--- a/ui/main.glade
+++ b/ui/main.glade
@@ -13,6 +13,7 @@
     <property name="page_increment">10</property>
   </object>
   <object class="GtkRevealer" id="floatingToolbox">
+    <property name="name">floatingToolbox</property>
     <property name="visible">True</property>
     <property name="can_focus">False</property>
     <property name="transition_type">crossfade</property>

--- a/ui/xournalpp.css
+++ b/ui/xournalpp.css
@@ -1,0 +1,43 @@
+/*  
+ * Backup before modifying
+ */
+
+
+
+/*Style the Floating Toolbox!*/
+
+#floatingToolbox>GtkBox 
+{
+	background-color: rgba(0,0,0,0.05);
+	border-radius:10%;
+}
+#floatingToolbox GtkBox GtkToolbar 
+{
+	background-color: rgba(255,255,255,0);
+}
+#floatingToolbox GtkButton 
+{
+	background-color: rgba(255,255,255,1);
+	border-radius: 50%;
+}
+
+
+
+/*Fix ugly Background drop down button
+ * 
+ * We need to select the button beside two labels or we will affect 
+ * the pen tool when in FloatingToolbox (and can't see activation highlight).
+ * 
+ * Ideally we will give name properties to all of the widgets created in 
+ * code as well as specifying names in glade files.
+ * 
+ * Note: in glade files, property with name="name". i.e. <property name="name">floatingToolbox</property>
+ */
+
+
+GtkToolItem>GtkBox>GtkLabel+GtkLabel+GtkButton 
+{
+	border-width:0;
+	box-shadow:none;
+	background-image:none
+}


### PR DESCRIPTION
I've meant to look into this for a while...

This PR will load a CSS file called  ui/xournalpp.css

We can pretty up Xournal using it and the users can make adjustments as well.
Non-coding contributors can potentially contribute css stylings.
I'm going to be doing some cursors using it ( I've converted all except custom cursors to css  - my next PR ).

NOTE:  The CSS selector uses the "name" property NOT the id. So I had to change main.glade:
```
 <object class="GtkRevealer" id="floatingToolbox">
    <property name="name">floatingToolbox</property>
     <property name="visible">True</property>
 ...
```
**Note the** `<property name="name">floatingToolbox</property>`
We will have to go through the glade files and do some proper naming in order to allow clean css selectors.

--------------
I've also changed the XojMsgBox to allow Pango markup.. and put in a bit of markup.  Rename the xournalpp.css file temporarily to see the result.
**This might cause problems for internationalization if markup characters are used that confuse Pango.
Comments?**
