### PR TITLE
Fix segfault when pasting strokes (regression due to #1511)

### DIFF
--- a/src/model/Stroke.cpp
+++ b/src/model/Stroke.cpp
@@ -91,7 +91,7 @@ void Stroke::readSerialized(ObjectInputStream& in)
 	int count{};
 	in.readData((void**) &p, &count);
 	this->points = std::vector<Point>{p, p + count};
-	delete[] p;
+	g_free(p);
 	this->lineStyle.readSerialized(in);
 
 	in.endObject();


### PR DESCRIPTION
Fixes #1542. Temporary point array was allocated using `g_malloc` instead of `new`, and should be deallocated using `free` instead of `delete[]`.

Since this is a serious issue, I will merge by tomorrow at the latest.