### PR TITLE
Support CSS:  Add name="name" property matching id's for all non-default id's

### DIFF
--- a/ui/about.glade
+++ b/ui/about.glade
@@ -3,6 +3,7 @@
 <interface>
   <requires lib="gtk+" version="3.0"/>
   <object class="GtkDialog" id="aboutDialog">
+    <property name="name">aboutDialog</property>
     <property name="width_request">320</property>
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">About Xournal++</property>
@@ -21,11 +22,13 @@
         <property name="orientation">vertical</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="dialog-action_area2">
+            <property name="name">dialog-action_area2</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="closebutton1">
+                <property name="name">closebutton1</property>
                 <property name="label">gtk-close</property>
                 <property name="use_action_appearance">False</property>
                 <property name="visible">True</property>
@@ -50,6 +53,7 @@
         </child>
         <child>
           <object class="GtkImage" id="XournalIcon">
+            <property name="name">XournalIcon</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="pixbuf">pixmaps/xournalpp.svg</property>
@@ -63,6 +67,7 @@
         </child>
         <child>
           <object class="GtkLabel" id="labelTitle">
+            <property name="name">labelTitle</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="label" translatable="yes">&lt;span size="xx-large" weight="bold"&gt;Xournal++&lt;/span&gt;
@@ -105,6 +110,7 @@
                 </child>
                 <child>
                   <object class="GtkLabel" id="lbVersion">
+                    <property name="name">lbVersion</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="label">X.X.X</property>
@@ -129,6 +135,7 @@
                 </child>
                 <child>
                   <object class="GtkLabel" id="lbBuildDate">
+                    <property name="name">lbBuildDate</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="label">DATE TIME</property>
@@ -165,6 +172,7 @@
             </child>
             <child>
               <object class="GtkLabel" id="lbAuthors">
+                <property name="name">lbAuthors</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="margin_top">5</property>
@@ -186,6 +194,7 @@ Justin Jones, 2019</property>
             </child>
             <child>
               <object class="GtkLabel" id="lbComunity">
+                <property name="name">lbComunity</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="margin_top">10</property>
@@ -202,6 +211,7 @@ Justin Jones, 2019</property>
             </child>
             <child>
               <object class="GtkLabel" id="lbXournal">
+                <property name="name">lbXournal</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Partially based on Xournal
@@ -217,6 +227,7 @@ by Denis Auroux</property>
             </child>
             <child>
               <object class="GtkLabel" id="lbLicense">
+                <property name="name">lbLicense</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="margin_top">10</property>

--- a/ui/exportSettings.glade
+++ b/ui/exportSettings.glade
@@ -20,6 +20,7 @@
     <property name="page_increment">10</property>
   </object>
   <object class="GtkDialog" id="exportDialog">
+    <property name="name">exportDialog</property>
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">Export</property>
     <property name="window_position">center</property>
@@ -33,11 +34,13 @@
         <property name="spacing">4</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="dialog-action_area2">
+            <property name="name">dialog-action_area2</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="btCancel">
+                <property name="name">btCancel</property>
                 <property name="label">gtk-cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
@@ -53,6 +56,7 @@
             </child>
             <child>
               <object class="GtkButton" id="btOk">
+                <property name="name">btOk</property>
                 <property name="label">gtk-ok</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
@@ -102,6 +106,7 @@ Select pages to export</property>
                 <property name="column_spacing">10</property>
                 <child>
                   <object class="GtkLabel" id="lbResolution">
+                    <property name="name">lbResolution</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="label" translatable="yes">Resolution</property>
@@ -133,6 +138,7 @@ Select pages to export</property>
                 </child>
                 <child>
                   <object class="GtkRadioButton" id="rdRangeAll">
+                    <property name="name">rdRangeAll</property>
                     <property name="label" translatable="yes">All pages</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
@@ -148,6 +154,7 @@ Select pages to export</property>
                 </child>
                 <child>
                   <object class="GtkRadioButton" id="rdRangeCurrent">
+                    <property name="name">rdRangeCurrent</property>
                     <property name="label" translatable="yes">Current page</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
@@ -164,6 +171,7 @@ Select pages to export</property>
                 </child>
                 <child>
                   <object class="GtkRadioButton" id="rdRangePages">
+                    <property name="name">rdRangePages</property>
                     <property name="label" translatable="yes">Pages:</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
@@ -180,6 +188,7 @@ Select pages to export</property>
                 </child>
                 <child>
                   <object class="GtkEntry" id="txtPages">
+                    <property name="name">txtPages</property>
                     <property name="visible">True</property>
                     <property name="sensitive">False</property>
                     <property name="can_focus">True</property>
@@ -208,6 +217,7 @@ Select pages to export</property>
                 </child>
                 <child>
                   <object class="GtkLabel" id="lbDpi">
+                    <property name="name">lbDpi</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="label" translatable="yes">dpi</property>
@@ -221,6 +231,7 @@ Select pages to export</property>
                 </child>
                 <child>
                   <object class="GtkLabel" id="lbAllPagesInfo">
+                    <property name="name">lbAllPagesInfo</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="label">PLACEHOLDER</property>
@@ -236,6 +247,7 @@ Select pages to export</property>
                 </child>
                 <child>
                   <object class="GtkLabel" id="lbCurrentPage">
+                    <property name="name">lbCurrentPage</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="label">PLACEHOLDER</property>
@@ -251,6 +263,7 @@ Select pages to export</property>
                 </child>
                 <child>
                   <object class="GtkSpinButton" id="spDpi">
+                    <property name="name">spDpi</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="invisible_char">●</property>
@@ -299,6 +312,7 @@ Select pages to export</property>
     </action-widgets>
   </object>
   <object class="GtkEntryBuffer" id="entrybuffer1">
+    <property name="name">entrybuffer1</property>
     <property name="text">0</property>
   </object>
 </interface>

--- a/ui/fillTransparency.glade
+++ b/ui/fillTransparency.glade
@@ -9,6 +9,7 @@
     <property name="page_increment">10</property>
   </object>
   <object class="GtkDialog" id="fillTransparencyDialog">
+    <property name="name">fillTransparencyDialog</property>
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">Transparency settings</property>
     <property name="window_position">center</property>
@@ -22,11 +23,13 @@
         <property name="spacing">4</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="dialog-action_area2">
+            <property name="name">dialog-action_area2</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="btCancel">
+                <property name="name">btCancel</property>
                 <property name="label">gtk-cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
@@ -42,6 +45,7 @@
             </child>
             <child>
               <object class="GtkButton" id="btOk">
+                <property name="name">btOk</property>
                 <property name="label">gtk-ok</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
@@ -90,6 +94,7 @@ Select transparency for fill color</property>
                 <property name="spacing">10</property>
                 <child>
                   <object class="GtkImage" id="imgPreview">
+                    <property name="name">imgPreview</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="stock">gtk-missing-image</property>
@@ -102,6 +107,7 @@ Select transparency for fill color</property>
                 </child>
                 <child>
                   <object class="GtkScale" id="scaleAlpha">
+                    <property name="name">scaleAlpha</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="adjustment">adjustment1</property>

--- a/ui/goto.glade
+++ b/ui/goto.glade
@@ -8,6 +8,7 @@
     <property name="page_increment">1</property>
   </object>
   <object class="GtkDialog" id="gotoDialog">
+    <property name="name">gotoDialog</property>
     <property name="can_focus">False</property>
     <property name="border_width">5</property>
     <property name="title" translatable="yes">Goto Page</property>
@@ -23,6 +24,7 @@
         <property name="spacing">2</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="dialog-action_area2">
+            <property name="name">dialog-action_area2</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
@@ -71,6 +73,7 @@
             <property name="can_focus">False</property>
             <child>
               <object class="GtkSpinButton" id="spinPage">
+                <property name="name">spinPage</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="invisible_char">•</property>

--- a/ui/images.glade
+++ b/ui/images.glade
@@ -3,6 +3,7 @@
 <interface>
   <requires lib="gtk+" version="3.0"/>
   <object class="GtkDialog" id="ImagesDialog">
+    <property name="name">ImagesDialog</property>
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">Select Image</property>
     <property name="modal">True</property>
@@ -17,11 +18,13 @@
         <property name="orientation">vertical</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="dialog-action_area2">
+            <property name="name">dialog-action_area2</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="closebutton1">
+                <property name="name">closebutton1</property>
                 <property name="label">gtk-close</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
@@ -37,6 +40,7 @@
             </child>
             <child>
               <object class="GtkButton" id="buttonOk">
+                <property name="name">buttonOk</property>
                 <property name="label">gtk-ok</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
@@ -59,11 +63,13 @@
         </child>
         <child>
           <object class="GtkBox" id="vbox">
+            <property name="name">vbox</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="orientation">vertical</property>
             <child>
               <object class="GtkButton" id="btFilechooser">
+                <property name="name">btFilechooser</property>
                 <property name="label" translatable="yes">Load file</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
@@ -90,6 +96,7 @@
             </child>
             <child>
               <object class="GtkScrolledWindow" id="scrollContents">
+                <property name="name">scrollContents</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="shadow_type">in</property>

--- a/ui/main.glade
+++ b/ui/main.glade
@@ -14,16 +14,19 @@
   </object>
   <object class="GtkRevealer" id="floatingToolbox">
     <property name="name">floatingToolbox</property>
+    <property name="name">floatingToolbox</property>
     <property name="visible">True</property>
     <property name="can_focus">False</property>
     <property name="transition_type">crossfade</property>
     <property name="reveal_child">True</property>
     <child>
       <object class="GtkBox" id="floatingvbox">
+        <property name="name">floatingvbox</property>
         <property name="can_focus">False</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkLabel" id="labelFloatingToolbox">
+            <property name="name">labelFloatingToolbox</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="label" translatable="yes"> = Floating Toolbox (experimental) =</property>
@@ -41,6 +44,7 @@
         </child>
         <child>
           <object class="GtkToolbar" id="tbFloat1">
+            <property name="name">tbFloat1</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <style>
@@ -55,6 +59,7 @@
         </child>
         <child>
           <object class="GtkToolbar" id="tbFloat2">
+            <property name="name">tbFloat2</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <style>
@@ -69,6 +74,7 @@
         </child>
         <child>
           <object class="GtkToolbar" id="tbFloat3">
+            <property name="name">tbFloat3</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <style>
@@ -83,6 +89,7 @@
         </child>
         <child>
           <object class="GtkToolbar" id="tbFloat4">
+            <property name="name">tbFloat4</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <style>
@@ -97,6 +104,7 @@
         </child>
         <child>
           <object class="GtkLabel" id="showIfEmpty">
+            <property name="name">showIfEmpty</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="xpad">15</property>
@@ -121,23 +129,28 @@
     </child>
   </object>
   <object class="GtkWindow" id="mainWindow">
+    <property name="name">mainWindow</property>
     <property name="can_focus">False</property>
     <property name="icon">pixmaps/xournalpp.svg</property>
     <child>
       <object class="GtkOverlay" id="mainOverlay">
+        <property name="name">mainOverlay</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <child>
           <object class="GtkBox" id="mainBox">
+            <property name="name">mainBox</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="orientation">vertical</property>
             <child>
               <object class="GtkMenuBar" id="mainMenubar">
+                <property name="name">mainMenubar</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <child>
                   <object class="GtkMenuItem" id="menuitemFile">
