### PR TITLE
Fixed misspelling of openSUSE and SUSE.

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ sudo apt update
 sudo apt install xournalpp
 ```
 
-### OpenSuse
+### openSUSE
 On openSUSE Tumbleweed, the released version of xournalpp is available from the main repository:
 ```bash
 sudo zypper in xournalpp

--- a/desktop/com.github.xournalpp.xournalpp.appdata.xml
+++ b/desktop/com.github.xournalpp.xournalpp.appdata.xml
@@ -16,7 +16,7 @@
     Xournal++ is a hand note taking software written in C++ with the target of
     flexibility, functionality and speed. Stroke recognizer and other parts are
     based on Xournal Code, which you can find at sourceforge. It supports Linux
-    (e.g. Ubuntu, Debian, Arch, Suse), macOS and Windows 10. Supports pen input
+    (e.g. Ubuntu, Debian, Arch, SUSE), macOS and Windows 10. Supports pen input
     from devices such as Wacom Tablets.
    </p>
    <p>Xournal++ features:</p>

--- a/readme/LinuxBuild.md
+++ b/readme/LinuxBuild.md
@@ -39,7 +39,7 @@ sudo apt-get install cmake libgtk-3-dev libpoppler-glib-dev portaudio19-dev libs
 libcppunit-dev dvipng texlive libxml2-dev liblua5.3-dev libzip-dev
 ````
 
-#### For OpenSuse:
+#### For openSUSE:
 ```bash
 sudo zypper install cmake gtk3-devel cppunit-devel portaudio-devel libsndfile-devel \
 texlive-dvipng texlive libxml2-devel libpoppler-glib-devel libzip-devel


### PR DESCRIPTION
The correct spelling of openSUSE can be checked on https://en.opensuse.org/Portal:Distribution and of SUSE on https://www.suse.com.