### PR TITLE
Fix text objects not rendering with the correct cairo operator

### DIFF
--- a/src/view/DocumentView.cpp
+++ b/src/view/DocumentView.cpp
@@ -103,6 +103,8 @@ void DocumentView::drawText(cairo_t* cr, Text* t)
 	{
 		return;
 	}
+
+	cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
 	applyColor(cr, t);
 
 	TextView::drawText(cr, t);


### PR DESCRIPTION
Fixes #1394. Will merge in 3 days if there are no objections.

The issue was that the cairo operator changes in
https://github.com/xournalpp/xournalpp/blob/a6276cd2955ba9762eba19d476b5fe67e55681bb/src/view/StrokeView.cpp#L84-L91
but the appropriate operator was not set before rendering text objects. Thus the text objects were rendered with the multiply operator instead of e.g. the over operator.