+                    <property name="name">menuitemFile</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="label" translatable="yes">_File</property>
@@ -148,6 +161,7 @@
                         <property name="can_focus">False</property>
                         <child>
                           <object class="GtkImageMenuItem" id="menuFileNew">
+                            <property name="name">menuFileNew</property>
                             <property name="label">gtk-new</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
@@ -159,6 +173,7 @@
                         </child>
                         <child>
                           <object class="GtkImageMenuItem" id="menuFileOpen">
+                            <property name="name">menuFileOpen</property>
                             <property name="label">gtk-open</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
@@ -170,6 +185,7 @@
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="menuFileRecent">
+                            <property name="name">menuFileRecent</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">Recent _Documents</property>
@@ -178,6 +194,7 @@
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="menuFileAnnotate">
+                            <property name="name">menuFileAnnotate</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">_Annotate PDF</property>
@@ -187,6 +204,7 @@
                         </child>
                         <child>
                           <object class="GtkImageMenuItem" id="menuFileSave">
+                            <property name="name">menuFileSave</property>
                             <property name="label">gtk-save</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
@@ -198,6 +216,7 @@
                         </child>
                         <child>
                           <object class="GtkImageMenuItem" id="menuFileSaveAs">
+                            <property name="name">menuFileSaveAs</property>
                             <property name="label">gtk-save-as</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
@@ -216,6 +235,7 @@
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="menuFileExportPdf">
+                            <property name="name">menuFileExportPdf</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">_Export as PDF</property>
@@ -225,6 +245,7 @@
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="menuFileExportAs">
+                            <property name="name">menuFileExportAs</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">Export as...</property>
@@ -241,6 +262,7 @@
                         </child>
                         <child>
                           <object class="GtkImageMenuItem" id="menuFilePrint">
+                            <property name="name">menuFilePrint</property>
                             <property name="label">gtk-print</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
@@ -252,6 +274,7 @@
                         </child>
                         <child>
                           <object class="GtkImageMenuItem" id="menuFileQuit">
+                            <property name="name">menuFileQuit</property>
                             <property name="label">gtk-quit</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
@@ -267,6 +290,7 @@
                 </child>
                 <child>
                   <object class="GtkMenuItem" id="menuitemEdit">
+                    <property name="name">menuitemEdit</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="label" translatable="yes">_Edit</property>
@@ -277,6 +301,7 @@
                         <property name="can_focus">False</property>
                         <child>
                           <object class="GtkImageMenuItem" id="menuEditUndo">
+                            <property name="name">menuEditUndo</property>
                             <property name="label">gtk-undo</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
@@ -288,6 +313,7 @@
                         </child>
                         <child>
                           <object class="GtkImageMenuItem" id="menuEditRedo">
+                            <property name="name">menuEditRedo</property>
                             <property name="label">gtk-redo</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
@@ -305,6 +331,7 @@
                         </child>
                         <child>
                           <object class="GtkImageMenuItem" id="menuEditCut">
+                            <property name="name">menuEditCut</property>
                             <property name="label">gtk-cut</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
@@ -316,6 +343,7 @@
                         </child>
                         <child>
                           <object class="GtkImageMenuItem" id="menuEditCopy">
+                            <property name="name">menuEditCopy</property>
                             <property name="label">gtk-copy</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
@@ -327,6 +355,7 @@
                         </child>
                         <child>
                           <object class="GtkImageMenuItem" id="menuEditPaste">
+                            <property name="name">menuEditPaste</property>
                             <property name="label">gtk-paste</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
@@ -344,6 +373,7 @@
                         </child>
                         <child>
                           <object class="GtkImageMenuItem" id="menuEditSearch">
+                            <property name="name">menuEditSearch</property>
                             <property name="label">gtk-find</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
@@ -361,6 +391,7 @@
                         </child>
                         <child>
                           <object class="GtkImageMenuItem" id="menuEditDelete">
+                            <property name="name">menuEditDelete</property>
                             <property name="label">gtk-delete</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
@@ -378,6 +409,7 @@
                         </child>
                         <child>
                           <object class="GtkCheckMenuItem" id="menuSnapRotation">
+                            <property name="name">menuSnapRotation</property>
                             <property name="use_action_appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
@@ -387,6 +419,7 @@
                         </child>
                         <child>
                           <object class="GtkCheckMenuItem" id="menuSnapGrid">
+                            <property name="name">menuSnapGrid</property>
                             <property name="use_action_appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
@@ -402,6 +435,7 @@
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="menuEditSettings">
+                            <property name="name">menuEditSettings</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">Preferences</property>
@@ -415,6 +449,7 @@
                 </child>
                 <child>
                   <object class="GtkMenuItem" id="menuitemView">
+                    <property name="name">menuitemView</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="label" translatable="yes">_View</property>
@@ -425,6 +460,7 @@
                         <property name="can_focus">False</property>
                         <child>
                           <object class="GtkCheckMenuItem" id="menuViewPairedPages">
+                            <property name="name">menuViewPairedPages</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">_Pair Pages</property>
@@ -434,6 +470,7 @@
                         </child>
                         <child>
                           <object class="GtkCheckMenuItem" id="menuViewPresMode">
+                            <property name="name">menuViewPresMode</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">_Presentation Mode</property>
@@ -443,6 +480,7 @@
                         </child>
                         <child>
                           <object class="GtkCheckMenuItem" id="menuViewFullScreen">
+                            <property name="name">menuViewFullScreen</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">Fullscreen</property>
@@ -453,6 +491,7 @@
                         </child>
                         <child>
                           <object class="GtkCheckMenuItem" id="menuViewSidebarVisible">
+                            <property name="name">menuViewSidebarVisible</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">Show sidebar</property>
@@ -468,16 +507,19 @@
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="menuitemLayout">
+                            <property name="name">menuitemLayout</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">Layout</property>
                             <property name="use_underline">True</property>
                             <child type="submenu">
                               <object class="GtkMenu" id="layoutmenu">
+                                <property name="name">layoutmenu</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <child>
                                   <object class="GtkCheckMenuItem" id="menuLayoutHorizontal">
+                                    <property name="name">menuLayoutHorizontal</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">_Horizontal</property>
@@ -488,6 +530,7 @@
                                 </child>
                                 <child>
                                   <object class="GtkCheckMenuItem" id="menuLayoutVertical">
+                                    <property name="name">menuLayoutVertical</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">_Vertical</property>
@@ -498,12 +541,14 @@
                                 </child>
                                 <child>
                                   <object class="GtkSeparatorMenuItem" id="separatormenuitemLayout1">
+                                    <property name="name">separatormenuitemLayout1</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkCheckMenuItem" id="menuLayoutLR">
+                                    <property name="name">menuLayoutLR</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">_Left To Right</property>
@@ -514,6 +559,7 @@
                                 </child>
                                 <child>
                                   <object class="GtkCheckMenuItem" id="menuLayoutRL">
+                                    <property name="name">menuLayoutRL</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">_Right To Left</property>
@@ -524,12 +570,14 @@
                                 </child>
                                 <child>
                                   <object class="GtkSeparatorMenuItem" id="separatormenuitemLayout2">
+                                    <property name="name">separatormenuitemLayout2</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkCheckMenuItem" id="menuLayoutTB">
+                                    <property name="name">menuLayoutTB</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">_Top to Bottom</property>
@@ -540,6 +588,7 @@
                                 </child>
                                 <child>
                                   <object class="GtkCheckMenuItem" id="menuLayoutBT">
+                                    <property name="name">menuLayoutBT</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">_Bottom to Top</property>
@@ -554,16 +603,19 @@
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="menuitemViewDimensions">
+                            <property name="name">menuitemViewDimensions</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">_Cols/Rows</property>
                             <property name="use_underline">True</property>
                             <child type="submenu">
                               <object class="GtkMenu" id="menuViewDimensions">
+                                <property name="name">menuViewDimensions</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <child>
                                   <object class="GtkMenuItem" id="menuitemViewColumns">
+                                    <property name="name">menuitemViewColumns</property>
                                     <property name="width_request">-1</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
@@ -571,10 +623,12 @@
                                     <property name="use_underline">True</property>
                                     <child type="submenu">
                                       <object class="GtkMenu" id="menuViewColumns">
+                                        <property name="name">menuViewColumns</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
                                         <child>
                                           <object class="GtkCheckMenuItem" id="menuViewColumns1">
+                                            <property name="name">menuViewColumns1</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">_1</property>
@@ -585,6 +639,7 @@
                                         </child>
                                         <child>
                                           <object class="GtkCheckMenuItem" id="menuViewColumns2">
+                                            <property name="name">menuViewColumns2</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">_2</property>
@@ -595,6 +650,7 @@
                                         </child>
                                         <child>
                                           <object class="GtkCheckMenuItem" id="menuViewColumns3">
+                                            <property name="name">menuViewColumns3</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">_3</property>
@@ -605,6 +661,7 @@
                                         </child>
                                         <child>
                                           <object class="GtkCheckMenuItem" id="menuViewColumns4">
+                                            <property name="name">menuViewColumns4</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">_4</property>
@@ -615,6 +672,7 @@
                                         </child>
                                         <child>
                                           <object class="GtkCheckMenuItem" id="menuViewColumns5">
+                                            <property name="name">menuViewColumns5</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">_5</property>
@@ -625,6 +683,7 @@
                                         </child>
                                         <child>
                                           <object class="GtkCheckMenuItem" id="menuViewColumns6">
+                                            <property name="name">menuViewColumns6</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">6</property>
@@ -635,6 +694,7 @@
                                         </child>
                                         <child>
                                           <object class="GtkCheckMenuItem" id="menuViewColumns7">
+                                            <property name="name">menuViewColumns7</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">7</property>
@@ -645,6 +705,7 @@
                                         </child>
                                         <child>
                                           <object class="GtkCheckMenuItem" id="menuViewColumns8">
+                                            <property name="name">menuViewColumns8</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">8</property>
@@ -659,6 +720,7 @@
                                 </child>
                                 <child>
                                   <object class="GtkMenuItem" id="menuitemViewRows">
+                                    <property name="name">menuitemViewRows</property>
                                     <property name="width_request">-1</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
@@ -666,10 +728,12 @@
                                     <property name="use_underline">True</property>
                                     <child type="submenu">
                                       <object class="GtkMenu" id="menuViewRows">
+                                        <property name="name">menuViewRows</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
                                         <child>
                                           <object class="GtkCheckMenuItem" id="menuViewRows1">
+                                            <property name="name">menuViewRows1</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">_1</property>
@@ -680,6 +744,7 @@
                                         </child>
                                         <child>
                                           <object class="GtkCheckMenuItem" id="menuViewRows2">
+                                            <property name="name">menuViewRows2</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">_2</property>
@@ -690,6 +755,7 @@
                                         </child>
                                         <child>
                                           <object class="GtkCheckMenuItem" id="menuViewRows3">
+                                            <property name="name">menuViewRows3</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">_3</property>
@@ -700,6 +766,7 @@
                                         </child>
                                         <child>
                                           <object class="GtkCheckMenuItem" id="menuViewRows4">
+                                            <property name="name">menuViewRows4</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">_4</property>
@@ -710,6 +777,7 @@
                                         </child>
                                         <child>
                                           <object class="GtkCheckMenuItem" id="menuViewRows5">
