### PR TITLE
Outsource Windows dependency creation to separate pipeline

### DIFF
--- a/azure-pipelines/CI.yml
+++ b/azure-pipelines/CI.yml
@@ -43,8 +43,8 @@ stages:
               build_type: 'Debug'
               cmake_flags: '-DCMAKE_DEBUG_INCLUDES_LDFLAGS=ON -DENABLE_CPPUNIT=ON -DDEBUG_COMPILE=ON'
           - script: |
-              set PATH=%PATH%;%CD:~0,2%\msys64\usr\bin;%CD:~0,2%\msys64\mingw64\bin"
-              %CD:~0,2%\msys64\usr\bin\bash -lc "CI=true ctest --verbose"
+              set PATH=%PATH%;C:\msys64\usr\bin;C:\msys64\mingw64\bin"
+              C:\msys64\usr\bin\bash -lc "CI=true ctest --verbose"
             workingDirectory: ./build
             env:
               MSYS2_ARCH: x86_64

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -98,8 +98,8 @@ stages:
               build_type: 'RelWithDebInfo'
               cmake_flags: ''
           - script: |
-              set PATH=%PATH%;%CD:~0,2%\msys64\usr\bin;%CD:~0,2%\msys64\mingw64\bin"
-              %CD:~0,2%\msys64\usr\bin\bash -lc "./build-setup.sh"
+              set PATH=%PATH%;C:\msys64\usr\bin;C:\msys64\mingw64\bin"
+              C:\msys64\usr\bin\bash -lc "./build-setup.sh"
             workingDirectory: ./windows-setup
             env:
               MSYS2_ARCH: x86_64

--- a/azure-pipelines/steps/build_windows.yml
+++ b/azure-pipelines/steps/build_windows.yml
@@ -5,56 +5,35 @@ parameters:
   cmake_flags: ''
 
 steps:
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      buildType: 'specific'
+      project: 'ce85de88-4b71-44a0-8a57-2707c0b9a6e7'
+      definition: '8'
+      buildVersionToDownload: 'latest'
+      targetPath: 'C:\'
+      artifact: 'msys'
+  - task: ExtractFiles@1
+    inputs:
+      archiveFilePatterns: 'C:\msys.7z'
+      destinationFolder: 'C:\'
+      cleanDestinationFolder: false
   - script: |
-      git clone https://github.com/msys2/msys2-ci-base.git %CD:~0,2%\msys64
-      %CD:~0,2%\msys64\usr\bin\rm -rf %CD:~0,2%\msys64\.git
-    displayName: 'Install MSYS2'
-  - script: |
-      set PATH=%CD:~0,2%\msys64\usr\bin;%CD:~0,2%\msys64\mingw64\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem
-      %CD:~0,2%\msys64\usr\bin\pacman --noconfirm -Syuu
-      %CD:~0,2%\msys64\usr\bin\pacman --noconfirm -Syuu
-      %CD:~0,2%\msys64\usr\bin\pacman --noconfirm -S mingw-w64-x86_64-toolchain mingw-w64-x86_64-cmake mingw-w64-x86_64-make mingw-w64-x86_64-ninja patch mingw-w64-x86_64-cppunit
-      %CD:~0,2%\msys64\usr\bin\pacman --noconfirm -S mingw-w64-x86_64-poppler mingw-w64-x86_64-gtk3 mingw-w64-x86_64-libsndfile mingw-w64-x86_64-libzip
-      %CD:~0,2%\msys64\usr\bin\pacman --noconfirm -Scc
-    env:
-      MSYS2_ARCH: x86_64
-      MSYSTEM: MINGW64
-      CHERE_INVOKING: yes
-    displayName: 'Install dependencies on Windows'
-  - script: |
-      set PATH=%PATH%;%CD:~0,2%\msys64\usr\bin;%CD:~0,2%\msys64\mingw64\bin"
-      %CD:~0,2%\msys64\usr\bin\bash -lc "./build-portaudio.sh"
-    workingDirectory: ./windows-setup
-    env:
-      MSYS2_ARCH: x86_64
-      MSYSTEM: MINGW64
-      CHERE_INVOKING: yes
-    displayName: 'Build Portaudio'
-  - script: |
-      set PATH=%PATH%;%CD:~0,2%\msys64\usr\bin;%CD:~0,2%\msys64\mingw64\bin"
-      %CD:~0,2%\msys64\usr\bin\bash -lc "./build-lua.sh"
-    workingDirectory: ./windows-setup
-    env:
-      MSYS2_ARCH: x86_64
-      MSYSTEM: MINGW64
-      CHERE_INVOKING: yes
-    displayName: 'Build Lua'
-  - script: |
-      set PATH=%PATH%;%CD:~0,2%\msys64\usr\bin;%CD:~0,2%\msys64\mingw64\bin"
-      %CD:~0,2%\msys64\usr\bin\bash -lc "mkdir build"
+      set PATH=%PATH%;C:\msys64\usr\bin;C:\msys64\mingw64\bin"
+      C:\msys64\usr\bin\bash -lc "mkdir build"
     env:
       MSYS2_ARCH: x86_64
       MSYSTEM: MINGW64
       CHERE_INVOKING: yes
     displayName: 'Create build directory'
   - script: |
