### PR TITLE
Fix zoom fit scroll

### DIFF
--- a/src/control/zoom/ZoomControl.cpp
+++ b/src/control/zoom/ZoomControl.cpp
@@ -590,13 +590,9 @@ bool ZoomControl::onWidgetSizeChangedEvent(GtkWidget* widget, GdkRectangle* allo
 	zoom->updateZoomPresentationValue();
 	zoom->updateZoomFitValue(r);
 
-	// Todo: remove after change to "expose_event"
 	auto layout = gtk_xournal_get_layout(zoom->view->getWidget());
-	GdkRectangle allNew = {allocation->x, allocation->y, std::max(allocation->width, layout->getMinimalWidth()),
-	                       std::max(allocation->height, layout->getMinimalHeight())};
-
 	layout->layoutPages(allocation->width, allocation->height);
-	gtk_widget_set_allocation(zoom->view->getWidget(), &allNew);
+	gtk_widget_queue_resize(zoom->view->getWidget());
 
 	return true;
 }


### PR DESCRIPTION
Fixes scrolling when using zoom fit and resizing window.

Underlying issue was missing repaint of child widget. (refactor_layout_resize should be merged first)

Closes #1383
Closes #1132 
Closes #941