### PR TITLE
Issue #1397: File contents are now kept if load fails

### DIFF
--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -2316,8 +2316,6 @@ bool Control::openFile(Path filename, int scrollToPage, bool forceOpen)
 		}
 	}
 
-	this->closeDocument();
-
 	// Read template file
 	if (filename.hasExtension(".xopt"))
 	{
@@ -2381,6 +2379,8 @@ bool Control::openFile(Path filename, int scrollToPage, bool forceOpen)
 	}
 	else
 	{
+		this->closeDocument();
+
 		this->doc->lock();
 		this->doc->clearDocument();
 		*this->doc = *loadedDocument;


### PR DESCRIPTION
Fixes #1397.

If the file was not loaded correctly, it will keep the existing document in the window, regardless of whether the document was saved or discarded (which I would expect, since I might want to continue working if the file wasn't loaded correctly). When this happens, you can check/uncheck the background layer and the document works like usual.

Currently, if you open a document, a dialog appears and has the "Save" or "Discard" options. If you do either of these things, the open dialog is shown.

Currently, when you click on a valid file in the open dialog, the current document in the window is "closed" (because it's either saved or discarded) which clears the document, so the strokes, etc would be erased: https://github.com/siliconninja/xournalpp/blob/ce945431ae7539e4fc92dc73c37b073cb2780677/src/control/Control.cpp#L2319, https://github.com/siliconninja/xournalpp/blob/ce945431ae7539e4fc92dc73c37b073cb2780677/src/control/Control.cpp#L2961

and the "preview" which contains the document is destroyed: https://github.com/siliconninja/xournalpp/blob/ce945431ae7539e4fc92dc73c37b073cb2780677/src/model/Document.cpp#L98

I changed this so that this "closing" and destroying happens only if the document was loaded correctly, because it would re-create the "preview" with the loaded document contents in that case.