### PR TITLE
Correct "dash-/ doted" typo in drop down menu

### DIFF
--- a/po/cs.po
+++ b/po/cs.po
@@ -2839,7 +2839,7 @@ msgid "cursor"
 msgstr "kurzor"
 
 #: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:298
-msgid "dash-/ doted"
+msgid "dash-/ dotted"
 msgstr ""
 
 #: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:295

--- a/po/de.po
+++ b/po/de.po
@@ -2841,7 +2841,7 @@ msgid "cursor"
 msgstr "XournalppCursor"
 
 #: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:298
-msgid "dash-/ doted"
+msgid "dash-/ dotted"
 msgstr "gepunkted / gestrichelt"
 
 #: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:295

--- a/po/it.po
+++ b/po/it.po
@@ -2821,7 +2821,7 @@ msgid "cursor"
 msgstr "cursore"
 
 #: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:298
-msgid "dash-/ doted"
+msgid "dash-/ dotted"
 msgstr "tratteggiato-/ puntinato"
 
 #: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:295

--- a/po/pl.po
+++ b/po/pl.po
@@ -2840,7 +2840,7 @@ msgid "cursor"
 msgstr "kursor"
 
 #: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:298
-msgid "dash-/ doted"
+msgid "dash-/ dotted"
 msgstr ""
 
 #: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:295

--- a/po/xournalpp.pot
+++ b/po/xournalpp.pot
@@ -1360,7 +1360,7 @@ msgid "cursor"
 msgstr ""
 
 #: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:298
-msgid "dash-/ doted"
+msgid "dash-/ dotted"
 msgstr ""
 
 #: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:295

--- a/po/zh.po
+++ b/po/zh.po
@@ -2788,7 +2788,7 @@ msgid "cursor"
 msgstr "光标"
 
 #: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:298
-msgid "dash-/ doted"
+msgid "dash-/ dotted"
 msgstr ""
 
 #: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:295

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -2789,7 +2789,7 @@ msgid "cursor"
 msgstr "光標"
 
 #: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:298
-msgid "dash-/ doted"
+msgid "dash-/ dotted"
 msgstr ""
 
 #: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:295

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -2788,7 +2788,7 @@ msgid "cursor"
 msgstr "光標"
 
 #: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:298
-msgid "dash-/ doted"
+msgid "dash-/ dotted"
 msgstr ""
 
 #: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:295

--- a/src/gui/toolbarMenubar/ToolMenuHandler.cpp
+++ b/src/gui/toolbarMenubar/ToolMenuHandler.cpp
@@ -295,7 +295,7 @@ void ToolMenuHandler::initPenToolItem()
 	registerMenupoint(tbPen->registerPopupMenuEntry(_("dashed"), "line-style-dash"),
 			ACTION_TOOL_LINE_STYLE_DASH, GROUP_LINE_STYLE);
 
-	registerMenupoint(tbPen->registerPopupMenuEntry(_("dash-/ doted"), "line-style-dash-dot"),
+	registerMenupoint(tbPen->registerPopupMenuEntry(_("dash-/ dotted"), "line-style-dash-dot"),
 			ACTION_TOOL_LINE_STYLE_DASH_DOT, GROUP_LINE_STYLE);
 
 	registerMenupoint(tbPen->registerPopupMenuEntry(_("dotted"), "line-style-dot"),

--- a/ui/main.glade
+++ b/ui/main.glade
@@ -1402,7 +1402,7 @@
                                   <object class="GtkCheckMenuItem" id="penStyleDashDotted">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="label" translatable="yes">dash-/ doted</property>
+                                    <property name="label" translatable="yes">dash-/ dotted</property>
                                     <property name="use_underline">True</property>
                                     <property name="draw_as_radio">True</property>
                                     <signal name="toggled" handler="ACTION_TOOL_LINE_STYLE_DASH_DOT:GROUP_LINE_STYLE" swapped="no"/>


### PR DESCRIPTION
Simple fix, I think I found everywhere it was misspelled.