### PR TITLE
Toolbars: icon size glitch and Customization misalignment

### DIFF
--- a/src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp
+++ b/src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp
@@ -133,7 +133,6 @@ void ToolbarAdapter::showToolbar()
 	gtk_widget_show(this->w);
 
 	GtkToolbar* tb = GTK_TOOLBAR(this->w);
-	gtk_toolbar_set_icon_size(tb, GTK_ICON_SIZE_SMALL_TOOLBAR);
 
 	GtkToolItem* it = gtk_tool_item_new();
 	this->spacerItem = it;

--- a/src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp
+++ b/src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp
@@ -258,7 +258,13 @@ bool ToolbarAdapter::toolbarDragMotionCb(GtkToolbar* toolbar, GdkDragContext* co
 		return false;
 	}
 
-	gint ipos = gtk_toolbar_get_drop_index(toolbar, x, y);
+	// x,y are already in toolbar coordinates as the gtk_toolbar_get_drop_index() specification requires.
+	// However, without this translation we have an unwanted vertical offset.
+	gint wx = 0;
+	gint wy = 0;
+	gtk_widget_translate_coordinates(GTK_WIDGET(toolbar), gtk_widget_get_toplevel(GTK_WIDGET(toolbar)), x, y, &wx, &wy);
+
+	gint ipos = gtk_toolbar_get_drop_index(toolbar, wx, wy);
 
 	GtkOrientation orientation = gtk_orientable_get_orientation(GTK_ORIENTABLE(toolbar));
 	gdk_drag_status(context, gdk_drag_context_get_suggested_action(context), time);
@@ -306,7 +312,12 @@ void ToolbarAdapter::toolbarDragDataReceivedCb(GtkToolbar* toolbar, GdkDragConte
 	ToolItemDragDropData* d = (ToolItemDragDropData*) gtk_selection_data_get_data( data);
 	g_return_if_fail(ToolitemDragDrop::checkToolItemDragDropData(d));
 
-	int pos = gtk_toolbar_get_drop_index(toolbar, x, y);
+	// fix vertical position bug as in toolbarDragMotionCb() above.
+	gint wx = 0;
+	gint wy = 0;
+	gtk_widget_translate_coordinates(GTK_WIDGET(toolbar), gtk_widget_get_toplevel(GTK_WIDGET(toolbar)), x, y, &wx, &wy);
+
+	gint pos = gtk_toolbar_get_drop_index(toolbar, wx, wy);
 
 	if (d->type == TOOL_ITEM_ITEM)
 	{

--- a/ui/xournalpp.css
+++ b/ui/xournalpp.css
@@ -1,5 +1,10 @@
 /*  
  * Backup before modifying
+ *
+ * 
+ *  Try running Xournal++ like this:    GTK_DEBUG=interactive  xournalpp
+ * 
+ *  See: https://wiki.gnome.org/action/show/Projects/GTK/Inspector
  */
 
 
@@ -41,3 +46,28 @@ GtkToolItem>GtkBox>GtkLabel+GtkLabel+GtkButton
 	box-shadow:none;
 	background-image:none
 }
+
+
+
+/*  If you want to change the size of toolbar buttons try these:
+*   All toolbars:
+*/
+
+/*
+GtkToolbar GtkButton
+{
+	padding: 2
+}
+*/
+
+
+
+/* Or for individual toolbars: tbLeft1 tbLeft2 tbTop1 tbTop2 tbBottom1 tbFloat4 etc: 
+ */
+ 
+/*
+#tbLeft2 GtkButton
+{
+	padding: 2
+}
+*/


### PR DESCRIPTION
Fixes two toolbar glitches:
 

- Icons changing size after customization (#1395)
-  Misaligned drop point during customization (#1455 )

It also adds instructions in css file for those who want to modify toolbar icon sizes (specifically see #1395)