### PR TITLE
Only apply clang-format to changed lines

### DIFF
--- a/azure-pipelines/clang-format-applied.yml
+++ b/azure-pipelines/clang-format-applied.yml
@@ -24,29 +24,35 @@ stages:
         git checkout $(System.PullRequest.TargetBranch)
         git fetch origin +$(Build.SourceBranch)
 
-        echo "List of modified source files:"
-        git --no-pager diff --name-only FETCH_HEAD $(git merge-base FETCH_HEAD $(System.PullRequest.TargetBranch)) | grep ".cpp$\|.hpp$\|.h$"
+        BASE_COMMIT=$(git merge-base FETCH_HEAD $(System.PullRequest.TargetBranch))
+        FILES=$(git --no-pager diff --name-only $BASE_COMMIT FETCH_HEAD -- '*.cpp' '*.hpp' '*.h')
 
-        # Actually get the list in a parsable state
-        LOMF=$(git --no-pager diff --name-only FETCH_HEAD $(git merge-base FETCH_HEAD $(System.PullRequest.TargetBranch)) | grep ".cpp$\|.hpp$\|.h$")
-        
-        # Checkout the PR again so we can check the modified files for correct format
+        echo "List of modified source files:"
+        for f in $FILES; do echo "$f"; done
+
+        # Checkout the PR so we can check the modified files for correct formatting
         git checkout FETCH_HEAD
-        if [ -n "$LOMF" ]; then
-            # Apply clang-format to enforce proper format
-            clang-format-8 -i -style=file $LOMF
-            # All previously badly formatted files should now be modified
+
+        # Apply clang-format, modifying all badly formatted files
+        if [ ! -z "$FILES" ]; then
+            git --no-pager diff -U0 $BASE_COMMIT -- $FILES | perl azure-pipelines/format_diff_lines.pl
         fi
-      displayName: 'Apply clang-format on modified files'
+
+      displayName: 'Run clang-format on modified files'
     - bash: |
         # Check for modified files
         if [ -z "$(git status --porcelain)" ]; then 
             # Working directory clean
-            echo "The code was properly formated using clang-format before being submitted."
+            echo "The code was properly formatted using clang-format before being submitted."
             exit 0
         else 
             # Uncommitted changes
-            echo "The code was not formated using clang-format before being submitted."
+            echo "The code was not formatted using clang-format before being submitted."
+            echo "To format the code, try running the following command from the root of the repository:"
+            echo "    git --no-pager diff -U0 -- '*.cpp' '*.c' '*.h' '*.hpp' | perl azure-pipelines/format_diff_lines.pl"
+            echo
+            echo "The formatting changes required are shown below."
+            git --no-pager diff
             exit 1
         fi
       displayName: 'Check for badly formatted modified files'

--- a/azure-pipelines/format_diff_lines.pl
+++ b/azure-pipelines/format_diff_lines.pl
@@ -1,0 +1,49 @@
+#/usr/bin/perl
+
+# Given the diff output on stdin, run clang-format on the input hunks.
+#
+# Author: Bryan Tan (Technius)
+
+use strict;
+
+# Table mapping changed files to array of hunks.
+my %changed_files;
+# Array of hunks in the current file. Only stores the new location.
+my @hunks;
+# Current file
+my $current_file;
+
+# Push the pending hunks to the changed file table.
+sub push_changes {
+	if (scalar @hunks > 0) {
+		$changed_files{$current_file} = [@hunks];
+		@hunks = ();
+	}
+}
+
+while (my $line = <STDIN>) {
+	if ($line =~ /^diff .* a\/(?<old_file>.*) b\/(?<new_file>.*)$/) {
+		# New file
+		push_changes;
+		$current_file = $+{new_file};
+	} elsif ($line =~ /^@@ -([0-9]+)(,([0-9]+))? \+(?<new_pos>[0-9]+)(,(?<new_len>[0-9]+))? @@/) {
+		my $new_len = $+{new_len};
+		$new_len = 1 if ($new_len eq "");
+		push @hunks, [$+{new_pos}, $new_len];
+	}
+}
+push_changes;
+
+# Now, run clang format on the changed lines.
+while (my ($file_name, $hunks_ref) = each %changed_files) {
+	foreach my $hunk_ref (@{$hunks_ref}) {
+		my $start_pos = @{$hunk_ref}[0];
+		my $line_count = @{$hunk_ref}[1];
+		my $end_pos = $start_pos + $line_count - 1;
+		if ($line_count > 0) {
+			printf "Running clang-format-8 on %s, lines %i-%i\n", $file_name, $start_pos, $end_pos;
+			`clang-format-8 -i -style=file -lines=$start_pos:$end_pos $file_name`;
+			die "Failed to run clang-format-8: exit code $?" if $? != 0;
+		}
+	}
+}


### PR DESCRIPTION
This PR makes the format check less aggressive by only checking lines changed by a commit/PR.

The test file is temporary and is meant to test the check; it will be removed by a rebase before merge.