### PR TITLE
NULL-terminate argument vector given to kpsewhich.

### DIFF
--- a/src/control/LatexController.cpp
+++ b/src/control/LatexController.cpp
@@ -86,7 +86,7 @@ LatexController::FindDependencyStatus LatexController::findTexDependencies()
 	g_free(pdflatex);
 
 	// Check for 'standalone' latex package
-	static gchar* kpsewhichArgs[] = {g_strdup("kpsewhich"), g_strdup("standalone")};
+	static gchar* kpsewhichArgs[] = {g_strdup("kpsewhich"), g_strdup("standalone"), nullptr};
 	auto kpsewhichFlags = GSpawnFlags(G_SPAWN_DEFAULT | G_SPAWN_SEARCH_PATH | G_SPAWN_STDOUT_TO_DEV_NULL);
 	GError* kpsewhichErr = nullptr;
 	gint kpsewhichStatus;


### PR DESCRIPTION
Otherwise glib will provide a (likely spurious) last element in argv,
causing EFAULT to be returned from execve in the child:

```
...
[pid 32237] execve("/usr/local/bin/kpsewhich", ["kpsewhich", "standalone", 0x1], 0x7ffe7141a078 /* 69 vars */) = -1 ENOENT (No such file or directory)
[pid 32237] execve("/usr/bin/kpsewhich", ["kpsewhich", "standalone", 0x1], 0x7ffe7141a078 /* 69 vars */) = -1 EFAULT (Bad address)
...
```