### PR TITLE
Make sure translations are built before installation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -94,6 +94,7 @@ add_executable (xournalpp
 add_dependencies (xournalpp
   xournalpp-core
   util
+  translations
 )
 
 target_link_libraries (xournalpp ${xournalpp_LDFLAGS})


### PR DESCRIPTION
Fixes the following issue in a clean checkout when trying to `make install`:

```
CMake Error at po/cmake_install.cmake:41 (file):
  file INSTALL cannot find
  ".../xournalpp/craftbuild/cmake-build/po/cs.gmo".
Call Stack (most recent call first):
  cmake_install.cmake:102 (include)
```

I've discovered this bug while building a new AppImage for the last release only. I'm not sure if the dependency on the main binary makes too much sense, but on the other hand that's where the translations are needed. Please feel free to change the dependency to some other target if you think that's more suitable.