+                                            <property name="name">menuViewRows5</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">_5</property>
@@ -720,6 +788,7 @@
                                         </child>
                                         <child>
                                           <object class="GtkCheckMenuItem" id="menuViewRows6">
+                                            <property name="name">menuViewRows6</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">6</property>
@@ -730,6 +799,7 @@
                                         </child>
                                         <child>
                                           <object class="GtkCheckMenuItem" id="menuViewRows7">
+                                            <property name="name">menuViewRows7</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">7</property>
@@ -740,6 +810,7 @@
                                         </child>
                                         <child>
                                           <object class="GtkCheckMenuItem" id="menuViewRows8">
+                                            <property name="name">menuViewRows8</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">8</property>
@@ -764,12 +835,14 @@
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="menuitemViewToolbar">
+                            <property name="name">menuitemViewToolbar</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">T_oolbars</property>
                             <property name="use_underline">True</property>
                             <child type="submenu">
                               <object class="GtkMenu" id="menuViewToolbar">
+                                <property name="name">menuViewToolbar</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <child>
@@ -780,6 +853,7 @@
                                 </child>
                                 <child>
                                   <object class="GtkMenuItem" id="menuViewToolbarManage">
+                                    <property name="name">menuViewToolbarManage</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">_Manage</property>
@@ -789,6 +863,7 @@
                                 </child>
                                 <child>
                                   <object class="GtkMenuItem" id="menuViewToolbarCustomize">
+                                    <property name="name">menuViewToolbarCustomize</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">_Customize</property>
@@ -808,6 +883,7 @@
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="menuHideMenu">
+                            <property name="name">menuHideMenu</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">Hide Menu</property>
@@ -823,6 +899,7 @@
                         </child>
                         <child>
                           <object class="GtkImageMenuItem" id="menuViewZoomIn">
+                            <property name="name">menuViewZoomIn</property>
                             <property name="label">gtk-zoom-in</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
@@ -835,6 +912,7 @@
                         </child>
                         <child>
                           <object class="GtkImageMenuItem" id="menuViewZoomOut">
+                            <property name="name">menuViewZoomOut</property>
                             <property name="label">gtk-zoom-out</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
@@ -847,6 +925,7 @@
                         </child>
                         <child>
                           <object class="GtkImageMenuItem" id="menuViewZoom100">
+                            <property name="name">menuViewZoom100</property>
                             <property name="label">gtk-zoom-100</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
@@ -857,6 +936,7 @@
                         </child>
                         <child>
                           <object class="GtkImageMenuItem" id="menuViewZoomFit">
+                            <property name="name">menuViewZoomFit</property>
                             <property name="label">gtk-zoom-fit</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
@@ -871,6 +951,7 @@
                 </child>
                 <child>
                   <object class="GtkMenuItem" id="menuitemNavigation">
+                    <property name="name">menuitemNavigation</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="label" translatable="yes">_Navigation</property>
@@ -881,6 +962,7 @@
                         <property name="can_focus">False</property>
                         <child>
                           <object class="GtkMenuItem" id="menuViewFirstPage">
+                            <property name="name">menuViewFirstPage</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">_First Page</property>
@@ -891,6 +973,7 @@
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="menuNavigationPreviousPage">
+                            <property name="name">menuNavigationPreviousPage</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">_Previous Page</property>
@@ -901,6 +984,7 @@
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="menuNavigationGotoPage">
+                            <property name="name">menuNavigationGotoPage</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">_Goto Page</property>
@@ -911,6 +995,7 @@
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="menuNavigationNextPage">
+                            <property name="name">menuNavigationNextPage</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">_Next Page</property>
@@ -921,6 +1006,7 @@
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="menuNavigationLastPage">
+                            <property name="name">menuNavigationLastPage</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">_Last Page</property>
@@ -937,6 +1023,7 @@
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="menuNavigationPreviousLayer">
+                            <property name="name">menuNavigationPreviousLayer</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">_Previous Layer</property>
@@ -947,6 +1034,7 @@
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="menuNavigationNextLayer">
+                            <property name="name">menuNavigationNextLayer</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">_Next Layer</property>
@@ -957,6 +1045,7 @@
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="menuNavigationTopLayer">
+                            <property name="name">menuNavigationTopLayer</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">_Top Layer</property>
@@ -972,6 +1061,7 @@
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="menuNavigationNextAnnotatedPage">
+                            <property name="name">menuNavigationNextAnnotatedPage</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">N_ext annotated page</property>
@@ -982,6 +1072,7 @@
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="menuNavigationPreviousAnnotatedPage">
+                            <property name="name">menuNavigationPreviousAnnotatedPage</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">P_revious annotated Page</property>
@@ -996,6 +1087,7 @@
                 </child>
                 <child>
                   <object class="GtkMenuItem" id="menuitemJournal">
+                    <property name="name">menuitemJournal</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="label" translatable="yes">_Journal</property>
@@ -1006,6 +1098,7 @@
                         <property name="can_focus">False</property>
                         <child>
                           <object class="GtkMenuItem" id="menuJournalNewPageBefore">
+                            <property name="name">menuJournalNewPageBefore</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">New Page _Before</property>
@@ -1015,6 +1108,7 @@
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="menuJournalNewPageAfter">
+                            <property name="name">menuJournalNewPageAfter</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">New Page _After</property>
@@ -1025,6 +1119,7 @@
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="menuJournalNewPageAtEnd">
+                            <property name="name">menuJournalNewPageAtEnd</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">New Page at _End</property>
@@ -1034,6 +1129,7 @@
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="menuJournalTemplateConfig">
+                            <property name="name">menuJournalTemplateConfig</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">Configure Page Template</property>
@@ -1043,6 +1139,7 @@
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="menuDeletePage">
+                            <property name="name">menuDeletePage</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">_Delete Page</property>
@@ -1059,6 +1156,7 @@
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="menuJournalNewLayer">
+                            <property name="name">menuJournalNewLayer</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">New _Layer</property>
@@ -1069,6 +1167,7 @@
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="menuJournalDeleteLayer">
+                            <property name="name">menuJournalDeleteLayer</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">Delete Layer</property>
@@ -1085,6 +1184,7 @@
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="menuJournalPaperFormat">
+                            <property name="name">menuJournalPaperFormat</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">Paper _Format</property>
@@ -1094,6 +1194,7 @@
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="menuJournalPaperColor">
+                            <property name="name">menuJournalPaperColor</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">Paper _Color</property>
@@ -1103,6 +1204,7 @@
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="menuJournalPaperBackground">
+                            <property name="name">menuJournalPaperBackground</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">Paper b_ackground</property>
@@ -1115,6 +1217,7 @@
                 </child>
                 <child>
                   <object class="GtkMenuItem" id="menuitemTools">
+                    <property name="name">menuitemTools</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="label" translatable="yes">_Tools</property>
@@ -1125,6 +1228,7 @@
                         <property name="can_focus">False</property>
                         <child>
                           <object class="GtkCheckMenuItem" id="menuToolsPen">
+                            <property name="name">menuToolsPen</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">_Pen</property>
@@ -1136,6 +1240,7 @@
                         </child>
                         <child>
                           <object class="GtkCheckMenuItem" id="menuToolsEraser">
+                            <property name="name">menuToolsEraser</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">_Eraser</property>
@@ -1147,6 +1252,7 @@
                         </child>
                         <child>
                           <object class="GtkCheckMenuItem" id="menuToolsHighlighter">
+                            <property name="name">menuToolsHighlighter</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">_Highlighter</property>
@@ -1158,6 +1264,7 @@
                         </child>
                         <child>
                           <object class="GtkCheckMenuItem" id="menuToolsText">
+                            <property name="name">menuToolsText</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">_Text</property>
@@ -1169,6 +1276,7 @@
                         </child>
                         <child>
                           <object class="GtkCheckMenuItem" id="menuToolsImage">
+                            <property name="name">menuToolsImage</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">_Image</property>
@@ -1180,6 +1288,7 @@
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="menuToolsDefault">
+                            <property name="name">menuToolsDefault</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">_Default Tools</property>
@@ -1195,6 +1304,7 @@
                         </child>
                         <child>
                           <object class="GtkCheckMenuItem" id="menuToolsShapeRecognizer">
+                            <property name="name">menuToolsShapeRecognizer</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">_Shape Recognizer</property>
@@ -1205,6 +1315,7 @@
                         </child>
                         <child>
                           <object class="GtkCheckMenuItem" id="menuToolsDrawRect">
+                            <property name="name">menuToolsDrawRect</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">Draw Rectangle</property>
@@ -1215,6 +1326,7 @@
                         </child>
                         <child>
                           <object class="GtkCheckMenuItem" id="menuToolsDrawCircle">
+                            <property name="name">menuToolsDrawCircle</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">Draw Circle</property>
@@ -1225,6 +1337,7 @@
                         </child>
                         <child>
                           <object class="GtkCheckMenuItem" id="menuToolsDrawArrow">
+                            <property name="name">menuToolsDrawArrow</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">Draw Arrow</property>
@@ -1235,6 +1348,7 @@
                         </child>
                         <child>
                           <object class="GtkCheckMenuItem" id="menuToolsDrawCoordinateSystem">
+                            <property name="name">menuToolsDrawCoordinateSystem</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">Draw coordinate system</property>
@@ -1245,6 +1359,7 @@
                         </child>
                         <child>
                           <object class="GtkCheckMenuItem" id="menuToolsRuler">
+                            <property name="name">menuToolsRuler</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">Draw _Line</property>
@@ -1261,6 +1376,7 @@
                         </child>
                         <child>
                           <object class="GtkCheckMenuItem" id="menuToolsSelectRegion">
+                            <property name="name">menuToolsSelectRegion</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">Select Region</property>
@@ -1272,6 +1388,7 @@
                         </child>
                         <child>
                           <object class="GtkCheckMenuItem" id="menuToolsSelectRectangle">
+                            <property name="name">menuToolsSelectRectangle</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">Select Rectangle</property>
@@ -1283,6 +1400,7 @@
                         </child>
                         <child>
                           <object class="GtkCheckMenuItem" id="menuToolsSelectObject">
+                            <property name="name">menuToolsSelectObject</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">Select Object</property>
@@ -1294,6 +1412,7 @@
                         </child>
                         <child>
                           <object class="GtkCheckMenuItem" id="menuToolsVerticalSpace">
+                            <property name="name">menuToolsVerticalSpace</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">_Vertical Space</property>
@@ -1305,6 +1424,7 @@
                         </child>
                         <child>
                           <object class="GtkCheckMenuItem" id="menuToolsPlayObject">
+                            <property name="name">menuToolsPlayObject</property>
                             <property name="use_action_appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
@@ -1316,6 +1436,7 @@
                         </child>
                         <child>
                           <object class="GtkCheckMenuItem" id="menuToolsHand">
+                            <property name="name">menuToolsHand</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">H_and Tool</property>
@@ -1333,6 +1454,7 @@
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="menuToolsPenOptions">
+                            <property name="name">menuToolsPenOptions</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">Pen _Options</property>
@@ -1343,6 +1465,7 @@
                                 <property name="can_focus">False</property>
                                 <child>
                                   <object class="GtkCheckMenuItem" id="penthicknessVeryFine">
+                                    <property name="name">penthicknessVeryFine</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">_very fine</property>
@@ -1353,6 +1476,7 @@
                                 </child>
                                 <child>
                                   <object class="GtkCheckMenuItem" id="penthicknessFine">
