### PR TITLE
Fix automatic releases by pushing tags

### DIFF
--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -1,7 +1,7 @@
 trigger:
   tags:
     include:
-      - '*'
+      - ?*.?*.?*
     exclude:
       - nightly
 schedules:
@@ -36,14 +36,14 @@ stages:
             name: 'VersionNightly'
             displayName: 'Set Version Information for Nightly'
             workingDirectory: ./build
-            condition: or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['runForRelease'], False)) # Run for scheduled (nightlies)
+            condition: or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['runForRelease'], 'False')) # Run for scheduled (nightlies)
           - bash: |
               VER=$(cat VERSION | sed '1q;d')
               echo "##vso[build.updatebuildnumber]${VER}"
             name: 'VersionRelease'
             displayName: 'Set Version Information for Release'
             workingDirectory: ./build
-            condition: and(ne(variables['Build.Reason'], 'Schedule'), ne(variables['runForRelease'], False)) # Run for non-scheduled (release)
+            condition: or(ne(variables['Build.Reason'], 'Schedule'), ne(variables['runForRelease'], 'False')) # Run for non-scheduled (release)
   - stage: Release
     jobs:
       - job: 'Ubuntu'


### PR DESCRIPTION
Fixed conditions and optimized tag matching for the Azure pipeline to push official releases via tags.
The new tag filter will take everything that starts with a version string or something resembling one. 

E.g. `1.0.1`, `1.0.1-alpha` but also `a.b.c` or `a-b.c.d` will trigger a release. Unfortunately a better trigger is not possible.

The releases will use the official git tag instead of using the generated version number from the CMakefile.