### PR TITLE
Add device listing for devices not recognized by GDK

### DIFF
--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -812,7 +812,7 @@ void Settings::saveDeviceClasses()
 
 	SElement& s = getCustomElement("deviceClasses");
 
-	for (const std::map<string, std::pair<int, GdkInputSource>>::value_type& device : inputDeviceClasses)
+	for (const std::map<string, std::pair<int, GdkInputSource>>::value_type& device: inputDeviceClasses)
 	{
 		SElement& e = s.child(device.first);
 		e.setInt("deviceClass", device.second.first);

--- a/src/control/settings/Settings.h
+++ b/src/control/settings/Settings.h
@@ -41,6 +41,7 @@ enum ScrollbarHideType
 };
 
 class ButtonConfig;
+class InputDevice;
 
 extern const char* BUTTON_NAMES[];
 const int BUTTON_COUNT = 7;
@@ -374,7 +375,10 @@ public:
 	void loadDeviceClasses();
 	void saveDeviceClasses();
 	void setDeviceClassForDevice(GdkDevice* device, int deviceClass);
+	void setDeviceClassForDevice(const string& deviceName, GdkInputSource deviceSource, int deviceClass);
 	int getDeviceClassForDevice(GdkDevice* device);
+	int getDeviceClassForDevice(const string& deviceName, GdkInputSource deviceSource);
+	std::vector<InputDevice> getKnownInputDevices();
 
 	/**
 	 * Get name, e.g. "cm"
@@ -829,7 +833,7 @@ private:
 
 	bool inputSystemDrawOutsideWindow;
 
-	std::map<string, int> inputDeviceClasses = {};
+	std::map<string, std::pair<int, GdkInputSource>> inputDeviceClasses = {};
 
 	/**
 	 * "Transaction" running, do not save until the end is reached

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -281,11 +281,11 @@ void MainWindow::setTouchscreenScrollingForDeviceMapping()
 {
 	XOJ_CHECK_TYPE(MainWindow);
 
-	for (InputDevice const& inputDevice: DeviceListHelper::getDeviceList())
+	for (InputDevice const& inputDevice: DeviceListHelper::getDeviceList(this->getControl()->getSettings()))
 	{
-		GdkDevice* device = inputDevice.getDevice();
-		InputDeviceClass deviceClass = InputEvents::translateDeviceType(device, this->getControl()->getSettings());
-		if (gdk_device_get_source(device) == GDK_SOURCE_TOUCHSCREEN && deviceClass != INPUT_DEVICE_TOUCHSCREEN)
+		InputDeviceClass deviceClass = InputEvents::translateDeviceType(inputDevice.getName(), inputDevice.getSource(),
+		                                                                this->getControl()->getSettings());
+		if (inputDevice.getSource() == GDK_SOURCE_TOUCHSCREEN && deviceClass != INPUT_DEVICE_TOUCHSCREEN)
 		{
 			gtk_scrolled_window_set_kinetic_scrolling(GTK_SCROLLED_WINDOW(winXournal), false);
 			break;
@@ -944,4 +944,3 @@ void MainWindow::loadMainCSS(GladeSearchpath* gladeSearchPath, const gchar* cssF
 											  GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
 	g_object_unref(provider);
 }
-	

--- a/src/gui/dialog/ButtonConfigGui.cpp
+++ b/src/gui/dialog/ButtonConfigGui.cpp
@@ -43,7 +43,7 @@ ButtonConfigGui::ButtonConfigGui(GladeSearchpath* gladeSearchPath, GtkWidget* w,
 	{
 		gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(this->cbDevice), _("No device"));
 
-		this->deviceList = DeviceListHelper::getDeviceList(true);
+		this->deviceList = DeviceListHelper::getDeviceList(this->settings, true);
 		for (InputDevice const& dev: this->deviceList)
 		{
 			string txt = dev.getName()  + " (" + dev.getType() + ")";

--- a/src/gui/dialog/DeviceClassConfigGui.cpp
+++ b/src/gui/dialog/DeviceClassConfigGui.cpp
@@ -37,7 +37,8 @@ void DeviceClassConfigGui::loadSettings()
 {
 	XOJ_CHECK_TYPE(DeviceClassConfigGui);
 
-	int deviceType = this->settings->getDeviceClassForDevice(this->device.getDevice());
+	// Get device class of device if available or
+	int deviceType = this->settings->getDeviceClassForDevice(this->device.getName(), this->device.getSource());
 	gtk_combo_box_set_active(GTK_COMBO_BOX(this->cbDeviceClass), deviceType);
 }
 
@@ -51,5 +52,5 @@ void DeviceClassConfigGui::saveSettings()
 	XOJ_CHECK_TYPE(DeviceClassConfigGui);
 
 	int deviceClass = gtk_combo_box_get_active(GTK_COMBO_BOX(this->cbDeviceClass));
-	this->settings->setDeviceClassForDevice(this->device.getDevice(), deviceClass);
+	this->settings->setDeviceClassForDevice(this->device.getName(), this->device.getSource(), deviceClass);
 }

--- a/src/gui/dialog/SettingsDialog.cpp
+++ b/src/gui/dialog/SettingsDialog.cpp
@@ -105,16 +105,13 @@ SettingsDialog::SettingsDialog(GladeSearchpath* gladeSearchPath, Settings* setti
 
 	initMouseButtonEvents();
 
-	vector<InputDevice> deviceList = DeviceListHelper::getDeviceList();
+	vector<InputDevice> deviceList = DeviceListHelper::getDeviceList(this->settings);
 	GtkWidget* container = get("hboxInputDeviceClasses");
-	for (InputDevice const& inputDevice: deviceList)
+	for (const InputDevice& inputDevice: deviceList)
 	{
-		// Only add real devices (core pointers have vendor and product id NULL) and ignore keyboards
-		GdkDevice* device = inputDevice.getDevice();
-		if (gdk_device_get_vendor_id(device) != nullptr && gdk_device_get_product_id(device) != nullptr && gdk_device_get_source(device) != GDK_SOURCE_KEYBOARD)
-		{
-			this->deviceClassConfigs.push_back(new DeviceClassConfigGui(getGladeSearchPath(), container, settings, inputDevice));
-		}
+		// Only add real devices (core pointers have vendor and product id NULL)
+		this->deviceClassConfigs.push_back(
+		        new DeviceClassConfigGui(getGladeSearchPath(), container, settings, inputDevice));
 	}
 	if (deviceList.empty())
 	{

--- a/src/gui/inputdevices/InputContext.cpp
+++ b/src/gui/inputdevices/InputContext.cpp
@@ -5,6 +5,8 @@
 #include "InputContext.h"
 #include "InputEvents.h"
 
+#include <util/DeviceListHelper.h>
+
 InputContext::InputContext(XournalView* view, ScrollHandling* scrollHandling)
 {
 	XOJ_INIT_TYPE(InputContext);
@@ -19,6 +21,11 @@ InputContext::InputContext(XournalView* view, ScrollHandling* scrollHandling)
 	this->keyboardHandler = new KeyboardInputHandler(this);
 
 	this->touchWorkaroundEnabled = this->getSettings()->isTouchWorkaround();
+
+	for (const InputDevice& savedDevices: this->view->getControl()->getSettings()->getKnownInputDevices())
+	{
+		this->knownDevices.insert(savedDevices.getName());
+	}
 }
 
 InputContext::~InputContext()
@@ -85,6 +92,18 @@ bool InputContext::handle(GdkEvent* sourceEvent)
 	printDebug(sourceEvent);
 
 	InputEvent* event = InputEvents::translateEvent(sourceEvent, this->getSettings());
+
+	// Add the device to the list of known devices if it is currently unknown
+	GdkDevice* sourceDevice = gdk_event_get_source_device(sourceEvent);
+	if (GDK_SOURCE_KEYBOARD != gdk_device_get_source(sourceDevice) &&
+	    gdk_device_get_device_type(sourceDevice) != GDK_DEVICE_TYPE_MASTER &&
+	    this->knownDevices.find(string(event->deviceName)) == this->knownDevices.end())
+	{
+		this->knownDevices.insert(string(event->deviceName));
+		this->getSettings()->transactionStart();
+		this->getSettings()->setDeviceClassForDevice(gdk_event_get_source_device(sourceEvent), event->deviceClass);
+		this->getSettings()->transactionEnd();
+	}
 
 	// We do not handle scroll events manually but let GTK do it for us
 	if (event->type == SCROLL_EVENT)

--- a/src/gui/inputdevices/InputContext.h
+++ b/src/gui/inputdevices/InputContext.h
@@ -32,6 +32,8 @@
 #include <gdk/gdk.h>
 #include <gtk/gtk.h>
 
+#include <set>
+
 class InputContext
 {
 
@@ -51,6 +53,8 @@ private:
 	GdkModifierType modifierState = (GdkModifierType)0;
 
 	bool touchWorkaroundEnabled = false;
+
+	std::set<string> knownDevices;
 
 public:
 	enum DeviceType {

--- a/src/gui/inputdevices/InputEvents.cpp
+++ b/src/gui/inputdevices/InputEvents.cpp
@@ -83,9 +83,9 @@ InputDeviceClass InputEvents::translateDeviceType(const string& name, GdkInputSo
 			// Keyboards are not matched in their own class - do this here manually
 		    if (source == GDK_SOURCE_KEYBOARD)
 		    {
-		    	return INPUT_DEVICE_KEYBOARD;
+				return INPUT_DEVICE_KEYBOARD;
 		    }
-			return INPUT_DEVICE_IGNORE;
+		    return INPUT_DEVICE_IGNORE;
 		}
 		case 1:
 			return INPUT_DEVICE_MOUSE;

--- a/src/gui/inputdevices/InputEvents.cpp
+++ b/src/gui/inputdevices/InputEvents.cpp
@@ -73,16 +73,16 @@ InputEventType InputEvents::translateEventType(GdkEventType type)
 	}
 }
 
-InputDeviceClass InputEvents::translateDeviceType(GdkDevice* device, Settings* settings)
+InputDeviceClass InputEvents::translateDeviceType(const string& name, GdkInputSource source, Settings* settings)
 {
-	int deviceType = settings->getDeviceClassForDevice(device);
+	int deviceType = settings->getDeviceClassForDevice(name, source);
 	switch (deviceType)
 	{
 		case 0:
 		{
 			// Keyboards are not matched in their own class - do this here manually
-			if (gdk_device_get_source(device) == GDK_SOURCE_KEYBOARD)
-			{
+		    if (source == GDK_SOURCE_KEYBOARD)
+		    {
 				return INPUT_DEVICE_KEYBOARD;
 			}
 			return INPUT_DEVICE_IGNORE;
@@ -98,6 +98,11 @@ InputDeviceClass InputEvents::translateDeviceType(GdkDevice* device, Settings* s
 		default:
 			return INPUT_DEVICE_IGNORE;
 	}
+}
+
+InputDeviceClass InputEvents::translateDeviceType(GdkDevice* device, Settings* settings)
+{
+	return translateDeviceType(gdk_device_get_name(device), gdk_device_get_source(device), settings);
 }
 
 InputEvent* InputEvents::translateEvent(GdkEvent* sourceEvent, Settings* settings)

--- a/src/gui/inputdevices/InputEvents.cpp
+++ b/src/gui/inputdevices/InputEvents.cpp
@@ -83,8 +83,8 @@ InputDeviceClass InputEvents::translateDeviceType(const string& name, GdkInputSo
 			// Keyboards are not matched in their own class - do this here manually
 		    if (source == GDK_SOURCE_KEYBOARD)
 		    {
-				return INPUT_DEVICE_KEYBOARD;
-			}
+		    	return INPUT_DEVICE_KEYBOARD;
+		    }
 			return INPUT_DEVICE_IGNORE;
 		}
 		case 1:

--- a/src/gui/inputdevices/InputEvents.h
+++ b/src/gui/inputdevices/InputEvents.h
@@ -79,6 +79,7 @@ class InputEvents
 public:
 
 	static InputDeviceClass translateDeviceType(GdkDevice* device, Settings* settings);
+	static InputDeviceClass translateDeviceType(const string& name, GdkInputSource source, Settings* settings);
 
 	static InputEvent* translateEvent(GdkEvent* sourceEvent, Settings* settings);
 };

--- a/src/util/DeviceListHelper.cpp
+++ b/src/util/DeviceListHelper.cpp
@@ -88,7 +88,6 @@ InputDevice::InputDevice(GdkDevice* device)
  : name(gdk_device_get_name(device))
  , source(gdk_device_get_source(device))
 {
-
 }
 
 InputDevice::InputDevice(string name, GdkInputSource source)

--- a/src/util/DeviceListHelper.cpp
+++ b/src/util/DeviceListHelper.cpp
@@ -2,34 +2,63 @@
 
 #include <i18n.h>
 
+#include <algorithm>
+#include <utility>
 #include <vector>
 
-std::vector<InputDevice> addDevicesToList(GList* const devList, bool ignoreTouchDevices)
+void storeNewUnlistedDevice(std::vector<InputDevice>& deviceList, GdkDevice* device)
 {
-	std::vector<InputDevice> v;
-	for (auto iter = devList; iter != nullptr; iter = iter->next)
+	// This could potentially be problematic with systems having a multitude of input devices as it searches linearily
+	auto it = std::find(deviceList.begin(), deviceList.end(), InputDevice(device));
+	if (it != deviceList.end())
 	{
-		auto* dev = (GdkDevice*) iter->data;
+		// Device is already known but source may be unknown
+		it->updateType(gdk_device_get_source(device));
+		return;
+	}
+
+	deviceList.emplace_back(device);
+}
+
+void addDevicesToList(std::vector<InputDevice>& deviceList, GList* devList, bool ignoreTouchDevices)
+{
+	while (devList != nullptr)
+	{
+		auto dev = (GdkDevice*) devList->data;
 		if (GDK_SOURCE_KEYBOARD == gdk_device_get_source(dev))
 		{
+			// Skip keyboard
+			devList = devList->next;
+			continue;
+		}
+		if (gdk_device_get_vendor_id(dev) == nullptr && gdk_device_get_product_id(dev) == nullptr)
+		{
+			// Skip core pointer
+			devList = devList->next;
 			continue;
 		}
 		if (ignoreTouchDevices && GDK_SOURCE_TOUCHSCREEN == gdk_device_get_source(dev))
 		{
+			devList = devList->next;
 			continue;
 		}
 
-		v.emplace_back(dev);
+		storeNewUnlistedDevice(deviceList, dev);
+		devList = devList->next;
 	}
-
-	g_list_free(devList);
-	return v;
 }
 
-
-vector<InputDevice> DeviceListHelper::getDeviceList(bool ignoreTouchDevices)
+vector<InputDevice> DeviceListHelper::getDeviceList(Settings* settings, bool ignoreTouchDevices)
 {
-	vector<InputDevice> devices;
+	vector<InputDevice> deviceList = settings->getKnownInputDevices();
+	if (ignoreTouchDevices)
+	{
+		deviceList.erase(
+		        std::remove_if(deviceList.begin(),
+		                       deviceList.end(),
+		                       [](InputDevice device) { return device.getSource() == GDK_SOURCE_TOUCHSCREEN; }),
+		        deviceList.end());
+	}
 
 	GList* pointerSlaves;
 	// TODO remove after completely switching to gtk 3.20 or use c++17 if constexpr (predicate){...} else{...} ...
@@ -43,34 +72,47 @@ vector<InputDevice> DeviceListHelper::getDeviceList(bool ignoreTouchDevices)
 	GdkDeviceManager* deviceManager = gdk_display_get_device_manager(gdk_display_get_default());
 	pointerSlaves = gdk_device_manager_list_devices(deviceManager, GDK_DEVICE_TYPE_SLAVE);
 #endif
-	devices = addDevicesToList(pointerSlaves, ignoreTouchDevices);
+	addDevicesToList(deviceList, pointerSlaves, ignoreTouchDevices);
+	g_list_free(pointerSlaves);
 
-	if (devices.empty())
+	if (deviceList.empty())
 	{
 		g_warning("No device found. Is Xournal++ running in debugger / Eclipse...?\n"
 		          "Probably this is the reason for not finding devices!\n");
 	}
-	return devices;
+
+	return deviceList;
 }
 
 InputDevice::InputDevice(GdkDevice* device)
- : device(device)
+ : name(gdk_device_get_name(device))
+ , source(gdk_device_get_source(device))
 {
 }
 
-GdkDevice* InputDevice::getDevice() const
+InputDevice::InputDevice(string name, GdkInputSource source)
+ : name(std::move(name))
+ , source(source)
 {
-	return device;
 }
 
 string InputDevice::getName() const
 {
-	return gdk_device_get_name(device);
+	return this->name;
+}
+
+GdkInputSource InputDevice::getSource() const
+{
+	return this->source;
+}
+
+void InputDevice::updateType(GdkInputSource newSource)
+{
+	this->source = newSource;
 }
 
 string InputDevice::getType() const
 {
-	GdkInputSource source = gdk_device_get_source(device);
 	if (source == GDK_SOURCE_MOUSE)
 	{
 		return _("mouse");
@@ -108,4 +150,9 @@ string InputDevice::getType() const
 #endif
 
 	return "";
+}
+
+bool InputDevice::operator==(const InputDevice& inputDevice) const
+{
+	return this->getName() == inputDevice.getName();
 }

--- a/src/util/DeviceListHelper.h
+++ b/src/util/DeviceListHelper.h
@@ -11,6 +11,8 @@
 
 #pragma once
 
+#include <control/settings/Settings.h>
+
 #include <gdk/gdk.h>
 #include <gtk/gtk.h>
 
@@ -24,18 +26,23 @@ class InputDevice
 {
 public:
 	explicit InputDevice(GdkDevice* device);
+	explicit InputDevice(string name, GdkInputSource source);
 	~InputDevice() = default;
 
 public:
-	GdkDevice* getDevice() const;
 	string getType() const;
 	string getName() const;
+	GdkInputSource getSource() const;
+	void updateType(GdkInputSource newSource);
+
+	bool operator==(const InputDevice& inputDevice) const;
 
 private:
-	GdkDevice* device;
+	string name;
+	GdkInputSource source;
 };
 
 namespace DeviceListHelper
 {
-vector<InputDevice> getDeviceList(bool ignoreTouchDevices = false);
+vector<InputDevice> getDeviceList(Settings* settings, bool ignoreTouchDevices = false);
 }


### PR DESCRIPTION
This inherits the changes from #1242. Including the fix to actually list the devices.

@michaelschufi please try it out.
There seems to still be a problem with the automatic mapping of the devices as a pen is currently automatically mapped to a mouse (or this is just Windows for you...)