### PR TITLE
Translation cleanup

### DIFF
--- a/src/undo/AddUndoAction.cpp
+++ b/src/undo/AddUndoAction.cpp
@@ -126,16 +126,16 @@ string AddUndoAction::getText()
 			switch (type)
 			{
 			case ELEMENT_STROKE:
-				text += _(" stroke");
+				text += _("stroke");
 				break;
 			case ELEMENT_IMAGE:
-				text += _(" image");
+				text += _("image");
 				break;
 			case ELEMENT_TEXIMAGE:
-				text += _(" latex");
+				text += _("latex");
 				break;
 			case ELEMENT_TEXT:
-				text += _(" text");
+				text += _("text");
 				break;
 			}
 		}

--- a/src/undo/AddUndoAction.cpp
+++ b/src/undo/AddUndoAction.cpp
@@ -9,7 +9,7 @@
 
 #include <i18n.h>
 
-AddUndoAction::AddUndoAction(PageRef page, bool eraser)
+AddUndoAction::AddUndoAction(const PageRef& page, bool eraser)
  : UndoAction("AddUndoAction")
 {
 	XOJ_INIT_TYPE(AddUndoAction);
@@ -22,9 +22,9 @@ AddUndoAction::~AddUndoAction()
 {
 	XOJ_CHECK_TYPE(AddUndoAction);
 
-	for (GList* l = this->elements; l != NULL; l = l->next)
+	for (GList* l = this->elements; l != nullptr; l = l->next)
 	{
-		PageLayerPosEntry<Element>* e = (PageLayerPosEntry<Element>*) l->data;
+		auto e = (PageLayerPosEntry<Element>*) l->data;
 		if (!undone)
 		{
 			//The element will be deleted when the layer is removed.
@@ -46,11 +46,11 @@ void AddUndoAction::addElement(Layer* layer, Element* e, int pos)
 										  (GCompareFunc) PageLayerPosEntry<Element>::cmp);
 }
 
-bool AddUndoAction::redo(Control* control)
+bool AddUndoAction::redo(Control*)
 {
 	XOJ_CHECK_TYPE(AddUndoAction);
 
-	if (this->elements == NULL)
+	if (this->elements == nullptr)
 	{
 		g_warning("Could not undo AddUndoAction, there is nothing to undo");
 
@@ -58,9 +58,9 @@ bool AddUndoAction::redo(Control* control)
 		return false;
 	}
 
-	for (GList* l = this->elements; l != NULL; l = l->next)
+	for (GList* l = this->elements; l != nullptr; l = l->next)
 	{
-		PageLayerPosEntry<Element>* e = (PageLayerPosEntry<Element>*) l->data;
+		auto e = (PageLayerPosEntry<Element>*) l->data;
 		e->layer->insertElement(e->element, e->pos);
 		this->page->fireElementChanged(e->element);
 	}
@@ -69,11 +69,11 @@ bool AddUndoAction::redo(Control* control)
 	return true;
 }
 
-bool AddUndoAction::undo(Control* control)
+bool AddUndoAction::undo(Control*)
 {
 	XOJ_CHECK_TYPE(AddUndoAction);
 
-	if (this->elements == NULL)
+	if (this->elements == nullptr)
 	{
 		g_warning("Could not redo AddUndoAction, there is nothing to redo");
 
@@ -81,9 +81,9 @@ bool AddUndoAction::undo(Control* control)
 		return false;
 	}
 
-	for (GList* l = this->elements; l != NULL; l = l->next)
+	for (GList* l = this->elements; l != nullptr; l = l->next)
 	{
-		PageLayerPosEntry<Element>* e = (PageLayerPosEntry<Element>*) l->data;
+		auto e = (PageLayerPosEntry<Element>*) l->data;
 		e->layer->removeElement(e->element, false);
 		this->page->fireElementChanged(e->element);
 	}
@@ -107,13 +107,13 @@ string AddUndoAction::getText()
 	{
 		text = _("Paste");
 
-		if (this->elements != NULL)
+		if (this->elements != nullptr)
 		{
 			ElementType type = ((PageLayerPosEntry<Element>*) this->elements->data)->element->getType();
 
-			for (GList* l = this->elements->next; l != NULL; l = l->next)
+			for (GList* l = this->elements->next; l != nullptr; l = l->next)
 			{
-				PageLayerPosEntry<Element>* e = (PageLayerPosEntry<Element>*) l->data;
+				auto e = (PageLayerPosEntry<Element>*) l->data;
 				if (type != e->element->getType())
 				{
 					text += " ";

--- a/src/undo/AddUndoAction.cpp
+++ b/src/undo/AddUndoAction.cpp
@@ -123,20 +123,20 @@ string AddUndoAction::getText()
 			}
 
 			text += " ";
-			switch(type)
+			switch (type)
 			{
-				case ELEMENT_STROKE:
-					text += _(" stroke");
-					break;
-				case ELEMENT_IMAGE:
-					text += _(" image");
-					break;
-				case ELEMENT_TEXIMAGE:
-					text += _(" latex");
-					break;
-				case ELEMENT_TEXT:
-					text += _(" text");
-					break;
+			case ELEMENT_STROKE:
+				text += _(" stroke");
+				break;
+			case ELEMENT_IMAGE:
+				text += _(" image");
+				break;
+			case ELEMENT_TEXIMAGE:
+				text += _(" latex");
+				break;
+			case ELEMENT_TEXT:
+				text += _(" text");
+				break;
 			}
 		}
 	}

--- a/src/undo/AddUndoAction.cpp
+++ b/src/undo/AddUndoAction.cpp
@@ -116,26 +116,27 @@ string AddUndoAction::getText()
 				PageLayerPosEntry<Element>* e = (PageLayerPosEntry<Element>*) l->data;
 				if (type != e->element->getType())
 				{
-					text += _(" elements");
+					text += " ";
+					text += _("elements");
 					return text;
 				}
 			}
 
-			if (type == ELEMENT_STROKE)
+			text += " ";
+			switch(type)
 			{
-				text += _(" stroke");
-			}
-			else if (type == ELEMENT_TEXT)
-			{
-				text += _(" text");
-			}
-			else if (type == ELEMENT_IMAGE)
-			{
-				text += _(" image");
-			}
-			else if (type == ELEMENT_TEXIMAGE)
-			{
-				text += _(" latex");
+				case ELEMENT_STROKE:
+					text += _(" stroke");
+					break;
+				case ELEMENT_IMAGE:
+					text += _(" image");
+					break;
+				case ELEMENT_TEXIMAGE:
+					text += _(" latex");
+					break;
+				case ELEMENT_TEXT:
+					text += _(" text");
+					break;
 			}
 		}
 	}

--- a/src/undo/AddUndoAction.h
+++ b/src/undo/AddUndoAction.h
@@ -21,20 +21,20 @@ class Redrawable;
 class AddUndoAction : public UndoAction
 {
 public:
-	AddUndoAction(PageRef page, bool eraser);
-	virtual ~AddUndoAction();
+	AddUndoAction(const PageRef& page, bool eraser);
+	~AddUndoAction() override;
 
 public:
-	virtual bool undo(Control* control);
-	virtual bool redo(Control* control);
+	bool undo(Control*) override;
+	bool redo(Control*) override;
 
 	void addElement(Layer* layer, Element* e, int pos);
 
-	virtual string getText();
+	string getText() override;
 
 private:
 	XOJ_TYPE_ATTRIB;
 
-	GList* elements = NULL;
+	GList* elements = nullptr;
 	bool eraser = false;
 };


### PR DESCRIPTION
Decrease translation complexity by removing redundant translation strings that differ by one whitespace.

Do some minor code cleanup