### PR TITLE
Fix app generation for MacOS

### DIFF
--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -66,7 +66,7 @@ stages:
               cmake_flags: ''
           - bash: |
               export PATH="$HOME/.local/bin:/Users/git-bin/gtk/inst/bin:$PATH"
-              ./build-app.sh /Users/gtk-bin/gtk
+              ./build-app.sh /Users/git-bin/gtk
             workingDirectory: ./mac-setup
             displayName: 'Create App'
           - task: PublishPipelineArtifact@0

--- a/mac-setup/build-app.sh
+++ b/mac-setup/build-app.sh
@@ -36,6 +36,8 @@ cd ..
 
 echo "create package"
 
+export GTKDIR="$1/inst"
+
 gtk-mac-bundler xournalpp.bundle
 
 mkdir -p Xournal++.app/Contents/Resources

--- a/mac-setup/xournalpp.bundle
+++ b/mac-setup/xournalpp.bundle
@@ -2,7 +2,7 @@
 <app-bundle>
 
   <meta>
-    <prefix name="default">${env:HOME}/gtk/inst</prefix>
+    <prefix name="default">${env:GTKDIR}</prefix>
     <destination overwrite="yes">.</destination>
 
     <!-- Comment this out to keep the install names in binaries -->


### PR DESCRIPTION
While packages are now created they miss parts of the application. This is because the Path was hardcoded which is not compatible with our pipeline setup. This PR makes the path parameterized.