### PR TITLE
Improve format_diff_lines.pl utility script

### DIFF
--- a/azure-pipelines/util/format_diff_lines.pl
+++ b/azure-pipelines/util/format_diff_lines.pl
@@ -13,6 +13,20 @@ my @hunks;
 # Current file
 my $current_file;
 
+my @CLANG_FMT_CMDS = ("clang-format", "clang-format-8");
+my $clang_format_cmd = "";
+for my $c (@CLANG_FMT_CMDS) {
+	if (`$c --version`) {
+		$clang_format_cmd = $c;
+		last;
+	}
+}
+
+if ($clang_format_cmd eq "") {
+	printf "$0: clang-format not found\n";
+	exit 1;
+}
+
 # Push the pending hunks to the changed file table.
 sub push_changes {
 	if (scalar @hunks > 0) {
@@ -36,14 +50,18 @@ push_changes;
 
 # Now, run clang format on the changed lines.
 while (my ($file_name, $hunks_ref) = each %changed_files) {
+	my @ranges = ();
 	foreach my $hunk_ref (@{$hunks_ref}) {
 		my $start_pos = @{$hunk_ref}[0];
 		my $line_count = @{$hunk_ref}[1];
 		my $end_pos = $start_pos + $line_count - 1;
 		if ($line_count > 0) {
-			printf "Running clang-format-8 on %s, lines %i-%i\n", $file_name, $start_pos, $end_pos;
-			`clang-format-8 -i -style=file -lines=$start_pos:$end_pos $file_name`;
-			die "Failed to run clang-format-8: exit code $?" if $? != 0;
+			push @ranges, [$start_pos, $end_pos];
 		}
 	}
+	my $ranges_str = join(", ", map { "@{$_}[0]-@{$_}[1]" } @ranges);
+	my $lines_arg = join(" ", map { "-lines=@{$_}[0]:@{$_}[1]" } @ranges);
+	printf "Running $clang_format_cmd on %s, lines %s (inclusive)\n", $file_name, $ranges_str;
+	`$clang_format_cmd -i -style=file $lines_arg $file_name`;
+	die "Failed to run $clang_format_cmd: exit code $?" if $? != 0;
 }

--- a/azure-pipelines/util/sample.cpp
+++ b/azure-pipelines/util/sample.cpp
@@ -1,0 +1,28 @@
+void foo() {
+int bar;
+}
+
+class Hi
+{
+	Hi(
+		) : a(a), b(b)
+	{
+	}
+	int a;
+	int b; int c; int d;
+}
+	;
+
+
+void goodFormatting()
+{
+	int a = 0;
+	int b;
+	int c;
+	int d;
+	if (a) {
+		while (true) {
+			b = 1;
+		}
+	}
+}


### PR DESCRIPTION
* Now autodetects whether clang-format is called `clang-format` or `clang-format-8`
* Fixes an issue where irrelevant lines are formatted due to changed lines being formatted one-at-a-time. This should make the CI format checks way more reliable.

Merging in 3 days if there are no objections. A `sample.cpp` file is provided to demonstrate the changes; it will be removed in a rebase before merging. You can try out the new formatting logic by messing up the formatting on specific lines and then running
```bash
git --no-pager diff -U0 -- '*.cpp' | perl azure-pipelines/util/format_diff_lines.pl
````