### PR TITLE
Windows build: needed packages update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ repo/
 flatpak-build/
 .flatpak-builder/
 *.flatpak
+
+# LUA build
+lua-5.3.5/

--- a/.gitignore
+++ b/.gitignore
@@ -51,4 +51,4 @@ flatpak-build/
 *.flatpak
 
 # LUA build
-lua-5.3.5/
+lua-*/

--- a/readme/WindowsBuild.md
+++ b/readme/WindowsBuild.md
@@ -31,19 +31,12 @@ pacman -S git
 
 ## Install Build tools
 ```bash
+pacman -S mingw-w64-x86_64-gcc; \
 pacman -S mingw-w64-x86_64-cmake; \
 pacman -S make; \
-pacman -S mingw-w64-x86_64-toolchain; \
-pacman -S --needed base-devel mingw-w64-x86_64-toolchain \
-mingw-w64-x86_64-cmake
+pacman -S patch
 ```
-(this is a duplicate of the lines above, probably only this line is needed.
-Can anybody confirm this?)
 -> press enter multiple times / confirm all default values
-
-```bash
-pacman -S mingw-w64-x86_64-gcc
-```
 
 ## Install dependencies
 
@@ -79,7 +72,15 @@ mkdir build
 cd build/
 cmake ..
 make
+cd ..
 ```
+
+You can now run Xournal++ with
+```bash
+./build/src/xournalpp.exe
+```
+
+or create a setup package (see below).
 
 ## Packaging and Setup
 Create the installer with

--- a/readme/WindowsBuild.md
+++ b/readme/WindowsBuild.md
@@ -33,7 +33,7 @@ pacman -S git
 ```bash
 pacman -S mingw-w64-x86_64-gcc; \
 pacman -S mingw-w64-x86_64-cmake; \
-pacman -S make; \
+pacman -S mingw-w64-x86_64-make; \
 pacman -S patch
 ```
 -> press enter multiple times / confirm all default values


### PR DESCRIPTION
Since I reinstalled msys2 recently, I went through the Windows build process again. I found that you need the following msys2 packages:
- mingw-w64-x86_64-gcc
- mingw-w64-x86_64-cmake
- mingw-w64-x86_64-make
- patch (for the lua setup)