+                                    <property name="name">penthicknessFine</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">_fine</property>
@@ -1363,6 +1487,7 @@
                                 </child>
                                 <child>
                                   <object class="GtkCheckMenuItem" id="penthicknessMedium">
+                                    <property name="name">penthicknessMedium</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">_medium</property>
@@ -1373,6 +1498,7 @@
                                 </child>
                                 <child>
                                   <object class="GtkCheckMenuItem" id="penthicknessThick">
+                                    <property name="name">penthicknessThick</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">_thick</property>
@@ -1383,6 +1509,7 @@
                                 </child>
                                 <child>
                                   <object class="GtkCheckMenuItem" id="penthicknessVeryThick">
+                                    <property name="name">penthicknessVeryThick</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">ver_y thick</property>
@@ -1399,6 +1526,7 @@
                                 </child>
                                 <child>
                                   <object class="GtkCheckMenuItem" id="penStandard">
+                                    <property name="name">penStandard</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">standard</property>
@@ -1409,6 +1537,7 @@
                                 </child>
                                 <child>
                                   <object class="GtkCheckMenuItem" id="penStyleDashed">
+                                    <property name="name">penStyleDashed</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">dashed</property>
@@ -1419,6 +1548,7 @@
                                 </child>
                                 <child>
                                   <object class="GtkCheckMenuItem" id="penStyleDashDotted">
+                                    <property name="name">penStyleDashDotted</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">dash-/ dotted</property>
@@ -1429,6 +1559,7 @@
                                 </child>
                                 <child>
                                   <object class="GtkCheckMenuItem" id="penStyleDotted">
+                                    <property name="name">penStyleDotted</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">dotted</property>
@@ -1445,6 +1576,7 @@
                                 </child>
                                 <child>
                                   <object class="GtkCheckMenuItem" id="penFill">
+                                    <property name="name">penFill</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Fi_ll</property>
@@ -1454,6 +1586,7 @@
                                 </child>
                                 <child>
                                   <object class="GtkMenuItem" id="penFillTransparency">
+                                    <property name="name">penFillTransparency</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Fill transparency</property>
@@ -1467,6 +1600,7 @@
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="menuToolsEraserOptions">
+                            <property name="name">menuToolsEraserOptions</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">Eraser Optio_ns</property>
@@ -1477,6 +1611,7 @@
                                 <property name="can_focus">False</property>
                                 <child>
                                   <object class="GtkCheckMenuItem" id="eraserFine">
+                                    <property name="name">eraserFine</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">_fine</property>
@@ -1487,6 +1622,7 @@
                                 </child>
                                 <child>
                                   <object class="GtkCheckMenuItem" id="eraserMedium">
+                                    <property name="name">eraserMedium</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">_medium</property>
@@ -1497,6 +1633,7 @@
                                 </child>
                                 <child>
                                   <object class="GtkCheckMenuItem" id="eraserThick">
+                                    <property name="name">eraserThick</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">_thick</property>
@@ -1513,6 +1650,7 @@
                                 </child>
                                 <child>
                                   <object class="GtkCheckMenuItem" id="eraserStandard">
+                                    <property name="name">eraserStandard</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">_standard</property>
@@ -1523,6 +1661,7 @@
                                 </child>
                                 <child>
                                   <object class="GtkCheckMenuItem" id="eraserWhiteout">
+                                    <property name="name">eraserWhiteout</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">_whiteout</property>
@@ -1533,6 +1672,7 @@
                                 </child>
                                 <child>
                                   <object class="GtkCheckMenuItem" id="eraserDeleteStrokes">
+                                    <property name="name">eraserDeleteStrokes</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">_delete strokes</property>
@@ -1547,6 +1687,7 @@
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="menuToolsHighlighterOptions">
+                            <property name="name">menuToolsHighlighterOptions</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">Highlighter Opti_ons</property>
@@ -1557,6 +1698,7 @@
                                 <property name="can_focus">False</property>
                                 <child>
                                   <object class="GtkCheckMenuItem" id="highlighterFine">
+                                    <property name="name">highlighterFine</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">_fine</property>
@@ -1567,6 +1709,7 @@
                                 </child>
                                 <child>
                                   <object class="GtkCheckMenuItem" id="highlighterMedium">
+                                    <property name="name">highlighterMedium</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">_medium</property>
@@ -1577,6 +1720,7 @@
                                 </child>
                                 <child>
                                   <object class="GtkCheckMenuItem" id="highlighterThick">
+                                    <property name="name">highlighterThick</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">_thick</property>
@@ -1593,6 +1737,7 @@
                                 </child>
                                 <child>
                                   <object class="GtkCheckMenuItem" id="highlighterFill">
+                                    <property name="name">highlighterFill</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Fi_ll</property>
@@ -1602,6 +1747,7 @@
                                 </child>
                                 <child>
                                   <object class="GtkMenuItem" id="highlighterFillTransparency">
+                                    <property name="name">highlighterFillTransparency</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Fill transparency</property>
@@ -1615,6 +1761,7 @@
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="menuToolsTextFont">
+                            <property name="name">menuToolsTextFont</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">Text Font...</property>
@@ -1625,6 +1772,7 @@
                         </child>
                         <child>
                           <object class="GtkCheckMenuItem" id="menuAudioRecord">
+                            <property name="name">menuAudioRecord</property>
                             <property name="use_action_appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
@@ -1634,6 +1782,7 @@
                         </child>
                         <child>
                           <object class="GtkCheckMenuItem" id="menuAudioPausePlayback">
+                            <property name="name">menuAudioPausePlayback</property>
                             <property name="use_action_appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
@@ -1643,6 +1792,7 @@
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="menuAudioStopPlayback">
+                            <property name="name">menuAudioStopPlayback</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">Stop</property>
@@ -1652,6 +1802,7 @@
                         </child>
                         <child>
                           <object class="GtkMenuItem" id="menuEditTex">
+                            <property name="name">menuEditTex</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">Add/Edit Tex</property>
@@ -1666,12 +1817,14 @@
                 </child>
                 <child>
                   <object class="GtkMenuItem" id="menuitemPlugin">
+                    <property name="name">menuitemPlugin</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="label" translatable="yes">_Plugin</property>
                     <property name="use_underline">True</property>
                     <child type="submenu">
                       <object class="GtkMenu" id="menuPlugin">
+                        <property name="name">menuPlugin</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <child>
@@ -1689,6 +1842,7 @@
                 </child>
                 <child>
                   <object class="GtkMenuItem" id="menuitemHelp">
+                    <property name="name">menuitemHelp</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="label" translatable="yes">_Help</property>
@@ -1699,6 +1853,7 @@
                         <property name="can_focus">False</property>
                         <child>
                           <object class="GtkImageMenuItem" id="menuHelpHelp">
+                            <property name="name">menuHelpHelp</property>
                             <property name="label">gtk-help</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
@@ -1709,6 +1864,7 @@
                         </child>
                         <child>
                           <object class="GtkImageMenuItem" id="menuHelpAbout">
+                            <property name="name">menuHelpAbout</property>
                             <property name="label">gtk-about</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
@@ -1731,6 +1887,7 @@
             </child>
             <child>
               <object class="GtkToolbar" id="tbTop1">
+                <property name="name">tbTop1</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="toolbar_style">icons</property>
@@ -1743,6 +1900,7 @@
             </child>
             <child>
               <object class="GtkToolbar" id="tbTop2">
+                <property name="name">tbTop2</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
               </object>
@@ -1754,10 +1912,12 @@
             </child>
             <child>
               <object class="GtkBox" id="mainContainerBox">
+                <property name="name">mainContainerBox</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <child>
                   <object class="GtkToolbar" id="tbLeft1">
+                    <property name="name">tbLeft1</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="orientation">vertical</property>
@@ -1771,6 +1931,7 @@
                 </child>
                 <child>
                   <object class="GtkToolbar" id="tbLeft2">
+                    <property name="name">tbLeft2</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="orientation">vertical</property>
@@ -1784,15 +1945,18 @@
                 </child>
                 <child>
                   <object class="GtkPaned" id="panelMainContents">
+                    <property name="name">panelMainContents</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <child>
                       <object class="GtkBox" id="sidebar">
+                        <property name="name">sidebar</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="orientation">vertical</property>
                         <child>
                           <object class="GtkToolbar" id="tbSelectSidebarPage">
+                            <property name="name">tbSelectSidebarPage</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                           </object>
@@ -1804,6 +1968,7 @@
                         </child>
                         <child>
                           <object class="GtkBox" id="sidebarContents">
+                            <property name="name">sidebarContents</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="orientation">vertical</property>
@@ -1827,6 +1992,7 @@
                                 <property name="can_focus">False</property>
                                 <child>
                                   <object class="GtkButton" id="btUp">
+                                    <property name="name">btUp</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">True</property>
@@ -1848,6 +2014,7 @@
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="btDown">
+                                    <property name="name">btDown</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">True</property>
@@ -1868,6 +2035,7 @@
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="btCopy">
+                                    <property name="name">btCopy</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">True</property>
@@ -1888,6 +2056,7 @@
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="btDelete">
+                                    <property name="name">btDelete</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">True</property>
@@ -1919,6 +2088,7 @@
                             </child>
                             <child>
                               <object class="GtkButton" id="buttonCloseSidebar">
+                                <property name="name">buttonCloseSidebar</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">False</property>
@@ -1957,6 +2127,7 @@
                     </child>
                     <child>
                       <object class="GtkBox" id="boxContents">
+                        <property name="name">boxContents</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="orientation">vertical</property>
@@ -1978,6 +2149,7 @@
                 </child>
                 <child>
                   <object class="GtkToolbar" id="tbRight1">
+                    <property name="name">tbRight1</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="orientation">vertical</property>
@@ -1991,6 +2163,7 @@
                 </child>
                 <child>
                   <object class="GtkToolbar" id="tbRight2">
+                    <property name="name">tbRight2</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="orientation">vertical</property>
@@ -2011,11 +2184,13 @@
             </child>
             <child>
               <object class="GtkBox" id="searchBar">
+                <property name="name">searchBar</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkSeparator" id="separator1">
+                    <property name="name">separator1</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                   </object>
@@ -2027,10 +2202,12 @@
                 </child>
                 <child>
                   <object class="GtkToolbar" id="searchToolbar">
+                    <property name="name">searchToolbar</property>
                     <property name="can_focus">False</property>
                     <property name="toolbar_style">icons</property>
                     <child>
                       <object class="GtkToolItem" id="toolbutton1">
+                        <property name="name">toolbutton1</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="margin_right">12</property>
@@ -2040,6 +2217,7 @@
                             <property name="can_focus">False</property>
                             <child>
                               <object class="GtkSearchEntry" id="searchTextField">
+                                <property name="name">searchTextField</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="primary_icon_name">edit-find-symbolic</property>
@@ -2054,6 +2232,7 @@
                             </child>
                             <child>
                               <object class="GtkButton" id="btSearchBack">
+                                <property name="name">btSearchBack</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="receives_default">True</property>
@@ -2075,6 +2254,7 @@
                             </child>
                             <child>
                               <object class="GtkButton" id="btSearchForward">
+                                <property name="name">btSearchForward</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="receives_default">True</property>
@@ -2108,10 +2288,12 @@
                     </child>
                     <child>
                       <object class="GtkToolItem" id="toolbutton3">
