### PR TITLE
Improve desktop entry categories

### DIFF
--- a/desktop/xournalpp.desktop
+++ b/desktop/xournalpp.desktop
@@ -20,4 +20,4 @@ Terminal=false
 StartupNotify=true
 MimeType=application/x-xoj;application/x-xojpp;application/x-xopp;application/x-xopt;application/pdf;
 Icon=xournalpp
-Categories=GNOME;GTK;Utility;TextEditor;
+Categories=Office;GNOME;GTK;


### PR DESCRIPTION
At the moment, Xournal++ is listed in "Utility" on most desktops, which is IMO not a suitable location. I think it belongs to "Office". Unfortunately "TextEditor" has been specified to belong to "Utility", therefore it must be removed. A replacement might be "WordProcessor", which belongs to "Office", but on the other hand a top level category should be sufficient.

See also https://specifications.freedesktop.org/menu-spec/latest/apas02.html, https://specifications.freedesktop.org/menu-spec/latest/apa.html.