### PR TITLE
Enabled newlines in Latex

### DIFF
--- a/src/control/LatexController.cpp
+++ b/src/control/LatexController.cpp
@@ -22,7 +22,7 @@
  * the rendered formula is blank. Otherwise, a completely blank, sizeless PDF
  * will be generated, which Poppler will be unable to load.
  */
-const char* LATEX_TEMPLATE_1 = R"(\documentclass[crop, border=5pt]{standalone})"
+const char* LATEX_TEMPLATE_1 = R"(\documentclass[varwidth=true, crop, border=5pt]{standalone})"
                                "\n"
                                R"(\usepackage{amsmath})"
                                "\n"


### PR DESCRIPTION
User can now use \newline,\\\,  etc, to write on a new line in Latex Mode. Previously, all text would go in 1 single line and fill the entire width, so user would have to start a new TexMode if equation was getting too long