+                        <property name="name">toolbutton3</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <child>
                           <object class="GtkLabel" id="lbSearchState">
+                            <property name="name">lbSearchState</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="ellipsize">end</property>
@@ -2126,10 +2308,12 @@
                     </child>
                     <child>
                       <object class="GtkToolItem" id="toolbutton2">
+                        <property name="name">toolbutton2</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <child>
                           <object class="GtkButton" id="buttonCloseSearch">
+                            <property name="name">buttonCloseSearch</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="receives_default">False</property>
@@ -2169,6 +2353,7 @@
             </child>
             <child>
               <object class="GtkToolbar" id="tbBottom1">
+                <property name="name">tbBottom1</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
               </object>
@@ -2180,6 +2365,7 @@
             </child>
             <child>
               <object class="GtkToolbar" id="tbBottom2">
+                <property name="name">tbBottom2</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
               </object>
@@ -2191,9 +2377,11 @@
             </child>
             <child>
               <object class="GtkBox" id="statusbar">
+                <property name="name">statusbar</property>
                 <property name="can_focus">False</property>
                 <child>
                   <object class="GtkLabel" id="lbState">
+                    <property name="name">lbState</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="label" translatable="yes">State PLACEHOLDER</property>
@@ -2207,6 +2395,7 @@
                 </child>
                 <child>
                   <object class="GtkProgressBar" id="pgState">
+                    <property name="name">pgState</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                   </object>
@@ -2218,6 +2407,7 @@
                 </child>
                 <child>
                   <object class="GtkStatusbar" id="statusbar1">
+                    <property name="name">statusbar1</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="margin_left">10</property>

--- a/ui/pageTemplate.glade
+++ b/ui/pageTemplate.glade
@@ -13,6 +13,7 @@
     <property name="page_increment">10</property>
   </object>
   <object class="GtkDialog" id="templateDialog">
+    <property name="name">templateDialog</property>
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">Page Template</property>
     <property name="window_position">center</property>
@@ -26,11 +27,13 @@
         <property name="spacing">4</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="dialog-action_area2">
+            <property name="name">dialog-action_area2</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="btSave">
+                <property name="name">btSave</property>
                 <property name="label" translatable="yes">save to file</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
@@ -44,6 +47,7 @@
             </child>
             <child>
               <object class="GtkButton" id="btLoad">
+                <property name="name">btLoad</property>
                 <property name="label" translatable="yes">load from file</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
@@ -57,6 +61,7 @@
             </child>
             <child>
               <object class="GtkButton" id="btCancel">
+                <property name="name">btCancel</property>
                 <property name="label">gtk-cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
@@ -72,6 +77,7 @@
             </child>
             <child>
               <object class="GtkButton" id="btOk">
+                <property name="name">btOk</property>
                 <property name="label">gtk-ok</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
@@ -135,6 +141,7 @@ This settings will be used if you create a new document</property>
                 </child>
                 <child>
                   <object class="GtkLabel" id="lbPageSize">
+                    <property name="name">lbPageSize</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="label">10cm x 20cm</property>
@@ -147,6 +154,7 @@ This settings will be used if you create a new document</property>
                 </child>
                 <child>
                   <object class="GtkButton" id="btChangePaperSize">
+                    <property name="name">btChangePaperSize</property>
                     <property name="label" translatable="yes">change</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
@@ -159,6 +167,7 @@ This settings will be used if you create a new document</property>
                 </child>
                 <child>
                   <object class="GtkColorButton" id="cbBackgroundButton">
+                    <property name="name">cbBackgroundButton</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
@@ -172,6 +181,7 @@ This settings will be used if you create a new document</property>
                 </child>
                 <child>
                   <object class="GtkCheckButton" id="cbCopyLastPage">
+                    <property name="name">cbCopyLastPage</property>
                     <property name="label" translatable="yes">Copy last page settings</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
@@ -191,6 +201,7 @@ This settings will be used if you create a new document</property>
                     <property name="can_focus">False</property>
                     <child>
                       <object class="GtkLabel" id="lbBackgroundType">
+                        <property name="name">lbBackgroundType</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="label">BACKGROUND_TYPE</property>
@@ -204,6 +215,7 @@ This settings will be used if you create a new document</property>
                     </child>
                     <child>
                       <object class="GtkButton" id="btBackgroundDropdown">
+                        <property name="name">btBackgroundDropdown</property>
                         <property name="label">⌄</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
@@ -280,6 +292,7 @@ for the fist Page</property>
                 </child>
                 <child>
                   <object class="GtkCheckButton" id="cbCopyLastPageSize">
+                    <property name="name">cbCopyLastPageSize</property>
                     <property name="label" translatable="yes">Copy last page size</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>

--- a/ui/pagesize.glade
+++ b/ui/pagesize.glade
@@ -13,6 +13,7 @@
     <property name="page_increment">10</property>
   </object>
   <object class="GtkDialog" id="pagesizeDialog">
+    <property name="name">pagesizeDialog</property>
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">Paper Format</property>
     <property name="window_position">center</property>
@@ -26,11 +27,13 @@
         <property name="spacing">4</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="dialog-action_area2">
+            <property name="name">dialog-action_area2</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="btReset">
+                <property name="name">btReset</property>
                 <property name="label">gtk-revert-to-saved</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
@@ -45,6 +48,7 @@
             </child>
             <child>
               <object class="GtkButton" id="btCancel">
+                <property name="name">btCancel</property>
                 <property name="label">gtk-cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
@@ -60,6 +64,7 @@
             </child>
             <child>
               <object class="GtkButton" id="btOk">
+                <property name="name">btOk</property>
                 <property name="label">gtk-ok</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
@@ -104,6 +109,7 @@
                 </child>
                 <child>
                   <object class="GtkComboBox" id="cbTemplate">
+                    <property name="name">cbTemplate</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                   </object>
@@ -157,6 +163,7 @@
                 <property name="can_focus">False</property>
                 <child>
                   <object class="GtkFixed" id="fixed1">
+                    <property name="name">fixed1</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                   </object>
@@ -219,6 +226,7 @@
                     </child>
                     <child>
                       <object class="GtkSpinButton" id="spinWidth">
+                        <property name="name">spinWidth</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="invisible_char">●</property>
@@ -233,6 +241,7 @@
                     </child>
                     <child>
                       <object class="GtkSpinButton" id="spinHeight">
+                        <property name="name">spinHeight</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="invisible_char">●</property>
@@ -247,11 +256,13 @@
                     </child>
                     <child>
                       <object class="GtkToolbar" id="toolbar1">
+                        <property name="name">toolbar1</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="toolbar_style">icons</property>
                         <child>
                           <object class="GtkToggleToolButton" id="btPortrait">
+                            <property name="name">btPortrait</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label">toolbutton1</property>
@@ -265,6 +276,7 @@
                         </child>
                         <child>
                           <object class="GtkToggleToolButton" id="btLandscape">
+                            <property name="name">btLandscape</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label">toolbutton2</property>
@@ -285,6 +297,7 @@
                     </child>
                     <child>
                       <object class="GtkComboBoxText" id="cbUnit">
+                        <property name="name">cbUnit</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                       </object>

--- a/ui/pdfpages.glade
+++ b/ui/pdfpages.glade
@@ -3,6 +3,7 @@
 <interface>
   <requires lib="gtk+" version="3.0"/>
   <object class="GtkDialog" id="pdfPagesDialog">
+    <property name="name">pdfPagesDialog</property>
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">Select PDF Page</property>
     <property name="modal">True</property>
@@ -17,11 +18,13 @@
         <property name="orientation">vertical</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="dialog-action_area2">
+            <property name="name">dialog-action_area2</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="buttonClose">
+                <property name="name">buttonClose</property>
                 <property name="label">gtk-close</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
@@ -37,6 +40,7 @@
             </child>
             <child>
               <object class="GtkButton" id="buttonOk">
+                <property name="name">buttonOk</property>
                 <property name="label">gtk-ok</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
@@ -59,11 +63,13 @@
         </child>
         <child>
           <object class="GtkBox" id="vbox">
+            <property name="name">vbox</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="orientation">vertical</property>
             <child>
               <object class="GtkCheckButton" id="cbOnlyNotUsed">
+                <property name="name">cbOnlyNotUsed</property>
                 <property name="label" translatable="yes">Show only not used pages
 THIS TEXT IS A PLACEHOLDER!</property>
                 <property name="visible">True</property>
@@ -80,6 +86,7 @@ THIS TEXT IS A PLACEHOLDER!</property>
             </child>
             <child>
               <object class="GtkScrolledWindow" id="scrollContents">
+                <property name="name">scrollContents</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="shadow_type">in</property>

--- a/ui/plugin.glade
+++ b/ui/plugin.glade
@@ -8,6 +8,7 @@
     <property name="page_increment">1</property>
   </object>
   <object class="GtkDialog" id="pluginDialog">
+    <property name="name">pluginDialog</property>
     <property name="can_focus">False</property>
     <property name="border_width">5</property>
     <property name="title" translatable="yes">Plugin Manager</property>
@@ -25,6 +26,7 @@
         <property name="spacing">2</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="dialog-action_area2">
+            <property name="name">dialog-action_area2</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
@@ -85,6 +87,7 @@
                     <property name="can_focus">False</property>
                     <child>
                       <object class="GtkBox" id="pluginBox">
+                        <property name="name">pluginBox</property>
                         <property name="name">pluginBox</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>

--- a/ui/pluginEntry.glade
+++ b/ui/pluginEntry.glade
@@ -3,17 +3,20 @@
 <interface>
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkOffscreenWindow" id="offscreenwindow">
+    <property name="name">offscreenwindow</property>
     <property name="can_focus">False</property>
     <child>
       <placeholder/>
     </child>
     <child>
       <object class="GtkBox" id="pluginMainBox">
+        <property name="name">pluginMainBox</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkLabel" id="pluginName">
+            <property name="name">pluginName</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="label" translatable="yes">pluginName</property>
@@ -29,6 +32,7 @@
         </child>
         <child>
           <object class="GtkLabel" id="lbDescription">
+            <property name="name">lbDescription</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="margin_bottom">10</property>
@@ -60,6 +64,7 @@
             </child>
             <child>
               <object class="GtkLabel" id="lbAuthor">
+                <property name="name">lbAuthor</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Author</property>
@@ -96,6 +101,7 @@
             </child>
             <child>
               <object class="GtkLabel" id="lbVersion">
+                <property name="name">lbVersion</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="label" translatable="yes">1.2.3</property>
@@ -120,6 +126,7 @@
             <property name="halign">center</property>
             <child>
               <object class="GtkCheckButton" id="cbEnabled">
+                <property name="name">cbEnabled</property>
                 <property name="label" translatable="yes">enabled,</property>
                 <property name="name">cbEnabled</property>
                 <property name="visible">True</property>
@@ -135,6 +142,7 @@
             </child>
             <child>
               <object class="GtkLabel" id="lbDefaultText">
+                <property name="name">lbDefaultText</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="label" translatable="yes">default enabled / disabled</property>

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -99,6 +99,7 @@
     <property name="page_increment">10</property>
   </object>
   <object class="GtkDialog" id="settingsDialog">
+    <property name="name">settingsDialog</property>
     <property name="can_focus">False</property>
     <property name="border_width">5</property>
     <property name="title" translatable="yes">Xournal++ Preferences</property>
