### PR TITLE
Fix build configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,9 +61,6 @@ macro (add_includes_ldflags LDFLAGS INCLUDES)
     set (xournalpp_INCLUDE_DIRS ${xournalpp_INCLUDE_DIRS} "${INCLUDES}")
 endmacro (add_includes_ldflags LDFLAGS INCLUDES)
 
-find_package(CXX17 REQUIRED COMPONENTS optional)
-set(xournalpp_LDFLAGS ${xournalpp_LDFLAGS} cxx17)
-
 # libexec
 if (WIN32)
     set (xournalpp_LDFLAGS ${xournalpp_LDFLAGS} "-mwindows")

--- a/cmake/find/FindCXX17.cmake
+++ b/cmake/find/FindCXX17.cmake
@@ -23,13 +23,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED on)
 
 # Normalize and check the component list we were given
 set(want_components ${CXX17_FIND_COMPONENTS})
-if (CXX17_FIND_COMPONENTS STREQUAL "")
-#Nothing to do here
-endif ()
 
 # Warn on any unrecognized components
-if (NOT extra_components STREQUAL "")
-    set(extra_components ${want_components})
+if (extra_components)
     list(REMOVE_ITEM extra_components optional filesystem map)
     foreach (component IN LISTS extra_components)
         message(WARNING "Extraneous find_package component for Filesystem: ${component}")
@@ -63,13 +59,6 @@ if ("map" IN_LIST want_components)
     endif ()
 endif ()
 
-if (TARGET cxx17)
-    # This module has already been processed. Don't do it again.
-    return()
-endif ()
-
-add_library(cxx17 INTERFACE IMPORTED)
-target_compile_features(cxx17 INTERFACE cxx_std_17)
 set(_found TRUE)
 
 cmake_pop_check_state()

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -3,6 +3,4 @@ unset (util_SOURCES)
 file (GLOB_RECURSE util_SOURCES *.cpp)
 
 add_library (util STATIC ${util_SOURCES})
-find_package(CXX17 REQUIRED)
-target_link_libraries(util PRIVATE cxx17)
 target_compile_features(util PUBLIC ${PROJECT_CXX_FEATURES})


### PR DESCRIPTION
Fixes #1553 (tested on a Ubuntu 18.04 image on Docker).

Note that CI did not catch this issue because the "new toolchain" PPA was added before installing build dependencies.

`readme/LinuxBuild.md` will need to be updated to indicate the new dependency on a compiler that supports C++17.