### PR TITLE
correctly handle extensions when exporting

### DIFF
--- a/src/control/jobs/CustomExportJob.cpp
+++ b/src/control/jobs/CustomExportJob.cpp
@@ -71,7 +71,7 @@ bool CustomExportJob::isUriValid(string& uri)
 	this->chosenFilterName = BaseExportJob::getFilterName();
 	
 	// Remove any pre-existing extension and adds the chosen one
-	filename.clearExtensions();
+	filename.clearExtensions(filters[this->chosenFilterName]->extension);
 	filename += filters[this->chosenFilterName]->extension;
 
 	return checkOverwriteBackgroundPDF(filename);

--- a/src/control/jobs/PdfExportJob.cpp
+++ b/src/control/jobs/PdfExportJob.cpp
@@ -33,7 +33,7 @@ bool PdfExportJob::isUriValid(string& uri)
 	}
 
 	// Remove any pre-existing extension and adds .pdf
-	filename.clearExtensions();
+	filename.clearExtensions(".pdf");
 	filename += ".pdf";
 	
 	return checkOverwriteBackgroundPDF(filename);

--- a/src/util/Path.cpp
+++ b/src/util/Path.cpp
@@ -136,17 +136,28 @@ bool Path::hasExtension(const string& ext) const
 	return StringUtils::toLowerCase(pathExt) == StringUtils::toLowerCase(ext);
 }
 
-void Path::clearExtensions()
+void Path::clearExtensions(const string& ext)
 {
 	string plower = StringUtils::toLowerCase(path);
 	auto rm_ext = [&](string const& ext) {
 		if (StringUtils::endsWith(plower, ext))
 		{
-			this->path = path.substr(0, path.length() - ext.size());
+			auto newLen = plower.length() - ext.size();
+			if (newLen < path.length())
+			{
+				this->path = path.substr(0, newLen);
+			}
 		}
 	};
 	rm_ext(".xoj");
 	rm_ext(".xopp");
+	if (!ext.empty())
+	{
+		string extLower = StringUtils::toLowerCase(ext);
+		rm_ext(extLower);
+		rm_ext(extLower + ".xoj");
+		rm_ext(extLower + ".xopp");
+	}
 }
 
 const string& Path::str() const

--- a/src/util/Path.h
+++ b/src/util/Path.h
@@ -65,9 +65,12 @@ public:
 	bool hasExtension(const string& ext) const;
 
 	/**
-	 * Clear the the last known extension (last .pdf, .pdf.xoj, .pdf.xopp etc.)
+	 * Clear the the last known xournal extension (last .xoj, .xopp etc.)
+	 *
+	 * @param ext An extension to clear additionally, eg .pdf (would also clear
+	 *  .pdf.xopp etc.)
 	 */
-	void clearExtensions();
+	void clearExtensions(const string& ext = "");
 
 	/**
 	 * @return true if this file has .xopp or .xoj extension

--- a/test/util/PathTest.cpp
+++ b/test/util/PathTest.cpp
@@ -96,6 +96,8 @@ public:
 		Path b = Path("/test/asdf.TXT");
 		b.clearExtensions();
 		CPPUNIT_ASSERT_EQUAL(string("/test/asdf.TXT"), b.str());
+		b.clearExtensions(".txt");
+		CPPUNIT_ASSERT_EQUAL(string("/test/asdf"), b.str());
 
 		b = Path("/test/asdf.asdf/asdf");
 		b.clearExtensions();
@@ -104,20 +106,38 @@ public:
 		b = Path("/test/asdf.PDF");
 		b.clearExtensions();
 		CPPUNIT_ASSERT_EQUAL(string("/test/asdf.PDF"), b.str());
+		b.clearExtensions(".pdf");
+		CPPUNIT_ASSERT_EQUAL(string("/test/asdf"), b.str());
 
 		b = Path("/test/asdf.PDF.xoj");
 		b.clearExtensions();
 		CPPUNIT_ASSERT_EQUAL(string("/test/asdf.PDF"), b.str());
-        
-        	b = Path("/test/asdf.PDF.xopp");
+
+		b = Path("/test/asdf.PDF.xoj");
+		b.clearExtensions(".Pdf");
+		CPPUNIT_ASSERT_EQUAL(string("/test/asdf"), b.str());
+
+		b = Path("/test/asdf.pdf.pdf");
+		b.clearExtensions(".pdf");
+		CPPUNIT_ASSERT_EQUAL(string("/test/asdf.pdf"), b.str());
+
+		b = Path("/test/asdf.xopp.xopp");
+		b.clearExtensions();
+		CPPUNIT_ASSERT_EQUAL(string("/test/asdf.xopp"), b.str());
+
+		b = Path("/test/asdf.PDF.xopp");
 		b.clearExtensions();
 		CPPUNIT_ASSERT_EQUAL(string("/test/asdf.PDF"), b.str());
+
+		b = Path("/test/asdf.SVG.xopp");
+		b.clearExtensions(".svg");
+		CPPUNIT_ASSERT_EQUAL(string("/test/asdf"), b.str());
 
 		b = Path("/test/asdf.xoj");
 		b.clearExtensions();
 		CPPUNIT_ASSERT_EQUAL(string("/test/asdf"), b.str());
-        
-        	b = Path("/test/asdf.xopp");
+
+		b = Path("/test/asdf.xopp");
 		b.clearExtensions();
 		CPPUNIT_ASSERT_EQUAL(string("/test/asdf"), b.str());
 


### PR DESCRIPTION
Since #1117, we allow for extension like ".pdf.xopp". This change led to
a bug where overwrithing an existing ".pdf" file in pdf export created a
new file with the extension ".pdf.pdf" instead of overwriting the old
one. This is fixed and additionally all current and future export
filetypes show the same behaviour now.