### PR TITLE
Respect the XDG base directory specification

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,7 +201,6 @@ mark_as_advanced (FORCE
 )
 
 # Advanced development config
-set (DEV_CONFIG_DIR ".xournalpp" CACHE STRING "Xournal++ config dir, relative to user's home dir")
 set (DEV_TOOLBAR_CONFIG "toolbar.ini" CACHE STRING "Toolbar config file name")
 set (DEV_SETTINGS_XML_FILE "settings.xml" CACHE STRING "Settings file name")
 set (DEV_PRINT_CONFIG_FILE "print-config.ini" CACHE STRING "Print config file name")
@@ -215,10 +214,10 @@ if (DEV_CHECK_GTK3_COMPAT)
 	add_definitions(-DGTK_DISABLE_SINGLE_INCLUDES -DGDK_DISABLE_DEPRECATED -DGTK_DISABLE_DEPRECATED -DGSEAL_ENABLE)
 endif ()
 
-mark_as_advanced(FORCE
-		DEV_CONFIG_DIR DEV_TOOLBAR_CONFIG DEV_SETTINGS_XML_FILE DEV_PRINT_CONFIG_FILE DEV_METADATA_FILE DEV_METADATA_MAX_ITEMS
+mark_as_advanced (FORCE
+		DEV_TOOLBAR_CONFIG DEV_SETTINGS_XML_FILE DEV_PRINT_CONFIG_FILE DEV_METADATA_FILE DEV_METADATA_MAX_ITEMS
 		DEV_ENABLE_GCOV DEV_CHECK_GTK3_COMPAT
-		)
+)
 
 configure_file(
 		src/config.h.in

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -30,7 +30,6 @@ Here you can find complete list of Xournal++ CMake flags (sorted by categories).
 | ------------------------------ | ---------------- | -----------
 | `DEV_CALL_LOG`                 | OFF              | Call log (can take loooot of disk space and IO!)
 | `DEV_CHECK_GTK3_COMPAT` *[A]*  | OFF              | Adds a few compiler flags to check basic GTK3 upgradeability support (still compiles for GTK2!)
-| `DEV_CONFIG_DIR` *[A]*         | .xournalpp       | Xournal++ config dir, relative to user's home dir
 | `DEV_ENABLE_GCOV` *[A]*        | OFF              | Build with gcov support
 | `DEV_MEMORY_CHECKING`          | ON               | Memory checking
 | `DEV_MEMORY_LEAK_CHECKING`     | ON               | Memory leak checking
@@ -39,7 +38,7 @@ Here you can find complete list of Xournal++ CMake flags (sorted by categories).
 | `DEV_PRINT_CONFIG_FILE` *[A]*  | print-config.ini | Print config file name
 | `DEV_SETTINGS_XML_FILE` *[A]*  | settings.xml     | Settings file name
 | `DEV_TOOLBAR_CONFIG` *[A]*     | toolbar.ini      | Toolbar config file name
-| `DEV_ERRORLOG_DIR` *[A]*       | ""               | Directory where errorlogfiles will be placed
+| `DEV_ERRORLOG_DIR` *[A]*       | errorlogs        | Directory where errorlogfiles will be placed
 
 
 ## `EXT` – add dependency basing on precompiled deb packages (UNIX only)

--- a/src/config-dev.h.in
+++ b/src/config-dev.h.in
@@ -12,11 +12,6 @@
 #pragma once
 
 /**
- * Xournal++ config dir, relative to user's home dir
- */
-#define CONFIG_DIR "@DEV_CONFIG_DIR@"
-
-/**
  * Toolbar config file name
  */
 #define TOOLBAR_CONFIG "@DEV_TOOLBAR_CONFIG@"

--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -84,9 +84,7 @@ Control::Control(GladeSearchpath* gladeSearchPath) {
     this->lastGroup = GROUP_NOGROUP;
     this->lastEnabled = false;
 
-    Path name = Path(g_get_home_dir());
-    name /= CONFIG_DIR;
-    name /= SETTINGS_XML_FILE;
+    Path name = Util::getConfigFile(SETTINGS_XML_FILE);
     this->settings = new Settings(name);
     this->settings->load();
 

--- a/src/control/XournalMain.cpp
+++ b/src/control/XournalMain.cpp
@@ -82,7 +82,10 @@ bool XournalMain::migrateSettings() {
         if (oldConfigPath.exists()) {
             g_message("Migrating configuration from %s to %s", oldConfigPath.str().c_str(),
                       newConfigPath.str().c_str());
-            fs::create_directories(newConfigPath.str());
+            auto xdgConfDir = fs::path(newConfigPath.str()).parent_path();
+            if (!fs::exists(xdgConfDir)) {
+                fs::create_directories(xdgConfDir);
+            }
             fs::copy(oldConfigPath.str(), newConfigPath.str(), fs::copy_options::recursive);
             return true;
         }

--- a/src/control/XournalMain.cpp
+++ b/src/control/XournalMain.cpp
@@ -72,7 +72,7 @@ void XournalMain::initLocalisation() {
 }
 
 void XournalMain::checkForErrorlog() {
-    Path errorDir = Util::getConfigSubfolder(ERRORLOG_DIR);
+    Path errorDir = Util::getCacheSubfolder(ERRORLOG_DIR);
     GDir* home = g_dir_open(errorDir.c_str(), 0, nullptr);
 
     if (home == nullptr) {
@@ -120,7 +120,7 @@ void XournalMain::checkForErrorlog() {
 
     int res = gtk_dialog_run(GTK_DIALOG(dialog));
 
-    Path errorlogPath = Util::getConfigSubfolder(ERRORLOG_DIR);
+    Path errorlogPath = Util::getCacheSubfolder(ERRORLOG_DIR);
     errorlogPath /= errorList[0];
     if (res == 1)  // Send Bugreport
     {

--- a/src/control/XournalMain.h
+++ b/src/control/XournalMain.h
@@ -31,7 +31,11 @@ public:
 
 private:
     static void initLocalisation();
-    static void migrateSettings();
+
+    /**
+     * Returns true if configuration settings were migrated.
+     */
+    static bool migrateSettings();
 
     static void checkForErrorlog();
     static void checkForEmergencySave(Control* control);

--- a/src/control/XournalMain.h
+++ b/src/control/XournalMain.h
@@ -31,6 +31,7 @@ public:
 
 private:
     static void initLocalisation();
+    static void migrateSettings();
 
     static void checkForErrorlog();
     static void checkForEmergencySave(Control* control);

--- a/src/control/XournalMain.h
+++ b/src/control/XournalMain.h
@@ -33,9 +33,24 @@ private:
     static void initLocalisation();
 
     /**
-     * Returns true if configuration settings were migrated.
+     * Configuration migration status.
      */
-    static bool migrateSettings();
+    enum class MigrateStatus {
+        /** No migration was needed. */
+        NotNeeded,
+        /** Migration was carried out successfully. */
+        Success,
+        /** Migration failed. */
+        Failure,
+    };
+
+    struct MigrateResult {
+        MigrateStatus status;
+        /** Any additional information about the migration status. */
+        std::string message;
+    };
+
+    static MigrateResult migrateSettings();
 
     static void checkForErrorlog();
     static void checkForEmergencySave(Control* control);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -80,7 +80,7 @@ MainWindow::MainWindow(GladeSearchpath* gladeSearchPath, Control* control):
         XojMsgBox::showErrorToUser(control->getGtkWindow(), msg);
     }
 
-    file = string(g_get_home_dir()) + G_DIR_SEPARATOR_S + CONFIG_DIR + G_DIR_SEPARATOR_S + TOOLBAR_CONFIG;
+    file = Util::getConfigFile(TOOLBAR_CONFIG).str();
     if (g_file_test(file.c_str(), G_FILE_TEST_EXISTS)) {
         if (!tbModel->parse(file, false)) {
             string msg = FS(_F("Could not parse custom toolbar.ini file: {1}\n"

--- a/src/util/CrashHandlerUnix.h
+++ b/src/util/CrashHandlerUnix.h
@@ -70,10 +70,11 @@ static void crashHandler(int sig) {
     time_t curtime = time(0);
     char stime[128];
     strftime(stime, sizeof(stime), "%Y%m%d-%H%M%S", localtime(&curtime));
-    string filename = Util::getConfigFile(std::string("errorlogs/errorlog.") + stime + ".log").str();
-    ofstream fp(filename);
+    Path errorlogPath = Util::getCacheSubfolder(ERRORLOG_DIR);
+    errorlogPath /= std::string("errorlog.") + stime + ".log";
+    ofstream fp(errorlogPath.str());
     if (fp) {
-        g_warning("[Crash Handler] Wrote crash log to: %s", filename.c_str());
+        g_warning("[Crash Handler] Wrote crash log to: %s", errorlogPath.str().c_str());
     }
 
     lt = time(nullptr);

--- a/src/util/Util.cpp
+++ b/src/util/Util.cpp
@@ -81,8 +81,24 @@ auto Util::getAutosaveFilename() -> Path {
 }
 
 auto Util::getConfigSubfolder(const Path& subfolder) -> Path {
-    Path p(g_get_home_dir());
-    p /= CONFIG_DIR;
+    Path p(g_get_user_config_dir());
+    p /= g_get_prgname();
+    p /= subfolder;
+
+    return Util::ensureFolderExists(p);
+}
+
+auto Util::getCacheSubfolder(const Path& subfolder) -> Path {
+    Path p(g_get_user_cache_dir());
+    p /= g_get_prgname();
+    p /= subfolder;
+
+    return Util::ensureFolderExists(p);
+}
+
+auto Util::getDataSubfolder(const Path& subfolder) -> Path {
+    Path p(g_get_user_data_dir());
+    p /= g_get_prgname();
     p /= subfolder;
 
     return Util::ensureFolderExists(p);
@@ -90,6 +106,12 @@ auto Util::getConfigSubfolder(const Path& subfolder) -> Path {
 
 auto Util::getConfigFile(const Path& relativeFileName) -> Path {
     Path p = getConfigSubfolder(relativeFileName.getParentPath());
+    p /= relativeFileName.getFilename();
+    return p;
+}
+
+auto Util::getCacheFile(const Path& relativeFileName) -> Path {
+    Path p = getCacheSubfolder(relativeFileName.getParentPath());
     p /= relativeFileName.getFilename();
     return p;
 }

--- a/src/util/Util.cpp
+++ b/src/util/Util.cpp
@@ -80,9 +80,14 @@ auto Util::getAutosaveFilename() -> Path {
     return p;
 }
 
-auto Util::getConfigSubfolder(const Path& subfolder) -> Path {
+auto Util::getConfigFolder() -> Path {
     Path p(g_get_user_config_dir());
     p /= g_get_prgname();
+    return p;
+}
+
+auto Util::getConfigSubfolder(const Path& subfolder) -> Path {
+    Path p = getConfigFolder();
     p /= subfolder;
 
     return Util::ensureFolderExists(p);

--- a/src/util/Util.h
+++ b/src/util/Util.h
@@ -39,7 +39,11 @@ void openFileWithDefaultApplicaion(const Path& filename);
 void openFileWithFilebrowser(const Path& filename);
 
 Path getConfigSubfolder(const Path& subfolder = "");
+Path getCacheSubfolder(const Path& subfolder = "");
+Path getDataSubfolder(const Path& subfolder = "");
+
 Path getConfigFile(const Path& relativeFileName = "");
+Path getCacheFile(const Path& relativeFileName = "");
 
 Path getTmpDirSubfolder(const Path& subfolder = "");
 

--- a/src/util/Util.h
+++ b/src/util/Util.h
@@ -38,6 +38,10 @@ pid_t getPid();
 void openFileWithDefaultApplicaion(const Path& filename);
 void openFileWithFilebrowser(const Path& filename);
 
+/**
+ * Return the configuration folder path (may not be guaranteed to exist).
+ */
+Path getConfigFolder();
 Path getConfigSubfolder(const Path& subfolder = "");
 Path getCacheSubfolder(const Path& subfolder = "");
 Path getDataSubfolder(const Path& subfolder = "");


### PR DESCRIPTION
Fix https://github.com/xournalpp/xournalpp/issues/1101:
- [x] Removed build-time option `DEV_CONFIG_DIR` (run-time `XDG_CONFIG_HOME` env variable can be used instead)
- [x] Use `g_get_user_config_dir()` instead of `g_get_home_dir()` for building configuration file path
- [x] Tested on Linux
- [x] Migration (do we really need it?)
- [ ] Load custom plugins from `$XDG_DATA_HOME/xournalpp/plugins`
- [x] Save errorlogs to `$XDG_CACHE_HOME/xournalpp/errorlogs` (as far as these are "user specific non-essential data files")
- [ ] Test on Windows and macOS