### PR TITLE
Left and right key for navigation in presentation mode

### DIFF
--- a/src/gui/XournalView.cpp
+++ b/src/gui/XournalView.cpp
@@ -318,7 +318,14 @@ bool XournalView::onKeyPressEvent(GdkEventKey* event)
 		}
 		else
 		{
-			layout->scrollRelative(-scrollKeySize, 0);
+			if (control->getSettings()->isPresentationMode())
+			{
+				control->getScrollHandler()->goToPreviousPage();
+			}
+			else
+			{
+				layout->scrollRelative(-scrollKeySize, 0);
+			}
 		}
 		return true;
 	}
@@ -331,7 +338,14 @@ bool XournalView::onKeyPressEvent(GdkEventKey* event)
 		}
 		else
 		{
-			layout->scrollRelative(scrollKeySize, 0);
+			if (control->getSettings()->isPresentationMode())
+			{
+				control->getScrollHandler()->goToNextPage();
+			}
+			else
+			{
+				layout->scrollRelative(scrollKeySize, 0);
+			}
 		}
 		return true;
 	}


### PR DESCRIPTION
As the presentation remotes use the left and right keys for navigation, add the setting to enable them in presentation mode. The presenter can then use the remote and the xournalpp features, but not move elements with those keys anymore, hence its better to be an option.

This is a very tiny first step towards the wish list in #1168 