### PR TITLE
Fix textbox issues when exporting pdf

### DIFF
--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -2700,11 +2700,13 @@ void Control::updateWindowTitle()
 
 void Control::exportAsPdf()
 {
+	this->clearSelectionEndText();
 	exportBase(new PdfExportJob(this));
 }
 
 void Control::exportAs()
 {
+	this->clearSelectionEndText();
 	exportBase(new CustomExportJob(this));
 }
 


### PR DESCRIPTION
Fixes #1341, now calls `this->clearSelectionEndText();` before exporting a document. Tested in my local environment (Kubuntu 19.04) and works correctly.