### PR TITLE
Add option to disable overlay scrolling

### DIFF
--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -84,6 +84,7 @@ void Settings::loadDefault()
 	this->highlightPosition = false;
 	this->darkTheme = false;
 	this->scrollbarHideType = SCROLLBAR_HIDE_NONE;
+	this->disableScrollbarFadeout = true;
 
 	//Set this for autosave frequency in minutes.
 	this->autosaveTimeout = 3;
@@ -562,6 +563,10 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur)
 			this->scrollbarHideType = SCROLLBAR_HIDE_NONE;
 		}
 	}
+	else if (xmlStrcmp(name, (const xmlChar*) "disableScrollbarFadeout") == 0)
+	{
+		this->disableScrollbarFadeout = xmlStrcmp(value, (const xmlChar*) "true") ? false : true;
+	}
 	else if (xmlStrcmp(name, (const xmlChar*) "audioSampleRate") == 0)
 	{
 		this->audioSampleRate = tempg_ascii_strtod((const char *) value, NULL);
@@ -963,6 +968,8 @@ void Settings::save()
 	WRITE_BOOL_PROP(highlightPosition);
 	WRITE_BOOL_PROP(darkTheme);
 
+	WRITE_BOOL_PROP(disableScrollbarFadeout);
+
 	if (this->scrollbarHideType == SCROLLBAR_HIDE_BOTH)
 	{
 		saveProperty((const char*) "scrollbarHideType", "both", root);
@@ -979,7 +986,6 @@ void Settings::save()
 	{
 		saveProperty((const char*) "scrollbarHideType", "none", root);
 	}
-
 
 	WRITE_BOOL_PROP(autoloadPdfXoj);
 	WRITE_COMMENT("Hides scroolbars in the main window, allowed values: \"none\", \"horizontal\", \"vertical\", \"both\"");
@@ -2577,6 +2583,18 @@ int Settings::getDeviceClassForDevice(const string& deviceName, GdkInputSource d
 		}
 		return deviceType;
 	}
+}
+
+bool Settings::isScrollbarFadeoutDisabled()
+{
+	return disableScrollbarFadeout;
+}
+
+void Settings::setScrollbarFadeoutDisabled(bool disable)
+{
+	if (disableScrollbarFadeout == disable) return;
+	disableScrollbarFadeout = disable;
+	save();
 }
 
 //////////////////////////////////////////////////

--- a/src/control/settings/Settings.h
+++ b/src/control/settings/Settings.h
@@ -308,6 +308,9 @@ public:
 	ScrollbarHideType getScrollbarHideType();
 	void setScrollbarHideType(ScrollbarHideType type);
 
+	bool isScrollbarFadeoutDisabled();
+	void setScrollbarFadeoutDisabled(bool disable);
+
 	string getDefaultSaveName();
 	void setDefaultSaveName(string name);
 
@@ -538,6 +541,11 @@ private:
 	 *  Hide the scrollbar
 	 */
 	ScrollbarHideType scrollbarHideType;
+
+	/**
+	 * Disable scrollbar fade out (overlay scrolling)
+	 */
+	bool disableScrollbarFadeout;
 
 	/**
 	 *  The selected Toolbar name

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -508,6 +508,9 @@ void MainWindow::updateScrollbarSidebarPosition()
 
 		gtk_widget_set_visible(gtk_scrolled_window_get_hscrollbar(scrolledWindow), !(type & SCROLLBAR_HIDE_HORIZONTAL));
 		gtk_widget_set_visible(gtk_scrolled_window_get_vscrollbar(scrolledWindow), !(type & SCROLLBAR_HIDE_VERTICAL));
+
+		gtk_scrolled_window_set_overlay_scrolling(scrolledWindow,
+		                                          !control->getSettings()->isScrollbarFadeoutDisabled());
 	}
 
 	GtkWidget* sidebar = get("sidebar");

--- a/src/gui/dialog/SettingsDialog.cpp
+++ b/src/gui/dialog/SettingsDialog.cpp
@@ -253,6 +253,7 @@ void SettingsDialog::load()
 	loadCheckbox("cbDarkTheme", settings->isDarkTheme());
 	loadCheckbox("cbHideHorizontalScrollbar", settings->getScrollbarHideType() & SCROLLBAR_HIDE_HORIZONTAL);
 	loadCheckbox("cbHideVerticalScrollbar", settings->getScrollbarHideType() & SCROLLBAR_HIDE_VERTICAL);
+	loadCheckbox("cbDisableScrollbarFadeout", settings->isScrollbarFadeoutDisabled());
 	loadCheckbox("cbTouchWorkaround", settings->isTouchWorkaround());
 	loadCheckbox("cbNewInputSystem", settings->getExperimentalInputSystemEnabled());
 	loadCheckbox("cbInputSystemTPCButton", settings->getInputSystemTPCButtonEnabled());
@@ -533,6 +534,7 @@ void SettingsDialog::save()
 	settings->setExperimentalInputSystemEnabled(getCheckbox("cbNewInputSystem"));
 	settings->setInputSystemTPCButtonEnabled(getCheckbox("cbInputSystemTPCButton"));
 	settings->setInputSystemDrawOutsideWindowEnabled(getCheckbox("cbInputSystemDrawOutsideWindow"));
+	settings->setScrollbarFadeoutDisabled(getCheckbox("cbDisableScrollbarFadeout"));
 
 	auto scrollbarHideType =
 	        static_cast<std::make_unsigned<std::underlying_type<ScrollbarHideType>::type>::type>(SCROLLBAR_HIDE_NONE);

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -2273,7 +2273,6 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
                                             <property name="receives_default">False</property>
-                                            <property name="xalign">0</property>
                                             <property name="draw_indicator">True</property>
                                           </object>
                                           <packing>
@@ -2289,13 +2288,26 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
                                             <property name="receives_default">False</property>
-                                            <property name="xalign">0</property>
                                             <property name="draw_indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
                                             <property name="fill">True</property>
                                             <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="cbDisableScrollbarFadeout">
+                                            <property name="label" translatable="yes">Disable scrollbar fade out</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="draw_indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">2</property>
                                           </packing>
                                         </child>
                                       </object>


### PR DESCRIPTION
Scrollbars normally fade out after a short time which makes it
impossible to use the scrollbars on touchscreens.