### PR TITLE
Refactored XournalType to remove empty statement warnings of clang-tidy

### DIFF
--- a/src/util/XournalType.h
+++ b/src/util/XournalType.h
@@ -38,7 +38,7 @@ void xoj_momoryleak_printRemainingObjects();
 #endif
 
 #ifdef DEV_CALL_LOG
-#define CALL_LOG(type, clazz, obj) Log::trace(type, clazz, __FUNCTION__, (long)obj)
+#define CALL_LOG(type, clazz, obj) Log::trace(type, clazz, __FUNCTION__, (long) obj)
 #else
 #define CALL_LOG(type, clazz, obj) (void(0))
 #endif
@@ -77,12 +77,15 @@ const char* xoj_type_getName(int id);
  * Release the Xournal type info, this should be called in the destructor
  */
 #ifdef DEV_MEMORY_LEAK_CHECKING
-#define XOJ_RELEASE_TYPE(type) do { \
-		XOJ_CHECK_TYPE(type); \
-		this->z__xoj_type = -(__XOJ_TYPE_ ## type); \
-		this->z__xoj_typeCheckvalue = 0xFFAA00AA; \
-		CALL_LOG("release", #type, this); \
-		xoj_memoryleak_releaseType(__XOJ_TYPE_ ## type); } while(false)
+#define XOJ_RELEASE_TYPE(type)                         \
+	do                                                 \
+	{                                                  \
+		XOJ_CHECK_TYPE(type);                          \
+		this->z__xoj_type = -(__XOJ_TYPE_##type);      \
+		this->z__xoj_typeCheckvalue = 0xFFAA00AA;      \
+		CALL_LOG("release", #type, this);              \
+		xoj_memoryleak_releaseType(__XOJ_TYPE_##type); \
+	} while (false)
 #else
 #define XOJ_RELEASE_TYPE(type) do { \
 		XOJ_CHECK_TYPE(type) \
@@ -127,11 +130,11 @@ const char* xoj_type_getName(int id);
 
 #else //DEV_MEMORY_CHECKING
 
-#define XOJ_DECLARE_TYPE(name, id) ((void)0)
+#define XOJ_DECLARE_TYPE(name, id) ((void) 0)
 #define XOJ_TYPE_ATTRIB
-#define XOJ_INIT_TYPE(name) ((void)0)
-#define XOJ_RELEASE_TYPE(name) ((void)0)
-#define XOJ_CHECK_TYPE_OBJ(obj, name) ((void)0)
-#define XOJ_CHECK_TYPE(name) ((void)0)
+#define XOJ_INIT_TYPE(name) ((void) 0)
+#define XOJ_RELEASE_TYPE(name) ((void) 0)
+#define XOJ_CHECK_TYPE_OBJ(obj, name) ((void) 0)
+#define XOJ_CHECK_TYPE(name) ((void) 0)
 
 #endif //DEV_MEMORY_CHECKING

--- a/src/util/XournalType.h
+++ b/src/util/XournalType.h
@@ -38,11 +38,9 @@ void xoj_momoryleak_printRemainingObjects();
 #endif
 
 #ifdef DEV_CALL_LOG
-#define CALL_LOG(type, clazz, obj) { \
-		Log::trace(type, clazz, __FUNCTION__, (long)obj); \
-	}
+#define CALL_LOG(type, clazz, obj) Log::trace(type, clazz, __FUNCTION__, (long)obj)
 #else
-#define CALL_LOG(type, clazz, obj)
+#define CALL_LOG(type, clazz, obj) (void(0))
 #endif
 
 #define XOJ_DECLARE_TYPE(type, id) \
@@ -80,7 +78,7 @@ const char* xoj_type_getName(int id);
  */
 #ifdef DEV_MEMORY_LEAK_CHECKING
 #define XOJ_RELEASE_TYPE(type) do { \
-		XOJ_CHECK_TYPE(type) \
+		XOJ_CHECK_TYPE(type); \
 		this->z__xoj_type = -(__XOJ_TYPE_ ## type); \
 		this->z__xoj_typeCheckvalue = 0xFFAA00AA; \
 		CALL_LOG("release", #type, this); \
@@ -129,11 +127,11 @@ const char* xoj_type_getName(int id);
 
 #else //DEV_MEMORY_CHECKING
 
-#define XOJ_DECLARE_TYPE(name, id)
+#define XOJ_DECLARE_TYPE(name, id) ((void)0)
 #define XOJ_TYPE_ATTRIB
-#define XOJ_INIT_TYPE(name)
-#define XOJ_RELEASE_TYPE(name)
-#define XOJ_CHECK_TYPE_OBJ(obj, name)
-#define XOJ_CHECK_TYPE(name)
+#define XOJ_INIT_TYPE(name) ((void)0)
+#define XOJ_RELEASE_TYPE(name) ((void)0)
+#define XOJ_CHECK_TYPE_OBJ(obj, name) ((void)0)
+#define XOJ_CHECK_TYPE(name) ((void)0)
 
 #endif //DEV_MEMORY_CHECKING


### PR DESCRIPTION
this is a commit from refactor_layout_resize but has nothing to do with the layout or the resize.
But it is recommended change, since it removes nearly all warnings regarding the XournalType checks. 
(empty statement)