### PR TITLE
improve hint for latex first timers.

### DIFF
--- a/src/control/LatexController.cpp
+++ b/src/control/LatexController.cpp
@@ -108,7 +108,7 @@ LatexController::FindDependencyStatus LatexController::findTexDependencies()
 	}
 	else if (kpsewhichStatus != 0)
 	{
-		string msg = FS(_F("Could not find the LaTeX package 'standalone'.\nPlease install standalone and make sure "
+		string msg = FS(_F("Could not find the LaTeX package 'standalone'.\nPlease install standalone (found in texlive-latex-extra) and make sure "
 		                   "it's accessible by your LaTeX installation."));
 		return LatexController::FindDependencyStatus(false, msg);
 	}


### PR DESCRIPTION
Indicate the latex package that includes standalone when telling the user they need to install standalone.