-      set PATH=%PATH%;%CD:~0,2%\msys64\usr\bin;%CD:~0,2%\msys64\mingw64\bin"
-      %CD:~0,2%\msys64\usr\bin\bash -lc "cmake -GNinja .. -DCMAKE_BUILD_TYPE=${{ parameters.build_type}} ${{ parameters.cmake_flags }}"
-      # Make sure pot is up to date with sources (maybe translation pipeline is currently running)
-      %CD:~0,2%\msys64\usr\bin\bash -lc "cmake --build . --target pot"
-      %CD:~0,2%\msys64\usr\bin\bash -lc "cmake --build . --target translations"
-      # Build Xournal++
-      %CD:~0,2%\msys64\usr\bin\bash -lc "cmake --build ."
+      set PATH=%PATH%;C:\msys64\usr\bin;C:\msys64\mingw64\bin"
+      C:\msys64\usr\bin\bash -lc "cmake -GNinja .. -DCMAKE_BUILD_TYPE=${{ parameters.build_type}} ${{ parameters.cmake_flags }}"
+      rem Make sure pot is up to date with sources (maybe translation pipeline is currently running)
+      C:\msys64\usr\bin\bash -lc "cmake --build . --target pot"
+      C:\msys64\usr\bin\bash -lc "cmake --build . --target translations"
+      rem Build Xournal++
+      C:\msys64\usr\bin\bash -lc "cmake --build ."
     workingDirectory: ./build
     env:
       MSYS2_ARCH: x86_64

--- a/azure-pipelines/util/mingw-blob.yml
+++ b/azure-pipelines/util/mingw-blob.yml
@@ -1,0 +1,61 @@
+trigger:
+  branches:
+    include:
+    - master
+  paths:
+    include:
+    - windows-setup/build-*.sh
+    exclude:
+    - windows-setup/build-launcher.sh
+    - windows-setup/build-setup.sh
+pr: none
+
+pool:
+  vmImage: 'vs2017-win2016'
+        
+steps:
+- script: |
+    git clone https://github.com/msys2/msys2-ci-base.git C:\msys64
+    rm -rf C:\msys64\.git
+  displayName: 'Install MSYS2'
+- script: |
+    set PATH=C:\msys64\usr\bin;C:\msys64\mingw64\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem
+    pacman --noconfirm -Syuu
+    pacman --noconfirm -Syuu
+    pacman --noconfirm -S mingw-w64-x86_64-toolchain mingw-w64-x86_64-cmake mingw-w64-x86_64-make mingw-w64-x86_64-ninja patch mingw-w64-x86_64-cppunit
+    pacman --noconfirm -S mingw-w64-x86_64-poppler mingw-w64-x86_64-gtk3 mingw-w64-x86_64-libsndfile mingw-w64-x86_64-libzip
+    pacman --noconfirm -Scc
+  env:
+    MSYS2_ARCH: x86_64
+    MSYSTEM: MINGW64
+    CHERE_INVOKING: yes
+  displayName: 'Install dependencies on Windows'
+- script: |
+    set PATH=%PATH%;C:\msys64\usr\bin;C:\msys64\mingw64\bin"
+    C:\msys64\usr\bin\bash -lc "./build-portaudio.sh"
+  workingDirectory: ./windows-setup
+  env:
+    MSYS2_ARCH: x86_64
+    MSYSTEM: MINGW64
+    CHERE_INVOKING: yes
+  displayName: 'Build Portaudio'
+- script: |
+    set PATH=%PATH%;C:\msys64\usr\bin;C:\msys64\mingw64\bin"
+    C:\msys64\usr\bin\bash -lc "./build-lua.sh"
+  workingDirectory: ./windows-setup
+  env:
+    MSYS2_ARCH: x86_64
+    MSYSTEM: MINGW64
+    CHERE_INVOKING: yes
+  displayName: 'Build Lua'
+- task: ArchiveFiles@2
+  inputs:
+    rootFolderOrFile: 'C:\msys64'
+    includeRootFolder: true
+    archiveType: '7z'
+    archiveFile: '$(Build.ArtifactStagingDirectory)/msys.7z'
+    replaceExistingArchive: true
+- task: PublishPipelineArtifact@1
+  inputs:
+    targetPath: '$(Build.ArtifactStagingDirectory)/msys.7z'
+    artifact: 'msys'


### PR DESCRIPTION
Building of the Windows dependencies is now outsourced to a separate pipeline saving three minutes of buildtime for CI and release jobs.