@@ -115,11 +116,13 @@
         <property name="spacing">2</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="btSettingsButton">
+            <property name="name">btSettingsButton</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="btSettingsCancel">
+                <property name="name">btSettingsCancel</property>
                 <property name="label">gtk-cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
@@ -134,6 +137,7 @@
             </child>
             <child>
               <object class="GtkButton" id="btSettingsOk">
+                <property name="name">btSettingsOk</property>
                 <property name="label">gtk-ok</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
@@ -156,12 +160,14 @@
         </child>
         <child>
           <object class="GtkNotebook" id="notebook1">
+            <property name="name">notebook1</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="tab_pos">left</property>
             <property name="show_border">False</property>
             <child>
               <object class="GtkBox" id="saveLoadTabBox">
+                <property name="name">saveLoadTabBox</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="margin_left">5</property>
@@ -223,6 +229,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             <property name="can_focus">False</property>
                                             <child>
                                               <object class="GtkCheckButton" id="cbAutosave">
+                                                <property name="name">cbAutosave</property>
                                                 <property name="label" translatable="yes">Enable Autosaving</property>
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">True</property>
@@ -238,10 +245,12 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             </child>
                                             <child>
                                               <object class="GtkBox" id="boxAutosave">
+                                                <property name="name">boxAutosave</property>
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
                                                 <child>
                                                   <object class="GtkLabel" id="lbAutosaveTimeout1">
+                                                    <property name="name">lbAutosaveTimeout1</property>
                                                     <property name="visible">True</property>
                                                     <property name="can_focus">False</property>
                                                     <property name="label" translatable="yes">every</property>
@@ -254,6 +263,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                                 </child>
                                                 <child>
                                                   <object class="GtkSpinButton" id="spAutosaveTimeout">
+                                                    <property name="name">spAutosaveTimeout</property>
                                                     <property name="visible">True</property>
                                                     <property name="can_focus">True</property>
                                                     <property name="adjustment">adjustmentTimeout</property>
@@ -267,6 +277,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                                 </child>
                                                 <child>
                                                   <object class="GtkLabel" id="lbAutosaveTimeout2">
+                                                    <property name="name">lbAutosaveTimeout2</property>
                                                     <property name="visible">True</property>
                                                     <property name="can_focus">False</property>
                                                     <property name="label" translatable="yes">minutes</property>
@@ -344,6 +355,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                         </child>
                                         <child>
                                           <object class="GtkEntry" id="txtDefaultSaveName">
+                                            <property name="name">txtDefaultSaveName</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
                                           </object>
@@ -372,6 +384,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             </child>
                                             <child>
                                               <object class="GtkLabel" id="lbDefaultSavename">
+                                                <property name="name">lbDefaultSavename</property>
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">%F-Note-%H-%M</property>
@@ -391,6 +404,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                         </child>
                                         <child>
                                           <object class="GtkExpander" id="expander1">
+                                            <property name="name">expander1</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
                                             <child>
@@ -517,6 +531,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                         </child>
                                         <child>
                                           <object class="GtkCheckButton" id="cbAutoloadXoj">
+                                            <property name="name">cbAutoloadXoj</property>
                                             <property name="label" translatable="yes">Enable Autoloading of Journals</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
@@ -563,6 +578,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
             </child>
             <child type="tab">
               <object class="GtkLabel" id="saveLoadTabLabel">
+                <property name="name">saveLoadTabLabel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Load / Save</property>
@@ -573,6 +589,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
             </child>
             <child>
               <object class="GtkBox" id="inputTabBox">
+                <property name="name">inputTabBox</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="margin_left">5</property>
@@ -613,6 +630,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                 <property name="can_focus">False</property>
                                 <child>
                                   <object class="GtkCheckButton" id="cbNewInputSystem">
+                                    <property name="name">cbNewInputSystem</property>
                                     <property name="label" translatable="yes">Enable new input system (Requires restart)</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
@@ -691,6 +709,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                             </child>
                             <child>
                               <object class="GtkBox" id="hboxInputDeviceClasses">
+                                <property name="name">hboxInputDeviceClasses</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="orientation">vertical</property>
@@ -754,6 +773,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                             </child>
                             <child>
                               <object class="GtkCheckButton" id="cbInputSystemDrawOutsideWindow">
+                                <property name="name">cbInputSystemDrawOutsideWindow</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">False</property>
@@ -778,6 +798,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                             </child>
                             <child>
                               <object class="GtkCheckButton" id="cbInputSystemTPCButton">
+                                <property name="name">cbInputSystemTPCButton</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">False</property>
@@ -832,6 +853,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
             </child>
             <child type="tab">
               <object class="GtkLabel" id="inputTabLabel">
+                <property name="name">inputTabLabel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Input System</property>
@@ -843,6 +865,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
             </child>
             <child>
               <object class="GtkBox" id="mouseTabBox">
+                <property name="name">mouseTabBox</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="margin_left">5</property>
@@ -911,6 +934,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                                 <property name="right_padding">12</property>
                                                 <child>
                                                   <object class="GtkBox" id="hboxMidleMouse">
+                                                    <property name="name">hboxMidleMouse</property>
                                                     <property name="visible">True</property>
                                                     <property name="can_focus">False</property>
                                                     <child>
@@ -948,6 +972,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                                 <property name="right_padding">12</property>
                                                 <child>
                                                   <object class="GtkBox" id="hboxRightMouse">
+                                                    <property name="name">hboxRightMouse</property>
                                                     <property name="visible">True</property>
                                                     <property name="can_focus">False</property>
                                                     <child>
@@ -1007,6 +1032,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
             </child>
             <child type="tab">
               <object class="GtkLabel" id="mouseTabLabel">
+                <property name="name">mouseTabLabel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Mouse</property>
@@ -1018,6 +1044,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
             </child>
             <child>
               <object class="GtkBox" id="stylusTabBox">
+                <property name="name">stylusTabBox</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="margin_left">5</property>
@@ -1074,6 +1101,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                         </child>
                                         <child>
                                           <object class="GtkCheckButton" id="cbSettingPresureSensitivity">
+                                            <property name="name">cbSettingPresureSensitivity</property>
                                             <property name="label" translatable="yes">Enable Pressure Sensitivity</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
@@ -1153,6 +1181,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                                 <property name="right_padding">12</property>
                                                 <child>
                                                   <object class="GtkBox" id="hboxPenButton1">
+                                                    <property name="name">hboxPenButton1</property>
                                                     <property name="visible">True</property>
                                                     <property name="can_focus">False</property>
                                                     <child>
@@ -1190,6 +1219,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                                 <property name="right_padding">12</property>
                                                 <child>
                                                   <object class="GtkBox" id="hboxPenButton2">
+                                                    <property name="name">hboxPenButton2</property>
                                                     <property name="visible">True</property>
                                                     <property name="can_focus">False</property>
                                                     <child>
@@ -1227,6 +1257,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                                 <property name="right_padding">12</property>
                                                 <child>
                                                   <object class="GtkBox" id="hboxEraser">
+                                                    <property name="name">hboxEraser</property>
                                                     <property name="visible">True</property>
                                                     <property name="can_focus">False</property>
                                                     <child>
@@ -1286,6 +1317,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
             </child>
             <child type="tab">
               <object class="GtkLabel" id="stylusTabLabel">
+                <property name="name">stylusTabLabel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Stylus</property>
@@ -1297,6 +1329,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
             </child>
             <child>
               <object class="GtkBox" id="touchTabBox">
+                <property name="name">touchTabBox</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="margin_left">5</property>
@@ -1353,6 +1386,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                         </child>
                                         <child>
                                           <object class="GtkBox" id="hboxTouch">
+                                            <property name="name">hboxTouch</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <child>
@@ -1419,6 +1453,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                         </child>
                                         <child>
                                           <object class="GtkCheckButton" id="cbDisableTouchOnPenNear">
+                                            <property name="name">cbDisableTouchOnPenNear</property>
                                             <property name="label" translatable="yes">Enable internal Hand Recognition</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
@@ -1434,6 +1469,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                         </child>
                                         <child>
                                           <object class="GtkBox" id="boxInternalHandRecognition">
+                                            <property name="name">boxInternalHandRecognition</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="orientation">vertical</property>
@@ -1468,6 +1504,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                                 </child>
                                                 <child>
                                                   <object class="GtkComboBoxText" id="cbTouchDisableMethod">
+                                                    <property name="name">cbTouchDisableMethod</property>
                                                     <property name="visible">True</property>
                                                     <property name="can_focus">False</property>
                                                     <property name="active">0</property>
@@ -1484,6 +1521,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                                 </child>
                                                 <child>
                                                   <object class="GtkSpinButton" id="spTouchDisableTimeout">
+                                                    <property name="name">spTouchDisableTimeout</property>
                                                     <property name="visible">True</property>
                                                     <property name="can_focus">True</property>
                                                     <property name="adjustment">adjustmentTouchTImeout</property>
@@ -1521,6 +1559,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                             </child>
                                             <child>
                                               <object class="GtkFrame" id="boxCustomTouchDisableSettings">
+                                                <property name="name">boxCustomTouchDisableSettings</property>
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
                                                 <property name="label_xalign">0.0099999997764825821</property>
@@ -1584,6 +1623,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                                             </child>
                                                             <child>
                                                             <object class="GtkEntry" id="txtEnableTouchCommand">
+                                                              <property name="name">txtEnableTouchCommand</property>
                                                             <property name="visible">True</property>
                                                             <property name="can_focus">True</property>
                                                             <property name="hexpand">True</property>
@@ -1595,6 +1635,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                                             </child>
                                                             <child>
                                                             <object class="GtkEntry" id="txtDisableTouchCommand">
+                                                              <property name="name">txtDisableTouchCommand</property>
                                                             <property name="visible">True</property>
                                                             <property name="can_focus">True</property>
                                                             <property name="hexpand">True</property>
@@ -1606,6 +1647,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                                             </child>
                                                             <child>
                                                             <object class="GtkButton" id="btTestEnable">
+                                                              <property name="name">btTestEnable</property>
                                                             <property name="label" translatable="yes">Test</property>
                                                             <property name="visible">True</property>
                                                             <property name="can_focus">True</property>
@@ -1618,6 +1660,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                                             </child>
                                                             <child>
                                                             <object class="GtkButton" id="btTestDisable">
+                                                              <property name="name">btTestDisable</property>
                                                             <property name="label" translatable="yes">Test</property>
                                                             <property name="visible">True</property>
                                                             <property name="can_focus">True</property>
@@ -1711,6 +1754,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                         </child>
                                         <child>
                                           <object class="GtkCheckButton" id="cbEnableZoomGestures">
+                                            <property name="name">cbEnableZoomGestures</property>
                                             <property name="label" translatable="yes">Enable zoom gestures (requires restart)</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
@@ -1779,6 +1823,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                         </child>
                                         <child>
                                           <object class="GtkCheckButton" id="cbTouchWorkaround">
+                                            <property name="name">cbTouchWorkaround</property>
                                             <property name="label" translatable="yes">Enable GTK Touch / Scrolling workaround  (requires restart)</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
@@ -1828,6 +1873,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
             </child>
             <child type="tab">
               <object class="GtkLabel" id="touchTabLabel">
