### PR TITLE
Fixed a bug, preventing some compilers to compile (narrowing conversion)

### DIFF
--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -2913,7 +2913,7 @@ bool Control::close(const bool allowDestroy, const bool allowCancel)
 		}
 
 		gtk_window_set_transient_for(GTK_WINDOW(dialog), GTK_WINDOW(this->getWindow()->getWindow()));
-		const guint dialogResponse = gtk_dialog_run(GTK_DIALOG(dialog));
+		const auto dialogResponse = gtk_dialog_run(GTK_DIALOG(dialog));
 		gtk_widget_destroy(dialog);
 
 		switch (dialogResponse)


### PR DESCRIPTION
Thats by the way why we should use the AAA style.

/home/febbe/ClionProjects/xournalpp/src/control/Control.cpp:2921:8: error: case value evaluates to -3, which cannot be narrowed to type 'guint' (aka 'unsigned int') [-Wc++11-narrowing]
                case GTK_RESPONSE_ACCEPT:
                     ^
/home/febbe/ClionProjects/xournalpp/src/control/Control.cpp:2931:8: error: case value evaluates to -2, which cannot be narrowed to type 'guint' (aka 'unsigned int') [-Wc++11-narrowing]
                case GTK_RESPONSE_REJECT: