### PR TITLE
Issue #1397: File contents are now kept if load fails, add "no pages" loading error

### DIFF
--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -2316,8 +2316,6 @@ bool Control::openFile(Path filename, int scrollToPage, bool forceOpen)
 		}
 	}
 
-	this->closeDocument();
-
 	// Read template file
 	if (filename.hasExtension(".xopt"))
 	{
@@ -2381,6 +2379,8 @@ bool Control::openFile(Path filename, int scrollToPage, bool forceOpen)
 	}
 	else
 	{
+		this->closeDocument();
+
 		this->doc->lock();
 		this->doc->clearDocument();
 		*this->doc = *loadedDocument;

--- a/src/control/xojfile/LoadHandler.cpp
+++ b/src/control/xojfile/LoadHandler.cpp
@@ -298,6 +298,11 @@ bool LoadHandler::parseXml()
 		lastError = _("Document is not complete (maybe the end is cut off?)");
 		return false;
 	}
+	else if (this->pos == PASER_POS_FINISHED && this->doc.getPageCount() == 0)
+	{
+		lastError = _("Document is corrupted (no pages found in file)");
+		return false;
+	}
 
 	doc.setCreateBackupOnSave(this->fileVersion >= 3);
 


### PR DESCRIPTION
Fixes #1397.

Test files used (.xopp files are in the .zip files), thanks to @tumb1er for the detailed report and the files!:
[new_corrupted.zip](https://github.com/xournalpp/xournalpp/files/3468831/new_corrupted.zip)
[2019-08-03-Note-16-17.zip](https://github.com/xournalpp/xournalpp/files/3468835/2019-08-03-Note-16-17.zip)

With this PR and the latest Xournal++ build from `master`:
- Opening 2019-08-03-Note-16-17.xopp gives the error `XML Parser error: Wrong count of points (1)` and keeps the current document in view, regardless of save/discard
- Opening new_corrupted.**xopp** gives the error `Document has no pages, so it is corrupted` and keeps the current document in view, regardless of save/discard
- Opening new_corrupted.**zip** DIRECTLY with the GTK type-to-search feature gives the error `The file is no valid .xopp file (mimetype missing): "/home/siliconninja/Downloads/new_corrupted.zip"` and keeps the current document in view, regardless of save/discard

What I changed:
If the file that was given in the open dialog was not loaded correctly, it will keep the existing document in the window, regardless of whether the document was saved or discarded (which I would expect, since I feel it's the best UX option -- if the new file wasn't loaded correctly, it wouldn't make sense to suddenly make a new document, so intuitively, keeping the existing document loaded makes sense to me). When this happens, you can still check/uncheck the background layer and the document works like usual (which used to crash the app).

Current behavior before this PR:

- if you open a document, a dialog appears and has the "Save" or "Discard" options. If you do either of these things, the open dialog is shown.
- Then, when you double-click on a valid file in the open dialog:
    - the current document in the window is "closed" (because it's either saved or discarded) which clears the document, so the strokes, etc would be erased: https://github.com/siliconninja/xournalpp/blob/ce945431ae7539e4fc92dc73c37b073cb2780677/src/control/Control.cpp#L2319, https://github.com/siliconninja/xournalpp/blob/ce945431ae7539e4fc92dc73c37b073cb2780677/src/control/Control.cpp#L2961
    - and the "preview" which contains the current document's contents in the window is destroyed: https://github.com/siliconninja/xournalpp/blob/ce945431ae7539e4fc92dc73c37b073cb2780677/src/model/Document.cpp#L98

New behavior after this PR:
This "closing" and destroying happens only if the document was loaded correctly, because if that happens, it would re-create the "preview" with the loaded document contents. Otherwise, "closing" and destroying the current document is not necessary.