+                <property name="name">touchTabLabel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Touchscreen</property>
@@ -1839,6 +1885,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
             </child>
             <child>
               <object class="GtkBox" id="viewTabBox">
+                <property name="name">viewTabBox</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="margin_left">5</property>
@@ -1883,6 +1930,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                             <property name="halign">start</property>
                                             <child>
                                               <object class="GtkCheckButton" id="cbHideMenubarStartup">
+                                                <property name="name">cbHideMenubarStartup</property>
                                                 <property name="label" translatable="yes">Show Menubar on Startup</property>
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">True</property>
@@ -1919,6 +1967,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                         </child>
                                         <child>
                                           <object class="GtkFrame" id="colorsFrame">
+                                            <property name="name">colorsFrame</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="label_xalign">0.0099999997764825821</property>
@@ -1949,6 +1998,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                                     </child>
                                                     <child>
                                                       <object class="GtkColorButton" id="colorBorder">
+                                                        <property name="name">colorBorder</property>
                                                         <property name="visible">True</property>
                                                         <property name="can_focus">True</property>
                                                         <property name="receives_default">True</property>
@@ -1973,6 +2023,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                                     </child>
                                                     <child>
                                                       <object class="GtkColorButton" id="colorBackground">
+                                                        <property name="name">colorBackground</property>
                                                         <property name="visible">True</property>
                                                         <property name="can_focus">True</property>
                                                         <property name="receives_default">True</property>
@@ -1997,6 +2048,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                                     </child>
                                                     <child>
                                                       <object class="GtkColorButton" id="colorSelection">
+                                                        <property name="name">colorSelection</property>
                                                         <property name="visible">True</property>
                                                         <property name="can_focus">True</property>
                                                         <property name="receives_default">True</property>
@@ -2009,6 +2061,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                                     </child>
                                                     <child>
                                                       <object class="GtkCheckButton" id="cbDarkTheme">
+                                                        <property name="name">cbDarkTheme</property>
                                                         <property name="label" translatable="yes">Dark Theme (requires restart)</property>
                                                         <property name="visible">True</property>
                                                         <property name="can_focus">True</property>
@@ -2078,6 +2131,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkCheckButton" id="cbHighlightPosition">
+                                            <property name="name">cbHighlightPosition</property>
                                             <property name="label" translatable="yes">Highlight cursor position</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
@@ -2093,6 +2147,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                         </child>
                                         <child>
                                           <object class="GtkCheckButton" id="cbBigCursor">
+                                            <property name="name">cbBigCursor</property>
                                             <property name="label" translatable="yes">Big cursor for pen</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
@@ -2143,6 +2198,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkCheckButton" id="cbShowSidebarRight">
+                                            <property name="name">cbShowSidebarRight</property>
                                             <property name="label" translatable="yes">Show sidebar on the right side</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
@@ -2158,6 +2214,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                         </child>
                                         <child>
                                           <object class="GtkCheckButton" id="cbShowScrollbarLeft">
+                                            <property name="name">cbShowScrollbarLeft</property>
                                             <property name="label" translatable="yes">Show vertical scrollbar on the left side</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
@@ -2208,6 +2265,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkCheckButton" id="cbHideHorizontalScrollbar">
+                                            <property name="name">cbHideHorizontalScrollbar</property>
                                             <property name="label" translatable="yes">Hide the horizontal scrollbar</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
@@ -2223,6 +2281,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                         </child>
                                         <child>
                                           <object class="GtkCheckButton" id="cbHideVerticalScrollbar">
+                                            <property name="name">cbHideVerticalScrollbar</property>
                                             <property name="label" translatable="yes">Hide the vertical scrollbar</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
@@ -2273,6 +2332,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkCheckButton" id="cbHideFullscreenMenubar">
+                                            <property name="name">cbHideFullscreenMenubar</property>
                                             <property name="label" translatable="yes">Hide Menubar</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
@@ -2288,6 +2348,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                         </child>
                                         <child>
                                           <object class="GtkCheckButton" id="cbHideFullscreenSidebar">
+                                            <property name="name">cbHideFullscreenSidebar</property>
                                             <property name="label" translatable="yes">Hide Sidebar</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
@@ -2338,6 +2399,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkCheckButton" id="cbHidePresentationMenubar">
+                                            <property name="name">cbHidePresentationMenubar</property>
                                             <property name="label" translatable="yes">Hide Menubar</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
@@ -2353,6 +2415,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                         </child>
                                         <child>
                                           <object class="GtkCheckButton" id="cbHidePresentationSidebar">
+                                            <property name="name">cbHidePresentationSidebar</property>
                                             <property name="label" translatable="yes">Hide Sidebar</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
@@ -2383,6 +2446,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                             </child>
                                             <child>
                                               <object class="GtkComboBoxText" id="comboboxtext1">
+                                                <property name="name">comboboxtext1</property>
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
                                               </object>
@@ -2435,6 +2499,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
             </child>
             <child type="tab">
               <object class="GtkLabel" id="viewTabLabel">
+                <property name="name">viewTabLabel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="label" translatable="yes">View</property>
@@ -2446,6 +2511,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
             </child>
             <child>
               <object class="GtkBox" id="zoomTabBox">
+                <property name="name">zoomTabBox</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="margin_left">5</property>
@@ -2485,6 +2551,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                         <property name="column_spacing">5</property>
                                         <child>
                                           <object class="GtkLabel" id="settingZoomCtrlScrollSpeedLabel">
+                                            <property name="name">settingZoomCtrlScrollSpeedLabel</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Speed for Ctrl + Scroll</property>
@@ -2497,6 +2564,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="spZoomStepScroll">
+                                            <property name="name">spZoomStepScroll</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
                                             <property name="text" translatable="yes">2.0</property>
@@ -2512,6 +2580,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="settingZoomStepSpeedLabel">
+                                            <property name="name">settingZoomStepSpeedLabel</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Speed for a Zoomstep</property>
@@ -2524,6 +2593,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="spZoomStep">
+                                            <property name="name">spZoomStep</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
                                             <property name="margin_top">5</property>
@@ -2635,6 +2705,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                             </child>
                                             <child>
                                               <object class="GtkScale" id="zoomCallibSlider">
+                                                <property name="name">zoomCallibSlider</property>
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">True</property>
                                                 <property name="margin_top">10</property>
@@ -2651,6 +2722,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                             </child>
                                             <child>
                                               <object class="GtkBox" id="zoomVBox">
+                                                <property name="name">zoomVBox</property>
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
                                                 <property name="orientation">vertical</property>
@@ -2719,6 +2791,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
             </child>
             <child type="tab">
               <object class="GtkLabel" id="zoomTabLabel">
+                <property name="name">zoomTabLabel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Zoom</property>
@@ -2730,6 +2803,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
             </child>
             <child>
               <object class="GtkBox" id="drawingAreaTabBox">
+                <property name="name">drawingAreaTabBox</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="margin_left">5</property>
@@ -2792,6 +2866,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                             <property name="column_spacing">5</property>
                                             <child>
                                               <object class="GtkCheckButton" id="cbAddVerticalSpace">
+                                                <property name="name">cbAddVerticalSpace</property>
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">True</property>
                                                 <property name="receives_default">False</property>
@@ -2813,6 +2888,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                             </child>
                                             <child>
                                               <object class="GtkCheckButton" id="cbAddHorizontalSpace">
+                                                <property name="name">cbAddHorizontalSpace</property>
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">True</property>
                                                 <property name="receives_default">False</property>
@@ -2835,6 +2911,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                             </child>
                                             <child>
                                               <object class="GtkSpinButton" id="spAddVerticalSpace">
+                                                <property name="name">spAddVerticalSpace</property>
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">True</property>
                                                 <property name="adjustment">adjustmentVerticalSpace</property>
@@ -2846,6 +2923,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                             </child>
                                             <child>
                                               <object class="GtkSpinButton" id="spAddHorizontalSpace">
+                                                <property name="name">spAddHorizontalSpace</property>
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">True</property>
                                                 <property name="adjustment">adjustmentHorizontalSpace</property>
@@ -2921,6 +2999,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                         <property name="column_spacing">5</property>
                                         <child>
                                           <object class="GtkLabel" id="label58a">
+                                            <property name="name">label58a</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="tooltip_markup" translatable="yes">Offset first page this many pages when &lt;b&gt;Pair Pages&lt;/b&gt; enabled</property>
@@ -2933,6 +3012,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="spPairsOffset">
+                                            <property name="name">spPairsOffset</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
                                             <property name="tooltip_text" translatable="yes">Usually 0 or 1</property>
@@ -2986,6 +3066,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                         <property name="column_spacing">5</property>
                                         <child>
                                           <object class="GtkLabel" id="lbSnapRotationTolerance">
+                                            <property name="name">lbSnapRotationTolerance</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Rotation snapping tolerance</property>
@@ -2998,6 +3079,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="lbSnapGridTolerance">
+                                            <property name="name">lbSnapGridTolerance</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Grid snapping tolerance</property>
@@ -3010,6 +3092,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="spSnapRotationTolerance">
+                                            <property name="name">spSnapRotationTolerance</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
                                             <property name="text" translatable="yes">0,20</property>
@@ -3025,6 +3108,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="spSnapGridTolerance">
+                                            <property name="name">spSnapGridTolerance</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
                                             <property name="text" translatable="yes">0,25</property>
@@ -3075,6 +3159,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                         <property name="column_spacing">5</property>
                                         <child>
                                           <object class="GtkCheckButton" id="cbDrawDirModsEnabled">
+                                            <property name="name">cbDrawDirModsEnabled</property>
                                             <property name="label" translatable="yes">Enable  with determination radius of </property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
@@ -3095,6 +3180,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="spDrawDirModsRadius">
+                                            <property name="name">spDrawDirModsRadius</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
                                             <property name="valign">start</property>
@@ -3161,6 +3247,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                         <property name="column_spacing">5</property>
                                         <child>
                                           <object class="GtkCheckButton" id="cbStrokeFilterEnabled">
+                                            <property name="name">cbStrokeFilterEnabled</property>
                                             <property name="label" translatable="yes">Enable Tap action.</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
@@ -3188,6 +3275,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="spStrokeIgnoreTime">
+                                            <property name="name">spStrokeIgnoreTime</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
                                             <property name="tooltip_markup" translatable="yes">How short (time)  AND...
@@ -3208,6 +3296,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="spStrokeIgnoreLength">
+                                            <property name="name">spStrokeIgnoreLength</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
                                             <property name="tooltip_markup" translatable="yes">How short (screen mm)  of the stroke  AND...
@@ -3251,6 +3340,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="spStrokeSuccessiveTime">
+                                            <property name="name">spStrokeSuccessiveTime</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
                                             <property name="tooltip_markup" translatable="yes">... AND How much time must have passed since last stroke.
@@ -3271,6 +3361,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                         </child>
                                         <child>
                                           <object class="GtkCheckButton" id="cbTrySelectOnStrokeFiltered">
+                                            <property name="name">cbTrySelectOnStrokeFiltered</property>
                                             <property name="label" translatable="yes">Try to select object first.</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
@@ -3300,6 +3391,7 @@ It must be short in time and length and we can't have ignored another stroke rec
                                         </child>
                                         <child>
                                           <object class="GtkCheckButton" id="cbDoActionOnStrokeFiltered">
+                                            <property name="name">cbDoActionOnStrokeFiltered</property>
                                             <property name="label" translatable="yes">Show Floating Toolbox</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
