### PR TITLE
Bugfix: The undoList of UndoRedoHandler is not cleared after calling …

### DIFF
--- a/src/undo/UndoRedoHandler.cpp
+++ b/src/undo/UndoRedoHandler.cpp
@@ -76,6 +76,7 @@ void UndoRedoHandler::clearContents()
 	}
 #endif  // UNDO_TRACE
 
+	undoList.clear();
 	clearRedo();
 
 	this->savedUndo = nullptr;
@@ -183,7 +184,7 @@ void UndoRedoHandler::addUndoAction(UndoActionPtr action)
 {
 	XOJ_CHECK_TYPE(UndoRedoHandler);
 
-	if (action == nullptr)
+	if (!action)
 	{
 		return;
 	}


### PR DESCRIPTION
…UndoRedoHandler::clearContents().

As a result the undoList is not cleared after creating a new Document.

Signed-off-by: Fabian Keßler <fabian_kessler@gmx.de>