### PR TITLE
Update WindowsBuild.md

### DIFF
--- a/readme/WindowsBuild.md
+++ b/readme/WindowsBuild.md
@@ -33,7 +33,7 @@ pacman -S git
 ```bash
 pacman -S mingw-w64-x86_64-toolchain; \
 pacman -S mingw-w64-x86_64-cmake; \
-pacman -S mingw-w64-x86_64-make; \
+pacman -S make; \
 pacman -S mingw-w64-x86_64-ninja; \
 pacman -S patch; \
 pacman -S mingw-w64-x86_64-cppunit

--- a/readme/WindowsBuild.md
+++ b/readme/WindowsBuild.md
@@ -3,7 +3,7 @@
 **Windows Build is working now, but Xournal++ is not yet fully supported
 on Windows.**
 
-See also [Linux Build](LinuxBuild.md)
+See also [Linux Build](LinuxBuild.md) and the [azure configuration](/azure-pipelines/release.yml) 
 
 Pull requests with fixes to the Code **and to this manual** are welcome!
 This manual is not yet completed.


### PR DESCRIPTION
Wrong dependency is named. You need package `make` not `mingw-w64-x86_64_make`. This is correctly stated in the azure config.