@@ -3351,6 +3443,7 @@ It must be short in time and length and we can't have ignored another stroke rec
             </child>
             <child type="tab">
               <object class="GtkLabel" id="drawingAreaTabLabel">
+                <property name="name">drawingAreaTabLabel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Drawing Area</property>
@@ -3362,6 +3455,7 @@ It must be short in time and length and we can't have ignored another stroke rec
             </child>
             <child>
               <object class="GtkBox" id="defaultTabBox">
+                <property name="name">defaultTabBox</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="margin_left">5</property>
@@ -3418,6 +3512,7 @@ It must be short in time and length and we can't have ignored another stroke rec
                                         </child>
                                         <child>
                                           <object class="GtkBox" id="hboxDefault">
+                                            <property name="name">hboxDefault</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <child>
@@ -3494,6 +3589,7 @@ It must be short in time and length and we can't have ignored another stroke rec
             </child>
             <child type="tab">
               <object class="GtkLabel" id="defaultTabLabel">
+                <property name="name">defaultTabLabel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Defaults</property>
@@ -3505,6 +3601,7 @@ It must be short in time and length and we can't have ignored another stroke rec
             </child>
             <child>
               <object class="GtkBox" id="audioRecordingTabBox">
+                <property name="name">audioRecordingTabBox</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="margin_left">5</property>
@@ -3578,6 +3675,7 @@ It must be short in time and length and we can't have ignored another stroke rec
                                             </child>
                                             <child>
                                               <object class="GtkFileChooserButton" id="fcAudioPath">
+                                                <property name="name">fcAudioPath</property>
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
                                                 <property name="hexpand">True</property>
@@ -3669,6 +3767,7 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                             </child>
                                             <child>
                                               <object class="GtkComboBoxText" id="cbAudioInputDevice">
+                                                <property name="name">cbAudioInputDevice</property>
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
                                               </object>
@@ -3691,6 +3790,7 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                             </child>
                                             <child>
                                               <object class="GtkComboBoxText" id="cbAudioOutputDevice">
+                                                <property name="name">cbAudioOutputDevice</property>
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
                                               </object>
@@ -3768,6 +3868,7 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                         </child>
                                         <child>
                                           <object class="GtkComboBoxText" id="cbAudioSampleRate">
+                                            <property name="name">cbAudioSampleRate</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="active">0</property>
@@ -3784,6 +3885,7 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="spAudioGain">
+                                            <property name="name">spAudioGain</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
                                             <property name="adjustment">adjustmentAudioGain</property>
@@ -3849,6 +3951,7 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
             </child>
             <child type="tab">
               <object class="GtkLabel" id="audioRecordingTabLabel">
+                <property name="name">audioRecordingTabLabel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Audio Recording</property>

--- a/ui/settingsButtonConfig.glade
+++ b/ui/settingsButtonConfig.glade
@@ -3,9 +3,11 @@
 <interface>
   <requires lib="gtk+" version="3.12"/>
   <object class="GtkOffscreenWindow" id="offscreenwindow">
+    <property name="name">offscreenwindow</property>
     <property name="can_focus">False</property>
     <child>
       <object class="GtkGrid" id="mainGrid">
+        <property name="name">mainGrid</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="hexpand">True</property>
@@ -16,6 +18,7 @@
             <property name="hexpand">True</property>
             <child>
               <object class="GtkLabel" id="lbDevice">
+                <property name="name">lbDevice</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="hexpand">True</property>
@@ -30,6 +33,7 @@
             </child>
             <child>
               <object class="GtkComboBoxText" id="labelDevice">
+                <property name="name">labelDevice</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="hexpand">True</property>
@@ -42,6 +46,7 @@
             </child>
             <child>
               <object class="GtkCheckButton" id="cbDisableDrawing">
+                <property name="name">cbDisableDrawing</property>
                 <property name="label" translatable="yes">Disable drawing for this device</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
@@ -68,6 +73,7 @@
             <property name="can_focus">False</property>
             <child>
               <object class="GtkComboBox" id="cbTool">
+                <property name="name">cbTool</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="hexpand">True</property>
@@ -79,6 +85,7 @@
             </child>
             <child>
               <object class="GtkComboBoxText" id="cbThickness">
+                <property name="name">cbThickness</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="hexpand">True</property>
@@ -90,6 +97,7 @@
             </child>
             <child>
               <object class="GtkColorButton" id="colorButton">
+                <property name="name">colorButton</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
@@ -101,6 +109,7 @@
             </child>
             <child>
               <object class="GtkComboBoxText" id="cbDrawingType">
+                <property name="name">cbDrawingType</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="hexpand">True</property>
@@ -112,6 +121,7 @@
             </child>
             <child>
               <object class="GtkComboBoxText" id="cbEraserType">
+                <property name="name">cbEraserType</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="hexpand">True</property>

--- a/ui/settingsDeviceClassConfig.glade
+++ b/ui/settingsDeviceClassConfig.glade
@@ -3,18 +3,21 @@
 <interface>
   <requires lib="gtk+" version="3.0"/>
   <object class="GtkOffscreenWindow" id="offscreenwindow">
+    <property name="name">offscreenwindow</property>
     <property name="can_focus">False</property>
     <child>
       <placeholder/>
     </child>
     <child>
       <object class="GtkBox" id="deviceClassGrid">
+        <property name="name">deviceClassGrid</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="valign">start</property>
         <property name="hexpand">True</property>
         <child>
           <object class="GtkLabel" id="labelDevice">
+            <property name="name">labelDevice</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="hexpand">True</property>
@@ -28,6 +31,7 @@
         </child>
         <child>
           <object class="GtkComboBoxText" id="cbDeviceClass">
+            <property name="name">cbDeviceClass</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="halign">end</property>

--- a/ui/texdialog.glade
+++ b/ui/texdialog.glade
@@ -3,6 +3,7 @@
 <interface>
   <requires lib="gtk+" version="3.0"/>
   <object class="GtkDialog" id="texDialog">
+    <property name="name">texDialog</property>
     <property name="width_request">320</property>
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">Insert Latex</property>
@@ -20,11 +21,13 @@
         <property name="orientation">vertical</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="dialog-action_area2">
+            <property name="name">dialog-action_area2</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="texcancelbutton">
+                <property name="name">texcancelbutton</property>
                 <property name="label">gtk-cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
@@ -39,6 +42,7 @@
             </child>
             <child>
               <object class="GtkButton" id="texokbutton">
+                <property name="name">texokbutton</property>
                 <property name="label">gtk-ok</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
@@ -62,6 +66,7 @@
         </child>
         <child>
           <object class="GtkLabel" id="labelTitle">
+            <property name="name">labelTitle</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="label" translatable="yes">Enter / edit LaTeX Text</property>
@@ -77,6 +82,7 @@
         </child>
         <child>
           <object class="GtkImage" id="texImage">
+            <property name="name">texImage</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
           </object>
@@ -89,6 +95,7 @@
         </child>
         <child>
           <object class="GtkLabel" id="texErrorLabel">
+            <property name="name">texErrorLabel</property>
             <property name="visible">True</property>
             <property name="sensitive">False</property>
             <property name="can_focus">False</property>
@@ -102,6 +109,7 @@
         </child>
         <child>
           <object class="GtkTextView" id="texView">
+            <property name="name">texView</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
           </object>

--- a/ui/toolbarCustomizeDialog.glade
+++ b/ui/toolbarCustomizeDialog.glade
@@ -3,6 +3,7 @@
 <interface>
   <requires lib="gtk+" version="3.0"/>
   <object class="GtkDialog" id="DialogCustomizeToolbar">
+    <property name="name">DialogCustomizeToolbar</property>
     <property name="width_request">500</property>
     <property name="height_request">400</property>
     <property name="can_focus">False</property>
@@ -18,6 +19,7 @@
         <property name="spacing">2</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="dialog-action_area1">
+            <property name="name">dialog-action_area1</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
@@ -62,11 +64,13 @@
             </child>
             <child>
               <object class="GtkScrolledWindow" id="scrolledwindow1">
+                <property name="name">scrolledwindow1</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="shadow_type">in</property>
                 <child>
                   <object class="GtkViewport" id="viewport1">
+                    <property name="name">viewport1</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <child>
@@ -90,6 +94,7 @@
                         </child>
                         <child>
                           <object class="GtkGrid" id="tbDefaultTools">
+                            <property name="name">tbDefaultTools</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="row_spacing">5</property>
@@ -144,6 +149,7 @@
                         </child>
                         <child>
                           <object class="GtkGrid" id="tbColor">
+                            <property name="name">tbColor</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="row_spacing">5</property>
@@ -198,6 +204,7 @@
                         </child>
                         <child>
                           <object class="GtkGrid" id="tbSeparator">
+                            <property name="name">tbSeparator</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="row_spacing">5</property>

--- a/ui/toolbarManageDialog.glade
+++ b/ui/toolbarManageDialog.glade
@@ -3,6 +3,7 @@
 <interface>
   <requires lib="gtk+" version="3.0"/>
   <object class="GtkDialog" id="DialogManageToolbar">
+    <property name="name">DialogManageToolbar</property>
     <property name="can_focus">False</property>
     <property name="border_width">5</property>
     <property name="title" translatable="yes">Manage Toolbar</property>
@@ -16,6 +17,7 @@
         <property name="spacing">2</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="dialog-action_area1">
+            <property name="name">dialog-action_area1</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
@@ -52,10 +54,12 @@
                 <property name="can_focus">False</property>
                 <child>
                   <object class="GtkTreeView" id="toolbarList">
+                    <property name="name">toolbarList</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <child internal-child="selection">
                       <object class="GtkTreeSelection" id="treeview-selection"/>
+                        <property name="name">treeview-selection</property>
                     </child>
                   </object>
                   <packing>
@@ -71,6 +75,7 @@
                     <property name="orientation">vertical</property>
                     <child>
                       <object class="GtkButton" id="btCopy">
+                        <property name="name">btCopy</property>
                         <property name="label">gtk-copy</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
@@ -86,6 +91,7 @@
                     </child>
                     <child>
                       <object class="GtkButton" id="btDelete">
+                        <property name="name">btDelete</property>
                         <property name="label">gtk-delete</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
@@ -101,6 +107,7 @@
                     </child>
                     <child>
                       <object class="GtkButton" id="btNew">
+                        <property name="name">btNew</property>
                         <property name="label">gtk-new</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>


### PR DESCRIPTION
Now that there is a xournalpp.css file  someone might want to style parts of Xournal++
I've added CSS accessible names to the glade file which match the id's. Only objects with non-generic id's have been done.

Script used:
```
#do not run twice... be careful but do delete current name="names" lines before 
#running this again by using:
#    sed -r -i  '/.*name="name"/d' ui/*.glade
#Note: remove the -i to test.

gawk -i inplace 'match($0, /(\s*).*class="(\S+)".*id="(\S+)"/,arr){ print $0; if(arr[2] != "GtkAdjustment") print arr[1] "  <property name=\"name\">" arr[3] "</property>"; next}{print}'  ui/*.glade
#now remove lines generated from for non-generic id's:
for xx in sid label vbox hbox box separatormenuitem menuitem image grid menu button; \
do sed -r -i  "/.*name=\"name\".*\\b$xx[0-9]+\\b/d" ui/*.glade;done
```