### PR TITLE
Apply clang tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,5 @@
 Checks: "*,\
+-readability-identifier-naming,\
 -misc-unused-parameters,\
 -cppcoreguidelines-pro-type-union-access,\
 -clang-analyzer-alpha*,\

--- a/src/control/AudioController.cpp
+++ b/src/control/AudioController.cpp
@@ -144,7 +144,7 @@ auto AudioController::getAudioFolder() -> Path
 	return Path::fromUri(af);
 }
 
-auto AudioController::getStartTime() -> size_t
+auto AudioController::getStartTime() const -> size_t
 {
 	return this->timestamp;
 }

--- a/src/control/AudioController.cpp
+++ b/src/control/AudioController.cpp
@@ -32,7 +32,7 @@ auto AudioController::startRecording() -> bool
 
 		this->timestamp = static_cast<size_t>(g_get_monotonic_time() / 1000);
 
-		std::array<char, 50> buffer;
+		std::array<char, 50> buffer{};
 		time_t secs = time(nullptr);
 		tm* t = localtime(&secs);
 		// This prints the date and time in ISO format.

--- a/src/control/AudioController.h
+++ b/src/control/AudioController.h
@@ -40,7 +40,7 @@ public:
 
 	string getAudioFilename();
 	Path getAudioFolder();
-	size_t getStartTime();
+	size_t getStartTime() const;
 	vector<DeviceInfo> getOutputDevices();
 	vector<DeviceInfo> getInputDevices();
 

--- a/src/control/ClipboardHandler.cpp
+++ b/src/control/ClipboardHandler.cpp
@@ -175,7 +175,7 @@ auto ClipboardHandler::copy() -> bool
 		}
 	}
 
-	string text = text;
+	string text{};
 	for (GList* l = textElements; l != nullptr; l = l->next)
 	{
 		Text* e = static_cast<Text*>(l->data);

--- a/src/control/ClipboardHandler.cpp
+++ b/src/control/ClipboardHandler.cpp
@@ -26,7 +26,7 @@ ClipboardHandler::ClipboardHandler(ClipboardListener* listener, GtkWidget* widge
 	this->listener->clipboardCutCopyEnabled(false);
 
 	gtk_clipboard_request_contents(clipboard, gdk_atom_intern_static_string("TARGETS"),
-								   (GtkClipboardReceivedFunc) receivedClipboardContents, this);
+	                               reinterpret_cast<GtkClipboardReceivedFunc>(receivedClipboardContents), this);
 }
 
 ClipboardHandler::~ClipboardHandler()
@@ -41,19 +41,19 @@ auto ClipboardHandler::paste() -> bool
 	if (this->containsXournal)
 	{
 		gtk_clipboard_request_contents(this->clipboard, atomXournal,
-									   (GtkClipboardReceivedFunc) pasteClipboardContents, this);
+		                               reinterpret_cast<GtkClipboardReceivedFunc>(pasteClipboardContents), this);
 		return true;
 	}
 	else if (this->containsText)
 	{
-		gtk_clipboard_request_text(this->clipboard,
-		                           (GtkClipboardTextReceivedFunc) pasteClipboardText, this);
+		gtk_clipboard_request_text(this->clipboard, reinterpret_cast<GtkClipboardTextReceivedFunc>(pasteClipboardText),
+		                           this);
 		return true;
 	}
 	else if (this->containsImage)
 	{
 		gtk_clipboard_request_image(this->clipboard,
-									(GtkClipboardImageReceivedFunc) pasteClipboardImage, this);
+		                            reinterpret_cast<GtkClipboardImageReceivedFunc>(pasteClipboardImage), this);
 		return true;
 	}
 
@@ -122,7 +122,8 @@ public:
 		}
 		else if (atomXournal == target)
 		{
-			gtk_selection_data_set(selection, target, 8, (guchar*) contents->str->str, contents->str->len);
+			gtk_selection_data_set(selection, target, 8, reinterpret_cast<guchar*>(contents->str->str),
+			                       contents->str->len);
 		}
 	}
 
@@ -140,7 +141,7 @@ private:
 
 static auto svgWriteFunction(GString* string, const unsigned char* data, unsigned int length) -> cairo_status_t
 {
-	g_string_append_len(string, (const gchar*) data, length);
+	g_string_append_len(string, reinterpret_cast<const gchar*>(data), length);
 	return CAIRO_STATUS_SUCCESS;
 }
 
@@ -171,14 +172,14 @@ auto ClipboardHandler::copy() -> bool
 	{
 		if (e->getType() == ELEMENT_TEXT)
 		{
-			textElements = g_list_insert_sorted(textElements, e, (GCompareFunc) ElementCompareFunc);
+			textElements = g_list_insert_sorted(textElements, e, reinterpret_cast<GCompareFunc>(ElementCompareFunc));
 		}
 	}
 
 	string text = "";
 	for (GList* l = textElements; l != nullptr; l = l->next)
 	{
-		Text* e = (Text*) l->data;
+		Text* e = static_cast<Text*>(l->data);
 		if (text != "")
 		{
 			text += "\n";
@@ -216,10 +217,9 @@ auto ClipboardHandler::copy() -> bool
 
 	GString* svgString = g_string_sized_new(1048576); // 1MB
 
-	cairo_surface_t* surfaceSVG = cairo_svg_surface_create_for_stream(
-									(cairo_write_func_t) svgWriteFunction, svgString,
-									selection->getWidth(), selection->getHeight()
-									);
+	cairo_surface_t* surfaceSVG =
+	        cairo_svg_surface_create_for_stream(reinterpret_cast<cairo_write_func_t>(svgWriteFunction), svgString,
+	                                            selection->getWidth(), selection->getHeight());
 	cairo_t* crSVG = cairo_create(surfaceSVG);
 
 	view.drawSelection(crSVG, this->selection);
@@ -251,8 +251,8 @@ auto ClipboardHandler::copy() -> bool
 	auto* contents = new ClipboardContents(text, image, svgString->str, out.getStr());
 
 	gtk_clipboard_set_with_data(this->clipboard, targets, n_targets,
-								(GtkClipboardGetFunc) ClipboardContents::getFunction,
-								(GtkClipboardClearFunc) ClipboardContents::clearFunction, contents);
+	                            reinterpret_cast<GtkClipboardGetFunc>(ClipboardContents::getFunction),
+	                            reinterpret_cast<GtkClipboardClearFunc>(ClipboardContents::clearFunction), contents);
 	gtk_clipboard_set_can_store(this->clipboard, nullptr, 0);
 
 	gtk_target_table_free(targets, n_targets);
@@ -292,9 +292,8 @@ void ClipboardHandler::ownerChangedCallback(GtkClipboard* clip, GdkEvent* event,
 
 void ClipboardHandler::clipboardUpdated(GdkAtom atom)
 {
-	gtk_clipboard_request_contents(clipboard,
-								   gdk_atom_intern_static_string("TARGETS"),
-								   (GtkClipboardReceivedFunc) receivedClipboardContents, this);
+	gtk_clipboard_request_contents(clipboard, gdk_atom_intern_static_string("TARGETS"),
+	                               reinterpret_cast<GtkClipboardReceivedFunc>(receivedClipboardContents), this);
 }
 
 void ClipboardHandler::pasteClipboardImage(GtkClipboard* clipboard, GdkPixbuf* pixbuf, ClipboardHandler* handler)
@@ -307,7 +306,8 @@ void ClipboardHandler::pasteClipboardContents(GtkClipboard* clipboard, GtkSelect
 {
 	ObjectInputStream in;
 
-	if (in.read((const char*) gtk_selection_data_get_data(selectionData), gtk_selection_data_get_length(selectionData)))
+	if (in.read(reinterpret_cast<const char*>(gtk_selection_data_get_data(selectionData)),
+	            gtk_selection_data_get_length(selectionData)))
 	{
 		handler->listener->clipboardPasteXournal(in);
 	}

--- a/src/control/ClipboardHandler.cpp
+++ b/src/control/ClipboardHandler.cpp
@@ -44,13 +44,13 @@ auto ClipboardHandler::paste() -> bool
 		                               reinterpret_cast<GtkClipboardReceivedFunc>(pasteClipboardContents), this);
 		return true;
 	}
-	else if (this->containsText)
+	if (this->containsText)
 	{
 		gtk_clipboard_request_text(this->clipboard, reinterpret_cast<GtkClipboardTextReceivedFunc>(pasteClipboardText),
 		                           this);
 		return true;
 	}
-	else if (this->containsImage)
+	if (this->containsImage)
 	{
 		gtk_clipboard_request_image(this->clipboard,
 		                            reinterpret_cast<GtkClipboardImageReceivedFunc>(pasteClipboardImage), this);
@@ -98,7 +98,6 @@ public:
 		g_string_free(this->str, true);
 	}
 
-public:
 
 	static void getFunction(GtkClipboard* clipboard, GtkSelectionData* selection,
 							guint info, ClipboardContents* contents)
@@ -176,11 +175,11 @@ auto ClipboardHandler::copy() -> bool
 		}
 	}
 
-	string text = "";
+	string text = text;
 	for (GList* l = textElements; l != nullptr; l = l->next)
 	{
 		Text* e = static_cast<Text*>(l->data);
-		if (text != "")
+		if (!text.empty())
 		{
 			text += "\n";
 		}

--- a/src/control/ClipboardHandler.cpp
+++ b/src/control/ClipboardHandler.cpp
@@ -232,8 +232,8 @@ auto ClipboardHandler::copy() -> bool
 	/////////////////////////////////////////////////////////////////
 
 	GtkTargetList* list = gtk_target_list_new(nullptr, 0);
-	GtkTargetEntry* targets;
-	int n_targets;
+	GtkTargetEntry* targets = nullptr;
+	int n_targets = 0;
 
 	// if we have text elements...
 	if (!text.empty())
@@ -324,8 +324,8 @@ void ClipboardHandler::pasteClipboardText(GtkClipboard* clipboard, const gchar* 
 
 auto gtk_selection_data_targets_include_xournal(GtkSelectionData* selection_data) -> gboolean
 {
-	GdkAtom* targets;
-	gint n_targets;
+	GdkAtom* targets = nullptr;
+	gint n_targets = 0;
 	gboolean result = false;
 
 	if (gtk_selection_data_get_targets(selection_data, &targets, &n_targets))

--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -380,10 +380,10 @@ auto Control::autosaveCallback(Control* control) -> bool
 		// do nothing, nothing changed
 		return true;
 	}
-	else
-	{
-		g_message("Info: autosave document...");
-	}
+
+
+	    g_message("Info: autosave document...");
+
 
 	auto* job = new AutosaveJob(control);
 	control->scheduler->addJob(job, JOB_PRIORITY_NONE);
@@ -971,7 +971,7 @@ void Control::actionPerformed(ActionType type, ActionGroup group, GdkEvent* even
 
 	case ACTION_AUDIO_RECORD:
 	{
-		bool result = 0;
+		bool result = false;
 		if (enabled)
 		{
 			result = audioController->startRecording();
@@ -1242,7 +1242,7 @@ auto Control::isInDragAndDropToolbar() -> bool
 
 void Control::setShapeTool(ActionType type, bool enabled)
 {
-	if (enabled == false)
+	if (!enabled)
 	{
 		// Disable all entries
 		this->toolHandler->setDrawingType(DRAWING_TYPE_DEFAULT);
@@ -1313,7 +1313,7 @@ void Control::disableSidebarTmp(bool disabled)
 
 void Control::addDefaultPage(string pageTemplate)
 {
-	if (pageTemplate == "")
+	if (pageTemplate.empty())
 	{
 		pageTemplate = settings->getPageTemplate();
 	}
@@ -1476,7 +1476,7 @@ void Control::paperFormat()
 	if (width > 0)
 	{
 		this->doc->lock();
-		this->doc->setPageSize(page, width, height);
+		Document::setPageSize(page, width, height);
 		this->doc->unlock();
 	}
 
@@ -2301,9 +2301,9 @@ auto Control::openFile(Path filename, int scrollToPage, bool forceOpen) -> bool
 		fileLoaded(scrollToPage);
 		return false;
 	}
-	else
-	{
-		this->closeDocument();
+
+
+	    this->closeDocument();
 
 		this->doc->lock();
 		this->doc->clearDocument();
@@ -2314,7 +2314,7 @@ auto Control::openFile(Path filename, int scrollToPage, bool forceOpen) -> bool
 		// This is important because of the new .xopp format, where Xournal .xoj handled as import,
 		// not as file to load
 		settings->setLastSavePath(filename.getParentPath());
-	}
+
 
 	fileLoaded(scrollToPage);
 	return true;
@@ -2388,7 +2388,7 @@ void Control::fileLoaded(int scrollToPage)
 		}
 
 		loadMetadata(md);
-		recent->addRecentFileFilename(file);
+		RecentManager::addRecentFileFilename(file);
 	}
 	else
 	{
@@ -2477,7 +2477,7 @@ auto Control::annotatePdf(Path filename, bool attachPdf, bool attachToDocument) 
 
 	if (res)
 	{
-		this->recent->addRecentFileFilename(filename.c_str());
+		RecentManager::addRecentFileFilename(filename.c_str());
 
 		this->doc->lock();
 		Path file = this->doc->getEvMetadataFilename();
@@ -2665,7 +2665,7 @@ auto Control::showSaveDialog() -> bool
 
 void Control::updateWindowTitle()
 {
-	string title = "";
+	string title = title;
 
 	this->doc->lock();
 	if (doc->getFilename().isEmpty())
@@ -2752,7 +2752,7 @@ void Control::resetSavedStatus()
 	this->doc->unlock();
 
 	this->undoRedo->documentSaved();
-	this->recent->addRecentFileFilename(filename);
+	RecentManager::addRecentFileFilename(filename);
 	this->updateWindowTitle();
 }
 

--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -971,7 +971,7 @@ void Control::actionPerformed(ActionType type, ActionGroup group, GdkEvent* even
 
 	case ACTION_AUDIO_RECORD:
 	{
-		bool result;
+		bool result = 0;
 		if (enabled)
 		{
 			result = audioController->startRecording();
@@ -1593,7 +1593,7 @@ void Control::setViewColumns(int numColumns)
 	settings->setViewColumns(numColumns);
 	settings->setViewFixedRows(false);
 
-	ActionType action;
+	ActionType action{};
 
 	switch (numColumns)
 	{
@@ -1637,7 +1637,7 @@ void Control::setViewRows(int numRows)
 	settings->setViewRows(numRows);
 	settings->setViewFixedRows(true);
 
-	ActionType action;
+	ActionType action{};
 
 	switch (numRows)
 	{
@@ -1680,7 +1680,7 @@ void Control::setViewLayoutVert(bool vert)
 {
 	settings->setViewLayoutVert(vert);
 
-	ActionType action;
+	ActionType action{};
 
 	if (vert)
 	{
@@ -1702,7 +1702,7 @@ void Control::setViewLayoutR2L(bool r2l)
 {
 	settings->setViewLayoutR2L(r2l);
 
-	ActionType action;
+	ActionType action{};
 
 	if (r2l)
 	{
@@ -1724,7 +1724,7 @@ void Control::setViewLayoutB2T(bool b2t)
 {
 	settings->setViewLayoutB2T(b2t);
 
-	ActionType action;
+	ActionType action{};
 
 	if (b2t)
 	{
@@ -2405,7 +2405,7 @@ void Control::fileLoaded(int scrollToPage)
 class MetadataCallbackData
 {
 public:
-	Control* ctrl;
+	Control* ctrl{};
 	MetadataEntry md;
 };
 

--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -382,7 +382,7 @@ auto Control::autosaveCallback(Control* control) -> bool
 	}
 
 
-	    g_message("Info: autosave document...");
+	g_message("Info: autosave document...");
 
 
 	auto* job = new AutosaveJob(control);
@@ -2303,17 +2303,17 @@ auto Control::openFile(Path filename, int scrollToPage, bool forceOpen) -> bool
 	}
 
 
-	    this->closeDocument();
+	this->closeDocument();
 
-		this->doc->lock();
-		this->doc->clearDocument();
-		*this->doc = *loadedDocument;
-		this->doc->unlock();
+	this->doc->lock();
+	this->doc->clearDocument();
+	*this->doc = *loadedDocument;
+	this->doc->unlock();
 
-		// Set folder as last save path, so the next save will be at the current document location
-		// This is important because of the new .xopp format, where Xournal .xoj handled as import,
-		// not as file to load
-		settings->setLastSavePath(filename.getParentPath());
+	// Set folder as last save path, so the next save will be at the current document location
+	// This is important because of the new .xopp format, where Xournal .xoj handled as import,
+	// not as file to load
+	settings->setLastSavePath(filename.getParentPath());
 
 
 	fileLoaded(scrollToPage);

--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -122,7 +122,7 @@ Control::Control(GladeSearchpath* gladeSearchPath)
 	/**
 	 * This is needed to update the previews
 	 */
-	this->changeTimout = g_timeout_add_seconds(5, (GSourceFunc) checkChangedDocument, this);
+	this->changeTimout = g_timeout_add_seconds(5, reinterpret_cast<GSourceFunc>(checkChangedDocument), this);
 
 	this->pageBackgroundChangeController = new PageBackgroundChangeController(this);
 
@@ -403,7 +403,7 @@ void Control::enableAutosave(bool enable)
 	if (enable)
 	{
 		int timeout = settings->getAutosaveTimeout() * 60;
-		this->autosaveTimeout = g_timeout_add_seconds(timeout, (GSourceFunc) autosaveCallback, this);
+		this->autosaveTimeout = g_timeout_add_seconds(timeout, reinterpret_cast<GSourceFunc>(autosaveCallback), this);
 	}
 }
 
@@ -984,7 +984,7 @@ void Control::actionPerformed(ActionType type, ActionGroup group, GdkEvent* even
 		if (!result)
 		{
 			Util::execInUiThread([=]() {
-				gtk_toggle_tool_button_set_active((GtkToggleToolButton*) toolbutton, !enabled);
+				gtk_toggle_tool_button_set_active(reinterpret_cast<GtkToggleToolButton*>(toolbutton), !enabled);
 				string msg = _("Recorder could not be started.");
 				g_warning("%s", msg.c_str());
 				XojMsgBox::showErrorToUser(Control::getGtkWindow(), msg);
@@ -1056,7 +1056,7 @@ void Control::actionPerformed(ActionType type, ActionGroup group, GdkEvent* even
 
 	if (type >= ACTION_TOOL_PEN && type <= ACTION_TOOL_HAND)
 	{
-		auto at = (ActionType)(toolHandler->getToolType() - TOOL_PEN + ACTION_TOOL_PEN);
+		auto at = static_cast<ActionType>(toolHandler->getToolType() - TOOL_PEN + ACTION_TOOL_PEN);
 		if (type == at && !enabled)
 		{
 			fireActionSelected(GROUP_TOOL, at);
@@ -1848,7 +1848,7 @@ void Control::toolChanged()
 	ToolType type = toolHandler->getToolType();
 
 	// Convert enum values, enums has to be in the same order!
-	auto at = (ActionType)(type - TOOL_PEN + ACTION_TOOL_PEN);
+	auto at = static_cast<ActionType>(type - TOOL_PEN + ACTION_TOOL_PEN);
 
 	fireActionSelected(GROUP_TOOL, at);
 
@@ -2448,7 +2448,7 @@ void Control::loadMetadata(MetadataEntry md)
 	data->md = std::move(md);
 	data->ctrl = this;
 
-	g_idle_add((GSourceFunc) loadMetadataCallback, data);
+	g_idle_add(reinterpret_cast<GSourceFunc>(loadMetadataCallback), data);
 }
 
 auto Control::annotatePdf(Path filename, bool attachPdf, bool attachToDocument) -> bool
@@ -3161,7 +3161,7 @@ void Control::setLineStyle(const string& style)
 		sel = this->win->getXournal()->getSelection();
 	}
 
-	// TODO allow to change selection
+	// TODO(fabian): allow to change selection
 	if (sel)
 	{
 		//		UndoAction* undo = sel->setSize(size, toolHandler->getToolThickness(TOOL_PEN),

--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -2665,7 +2665,7 @@ auto Control::showSaveDialog() -> bool
 
 void Control::updateWindowTitle()
 {
-	string title = title;
+	string title{};
 
 	this->doc->lock();
 	if (doc->getFilename().isEmpty())

--- a/src/control/FullscreenHandler.cpp
+++ b/src/control/FullscreenHandler.cpp
@@ -5,7 +5,6 @@
 
 #include <StringUtils.h>
 
-auto gtk_invisible_new() -> GtkWidget*;
 
 FullscreenHandler::FullscreenHandler(Settings* settings)
  : settings(settings)
@@ -14,7 +13,7 @@ FullscreenHandler::FullscreenHandler(Settings* settings)
 
 FullscreenHandler::~FullscreenHandler() = default;
 
-auto FullscreenHandler::isFullscreen() -> bool
+auto FullscreenHandler::isFullscreen() const -> bool
 {
 	return this->fullscreen;
 }
@@ -61,8 +60,6 @@ void FullscreenHandler::hideWidget(MainWindow* win, const string& widgetName)
 
 		return;
 	}
-
-	return;
 }
 
 void FullscreenHandler::enableFullscreen(MainWindow* win)

--- a/src/control/FullscreenHandler.cpp
+++ b/src/control/FullscreenHandler.cpp
@@ -193,8 +193,8 @@ auto gtk_invisible_get_type() -> GType
 		        // value table
 		        (const GTypeValueTable*) nullptr};
 
-		gtk_invisible_menu_type = g_type_register_static(
-		        GTK_TYPE_FIXED, "GtkInvisibleMenu", &gtk_inivisible_menu_info, static_cast<GTypeFlags>(0));
+		gtk_invisible_menu_type = g_type_register_static(GTK_TYPE_FIXED, "GtkInvisibleMenu", &gtk_inivisible_menu_info,
+		                                                 static_cast<GTypeFlags>(0));
 	}
 
 	return gtk_invisible_menu_type;

--- a/src/control/FullscreenHandler.cpp
+++ b/src/control/FullscreenHandler.cpp
@@ -175,30 +175,29 @@ auto gtk_invisible_get_type() -> GType
 
 	if (!gtk_invisible_menu_type)
 	{
-		static const GTypeInfo gtk_inivisible_menu_info = {sizeof(GtkInvisibleMenuClass),
-		                                                   // base initialize
-		                                                   nullptr,
-		                                                   // base finalize
-		                                                   nullptr,
-		                                                   // class initialize
-		                                                   (GClassInitFunc) gtk_invisible_menu_class_init,
-		                                                   // class finalize
-		                                                   nullptr,
-		                                                   // class data,
-		                                                   nullptr,
-		                                                   // instance size
-		                                                   sizeof(GtkInvisibleMenu),
-		                                                   // n_preallocs
-		                                                   0,
-		                                                   // instance init
-		                                                   nullptr,
-		                                                   // value table
-		                                                   (const GTypeValueTable*) nullptr};
+		static const GTypeInfo gtk_inivisible_menu_info = {
+		        sizeof(GtkInvisibleMenuClass),
+		        // base initialize
+		        nullptr,
+		        // base finalize
+		        nullptr,
+		        // class initialize
+		        reinterpret_cast<GClassInitFunc>(gtk_invisible_menu_class_init),
+		        // class finalize
+		        nullptr,
+		        // class data,
+		        nullptr,
+		        // instance size
+		        sizeof(GtkInvisibleMenu),
+		        // n_preallocs
+		        0,
+		        // instance init
+		        nullptr,
+		        // value table
+		        (const GTypeValueTable*) nullptr};
 
-		gtk_invisible_menu_type = g_type_register_static(GTK_TYPE_FIXED,
-		                                          "GtkInvisibleMenu",
-		                                          &gtk_inivisible_menu_info,
-		                                          (GTypeFlags) 0);
+		gtk_invisible_menu_type = g_type_register_static(
+		        GTK_TYPE_FIXED, "GtkInvisibleMenu", &gtk_inivisible_menu_info, static_cast<GTypeFlags>(0));
 	}
 
 	return gtk_invisible_menu_type;

--- a/src/control/FullscreenHandler.h
+++ b/src/control/FullscreenHandler.h
@@ -25,7 +25,7 @@ public:
 	virtual ~FullscreenHandler();
 
 public:
-	bool isFullscreen();
+	bool isFullscreen() const;
 	void setFullscreen(MainWindow* win, bool enabled);
 
 private:

--- a/src/control/LatexController.cpp
+++ b/src/control/LatexController.cpp
@@ -101,7 +101,7 @@ auto LatexController::findTexDependencies() -> LatexController::FindDependencySt
 		string msg = _("Could not find kpsewhich in PATH; please install kpsewhich and put it on path.");
 		return LatexController::FindDependencyStatus(false, msg);
 	}
-	else if (kpsewhichStatus != 0)
+	if (kpsewhichStatus != 0)
 	{
 		string msg = FS(_F("Could not find the LaTeX package 'standalone'.\nPlease install standalone (found in texlive-latex-extra) and make sure "
 		                   "it's accessible by your LaTeX installation."));
@@ -255,7 +255,7 @@ auto LatexController::showTexEditDialog() -> string
 
 	string result = this->dlg.getFinalTex();
 	// If the user cancelled, there is no change in the latex string.
-	result = result == "" ? initialTex : result;
+	result = result.empty() ? initialTex : result;
 	return result;
 }
 
@@ -374,7 +374,7 @@ void LatexController::deleteOldImage()
 	}
 }
 
-auto LatexController::convertDocumentToImage(PopplerDocument* doc, string formula) -> std::unique_ptr<TexImage>
+auto LatexController::convertDocumentToImage(PopplerDocument* doc, string formula) const -> std::unique_ptr<TexImage>
 {
 	if (poppler_document_get_n_pages(doc) < 1)
 	{

--- a/src/control/LatexController.cpp
+++ b/src/control/LatexController.cpp
@@ -84,7 +84,7 @@ auto LatexController::findTexDependencies() -> LatexController::FindDependencySt
 	static gchar* kpsewhichArgs[] = {g_strdup("kpsewhich"), g_strdup("standalone"), nullptr};
 	auto kpsewhichFlags = GSpawnFlags(G_SPAWN_DEFAULT | G_SPAWN_SEARCH_PATH | G_SPAWN_STDOUT_TO_DEV_NULL);
 	GError* kpsewhichErr = nullptr;
-	gint kpsewhichStatus;
+	gint kpsewhichStatus = 0;
 	g_spawn_sync(nullptr,
 	             kpsewhichArgs,
 	             nullptr,

--- a/src/control/LatexController.h
+++ b/src/control/LatexController.h
@@ -120,7 +120,7 @@ private:
 	 * Convert the given PDF Document to a TexImage and set the formula to the
 	 * given formula.
 	 */
-	std::unique_ptr<TexImage> convertDocumentToImage(PopplerDocument* doc, string formula);
+	std::unique_ptr<TexImage> convertDocumentToImage(PopplerDocument* doc, string formula) const;
 
 	/**
 	 * Load the preview PDF from disk and create a TexImage object.

--- a/src/control/PageBackgroundChangeController.cpp
+++ b/src/control/PageBackgroundChangeController.cpp
@@ -221,7 +221,7 @@ auto PageBackgroundChangeController::applyPdfBackground(PageRef page) -> bool
 	int selected = dlg->getSelectedPage();
 	delete dlg;
 
-	if (selected >= 0 && selected < (int) doc->getPdfPageCount())
+	if (selected >= 0 && selected < static_cast<int>(doc->getPdfPageCount()))
 	{
 		// no need to set a type, if we set the page number the type is also set
 		page->setBackgroundPdfPageNr(selected);

--- a/src/control/PageBackgroundChangeController.cpp
+++ b/src/control/PageBackgroundChangeController.cpp
@@ -149,15 +149,15 @@ auto PageBackgroundChangeController::applyImageBackground(PageRef page) -> bool
 			// The user canceled
 			return false;
 		}
-		else
-		{
-			char* name = g_file_get_path(file);
+
+
+		    char* name = g_file_get_path(file);
 			filename = name;
 			g_free(name);
 			name = nullptr;
 			g_object_unref(file);
 			file = nullptr;
-		}
+
 
 		BackgroundImage newImg;
 		GError* err = nullptr;
@@ -170,11 +170,10 @@ auto PageBackgroundChangeController::applyImageBackground(PageRef page) -> bool
 			g_error_free(err);
 			return false;
 		}
-		else
-		{
-			page->setBackgroundImage(newImg);
+
+
+		    page->setBackgroundImage(newImg);
 			page->setBackgroundType(PageType(PageTypeFormat::Image));
-		}
 	}
 
 	// Apply correct page size
@@ -238,21 +237,20 @@ auto PageBackgroundChangeController::applyPdfBackground(PageRef page) -> bool
  *
  * @return true on success, false if the user cancels
  */
-auto PageBackgroundChangeController::applyPageBackground(PageRef page, PageType pt) -> bool
+auto PageBackgroundChangeController::applyPageBackground(PageRef page, const PageType& pt) -> bool
 {
 	if (pt.isPdfPage())
 	{
 		return applyPdfBackground(page);
 	}
-	else if (pt.isImagePage())
+	if (pt.isImagePage())
 	{
 		return applyImageBackground(page);
 	}
-	else
-	{
-		page->setBackgroundType(pt);
+
+
+	    page->setBackgroundType(pt);
 		return true;
-	}
 }
 
 /**

--- a/src/control/PageBackgroundChangeController.cpp
+++ b/src/control/PageBackgroundChangeController.cpp
@@ -151,12 +151,12 @@ auto PageBackgroundChangeController::applyImageBackground(PageRef page) -> bool
 		}
 
 
-		    char* name = g_file_get_path(file);
-			filename = name;
-			g_free(name);
-			name = nullptr;
-			g_object_unref(file);
-			file = nullptr;
+		char* name = g_file_get_path(file);
+		filename = name;
+		g_free(name);
+		name = nullptr;
+		g_object_unref(file);
+		file = nullptr;
 
 
 		BackgroundImage newImg;
@@ -172,8 +172,8 @@ auto PageBackgroundChangeController::applyImageBackground(PageRef page) -> bool
 		}
 
 
-		    page->setBackgroundImage(newImg);
-			page->setBackgroundType(PageType(PageTypeFormat::Image));
+		page->setBackgroundImage(newImg);
+		page->setBackgroundType(PageType(PageTypeFormat::Image));
 	}
 
 	// Apply correct page size
@@ -249,8 +249,8 @@ auto PageBackgroundChangeController::applyPageBackground(PageRef page, const Pag
 	}
 
 
-	    page->setBackgroundType(pt);
-		return true;
+	page->setBackgroundType(pt);
+	return true;
 }
 
 /**

--- a/src/control/PageBackgroundChangeController.h
+++ b/src/control/PageBackgroundChangeController.h
@@ -53,14 +53,14 @@ private:
 	/**
 	 * Copy the background from source to target
 	 */
-	void copyBackgroundFromOtherPage(PageRef target, PageRef source);
+	static void copyBackgroundFromOtherPage(PageRef target, PageRef source);
 
 	/**
 	 * Apply the background to the page, asks for PDF Page or Image, if needed
 	 *
 	 * @return true on success, false if the user cancels
 	 */
-	bool applyPageBackground(PageRef page, PageType pt);
+	bool applyPageBackground(PageRef page, const PageType& pt);
 
 	/**
 	 * Apply a new PDF Background, asks the user which page should be selected

--- a/src/control/PdfCache.h
+++ b/src/control/PdfCache.h
@@ -40,7 +40,7 @@ private:
 	void cache(XojPdfPageSPtr popplerPage, cairo_surface_t* img);
 
 private:
-	GMutex renderMutex;
+	GMutex renderMutex{};
 
 	list<PdfCacheEntry*> data;
 	list<PdfCacheEntry*>::size_type size = 0;

--- a/src/control/RecentManager.cpp
+++ b/src/control/RecentManager.cpp
@@ -49,8 +49,8 @@ void RecentManager::recentManagerChangedCallback(GtkRecentManager* manager, Rece
 
 void RecentManager::addRecentFileFilename(const Path& filename)
 {
-	GtkRecentManager* recentManager;
-	GtkRecentData* recentData;
+	GtkRecentManager* recentManager = nullptr;
+	GtkRecentData* recentData = nullptr;
 
 	static gchar* groups[2] = {g_strdup(GROUP), nullptr};
 

--- a/src/control/RecentManager.cpp
+++ b/src/control/RecentManager.cpp
@@ -97,7 +97,7 @@ void RecentManager::removeRecentFileFilename(const Path& filename)
 	g_object_unref(file);
 }
 
-auto RecentManager::getMaxRecent() -> int
+auto RecentManager::getMaxRecent() const -> int
 {
 	return this->maxRecent;
 }

--- a/src/control/RecentManager.cpp
+++ b/src/control/RecentManager.cpp
@@ -63,14 +63,14 @@ void RecentManager::addRecentFileFilename(const Path& filename)
 
 	if (filename.hasExtension(".pdf"))
 	{
-		recentData->mime_type = (gchar*) g_strdup(MIME_PDF);
+		recentData->mime_type = g_strdup(MIME_PDF);
 	}
 	else
 	{
-		recentData->mime_type = (gchar*) g_strdup(MIME);
+		recentData->mime_type = g_strdup(MIME);
 	}
 
-	recentData->app_name = (gchar*) g_get_application_name();
+	recentData->app_name = const_cast<gchar*>(g_get_application_name());
 	recentData->app_exec = g_strjoin(" ", g_get_prgname(), "%u", nullptr);
 	recentData->groups = groups;
 	recentData->is_private = false;
@@ -147,7 +147,7 @@ auto RecentManager::filterRecent(GList* items, bool xoj) -> GList*
 	// filter
 	for (GList* l = items; l != nullptr; l = l->next)
 	{
-		auto* info = (GtkRecentInfo*) l->data;
+		auto* info = static_cast<GtkRecentInfo*>(l->data);
 
 		const gchar * uri = gtk_recent_info_get_uri(info);
 		if( !uri )	// issue #1071
@@ -174,14 +174,14 @@ auto RecentManager::filterRecent(GList* items, bool xoj) -> GList*
 	}
 
 	// sort
-	filteredItems = g_list_sort(filteredItems, (GCompareFunc) sortRecentsEntries);
+	filteredItems = g_list_sort(filteredItems, reinterpret_cast<GCompareFunc>(sortRecentsEntries));
 
 	return filteredItems;
 }
 
 void RecentManager::recentsMenuActivateCallback(GtkAction* action, RecentManager* recentManager)
 {
-	auto* info = (GtkRecentInfo*) g_object_get_data(G_OBJECT(action), "gtk-recent-info");
+	auto* info = static_cast<GtkRecentInfo*>(g_object_get_data(G_OBJECT(action), "gtk-recent-info"));
 	g_return_if_fail(info != nullptr);
 
 	Path p = Path::fromUri(gtk_recent_info_get_uri(info));
@@ -226,7 +226,7 @@ void RecentManager::addRecentMenu(GtkRecentInfo* info, int i)
 	gtk_widget_set_tooltip_text(item, tip.c_str());
 
 	g_object_set_data_full(G_OBJECT(item), "gtk-recent-info", gtk_recent_info_ref(info),
-						   (GDestroyNotify) gtk_recent_info_unref);
+	                       reinterpret_cast<GDestroyNotify>(gtk_recent_info_unref));
 
 	g_signal_connect(item, "activate", G_CALLBACK(recentsMenuActivateCallback), this);
 
@@ -248,7 +248,7 @@ void RecentManager::updateMenu()
 	int xojCount = 0;
 	for (GList* l = filteredItemsXoj; l != nullptr; l = l->next)
 	{
-		auto* info = (GtkRecentInfo*) l->data;
+		auto* info = static_cast<GtkRecentInfo*>(l->data);
 
 		if (xojCount >= maxRecent)
 		{
@@ -269,7 +269,7 @@ void RecentManager::updateMenu()
 	int pdfCount = 0;
 	for (GList* l = filteredItemsPdf; l != nullptr; l = l->next)
 	{
-		auto* info = (GtkRecentInfo*) l->data;
+		auto* info = static_cast<GtkRecentInfo*>(l->data);
 
 		if (pdfCount >= maxRecent)
 		{
@@ -281,6 +281,6 @@ void RecentManager::updateMenu()
 	}
 	g_list_free(filteredItemsPdf);
 
-	g_list_foreach(items, (GFunc) gtk_recent_info_unref, nullptr);
+	g_list_foreach(items, reinterpret_cast<GFunc>(gtk_recent_info_unref), nullptr);
 	g_list_free(items);
 }

--- a/src/control/RecentManager.h
+++ b/src/control/RecentManager.h
@@ -43,13 +43,13 @@ public:
 	 * Adds a file to the underlying GtkRecentManager
 	 * without altering the menu
 	 */
-	void addRecentFileFilename(const Path& filename);
+	static void addRecentFileFilename(const Path& filename);
 
 	/**
 	 * Removes a file from the underlying GtkRecentManager
 	 * without altering the menu
 	 */
-	void removeRecentFileFilename(const Path& filename);
+	static void removeRecentFileFilename(const Path& filename);
 
 	/**
 	 * Removes all of the menu items corresponding to recent files
@@ -64,7 +64,7 @@ public:
 	/**
 	 * Returns the maximal number of recent files to be displayed
 	 */
-	int getMaxRecent();
+	int getMaxRecent() const;
 
 	/**
 	 * Sets the maximal number of recent files to be displayed
@@ -100,7 +100,7 @@ private:
 	 * @return      A pointer to a GList containing the relevant GtkRecentInfo%s sorted according to their
 	 *              modification dates
 	 */
-	GList* filterRecent(GList* items, bool xoj);
+	static GList* filterRecent(GList* items, bool xoj);
 	void addRecentMenu(GtkRecentInfo* info, int i);
 
 	/**

--- a/src/control/SearchControl.cpp
+++ b/src/control/SearchControl.cpp
@@ -41,7 +41,10 @@ auto SearchControl::search(string text, int* occures, double* top) -> bool
 {
 	freeSearchResults();
 
-	if (text.empty()) return true;
+	if (text.empty())
+	{
+		return true;
+	}
 
 	if (this->pdf)
 	{

--- a/src/control/SearchControl.cpp
+++ b/src/control/SearchControl.cpp
@@ -22,7 +22,7 @@ void SearchControl::freeSearchResults()
 	this->results.clear();
 }
 
-void SearchControl::paint(cairo_t* cr, GdkRectangle* rect, double zoom, GtkColorWrapper color)
+void SearchControl::paint(cairo_t* cr, GdkRectangle* rect, double zoom, const GtkColorWrapper& color)
 {
 	// set the line always the same size on display
 	cairo_set_line_width(cr, 1 / zoom);
@@ -78,7 +78,7 @@ auto SearchControl::search(string text, int* occures, double* top) -> bool
 
 	if (top)
 	{
-		if (this->results.size() == 0)
+		if (this->results.empty())
 		{
 			*top = 0;
 		}
@@ -97,5 +97,5 @@ auto SearchControl::search(string text, int* occures, double* top) -> bool
 		}
 	}
 
-	return this->results.size() > 0;
+	return !this->results.empty();
 }

--- a/src/control/SearchControl.cpp
+++ b/src/control/SearchControl.cpp
@@ -59,7 +59,7 @@ auto SearchControl::search(string text, int* occures, double* top) -> bool
 		{
 			if (e->getType() == ELEMENT_TEXT)
 			{
-				Text* t = (Text*) e;
+				Text* t = dynamic_cast<Text*>(e);
 
 				vector<XojPdfRectangle> textResult = TextView::findText(t, text);
 

--- a/src/control/SearchControl.h
+++ b/src/control/SearchControl.h
@@ -22,7 +22,8 @@ public:
 	virtual ~SearchControl();
 
 	bool search(string text, int* occures, double* top);
-	void paint(cairo_t* cr, GdkRectangle* rect, double zoom, GtkColorWrapper color);
+	void paint(cairo_t* cr, GdkRectangle* rect, double zoom, const GtkColorWrapper& color);
+
 private:
 	void freeSearchResults();
 

--- a/src/control/Tool.cpp
+++ b/src/control/Tool.cpp
@@ -36,7 +36,7 @@ void Tool::setCapability(int capability, bool enabled)
 	}
 }
 
-auto Tool::hasCapability(ToolCapabilities cap) -> bool
+auto Tool::hasCapability(ToolCapabilities cap) const -> bool
 {
 	return (this->capabilities & cap) != 0;
 }

--- a/src/control/Tool.h
+++ b/src/control/Tool.h
@@ -18,13 +18,13 @@
 class Tool : public ToolBase
 {
 public:
-	Tool(string name, ToolType tool, int color, int capabilities, double* thickness);
+	Tool(string name, ToolType type, int color, int capabilities, double* thickness);
 	virtual ~Tool();
 
 public:
 	string getName();
 
-	bool hasCapability(ToolCapabilities cap);
+	bool hasCapability(ToolCapabilities cap) const;
 
 	double getThickness(ToolSize size);
 

--- a/src/control/ToolEnums.cpp
+++ b/src/control/ToolEnums.cpp
@@ -20,7 +20,7 @@ auto toolSizeFromString(const string& size) -> ToolSize
 	{
 		return TOOL_SIZE_VERY_FINE;
 	}
-	else if (size == "thin")
+	if (size == "thin")
 	{
 		return TOOL_SIZE_FINE;
 	}
@@ -68,7 +68,7 @@ auto drawingTypeFromString(const string& type) -> DrawingType
 	{
 		return DRAWING_TYPE_DONT_CHANGE;
 	}
-	else if (type == "line")
+	if (type == "line")
 	{
 		return DRAWING_TYPE_LINE;
 	}
@@ -133,7 +133,7 @@ auto toolTypeFromString(const string& type) -> ToolType
 	{
 		return TOOL_NONE;
 	}
-	else if (type == "pen")
+	if (type == "pen")
 	{
 		return TOOL_PEN;
 	}
@@ -217,7 +217,7 @@ auto eraserTypeFromString(const string& type) -> EraserType
 	{
 		return ERASER_TYPE_NONE;
 	}
-	else if (type == "default")
+	if (type == "default")
 	{
 		return ERASER_TYPE_DEFAULT;
 	}

--- a/src/control/ToolEnums.cpp
+++ b/src/control/ToolEnums.cpp
@@ -24,7 +24,7 @@ auto toolSizeFromString(const string& size) -> ToolSize
 	{
 		return TOOL_SIZE_FINE;
 	}
-	else if (size == "medium")
+	if (size == "medium")
 	{
 		return TOOL_SIZE_MEDIUM;
 	}
@@ -72,7 +72,7 @@ auto drawingTypeFromString(const string& type) -> DrawingType
 	{
 		return DRAWING_TYPE_LINE;
 	}
-	else if (type == "rectangle")
+	if (type == "rectangle")
 	{
 		return DRAWING_TYPE_RECTANGLE;
 	}
@@ -137,7 +137,7 @@ auto toolTypeFromString(const string& type) -> ToolType
 	{
 		return TOOL_PEN;
 	}
-	else if (type == "eraser")
+	if (type == "eraser")
 	{
 		return TOOL_ERASER;
 	}
@@ -221,7 +221,7 @@ auto eraserTypeFromString(const string& type) -> EraserType
 	{
 		return ERASER_TYPE_DEFAULT;
 	}
-	else if (type == "whiteout")
+	if (type == "whiteout")
 	{
 		return ERASER_TYPE_WHITEOUT;
 	}

--- a/src/control/ToolEnums.cpp
+++ b/src/control/ToolEnums.cpp
@@ -16,13 +16,34 @@ auto toolSizeToString(ToolSize size) -> string
 
 auto toolSizeFromString(const string& size) -> ToolSize
 {
-	if (size == "veryThin")  			return TOOL_SIZE_VERY_FINE;
-	else if (size == "thin")			return TOOL_SIZE_FINE;
-	else if (size == "medium")  		return TOOL_SIZE_MEDIUM;
-	else if (size == "thick")			return TOOL_SIZE_THICK;
-	else if (size == "veryThick")		return TOOL_SIZE_VERY_THICK;
-	else if (size == "none")			return TOOL_SIZE_NONE;
-	else        						return TOOL_SIZE_NONE;
+	if (size == "veryThin")
+	{
+		return TOOL_SIZE_VERY_FINE;
+	}
+	else if (size == "thin")
+	{
+		return TOOL_SIZE_FINE;
+	}
+	else if (size == "medium")
+	{
+		return TOOL_SIZE_MEDIUM;
+	}
+	else if (size == "thick")
+	{
+		return TOOL_SIZE_THICK;
+	}
+	else if (size == "veryThick")
+	{
+		return TOOL_SIZE_VERY_THICK;
+	}
+	else if (size == "none")
+	{
+		return TOOL_SIZE_NONE;
+	}
+	else
+	{
+		return TOOL_SIZE_NONE;
+	}
 }
 
 auto drawingTypeToString(DrawingType type) -> string
@@ -43,15 +64,42 @@ auto drawingTypeToString(DrawingType type) -> string
 
 auto drawingTypeFromString(const string& type) -> DrawingType
 {
-	if (type == "dontChange")   					return DRAWING_TYPE_DONT_CHANGE;
-	else if (type == "line")						return DRAWING_TYPE_LINE;
-	else if (type == "rectangle")					return DRAWING_TYPE_RECTANGLE;
-	else if (type == "circle")						return DRAWING_TYPE_CIRCLE;
-	else if (type == "arrow")    					return DRAWING_TYPE_ARROW;
-	else if (type == "strokeRecognizer")			return DRAWING_TYPE_STROKE_RECOGNIZER;
-	else if (type == "drawCoordinateSystem")		return DRAWING_TYPE_COORDINATE_SYSTEM;
-	else if (type == "default")    					return DRAWING_TYPE_DEFAULT;
-	else	        								return DRAWING_TYPE_DEFAULT;
+	if (type == "dontChange")
+	{
+		return DRAWING_TYPE_DONT_CHANGE;
+	}
+	else if (type == "line")
+	{
+		return DRAWING_TYPE_LINE;
+	}
+	else if (type == "rectangle")
+	{
+		return DRAWING_TYPE_RECTANGLE;
+	}
+	else if (type == "circle")
+	{
+		return DRAWING_TYPE_CIRCLE;
+	}
+	else if (type == "arrow")
+	{
+		return DRAWING_TYPE_ARROW;
+	}
+	else if (type == "strokeRecognizer")
+	{
+		return DRAWING_TYPE_STROKE_RECOGNIZER;
+	}
+	else if (type == "drawCoordinateSystem")
+	{
+		return DRAWING_TYPE_COORDINATE_SYSTEM;
+	}
+	else if (type == "default")
+	{
+		return DRAWING_TYPE_DEFAULT;
+	}
+	else
+	{
+		return DRAWING_TYPE_DEFAULT;
+	}
 }
 
 auto toolTypeToString(ToolType type) -> string
@@ -81,23 +129,74 @@ auto toolTypeToString(ToolType type) -> string
 
 auto toolTypeFromString(const string& type) -> ToolType
 {
-	if (type == "none") 							return TOOL_NONE;
-	else if (type == "pen")  						return TOOL_PEN;
-	else if (type == "eraser")  					return TOOL_ERASER;
-	else if (type == "hilighter")					return TOOL_HILIGHTER;
-	else if (type == "image")   					return TOOL_IMAGE;
-	else if (type == "selectRect")					return TOOL_SELECT_RECT;
-	else if (type == "selectRegion")				return TOOL_SELECT_REGION;
-	else if (type == "selectObject")				return TOOL_SELECT_OBJECT;
-	else if (type == "playObject")  				return TOOL_PLAY_OBJECT;
-	else if (type == "verticalSpace")				return TOOL_VERTICAL_SPACE;
-	else if (type == "hand")						return TOOL_HAND;
-	else if (type == "drawRect")					return TOOL_DRAW_RECT;
-	else if (type == "drawCircle")  				return TOOL_DRAW_CIRCLE;
-	else if (type == "drawArrow")   				return TOOL_DRAW_ARROW;
-	else if (type == "drawCoordinateSystem")		return TOOL_DRAW_COORDINATE_SYSTEM;
-	else if (type == "showFloatingToolbox") 		return TOOL_FLOATING_TOOLBOX;
-	else	      									return TOOL_NONE;
+	if (type == "none")
+	{
+		return TOOL_NONE;
+	}
+	else if (type == "pen")
+	{
+		return TOOL_PEN;
+	}
+	else if (type == "eraser")
+	{
+		return TOOL_ERASER;
+	}
+	else if (type == "hilighter")
+	{
+		return TOOL_HILIGHTER;
+	}
+	else if (type == "image")
+	{
+		return TOOL_IMAGE;
+	}
+	else if (type == "selectRect")
+	{
+		return TOOL_SELECT_RECT;
+	}
+	else if (type == "selectRegion")
+	{
+		return TOOL_SELECT_REGION;
+	}
+	else if (type == "selectObject")
+	{
+		return TOOL_SELECT_OBJECT;
+	}
+	else if (type == "playObject")
+	{
+		return TOOL_PLAY_OBJECT;
+	}
+	else if (type == "verticalSpace")
+	{
+		return TOOL_VERTICAL_SPACE;
+	}
+	else if (type == "hand")
+	{
+		return TOOL_HAND;
+	}
+	else if (type == "drawRect")
+	{
+		return TOOL_DRAW_RECT;
+	}
+	else if (type == "drawCircle")
+	{
+		return TOOL_DRAW_CIRCLE;
+	}
+	else if (type == "drawArrow")
+	{
+		return TOOL_DRAW_ARROW;
+	}
+	else if (type == "drawCoordinateSystem")
+	{
+		return TOOL_DRAW_COORDINATE_SYSTEM;
+	}
+	else if (type == "showFloatingToolbox")
+	{
+		return TOOL_FLOATING_TOOLBOX;
+	}
+	else
+	{
+		return TOOL_NONE;
+	}
 }
 
 auto eraserTypeToString(EraserType type) -> string
@@ -114,10 +213,25 @@ auto eraserTypeToString(EraserType type) -> string
 
 auto eraserTypeFromString(const string& type) -> EraserType
 {
-	if (type == "none") 					return ERASER_TYPE_NONE;
-	else if (type == "default")  			return ERASER_TYPE_DEFAULT;
-	else if (type == "whiteout")			return ERASER_TYPE_WHITEOUT;
-	else if (type == "deleteStroke")		return ERASER_TYPE_DELETE_STROKE;
-	else        							return ERASER_TYPE_NONE;
+	if (type == "none")
+	{
+		return ERASER_TYPE_NONE;
+	}
+	else if (type == "default")
+	{
+		return ERASER_TYPE_DEFAULT;
+	}
+	else if (type == "whiteout")
+	{
+		return ERASER_TYPE_WHITEOUT;
+	}
+	else if (type == "deleteStroke")
+	{
+		return ERASER_TYPE_DELETE_STROKE;
+	}
+	else
+	{
+		return ERASER_TYPE_NONE;
+	}
 }
 

--- a/src/control/ToolHandler.cpp
+++ b/src/control/ToolHandler.cpp
@@ -281,8 +281,8 @@ auto ToolHandler::getThickness() -> double
 	}
 
 
-	    g_warning("Request size of \"%s\"", this->current->getName().c_str());
-		return 0;
+	g_warning("Request size of \"%s\"", this->current->getName().c_str());
+	return 0;
 }
 
 void ToolHandler::setSize(ToolSize size)

--- a/src/control/ToolHandler.cpp
+++ b/src/control/ToolHandler.cpp
@@ -279,11 +279,10 @@ auto ToolHandler::getThickness() -> double
 	{
 		return this->current->thickness[this->current->getSize()];
 	}
-	else
-	{
-		g_warning("Request size of \"%s\"", this->current->getName().c_str());
+
+
+	    g_warning("Request size of \"%s\"", this->current->getName().c_str());
 		return 0;
-	}
 }
 
 void ToolHandler::setSize(ToolSize size)

--- a/src/control/ToolHandler.cpp
+++ b/src/control/ToolHandler.cpp
@@ -493,16 +493,29 @@ void ToolHandler::loadSettings()
 			if (tool->hasCapability(TOOL_CAP_SIZE) && st.getString("size", value))
 			{
 				if (value == "VERY_FINE")
+				{
 					tool->setSize(TOOL_SIZE_VERY_FINE);
+				}
 				else if (value == "THIN")
+				{
 					tool->setSize(TOOL_SIZE_FINE);
+				}
 				else if (value == "MEDIUM")
+				{
 					tool->setSize(TOOL_SIZE_MEDIUM);
+				}
 				else if (value == "BIG")
+				{
 					tool->setSize(TOOL_SIZE_THICK);
+				}
 				else if (value == "VERY_BIG")
+				{
 					tool->setSize(TOOL_SIZE_VERY_THICK);
-				else g_warning("Settings::Unknown tool size: %s\n", value.c_str());
+				}
+				else
+				{
+					g_warning("Settings::Unknown tool size: %s\n", value.c_str());
+				}
 			}
 
 			if (tool->type == TOOL_ERASER)
@@ -511,9 +524,18 @@ void ToolHandler::loadSettings()
 
 				if (st.getString("type", type))
 				{
-					if (type == "deleteStroke")	 setEraserType(ERASER_TYPE_DELETE_STROKE);
-					else if (type == "whiteout") setEraserType(ERASER_TYPE_WHITEOUT);
-					else						 setEraserType(ERASER_TYPE_DEFAULT);
+					if (type == "deleteStroke")
+					{
+						setEraserType(ERASER_TYPE_DELETE_STROKE);
+					}
+					else if (type == "whiteout")
+					{
+						setEraserType(ERASER_TYPE_WHITEOUT);
+					}
+					else
+					{
+						setEraserType(ERASER_TYPE_DEFAULT);
+					}
 					eraserTypeChanged();
 				}
 			}

--- a/src/control/XournalMain.cpp
+++ b/src/control/XournalMain.cpp
@@ -239,7 +239,7 @@ auto XournalMain::exportImg(const char* input, const char* output) -> int
 	exportRange.clear();
 
 	string errorMsg = imgExport.getLastErrorMsg();
-	if (errorMsg != "")
+	if (!errorMsg.empty())
 	{
 		g_message("Error exporting image: %s\n", errorMsg.c_str());
 		return -3;
@@ -512,7 +512,7 @@ void XournalMain::initResourcePath(GladeSearchpath* gladePath, const gchar* rela
 {
 	string uiPath = findResourcePath(relativePathAndFile);	//i.e.  relativePathAndFile = "ui/about.glade"
 
-	if (uiPath != "")
+	if (!uiPath.empty())
 	{
 		gladePath->addSearchDirectory(uiPath);
 		return;

--- a/src/control/XournalMain.cpp
+++ b/src/control/XournalMain.cpp
@@ -88,7 +88,7 @@ void XournalMain::checkForErrorlog()
 
 	vector<string> errorList;
 
-	const gchar* file;
+	const gchar* file = nullptr;
 	while ((file = g_dir_read_name(home)) != nullptr)
 	{
 		if (g_file_test(file, G_FILE_TEST_IS_REGULAR))

--- a/src/control/XournalMain.h
+++ b/src/control/XournalMain.h
@@ -27,18 +27,19 @@ public:
 	int run(int argc, char* argv[]);
 
 private:
-	void initLocalisation();
+	static void initLocalisation();
 
-	void checkForErrorlog();
-	void checkForEmergencySave(Control* control);
+	static void checkForErrorlog();
+	static void checkForEmergencySave(Control* control);
 
-	int exportPdf(const char* input, const char* output);
-	int exportImg(const char* input, const char* output);
+	static int exportPdf(const char* input, const char* output);
+	static int exportImg(const char* input, const char* output);
 
 	void initSettingsPath();
 	void initResourcePath(GladeSearchpath* gladePath);
-	void initResourcePath(GladeSearchpath* gladePath, const gchar* relativePathAndFile, bool failIfNotFound = true);
-	string findResourcePath(const string& searchFile);
+	static void initResourcePath(GladeSearchpath* gladePath, const gchar* relativePathAndFile,
+	                             bool failIfNotFound = true);
+	static string findResourcePath(const string& searchFile);
 
 private:
 };

--- a/src/control/jobs/BlockingJob.cpp
+++ b/src/control/jobs/BlockingJob.cpp
@@ -18,7 +18,7 @@ void BlockingJob::execute()
 {
 	this->run();
 
-	g_idle_add((GSourceFunc) finished, this->control);
+	g_idle_add(reinterpret_cast<GSourceFunc>(finished), this->control);
 }
 
 auto BlockingJob::finished(Control* control) -> bool

--- a/src/control/jobs/ImageExport.cpp
+++ b/src/control/jobs/ImageExport.cpp
@@ -34,7 +34,7 @@ void ImageExport::setPngDpi(int dpi)
 /**
  * @return the last error message to show to the user
  */
-auto ImageExport::getLastErrorMsg() -> string
+auto ImageExport::getLastErrorMsg() const -> string
 {
 	return lastError;
 }
@@ -82,18 +82,13 @@ auto ImageExport::freeSurface(int id) -> bool
 	cairo_surface_destroy(surface);
 
 	// we ignore this problem
-	if (status != CAIRO_STATUS_SUCCESS)
-	{
-		return false;
-	}
-
-	return true;
+	return status == CAIRO_STATUS_SUCCESS;
 }
 
 /**
  * Get a filename with a number, e.g. .../export-1.png, if the no is -1, return .../export.png
  */
-auto ImageExport::getFilenameWithNumber(int no) -> string
+auto ImageExport::getFilenameWithNumber(int no) const -> string
 {
 	if (no == -1)
 	{

--- a/src/control/jobs/ImageExport.h
+++ b/src/control/jobs/ImageExport.h
@@ -44,7 +44,7 @@ public:
 	/**
 	 * @return The last error message to show to the user
 	 */
-	string getLastErrorMsg();
+	string getLastErrorMsg() const;
 
 	/**
 	 * Create one Graphics file per page
@@ -65,7 +65,7 @@ private:
 	/**
 	 * Get a filename with a number, e.g. .../export-1.png, if the no is -1, return .../export.png
 	 */
-	string getFilenameWithNumber(int no);
+	string getFilenameWithNumber(int no) const;
 
 	/**
 	 * Export a single Image page

--- a/src/control/jobs/Job.cpp
+++ b/src/control/jobs/Job.cpp
@@ -69,7 +69,7 @@ void Job::callAfterRun()
 
 	this->ref();
 
-	this->afterRunId = gdk_threads_add_idle((GSourceFunc) Job::callAfterCallback, this);
+	this->afterRunId = gdk_threads_add_idle(reinterpret_cast<GSourceFunc>(Job::callAfterCallback), this);
 }
 
 /**

--- a/src/control/jobs/Job.h
+++ b/src/control/jobs/Job.h
@@ -81,5 +81,5 @@ private:
 	int afterRunId = 0;
 
 	int refCount = 1;
-	GMutex refMutex;
+	GMutex refMutex{};
 };

--- a/src/control/jobs/PreviewJob.cpp
+++ b/src/control/jobs/PreviewJob.cpp
@@ -119,7 +119,7 @@ void PreviewJob::run()
 
 	if (RENDER_TYPE_PAGE_LAYER == type)
 	{
-		layer = ((SidebarPreviewLayerEntry*)this->sidebarPreview)->getLayer();
+		layer = (dynamic_cast<SidebarPreviewLayerEntry*>(this->sidebarPreview))->getLayer();
 	}
 
 	if (this->sidebarPreview->page->getBackgroundType().isPdfPage())

--- a/src/control/jobs/RenderJob.h
+++ b/src/control/jobs/RenderJob.h
@@ -39,7 +39,7 @@ private:
 	/**
 	 * Repaint the widget in UI Thread
 	 */
-	void repaintWidget(GtkWidget* widget);
+	static void repaintWidget(GtkWidget* widget);
 
 	void rerenderRectangle(Rectangle* rect);
 

--- a/src/control/jobs/Scheduler.cpp
+++ b/src/control/jobs/Scheduler.cpp
@@ -114,7 +114,7 @@ auto Scheduler::getNextJobUnlocked(bool onlyNotRender, bool* hasRenderJobs) -> J
 					g_queue_delete_link(this->jobQueue[i], l);
 					return job;
 				}
-				else if (hasRenderJobs)
+				if (hasRenderJobs)
 				{
 					*hasRenderJobs = true;
 				}

--- a/src/control/jobs/Scheduler.cpp
+++ b/src/control/jobs/Scheduler.cpp
@@ -62,7 +62,7 @@ void Scheduler::start()
 	SDEBUG("Starting scheduler");
 	g_return_if_fail(this->thread == nullptr);
 
-	this->thread = g_thread_new(name.c_str(), (GThreadFunc) jobThreadCallback, this);
+	this->thread = g_thread_new(name.c_str(), reinterpret_cast<GThreadFunc>(jobThreadCallback), this);
 }
 
 void Scheduler::stop()
@@ -107,7 +107,7 @@ auto Scheduler::getNextJobUnlocked(bool onlyNotRender, bool* hasRenderJobs) -> J
 		{
 			for (GList* l = this->jobQueue[i]->head; l != nullptr; l = l->next)
 			{
-				job = (Job*) l->data;
+				job = static_cast<Job*>(l->data);
 
 				if (job->getType() != JOB_TYPE_RENDER)
 				{
@@ -122,7 +122,7 @@ auto Scheduler::getNextJobUnlocked(bool onlyNotRender, bool* hasRenderJobs) -> J
 		}
 		else
 		{
-			job = (Job*) g_queue_pop_head(this->jobQueue[i]);
+			job = static_cast<Job*>(g_queue_pop_head(this->jobQueue[i]));
 			if (job)
 			{
 				return job;
@@ -268,7 +268,8 @@ auto Scheduler::jobThreadCallback(Scheduler* scheduler) -> gpointer
 				{
 					g_source_remove(scheduler->jobRenderThreadTimerId);
 				}
-				scheduler->jobRenderThreadTimerId = g_timeout_add(diff, (GSourceFunc) jobRenderThreadTimer, scheduler);
+				scheduler->jobRenderThreadTimerId =
+				        g_timeout_add(diff, reinterpret_cast<GSourceFunc>(jobRenderThreadTimer), scheduler);
 			}
 
 			g_cond_wait(&scheduler->jobQueueCond, &scheduler->jobQueueMutex);

--- a/src/control/jobs/Scheduler.h
+++ b/src/control/jobs/Scheduler.h
@@ -110,25 +110,25 @@ protected:
 
 	GThread* thread = nullptr;
 
-	GCond jobQueueCond;
-	GMutex jobQueueMutex;
+	GCond jobQueueCond{};
+	GMutex jobQueueMutex{};
 
-	GMutex schedulerMutex;
+	GMutex schedulerMutex{};
 
 	/**
 	 * This is need to be sure there is no job running if we delete a page, else we may access delete memory...
 	 */
-	GMutex jobRunningMutex;
+	GMutex jobRunningMutex{};
 
-	GQueue queueUrgent;
-	GQueue queueHigh;
-	GQueue queueLow;
-	GQueue queueNone;
+	GQueue queueUrgent{};
+	GQueue queueHigh{};
+	GQueue queueLow{};
+	GQueue queueNone{};
 
-	GQueue* jobQueue[JOB_N_PRIORITIES];
+	GQueue* jobQueue[JOB_N_PRIORITIES]{};
 
 	GTimeVal* blockRenderZoomTime = nullptr;
-	GMutex blockRenderMutex;
+	GMutex blockRenderMutex{};
 
 	string name;
 };

--- a/src/control/jobs/XournalScheduler.cpp
+++ b/src/control/jobs/XournalScheduler.cpp
@@ -4,7 +4,7 @@
 #include "RenderJob.h"
 
 XournalScheduler::XournalScheduler()
- : Scheduler()
+
 {
 	this->name = "XournalScheduler";
 }

--- a/src/control/jobs/XournalScheduler.cpp
+++ b/src/control/jobs/XournalScheduler.cpp
@@ -30,7 +30,7 @@ void XournalScheduler::removeAllJobs()
 		int length = g_queue_get_length(this->jobQueue[priority]);
 		for (int i = 0; i < length; i++)
 		{
-			Job* job = (Job*) g_queue_peek_nth(this->jobQueue[priority], i);
+			Job* job = static_cast<Job*>(g_queue_peek_nth(this->jobQueue[priority], i));
 
 			JobType type = job->getType();
 			if (type == JOB_TYPE_PREVIEW || type == JOB_TYPE_RENDER)
@@ -59,7 +59,7 @@ void XournalScheduler::removeSource(void* source, JobType type, JobPriority prio
 	int length = g_queue_get_length(this->jobQueue[priority]);
 	for (int i = 0; i < length; i++)
 	{
-		Job* job = (Job*) g_queue_peek_nth(this->jobQueue[priority], i);
+		Job* job = static_cast<Job*>(g_queue_peek_nth(this->jobQueue[priority], i));
 
 		if (job->getType() == type)
 		{
@@ -88,7 +88,7 @@ auto XournalScheduler::existsSource(void* source, JobType type, JobPriority prio
 	int length = g_queue_get_length(this->jobQueue[priority]);
 	for (int i = 0; i < length; i++)
 	{
-		Job* job = (Job*) g_queue_peek_nth(this->jobQueue[priority], i);
+		Job* job = static_cast<Job*>(g_queue_peek_nth(this->jobQueue[priority], i));
 
 		if (job->getType() == type)
 		{

--- a/src/control/layer/LayerController.cpp
+++ b/src/control/layer/LayerController.cpp
@@ -101,30 +101,30 @@ auto LayerController::actionPerformed(ActionType type) -> bool
 			int layer = p->getSelectedLayerId();
 		    if (layer < static_cast<int>(p->getLayerCount()))
 		    {
-				switchToLay(layer + 1, true);
-			}
-		}
-		return true;
+			    switchToLay(layer + 1, true);
+		    }
+	    }
+		    return true;
 
-	case ACTION_GOTO_PREVIOUS_LAYER:
-		{
-			PageRef p = getCurrentPage();
-			int layer = p->getSelectedLayerId();
-			if (layer > 0)
-			{
-				switchToLay(layer - 1, true);
-			}
-		}
-		return true;
+	    case ACTION_GOTO_PREVIOUS_LAYER:
+	    {
+		    PageRef p = getCurrentPage();
+		    int layer = p->getSelectedLayerId();
+		    if (layer > 0)
+		    {
+			    switchToLay(layer - 1, true);
+		    }
+	    }
+		    return true;
 
-	case ACTION_GOTO_TOP_LAYER:
-		{
-			PageRef p = getCurrentPage();
-			switchToLay(p->getLayerCount(), true);
-		}
-		return true;
-	default:
-		return false;
+	    case ACTION_GOTO_TOP_LAYER:
+	    {
+		    PageRef p = getCurrentPage();
+		    switchToLay(p->getLayerCount(), true);
+	    }
+		    return true;
+	    default:
+		    return false;
 	}
 }
 

--- a/src/control/layer/LayerController.cpp
+++ b/src/control/layer/LayerController.cpp
@@ -99,8 +99,8 @@ auto LayerController::actionPerformed(ActionType type) -> bool
 		{
 			PageRef p = getCurrentPage();
 			int layer = p->getSelectedLayerId();
-			if (layer < (int)p->getLayerCount())
-			{
+		    if (layer < static_cast<int>(p->getLayerCount()))
+		    {
 				switchToLay(layer + 1, true);
 			}
 		}
@@ -235,7 +235,7 @@ void LayerController::moveCurrentLayer(bool up)
 		return;
 	}
 
-	if (lId == (int)p->getLayerCount() && up)
+	if (lId == static_cast<int>(p->getLayerCount()) && up)
 	{
 		// top layer cannot be moved up
 		return;
@@ -334,7 +334,7 @@ void LayerController::switchToLay(int layer, bool hideShow)
 	{
 		for (size_t i = 1; i <= p->getLayerCount(); i++)
 		{
-			p->setLayerVisible(i, (int)i <= layer);
+			p->setLayerVisible(i, static_cast<int>(i) <= layer);
 		}
 	}
 

--- a/src/control/layer/LayerController.cpp
+++ b/src/control/layer/LayerController.cpp
@@ -299,7 +299,7 @@ auto LayerController::getCurrentPage() -> PageRef
 	return control->getDocument()->getPage(selectedPage);
 }
 
-auto LayerController::getCurrentPageId() -> size_t
+auto LayerController::getCurrentPageId() const -> size_t
 {
 	return selectedPage;
 }

--- a/src/control/layer/LayerController.h
+++ b/src/control/layer/LayerController.h
@@ -71,7 +71,7 @@ public:
 	void setLayerVisible(int layerId, bool visible);
 
 	PageRef getCurrentPage();
-	size_t getCurrentPageId();
+	size_t getCurrentPageId() const;
 
 	/**
 	 * @return Layer count of the current page

--- a/src/control/pagetype/PageTypeHandler.cpp
+++ b/src/control/pagetype/PageTypeHandler.cpp
@@ -114,11 +114,11 @@ auto PageTypeHandler::getPageTypeFormatForString(const string& format) -> PageTy
 	{
 		return PageTypeFormat::Plain;
 	}
-	else if (format == "ruled")
+	if (format == "ruled")
 	{
 		return PageTypeFormat::Ruled;
 	}
-	else if (format == "lined")
+	if (format == "lined")
 	{
 		return PageTypeFormat::Lined;
 	}

--- a/src/control/pagetype/PageTypeHandler.cpp
+++ b/src/control/pagetype/PageTypeHandler.cpp
@@ -122,7 +122,7 @@ auto PageTypeHandler::getPageTypeFormatForString(const string& format) -> PageTy
 	{
 		return PageTypeFormat::Lined;
 	}
-	else if (format == "staves")
+	if (format == "staves")
 	{
 		return PageTypeFormat::Staves;
 	}

--- a/src/control/pagetype/PageTypeMenu.h
+++ b/src/control/pagetype/PageTypeMenu.h
@@ -62,7 +62,7 @@ public:
 	void addApplyBackgroundButton(PageTypeApplyListener* pageTypeApplyListener, bool onlyAllMenu);
 
 private:
-	GtkWidget* createApplyMenuItem(const char* text);
+	static GtkWidget* createApplyMenuItem(const char* text);
 	void initDefaultMenu();
 	void addMenuEntry(PageTypeInfo* t);
 	void entrySelected(PageTypeInfo* t);

--- a/src/control/settings/ButtonConfig.cpp
+++ b/src/control/settings/ButtonConfig.cpp
@@ -14,7 +14,7 @@ ButtonConfig::ButtonConfig(ToolType action, int color, ToolSize size, DrawingTyp
 
 ButtonConfig::~ButtonConfig() = default;
 
-auto ButtonConfig::getDisableDrawing() -> bool
+auto ButtonConfig::getDisableDrawing() const -> bool
 {
 	return this->disableDrawing;
 }

--- a/src/control/settings/ButtonConfig.h
+++ b/src/control/settings/ButtonConfig.h
@@ -26,7 +26,7 @@ public:
 public:
 	void acceptActions(ToolHandler* toolHandler);
 	ToolType getAction();
-	bool getDisableDrawing();
+	bool getDisableDrawing() const;
 	DrawingType getDrawingType();
 
 private:

--- a/src/control/settings/MetadataManager.cpp
+++ b/src/control/settings/MetadataManager.cpp
@@ -206,7 +206,7 @@ auto MetadataManager::getForFile(const string& file) -> MetadataEntry
 		}
 	}
 
-	for (int i = 20; i < (int)files.size(); i++)
+	for (int i = 20; i < static_cast<int>(files.size()); i++)
 	{
 		string path = files[i].metadataFile;
 		deleteMetadataFile(path);

--- a/src/control/settings/MetadataManager.cpp
+++ b/src/control/settings/MetadataManager.cpp
@@ -95,7 +95,7 @@ auto MetadataManager::loadList() -> vector<MetadataEntry>
 		return data;
 	}
 
-	const gchar* file;
+	const gchar* file = nullptr;
 	while ((file = g_dir_read_name(home)) != nullptr)
 	{
 		string path = folder.str();

--- a/src/control/settings/MetadataManager.cpp
+++ b/src/control/settings/MetadataManager.cpp
@@ -251,7 +251,7 @@ void MetadataManager::storeMetadata(MetadataEntry* m)
  */
 void MetadataManager::storeMetadata(const string& file, int page, double zoom)
 {
-	if (file == "")
+	if (file.empty())
 	{
 		return;
 	}

--- a/src/control/settings/MetadataManager.h
+++ b/src/control/settings/MetadataManager.h
@@ -53,7 +53,7 @@ private:
 	/**
 	 * Delete an old metadata file
 	 */
-	void deleteMetadataFile(const string& path);
+	static void deleteMetadataFile(const string& path);
 
 	/**
 	 * Parse a single metadata file

--- a/src/control/settings/MetadataManager.h
+++ b/src/control/settings/MetadataManager.h
@@ -58,7 +58,7 @@ private:
 	/**
 	 * Parse a single metadata file
 	 */
-	MetadataEntry loadMetadataFile(const string& path, const string& file);
+	static MetadataEntry loadMetadataFile(const string& path, const string& file);
 
 	/**
 	 * Store metadata to file

--- a/src/control/settings/MetadataManager.h
+++ b/src/control/settings/MetadataManager.h
@@ -73,6 +73,6 @@ private:
 
 
 private:
-	GMutex mutex;
+	GMutex mutex{};
 	MetadataEntry* metadata;
 };

--- a/src/control/settings/PageTemplateSettings.cpp
+++ b/src/control/settings/PageTemplateSettings.cpp
@@ -19,7 +19,7 @@ PageTemplateSettings::PageTemplateSettings()
 
 PageTemplateSettings::~PageTemplateSettings() = default;
 
-auto PageTemplateSettings::isCopyLastPageSettings() -> bool
+auto PageTemplateSettings::isCopyLastPageSettings() const -> bool
 {
 	return this->copyLastPageSettings;
 }
@@ -29,7 +29,7 @@ void PageTemplateSettings::setCopyLastPageSettings(bool copyLastPageSettings)
 	this->copyLastPageSettings = copyLastPageSettings;
 }
 
-auto PageTemplateSettings::isCopyLastPageSize() -> bool
+auto PageTemplateSettings::isCopyLastPageSize() const -> bool
 {
 	return this->copyLastPageSize;
 }
@@ -39,7 +39,7 @@ void PageTemplateSettings::setCopyLastPageSize(bool copyLastPageSize)
 	this->copyLastPageSize = copyLastPageSize;
 }
 
-auto PageTemplateSettings::getPageWidth() -> double
+auto PageTemplateSettings::getPageWidth() const -> double
 {
 	return this->pageWidth;
 }
@@ -49,7 +49,7 @@ void PageTemplateSettings::setPageWidth(double pageWidth)
 	this->pageWidth = pageWidth;
 }
 
-auto PageTemplateSettings::getPageHeight() -> double
+auto PageTemplateSettings::getPageHeight() const -> double
 {
 	return this->pageHeight;
 }
@@ -59,7 +59,7 @@ void PageTemplateSettings::setPageHeight(double pageHeight)
 	this->pageHeight = pageHeight;
 }
 
-auto PageTemplateSettings::getBackgroundColor() -> int
+auto PageTemplateSettings::getBackgroundColor() const -> int
 {
 	return this->backgroundColor;
 }
@@ -96,7 +96,7 @@ void PageTemplateSettings::setBackgroundType(const PageType& backgroundType)
  */
 auto PageTemplateSettings::parse(const string& tpl) -> bool
 {
-	stringstream ss(tpl.c_str());
+	stringstream ss(tpl);
 	string line;
 
 	if (!std::getline(ss, line, '\n'))
@@ -154,7 +154,7 @@ auto PageTemplateSettings::parse(const string& tpl) -> bool
 /**
  * Convert to a parsable string
  */
-auto PageTemplateSettings::toString() -> string
+auto PageTemplateSettings::toString() const -> string
 {
 	string str = "xoj/template\n";
 

--- a/src/control/settings/PageTemplateSettings.h
+++ b/src/control/settings/PageTemplateSettings.h
@@ -33,21 +33,21 @@ public:
 	/**
 	 * Convert to a parsable string
 	 */
-	string toString();
+	string toString() const;
 
-	bool isCopyLastPageSettings();
+	bool isCopyLastPageSettings() const;
 	void setCopyLastPageSettings(bool copyLastPageSettings);
 
-	bool isCopyLastPageSize();
+	bool isCopyLastPageSize() const;
 	void setCopyLastPageSize(bool copyLastPageSize);
 
-	double getPageWidth();
+	double getPageWidth() const;
 	void setPageWidth(double pageWidth);
 
-	double getPageHeight();
+	double getPageHeight() const;
 	void setPageHeight(double pageHeight);
 
-	int getBackgroundColor();
+	int getBackgroundColor() const;
 	void setBackgroundColor(int backgroundColor);
 
 	PageType getBackgroundType();

--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -2258,10 +2258,10 @@ auto Settings::getDeviceClassForDevice(const string& deviceName, GdkInputSource 
 	}
 
 
-	    guint deviceType = 0;
-		switch (deviceSource)
-		{
-			case GDK_SOURCE_CURSOR:
+	guint deviceType = 0;
+	switch (deviceSource)
+	{
+	case GDK_SOURCE_CURSOR:
 #if (GDK_MAJOR_VERSION >= 3 && GDK_MINOR_VERSION >= 22)
 			case GDK_SOURCE_TABLET_PAD:
 #endif

--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -2296,7 +2296,10 @@ auto Settings::isScrollbarFadeoutDisabled() const -> bool
 
 void Settings::setScrollbarFadeoutDisabled(bool disable)
 {
-	if (disableScrollbarFadeout == disable) return;
+	if (disableScrollbarFadeout == disable)
+	{
+		return;
+	}
 	disableScrollbarFadeout = disable;
 	save();
 }

--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -171,36 +171,37 @@ void Settings::parseData(xmlNodePtr cur, SElement& elem)
 {
 	for (xmlNodePtr x = cur->children; x != nullptr; x = x->next)
 	{
-		if (!xmlStrcmp(x->name, (const xmlChar*) "data"))
+		if (!xmlStrcmp(x->name, reinterpret_cast<const xmlChar*>("data")))
 		{
-			xmlChar* name = xmlGetProp(x, (const xmlChar*) "name");
-			parseData(x, elem.child((const char*) name));
+			xmlChar* name = xmlGetProp(x, reinterpret_cast<const xmlChar*>("name"));
+			parseData(x, elem.child(reinterpret_cast<const char*>(name)));
 			xmlFree(name);
 		}
-		else if (!xmlStrcmp(x->name, (const xmlChar*) "attribute"))
+		else if (!xmlStrcmp(x->name, reinterpret_cast<const xmlChar*>("attribute")))
 		{
-			xmlChar* name = xmlGetProp(x, (const xmlChar*) "name");
-			xmlChar* value = xmlGetProp(x, (const xmlChar*) "value");
-			xmlChar* type = xmlGetProp(x, (const xmlChar*) "type");
+			xmlChar* name = xmlGetProp(x, reinterpret_cast<const xmlChar*>("name"));
+			xmlChar* value = xmlGetProp(x, reinterpret_cast<const xmlChar*>("value"));
+			xmlChar* type = xmlGetProp(x, reinterpret_cast<const xmlChar*>("type"));
 
-			string sType = (const char*) type;
+			string sType = reinterpret_cast<const char*>(type);
 
 			if (sType == "int")
 			{
-				int i = atoi((const char*) value);
-				elem.setInt((const char*) name, i);
+				int i = atoi(reinterpret_cast<const char*>(value));
+				elem.setInt(reinterpret_cast<const char*>(name), i);
 			}
 			else if (sType == "double")
 			{
-				double d = tempg_ascii_strtod((const char*) value, nullptr);  //g_ascii_strtod ignores locale setting.
-				elem.setDouble((const char*) name, d);
+				double d = tempg_ascii_strtod(reinterpret_cast<const char*>(value),
+				                              nullptr);  //g_ascii_strtod ignores locale setting.
+				elem.setDouble(reinterpret_cast<const char*>(name), d);
 			}
 			else if (sType == "hex")
 			{
 				int i = 0;
-				if (sscanf((const char*) value, "%x", &i))
+				if (sscanf(reinterpret_cast<const char*>(value), "%x", &i))
 				{
-					elem.setIntHex((const char*) name, i);
+					elem.setIntHex(reinterpret_cast<const char*>(name), i);
 				}
 				else
 				{
@@ -209,11 +210,12 @@ void Settings::parseData(xmlNodePtr cur, SElement& elem)
 			}
 			else if (sType == "string")
 			{
-				elem.setString((const char*) name, (const char*) value);
+				elem.setString(reinterpret_cast<const char*>(name), reinterpret_cast<const char*>(value));
 			}
 			else if (sType == "boolean")
 			{
-				elem.setBool((const char*) name, strcmp((const char*) value, "true") == 0);
+				elem.setBool(reinterpret_cast<const char*>(name),
+				             strcmp(reinterpret_cast<const char*>(value), "true") == 0);
 			}
 			else
 			{
@@ -236,16 +238,16 @@ void Settings::parseData(xmlNodePtr cur, SElement& elem)
 void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur)
 {
 	// Parse data map
-	if (!xmlStrcmp(cur->name, (const xmlChar*) "data"))
+	if (!xmlStrcmp(cur->name, reinterpret_cast<const xmlChar*>("data")))
 	{
-		xmlChar* name = xmlGetProp(cur, (const xmlChar*) "name");
+		xmlChar* name = xmlGetProp(cur, reinterpret_cast<const xmlChar*>("name"));
 		if (name == nullptr)
 		{
 			g_warning("Settings::%s:No name property!\n", cur->name);
 			return;
 		}
 
-		parseData(cur, data[(const char*) name]);
+		parseData(cur, data[reinterpret_cast<const char*>(name)]);
 
 		xmlFree(name);
 		return;
@@ -256,37 +258,37 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur)
 		return;
 	}
 
-	if (xmlStrcmp(cur->name, (const xmlChar*) "property"))
+	if (xmlStrcmp(cur->name, reinterpret_cast<const xmlChar*>("property")))
 	{
 		g_warning("Settings::Unknown XML node: %s\n", cur->name);
 		return;
 	}
 
-	xmlChar* name = xmlGetProp(cur, (const xmlChar*) "name");
+	xmlChar* name = xmlGetProp(cur, reinterpret_cast<const xmlChar*>("name"));
 	if (name == nullptr)
 	{
 		g_warning("Settings::%s:No name property!\n", cur->name);
 		return;
 	}
 
-	if (xmlStrcmp(name, (const xmlChar*) "font") == 0)
+	if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("font")) == 0)
 	{
 		xmlFree(name);
 		xmlChar* font = nullptr;
 		xmlChar* size = nullptr;
 
-		font = xmlGetProp(cur, (const xmlChar*) "font");
+		font = xmlGetProp(cur, reinterpret_cast<const xmlChar*>("font"));
 		if (font)
 		{
-			this->font.setName((const char*) font);
+			this->font.setName(reinterpret_cast<const char*>(font));
 			xmlFree(font);
 		}
 
-		size = xmlGetProp(cur, (const xmlChar*) "size");
+		size = xmlGetProp(cur, reinterpret_cast<const xmlChar*>("size"));
 		if (size)
 		{
 			double dSize = DEFAULT_FONT_SIZE;
-			if (sscanf((const char*) size, "%lf", &dSize) == 1)
+			if (sscanf(reinterpret_cast<const char*>(size), "%lf", &dSize) == 1)
 			{
 				this->font.setSize(dSize);
 			}
@@ -297,7 +299,7 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur)
 		return;
 	}
 
-	xmlChar* value = xmlGetProp(cur, (const xmlChar*) "value");
+	xmlChar* value = xmlGetProp(cur, reinterpret_cast<const xmlChar*>("value"));
 	if (value == nullptr)
 	{
 		xmlFree(name);
@@ -305,246 +307,246 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur)
 		return;
 	}
 
-	// TODO: remove this typo fix in 2-3 release cycles
-	if (xmlStrcmp(name, (const xmlChar*) "presureSensitivity") == 0)
+	// TODO(fabian): remove this typo fix in 2-3 release cycles
+	if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("presureSensitivity")) == 0)
 	{
-		setPressureSensitivity(xmlStrcmp(value, (const xmlChar*) "true") ? false : true);
+		setPressureSensitivity(xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true);
 	}
-	if (xmlStrcmp(name, (const xmlChar*) "pressureSensitivity") == 0)
+	if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("pressureSensitivity")) == 0)
 	{
-		setPressureSensitivity(xmlStrcmp(value, (const xmlChar*) "true") ? false : true);
+		setPressureSensitivity(xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true);
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "zoomGesturesEnabled") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("zoomGesturesEnabled")) == 0)
 	{
-		this->zoomGesturesEnabled = xmlStrcmp(value, (const xmlChar*) "true") ? false : true;
+		this->zoomGesturesEnabled = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "selectedToolbar") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("selectedToolbar")) == 0)
 	{
-		this->selectedToolbar = (const char*) value;
+		this->selectedToolbar = reinterpret_cast<const char*>(value);
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "lastSavePath") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("lastSavePath")) == 0)
 	{
-		this->lastSavePath = (const char*) value;
+		this->lastSavePath = reinterpret_cast<const char*>(value);
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "lastOpenPath") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("lastOpenPath")) == 0)
 	{
-		this->lastOpenPath = (const char*) value;
+		this->lastOpenPath = reinterpret_cast<const char*>(value);
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "lastImagePath") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("lastImagePath")) == 0)
 	{
-		this->lastImagePath = (const char*) value;
+		this->lastImagePath = reinterpret_cast<const char*>(value);
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "zoomStep") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("zoomStep")) == 0)
 	{
-		this->zoomStep = tempg_ascii_strtod((const char*) value, nullptr);
+		this->zoomStep = tempg_ascii_strtod(reinterpret_cast<const char*>(value), nullptr);
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "zoomStepScroll") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("zoomStepScroll")) == 0)
 	{
-		this->zoomStepScroll = tempg_ascii_strtod((const char*) value, nullptr);
+		this->zoomStepScroll = tempg_ascii_strtod(reinterpret_cast<const char*>(value), nullptr);
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "displayDpi") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("displayDpi")) == 0)
 	{
-		this->displayDpi = g_ascii_strtoll((const char*) value, nullptr, 10);
+		this->displayDpi = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "mainWndWidth") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("mainWndWidth")) == 0)
 	{
-		this->mainWndWidth = g_ascii_strtoll((const char*) value, nullptr, 10);
+		this->mainWndWidth = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "mainWndHeight") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("mainWndHeight")) == 0)
 	{
-		this->mainWndHeight = g_ascii_strtoll((const char*) value, nullptr, 10);
+		this->mainWndHeight = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "maximized") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("maximized")) == 0)
 	{
-		this->maximized = xmlStrcmp(value, (const xmlChar*) "true") ? false : true;
+		this->maximized = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "showSidebar") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("showSidebar")) == 0)
 	{
-		this->showSidebar = xmlStrcmp(value, (const xmlChar*) "true") ? false : true;
+		this->showSidebar = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "sidebarWidth") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("sidebarWidth")) == 0)
 	{
-		this->sidebarWidth = std::max<int>(g_ascii_strtoll((const char*) value, nullptr, 10), 50);
+		this->sidebarWidth = std::max<int>(g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10), 50);
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "sidebarOnRight") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("sidebarOnRight")) == 0)
 	{
-		this->sidebarOnRight = xmlStrcmp(value, (const xmlChar*) "true") ? false : true;
+		this->sidebarOnRight = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "scrollbarOnLeft") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("scrollbarOnLeft")) == 0)
 	{
-		this->scrollbarOnLeft = xmlStrcmp(value, (const xmlChar*) "true") ? false : true;
+		this->scrollbarOnLeft = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "menubarVisible") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("menubarVisible")) == 0)
 	{
-		this->menubarVisible = xmlStrcmp(value, (const xmlChar*) "true") ? false : true;
+		this->menubarVisible = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "numColumns") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("numColumns")) == 0)
 	{
-		this->numColumns = g_ascii_strtoll((const char*) value, nullptr, 10);
+		this->numColumns = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "numRows") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("numRows")) == 0)
 	{
-		this->numRows = g_ascii_strtoll((const char*) value, nullptr, 10);
+		this->numRows = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "viewFixedRows") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("viewFixedRows")) == 0)
 	{
-		this->viewFixedRows = xmlStrcmp(value, (const xmlChar*) "true") ? false : true;
+		this->viewFixedRows = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "layoutVertical") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("layoutVertical")) == 0)
 	{
-		this->layoutVertical = xmlStrcmp(value, (const xmlChar*) "true") ? false : true;
+		this->layoutVertical = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "layoutRightToLeft") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("layoutRightToLeft")) == 0)
 	{
-		this->layoutRightToLeft = xmlStrcmp(value, (const xmlChar*) "true") ? false : true;
+		this->layoutRightToLeft = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "layoutBottomToTop") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("layoutBottomToTop")) == 0)
 	{
-		this->layoutBottomToTop = xmlStrcmp(value, (const xmlChar*) "true") ? false : true;
+		this->layoutBottomToTop = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "showPairedPages") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("showPairedPages")) == 0)
 	{
-		this->showPairedPages = xmlStrcmp(value, (const xmlChar*) "true") ? false : true;
+		this->showPairedPages = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "numPairsOffset") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("numPairsOffset")) == 0)
 	{
-		this->numPairsOffset = g_ascii_strtoll((const char*) value, nullptr, 10);
+		this->numPairsOffset = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "presentationMode") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("presentationMode")) == 0)
 	{
-		this->presentationMode = xmlStrcmp(value, (const xmlChar*) "true") ? false : true;
+		this->presentationMode = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "autoloadPdfXoj") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("autoloadPdfXoj")) == 0)
 	{
-		this->autoloadPdfXoj = xmlStrcmp(value, (const xmlChar*) "true") ? false : true;
+		this->autoloadPdfXoj = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "showBigCursor") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("showBigCursor")) == 0)
 	{
-		this->showBigCursor = xmlStrcmp(value, (const xmlChar*) "true") ? false : true;
+		this->showBigCursor = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "highlightPosition") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("highlightPosition")) == 0)
 	{
-		this->highlightPosition = xmlStrcmp(value, (const xmlChar*) "true") ? false : true;
+		this->highlightPosition = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "darkTheme") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("darkTheme")) == 0)
 	{
-		this->darkTheme = xmlStrcmp(value, (const xmlChar*) "true") ? false : true;
+		this->darkTheme = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "defaultSaveName") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("defaultSaveName")) == 0)
 	{
-		this->defaultSaveName = (const char*) value;
+		this->defaultSaveName = reinterpret_cast<const char*>(value);
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "pluginEnabled") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("pluginEnabled")) == 0)
 	{
-		this->pluginEnabled = (const char*) value;
+		this->pluginEnabled = reinterpret_cast<const char*>(value);
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "pluginDisabled") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("pluginDisabled")) == 0)
 	{
-		this->pluginDisabled = (const char*) value;
+		this->pluginDisabled = reinterpret_cast<const char*>(value);
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "pageTemplate") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("pageTemplate")) == 0)
 	{
-		this->pageTemplate = (const char*) value;
+		this->pageTemplate = reinterpret_cast<const char*>(value);
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "sizeUnit") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("sizeUnit")) == 0)
 	{
-		this->sizeUnit = (const char*) value;
+		this->sizeUnit = reinterpret_cast<const char*>(value);
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "audioFolder") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("audioFolder")) == 0)
 	{
-		this->audioFolder = (const char*) value;
+		this->audioFolder = reinterpret_cast<const char*>(value);
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "autosaveEnabled") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("autosaveEnabled")) == 0)
 	{
-		this->autosaveEnabled = xmlStrcmp(value, (const xmlChar*) "true") ? false : true;
+		this->autosaveEnabled = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "autosaveTimeout") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("autosaveTimeout")) == 0)
 	{
-		this->autosaveTimeout = g_ascii_strtoll((const char*) value, nullptr, 10);
+		this->autosaveTimeout = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "fullscreenHideElements") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("fullscreenHideElements")) == 0)
 	{
-		this->fullscreenHideElements = (const char*) value;
+		this->fullscreenHideElements = reinterpret_cast<const char*>(value);
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "presentationHideElements") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("presentationHideElements")) == 0)
 	{
-		this->presentationHideElements = (const char*) value;
+		this->presentationHideElements = reinterpret_cast<const char*>(value);
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "pdfPageCacheSize") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("pdfPageCacheSize")) == 0)
 	{
-		this->pdfPageCacheSize = g_ascii_strtoll((const char*) value, nullptr, 10);
+		this->pdfPageCacheSize = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "selectionBorderColor") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("selectionBorderColor")) == 0)
 	{
-		this->selectionBorderColor = g_ascii_strtoll((const char*) value, nullptr, 10);
+		this->selectionBorderColor = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "selectionMarkerColor") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("selectionMarkerColor")) == 0)
 	{
-		this->selectionMarkerColor = g_ascii_strtoll((const char*) value, nullptr, 10);
+		this->selectionMarkerColor = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "backgroundColor") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("backgroundColor")) == 0)
 	{
-		this->backgroundColor = g_ascii_strtoll((const char*) value, nullptr, 10);
+		this->backgroundColor = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "addHorizontalSpace") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("addHorizontalSpace")) == 0)
 	{
-		this->addHorizontalSpace = xmlStrcmp(value, (const xmlChar*) "true") ? false : true;
+		this->addHorizontalSpace = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "addHorizontalSpaceAmount") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("addHorizontalSpaceAmount")) == 0)
 	{
-		this->addHorizontalSpaceAmount = g_ascii_strtoll((const char*) value, nullptr, 10);
+		this->addHorizontalSpaceAmount = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "addVerticalSpace") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("addVerticalSpace")) == 0)
 	{
-		this->addVerticalSpace = xmlStrcmp(value, (const xmlChar*) "true") ? false : true;
+		this->addVerticalSpace = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "addVerticalSpaceAmount") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("addVerticalSpaceAmount")) == 0)
 	{
-		this->addVerticalSpaceAmount = g_ascii_strtoll((const char*) value, nullptr, 10);
+		this->addVerticalSpaceAmount = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "drawDirModsEnabled") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("drawDirModsEnabled")) == 0)
 	{
-		this->drawDirModsEnabled = xmlStrcmp(value, (const xmlChar*) "true") ? false : true;
+		this->drawDirModsEnabled = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "drawDirModsRadius") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("drawDirModsRadius")) == 0)
 	{
-		this->drawDirModsRadius = g_ascii_strtoll((const char*) value, nullptr, 10);
-	}	
-	else if (xmlStrcmp(name, (const xmlChar*) "snapRotation") == 0)
-	{
-		this->snapRotation = xmlStrcmp(value, (const xmlChar*) "true") ? false : true;
+		this->drawDirModsRadius = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "snapRotationTolerance") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("snapRotation")) == 0)
 	{
-		this->snapRotationTolerance = tempg_ascii_strtod((const char*) value, nullptr);
+		this->snapRotation = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "snapGrid") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("snapRotationTolerance")) == 0)
 	{
-		this->snapGrid = xmlStrcmp(value, (const xmlChar*) "true") ? false : true;
+		this->snapRotationTolerance = tempg_ascii_strtod(reinterpret_cast<const char*>(value), nullptr);
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "snapGrid") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("snapGrid")) == 0)
 	{
-		this->snapGrid = xmlStrcmp(value, (const xmlChar*) "true") ? false : true;
+		this->snapGrid = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "snapGridTolerance") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("snapGrid")) == 0)
 	{
-		this->snapGridTolerance = tempg_ascii_strtod((const char*) value, nullptr);
+		this->snapGrid = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "touchWorkaround") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("snapGridTolerance")) == 0)
 	{
-		this->touchWorkaround = xmlStrcmp(value, (const xmlChar*) "true") ? false : true;
+		this->snapGridTolerance = tempg_ascii_strtod(reinterpret_cast<const char*>(value), nullptr);
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "scrollbarHideType") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("touchWorkaround")) == 0)
 	{
-		if (xmlStrcmp(value, (const xmlChar*) "both") == 0)
+		this->touchWorkaround = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
+	}
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("scrollbarHideType")) == 0)
+	{
+		if (xmlStrcmp(value, reinterpret_cast<const xmlChar*>("both")) == 0)
 		{
 			this->scrollbarHideType = SCROLLBAR_HIDE_BOTH;
 		}
-		else if (xmlStrcmp(value, (const xmlChar*) "horizontal") == 0)
+		else if (xmlStrcmp(value, reinterpret_cast<const xmlChar*>("horizontal")) == 0)
 		{
 			this->scrollbarHideType = SCROLLBAR_HIDE_HORIZONTAL;
 		}
-		else if (xmlStrcmp(value, (const xmlChar*) "vertical") == 0)
+		else if (xmlStrcmp(value, reinterpret_cast<const xmlChar*>("vertical")) == 0)
 		{
 			this->scrollbarHideType = SCROLLBAR_HIDE_VERTICAL;
 		}
@@ -553,65 +555,65 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur)
 			this->scrollbarHideType = SCROLLBAR_HIDE_NONE;
 		}
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "disableScrollbarFadeout") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("disableScrollbarFadeout")) == 0)
 	{
-		this->disableScrollbarFadeout = xmlStrcmp(value, (const xmlChar*) "true") ? false : true;
+		this->disableScrollbarFadeout = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "audioSampleRate") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("audioSampleRate")) == 0)
 	{
-		this->audioSampleRate = tempg_ascii_strtod((const char*) value, nullptr);
+		this->audioSampleRate = tempg_ascii_strtod(reinterpret_cast<const char*>(value), nullptr);
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "audioGain") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("audioGain")) == 0)
 	{
-		this->audioGain = tempg_ascii_strtod((const char*) value, nullptr);
+		this->audioGain = tempg_ascii_strtod(reinterpret_cast<const char*>(value), nullptr);
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "defaultSeekTime") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("defaultSeekTime")) == 0)
 	{
-		this->defaultSeekTime = tempg_ascii_strtod((const char*) value, nullptr);
+		this->defaultSeekTime = tempg_ascii_strtod(reinterpret_cast<const char*>(value), nullptr);
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "audioInputDevice") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("audioInputDevice")) == 0)
 	{
-		this->audioInputDevice = g_ascii_strtoll((const char*) value, nullptr, 10);
+		this->audioInputDevice = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "audioOutputDevice") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("audioOutputDevice")) == 0)
 	{
-		this->audioOutputDevice = g_ascii_strtoll((const char*) value, nullptr, 10);
+		this->audioOutputDevice = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "newInputSystemEnabled") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("newInputSystemEnabled")) == 0)
 	{
-		this->newInputSystemEnabled = xmlStrcmp(value, (const xmlChar*) "true") ? false : true;
+		this->newInputSystemEnabled = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "inputSystemTPCButton") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("inputSystemTPCButton")) == 0)
 	{
-		this->inputSystemTPCButton = xmlStrcmp(value, (const xmlChar*) "true") ? false : true;
+		this->inputSystemTPCButton = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "inputSystemDrawOutsideWindow") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("inputSystemDrawOutsideWindow")) == 0)
 	{
-		this->inputSystemDrawOutsideWindow = xmlStrcmp(value, (const xmlChar*) "true") ? false : true;
+		this->inputSystemDrawOutsideWindow = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "strokeFilterIgnoreTime") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("strokeFilterIgnoreTime")) == 0)
 	{
-		this->strokeFilterIgnoreTime = g_ascii_strtoll((const char*) value, nullptr, 10);
+		this->strokeFilterIgnoreTime = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "strokeFilterIgnoreLength") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("strokeFilterIgnoreLength")) == 0)
 	{
-		this->strokeFilterIgnoreLength = tempg_ascii_strtod((const char*) value, nullptr);
+		this->strokeFilterIgnoreLength = tempg_ascii_strtod(reinterpret_cast<const char*>(value), nullptr);
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "strokeFilterSuccessiveTime") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("strokeFilterSuccessiveTime")) == 0)
 	{
-		this->strokeFilterSuccessiveTime = g_ascii_strtoll((const char*) value, nullptr, 10);
+		this->strokeFilterSuccessiveTime = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "strokeFilterEnabled") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("strokeFilterEnabled")) == 0)
 	{
-		this->strokeFilterEnabled = xmlStrcmp(value, (const xmlChar*) "true") ? false : true;
+		this->strokeFilterEnabled = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "doActionOnStrokeFiltered") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("doActionOnStrokeFiltered")) == 0)
 	{
-		this->doActionOnStrokeFiltered = xmlStrcmp(value, (const xmlChar*) "true") ? false : true;
+		this->doActionOnStrokeFiltered = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
 	}
-	else if (xmlStrcmp(name, (const xmlChar*) "trySelectOnStrokeFiltered") == 0)
+	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("trySelectOnStrokeFiltered")) == 0)
 	{
-		this->trySelectOnStrokeFiltered = xmlStrcmp(value, (const xmlChar*) "true") ? false : true;
+		this->trySelectOnStrokeFiltered = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
 	}
 
 	xmlFree(name);
@@ -629,7 +631,7 @@ void Settings::loadDeviceClasses()
 		deviceNode.getInt("deviceClass", deviceClass);
 		deviceNode.getInt("deviceSource", deviceSource);
 		inputDeviceClasses.insert(std::pair<string, std::pair<int, GdkInputSource>>(
-		        device.first, std::pair<int, GdkInputSource>(deviceClass, (GdkInputSource) deviceSource)));
+		        device.first, std::pair<int, GdkInputSource>(deviceClass, static_cast<GdkInputSource>(deviceSource))));
 	}
 }
 
@@ -743,7 +745,7 @@ auto Settings::load() -> bool
 		return false;
 	}
 
-	if (xmlStrcmp(cur->name, (const xmlChar*) "settings"))
+	if (xmlStrcmp(cur->name, reinterpret_cast<const xmlChar*>("settings")))
 	{
 		g_message("File \"%s\" is of the wrong type", filename.c_str());
 		xmlFreeDoc(doc);
@@ -788,11 +790,11 @@ auto Settings::saveProperty(const gchar* key, int value, xmlNodePtr parent) -> x
 
 auto Settings::saveProperty(const gchar* key, const gchar* value, xmlNodePtr parent) -> xmlNodePtr
 {
-	xmlNodePtr xmlNode = xmlNewChild(parent, nullptr, (const xmlChar*) "property", nullptr);
+	xmlNodePtr xmlNode = xmlNewChild(parent, nullptr, reinterpret_cast<const xmlChar*>("property"), nullptr);
 
-	xmlSetProp(xmlNode, (const xmlChar*) "name", (const xmlChar*) key);
+	xmlSetProp(xmlNode, reinterpret_cast<const xmlChar*>("name"), reinterpret_cast<const xmlChar*>(key));
 
-	xmlSetProp(xmlNode, (const xmlChar*) "value", (const xmlChar*) value);
+	xmlSetProp(xmlNode, reinterpret_cast<const xmlChar*>("value"), reinterpret_cast<const xmlChar*>(value));
 
 	return xmlNode;
 }
@@ -878,7 +880,7 @@ void Settings::save()
 
 	xmlIndentTreeOutput = true;
 
-	doc = xmlNewDoc((const xmlChar*) "1.0");
+	doc = xmlNewDoc(reinterpret_cast<const xmlChar*>("1.0"));
 	if (doc == nullptr)
 	{
 		return;
@@ -888,12 +890,12 @@ void Settings::save()
 	saveDeviceClasses();
 
 	/* Create metadata root */
-	root = xmlNewDocNode(doc, nullptr, (const xmlChar*) "settings", nullptr);
+	root = xmlNewDocNode(doc, nullptr, reinterpret_cast<const xmlChar*>("settings"), nullptr);
 	xmlDocSetRootElement(doc, root);
-	xmlNodePtr com = xmlNewComment((const xmlChar*)
-								   "The Xournal++ settings file. Do not edit this file! "
-								   "The most settings are available in the Settings dialog, "
-								   "the others are commented in this file, but handle with care!");
+	xmlNodePtr com = xmlNewComment(
+	        reinterpret_cast<const xmlChar*>("The Xournal++ settings file. Do not edit this file! "
+	                                         "The most settings are available in the Settings dialog, "
+	                                         "the others are commented in this file, but handle with care!"));
 	xmlAddPrevSibling(root, com);
 
 	WRITE_BOOL_PROP(pressureSensitivity);
@@ -1019,14 +1021,16 @@ void Settings::save()
 	WRITE_BOOL_PROP(inputSystemDrawOutsideWindow);
 
 	xmlNodePtr xmlFont = nullptr;
-	xmlFont = xmlNewChild(root, nullptr, (const xmlChar*) "property", nullptr);
-	xmlSetProp(xmlFont, (const xmlChar*) "name", (const xmlChar*) "font");
-	xmlSetProp(xmlFont, (const xmlChar*) "font", (const xmlChar*) this->font.getName().c_str());
+	xmlFont = xmlNewChild(root, nullptr, reinterpret_cast<const xmlChar*>("property"), nullptr);
+	xmlSetProp(xmlFont, reinterpret_cast<const xmlChar*>("name"), reinterpret_cast<const xmlChar*>("font"));
+	xmlSetProp(xmlFont,
+	           reinterpret_cast<const xmlChar*>("font"),
+	           reinterpret_cast<const xmlChar*>(this->font.getName().c_str()));
 
 	char sSize[G_ASCII_DTOSTR_BUF_SIZE];
 
 	g_ascii_formatd(sSize, G_ASCII_DTOSTR_BUF_SIZE, Util::PRECISION_FORMAT_STRING, this->font.getSize());  // no locale
-	xmlSetProp(xmlFont, (const xmlChar*) "size", (const xmlChar*) sSize);
+	xmlSetProp(xmlFont, reinterpret_cast<const xmlChar*>("size"), reinterpret_cast<const xmlChar*>(sSize));
 
 
 	for (std::map<string, SElement>::value_type p: data)
@@ -1040,9 +1044,9 @@ void Settings::save()
 
 void Settings::saveData(xmlNodePtr root, const string& name, SElement& elem)
 {
-	xmlNodePtr xmlNode = xmlNewChild(root, nullptr, (const xmlChar*) "data", nullptr);
+	xmlNodePtr xmlNode = xmlNewChild(root, nullptr, reinterpret_cast<const xmlChar*>("data"), nullptr);
 
-	xmlSetProp(xmlNode, (const xmlChar*) "name", (const xmlChar*) name.c_str());
+	xmlSetProp(xmlNode, reinterpret_cast<const xmlChar*>("name"), reinterpret_cast<const xmlChar*>(name.c_str()));
 
 	for (auto const& [aname, attrib]: elem.attributes())
 	{
@@ -1098,15 +1102,15 @@ void Settings::saveData(xmlNodePtr root, const string& name, SElement& elem)
 		}
 
 		xmlNodePtr at = nullptr;
-		at = xmlNewChild(xmlNode, nullptr, (const xmlChar*) "attribute", nullptr);
+		at = xmlNewChild(xmlNode, nullptr, reinterpret_cast<const xmlChar*>("attribute"), nullptr);
 
-		xmlSetProp(at, (const xmlChar*) "name", (const xmlChar*) aname.c_str());
-		xmlSetProp(at, (const xmlChar*) "type", (const xmlChar*) type.c_str());
-		xmlSetProp(at, (const xmlChar*) "value", (const xmlChar*) value.c_str());
+		xmlSetProp(at, reinterpret_cast<const xmlChar*>("name"), reinterpret_cast<const xmlChar*>(aname.c_str()));
+		xmlSetProp(at, reinterpret_cast<const xmlChar*>("type"), reinterpret_cast<const xmlChar*>(type.c_str()));
+		xmlSetProp(at, reinterpret_cast<const xmlChar*>("value"), reinterpret_cast<const xmlChar*>(value.c_str()));
 
 		if (!attrib.comment.empty())
 		{
-			xmlNodePtr com = xmlNewComment((const xmlChar*) attrib.comment.c_str());
+			xmlNodePtr com = xmlNewComment(reinterpret_cast<const xmlChar*>(attrib.comment.c_str()));
 			xmlAddPrevSibling(xmlNode, com);
 		}
 	}

--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -272,8 +272,8 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur)
 	if (xmlStrcmp(name, (const xmlChar*) "font") == 0)
 	{
 		xmlFree(name);
-		xmlChar* font;
-		xmlChar* size;
+		xmlChar* font = nullptr;
+		xmlChar* size = nullptr;
 
 		font = xmlGetProp(cur, (const xmlChar*) "font");
 		if (font)
@@ -624,8 +624,8 @@ void Settings::loadDeviceClasses()
 	for (auto device : s.children())
 	{
 		SElement& deviceNode = device.second;
-		int deviceClass;
-		int deviceSource;
+		int deviceClass = 0;
+		int deviceSource = 0;
 		deviceNode.getInt("deviceClass", deviceClass);
 		deviceNode.getInt("deviceSource", deviceSource);
 		inputDeviceClasses.insert(std::pair<string, std::pair<int, GdkInputSource>>(
@@ -872,9 +872,9 @@ void Settings::save()
 		return;
 	}
 
-	xmlDocPtr doc;
-	xmlNodePtr root;
-	xmlNodePtr xmlNode;
+	xmlDocPtr doc = nullptr;
+	xmlNodePtr root = nullptr;
+	xmlNodePtr xmlNode = nullptr;
 
 	xmlIndentTreeOutput = true;
 
@@ -1018,7 +1018,7 @@ void Settings::save()
 	WRITE_BOOL_PROP(inputSystemTPCButton);
 	WRITE_BOOL_PROP(inputSystemDrawOutsideWindow);
 
-	xmlNodePtr xmlFont;
+	xmlNodePtr xmlFont = nullptr;
 	xmlFont = xmlNewChild(root, nullptr, (const xmlChar*) "property", nullptr);
 	xmlSetProp(xmlFont, (const xmlChar*) "name", (const xmlChar*) "font");
 	xmlSetProp(xmlFont, (const xmlChar*) "font", (const xmlChar*) this->font.getName().c_str());
@@ -1097,7 +1097,7 @@ void Settings::saveData(xmlNodePtr root, const string& name, SElement& elem)
 			continue;
 		}
 
-		xmlNodePtr at;
+		xmlNodePtr at = nullptr;
 		at = xmlNewChild(xmlNode, nullptr, (const xmlChar*) "attribute", nullptr);
 
 		xmlSetProp(at, (const xmlChar*) "name", (const xmlChar*) aname.c_str());

--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -11,11 +11,13 @@
 #define DEFAULT_FONT "Sans"
 #define DEFAULT_FONT_SIZE 12
 
-#define WRITE_BOOL_PROP(var) xmlNode = saveProperty((const char *)#var, var ? "true" : "false", root)
-#define WRITE_STRING_PROP(var) xmlNode = saveProperty((const char *)#var, var.empty() ? "" : var.c_str(), root)
+#define WRITE_BOOL_PROP(var) xmlNode = saveProperty((const char*) #var, (var) ? "true" : "false", root)
+#define WRITE_STRING_PROP(var) xmlNode = saveProperty((const char*) #var, (var).empty() ? "" : (var).c_str(), root)
 #define WRITE_INT_PROP(var) xmlNode = saveProperty((const char *)#var, var, root)
 #define WRITE_DOUBLE_PROP(var) xmlNode = savePropertyDouble((const char *)#var, var, root)
-#define WRITE_COMMENT(var) com = xmlNewComment((const xmlChar *)var); xmlAddPrevSibling(xmlNode, com);
+#define WRITE_COMMENT(var)                       \
+	com = xmlNewComment((const xmlChar*) (var)); \
+	xmlAddPrevSibling(xmlNode, com);
 
 const char* BUTTON_NAMES[] = {"middle", "right", "eraser", "touch", "default", "stylus", "stylus2"};
 
@@ -310,15 +312,15 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur)
 	// TODO(fabian): remove this typo fix in 2-3 release cycles
 	if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("presureSensitivity")) == 0)
 	{
-		setPressureSensitivity(xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true);
+		setPressureSensitivity(xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0);
 	}
 	if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("pressureSensitivity")) == 0)
 	{
-		setPressureSensitivity(xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true);
+		setPressureSensitivity(xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0);
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("zoomGesturesEnabled")) == 0)
 	{
-		this->zoomGesturesEnabled = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
+		this->zoomGesturesEnabled = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("selectedToolbar")) == 0)
 	{
@@ -358,11 +360,11 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur)
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("maximized")) == 0)
 	{
-		this->maximized = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
+		this->maximized = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("showSidebar")) == 0)
 	{
-		this->showSidebar = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
+		this->showSidebar = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("sidebarWidth")) == 0)
 	{
@@ -370,15 +372,15 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur)
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("sidebarOnRight")) == 0)
 	{
-		this->sidebarOnRight = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
+		this->sidebarOnRight = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("scrollbarOnLeft")) == 0)
 	{
-		this->scrollbarOnLeft = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
+		this->scrollbarOnLeft = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("menubarVisible")) == 0)
 	{
-		this->menubarVisible = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
+		this->menubarVisible = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("numColumns")) == 0)
 	{
@@ -390,23 +392,23 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur)
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("viewFixedRows")) == 0)
 	{
-		this->viewFixedRows = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
+		this->viewFixedRows = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("layoutVertical")) == 0)
 	{
-		this->layoutVertical = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
+		this->layoutVertical = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("layoutRightToLeft")) == 0)
 	{
-		this->layoutRightToLeft = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
+		this->layoutRightToLeft = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("layoutBottomToTop")) == 0)
 	{
-		this->layoutBottomToTop = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
+		this->layoutBottomToTop = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("showPairedPages")) == 0)
 	{
-		this->showPairedPages = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
+		this->showPairedPages = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("numPairsOffset")) == 0)
 	{
@@ -414,23 +416,23 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur)
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("presentationMode")) == 0)
 	{
-		this->presentationMode = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
+		this->presentationMode = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("autoloadPdfXoj")) == 0)
 	{
-		this->autoloadPdfXoj = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
+		this->autoloadPdfXoj = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("showBigCursor")) == 0)
 	{
-		this->showBigCursor = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
+		this->showBigCursor = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("highlightPosition")) == 0)
 	{
-		this->highlightPosition = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
+		this->highlightPosition = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("darkTheme")) == 0)
 	{
-		this->darkTheme = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
+		this->darkTheme = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("defaultSaveName")) == 0)
 	{
@@ -458,7 +460,7 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur)
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("autosaveEnabled")) == 0)
 	{
-		this->autosaveEnabled = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
+		this->autosaveEnabled = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("autosaveTimeout")) == 0)
 	{
@@ -490,7 +492,7 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur)
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("addHorizontalSpace")) == 0)
 	{
-		this->addHorizontalSpace = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
+		this->addHorizontalSpace = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("addHorizontalSpaceAmount")) == 0)
 	{
@@ -498,7 +500,7 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur)
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("addVerticalSpace")) == 0)
 	{
-		this->addVerticalSpace = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
+		this->addVerticalSpace = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("addVerticalSpaceAmount")) == 0)
 	{
@@ -506,7 +508,7 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur)
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("drawDirModsEnabled")) == 0)
 	{
-		this->drawDirModsEnabled = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
+		this->drawDirModsEnabled = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("drawDirModsRadius")) == 0)
 	{
@@ -514,7 +516,7 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur)
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("snapRotation")) == 0)
 	{
-		this->snapRotation = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
+		this->snapRotation = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("snapRotationTolerance")) == 0)
 	{
@@ -522,11 +524,11 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur)
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("snapGrid")) == 0)
 	{
-		this->snapGrid = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
+		this->snapGrid = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("snapGrid")) == 0)
 	{
-		this->snapGrid = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
+		this->snapGrid = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("snapGridTolerance")) == 0)
 	{
@@ -534,7 +536,7 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur)
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("touchWorkaround")) == 0)
 	{
-		this->touchWorkaround = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
+		this->touchWorkaround = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("scrollbarHideType")) == 0)
 	{
@@ -557,7 +559,7 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur)
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("disableScrollbarFadeout")) == 0)
 	{
-		this->disableScrollbarFadeout = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
+		this->disableScrollbarFadeout = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("audioSampleRate")) == 0)
 	{
@@ -581,15 +583,15 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur)
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("newInputSystemEnabled")) == 0)
 	{
-		this->newInputSystemEnabled = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
+		this->newInputSystemEnabled = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("inputSystemTPCButton")) == 0)
 	{
-		this->inputSystemTPCButton = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
+		this->inputSystemTPCButton = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("inputSystemDrawOutsideWindow")) == 0)
 	{
-		this->inputSystemDrawOutsideWindow = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
+		this->inputSystemDrawOutsideWindow = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("strokeFilterIgnoreTime")) == 0)
 	{
@@ -605,15 +607,15 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur)
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("strokeFilterEnabled")) == 0)
 	{
-		this->strokeFilterEnabled = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
+		this->strokeFilterEnabled = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("doActionOnStrokeFiltered")) == 0)
 	{
-		this->doActionOnStrokeFiltered = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
+		this->doActionOnStrokeFiltered = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
 	}
 	else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("trySelectOnStrokeFiltered")) == 0)
 	{
-		this->trySelectOnStrokeFiltered = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) ? false : true;
+		this->trySelectOnStrokeFiltered = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
 	}
 
 	xmlFree(name);
@@ -2254,9 +2256,9 @@ auto Settings::getDeviceClassForDevice(const string& deviceName, GdkInputSource 
 	{
 		return search->second.first;
 	}
-	else
-	{
-		guint deviceType = 0;
+
+
+	    guint deviceType = 0;
 		switch (deviceSource)
 		{
 			case GDK_SOURCE_CURSOR:
@@ -2286,7 +2288,6 @@ auto Settings::getDeviceClassForDevice(const string& deviceName, GdkInputSource 
 			    deviceType = 0;
 		}
 		return deviceType;
-	}
 }
 
 auto Settings::isScrollbarFadeoutDisabled() const -> bool

--- a/src/control/settings/Settings.h
+++ b/src/control/settings/Settings.h
@@ -56,8 +56,8 @@ public:
 
 public:
 	string sValue;
-	int iValue;
-	double dValue;
+	int iValue{};
+	double dValue{};
 
 	AttributeType type;
 
@@ -478,48 +478,48 @@ private:
 	/**
 	 *  Use pen pressure to control stroke width?
 	 */
-	bool pressureSensitivity;
+	bool pressureSensitivity{};
 
 	/**
 	 * If the touch zoom gestures are enabled
 	 */
-	bool zoomGesturesEnabled;
+	bool zoomGesturesEnabled{};
 
 	/**
 	 *  If the sidebar is visible
 	 */
-	bool showSidebar;
+	bool showSidebar{};
 
 	/**
 	 *  The Width of the Sidebar
 	 */
-	int sidebarWidth;
+	int sidebarWidth{};
 
 	/**
 	 *  If the sidebar is on the right
 	 */
-	bool sidebarOnRight;
+	bool sidebarOnRight{};
 
 	/**
 	 *  Show a better visible cursor for pen
 	 */
-	bool showBigCursor;
+	bool showBigCursor{};
 
 	/**
 	 * Show a yellow circle around the cursor
 	 */
-	bool highlightPosition;
+	bool highlightPosition{};
 
 	/**
 	 * If the user uses a dark-themed DE, he should enable this
 	 * (white icons)
 	 */
-	bool darkTheme;
+	bool darkTheme{};
 
 	/**
 	 * If the menu bar is visible on startup
 	 */
-	 bool menubarVisible;
+	bool menubarVisible{};
 
 	/**
 	 *  Hide the scrollbar
@@ -529,7 +529,7 @@ private:
 	/**
 	 * Disable scrollbar fade out (overlay scrolling)
 	 */
-	bool disableScrollbarFadeout;
+	bool disableScrollbarFadeout{};
 
 	/**
 	 *  The selected Toolbar name
@@ -559,139 +559,137 @@ private:
 	/**
 	 * Zoomstep for one step
 	 */
-	double zoomStep;
+	double zoomStep{};
 
 	/**
 	 * Zoomstep for Ctrl + Scroll zooming
 	 */
-	double zoomStepScroll;
+	double zoomStepScroll{};
 
 	/**
 	 * The display resolution, in pixels per inch
 	 */
-	gint displayDpi;
+	gint displayDpi{};
 
 	/**
 	 *  If the window is maximized
 	 */
-	bool maximized;
+	bool maximized{};
 
 	/**
 	 * Width of the main window
 	 */
-	int mainWndWidth;
+	int mainWndWidth{};
 
 	/**
 	 * Height of the main window
 	 */
-	int mainWndHeight;
+	int mainWndHeight{};
 
 	/**
 	 * Show the scrollbar on the left side
 	 */
-	bool scrollbarOnLeft;
+	bool scrollbarOnLeft{};
 
 	/**
 	 *  Pairs pages
 	 */
-	bool showPairedPages;
+	bool showPairedPages{};
 
 	/**
 	 *  Sets presentation mode
 	 */
-	bool presentationMode;
+	bool presentationMode{};
 
 	/**
 	 *  Offsets first page ( to align pairing )
 	 */
-	int numPairsOffset;
+	int numPairsOffset{};
 
 	/**
 	 *  Use when fixed number of columns
 	 */
-	int numColumns;
+	int numColumns{};
 
 	/**
 	 *  Use when fixed number of rows
 	 */
-	int numRows;
+	int numRows{};
 
 	/**
 	 *  USE  fixed rows, otherwise fixed columns
 	 */
-	bool viewFixedRows;
+	bool viewFixedRows{};
 
 	/**
 	 *  Layout Vertical then Horizontal
 	 */
-	bool layoutVertical;
+	bool layoutVertical{};
 
 	/**
 	 *  Layout pages right to left
 	 */
-	bool layoutRightToLeft;
+	bool layoutRightToLeft{};
 
 	/**
 	 *  Layout Bottom to Top
 	 */
-	bool layoutBottomToTop;
-
-
+	bool layoutBottomToTop{};
 
 
 	/**
 	 * Automatically load filename.pdf.xoj / .pdf.xopp instead of filename.pdf (true/false)
 	 */
-	bool autoloadPdfXoj;
+	bool autoloadPdfXoj{};
 
 	/**
 	 * Automatically save documents for crash recovery each x minutes
 	 */
-	int autosaveTimeout;
+	int autosaveTimeout{};
 
 	/**
 	 *  Enable automatic save
 	 */
-	bool autosaveEnabled;
+	bool autosaveEnabled{};
 
 	/**
 	 * Allow scroll outside the page display area (horizontal)
 	 */
-	bool addHorizontalSpace;
+	bool addHorizontalSpace{};
 
 	/**
 	 * How much allowance to scroll outside the page display area (either side of )
 	 */
-	int addHorizontalSpaceAmount;
+	int addHorizontalSpaceAmount{};
 
 	/**
 	 * Allow scroll outside the page display area (vertical)
 	 */
-	bool addVerticalSpace;
+	bool addVerticalSpace{};
 
 	/** How much allowance to scroll outside the page display area (above and below)
 	*/
-	int addVerticalSpaceAmount;
+	int addVerticalSpaceAmount{};
 
 	/**
 	 * Emulate modifier keys based on initial direction of drawing tool ( for Rectangle, Ellipse etc. )
 	 */
-	bool drawDirModsEnabled;
+	bool drawDirModsEnabled{};
 
 	/**
 	 * Radius at which emulated modifiers are locked on for the rest of drawing operation
 	 */
-	int drawDirModsRadius;
+	int drawDirModsRadius{};
 
 	/**
 	 * Rotation snapping enabled by default
 	 */
-	bool snapRotation;
+	bool snapRotation{};
 
 	/**
 	 * grid snapping enabled by default
 	 */
-	bool snapGrid;
+	bool snapGrid{};
 
 	/**
 	 * Default name if you save a new document
@@ -709,7 +707,7 @@ private:
 	 * 5: Pen Button 1
 	 * 6: Pen Button 2
 	 */
-	ButtonConfig* buttonConfig[BUTTON_COUNT];
+	ButtonConfig* buttonConfig[BUTTON_COUNT]{};
 
 	/**
 	 * Which gui elements are hidden if you are in Fullscreen mode,
@@ -721,23 +719,23 @@ private:
 	/**
 	 *  The count of pages which will be cached
 	 */
-	int pdfPageCacheSize;
+	int pdfPageCacheSize{};
 
 	/**
 	 * The color to draw borders on selected elements
 	 * (Page, insert image selection etc.)
 	 */
-	int selectionBorderColor;
+	int selectionBorderColor{};
 
 	/**
 	 * Color for Text selection, Stroke selection etc.
 	 */
-	int selectionMarkerColor;
+	int selectionMarkerColor{};
 
 	/**
 	 * The color for Xournal page background
 	 */
-	int backgroundColor;
+	int backgroundColor{};
 
 	/**
 	 * Page template String
@@ -757,42 +755,42 @@ private:
 	/**
 	 * Snap tolerance for the graph/dotted grid
 	 */
-	double snapGridTolerance;
+	double snapGridTolerance{};
 
 	/**
 	 * Rotation epsilon for rotation snapping feature
 	 */
-	double snapRotationTolerance;
+	double snapRotationTolerance{};
 
 	/**
 	 * Do not use GTK Scrolling / Touch handling
 	 */
-	bool touchWorkaround;
+	bool touchWorkaround{};
 
 	/**
 	 * The index of the audio device used for recording
 	 */
-	PaDeviceIndex audioInputDevice;
+	PaDeviceIndex audioInputDevice{};
 
 	/**
 	 * The index of the audio device used for playback
 	 */
-	PaDeviceIndex audioOutputDevice;
+	PaDeviceIndex audioOutputDevice{};
 
 	/**
 	 * The sample rate used for recording
 	 */
-	double audioSampleRate;
+	double audioSampleRate{};
 
 	/**
 	 * The gain by which to amplify the recorded audio samples
 	 */
-	double audioGain;
+	double audioGain{};
 
 	/**
 	 * The default time by which the playback will seek backwards and forwards
 	 */
-	unsigned int defaultSeekTime;
+	unsigned int defaultSeekTime{};
 
 	/**
 	 * List of enabled plugins (only the one which are not enabled by default)
@@ -811,31 +809,29 @@ private:
 	 * strokeFilterIgnoreTime 			within this time (ms)  will be ignored..
 	 * strokeFilterSuccessiveTime		...unless successive within this time.
 	 */
-	int strokeFilterIgnoreTime;
-	double strokeFilterIgnoreLength;
-	int strokeFilterSuccessiveTime;
-	bool strokeFilterEnabled;
-	bool doActionOnStrokeFiltered;
-	bool trySelectOnStrokeFiltered;
+	int strokeFilterIgnoreTime{};
+	double strokeFilterIgnoreLength{};
+	int strokeFilterSuccessiveTime{};
+	bool strokeFilterEnabled{};
+	bool doActionOnStrokeFiltered{};
+	bool trySelectOnStrokeFiltered{};
 
 	/**
 	 * Whether the new experimental input system is activated
 	 */
-	bool newInputSystemEnabled;
+	bool newInputSystemEnabled{};
 
 	/**
 	 * Whether Wacom parameter TabletPCButton is enabled
 	 */
-	bool inputSystemTPCButton;
+	bool inputSystemTPCButton{};
 
-	bool inputSystemDrawOutsideWindow;
+	bool inputSystemDrawOutsideWindow{};
 
 	std::map<string, std::pair<int, GdkInputSource>> inputDeviceClasses = {};
 
 	/**
 	 * "Transaction" running, do not save until the end is reached
 	 */
-	bool inTransaction;
-
-
+	bool inTransaction{};
 };

--- a/src/control/settings/Settings.h
+++ b/src/control/settings/Settings.h
@@ -137,11 +137,9 @@ private:
 	void loadDefault();
 	void parseItem(xmlDocPtr doc, xmlNodePtr cur);
 
-	xmlNodePtr savePropertyDouble(const gchar* key, double value,
-								  xmlNodePtr parent);
-	xmlNodePtr saveProperty(const gchar* key, int value, xmlNodePtr parent);
-	xmlNodePtr saveProperty(const gchar* key, const gchar* value,
-							xmlNodePtr parent);
+	static xmlNodePtr savePropertyDouble(const gchar* key, double value, xmlNodePtr parent);
+	static xmlNodePtr saveProperty(const gchar* key, int value, xmlNodePtr parent);
+	static xmlNodePtr saveProperty(const gchar* key, const gchar* value, xmlNodePtr parent);
 
 	void saveData(xmlNodePtr root, const string& name, SElement& elem);
 
@@ -237,7 +235,7 @@ public:
 	void setPresentationMode(bool presentationMode);
 	bool isPresentationMode() const;
 
-	void setPairsOffset(int numPairsOffset);
+	void setPairsOffset(int numOffset);
 	int getPairsOffset() const;
 
 	void setViewColumns(int numColumns);

--- a/src/control/shaperecognizer/CircleRecognizer.cpp
+++ b/src/control/shaperecognizer/CircleRecognizer.cpp
@@ -12,7 +12,7 @@
  */
 auto CircleRecognizer::makeCircleShape(Stroke* originalStroke, Inertia& inertia) -> Stroke*
 {
-	int npts = (int) (2 * inertia.rad());
+	int npts = static_cast<int>(2 * inertia.rad());
 	if (npts < 12)
 	{
 		npts = 12; // min. number of points

--- a/src/control/shaperecognizer/Inertia.cpp
+++ b/src/control/shaperecognizer/Inertia.cpp
@@ -21,17 +21,17 @@ Inertia::Inertia(const Inertia& inertia)
 
 Inertia::~Inertia() = default;
 
-auto Inertia::centerX() -> double
+auto Inertia::centerX() const -> double
 {
 	return this->sx / this->mass;
 }
 
-auto Inertia::centerY() -> double
+auto Inertia::centerY() const -> double
 {
 	return this->sy / this->mass;
 }
 
-auto Inertia::xx() -> double
+auto Inertia::xx() const -> double
 {
 	if (this->mass <= 0.0)
 	{
@@ -40,7 +40,7 @@ auto Inertia::xx() -> double
 	return (this->sxx - this->sx * this->sx / this->mass) / this->mass;
 }
 
-auto Inertia::xy() -> double
+auto Inertia::xy() const -> double
 {
 	if (this->mass <= 0.0)
 	{
@@ -49,7 +49,7 @@ auto Inertia::xy() -> double
 	return (this->sxy - this->sx * this->sy / this->mass) / this->mass;
 }
 
-auto Inertia::yy() -> double
+auto Inertia::yy() const -> double
 {
 	if (this->mass <= 0.0)
 	{
@@ -58,7 +58,7 @@ auto Inertia::yy() -> double
 	return (this->syy - this->sy * this->sy / this->mass) / this->mass;
 }
 
-auto Inertia::rad() -> double
+auto Inertia::rad() const -> double
 {
 	double ixx = this->xx();
 	double iyy = this->yy();
@@ -69,7 +69,7 @@ auto Inertia::rad() -> double
 	return sqrt(ixx + iyy);
 }
 
-auto Inertia::det() -> double
+auto Inertia::det() const -> double
 {
 	double ixx = this->xx();
 	double iyy = this->yy();
@@ -87,7 +87,7 @@ auto Inertia::det() -> double
 	return 4 * (ixx * iyy - ixy * ixy) / (ixx + iyy) / (ixx + iyy);
 }
 
-auto Inertia::getMass() -> double
+auto Inertia::getMass() const -> double
 {
 	return mass;
 }

--- a/src/control/shaperecognizer/Inertia.h
+++ b/src/control/shaperecognizer/Inertia.h
@@ -40,10 +40,10 @@ public:
 	void calc(const Point* pt, int start, int end);
 
 private:
-	double mass;
-	double sx;
-	double sy;
-	double sxx;
-	double sxy;
-	double syy;
+	double mass{};
+	double sx{};
+	double sy{};
+	double sxx{};
+	double sxy{};
+	double syy{};
 };

--- a/src/control/shaperecognizer/Inertia.h
+++ b/src/control/shaperecognizer/Inertia.h
@@ -23,18 +23,18 @@ public:
 	virtual ~Inertia();
 
 public:
-	double centerX();
-	double centerY();
+	double centerX() const;
+	double centerY() const;
 
-	double xx();
-	double xy();
-	double yy();
+	double xx() const;
+	double xy() const;
+	double yy() const;
 
-	double rad();
+	double rad() const;
 
-	double det();
+	double det() const;
 
-	double getMass();
+	double getMass() const;
 
 	void increase(Point p1, Point p2, int coef);
 	void calc(const Point* pt, int start, int end);

--- a/src/control/shaperecognizer/RecoSegment.cpp
+++ b/src/control/shaperecognizer/RecoSegment.cpp
@@ -1,7 +1,7 @@
 #include "RecoSegment.h"
 
 #include "Inertia.h"
-#include "math.h"
+#include <cmath>
 
 #include <cmath>
 #include <cstdlib>
@@ -25,7 +25,7 @@ RecoSegment::RecoSegment()
 
 RecoSegment::~RecoSegment() = default;
 
-auto RecoSegment::calcEdgeIsect(RecoSegment* r2) -> Point
+auto RecoSegment::calcEdgeIsect(RecoSegment* r2) const -> Point
 {
 	double t = NAN;
 	t = (r2->xcenter - this->xcenter) * sin(r2->angle) - (r2->ycenter - this->ycenter) * cos(r2->angle);

--- a/src/control/shaperecognizer/RecoSegment.cpp
+++ b/src/control/shaperecognizer/RecoSegment.cpp
@@ -1,6 +1,7 @@
 #include "RecoSegment.h"
 
 #include "Inertia.h"
+#include "math.h"
 
 #include <cmath>
 #include <cstdlib>
@@ -26,7 +27,7 @@ RecoSegment::~RecoSegment() = default;
 
 auto RecoSegment::calcEdgeIsect(RecoSegment* r2) -> Point
 {
-	double t;
+	double t = NAN;
 	t = (r2->xcenter - this->xcenter) * sin(r2->angle) - (r2->ycenter - this->ycenter) * cos(r2->angle);
 	t /= sin(r2->angle - this->angle);
 	double x = this->xcenter + t * cos(this->angle);

--- a/src/control/shaperecognizer/RecoSegment.h
+++ b/src/control/shaperecognizer/RecoSegment.h
@@ -25,7 +25,7 @@ public:
 	virtual ~RecoSegment();
 
 public:
-	Point calcEdgeIsect(RecoSegment* r2);
+	Point calcEdgeIsect(RecoSegment* r2) const;
 
 	/**
 	 * Find the geometry of a recognized segment

--- a/src/control/shaperecognizer/ShapeRecognizer.cpp
+++ b/src/control/shaperecognizer/ShapeRecognizer.cpp
@@ -4,7 +4,7 @@
 #include "Inertia.h"
 #include "ShapeRecognizerResult.h"
 
-#include "math.h"
+#include <cmath>
 #include "model/Stroke.h"
 
 #include <config-debug.h>

--- a/src/control/shaperecognizer/ShapeRecognizer.cpp
+++ b/src/control/shaperecognizer/ShapeRecognizer.cpp
@@ -4,6 +4,7 @@
 #include "Inertia.h"
 #include "ShapeRecognizerResult.h"
 
+#include "math.h"
 #include "model/Stroke.h"
 
 #include <config-debug.h>
@@ -149,11 +150,11 @@ auto ShapeRecognizer::tryArrow() -> Stroke*
 		return nullptr;
 	}
 
-	double x1;
-	double y1;
-	double x2;
-	double y2;
-	double angle;
+	double x1 = NAN;
+	double y1 = NAN;
+	double x2 = NAN;
+	double y2 = NAN;
+	double angle = NAN;
 
 	if (rev[1])
 	{
@@ -286,7 +287,7 @@ auto ShapeRecognizer::tryArrow() -> Stroke*
 auto ShapeRecognizer::findPolygonal(const Point* pt, int start, int end, int nsides, int* breaks, Inertia* ss) -> int
 {
 	Inertia s;
-	int i1, i2, n1, n2;
+	int i1 = 0, i2 = 0, n1 = 0, n2 = 0;
 
 	if (end == start)
 	{
@@ -320,8 +321,8 @@ auto ShapeRecognizer::findPolygonal(const Point* pt, int start, int end, int nsi
 		return 0; // failed!
 	}
 
-	double det1;
-	double det2;
+	double det1 = NAN;
+	double det2 = NAN;
 	Inertia s1;
 	Inertia s2;
 

--- a/src/control/shaperecognizer/ShapeRecognizer.h
+++ b/src/control/shaperecognizer/ShapeRecognizer.h
@@ -33,8 +33,8 @@ private:
 	Stroke* tryRectangle();
 	Stroke* tryArrow();
 
-	Stroke* tryClosedPolygon(int nsides);
-	void optimizePolygonal(const Point* pt, int nsides, int* breaks, Inertia* ss);
+	static Stroke* tryClosedPolygon(int nsides);
+	static void optimizePolygonal(const Point* pt, int nsides, int* breaks, Inertia* ss);
 
 	int findPolygonal(const Point* pt, int start, int end, int nsides, int* breaks, Inertia* ss);
 

--- a/src/control/stockdlg/ImageOpenDlg.cpp
+++ b/src/control/stockdlg/ImageOpenDlg.cpp
@@ -24,7 +24,7 @@ auto ImageOpenDlg::show(GtkWindow* win, Settings* settings, bool localOnly, bool
 	}
 
 	GtkWidget* cbAttach = nullptr;
-	if (attach)
+	if (*attach)
 	{
 		cbAttach = gtk_check_button_new_with_label(_("Attach file to the journal"));
 		gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(cbAttach), false);

--- a/src/control/stockdlg/ImageOpenDlg.cpp
+++ b/src/control/stockdlg/ImageOpenDlg.cpp
@@ -71,7 +71,7 @@ auto ImageOpenDlg::pixbufScaleDownIfNecessary(GdkPixbuf* pixbuf, gint maxSize) -
 
 	if (width > maxSize || height > maxSize)
 	{
-		double factor = (gdouble) maxSize / std::max(width, height);
+		double factor = static_cast<gdouble>(maxSize) / std::max(width, height);
 
 		width = width * factor;
 		height = height * factor;
@@ -79,7 +79,7 @@ auto ImageOpenDlg::pixbufScaleDownIfNecessary(GdkPixbuf* pixbuf, gint maxSize) -
 		return gdk_pixbuf_scale_simple(pixbuf, width, height, GDK_INTERP_HYPER);
 	}
 
-	return (GdkPixbuf*) g_object_ref(pixbuf);
+	return static_cast<GdkPixbuf*>(g_object_ref(pixbuf));
 }
 
 void ImageOpenDlg::updatePreviewCallback(GtkFileChooser* fileChooser, void* userData)

--- a/src/control/tools/BaseStrokeHandler.cpp
+++ b/src/control/tools/BaseStrokeHandler.cpp
@@ -4,7 +4,7 @@
 #include "control/layer/LayerController.h"
 #include "gui/XournalView.h"
 #include "gui/XournalppCursor.h"
-#include "math.h"
+#include <cmath>
 #include "undo/InsertUndoAction.h"
 #include "util/cpp14memory.h"
 
@@ -197,22 +197,22 @@ void BaseStrokeHandler::onButtonReleaseEvent(const PositionInputData& pos)
 								    
 		if (   lengthSqrd < pow((strokeFilterIgnoreLength*dpmm),2) && pos.timestamp - this->startStrokeTime < strokeFilterIgnoreTime) 
 		{
-			if ( pos.timestamp - this->lastStrokeTime  > strokeFilterSuccessiveTime )
+			if (pos.timestamp - BaseStrokeHandler::lastStrokeTime > strokeFilterSuccessiveTime)
 			{
 				//stroke not being added to layer... delete here.
 				delete stroke;
 				stroke = nullptr;
 				this->userTapped = true;
-				
-				this->lastStrokeTime = pos.timestamp;
-				
+
+				BaseStrokeHandler::lastStrokeTime = pos.timestamp;
+
 				xournal->getCursor()->updateCursor();
 				
 				return;
 			}
 
 		}
-		this->lastStrokeTime = pos.timestamp;
+		BaseStrokeHandler::lastStrokeTime = pos.timestamp;
 	}
 	
 	
@@ -242,8 +242,6 @@ void BaseStrokeHandler::onButtonReleaseEvent(const PositionInputData& pos)
 	stroke = nullptr;
 
 	xournal->getCursor()->updateCursor();
-	
-	return;
 }
 
 void BaseStrokeHandler::onButtonPressEvent(const PositionInputData& pos)

--- a/src/control/tools/BaseStrokeHandler.cpp
+++ b/src/control/tools/BaseStrokeHandler.cpp
@@ -214,8 +214,8 @@ void BaseStrokeHandler::onButtonReleaseEvent(const PositionInputData& pos)
 		}
 		BaseStrokeHandler::lastStrokeTime = pos.timestamp;
 	}
-	
-	
+
+
 	// This is not a valid stroke
 	if (stroke->getPointCount() < 2)
 	{
@@ -277,10 +277,10 @@ void BaseStrokeHandler::modifyModifiersByDrawDir(double width, double height,  b
 		{
 			this->drawModifierFixed = static_cast<DIRSET_MODIFIERS>(SET | (gestureShift ? SHIFT : NONE) |
 			                                                        (gestureControl ? CONTROL : NONE));
-			if(changeCursor)
- 			{
+			if (changeCursor)
+			{
 				xournal->getCursor()->activateDrawDirCursor(false);
- 			}
+			}
 		}
 		else
 		{

--- a/src/control/tools/BaseStrokeHandler.cpp
+++ b/src/control/tools/BaseStrokeHandler.cpp
@@ -4,6 +4,7 @@
 #include "control/layer/LayerController.h"
 #include "gui/XournalView.h"
 #include "gui/XournalppCursor.h"
+#include "math.h"
 #include "undo/InsertUndoAction.h"
 #include "util/cpp14memory.h"
 
@@ -92,8 +93,8 @@ auto BaseStrokeHandler::onKeyEvent(GdkEventKey* event) -> bool
 	if(event->is_modifier)
 	{
 		Rectangle rect = stroke->boundingRect();
-			
-		PositionInputData pos;
+
+		PositionInputData pos{};
 		pos.x = pos.y = pos.pressure = 0; //not used in redraw
 		if( event->keyval == GDK_KEY_Shift_L || event->keyval == GDK_KEY_Shift_R)
 		{
@@ -181,10 +182,10 @@ void BaseStrokeHandler::onButtonReleaseEvent(const PositionInputData& pos)
 	Settings* settings = control->getSettings();
 	
 	if ( settings->getStrokeFilterEnabled() )		// Note: For simple strokes see StrokeHandler which has a slightly different version of this filter.  See //!
-	{	
-		int strokeFilterIgnoreTime,strokeFilterSuccessiveTime;
-		double strokeFilterIgnoreLength;
-		
+	{
+		int strokeFilterIgnoreTime = 0, strokeFilterSuccessiveTime = 0;
+		double strokeFilterIgnoreLength = NAN;
+
 		settings->getStrokeFilter( &strokeFilterIgnoreTime, &strokeFilterIgnoreLength, &strokeFilterSuccessiveTime  );
 		double dpmm = settings->getDisplayDpi()/25.4;
 		

--- a/src/control/tools/BaseStrokeHandler.cpp
+++ b/src/control/tools/BaseStrokeHandler.cpp
@@ -98,15 +98,17 @@ auto BaseStrokeHandler::onKeyEvent(GdkEventKey* event) -> bool
 		pos.x = pos.y = pos.pressure = 0; //not used in redraw
 		if( event->keyval == GDK_KEY_Shift_L || event->keyval == GDK_KEY_Shift_R)
 		{
-			pos.state = (GdkModifierType)(event->state ^ GDK_SHIFT_MASK);	// event state does not include current this modifier keypress - so ^toggle will work for press and release.
+			pos.state = static_cast<GdkModifierType>(
+			        event->state ^
+			        GDK_SHIFT_MASK);  // event state does not include current this modifier keypress - so ^toggle will work for press and release.
 		}
 		else if( event->keyval == GDK_KEY_Control_L || event->keyval == GDK_KEY_Control_R)
 		{
-			pos.state = (GdkModifierType)(event->state ^ GDK_CONTROL_MASK);
+			pos.state = static_cast<GdkModifierType>(event->state ^ GDK_CONTROL_MASK);
 		}
 		else if( event->keyval == GDK_KEY_Alt_L || event->keyval == GDK_KEY_Alt_R)
 		{
-			pos.state = (GdkModifierType)(event->state ^ GDK_MOD1_MASK);
+			pos.state = static_cast<GdkModifierType>(event->state ^ GDK_MOD1_MASK);
 		} 				
 		else{
 			return false;
@@ -275,10 +277,9 @@ void BaseStrokeHandler::modifyModifiersByDrawDir(double width, double height,  b
 		double fixate_Dir_Mods_Dist = std::pow( xournal->getControl()->getSettings()->getDrawDirModsRadius() / zoom, 2.0); 
 		if (std::pow(width,2.0) > fixate_Dir_Mods_Dist ||  std::pow(height,2.0) > fixate_Dir_Mods_Dist )
 		{
-			this->drawModifierFixed = (DIRSET_MODIFIERS)(SET |
-				(gestureShift? SHIFT:NONE) |
-				(gestureControl? CONTROL:NONE) );
- 			if(changeCursor)
+			this->drawModifierFixed = static_cast<DIRSET_MODIFIERS>(SET | (gestureShift ? SHIFT : NONE) |
+			                                                        (gestureControl ? CONTROL : NONE));
+			if(changeCursor)
  			{
 				xournal->getCursor()->activateDrawDirCursor(false);
  			}

--- a/src/control/tools/BaseStrokeHandler.h
+++ b/src/control/tools/BaseStrokeHandler.h
@@ -48,7 +48,7 @@ private:
 	bool flipControl = false; //use to reverse Control key modifier action.
 	
 	// to filter out short strokes (usually the user tapping on the page to select it)
-	guint32 startStrokeTime;
+	guint32 startStrokeTime{};
 	static guint32 lastStrokeTime;	//persist across strokes - allow us to not ignore persistent dotting.
 	
 protected:

--- a/src/control/tools/CircleHandler.cpp
+++ b/src/control/tools/CircleHandler.cpp
@@ -69,7 +69,7 @@ void CircleHandler::drawShape(Point& c, const PositionInputData& pos)
 		{
 			diameterX = width;
 			diameterY = height;
-			npts = (int) std::abs(diameterX * 2.0);
+			npts = static_cast<int>(std::abs(diameterX * 2.0));
 			center_x = this->startPoint.x + width / 2.0;
 			center_y = this->startPoint.y + height / 2.0;
 			angle = 0;
@@ -78,7 +78,7 @@ void CircleHandler::drawShape(Point& c, const PositionInputData& pos)
 		{	//control key down, draw centered at cursor
 			diameterX = width*2.0;
 			diameterY = height*2.0;
-			npts = (int) (std::abs(diameterX) + std::abs(diameterY));
+			npts = static_cast<int>(std::abs(diameterX) + std::abs(diameterY));
 			center_x = this->startPoint.x;
 			center_y = this->startPoint.y;
 			angle = 0;

--- a/src/control/tools/EditSelection.cpp
+++ b/src/control/tools/EditSelection.cpp
@@ -6,6 +6,7 @@
 #include "control/Control.h"
 #include "gui/PageView.h"
 #include "gui/XournalView.h"
+#include "math.h"
 #include "model/Document.h"
 #include "model/Layer.h"
 #include "model/Element.h"
@@ -452,7 +453,7 @@ void EditSelection::mouseMove(double mouseX, double mouseY)
 		{
 			dx = rx - this->x;
 			dy = ry - this->y;
-			double f;
+			double f = NAN;
 			if (std::abs(dy) < std::abs(dx))
 			{
 				f = (this->height + dy) / this->height;
@@ -475,7 +476,7 @@ void EditSelection::mouseMove(double mouseX, double mouseY)
 			dx = rx - this->x - this->width;
 			dy = ry - this->y;
 
-			double f;
+			double f = NAN;
 			if (std::abs(dy) < std::abs(dx))
 			{
 				f = this->height / (this->height + dy);
@@ -495,7 +496,7 @@ void EditSelection::mouseMove(double mouseX, double mouseY)
 		{
 			dx = rx - this->x;
 			dy = ry - this->y - this->height;
-			double f;
+			double f = NAN;
 			if (std::abs(dy) < std::abs(dx))
 			{
 				f = (this->height + dy) / this->height;
@@ -515,7 +516,7 @@ void EditSelection::mouseMove(double mouseX, double mouseY)
 		{
 			dx = rx - this->x - this->width;
 			dy = ry - this->y - this->height;
-			double f;
+			double f = NAN;
 			if (std::abs(dy) < std::abs(dx))
 			{
 				f = (this->height + dy) / this->height;

--- a/src/control/tools/EditSelection.cpp
+++ b/src/control/tools/EditSelection.cpp
@@ -6,7 +6,7 @@
 #include "control/Control.h"
 #include "gui/PageView.h"
 #include "gui/XournalView.h"
-#include "math.h"
+#include <cmath>
 #include "model/Document.h"
 #include "model/Layer.h"
 #include "model/Element.h"
@@ -188,7 +188,7 @@ void EditSelection::finalizeSelection()
  * get the X coordinate relative to the provided view (getView())
  * in document coordinates
  */
-auto EditSelection::getXOnView() -> double
+auto EditSelection::getXOnView() const -> double
 {
 	return this->x;
 }
@@ -197,7 +197,7 @@ auto EditSelection::getXOnView() -> double
  * get the Y coordinate relative to the provided view (getView())
  * in document coordinates
  */
-auto EditSelection::getYOnView() -> double
+auto EditSelection::getYOnView() const -> double
 {
 	return this->y;
 }
@@ -215,7 +215,7 @@ auto EditSelection::getOriginalYOnView() -> double
 /**
  * get the width in document coordinates (multiple with zoom)
  */
-auto EditSelection::getWidth() -> double
+auto EditSelection::getWidth() const -> double
 {
 	return this->width;
 }
@@ -223,7 +223,7 @@ auto EditSelection::getWidth() -> double
 /**
  * get the height in document coordinates (multiple with zoom)
  */
-auto EditSelection::getHeight() -> double
+auto EditSelection::getHeight() const -> double
 {
 	return this->height;
 }
@@ -366,16 +366,16 @@ void EditSelection::mouseUp()
 		this->view->getXournal()->deleteSelection();
 		return;
 	}
-	else
-	{
-		PageRef page = this->view->getPage();
+
+
+	    PageRef page = this->view->getPage();
 		Layer* layer = page->getSelectedLayer();
 
 		snapRotation();
 
 		this->contents->updateContent(this->x, this->y, this->rotation, this->width, this->height, this->aspectRatio,
 									layer, page, this->view, this->undo, this->mouseDownType);
-	}
+
 	this->mouseDownType = CURSOR_SELECTION_NONE;
 
 	double zoom = this->view->getXournal()->getZoom();
@@ -888,7 +888,7 @@ void EditSelection::drawAnchorRect(cairo_t* cr, double x, double y, double zoom)
 /**
  * draws an idicator where you can delete the selection
  */
-void EditSelection::drawDeleteRect(cairo_t* cr, double x, double y, double zoom)
+void EditSelection::drawDeleteRect(cairo_t* cr, double x, double y, double zoom) const
 {
 	cairo_set_source_rgb(cr, 0, 0, 0);
 	cairo_rectangle(cr, x * zoom - (this->btnWidth/2), y * zoom - (this->btnWidth/2), this->btnWidth, this->btnWidth);

--- a/src/control/tools/EditSelection.cpp
+++ b/src/control/tools/EditSelection.cpp
@@ -368,13 +368,13 @@ void EditSelection::mouseUp()
 	}
 
 
-	    PageRef page = this->view->getPage();
-		Layer* layer = page->getSelectedLayer();
+	PageRef page = this->view->getPage();
+	Layer* layer = page->getSelectedLayer();
 
-		snapRotation();
+	snapRotation();
 
-		this->contents->updateContent(this->x, this->y, this->rotation, this->width, this->height, this->aspectRatio,
-									layer, page, this->view, this->undo, this->mouseDownType);
+	this->contents->updateContent(this->x, this->y, this->rotation, this->width, this->height, this->aspectRatio, layer,
+	                              page, this->view, this->undo, this->mouseDownType);
 
 	this->mouseDownType = CURSOR_SELECTION_NONE;
 

--- a/src/control/tools/EditSelection.cpp
+++ b/src/control/tools/EditSelection.cpp
@@ -670,8 +670,9 @@ void EditSelection::ensureWithinVisibleArea()
 	double zoom = this->view->getXournal()->getZoom();
 	// need to modify this to take into account the position
 	// of the object, plus typecast because XojPageView takes ints
-	this->view->getXournal()->ensureRectIsVisible((int) (viewx + this->x * zoom), (int) (viewy + this->y * zoom),
-												  (int) (this->width * zoom), (int) (this->height * zoom));
+	this->view->getXournal()->ensureRectIsVisible(
+	        static_cast<int>(viewx + this->x * zoom), static_cast<int>(viewy + this->y * zoom),
+	        static_cast<int>(this->width * zoom), static_cast<int>(this->height * zoom));
 }
 
 /**

--- a/src/control/tools/EditSelection.h
+++ b/src/control/tools/EditSelection.h
@@ -259,40 +259,40 @@ private: // DATA
 	/**
 	 * The position (and rotation) relative to the current view
 	 */
-	double x;
-	double y;
+	double x{};
+	double y{};
 	double rotation = 0;
 
 	/**
 	 * Use to translate to rotated selection
 	 */
-		_cairo_matrix cmatrix;
-	
+	_cairo_matrix cmatrix{};
+
 	/**
 	 * The size
 	 */
-	double width;
-	double height;
+	double width{};
+	double height{};
 
 	/**
 	 * Mouse coordinates for moving / resizing
 	 */
 	CursorSelectionType mouseDownType;
-	double relMousePosX;
-	double relMousePosY;
+	double relMousePosX{};
+	double relMousePosY{};
 
 	/**
 	 * If both scale axes should have the same scale factor, e.g. for Text
 	 * (we cannot only set the font size for text)
 	 */
-	bool aspectRatio;
-	
+	bool aspectRatio{};
+
 	/**
 	 * Size of the editing handles 
 	 */
 
-	int btnWidth = 8;
-	
+	int btnWidth{8};
+
 	/**
 	 * The source page (form where the Elements come)
 	 */
@@ -301,22 +301,21 @@ private: // DATA
 	/**
 	 * The source layer (form where the Elements come)
 	 */
-	Layer* sourceLayer;
+	Layer* sourceLayer{};
 
 	/**
 	 * The contents of the selection
 	 */
-	EditSelectionContents* contents;
+	EditSelectionContents* contents{};
 
 private: // HANDLER
 	/**
 	 * The page view for the anchor
 	 */
-	XojPageView* view;
+	XojPageView* view{};
 
 	/**
 	 * Undo redo handler
 	 */
-	UndoRedoHandler* undo;
-
+	UndoRedoHandler* undo{};
 };

--- a/src/control/tools/EditSelection.h
+++ b/src/control/tools/EditSelection.h
@@ -57,13 +57,13 @@ public:
 	 * get the X coordinate relative to the provided view (getView())
 	 * in document coordinates
 	 */
-	double getXOnView();
+	double getXOnView() const;
 
 	/**
 	 * Get the Y coordinate relative to the provided view (getView())
 	 * in document coordinates
 	 */
-	double getYOnView();
+	double getYOnView() const;
 
 	/**
 	 * @return The original X coordinates of the provided view in document
@@ -80,12 +80,12 @@ public:
 	/**
 	 * Get the width in document coordinates (multiple with zoom)
 	 */
-	double getWidth();
+	double getWidth() const;
 
 	/**
 	 * Get the height in document coordinates (multiple with zoom)
 	 */
-	double getHeight();
+	double getHeight() const;
 
 	/**
 	 * Get the source page (where the selection was done)
@@ -228,9 +228,7 @@ private:
 	/**
 	 * Draws an indicator where you can delete the selection
 	 */
-	void drawDeleteRect(cairo_t* cr, double x, double y, double zoom);
-	
-
+	void drawDeleteRect(cairo_t* cr, double x, double y, double zoom) const;
 
 
 	/**

--- a/src/control/tools/EditSelectionContents.cpp
+++ b/src/control/tools/EditSelectionContents.cpp
@@ -134,11 +134,10 @@ auto EditSelectionContents::setSize(ToolSize size,
 
 		return undo;
 	}
-	else
-	{
-		delete undo;
+
+
+	    delete undo;
 		return nullptr;
-	}
 }
 
 /**
@@ -192,11 +191,10 @@ auto EditSelectionContents::setFill(int alphaPen, int alphaHighligther) -> UndoA
 
 		return undo;
 	}
-	else
-	{
-		delete undo;
+
+
+	    delete undo;
 		return nullptr;
-	}
 }
 
 /**
@@ -286,11 +284,11 @@ auto EditSelectionContents::setColor(int color) -> UndoAction*
 
 		return undo;
 	}
-	else
-	{
-		delete undo;
+
+
+	    delete undo;
 		return nullptr;
-	}
+
 
 	return nullptr;
 }
@@ -345,7 +343,7 @@ void EditSelectionContents::deleteViewBuffer()
 /**
  * Gets the original width of the contents
  */
-auto EditSelectionContents::getOriginalWidth() -> double
+auto EditSelectionContents::getOriginalWidth() const -> double
 {
 	return this->originalWidth;
 }
@@ -353,7 +351,7 @@ auto EditSelectionContents::getOriginalWidth() -> double
 /**
  * Gets the original height of the contents
  */
-auto EditSelectionContents::getOriginalHeight() -> double
+auto EditSelectionContents::getOriginalHeight() const -> double
 {
 	return this->originalHeight;
 }
@@ -400,12 +398,12 @@ void EditSelectionContents::finalizeSelection(double x, double y, double width, 
 	}
 }
 
-auto EditSelectionContents::getOriginalX() -> double
+auto EditSelectionContents::getOriginalX() const -> double
 {
 	return this->originalX;
 }
 
-auto EditSelectionContents::getOriginalY() -> double
+auto EditSelectionContents::getOriginalY() const -> double
 {
 	return this->originalY;
 }

--- a/src/control/tools/EditSelectionContents.cpp
+++ b/src/control/tools/EditSelectionContents.cpp
@@ -136,8 +136,8 @@ auto EditSelectionContents::setSize(ToolSize size,
 	}
 
 
-	    delete undo;
-		return nullptr;
+	delete undo;
+	return nullptr;
 }
 
 /**
@@ -193,8 +193,8 @@ auto EditSelectionContents::setFill(int alphaPen, int alphaHighligther) -> UndoA
 	}
 
 
-	    delete undo;
-		return nullptr;
+	delete undo;
+	return nullptr;
 }
 
 /**
@@ -286,8 +286,8 @@ auto EditSelectionContents::setColor(int color) -> UndoAction*
 	}
 
 
-	    delete undo;
-		return nullptr;
+	delete undo;
+	return nullptr;
 
 
 	return nullptr;

--- a/src/control/tools/EditSelectionContents.cpp
+++ b/src/control/tools/EditSelectionContents.cpp
@@ -515,8 +515,8 @@ void EditSelectionContents::paint(cairo_t* cr, double x, double y, double rotati
 		this->crBuffer = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width * zoom, height * zoom);
 		cairo_t* cr2 = cairo_create(this->crBuffer);
 
-		int dx = (int) (this->relativeX * zoom);
-		int dy = (int) (this->relativeY * zoom);
+		int dx = static_cast<int>(this->relativeX * zoom);
+		int dy = static_cast<int>(this->relativeY * zoom);
 
 		cairo_scale(cr2, fx, fy);
 		cairo_translate(cr2, -dx, -dy);
@@ -532,23 +532,23 @@ void EditSelectionContents::paint(cairo_t* cr, double x, double y, double rotati
 	int wImg = cairo_image_surface_get_width(this->crBuffer);
 	int hImg = cairo_image_surface_get_height(this->crBuffer);
 
-	int wTarget = (int) (width * zoom);
-	int hTarget = (int) (height * zoom);
+	int wTarget = static_cast<int>(width * zoom);
+	int hTarget = static_cast<int>(height * zoom);
 
-	double sx = (double) wTarget / wImg;
-	double sy = (double) hTarget / hImg;
+	double sx = static_cast<double>(wTarget) / wImg;
+	double sy = static_cast<double>(hTarget) / hImg;
 
 	if (wTarget != wImg || hTarget != hImg || std::abs(rotation) > __DBL_EPSILON__)
 	{
 		if (!this->rescaleId)
 		{
-			this->rescaleId = g_idle_add((GSourceFunc) repaintSelection, this);
+			this->rescaleId = g_idle_add(reinterpret_cast<GSourceFunc>(repaintSelection), this);
 		}
 		cairo_scale(cr, sx, sy);
 	}
 
-	double dx = (int) (x * zoom / sx);
-	double dy = (int) (y * zoom / sy);
+	double dx = static_cast<int>(x * zoom / sx);
+	double dy = static_cast<int>(y * zoom / sy);
 
 	cairo_set_source_surface(cr, this->crBuffer, dx, dy);
 	cairo_paint(cr);

--- a/src/control/tools/EditSelectionContents.cpp
+++ b/src/control/tools/EditSelectionContents.cpp
@@ -94,7 +94,7 @@ auto EditSelectionContents::setSize(ToolSize size,
 	{
 		if (e->getType() == ELEMENT_STROKE)
 		{
-			auto* s = (Stroke*) e;
+			auto* s = dynamic_cast<Stroke*>(e);
 			StrokeTool tool = s->getToolType();
 
 			double originalWidth = s->getWidth();
@@ -155,7 +155,7 @@ auto EditSelectionContents::setFill(int alphaPen, int alphaHighligther) -> UndoA
 	{
 		if (e->getType() == ELEMENT_STROKE)
 		{
-			auto* s = (Stroke*) e;
+			auto* s = dynamic_cast<Stroke*>(e);
 			StrokeTool tool = s->getToolType();
 			int newFill = 128;
 
@@ -216,7 +216,7 @@ auto EditSelectionContents::setFont(XojFont& font) -> UndoAction*
 	{
 		if (e->getType() == ELEMENT_TEXT)
 		{
-			Text* t = (Text*) e;
+			Text* t = dynamic_cast<Text*>(e);
 			undo->addStroke(t, t->getFont(), font);
 
 			if (std::isnan(x1))

--- a/src/control/tools/EditSelectionContents.h
+++ b/src/control/tools/EditSelectionContents.h
@@ -118,23 +118,23 @@ public:
 	/**
 	 * Gets the original X of the contents
 	 */
-	double getOriginalX();
+	double getOriginalX() const;
 
 	/**
 	 * Gets the original Y of the contents
 	 */
-	double getOriginalY();
+	double getOriginalY() const;
 
-	
+
 	/**
 	 * Gets the original width of the contents
 	 */
-	double getOriginalWidth();
+	double getOriginalWidth() const;
 
 	/**
 	 * Gets the original height of the contents
 	 */
-	double getOriginalHeight();
+	double getOriginalHeight() const;
 
 	UndoAction* copySelection(PageRef page, XojPageView *view, double x, double y);
 

--- a/src/control/tools/EraseHandler.cpp
+++ b/src/control/tools/EraseHandler.cpp
@@ -63,7 +63,7 @@ void EraseHandler::erase(double x, double y)
 	{
 		if (e->getType() == ELEMENT_STROKE && e->intersectsArea(&eraserRect))
 		{
-			eraseStroke(l, (Stroke*) e, x, y, range);
+			eraseStroke(l, dynamic_cast<Stroke*>(e), x, y, range);
 		}
 	}
 

--- a/src/control/tools/InputHandler.h
+++ b/src/control/tools/InputHandler.h
@@ -94,8 +94,7 @@ public:
 	bool userTapped = false;	
 
 protected:
-
-	bool validMotion(Point p, Point q);
+	static bool validMotion(Point p, Point q);
 
 	void createStroke(Point p);
 

--- a/src/control/tools/Selection.cpp
+++ b/src/control/tools/Selection.cpp
@@ -1,6 +1,6 @@
 #include "Selection.h"
 
-#include "math.h"
+#include <cmath>
 #include "model/Layer.h"
 #include "util/GtkColorWrapper.h"
 

--- a/src/control/tools/Selection.cpp
+++ b/src/control/tools/Selection.cpp
@@ -145,7 +145,7 @@ RegionSelect::~RegionSelect()
 {
 	for (GList* l = this->points; l != nullptr; l = l->next)
 	{
-		delete (RegionPoint*) l->data;
+		delete static_cast<RegionPoint*>(l->data);
 	}
 	g_list_free(this->points);
 }
@@ -161,12 +161,12 @@ void RegionSelect::paint(cairo_t* cr, GdkRectangle* rect, double zoom)
 		cairo_set_line_width(cr, 1 / zoom);
 		selectionColor.apply(cr);
 
-		auto* r0 = (RegionPoint*) this->points->data;
+		auto* r0 = static_cast<RegionPoint*>(this->points->data);
 		cairo_move_to(cr, r0->x, r0->y);
 
 		for (GList* l = this->points->next; l != nullptr; l = l->next)
 		{
-			auto* r = (RegionPoint*) l->data;
+			auto* r = static_cast<RegionPoint*>(l->data);
 			cairo_line_to(cr, r->x, r->y);
 		}
 
@@ -186,7 +186,7 @@ void RegionSelect::currentPos(double x, double y)
 	if (this->points && this->points->next && this->points->next->next)
 	{
 
-		auto* r0 = (RegionPoint*) this->points->data;
+		auto* r0 = static_cast<RegionPoint*>(this->points->data);
 		double ax = r0->x;
 		double bx = r0->x;
 		double ay = r0->y;
@@ -194,7 +194,7 @@ void RegionSelect::currentPos(double x, double y)
 
 		for (GList* l = this->points; l != nullptr; l = l->next)
 		{
-			auto* r = (RegionPoint*) l->data;
+			auto* r = static_cast<RegionPoint*>(l->data);
 			if (ax > r->x)
 			{
 				ax = r->x;
@@ -234,7 +234,7 @@ auto RegionSelect::contains(double x, double y) -> bool
 
 	int hits = 0;
 
-	auto* last = (RegionPoint*) g_list_last(this->points)->data;
+	auto* last = static_cast<RegionPoint*>(g_list_last(this->points)->data);
 
 	double lastx = last->x;
 	double lasty = last->y;
@@ -243,7 +243,7 @@ auto RegionSelect::contains(double x, double y) -> bool
 	// Walk the edges of the polygon
 	for (GList* l = this->points; l != nullptr; lastx = curx, lasty = cury, l = l->next)
 	{
-		auto* last = (RegionPoint*) l->data;
+		auto* last = static_cast<RegionPoint*>(l->data);
 		curx = last->x;
 		cury = last->y;
 
@@ -320,7 +320,7 @@ auto RegionSelect::finalize(PageRef page) -> bool
 
 	for (GList* l = this->points; l != nullptr; l = l->next)
 	{
-		auto* p = (RegionPoint*) l->data;
+		auto* p = static_cast<RegionPoint*>(l->data);
 
 		if (p->x < this->x1Box)
 		{

--- a/src/control/tools/Selection.cpp
+++ b/src/control/tools/Selection.cpp
@@ -1,5 +1,6 @@
 #include "Selection.h"
 
+#include "math.h"
 #include "model/Layer.h"
 #include "util/GtkColorWrapper.h"
 
@@ -237,7 +238,7 @@ auto RegionSelect::contains(double x, double y) -> bool
 
 	double lastx = last->x;
 	double lasty = last->y;
-	double curx, cury;
+	double curx = NAN, cury = NAN;
 
 	// Walk the edges of the polygon
 	for (GList* l = this->points; l != nullptr; lastx = curx, lasty = cury, l = l->next)
@@ -251,7 +252,7 @@ auto RegionSelect::contains(double x, double y) -> bool
 			continue;
 		}
 
-		int leftx;
+		int leftx = 0;
 		if (curx < lastx)
 		{
 			if (x >= lastx)
@@ -269,7 +270,7 @@ auto RegionSelect::contains(double x, double y) -> bool
 			leftx = lastx;
 		}
 
-		double test1, test2;
+		double test1 = NAN, test2 = NAN;
 		if (cury < lasty)
 		{
 			if (y < cury || y >= lasty)

--- a/src/control/tools/StrokeHandler.cpp
+++ b/src/control/tools/StrokeHandler.cpp
@@ -6,7 +6,7 @@
 #include "control/shaperecognizer/ShapeRecognizerResult.h"
 #include "gui/PageView.h"
 #include "gui/XournalView.h"
-#include "math.h"
+#include <cmath>
 #include "undo/InsertUndoAction.h"
 #include "undo/RecognizerUndoAction.h"
 
@@ -42,7 +42,7 @@ void StrokeHandler::draw(cairo_t* cr)
 		return;
 	}
 
-	view.applyColor(cr, stroke);
+	DocumentView::applyColor(cr, stroke);
 
 	if (stroke->getToolType() == STROKE_TOOL_HIGHLIGHTER) {
 		cairo_set_operator(cr, CAIRO_OPERATOR_MULTIPLY);
@@ -161,7 +161,7 @@ void StrokeHandler::onButtonReleaseEvent(const PositionInputData& pos)
 		if (lengthSqrd < pow((strokeFilterIgnoreLength * dpmm), 2) &&
 		    pos.timestamp - this->startStrokeTime < strokeFilterIgnoreTime)
 		{
-			if (pos.timestamp - this->lastStrokeTime > strokeFilterSuccessiveTime)
+			if (pos.timestamp - StrokeHandler::lastStrokeTime > strokeFilterSuccessiveTime)
 			{
 				// stroke not being added to layer... delete here but clear first!
 
@@ -174,12 +174,12 @@ void StrokeHandler::onButtonReleaseEvent(const PositionInputData& pos)
 				stroke = nullptr;
 				this->userTapped = true;
 
-				this->lastStrokeTime = pos.timestamp;
+				StrokeHandler::lastStrokeTime = pos.timestamp;
 
 				return;
 			}
 		}
-		this->lastStrokeTime = pos.timestamp;
+		StrokeHandler::lastStrokeTime = pos.timestamp;
 	}
 
 	// Backward compatibility and also easier to handle for me;-)

--- a/src/control/tools/StrokeHandler.cpp
+++ b/src/control/tools/StrokeHandler.cpp
@@ -6,6 +6,7 @@
 #include "control/shaperecognizer/ShapeRecognizerResult.h"
 #include "gui/PageView.h"
 #include "gui/XournalView.h"
+#include "math.h"
 #include "undo/InsertUndoAction.h"
 #include "undo/RecognizerUndoAction.h"
 
@@ -146,8 +147,8 @@ void StrokeHandler::onButtonReleaseEvent(const PositionInputData& pos)
 	if (settings->getStrokeFilterEnabled())  // Note: For shape tools see BaseStrokeHandler which has a slightly
 	                                         // different version of this filter. See //!
 	{
-		int strokeFilterIgnoreTime, strokeFilterSuccessiveTime;
-		double strokeFilterIgnoreLength;
+		int strokeFilterIgnoreTime = 0, strokeFilterSuccessiveTime = 0;
+		double strokeFilterIgnoreLength = NAN;
 
 		settings->getStrokeFilter(&strokeFilterIgnoreTime, &strokeFilterIgnoreLength, &strokeFilterSuccessiveTime);
 		double dpmm = settings->getDisplayDpi() / 25.4;

--- a/src/control/tools/StrokeHandler.h
+++ b/src/control/tools/StrokeHandler.h
@@ -67,7 +67,7 @@ private:
 
 	
 	// to filter out short strokes (usually the user tapping on the page to select it)
-	guint32 startStrokeTime;
+	guint32 startStrokeTime{};
 	static guint32 lastStrokeTime;	//persist across strokes - allow us to not ignore persistent dotting.
 	
 

--- a/src/control/tools/VerticalToolHandler.cpp
+++ b/src/control/tools/VerticalToolHandler.cpp
@@ -1,7 +1,7 @@
 #include "VerticalToolHandler.h"
 #include <util/cpp14memory.h>
 
-#include "math.h"
+#include <cmath>
 #include "model/Layer.h"
 #include "undo/UndoRedoHandler.h"
 #include "util/GtkColorWrapper.h"

--- a/src/control/tools/VerticalToolHandler.cpp
+++ b/src/control/tools/VerticalToolHandler.cpp
@@ -1,6 +1,7 @@
 #include "VerticalToolHandler.h"
 #include <util/cpp14memory.h>
 
+#include "math.h"
 #include "model/Layer.h"
 #include "undo/UndoRedoHandler.h"
 #include "util/GtkColorWrapper.h"
@@ -63,8 +64,8 @@ void VerticalToolHandler::paint(cairo_t* cr, GdkRectangle* rect, double zoom)
 
 	selectionColor.apply(cr);
 
-	double y;
-	double height;
+	double y = NAN;
+	double height = NAN;
 
 	if (this->startY < this->endY)
 	{

--- a/src/control/xml/XmlImageNode.cpp
+++ b/src/control/xml/XmlImageNode.cpp
@@ -24,7 +24,8 @@ void XmlImageNode::setImage(cairo_surface_t* img)
 	this->img = cairo_surface_reference(img);
 }
 
-auto XmlImageNode::pngWriteFunction(XmlImageNode* image, unsigned char* data, unsigned int length) -> cairo_status_t
+auto XmlImageNode::pngWriteFunction(XmlImageNode* image, const unsigned char* data, unsigned int length)
+        -> cairo_status_t
 {
 	for (unsigned int i = 0; i < length; i++, image->pos++)
 	{

--- a/src/control/xml/XmlImageNode.cpp
+++ b/src/control/xml/XmlImageNode.cpp
@@ -57,7 +57,7 @@ void XmlImageNode::writeOut(OutputStream* out)
 	{
 		this->out = out;
 		this->pos = 0;
-		cairo_surface_write_to_png_stream(this->img, (cairo_write_func_t) &pngWriteFunction, this);
+		cairo_surface_write_to_png_stream(this->img, reinterpret_cast<cairo_write_func_t>(&pngWriteFunction), this);
 		gchar* base64_str = g_base64_encode(this->buffer, this->pos);
 		out->write(base64_str);
 		g_free(base64_str);

--- a/src/control/xml/XmlImageNode.h
+++ b/src/control/xml/XmlImageNode.h
@@ -22,7 +22,7 @@ public:
 public:
 	void setImage(cairo_surface_t* img);
 
-	static cairo_status_t pngWriteFunction(XmlImageNode* image, unsigned char* data, unsigned int length);
+	static cairo_status_t pngWriteFunction(XmlImageNode* image, const unsigned char* data, unsigned int length);
 
 	virtual void writeOut(OutputStream* out);
 

--- a/src/control/xml/XmlNode.cpp
+++ b/src/control/xml/XmlNode.cpp
@@ -22,7 +22,7 @@ XmlNode::~XmlNode()
 {
 	for (GList* l = this->children; l != nullptr; l = l->next)
 	{
-		auto* node = (XmlNode*) l->data;
+		auto* node = static_cast<XmlNode*>(l->data);
 		delete node;
 	}
 	g_list_free(this->children);
@@ -30,7 +30,7 @@ XmlNode::~XmlNode()
 
 	for (GList* l = this->attributes; l != nullptr; l = l->next)
 	{
-		auto* attrib = (XMLAttribute*) l->data;
+		auto* attrib = static_cast<XMLAttribute*>(l->data);
 		delete attrib;
 	}
 	g_list_free(this->attributes);
@@ -101,7 +101,7 @@ void XmlNode::writeOut(OutputStream* out, ProgressListener* listener)
 
 		for (GList* l = this->children; l != nullptr; l = l->next, ++i)
 		{
-			auto* node = (XmlNode*) l->data;
+			auto* node = static_cast<XmlNode*>(l->data);
 			node->writeOut(out);
 			if (listener)
 			{
@@ -124,7 +124,7 @@ void XmlNode::putAttrib(XMLAttribute* a)
 {
 	for (GList* l = this->attributes; l != nullptr; l = l->next)
 	{
-		auto* attrib = (XMLAttribute*) l->data;
+		auto* attrib = static_cast<XMLAttribute*>(l->data);
 
 		if (attrib->getName() == a->getName())
 		{
@@ -141,7 +141,7 @@ void XmlNode::writeAttributes(OutputStream* out)
 {
 	for (GList* l = this->attributes; l != nullptr; l = l->next)
 	{
-		auto* attrib = (XMLAttribute*) l->data;
+		auto* attrib = static_cast<XMLAttribute*>(l->data);
 		out->write(" ");
 		out->write(attrib->getName());
 		out->write("=\"");

--- a/src/control/xml/XmlPointNode.cpp
+++ b/src/control/xml/XmlPointNode.cpp
@@ -11,7 +11,7 @@ XmlPointNode::~XmlPointNode()
 {
 	for (GList* l = this->points; l != nullptr; l = l->next)
 	{
-		auto* p = (Point*) l->data;
+		auto* p = static_cast<Point*>(l->data);
 		delete p;
 	}
 	g_list_free(this->points);
@@ -34,7 +34,7 @@ void XmlPointNode::writeOut(OutputStream* out)
 
 	for (GList* l = this->points; l != nullptr; l = l->next)
 	{
-		auto* p = (Point*) l->data;
+		auto* p = static_cast<Point*>(l->data);
 		if (l != this->points)
 		{
 			out->write(" ");

--- a/src/control/xml/XmlStrokeNode.cpp
+++ b/src/control/xml/XmlStrokeNode.cpp
@@ -18,10 +18,10 @@ XmlStrokeNode::~XmlStrokeNode()
 
 void XmlStrokeNode::setPoints(Point* points, int pointsLength)
 {
-	if (this->points)
-	{
-		delete[] this->points;
-	}
+
+
+	    delete[] this->points;
+
 	this->points = new Point[pointsLength];
 	for (int i = 0; i < pointsLength; i++)
 	{
@@ -30,14 +30,13 @@ void XmlStrokeNode::setPoints(Point* points, int pointsLength)
 	this->pointsLength = pointsLength;
 }
 
-void XmlStrokeNode::setWidth(double width, double* widths, int widthsLength)
+void XmlStrokeNode::setWidth(double width, const double* widths, int widthsLength)
 {
 	this->width = width;
 
-	if (this->widths)
-	{
-		delete[] this->widths;
-	}
+
+	    delete[] this->widths;
+
 	this->widths = new double[widthsLength];
 	for (int i = 0; i < widthsLength; i++)
 	{

--- a/src/control/xml/XmlStrokeNode.cpp
+++ b/src/control/xml/XmlStrokeNode.cpp
@@ -20,7 +20,7 @@ void XmlStrokeNode::setPoints(Point* points, int pointsLength)
 {
 
 
-	    delete[] this->points;
+	delete[] this->points;
 
 	this->points = new Point[pointsLength];
 	for (int i = 0; i < pointsLength; i++)
@@ -35,7 +35,7 @@ void XmlStrokeNode::setWidth(double width, const double* widths, int widthsLengt
 	this->width = width;
 
 
-	    delete[] this->widths;
+	delete[] this->widths;
 
 	this->widths = new double[widthsLength];
 	for (int i = 0; i < widthsLength; i++)

--- a/src/control/xml/XmlStrokeNode.h
+++ b/src/control/xml/XmlStrokeNode.h
@@ -22,7 +22,7 @@ public:
 
 public:
 	void setPoints(Point* points, int pointsLength);
-	void setWidth(double width, double* widths, int widthsLength);
+	void setWidth(double width, const double* widths, int widthsLength);
 
 	virtual void writeOut(OutputStream* out);
 

--- a/src/control/xml/XmlTexNode.cpp
+++ b/src/control/xml/XmlTexNode.cpp
@@ -16,7 +16,8 @@ void XmlTexNode::writeOut(OutputStream* out)
 
 	out->write(">");
 
-	gchar* base64_str = g_base64_encode((const guchar*)this->binaryData.c_str(), this->binaryData.length());
+	gchar* base64_str =
+	        g_base64_encode(reinterpret_cast<const guchar*>(this->binaryData.c_str()), this->binaryData.length());
 	out->write(base64_str);
 	g_free(base64_str);
 

--- a/src/control/xojfile/LoadHandler.cpp
+++ b/src/control/xojfile/LoadHandler.cpp
@@ -425,7 +425,7 @@ void LoadHandler::parseBgPixmap()
 	{
 		//This is the new zip file attach domain
 		gpointer data = nullptr;
-		gsize dataLength;
+		gsize dataLength = 0;
 		bool success = readZipAttachment(filename, data, dataLength);
 		if (!success)
 		{
@@ -525,7 +525,7 @@ void LoadHandler::parseBgPdf()
 				} else
 				{
 					gpointer data = nullptr;
-					gsize dataLength;
+					gsize dataLength = 0;
 					bool success = readZipAttachment(pdfFilename, data, dataLength);
 					if (!success)
 					{
@@ -900,7 +900,7 @@ void LoadHandler::parseAudio()
 {
 	const char* filename = LoadHandlerHelper::getAttrib("fn", false, this);
 
-	GFileIOStream* fileStream;
+	GFileIOStream* fileStream = nullptr;
 	GFile* tmpFile = g_file_new_tmp("xournal_audio_XXXXXX.tmp", &fileStream, nullptr);
 	if (!tmpFile)
 	{
@@ -918,7 +918,7 @@ void LoadHandler::parseAudio()
 		return;
 	}
 
-	gsize length;
+	gsize length = 0;
 	if (attachmentFileStat.valid & ZIP_STAT_SIZE)
 	{
 		length = attachmentFileStat.size;

--- a/src/control/xojfile/LoadHandler.cpp
+++ b/src/control/xojfile/LoadHandler.cpp
@@ -192,9 +192,9 @@ auto LoadHandler::closeFile() -> bool
 		return static_cast<bool>(gzclose(this->gzFp));
 	}
 
-	    zip_fclose(this->zipContentFile);
-		int zipError = zip_close(this->zipFp);
-		return zipError == 0;
+	zip_fclose(this->zipContentFile);
+	int zipError = zip_close(this->zipFp);
+	return zipError == 0;
 }
 
 auto LoadHandler::readContentFile(char* buffer, zip_uint64_t len) -> zip_int64_t
@@ -208,13 +208,13 @@ auto LoadHandler::readContentFile(char* buffer, zip_uint64_t len) -> zip_int64_t
 		return gzread(this->gzFp, buffer, static_cast<unsigned int>(len));
 	}
 
-	    zip_int64_t lengthRead = zip_fread(this->zipContentFile, buffer, len);
-		if (lengthRead > 0)
-		{
-			return lengthRead;
-		}
+	zip_int64_t lengthRead = zip_fread(this->zipContentFile, buffer, len);
+	if (lengthRead > 0)
+	{
+		return lengthRead;
+	}
 
-	        return -1;
+	return -1;
 }
 
 auto LoadHandler::parseXml() -> bool
@@ -1275,6 +1275,6 @@ auto LoadHandler::getTempFileForPath(const string& filename) -> string
 		return string(static_cast<char*>(tmpFilename));
 	}
 
-	    error("%s", FC(_F("Requested temporary file was not found for attachment {1}") % filename));
-		return "";
+	error("%s", FC(_F("Requested temporary file was not found for attachment {1}") % filename));
+	return "";
 }

--- a/src/control/xojfile/LoadHandler.cpp
+++ b/src/control/xojfile/LoadHandler.cpp
@@ -95,7 +95,7 @@ auto LoadHandler::getLastError() -> string
 	return this->lastError;
 }
 
-auto LoadHandler::isAttachedPdfMissing() -> bool
+auto LoadHandler::isAttachedPdfMissing() const -> bool
 {
 	return this->attachedPdfMissing;
 }
@@ -190,12 +190,11 @@ auto LoadHandler::closeFile() -> bool
 	if (this->isGzFile)
 	{
 		return static_cast<bool>(gzclose(this->gzFp));
-	} else
-	{
-		zip_fclose(this->zipContentFile);
+	}
+
+	    zip_fclose(this->zipContentFile);
 		int zipError = zip_close(this->zipFp);
 		return zipError == 0;
-	}
 }
 
 auto LoadHandler::readContentFile(char* buffer, zip_uint64_t len) -> zip_int64_t
@@ -207,17 +206,15 @@ auto LoadHandler::readContentFile(char* buffer, zip_uint64_t len) -> zip_int64_t
 			return -1;
 		}
 		return gzread(this->gzFp, buffer, static_cast<unsigned int>(len));
-	} else
-	{
-		zip_int64_t lengthRead = zip_fread(this->zipContentFile, buffer, len);
+	}
+
+	    zip_int64_t lengthRead = zip_fread(this->zipContentFile, buffer, len);
 		if (lengthRead > 0)
 		{
 			return lengthRead;
-		} else
-		{
-			return -1;
 		}
-	}
+
+	        return -1;
 }
 
 auto LoadHandler::parseXml() -> bool
@@ -273,12 +270,12 @@ auto LoadHandler::parseXml() -> bool
 
 	g_markup_parse_context_free(context);
 
-	if (this->pos != PASER_POS_FINISHED && this->lastError == "")
+	if (this->pos != PASER_POS_FINISHED && this->lastError.empty())
 	{
 		lastError = _("Document is not complete (maybe the end is cut off?)");
 		return false;
 	}
-	else if (this->pos == PASER_POS_FINISHED && this->doc.getPageCount() == 0)
+	if (this->pos == PASER_POS_FINISHED && this->doc.getPageCount() == 0)
 	{
 		lastError = _("Document is corrupted (no pages found in file)");
 		return false;
@@ -478,7 +475,7 @@ void LoadHandler::parseBgPdf()
 	if (!this->pdfFilenameParsed)
 	{
 
-		if (this->pdfReplacementFilename == "")
+		if (this->pdfReplacementFilename.empty())
 		{
 			const char* domain = LoadHandlerHelper::getAttrib("domain", false, this);
 			const char* sFilename = LoadHandlerHelper::getAttrib("filename", false, this);
@@ -1110,7 +1107,7 @@ void LoadHandler::parserText(GMarkupParseContext* context, const gchar* text,
 			return;
 		}
 
-		if (handler->pressureBuffer.size() != 0)
+		if (!handler->pressureBuffer.empty())
 		{
 			if (static_cast<int>(handler->pressureBuffer.size()) >= handler->stroke->getPointCount() - 1)
 			{
@@ -1276,9 +1273,8 @@ auto LoadHandler::getTempFileForPath(const string& filename) -> string
 	if (tmpFilename)
 	{
 		return string(static_cast<char*>(tmpFilename));
-	} else
-	{
-		error("%s", FC(_F("Requested temporary file was not found for attachment {1}") % filename));
-		return "";
 	}
+
+	    error("%s", FC(_F("Requested temporary file was not found for attachment {1}") % filename));
+		return "";
 }

--- a/src/control/xojfile/LoadHandler.h
+++ b/src/control/xojfile/LoadHandler.h
@@ -48,7 +48,7 @@ public:
 	Document* loadDocument(const string& filename);
 
 	string getLastError();
-	bool isAttachedPdfMissing();
+	bool isAttachedPdfMissing() const;
 	string getMissingPdfFilename();
 
 	void removePdfBackground();
@@ -75,13 +75,12 @@ private:
 	bool openFile(const string& filename);
 	bool parseXml();
 
-	static void parserText(GMarkupParseContext* context, const gchar* text, gsize text_len, gpointer userdata,
+	static void parserText(GMarkupParseContext* context, const gchar* text, gsize textLen, gpointer userdata,
 	                       GError** error);
-	static void parserEndElement(GMarkupParseContext* context, const gchar* element_name, gpointer userdata,
+	static void parserEndElement(GMarkupParseContext* context, const gchar* elementName, gpointer userdata,
 	                             GError** error);
-	static void parserStartElement(GMarkupParseContext* context, const gchar* element_name,
-	                               const gchar** attribute_names, const gchar** attribute_values,
-	                               gpointer userdata, GError** error);
+	static void parserStartElement(GMarkupParseContext* context, const gchar* elementName, const gchar** attributeNames,
+	                               const gchar** attributeValues, gpointer userdata, GError** error);
 
 	const char* getAttrib(const char* name, bool optional = false);
 	double getAttribDouble(const char* name);
@@ -96,7 +95,7 @@ private:
 	void readTexImage(const gchar* base64string, gsize base64stringLen);
 
 private:
-	string parseBase64(const gchar* base64, gsize lenght);
+	static string parseBase64(const gchar* base64, gsize lenght);
 	bool readZipAttachment(const string& filename, gpointer& data, gsize& length);
 	string getTempFileForPath(const string& filename);
 

--- a/src/control/xojfile/LoadHandlerHelper.cpp
+++ b/src/control/xojfile/LoadHandlerHelper.cpp
@@ -89,16 +89,16 @@ auto LoadHandlerHelper::parseColor(const char* text, int& color, LoadHandler* lo
 	}
 
 
-	    for (auto& i: PREDEFINED_COLORS)
+	for (auto& i: PREDEFINED_COLORS)
+	{
+		if (!strcmp(text, i.name))
 		{
-			if (!strcmp(text, i.name))
-			{
-				color = i.rgb;
-				return true;
-			}
+			color = i.rgb;
+			return true;
 		}
-		error("%s", FC(_F("Color \"{1}\" unknown (not defined in default color list)!") % text));
-		return false;
+	}
+	error("%s", FC(_F("Color \"{1}\" unknown (not defined in default color list)!") % text));
+	return false;
 }
 
 

--- a/src/control/xojfile/LoadHandlerHelper.cpp
+++ b/src/control/xojfile/LoadHandlerHelper.cpp
@@ -87,9 +87,9 @@ auto LoadHandlerHelper::parseColor(const char* text, int& color, LoadHandler* lo
 
 		return true;
 	}
-	else
-	{
-		for (auto& i: PREDEFINED_COLORS)
+
+
+	    for (auto& i: PREDEFINED_COLORS)
 		{
 			if (!strcmp(text, i.name))
 			{
@@ -99,7 +99,6 @@ auto LoadHandlerHelper::parseColor(const char* text, int& color, LoadHandler* lo
 		}
 		error("%s", FC(_F("Color \"{1}\" unknown (not defined in default color list)!") % text));
 		return false;
-	}
 }
 
 

--- a/src/control/xojfile/SaveHandler.cpp
+++ b/src/control/xojfile/SaveHandler.cpp
@@ -184,14 +184,14 @@ void SaveHandler::visitLayer(XmlNode* page, Layer* l)
 	{
 		if (e->getType() == ELEMENT_STROKE)
 		{
-			auto* s = (Stroke*) e;
+			auto* s = dynamic_cast<Stroke*>(e);
 			auto* stroke = new XmlPointNode("stroke");
 			layer->addChild(stroke);
 			visitStroke(stroke, s);
 		}
 		else if (e->getType() == ELEMENT_TEXT)
 		{
-			Text* t = (Text*) e;
+			Text* t = dynamic_cast<Text*>(e);
 			auto* text = new XmlTextNode("text", t->getText().c_str());
 			layer->addChild(text);
 
@@ -207,7 +207,7 @@ void SaveHandler::visitLayer(XmlNode* page, Layer* l)
 		}
 		else if (e->getType() == ELEMENT_IMAGE)
 		{
-			auto* i = (Image*) e;
+			auto* i = dynamic_cast<Image*>(e);
 			auto* image = new XmlImageNode("image");
 			layer->addChild(image);
 
@@ -220,7 +220,7 @@ void SaveHandler::visitLayer(XmlNode* page, Layer* l)
 		}
 		else if (e->getType() == ELEMENT_TEXIMAGE)
 		{
-			auto* i = (TexImage*) e;
+			auto* i = dynamic_cast<TexImage*>(e);
 			auto* image = new XmlTexNode("teximage", i->getBinaryData());
 			layer->addChild(image);
 

--- a/src/control/xojfile/SaveHandler.cpp
+++ b/src/control/xojfile/SaveHandler.cpp
@@ -192,7 +192,7 @@ void SaveHandler::visitLayer(XmlNode* page, Layer* l)
 		else if (e->getType() == ELEMENT_TEXT)
 		{
 			Text* t = dynamic_cast<Text*>(e);
-			auto* text = new XmlTextNode("text", t->getText().c_str());
+			auto* text = new XmlTextNode("text", t->getText());
 			layer->addChild(text);
 
 			XojFont& f = t->getFont();

--- a/src/control/xojfile/SaveHandler.cpp
+++ b/src/control/xojfile/SaveHandler.cpp
@@ -33,7 +33,7 @@ SaveHandler::~SaveHandler()
 
 	for (GList* l = this->backgroundImages; l != nullptr; l = l->next)
 	{
-		delete (BackgroundImage*) l->data;
+		delete static_cast<BackgroundImage*>(l->data);
 	}
 	g_list_free(this->backgroundImages);
 	this->backgroundImages = nullptr;
@@ -49,7 +49,7 @@ void SaveHandler::prepareSave(Document* doc)
 
 		for (GList* l = this->backgroundImages; l != nullptr; l = l->next)
 		{
-			delete (BackgroundImage*) l->data;
+			delete static_cast<BackgroundImage*>(l->data);
 		}
 		g_list_free(this->backgroundImages);
 		this->backgroundImages = nullptr;
@@ -378,7 +378,7 @@ void SaveHandler::saveTo(OutputStream* out, const Path& filename, ProgressListen
 
 	for (GList* l = this->backgroundImages; l != nullptr; l = l->next)
 	{
-		auto* img = (BackgroundImage*) l->data;
+		auto* img = static_cast<BackgroundImage*>(l->data);
 
 		string tmpfn = filename.str() + "." + img->getFilename();
 		if (!gdk_pixbuf_save(img->getPixbuf(), tmpfn.c_str(), "png", nullptr, nullptr))

--- a/src/control/zoom/ZoomControl.cpp
+++ b/src/control/zoom/ZoomControl.cpp
@@ -5,7 +5,7 @@
 #include "gui/PageView.h"
 #include "gui/widgets/XournalWidget.h"
 #include "gui/XournalView.h"
-#include "math.h"
+#include <cmath>
 
 ZoomControl::ZoomControl()
 {
@@ -148,7 +148,7 @@ void ZoomControl::setScrollPositionAfterZoom(double x, double y)
 /**
  * Zoom to correct position on zooming
  */
-auto ZoomControl::getScrollPositionAfterZoom() -> std::tuple<double, double>
+auto ZoomControl::getScrollPositionAfterZoom() const -> std::tuple<double, double>
 {
 	if (this->zoomSequenceStart == -1 )
 	{
@@ -203,12 +203,12 @@ void ZoomControl::fireZoomRangeValueChanged()
 	}
 }
 
-auto ZoomControl::getZoom() -> double
+auto ZoomControl::getZoom() const -> double
 {
 	return this->zoom;
 }
 
-auto ZoomControl::getZoomReal() -> double
+auto ZoomControl::getZoomReal() const -> double
 {
 	return this->zoom / this->zoom100Value;
 }
@@ -262,7 +262,7 @@ auto ZoomControl::updateZoomFitValue(const Rectangle& widget_rect, size_t pageNo
 	return true;
 }
 
-auto ZoomControl::getZoomFitValue() -> double
+auto ZoomControl::getZoomFitValue() const -> double
 {
 	return this->zoomFitValue;
 }
@@ -293,12 +293,12 @@ auto ZoomControl::updateZoomPresentationValue(size_t pageNo) -> bool
 	return true;
 }
 
-auto ZoomControl::getZoomPresentationValue() -> double
+auto ZoomControl::getZoomPresentationValue() const -> double
 {
 	return this->zoomPresentationValue;
 }
 
-auto ZoomControl::getZoom100Value() -> double
+auto ZoomControl::getZoom100Value() const -> double
 {
 	return this->zoom100Value;
 }
@@ -354,7 +354,7 @@ void ZoomControl::setZoomFitMode(bool isZoomFitMode)
 	}
 }
 
-auto ZoomControl::isZoomFitMode() -> bool
+auto ZoomControl::isZoomFitMode() const -> bool
 {
 	return this->zoomFitMode;
 }
@@ -369,17 +369,17 @@ void ZoomControl::setZoomPresentationMode(bool isZoomPresentationMode)
 	}
 }
 
-auto ZoomControl::isZoomPresentationMode() -> bool
+auto ZoomControl::isZoomPresentationMode() const -> bool
 {
 	return this->zoomPresentationMode;
 }
 
-auto ZoomControl::getZoomStep() -> double
+auto ZoomControl::getZoomStep() const -> double
 {
 	return this->zoomStep;
 }
 
-auto ZoomControl::getZoomStepReal() -> double
+auto ZoomControl::getZoomStepReal() const -> double
 {
 	return this->zoomStepReal;
 }
@@ -390,12 +390,12 @@ void ZoomControl::setZoomStep(double zoomStep)
 	this->zoomStep = zoomStep * this->zoom100Value;
 }
 
-auto ZoomControl::getZoomStepScroll() -> double
+auto ZoomControl::getZoomStepScroll() const -> double
 {
 	return this->zoomStepScroll;
 }
 
-auto ZoomControl::getZoomStepScrollReal() -> double
+auto ZoomControl::getZoomStepScrollReal() const -> double
 {
 	return this->zoomStepScrollReal;
 }
@@ -406,12 +406,12 @@ void ZoomControl::setZoomStepScroll(double zoomStep)
 	this->zoomStepScroll = zoomStep * this->zoom100Value;
 }
 
-auto ZoomControl::getZoomMax() -> double
+auto ZoomControl::getZoomMax() const -> double
 {
 	return this->zoomMax;
 }
 
-auto ZoomControl::getZoomMaxReal() -> double
+auto ZoomControl::getZoomMaxReal() const -> double
 {
 	return this->zoomMaxReal;
 }
@@ -422,12 +422,12 @@ void ZoomControl::setZoomMax(double zoomMax)
 	this->zoomMax = zoomMax * this->zoom100Value;
 }
 
-auto ZoomControl::getZoomMin() -> double
+auto ZoomControl::getZoomMin() const -> double
 {
 	return this->zoomMin;
 }
 
-auto ZoomControl::getZoomMinReal() -> double
+auto ZoomControl::getZoomMinReal() const -> double
 {
 	return this->zoomMinReal;
 }

--- a/src/control/zoom/ZoomControl.cpp
+++ b/src/control/zoom/ZoomControl.cpp
@@ -480,7 +480,7 @@ auto ZoomControl::onScrolledwindowMainScrollEvent(GtkWidget* widget, GdkEventScr
 		return true;
 	}
 
-	//TODO: Disabling scroll here is maybe a bit hacky
+	// TODO(fabian): Disabling scroll here is maybe a bit hacky
 	if(zoom->isZoomPresentationMode())
 	{
 		//disable scroll while presentationMode

--- a/src/control/zoom/ZoomControl.cpp
+++ b/src/control/zoom/ZoomControl.cpp
@@ -5,6 +5,7 @@
 #include "gui/PageView.h"
 #include "gui/widgets/XournalWidget.h"
 #include "gui/XournalView.h"
+#include "math.h"
 
 ZoomControl::ZoomControl()
 {
@@ -30,7 +31,7 @@ void ZoomControl::zoomOneStep(bool zoomIn, double x, double y)
 		this->setZoomFitMode(false);
 	}
 
-	double newZoom;
+	double newZoom = NAN;
 	if (zoomIn)
 	{
 		newZoom = this->zoom + this->zoomStep;
@@ -63,7 +64,7 @@ void ZoomControl::zoomScroll(bool zoomIn, double x, double y)
 		startZoomSequence(x, y);
 	}
 
-	double newZoom;
+	double newZoom = NAN;
 	if (zoomIn)
 	{
 		newZoom = this->zoom + this->zoomStepScroll;

--- a/src/control/zoom/ZoomControl.h
+++ b/src/control/zoom/ZoomControl.h
@@ -62,13 +62,13 @@ public:
 	 * Zoom so that the page fits the current size of the window
 	 */
 	void setZoomFitMode(bool isZoomFitMode);
-	bool isZoomFitMode();
+	bool isZoomFitMode() const;
 
 	/**
 	 * Zoom so that the document completely fits the View.
 	 */
 	void setZoomPresentationMode(bool isZoomPresentationMode);
-	bool isZoomPresentationMode();
+	bool isZoomPresentationMode() const;
 
 	/**
 	 * Zoom so that the displayed page on the screen has the same size as the real size
@@ -79,12 +79,12 @@ public:
 	/**
 	 * @return zoom value depending zoom100Value
 	 */
-	double getZoom();
+	double getZoom() const;
 
 	/**
 	 * @return real zoom value in percent
 	 */
-	double getZoomReal();
+	double getZoomReal() const;
 
 	/**
 	 * Set the current zoom, does not preserve the current page position.
@@ -106,22 +106,22 @@ public:
 	/**
 	 * @return zoom value for zoom 100% depending zoom100Value
 	 */
-	double getZoom100Value();
+	double getZoom100Value() const;
 
 	/**
 	 * Updates when, the window size changes
 	 * @param zoom zoom value depending zoom100Value
 	 */
 	bool updateZoomFitValue(size_t pageNo = 0);
-	bool updateZoomFitValue(const Rectangle& allocation, size_t pageNo = 0);
+	bool updateZoomFitValue(const Rectangle& widget_rect, size_t pageNo = 0);
 
 	/**
 	 * @return zoom value for zoom fit depending zoom100Value
 	 */
-	double getZoomFitValue();
+	double getZoomFitValue() const;
 
 	bool updateZoomPresentationValue(size_t pageNo = 0);
-	double getZoomPresentationValue();
+	double getZoomPresentationValue() const;
 
 	void addZoomListener(ZoomListener* listener);
 
@@ -156,27 +156,27 @@ public:
 	/**
 	 * Zoom to correct position on zooming
 	 */
-	std::tuple<double, double> getScrollPositionAfterZoom();
+	std::tuple<double, double> getScrollPositionAfterZoom() const;
 
 	/**
 	 * Get visible rect on xournal view, for Zoom Gesture
 	 */
 	Rectangle getVisibleRect();
 
-	double getZoomStep();
-	double getZoomStepReal();
+	double getZoomStep() const;
+	double getZoomStepReal() const;
 	void setZoomStep(double zoomStep);
 
-	double getZoomStepScroll();
-	double getZoomStepScrollReal();
+	double getZoomStepScroll() const;
+	double getZoomStepScrollReal() const;
 	void setZoomStepScroll(double zoomStep);
 
-	double getZoomMax();
-	double getZoomMaxReal();
+	double getZoomMax() const;
+	double getZoomMaxReal() const;
 	void setZoomMax(double zoomMax);
 
-	double getZoomMin();
-	double getZoomMinReal();
+	double getZoomMin() const;
+	double getZoomMinReal() const;
 	void setZoomMin(double zoomMin);
 
 protected:

--- a/src/enums/generated/ActionGroup.generated.cpp
+++ b/src/enums/generated/ActionGroup.generated.cpp
@@ -11,8 +11,6 @@ using std::string;
 
 
 // ** This needs to be copied to the header
-auto ActionGroup_fromString(const string& value) -> ActionGroup;
-auto ActionGroup_toString(ActionGroup value) -> string;
 
 
 auto ActionGroup_fromString(const string& value) -> ActionGroup

--- a/src/enums/generated/ActionType.generated.cpp
+++ b/src/enums/generated/ActionType.generated.cpp
@@ -11,8 +11,6 @@ using std::string;
 
 
 // ** This needs to be copied to the header
-auto ActionType_fromString(const string& value) -> ActionType;
-auto ActionType_toString(ActionType value) -> string;
 
 
 auto ActionType_fromString(const string& value) -> ActionType

--- a/src/gui/FloatingToolbox.cpp
+++ b/src/gui/FloatingToolbox.cpp
@@ -94,7 +94,7 @@ void FloatingToolbox::showForConfiguration()
 	if (this->floatingToolboxActivated())		// Do not show if not being used - at least while experimental.
 	{
 		GtkWidget* boxContents = this->mainWindow->get("boxContents");
-		gint wx, wy;
+		gint wx = 0, wy = 0;
 		gtk_widget_translate_coordinates(boxContents, gtk_widget_get_toplevel(boxContents), 0, 0, &wx, &wy);
 		this->floatingToolboxX = wx + 40;	//when configuration state these are
 		this->floatingToolboxY = wy + 40;	// topleft coordinates( otherwise center).

--- a/src/gui/GladeGui.cpp
+++ b/src/gui/GladeGui.cpp
@@ -34,7 +34,7 @@ GladeGui::GladeGui(GladeSearchpath* gladeSearchPath, const string& glade, string
 		exit(-1);
 	}
 
-	this->window = get(std::move(mainWnd));
+	this->window = get(mainWnd);
 }
 
 GladeGui::~GladeGui()

--- a/src/gui/GladeGui.cpp
+++ b/src/gui/GladeGui.cpp
@@ -9,7 +9,7 @@
 #include <cstdlib>
 #include <utility>
 
-GladeGui::GladeGui(GladeSearchpath* gladeSearchPath, const string& glade, string mainWnd)
+GladeGui::GladeGui(GladeSearchpath* gladeSearchPath, const string& glade, const string& mainWnd)
 {
 	this->gladeSearchPath = gladeSearchPath;
 

--- a/src/gui/GladeGui.h
+++ b/src/gui/GladeGui.h
@@ -20,7 +20,7 @@ class GladeSearchpath;
 class GladeGui
 {
 public:
-	GladeGui(GladeSearchpath* gladeSearchPath, const string& glade, string mainWnd);
+	GladeGui(GladeSearchpath* gladeSearchPath, const string& glade, const string& mainWnd);
 	virtual ~GladeGui();
 
 	virtual void show(GtkWindow* parent) = 0;

--- a/src/gui/GladeSearchpath.cpp
+++ b/src/gui/GladeSearchpath.cpp
@@ -10,7 +10,7 @@ GladeSearchpath::~GladeSearchpath()
 auto GladeSearchpath::findFile(const string& subdir, const string& file) -> string
 {
 	string filename;
-	if (subdir == "")
+	if (subdir.empty())
 	{
 		filename = file;
 	}
@@ -38,7 +38,7 @@ auto GladeSearchpath::findFile(const string& subdir, const string& file) -> stri
  */
 auto GladeSearchpath::getFirstSearchPath() -> string
 {
-	if (this->directories.size() < 1)
+	if (this->directories.empty())
 	{
 		return "";
 	}

--- a/src/gui/Layout.cpp
+++ b/src/gui/Layout.cpp
@@ -40,14 +40,14 @@ Layout::Layout(XournalView* view, ScrollHandling* scrollHandling)
 
 void Layout::horizontalScrollChanged(GtkAdjustment* adjustment, Layout* layout)
 {
-	layout->checkScroll(adjustment, layout->lastScrollHorizontal);
+	Layout::checkScroll(adjustment, layout->lastScrollHorizontal);
 	layout->updateVisibility();
 	layout->scrollHandling->scrollChanged();
 }
 
 void Layout::verticalScrollChanged(GtkAdjustment* adjustment, Layout* layout)
 {
-	layout->checkScroll(adjustment, layout->lastScrollVertical);
+	Layout::checkScroll(adjustment, layout->lastScrollVertical);
 	layout->updateVisibility();
 	layout->scrollHandling->scrollChanged();
 }
@@ -334,12 +334,12 @@ auto Layout::getIndexAtGridMap(size_t row, size_t col) -> LayoutMapper::optional
 	return this->mapper.at({col, row});  //watch out.. x,y --> c,r
 }
 
-auto Layout::getMinimalHeight() -> int
+auto Layout::getMinimalHeight() const -> int
 {
 	return this->minHeight;
 }
 
-auto Layout::getMinimalWidth() -> int
+auto Layout::getMinimalWidth() const -> int
 {
 	return this->minWidth;
 }

--- a/src/gui/Layout.cpp
+++ b/src/gui/Layout.cpp
@@ -215,8 +215,8 @@ void Layout::layoutPages(int width, int height)
 				v->setMappedRowCol(r, c);  //store row and column for e.g. proper arrow key navigation
 				int64_t vDisplayWidth = v->getDisplayWidth();
 				{
-					int64_t paddingLeft;
-					int64_t paddingRight;
+					int64_t paddingLeft = 0;
+					int64_t paddingRight = 0;
 					auto columnPadding = static_cast<int64_t>(this->widthCols[c] - vDisplayWidth);
 
 					if (isPairedPages && len > 1)

--- a/src/gui/Layout.h
+++ b/src/gui/Layout.h
@@ -58,12 +58,12 @@ public:
 	/**
 	 * Returns the height of the entire Layout
 	 */
-	int getMinimalHeight();
+	int getMinimalHeight() const;
 
 	/**
 	 * Returns the width of the entire Layout
 	 */
-	int getMinimalWidth();
+	int getMinimalWidth() const;
 
 	/**
 	 * Returns the Rectangle which is currently visible
@@ -107,7 +107,7 @@ protected:
 	static void verticalScrollChanged(GtkAdjustment* adjustment, Layout* layout);
 
 private:
-	void checkScroll(GtkAdjustment* adjustment, double& lastScroll);
+	static void checkScroll(GtkAdjustment* adjustment, double& lastScroll);
 
 	void setLayoutSize(int width, int height);
 

--- a/src/gui/LayoutMapper.cpp
+++ b/src/gui/LayoutMapper.cpp
@@ -17,10 +17,10 @@ void calculate(LayoutMapper::internal_data& data, size_t numRows, size_t numCols
 {
 	if (useRows)
 	{
-		data.rows = std::max<size_t>(1ul, numRows);
+		data.rows = std::max<size_t>(1UL, numRows);
 
 		// using  + ( rows-1) to round up (int)pages/rows
-		data.cols = std::max<size_t>(1ul, (data.actualPages + firstPageOffset + (data.rows - 1)) / data.rows);
+		data.cols = std::max<size_t>(1UL, (data.actualPages + firstPageOffset + (data.rows - 1)) / data.rows);
 		if (data.showPairedPages)
 		{
 			data.cols += data.cols % 2;  //make even
@@ -28,12 +28,12 @@ void calculate(LayoutMapper::internal_data& data, size_t numRows, size_t numCols
 	}
 	else
 	{
-		data.cols = std::max<size_t>(1ul, numCols);
+		data.cols = std::max<size_t>(1UL, numCols);
 		if (data.showPairedPages)
 		{
 			data.cols += data.cols % 2;  //make even
 		}
-		data.rows = std::max<size_t>(1ul, (data.actualPages + firstPageOffset + (data.cols - 1)) / data.cols);
+		data.rows = std::max<size_t>(1UL, (data.actualPages + firstPageOffset + (data.cols - 1)) / data.cols);
 	}
 
 
@@ -129,7 +129,7 @@ auto LayoutMapper::isPairedPages() const -> bool
 // Todo: replace with
 //       boost::optional<size_t> LayoutMapper::map(size_t x, size_t y) or
 //       std::optional<size_t> LayoutMapper::map(size_t x, size_t y)
-auto LayoutMapper::map(size_t col, size_t row) -> LayoutMapper::optional_size_t
+auto LayoutMapper::map(size_t col, size_t row) const -> LayoutMapper::optional_size_t
 {
 	if (isRightToLeft())
 	{

--- a/src/gui/LayoutMapper.cpp
+++ b/src/gui/LayoutMapper.cpp
@@ -143,7 +143,7 @@ auto LayoutMapper::map(size_t col, size_t row) -> LayoutMapper::optional_size_t
 		row = data_.rows - 1 - row;
 	}
 
-	size_t res;
+	size_t res = 0;
 	if (isVertical())
 	{
 		if (data_.showPairedPages)

--- a/src/gui/LayoutMapper.h
+++ b/src/gui/LayoutMapper.h
@@ -150,7 +150,7 @@ private:
 	 *
 	 * @return Page index to put at coordinates
 	 */
-	optional_size_t map(size_t x, size_t y);
+	optional_size_t map(size_t col, size_t row) const;
 
 private:
 	struct internal_data

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -295,7 +295,7 @@ void MainWindow::initHideMenu()
 		                 G_CALLBACK(+[](GtkMenuItem* menuitem, MainWindow* self) { toggleMenuBar(self); }), this);
 
 		GtkAccelGroup* accelGroup = gtk_accel_group_new();
-		gtk_accel_group_connect(accelGroup, GDK_KEY_F10, (GdkModifierType) 0, GTK_ACCEL_VISIBLE,
+		gtk_accel_group_connect(accelGroup, GDK_KEY_F10, static_cast<GdkModifierType>(0), GTK_ACCEL_VISIBLE,
 		                        g_cclosure_new_swap(G_CALLBACK(toggleMenuBar), this, nullptr));
 		gtk_window_add_accel_group(GTK_WINDOW(getWindow()), accelGroup);
 	}
@@ -335,7 +335,7 @@ void MainWindow::dragDataRecived(GtkWidget* widget, GdkDragContext* dragContext,
 	guchar* text = gtk_selection_data_get_text(data);
 	if (text)
 	{
-		win->control->clipboardPasteText((const char*) text);
+		win->control->clipboardPasteText(reinterpret_cast<const char*>(text));
 
 		g_free(text);
 		gtk_drag_finish(dragContext, true, false, time);
@@ -360,7 +360,7 @@ void MainWindow::dragDataRecived(GtkWidget* widget, GdkDragContext* dragContext,
 			const char* uri = uris[i];
 
 			GCancellable* cancel = g_cancellable_new();
-			int cancelTimeout = g_timeout_add(3000, (GSourceFunc) cancellable_cancel, cancel);
+			int cancelTimeout = g_timeout_add(3000, reinterpret_cast<GSourceFunc>(cancellable_cancel), cancel);
 
 			GFile* file = g_file_new_for_uri(uri);
 			GError* err = nullptr;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -465,9 +465,9 @@ void MainWindow::updateScrollbarSidebarPosition()
 	}
 
 
-	    GtkAllocation allocation;
-		gtk_widget_get_allocation(panelMainContents, &allocation);
-		divider = allocation.width - divider;
+	GtkAllocation allocation;
+	gtk_widget_get_allocation(panelMainContents, &allocation);
+	divider = allocation.width - divider;
 
 
 	g_object_ref(sidebar);
@@ -515,10 +515,9 @@ auto MainWindow::onKeyPressCallback(GtkWidget* widget, GdkEventKey* event, MainW
 		win->getControl()->getSearchBar()->showSearchBar(false);
 		return true;
 	}
-	else
-	{
-		return false;
-	}
+
+
+	return false;
 }
 
 auto MainWindow::deleteEventCallback(GtkWidget* widget, GdkEvent* event, Control* control) -> bool

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -463,12 +463,12 @@ void MainWindow::updateScrollbarSidebarPosition()
 		// Already correct
 		return;
 	}
-	else
-	{
-		GtkAllocation allocation;
+
+
+	    GtkAllocation allocation;
 		gtk_widget_get_allocation(panelMainContents, &allocation);
 		divider = allocation.width - divider;
-	}
+
 
 	g_object_ref(sidebar);
 	g_object_ref(boxContents);
@@ -505,12 +505,12 @@ auto MainWindow::onKeyPressCallback(GtkWidget* widget, GdkEventKey* event, MainW
 		//something is selected - give that control
 		return false;
 	}
-	else if (win->getXournal()->getTextEditor())
+	if (win->getXournal()->getTextEditor())
 	{
 		//editing text - give that control
 		return false;
 	}
-	else if (event->keyval == GDK_KEY_Escape)
+	if (event->keyval == GDK_KEY_Escape)
 	{
 		win->getControl()->getSearchBar()->showSearchBar(false);
 		return true;
@@ -563,7 +563,7 @@ void MainWindow::setMaximized(bool maximized)
 	this->maximized = maximized;
 }
 
-auto MainWindow::isMaximized() -> bool
+auto MainWindow::isMaximized() const -> bool
 {
 	return this->maximized;
 }
@@ -620,7 +620,7 @@ auto MainWindow::clearToolbar() -> ToolbarData*
 	{
 		for (int i = 0; i < TOOLBAR_DEFINITIONS_LEN; i++)
 		{
-			this->toolbar->unloadToolbar(this->toolbarWidgets[i]);
+			ToolMenuHandler::unloadToolbar(this->toolbarWidgets[i]);
 		}
 
 		this->toolbar->freeDynamicToolbarItems();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -719,7 +719,7 @@ void MainWindow::updatePageNumbers(size_t page, size_t pagecount, size_t pdfpage
 {
 	SpinPageAdapter* spinPageNo = getSpinPageNo();
 
-	size_t min;
+	size_t min = 0;
 	size_t max = pagecount;
 
 	if (pagecount == 0)

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -64,7 +64,7 @@ public:
 	void saveSidebarSize();
 
 	void setMaximized(bool maximized);
-	bool isMaximized();
+	bool isMaximized() const;
 
 	XournalView* getXournal();
 
@@ -120,7 +120,7 @@ private:
 	/**
 	 * Sidebar show / hidden
 	 */
-	static void viewShowSidebar(GtkCheckMenuItem* checkmenuitem, MainWindow* control);
+	static void viewShowSidebar(GtkCheckMenuItem* checkmenuitem, MainWindow* win);
 
 	/**
 	 * Window close Button is pressed
@@ -146,8 +146,8 @@ private:
 	/**
 	 * Load Overall CSS file with custom icons, other styling and potentially, user changes
 	 */
-	void loadMainCSS(GladeSearchpath* gladeSearchPath, const gchar* cssFilename);
-	
+	static void loadMainCSS(GladeSearchpath* gladeSearchPath, const gchar* cssFilename);
+
 private:
 	Control* control;
 

--- a/src/gui/MainWindowToolbarMenu.cpp
+++ b/src/gui/MainWindowToolbarMenu.cpp
@@ -103,7 +103,7 @@ void MainWindowToolbarMenu::menuClicked(GtkCheckMenuItem* menuitem, MenuSelectTo
 
 	win->toolbarSelected(data->d);
 
-	for (int i = 0; i < (int)this->toolbarMenuData.size(); i++)
+	for (int i = 0; i < static_cast<int>(this->toolbarMenuData.size()); i++)
 	{
 		if (data->index == i)
 		{

--- a/src/gui/PageView.cpp
+++ b/src/gui/PageView.cpp
@@ -144,7 +144,7 @@ auto XojPageView::containsPoint(int x, int y, bool local) const -> bool
 	}
 
 
-	    return x >= 0 && y >= 0 && x <= this->getWidth() && y <= this->getHeight();
+	return x >= 0 && y >= 0 && x <= this->getWidth() && y <= this->getHeight();
 }
 
 auto XojPageView::searchTextOnPage(string& text, int* occures, double* top) -> bool
@@ -672,7 +672,7 @@ auto XojPageView::onKeyPressEvent(GdkEventKey* event) -> bool
 		}
 
 
-		    return false;
+		return false;
 	}
 
 	if (this->textEditor)

--- a/src/gui/PageView.cpp
+++ b/src/gui/PageView.cpp
@@ -254,7 +254,7 @@ void XojPageView::startText(double x, double y)
 				GdkRectangle matchRect = {gint(x - 10), gint(y - 10), 20, 20};
 				if (e->intersectsArea(&matchRect))
 				{
-					text = (Text*) e;
+					text = dynamic_cast<Text*>(e);
 					break;
 				}
 			}
@@ -436,7 +436,7 @@ auto XojPageView::onButtonPressEvent(const PositionInputData& pos) -> bool
 	}
 	else if (h->getToolType() == TOOL_FLOATING_TOOLBOX)
 	{
-		gint wx, wy;
+		gint wx = 0, wy = 0;
 		GtkWidget* widget = xournal->getWidget();
 		gtk_widget_translate_coordinates(widget, gtk_widget_get_toplevel(widget), 0, 0, &wx, &wy);
 
@@ -600,7 +600,7 @@ auto XojPageView::onButtonReleaseEvent(const PositionInputData& pos) -> bool
 
 			if (doAction)  // pop up a menu
 			{
-				gint wx, wy;
+				gint wx = 0, wy = 0;
 				GtkWidget* widget = xournal->getWidget();
 				gtk_widget_translate_coordinates(widget, gtk_widget_get_toplevel(widget), 0, 0, &wx, &wy);
 				wx += std::lround(pos.x + this->getX());
@@ -1064,7 +1064,7 @@ auto XojPageView::getSelectedTex() -> TexImage*
 	{
 		if (e->getType() == ELEMENT_TEXIMAGE)
 		{
-			return (TexImage*) e;
+			return dynamic_cast<TexImage*>(e);
 		}
 	}
 	return nullptr;
@@ -1082,7 +1082,7 @@ auto XojPageView::getSelectedText() -> Text*
 	{
 		if (e->getType() == ELEMENT_TEXT)
 		{
-			return (Text*) e;
+			return dynamic_cast<Text*>(e);
 		}
 	}
 	return nullptr;

--- a/src/gui/PageView.cpp
+++ b/src/gui/PageView.cpp
@@ -152,7 +152,10 @@ auto XojPageView::searchTextOnPage(string& text, int* occures, double* top) -> b
 {
 	if (this->search == nullptr)
 	{
-		if (text.empty()) return true;
+		if (text.empty())
+		{
+			return true;
+		}
 
 		int pNr = this->page->getPdfPageNr();
 		XojPdfPageSPtr pdf = nullptr;

--- a/src/gui/PageView.cpp
+++ b/src/gui/PageView.cpp
@@ -131,7 +131,7 @@ void XojPageView::deleteViewBuffer()
 	g_mutex_unlock(&this->drawingMutex);
 }
 
-auto XojPageView::containsPoint(int x, int y, bool local) -> bool
+auto XojPageView::containsPoint(int x, int y, bool local) const -> bool
 {
 	if (!local)
 	{
@@ -142,10 +142,9 @@ auto XojPageView::containsPoint(int x, int y, bool local) -> bool
 
 		return leftOk && rightOk && topOk && bottomOk;
 	}
-	else
-	{
-		return x >= 0 && y >= 0 && x <= this->getWidth() && y <= this->getHeight();
-	}
+
+
+	    return x >= 0 && y >= 0 && x <= this->getWidth() && y <= this->getHeight();
 }
 
 auto XojPageView::searchTextOnPage(string& text, int* occures, double* top) -> bool
@@ -666,15 +665,14 @@ auto XojPageView::onKeyPressEvent(GdkEventKey* event) -> bool
 			endText();
 			return true;
 		}
-		else if (xournal->getSelection())
+		if (xournal->getSelection())
 		{
 			xournal->clearSelection();
 			return true;
 		}
-		else
-		{
-			return false;
-		}
+
+
+		    return false;
 	}
 
 	if (this->textEditor)
@@ -953,7 +951,7 @@ auto XojPageView::paintPage(cairo_t* cr, GdkRectangle* rect) -> bool
 	return true;
 }
 
-auto XojPageView::containsY(int y) -> bool
+auto XojPageView::containsY(int y) const -> bool
 {
 	return (y >= this->getY() && y <= (this->getY() + this->getDisplayHeight()));
 }
@@ -962,7 +960,7 @@ auto XojPageView::containsY(int y) -> bool
  * GETTER / SETTER
  */
 
-auto XojPageView::isSelected() -> bool
+auto XojPageView::isSelected() const -> bool
 {
 	return selected;
 }
@@ -1013,13 +1011,13 @@ void XojPageView::setMappedRowCol(int row, int col)
 }
 
 
-auto XojPageView::getMappedRow() -> int
+auto XojPageView::getMappedRow() const -> int
 {
 	return this->mappedRow;
 }
 
 
-auto XojPageView::getMappedCol() -> int
+auto XojPageView::getMappedCol() const -> int
 {
 	return this->mappedCol;
 }
@@ -1091,7 +1089,7 @@ auto XojPageView::getSelectedText() -> Text*
 	return nullptr;
 }
 
-auto XojPageView::getRect() -> Rectangle
+auto XojPageView::getRect() const -> Rectangle
 {
 	return Rectangle(getX(), getY(), getDisplayWidth(), getDisplayHeight());
 }

--- a/src/gui/PageView.cpp
+++ b/src/gui/PageView.cpp
@@ -682,7 +682,7 @@ auto XojPageView::onKeyPressEvent(GdkEventKey* event) -> bool
 
 	if (this->inputHandler)
 	{
-		return this->inputHandler->onKeyEvent((GdkEventKey*) event);
+		return this->inputHandler->onKeyEvent(event);
 	}
 
 
@@ -696,7 +696,7 @@ auto XojPageView::onKeyReleaseEvent(GdkEventKey* event) -> bool
 		return true;
 	}
 
-	if (this->inputHandler && this->inputHandler->onKeyEvent((GdkEventKey*) event))
+	if (this->inputHandler && this->inputHandler->onKeyEvent(event))
 	{
 		return true;
 	}
@@ -868,7 +868,7 @@ void XojPageView::paintPageSync(cairo_t* cr, GdkRectangle* rect)
 
 	if (width != dispWidth)
 	{
-		double scale = ((double) dispWidth) / ((double) width);
+		double scale = (static_cast<double>(dispWidth)) / (width);
 
 		// Scale current image to fit the zoom level
 		cairo_scale(cr, scale, scale);

--- a/src/gui/PageView.h
+++ b/src/gui/PageView.h
@@ -52,7 +52,7 @@ public:
 
 	void setIsVisible(bool visible);
 
-	bool isSelected();
+	bool isSelected() const;
 
 	void endText();
 
@@ -75,19 +75,19 @@ public:
 	 * Returns whether this PageView contains the
 	 * given point on the display
 	 */
-	bool containsPoint(int x, int y, bool local = false);
-	bool containsY(int y);
-	
+	bool containsPoint(int x, int y, bool local = false) const;
+	bool containsY(int y) const;
+
 	/**
 	 * Returns Row assigned in current layout
-	 */ 
-	int getMappedRow();
-	
+	 */
+	int getMappedRow() const;
+
 	/**
 	 * Returns Column assigned in current layout
-	 */ 
-	int getMappedCol();
-	
+	 */
+	int getMappedCol() const;
+
 
 	GtkColorWrapper getSelectionColor();
 	int getBufferPixels();
@@ -144,7 +144,7 @@ public:
 	TexImage* getSelectedTex();
 	Text* getSelectedText();
 
-	Rectangle getRect();
+	Rectangle getRect() const;
 
 public: // event handler
 	bool onButtonPressEvent(const PositionInputData& pos);

--- a/src/gui/PageView.h
+++ b/src/gui/PageView.h
@@ -230,18 +230,18 @@ private:
 	 */
 	int lastVisibleTime = -1;
 
-	GMutex repaintRectMutex;
+	GMutex repaintRectMutex{};
 	vector<Rectangle*> rerenderRects;
 	bool rerenderComplete = false;
 
-	GMutex drawingMutex;
-	
-	int dispX;	//position on display - set in Layout::layoutPages
-	int dispY;
+	GMutex drawingMutex{};
+
+	int dispX{};  //position on display - set in Layout::layoutPages
+	int dispY{};
 
 
-	int mappedRow;
-	int mappedCol;
+	int mappedRow{};
+	int mappedCol{};
 
 
 	friend class RenderJob;

--- a/src/gui/SearchBar.cpp
+++ b/src/gui/SearchBar.cpp
@@ -20,7 +20,7 @@ SearchBar::SearchBar(Control* control)
 	g_signal_connect(previous, "clicked",
 	                 G_CALLBACK(+[](GtkButton* button, SearchBar* self) { self->searchPrevious(); }), this);
 
-	// TODO: When keybindings are implemented, handle previous search keybinding properly
+	// TODO(fabian): When keybindings are implemented, handle previous search keybinding properly
 	GtkWidget* searchTextField = win->get("searchTextField");
 	g_signal_connect(searchTextField, "search-changed", G_CALLBACK(searchTextChangedCallback), this);
 	// Enable next/previous search when pressing Enter / Shift+Enter

--- a/src/gui/Shadow.cpp
+++ b/src/gui/Shadow.cpp
@@ -1,6 +1,7 @@
 #include "Shadow.h"
 
 #include "ShadowCode.c"
+#include "math.h"
 
 Shadow* Shadow::instance = new Shadow();
 
@@ -116,7 +117,7 @@ void Shadow::drawShadowTop(cairo_t* cr, int x, int y, int width, double r, doubl
 		this->top = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, shadowTopLeftSize);
 		cairo_t* cr2 = cairo_create(this->top);
 
-		double a;
+		double a = NAN;
 
 		// draw shadow on top and left
 		for (int i = 0; i < shadowTopLeftSize; i++)
@@ -150,7 +151,7 @@ void Shadow::drawShadowLeft(cairo_t* cr, int x, int y, int height, double r, dou
 		this->left = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, shadowTopLeftSize, height);
 		cairo_t* cr2 = cairo_create(this->left);
 
-		double a;
+		double a = NAN;
 
 		// draw shadow on top and left
 		for (int i = 0; i < shadowTopLeftSize; i++)
@@ -184,7 +185,7 @@ void Shadow::drawShadowRight(cairo_t* cr, int x, int y, int height, double r, do
 		this->right = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, shadowBottomRightSize, height);
 		cairo_t* cr2 = cairo_create(this->right);
 
-		double a;
+		double a = NAN;
 
 		// draw shadow on top and left
 		for (int i = 0; i < shadowBottomRightSize; i++)
@@ -218,7 +219,7 @@ void Shadow::drawShadowBottom(cairo_t* cr, int x, int y, int width, double r, do
 		this->bottom = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, shadowBottomRightSize);
 		cairo_t* cr2 = cairo_create(this->bottom);
 
-		double a;
+		double a = NAN;
 
 		// draw shadow on top and left
 		for (int i = 0; i < shadowBottomRightSize; i++)

--- a/src/gui/Shadow.cpp
+++ b/src/gui/Shadow.cpp
@@ -1,7 +1,7 @@
 #include "Shadow.h"
 
 #include "ShadowCode.c"
-#include "math.h"
+#include <cmath>
 
 Shadow* Shadow::instance = new Shadow();
 

--- a/src/gui/Shadow.cpp
+++ b/src/gui/Shadow.cpp
@@ -14,22 +14,22 @@ Shadow::Shadow()
 
 	this->edgeTopLeft = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, sTlSize * 2, sTlSize * 2);
 	cairo_t* cr = cairo_create(this->edgeTopLeft);
-	drawShadowEdge(cr, 0, 0, sTlSize, sTlSize, (u8ptr) shadowEdge1, 0, 0, 0);
+	drawShadowEdge(cr, 0, 0, sTlSize, sTlSize, reinterpret_cast<u8ptr>(shadowEdge1), 0, 0, 0);
 	cairo_destroy(cr);
 
 	this->edgeTopRight = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, sBrSize * 2, sTlSize * 2);
 	cr = cairo_create(this->edgeTopRight);
-	drawShadowEdge(cr, 0, 0, sBrSize, sTlSize, (u8ptr) shadowEdge2, 0, 0, 0);
+	drawShadowEdge(cr, 0, 0, sBrSize, sTlSize, reinterpret_cast<u8ptr>(shadowEdge2), 0, 0, 0);
 	cairo_destroy(cr);
 
 	this->edgeBottomRight = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, sBrSize * 2, sBrSize * 2);
 	cr = cairo_create(this->edgeBottomRight);
-	drawShadowEdge(cr, 0, 0, sBrSize, sBrSize, (u8ptr) shadowEdge3, 0, 0, 0);
+	drawShadowEdge(cr, 0, 0, sBrSize, sBrSize, reinterpret_cast<u8ptr>(shadowEdge3), 0, 0, 0);
 	cairo_destroy(cr);
 
 	this->edgeBottomLeft = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, sTlSize * 2, sBrSize * 2);
 	cr = cairo_create(this->edgeBottomLeft);
-	drawShadowEdge(cr, 0, 0, sTlSize, sBrSize, (u8ptr) shadowEdge4, 0, 0, 0);
+	drawShadowEdge(cr, 0, 0, sTlSize, sBrSize, reinterpret_cast<u8ptr>(shadowEdge4), 0, 0, 0);
 	cairo_destroy(cr);
 }
 

--- a/src/gui/Shadow.h
+++ b/src/gui/Shadow.h
@@ -19,11 +19,11 @@ private:
 	Shadow();
 	virtual ~Shadow();
 
-	void drawShadowEdge(cairo_t* cr, int x, int y, int width, int height, const unsigned char* edge,
-						double r, double g, double b);
+	static void drawShadowEdge(cairo_t* cr, int x, int y, int width, int height, const unsigned char* edge, double r,
+	                           double g, double b);
 	void drawShadowImpl(cairo_t* cr, int x, int y, int width, int height);
 
-	void paintEdge(cairo_t* cr, cairo_surface_t* image, int x, int y, int width, int height);
+	static void paintEdge(cairo_t* cr, cairo_surface_t* image, int x, int y, int width, int height);
 
 	void drawShadowTop(cairo_t* cr, int x, int y, int width, double r, double g, double b);
 	void drawShadowLeft(cairo_t* cr, int x, int y, int height, double r, double g, double b);

--- a/src/gui/TextEditor.cpp
+++ b/src/gui/TextEditor.cpp
@@ -197,9 +197,9 @@ void TextEditor::iMCommitCallback(GtkIMContext* context, const gchar* str, TextE
 
 void TextEditor::iMPreeditChangedCallback(GtkIMContext* context, TextEditor* te)
 {
-	gchar* str;
-	PangoAttrList* attrs;
-	gint cursor_pos;
+	gchar* str = nullptr;
+	PangoAttrList* attrs = nullptr;
+	gint cursor_pos = 0;
 	GtkTextIter iter;
 
 	gtk_text_buffer_get_iter_at_mark(te->buffer, &iter, gtk_text_buffer_get_insert(te->buffer));
@@ -970,7 +970,7 @@ void TextEditor::backspace()
 auto TextEditor::getSelection() -> string
 {
 	GtkTextIter start, end;
-	char* text;
+	char* text = nullptr;
 	string s;
 
 	if (gtk_text_buffer_get_selection_bounds(buffer, &start, &end))

--- a/src/gui/TextEditor.cpp
+++ b/src/gui/TextEditor.cpp
@@ -751,7 +751,7 @@ void TextEditor::calcVirtualCursor()
 
 	PangoRectangle rect = {0};
 	pango_layout_index_to_pos(this->layout, offset, &rect);
-	this->virtualCursor = ((double) rect.x) / PANGO_SCALE;
+	this->virtualCursor = (static_cast<double>(rect.x)) / PANGO_SCALE;
 }
 
 void TextEditor::moveCursor(const GtkTextIter* newLocation, gboolean extendSelection)
@@ -788,9 +788,13 @@ static auto find_whitepace_region(const GtkTextIter* center, GtkTextIter* start,
 	*end = *center;
 
 	if (gtk_text_iter_backward_find_char(start, not_whitespace, nullptr, nullptr))
+	{
 		gtk_text_iter_forward_char(start); /* we want the first whitespace... */
+	}
 	if (whitespace(gtk_text_iter_get_char(end), nullptr))
+	{
 		gtk_text_iter_forward_find_char(end, not_whitespace, nullptr, nullptr);
+	}
 
 	return !gtk_text_iter_equal(start, end);
 }
@@ -1035,13 +1039,15 @@ auto TextEditor::blinkCallback(TextEditor* te) -> gint
 {
 	if (te->cursorVisible)
 	{
-		te->blinkTimeout = gdk_threads_add_timeout(
-		        te->cursorBlinkTime * CURSOR_OFF_MULTIPLIER / CURSOR_DIVIDER, (GSourceFunc) blinkCallback, te);
+		te->blinkTimeout = gdk_threads_add_timeout(te->cursorBlinkTime * CURSOR_OFF_MULTIPLIER / CURSOR_DIVIDER,
+		                                           reinterpret_cast<GSourceFunc>(blinkCallback),
+		                                           te);
 	}
 	else
 	{
-		te->blinkTimeout = gdk_threads_add_timeout(
-		        te->cursorBlinkTime * CURSOR_ON_MULTIPLIER / CURSOR_DIVIDER, (GSourceFunc) blinkCallback, te);
+		te->blinkTimeout = gdk_threads_add_timeout(te->cursorBlinkTime * CURSOR_ON_MULTIPLIER / CURSOR_DIVIDER,
+		                                           reinterpret_cast<GSourceFunc>(blinkCallback),
+		                                           te);
 	}
 
 	te->cursorVisible = !te->cursorVisible;
@@ -1183,16 +1189,16 @@ void TextEditor::paint(cairo_t* cr, GdkRectangle* repaintRect, double zoom)
 	int w = 0;
 	int h = 0;
 	pango_layout_get_size(this->layout, &w, &h);
-	double width = ((double) w) / PANGO_SCALE;
-	double height = ((double) h) / PANGO_SCALE;
+	double width = (static_cast<double>(w)) / PANGO_SCALE;
+	double height = (static_cast<double>(h)) / PANGO_SCALE;
 
 	int offset = gtk_text_iter_get_offset(&cursorIter);
 	PangoRectangle rect = {0};
 	int pangoOffset = getByteOffset(offset) + preeditString.length();
 	pango_layout_index_to_pos(this->layout, pangoOffset, &rect);
-	double cX = ((double) rect.x) / PANGO_SCALE;
-	double cY = ((double) rect.y) / PANGO_SCALE;
-	double cHeight = ((double) rect.height) / PANGO_SCALE;
+	double cX = (static_cast<double>(rect.x)) / PANGO_SCALE;
+	double cY = (static_cast<double>(rect.y)) / PANGO_SCALE;
+	double cHeight = (static_cast<double>(rect.height)) / PANGO_SCALE;
 
 	drawCursor(cr, cX, cY, cHeight, zoom);
 

--- a/src/gui/ToolitemDragDrop.cpp
+++ b/src/gui/ToolitemDragDrop.cpp
@@ -16,7 +16,7 @@ void ToolitemDragDrop::attachMetadata(GtkWidget* w, int id, AbstractToolItem* ai
 	d->type = TOOL_ITEM_ITEM;
 	d->color = 0;
 
-	g_object_set_data_full(G_OBJECT(w), ATTACH_DRAG_DROP_DATA, d, (GDestroyNotify) g_free);
+	g_object_set_data_full(G_OBJECT(w), ATTACH_DRAG_DROP_DATA, d, static_cast<GDestroyNotify>(g_free));
 }
 
 auto ToolitemDragDrop::ToolItemDragDropData_new(AbstractToolItem* item) -> ToolItemDragDropData*
@@ -40,7 +40,7 @@ void ToolitemDragDrop::attachMetadata(GtkWidget* w, int id, ToolItemType type)
 	d->type = type;
 	d->color = 0;
 
-	g_object_set_data_full(G_OBJECT(w), ATTACH_DRAG_DROP_DATA, d, (GDestroyNotify) g_free);
+	g_object_set_data_full(G_OBJECT(w), ATTACH_DRAG_DROP_DATA, d, static_cast<GDestroyNotify>(g_free));
 }
 
 void ToolitemDragDrop::attachMetadataColor(GtkWidget* w, int id, int color, AbstractToolItem* item)
@@ -52,7 +52,7 @@ void ToolitemDragDrop::attachMetadataColor(GtkWidget* w, int id, int color, Abst
 	d->type = TOOL_ITEM_COLOR;
 	d->color = color;
 
-	g_object_set_data_full(G_OBJECT(w), ATTACH_DRAG_DROP_DATA, d, (GDestroyNotify) g_free);
+	g_object_set_data_full(G_OBJECT(w), ATTACH_DRAG_DROP_DATA, d, static_cast<GDestroyNotify>(g_free));
 }
 
 auto ToolitemDragDrop::getIcon(ToolItemDragDropData* data) -> GtkWidget*
@@ -105,7 +105,7 @@ auto ToolitemDragDrop::isToolItemEnabled(ToolItemDragDropData* d) -> bool
 
 auto ToolitemDragDrop::metadataGetMetadata(GtkWidget* w) -> ToolItemDragDropData*
 {
-	const int* ptr = (const int*) g_object_get_data(G_OBJECT(w), ATTACH_DRAG_DROP_DATA);
+	const int* ptr = static_cast<const int*>(g_object_get_data(G_OBJECT(w), ATTACH_DRAG_DROP_DATA));
 
 	if (ptr == nullptr)
 	{

--- a/src/gui/ToolitemDragDrop.cpp
+++ b/src/gui/ToolitemDragDrop.cpp
@@ -61,7 +61,7 @@ auto ToolitemDragDrop::getIcon(ToolItemDragDropData* data) -> GtkWidget*
 	{
 		return data->item->getNewToolIcon();
 	}
-	else if (data->type == TOOL_ITEM_SEPARATOR)
+	if (data->type == TOOL_ITEM_SEPARATOR)
 	{
 		return ToolbarSeparatorImage::newSepeartorImage();
 	}

--- a/src/gui/XojColor.cpp
+++ b/src/gui/XojColor.cpp
@@ -10,7 +10,7 @@ XojColor::XojColor(int color, string name)
 
 XojColor::~XojColor() = default;
 
-auto XojColor::getColor() -> int
+auto XojColor::getColor() const -> int
 {
 	return this->color;
 }

--- a/src/gui/XojColor.h
+++ b/src/gui/XojColor.h
@@ -20,7 +20,7 @@ public:
 	virtual ~XojColor();
 
 public:
-	int getColor();
+	int getColor() const;
 	string getName();
 
 private:

--- a/src/gui/XournalView.cpp
+++ b/src/gui/XournalView.cpp
@@ -140,7 +140,7 @@ auto XournalView::clearMemoryTimer(XournalView* widget) -> gboolean
 	return true;
 }
 
-auto XournalView::getCurrentPage() -> size_t
+auto XournalView::getCurrentPage() const -> size_t
 {
 	return currentPage;
 }
@@ -257,9 +257,9 @@ auto XournalView::onKeyPressEvent(GdkEventKey* event) -> bool
 			control->getScrollHandler()->goToPreviousPage();
 			return true;
 		}
-		else
-		{
-			if (state & GDK_SHIFT_MASK)
+
+
+		    if (state & GDK_SHIFT_MASK)
 			{
 				this->pageRelativeXY(0, -1);
 			}
@@ -268,7 +268,6 @@ auto XournalView::onKeyPressEvent(GdkEventKey* event) -> bool
 				layout->scrollRelative(0, -scrollKeySize);
 			}
 			return true;
-		}
 	}
 
 	if (event->keyval == GDK_KEY_Down)
@@ -278,9 +277,9 @@ auto XournalView::onKeyPressEvent(GdkEventKey* event) -> bool
 			control->getScrollHandler()->goToNextPage();
 			return true;
 		}
-		else
-		{
-			if (state & GDK_SHIFT_MASK)
+
+
+		    if (state & GDK_SHIFT_MASK)
 			{
 				this->pageRelativeXY(0, 1);
 			}
@@ -289,7 +288,6 @@ auto XournalView::onKeyPressEvent(GdkEventKey* event) -> bool
 				layout->scrollRelative(0, scrollKeySize);
 			}
 			return true;
-		}
 	}
 
 	if (event->keyval == GDK_KEY_Left)

--- a/src/gui/XournalView.cpp
+++ b/src/gui/XournalView.cpp
@@ -780,7 +780,7 @@ void XournalView::setSelection(EditSelection* selection)
 		}
 		else if (e->getType() == ELEMENT_STROKE)
 		{
-			auto* s = static_cast<Stroke*>(e);
+			auto* s = dynamic_cast<Stroke*>(e);
 			if (s->getToolType() != STROKE_TOOL_ERASER)
 			{
 				canChangeColor = true;

--- a/src/gui/XournalView.cpp
+++ b/src/gui/XournalView.cpp
@@ -59,7 +59,7 @@ XournalView::XournalView(GtkWidget* parent, Control* control, ScrollHandling* sc
 
 	gtk_widget_grab_focus(this->widget);
 
-	this->cleanupTimeout = g_timeout_add_seconds(5, (GSourceFunc) clearMemoryTimer, this);
+	this->cleanupTimeout = g_timeout_add_seconds(5, reinterpret_cast<GSourceFunc>(clearMemoryTimer), this);
 }
 
 XournalView::~XournalView()
@@ -91,7 +91,7 @@ auto pageViewIncreasingClockTime(XojPageView* a, XojPageView* b) -> gint
 
 void XournalView::staticLayoutPages(GtkWidget* widget, GtkAllocation* allocation, void* data)
 {
-	auto* xv = (XournalView*) data;
+	auto* xv = static_cast<XournalView*>(data);
 	xv->layoutPages();
 }
 
@@ -103,7 +103,7 @@ auto XournalView::clearMemoryTimer(XournalView* widget) -> gboolean
 	{
 		if (page->getLastVisibleTime() > 0)
 		{
-			list = g_list_insert_sorted(list, page, (GCompareFunc) pageViewIncreasingClockTime);
+			list = g_list_insert_sorted(list, page, reinterpret_cast<GCompareFunc>(pageViewIncreasingClockTime));
 		}
 	}
 
@@ -120,7 +120,7 @@ auto XournalView::clearMemoryTimer(XournalView* widget) -> gboolean
 		}
 		else
 		{
-			auto* v = (XojPageView*) l->data;
+			auto* v = static_cast<XojPageView*>(l->data);
 
 			if (pixel <= 0)
 			{

--- a/src/gui/XournalView.cpp
+++ b/src/gui/XournalView.cpp
@@ -259,15 +259,15 @@ auto XournalView::onKeyPressEvent(GdkEventKey* event) -> bool
 		}
 
 
-		    if (state & GDK_SHIFT_MASK)
-			{
-				this->pageRelativeXY(0, -1);
-			}
-			else
-			{
-				layout->scrollRelative(0, -scrollKeySize);
-			}
-			return true;
+		if (state & GDK_SHIFT_MASK)
+		{
+			this->pageRelativeXY(0, -1);
+		}
+		else
+		{
+			layout->scrollRelative(0, -scrollKeySize);
+		}
+		return true;
 	}
 
 	if (event->keyval == GDK_KEY_Down)
@@ -279,15 +279,15 @@ auto XournalView::onKeyPressEvent(GdkEventKey* event) -> bool
 		}
 
 
-		    if (state & GDK_SHIFT_MASK)
-			{
-				this->pageRelativeXY(0, 1);
-			}
-			else
-			{
-				layout->scrollRelative(0, scrollKeySize);
-			}
-			return true;
+		if (state & GDK_SHIFT_MASK)
+		{
+			this->pageRelativeXY(0, 1);
+		}
+		else
+		{
+			layout->scrollRelative(0, scrollKeySize);
+		}
+		return true;
 	}
 
 	if (event->keyval == GDK_KEY_Left)

--- a/src/gui/XournalView.h
+++ b/src/gui/XournalView.h
@@ -53,7 +53,7 @@ public:
 	//Relative navigation in current layout:
 	void pageRelativeXY(int offCol, int offRow );
 
-	size_t getCurrentPage();
+	size_t getCurrentPage() const;
 
 	void clearSelection();
 

--- a/src/gui/XournalppCursor.cpp
+++ b/src/gui/XournalppCursor.cpp
@@ -429,8 +429,8 @@ auto XournalppCursor::createHighlighterOrPenCursor(int size, double alpha) -> Gd
 	int width = size;
 
 	// create a hash of variables so we notice if one changes despite being the same cursor type:
-	gulong flavour =
-	        (big ? 1 : 0) | (bright ? 2 : 0) | (gulong)(64 * alpha) << 2 | (gulong) size << 9 | (gulong) rgb << 14;
+	gulong flavour = (big ? 1 : 0) | (bright ? 2 : 0) | static_cast<gulong>(64 * alpha) << 2 |
+	                 static_cast<gulong>(size) << 9 | static_cast<gulong>(rgb) << 14;
 
 	if (CRSR_PENORHIGHLIGHTER == this->currentCursor && flavour == this->currentCursorFlavour) return nullptr;
 	this->currentCursor = CRSR_PENORHIGHLIGHTER;
@@ -548,7 +548,8 @@ auto XournalppCursor::createCustomDrawDirCursor(int size, bool shift, bool ctrl)
 	bool bright = control->getSettings()->isHighlightPosition();
 
 	int newCursorID = CRSR_DRAWDIRNONE + (shift ? 1 : 0) + (ctrl ? 2 : 0);
-	gulong flavour = (big ? 1 : 0) | (bright ? 2 : 0) | (gulong) size << 2;  // hash of variables for comparison only
+	gulong flavour =
+	        (big ? 1 : 0) | (bright ? 2 : 0) | static_cast<gulong>(size) << 2;  // hash of variables for comparison only
 
 	if (newCursorID == this->currentCursor && flavour == this->currentCursorFlavour) return nullptr;
 	this->currentCursor = newCursorID;

--- a/src/gui/XournalppCursor.cpp
+++ b/src/gui/XournalppCursor.cpp
@@ -411,7 +411,7 @@ auto XournalppCursor::getHighlighterCursor() -> GdkCursor*
 	}
 
 
-	    return createHighlighterOrPenCursor(5, 120 / 255.0);
+	return createHighlighterOrPenCursor(5, 120 / 255.0);
 }
 
 
@@ -423,7 +423,7 @@ auto XournalppCursor::getPenCursor() -> GdkCursor*
 	}
 
 
-	    return createHighlighterOrPenCursor(3, 1.0);
+	return createHighlighterOrPenCursor(3, 1.0);
 }
 
 

--- a/src/gui/XournalppCursor.cpp
+++ b/src/gui/XournalppCursor.cpp
@@ -2,6 +2,7 @@
 
 #include "XournalView.h"
 #include "control/Control.h"
+#include "math.h"
 
 #include <Util.h>
 #include <pixbuf-utils.h>
@@ -582,7 +583,7 @@ auto XournalppCursor::createCustomDrawDirCursor(int size, bool shift, bool ctrl)
 	{
 		cairo_text_extents_t extents;
 		const char* utf8 = "CONTROL";
-		double x, y;
+		double x = NAN, y = NAN;
 		cairo_select_font_face(cr, "Sans", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_NORMAL);
 		cairo_set_font_size(cr, fontSize);
 		cairo_text_extents(cr, utf8, &extents);
@@ -596,7 +597,7 @@ auto XournalppCursor::createCustomDrawDirCursor(int size, bool shift, bool ctrl)
 	{
 		cairo_text_extents_t extents;
 		const char* utf8 = "SHIFT";
-		double x, y;
+		double x = NAN, y = NAN;
 		cairo_select_font_face(cr, "Sans", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_NORMAL);
 		cairo_set_font_size(cr, fontSize);
 		cairo_text_extents(cr, utf8, &extents);

--- a/src/gui/XournalppCursor.cpp
+++ b/src/gui/XournalppCursor.cpp
@@ -2,7 +2,7 @@
 
 #include "XournalView.h"
 #include "control/Control.h"
-#include "math.h"
+#include <cmath>
 
 #include <Util.h>
 #include <pixbuf-utils.h>
@@ -409,10 +409,9 @@ auto XournalppCursor::getHighlighterCursor() -> GdkCursor*
 	{
 		return createCustomDrawDirCursor(48, this->drawDirShift, this->drawDirCtrl);
 	}
-	else
-	{
-		return createHighlighterOrPenCursor(5, 120 / 255.0);
-	}
+
+
+	    return createHighlighterOrPenCursor(5, 120 / 255.0);
 }
 
 
@@ -422,10 +421,9 @@ auto XournalppCursor::getPenCursor() -> GdkCursor*
 	{
 		return createCustomDrawDirCursor(48, this->drawDirShift, this->drawDirCtrl);
 	}
-	else
-	{
-		return createHighlighterOrPenCursor(3, 1.0);
-	}
+
+
+	    return createHighlighterOrPenCursor(3, 1.0);
 }
 
 

--- a/src/gui/XournalppCursor.cpp
+++ b/src/gui/XournalppCursor.cpp
@@ -150,7 +150,10 @@ void XournalppCursor::setMouseSelectionType(CursorSelectionType selectionType)
 void XournalppCursor::setCursorBusy(bool busy)
 {
 	MainWindow* win = control->getWindow();
-	if (!win) return;
+	if (!win)
+	{
+		return;
+	}
 
 	if (this->busy == busy)
 	{
@@ -207,10 +210,16 @@ void XournalppCursor::setInvisible(bool invisible)
 void XournalppCursor::updateCursor()
 {
 	MainWindow* win = control->getWindow();
-	if (!win) return;
+	if (!win)
+	{
+		return;
+	}
 
 	XournalView* xournal = win->getXournal();
-	if (!xournal) return;
+	if (!xournal)
+	{
+		return;
+	}
 
 	GdkCursor* cursor = nullptr;
 
@@ -369,7 +378,10 @@ void XournalppCursor::updateCursor()
 auto XournalppCursor::getEraserCursor() -> GdkCursor*
 {
 
-	if (CRSR_ERASER == this->currentCursor) return nullptr;  // cursor already set
+	if (CRSR_ERASER == this->currentCursor)
+	{
+		return nullptr;  // cursor already set
+	}
 	this->currentCursor = CRSR_ERASER;
 
 
@@ -432,7 +444,10 @@ auto XournalppCursor::createHighlighterOrPenCursor(int size, double alpha) -> Gd
 	gulong flavour = (big ? 1 : 0) | (bright ? 2 : 0) | static_cast<gulong>(64 * alpha) << 2 |
 	                 static_cast<gulong>(size) << 9 | static_cast<gulong>(rgb) << 14;
 
-	if (CRSR_PENORHIGHLIGHTER == this->currentCursor && flavour == this->currentCursorFlavour) return nullptr;
+	if (CRSR_PENORHIGHLIGHTER == this->currentCursor && flavour == this->currentCursorFlavour)
+	{
+		return nullptr;
+	}
 	this->currentCursor = CRSR_PENORHIGHLIGHTER;
 	this->currentCursorFlavour = flavour;
 
@@ -505,16 +520,28 @@ auto XournalppCursor::createHighlighterOrPenCursor(int size, double alpha) -> Gd
 
 void XournalppCursor::setCursor(int cursorID)
 {
-	if (cursorID == this->currentCursor) return;
+	if (cursorID == this->currentCursor)
+	{
+		return;
+	}
 
 	MainWindow* win = control->getWindow();
-	if (!win) return;
+	if (!win)
+	{
+		return;
+	}
 
 	XournalView* xournal = win->getXournal();
-	if (!xournal) return;
+	if (!xournal)
+	{
+		return;
+	}
 
 	GdkWindow* window = gtk_widget_get_window(xournal->getWidget());
-	if (!window) return;
+	if (!window)
+	{
+		return;
+	}
 
 	GdkCursor* cursor = gdk_cursor_new_from_name(gdk_window_get_display(window), cssCursors[cursorID].cssName);
 	if (cursor == nullptr)  // failed to get a cursor, try backup cursor.
@@ -526,7 +553,10 @@ void XournalppCursor::setCursor(int cursorID)
 			// Null cursor is ok but not wanted ... warn user
 			if (cursor == nullptr)
 			{
-				if (CRSR_nullptr == this->currentCursor) return;  // We've already been here
+				if (CRSR_nullptr == this->currentCursor)
+				{
+					return;  // We've already been here
+				}
 				g_warning("CSS Cursor and backup not valid '%s', '%s'",
 				          cssCursors[cursorID].cssName,
 				          cssCursors[cursorID].cssBackupName);
@@ -538,7 +568,10 @@ void XournalppCursor::setCursor(int cursorID)
 	this->currentCursor = cursorID;
 	gdk_window_set_cursor(gtk_widget_get_window(xournal->getWidget()), cursor);
 	gdk_window_set_cursor(window, cursor);
-	if (cursor) g_object_unref(cursor);
+	if (cursor)
+	{
+		g_object_unref(cursor);
+	}
 }
 
 
@@ -551,7 +584,10 @@ auto XournalppCursor::createCustomDrawDirCursor(int size, bool shift, bool ctrl)
 	gulong flavour =
 	        (big ? 1 : 0) | (bright ? 2 : 0) | static_cast<gulong>(size) << 2;  // hash of variables for comparison only
 
-	if (newCursorID == this->currentCursor && flavour == this->currentCursorFlavour) return nullptr;
+	if (newCursorID == this->currentCursor && flavour == this->currentCursorFlavour)
+	{
+		return nullptr;
+	}
 	this->currentCursor = newCursorID;
 	this->currentCursorFlavour = flavour;
 

--- a/src/gui/XournalppCursor.h
+++ b/src/gui/XournalppCursor.h
@@ -65,5 +65,5 @@ private:
 
 	// avoid re-assigning same cursor
 	guint currentCursor = 0;      // enum AVAILABLECURSORS
-	gulong currentCursorFlavour;  // for different flavours of a cursor (i.e. drawdir, pen and hilighter custom cursors)
+	gulong currentCursorFlavour{};  // for different flavours of a cursor (i.e. drawdir, pen and hilighter custom cursors)
 };

--- a/src/gui/dialog/ButtonConfigGui.cpp
+++ b/src/gui/dialog/ButtonConfigGui.cpp
@@ -17,8 +17,8 @@ void addToolToList(GtkListStore* typeModel, const char* icon, const char* name, 
 	GtkTreeIter iter;
 
 	gtk_list_store_append(typeModel, &iter);
-	GdkPixbuf* pixbuf =
-	        gtk_icon_theme_load_icon(gtk_icon_theme_get_default(), icon, 24, (GtkIconLookupFlags) 0, nullptr);
+	GdkPixbuf* pixbuf = gtk_icon_theme_load_icon(gtk_icon_theme_get_default(), icon, 24,
+	                                             static_cast<GtkIconLookupFlags>(0), nullptr);
 	gtk_list_store_set(typeModel, &iter, 0, pixbuf, -1);
 	gtk_list_store_set(typeModel, &iter, 1, name, 2, action, -1);
 }
@@ -226,7 +226,7 @@ void ButtonConfigGui::saveSettings()
 	GtkTreeModel* model = gtk_combo_box_get_model(GTK_COMBO_BOX(cbTool));
 	gtk_tree_model_get_value(model, &iter, 2, &value);
 
-	auto action = (ToolType) g_value_get_int(&value);
+	auto action = static_cast<ToolType>(g_value_get_int(&value));
 	ButtonConfig* cfg = settings->getButtonConfig(button);
 	cfg->action = action;
 
@@ -253,7 +253,7 @@ void ButtonConfigGui::saveSettings()
 	gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(colorButton), &color);
 	cfg->color = Util::gdkrgba_to_hex(color);
 
-	cfg->drawingType = (DrawingType) gtk_combo_box_get_active(GTK_COMBO_BOX(this->cbDrawingType));
+	cfg->drawingType = static_cast<DrawingType>(gtk_combo_box_get_active(GTK_COMBO_BOX(this->cbDrawingType)));
 
 	int eraserMode = gtk_combo_box_get_active(GTK_COMBO_BOX(this->cbEraserType));
 
@@ -297,7 +297,7 @@ void ButtonConfigGui::enableDisableTools()
 
 	GValue value = {0};
 	gtk_tree_model_get_value(model, &iter, 2, &value);
-	auto action = (ToolType) g_value_get_int(&value);
+	auto action = static_cast<ToolType>(g_value_get_int(&value));
 
 	switch (action)
 	{

--- a/src/gui/dialog/ExportDialog.cpp
+++ b/src/gui/dialog/ExportDialog.cpp
@@ -43,7 +43,7 @@ auto ExportDialog::getPngDpi() -> int
 	return gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spDpi")));
 }
 
-auto ExportDialog::isConfirmed() -> bool
+auto ExportDialog::isConfirmed() const -> bool
 {
 	return this->confirmed;
 }
@@ -57,18 +57,17 @@ auto ExportDialog::getRange() -> PageRangeVector
 	{
 		return PageRange::parse(gtk_entry_get_text(GTK_ENTRY(get("txtPages"))));
 	}
-	else if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(rdRangeCurrent)))
+	if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(rdRangeCurrent)))
 	{
 		PageRangeVector range;
 		range.push_back(new PageRangeEntry(this->currentPage, this->currentPage));
 		return range;
 	}
-	else
-	{
-		PageRangeVector range;
+
+
+	    PageRangeVector range;
 		range.push_back(new PageRangeEntry(0, this->pageCount - 1));
 		return range;
-	}
 }
 
 void ExportDialog::show(GtkWindow* parent)

--- a/src/gui/dialog/ExportDialog.cpp
+++ b/src/gui/dialog/ExportDialog.cpp
@@ -65,9 +65,9 @@ auto ExportDialog::getRange() -> PageRangeVector
 	}
 
 
-	    PageRangeVector range;
-		range.push_back(new PageRangeEntry(0, this->pageCount - 1));
-		return range;
+	PageRangeVector range;
+	range.push_back(new PageRangeEntry(0, this->pageCount - 1));
+	return range;
 }
 
 void ExportDialog::show(GtkWindow* parent)

--- a/src/gui/dialog/ExportDialog.h
+++ b/src/gui/dialog/ExportDialog.h
@@ -27,7 +27,7 @@ public:
 	void removeDpiSelection();
 	void initPages(int current, int count);
 	int getPngDpi();
-	bool isConfirmed();
+	bool isConfirmed() const;
 	PageRangeVector getRange();
 
 private:

--- a/src/gui/dialog/FillTransparencyDialog.cpp
+++ b/src/gui/dialog/FillTransparencyDialog.cpp
@@ -5,7 +5,7 @@ FillTransparencyDialog::FillTransparencyDialog(GladeSearchpath* gladeSearchPath,
 {
 	GtkWidget* scaleAlpha = get("scaleAlpha");
 
-	gtk_range_set_value(GTK_RANGE(scaleAlpha), (int)(alpha / 255.0 * 100));
+	gtk_range_set_value(GTK_RANGE(scaleAlpha), static_cast<int>(alpha / 255.0 * 100));
 
 	setPreviewImage(alpha);
 
@@ -68,7 +68,7 @@ void FillTransparencyDialog::show(GtkWindow* parent)
 	{
 
 		GtkWidget* scaleAlpha = get("scaleAlpha");
-		resultAlpha = (int)(gtk_range_get_value(GTK_RANGE(scaleAlpha)) * 255.0 / 100.0);
+		resultAlpha = static_cast<int>(gtk_range_get_value(GTK_RANGE(scaleAlpha)) * 255.0 / 100.0);
 	}
 	else
 	{

--- a/src/gui/dialog/FillTransparencyDialog.cpp
+++ b/src/gui/dialog/FillTransparencyDialog.cpp
@@ -52,7 +52,7 @@ void FillTransparencyDialog::setPreviewImage(int alpha)
 	gtk_image_set_from_surface(GTK_IMAGE(preview), surface);
 }
 
-auto FillTransparencyDialog::getResultAlpha() -> int
+auto FillTransparencyDialog::getResultAlpha() const -> int
 {
 	return resultAlpha;
 }

--- a/src/gui/dialog/FillTransparencyDialog.h
+++ b/src/gui/dialog/FillTransparencyDialog.h
@@ -22,7 +22,7 @@ public:
 public:
 	virtual void show(GtkWindow* parent);
 
-	int getResultAlpha();
+	int getResultAlpha() const;
 
 private:
 	void setPreviewImage(int alpha);

--- a/src/gui/dialog/FormatDialog.cpp
+++ b/src/gui/dialog/FormatDialog.cpp
@@ -134,12 +134,12 @@ void FormatDialog::loadPageFormats()
 	ADD_FORMAT("custom_4x3_320x240mm");
 }
 
-auto FormatDialog::getWidth() -> double
+auto FormatDialog::getWidth() const -> double
 {
 	return this->width;
 }
 
-auto FormatDialog::getHeight() -> double
+auto FormatDialog::getHeight() const -> double
 {
 	return this->height;
 }

--- a/src/gui/dialog/FormatDialog.cpp
+++ b/src/gui/dialog/FormatDialog.cpp
@@ -51,7 +51,7 @@ FormatDialog::FormatDialog(GladeSearchpath* gladeSearchPath, Settings* settings,
 	int i = 0;
 	for (GList* l = list; l != nullptr; l = l->next)
 	{
-		auto* s = (GtkPaperSize*) l->data;
+		auto* s = static_cast<GtkPaperSize*>(l->data);
 
 		string displayName = gtk_paper_size_get_display_name(s);
 		if (StringUtils::startsWith(displayName, "custom_"))
@@ -94,7 +94,7 @@ FormatDialog::~FormatDialog()
 {
 	for (GList* l = this->list; l != nullptr; l = l->next)
 	{
-		auto* s = (GtkPaperSize*) l->data;
+		auto* s = static_cast<GtkPaperSize*>(l->data);
 		gtk_paper_size_free(s);
 	}
 
@@ -113,7 +113,7 @@ void FormatDialog::loadPageFormats()
 	{
 		// Copy next here, because the entry may be deleted
 		next = l->next;
-		auto* s = (GtkPaperSize*) l->data;
+		auto* s = static_cast<GtkPaperSize*>(l->data);
 
 		string name = gtk_paper_size_get_name(s);
 		if (name == GTK_PAPER_NAME_A3 ||
@@ -185,11 +185,12 @@ void FormatDialog::spinValueChangedCb(GtkSpinButton* spinbutton, FormatDialog* d
 	int i = 0;
 	for (GList* l = dlg->list; l != nullptr; l = l->next)
 	{
-		auto* s = (GtkPaperSize*) l->data;
+		auto* s = static_cast<GtkPaperSize*>(l->data);
 		double w = gtk_paper_size_get_width(s, GTK_UNIT_POINTS);
 		double h = gtk_paper_size_get_height(s, GTK_UNIT_POINTS);
 
-		if (((int) (w - width) == 0 && (int) (h - height) == 0) || ((int) (h - width) == 0 && (int) (w - height) == 0))
+		if ((static_cast<int>(w - width) == 0 && static_cast<int>(h - height) == 0) ||
+		    (static_cast<int>(h - width) == 0 && static_cast<int>(w - height) == 0))
 		{
 			gtk_combo_box_set_active(GTK_COMBO_BOX(dlg->get("cbTemplate")), i);
 			return;
@@ -237,7 +238,7 @@ void FormatDialog::cbFormatChangedCb(GtkComboBox* widget, FormatDialog* dlg)
 	{
 		return;
 	}
-	auto* s = (GtkPaperSize*) g_value_get_pointer(&value);
+	auto* s = static_cast<GtkPaperSize*>(g_value_get_pointer(&value));
 
 	if (s == nullptr)
 	{

--- a/src/gui/dialog/FormatDialog.h
+++ b/src/gui/dialog/FormatDialog.h
@@ -28,16 +28,16 @@ public:
 public:
 	virtual void show(GtkWindow* parent);
 
-	double getWidth();
-	double getHeight();
+	double getWidth() const;
+	double getHeight() const;
 
 private:
 	void loadPageFormats();
-	void setOrientation(Orientation portrait);
+	void setOrientation(Orientation orientation);
 	void setSpinValues(double width, double heigth);
 
-	static void portraitSelectedCb(GtkToggleToolButton* toggle_tool_button, FormatDialog* dlg);
-	static void landscapeSelectedCb(GtkToggleToolButton* toggle_tool_button, FormatDialog* dlg);
+	static void portraitSelectedCb(GtkToggleToolButton* bt, FormatDialog* dlg);
+	static void landscapeSelectedCb(GtkToggleToolButton* bt, FormatDialog* dlg);
 	static void cbFormatChangedCb(GtkComboBox* widget, FormatDialog* dlg);
 	static void cbUnitChanged(GtkComboBox* widget, FormatDialog* dlg);
 	static void spinValueChangedCb(GtkSpinButton* spinbutton, FormatDialog* dlg);

--- a/src/gui/dialog/GotoDialog.cpp
+++ b/src/gui/dialog/GotoDialog.cpp
@@ -8,7 +8,7 @@ GotoDialog::GotoDialog(GladeSearchpath* gladeSearchPath, int maxPage)
 
 GotoDialog::~GotoDialog() = default;
 
-auto GotoDialog::getSelectedPage() -> int
+auto GotoDialog::getSelectedPage() const -> int
 {
 	return this->selectedPage;
 }

--- a/src/gui/dialog/GotoDialog.h
+++ b/src/gui/dialog/GotoDialog.h
@@ -23,7 +23,7 @@ public:
 	virtual void show(GtkWindow* parent);
 
 	// returns the selected page or -1 if closed
-	int getSelectedPage();
+	int getSelectedPage() const;
 
 private:
 	int selectedPage = -1;

--- a/src/gui/dialog/LatexDialog.cpp
+++ b/src/gui/dialog/LatexDialog.cpp
@@ -57,7 +57,8 @@ void LatexDialog::setTempRender(PopplerDocument* pdf)
 		zoom = 1200 / pageWidth;
 	}
 
-	this->scaledRender = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, (int)(pageWidth * zoom), (int)(pageHeight * zoom));
+	this->scaledRender = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, static_cast<int>(pageWidth * zoom),
+	                                                static_cast<int>(pageHeight * zoom));
 	cairo_t* cr = cairo_create(this->scaledRender);
 
 	cairo_scale(cr, zoom, zoom);

--- a/src/gui/dialog/PageTemplateDialog.cpp
+++ b/src/gui/dialog/PageTemplateDialog.cpp
@@ -188,7 +188,7 @@ void PageTemplateDialog::showPageSizeDialog()
 /**
  * The dialog was confirmed / saved
  */
-auto PageTemplateDialog::isSaved() -> bool
+auto PageTemplateDialog::isSaved() const -> bool
 {
 	return saved;
 }

--- a/src/gui/dialog/PageTemplateDialog.h
+++ b/src/gui/dialog/PageTemplateDialog.h
@@ -33,7 +33,7 @@ public:
 	/**
 	 * The dialog was confirmed / saved
 	 */
-	bool isSaved();
+	bool isSaved() const;
 
 	void changeCurrentPageBackground(PageTypeInfo* info);
 

--- a/src/gui/dialog/SelectBackgroundColorDialog.cpp
+++ b/src/gui/dialog/SelectBackgroundColorDialog.cpp
@@ -117,7 +117,7 @@ void SelectBackgroundColorDialog::storeLastUsedValuesInSettings()
 	settings->customSettingsChanged();
 }
 
-auto SelectBackgroundColorDialog::getSelectedColor() -> int
+auto SelectBackgroundColorDialog::getSelectedColor() const -> int
 {
 	return this->selected;
 }

--- a/src/gui/dialog/SelectBackgroundColorDialog.h
+++ b/src/gui/dialog/SelectBackgroundColorDialog.h
@@ -36,7 +36,7 @@ public:
 	/**
 	 * Return the selected color as RGB, -1 if no color is selected
 	 */
-	int getSelectedColor();
+	int getSelectedColor() const;
 
 private:
 	void storeLastUsedValuesInSettings();

--- a/src/gui/dialog/SettingsDialog.cpp
+++ b/src/gui/dialog/SettingsDialog.cpp
@@ -395,7 +395,7 @@ void SettingsDialog::load()
 		}
 	}
 
-	switch((int)settings->getAudioSampleRate())
+	switch (static_cast<int>(settings->getAudioSampleRate()))
 	{
 		case 96100:
 			gtk_combo_box_set_active(GTK_COMBO_BOX(get("cbAudioSampleRate")), 1);
@@ -606,21 +606,25 @@ void SettingsDialog::save()
 	touch.setString("cmdEnable", gtk_entry_get_text(GTK_ENTRY(get("txtEnableTouchCommand"))));
 	touch.setString("cmdDisable", gtk_entry_get_text(GTK_ENTRY(get("txtDisableTouchCommand"))));
 
-	touch.setInt("timeout", (int)(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spTouchDisableTimeout"))) * 1000));
+	touch.setInt("timeout",
+	             static_cast<int>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spTouchDisableTimeout"))) * 1000));
 
-	settings->setSnapRotationTolerance((double)gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spSnapRotationTolerance"))));
-	settings->setSnapGridTolerance((double)gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spSnapGridTolerance"))));
+	settings->setSnapRotationTolerance(
+	        static_cast<double>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spSnapRotationTolerance")))));
+	settings->setSnapGridTolerance(
+	        static_cast<double>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spSnapGridTolerance")))));
 
 	int selectedInputDeviceIndex = gtk_combo_box_get_active(GTK_COMBO_BOX(get("cbAudioInputDevice"))) - 1;
-	if (selectedInputDeviceIndex >= 0 && selectedInputDeviceIndex < (int)this->audioInputDevices.size())
+	if (selectedInputDeviceIndex >= 0 && selectedInputDeviceIndex < static_cast<int>(this->audioInputDevices.size()))
 	{
-		settings->setAudioInputDevice((int) this->audioInputDevices[selectedInputDeviceIndex].getIndex());
+		settings->setAudioInputDevice(static_cast<int>(this->audioInputDevices[selectedInputDeviceIndex].getIndex()));
 	}
 
 	int selectedOutputDeviceIndex = gtk_combo_box_get_active(GTK_COMBO_BOX(get("cbAudioOutputDevice"))) - 1;
-	if (selectedOutputDeviceIndex >= 0 && selectedOutputDeviceIndex < (int)this->audioOutputDevices.size())
+	if (selectedOutputDeviceIndex >= 0 && selectedOutputDeviceIndex < static_cast<int>(this->audioOutputDevices.size()))
 	{
-		settings->setAudioOutputDevice((int) this->audioOutputDevices[selectedOutputDeviceIndex].getIndex());
+		settings->setAudioOutputDevice(
+		        static_cast<int>(this->audioOutputDevices[selectedOutputDeviceIndex].getIndex()));
 	}
 
 	switch (gtk_combo_box_get_active(GTK_COMBO_BOX(get("cbAudioSampleRate"))))
@@ -637,8 +641,9 @@ void SettingsDialog::save()
 			break;
 	}
 
-	settings->setAudioGain((double)gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spAudioGain"))));
-	settings->setDefaultSeekTime((double) gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spDefaultSeekTime"))));
+	settings->setAudioGain(static_cast<double>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spAudioGain")))));
+	settings->setDefaultSeekTime(
+	        static_cast<double>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spDefaultSeekTime")))));
 
 	for (DeviceClassConfigGui* deviceClassConfigGui : this->deviceClassConfigs)
 	{

--- a/src/gui/dialog/SettingsDialog.h
+++ b/src/gui/dialog/SettingsDialog.h
@@ -43,7 +43,7 @@ private:
 	void loadCheckbox(const char* name, gboolean value);
 	bool getCheckbox(const char* name);
 
-	string updateHideString(const string& hidden, bool hideMenubar, bool hideSidebar);
+	static string updateHideString(const string& hidden, bool hideMenubar, bool hideSidebar);
 
 	void initMouseButtonEvents();
 	void initMouseButtonEvents(const char* hbox, int button, bool withDevice = false);

--- a/src/gui/dialog/ToolbarManageDialog.cpp
+++ b/src/gui/dialog/ToolbarManageDialog.cpp
@@ -194,10 +194,9 @@ auto ToolbarManageDialog::getSelectedEntry() -> ToolbarData*
 		gtk_tree_model_get(model, &iter, COLUMN_POINTER, &data, -1);
 		return data;
 	}
-	else
-	{
-		return nullptr;
-	}
+
+
+	    return nullptr;
 }
 
 void ToolbarManageDialog::updateSelectionData()

--- a/src/gui/dialog/ToolbarManageDialog.cpp
+++ b/src/gui/dialog/ToolbarManageDialog.cpp
@@ -196,7 +196,7 @@ auto ToolbarManageDialog::getSelectedEntry() -> ToolbarData*
 	}
 
 
-	    return nullptr;
+	return nullptr;
 }
 
 void ToolbarManageDialog::updateSelectionData()

--- a/src/gui/dialog/backgroundSelect/BackgroundSelectDialogBase.cpp
+++ b/src/gui/dialog/backgroundSelect/BackgroundSelectDialogBase.cpp
@@ -78,7 +78,8 @@ void BackgroundSelectDialogBase::layout()
 
 		gtk_layout_move(GTK_LAYOUT(this->layoutContainer), p->getWidget(), x, y);
 
-		height = std::max(height, (double) p->getHeight());  //TODO: page height should be double as well
+		height = std::max(height,
+		                  static_cast<double>(p->getHeight()));  // TODO(fabian): page height should be double as well
 
 		x += p->getWidth();
 	}
@@ -113,12 +114,12 @@ void BackgroundSelectDialogBase::setSelected(int selected)
 	}
 
 	int lastSelected = this->selected;
-	if (lastSelected >= 0 && lastSelected < (int)elements.size())
+	if (lastSelected >= 0 && lastSelected < static_cast<int>(elements.size()))
 	{
 		elements[lastSelected]->setSelected(false);
 	}
 
-	if (selected >= 0 && selected < (int)elements.size())
+	if (selected >= 0 && selected < static_cast<int>(elements.size()))
 	{
 		elements[selected]->setSelected(true);
 		this->selected = selected;

--- a/src/gui/dialog/backgroundSelect/BackgroundSelectDialogBase.cpp
+++ b/src/gui/dialog/backgroundSelect/BackgroundSelectDialogBase.cpp
@@ -8,7 +8,7 @@
 
 
 BackgroundSelectDialogBase::BackgroundSelectDialogBase(GladeSearchpath* gladeSearchPath, Document* doc,
-                                                       Settings* settings, const string& glade, string mainWnd)
+                                                       Settings* settings, const string& glade, const string& mainWnd)
  : GladeGui(gladeSearchPath, glade, std::move(mainWnd))
  , settings(settings)
  , doc(doc)

--- a/src/gui/dialog/backgroundSelect/BackgroundSelectDialogBase.h
+++ b/src/gui/dialog/backgroundSelect/BackgroundSelectDialogBase.h
@@ -22,7 +22,7 @@ class BackgroundSelectDialogBase : public GladeGui
 {
 public:
 	BackgroundSelectDialogBase(GladeSearchpath* gladeSearchPath, Document* doc, Settings* settings, const string& glade,
-	                           string mainWnd);
+	                           const string& mainWnd);
 	~BackgroundSelectDialogBase();
 
 public:

--- a/src/gui/dialog/backgroundSelect/ImagesDialog.cpp
+++ b/src/gui/dialog/backgroundSelect/ImagesDialog.cpp
@@ -83,10 +83,9 @@ auto ImagesDialog::getSelectedImage() -> BackgroundImage
 	{
 		return (dynamic_cast<ImageElementView*>(elements[selected]))->backgroundImage;
 	}
-	else
-	{
-		return BackgroundImage();
-	}
+
+
+	    return BackgroundImage();
 }
 
 void ImagesDialog::show(GtkWindow* parent)

--- a/src/gui/dialog/backgroundSelect/ImagesDialog.cpp
+++ b/src/gui/dialog/backgroundSelect/ImagesDialog.cpp
@@ -79,7 +79,7 @@ auto ImagesDialog::shouldShowFilechooser() -> bool
 
 auto ImagesDialog::getSelectedImage() -> BackgroundImage
 {
-	if (confirmed && selected >= 0 && selected < (int)elements.size())
+	if (confirmed && selected >= 0 && selected < static_cast<int>(elements.size()))
 	{
 		return (dynamic_cast<ImageElementView*>(elements[selected]))->backgroundImage;
 	}

--- a/src/gui/dialog/backgroundSelect/ImagesDialog.cpp
+++ b/src/gui/dialog/backgroundSelect/ImagesDialog.cpp
@@ -85,7 +85,7 @@ auto ImagesDialog::getSelectedImage() -> BackgroundImage
 	}
 
 
-	    return BackgroundImage();
+	return BackgroundImage();
 }
 
 void ImagesDialog::show(GtkWindow* parent)

--- a/src/gui/dialog/backgroundSelect/ImagesDialog.cpp
+++ b/src/gui/dialog/backgroundSelect/ImagesDialog.cpp
@@ -49,7 +49,7 @@ auto ImagesDialog::isImageAlreadyInTheList(BackgroundImage& image) -> bool
 {
 	for (BaseElementView* v : this->elements)
 	{
-		auto* iv = (ImageElementView*) v;
+		auto* iv = dynamic_cast<ImageElementView*>(v);
 		if (iv->backgroundImage == image)
 		{
 			return true;
@@ -81,7 +81,7 @@ auto ImagesDialog::getSelectedImage() -> BackgroundImage
 {
 	if (confirmed && selected >= 0 && selected < (int)elements.size())
 	{
-		return ((ImageElementView*)elements[selected])->backgroundImage;
+		return (dynamic_cast<ImageElementView*>(elements[selected]))->backgroundImage;
 	}
 	else
 	{

--- a/src/gui/dialog/backgroundSelect/PdfElementView.cpp
+++ b/src/gui/dialog/backgroundSelect/PdfElementView.cpp
@@ -32,18 +32,18 @@ void PdfElementView::setHideUnused()
 
 void PdfElementView::paintContents(cairo_t* cr)
 {
-	double zoom = ((PdfPagesDialog*)dlg)->getZoom();
+	double zoom = (dynamic_cast<PdfPagesDialog*>(dlg))->getZoom();
 	cairo_scale(cr, zoom, zoom);
 	page->render(cr);
 }
 
 auto PdfElementView::getContentWidth() -> int
 {
-	return page->getWidth() * ((PdfPagesDialog*)dlg)->getZoom();
+	return page->getWidth() * (dynamic_cast<PdfPagesDialog*>(dlg))->getZoom();
 }
 
 auto PdfElementView::getContentHeight() -> int
 {
-	return page->getHeight() * ((PdfPagesDialog*)dlg)->getZoom();
+	return page->getHeight() * (dynamic_cast<PdfPagesDialog*>(dlg))->getZoom();
 }
 

--- a/src/gui/dialog/backgroundSelect/PdfElementView.cpp
+++ b/src/gui/dialog/backgroundSelect/PdfElementView.cpp
@@ -15,7 +15,7 @@ PdfElementView::PdfElementView(int id, XojPdfPageSPtr page, PdfPagesDialog* dlg)
 
 PdfElementView::~PdfElementView() = default;
 
-auto PdfElementView::isUsed() -> bool
+auto PdfElementView::isUsed() const -> bool
 {
 	return this->used;
 }
@@ -32,18 +32,18 @@ void PdfElementView::setHideUnused()
 
 void PdfElementView::paintContents(cairo_t* cr)
 {
-	double zoom = (dynamic_cast<PdfPagesDialog*>(dlg))->getZoom();
+	double zoom = PdfPagesDialog::getZoom();
 	cairo_scale(cr, zoom, zoom);
 	page->render(cr);
 }
 
 auto PdfElementView::getContentWidth() -> int
 {
-	return page->getWidth() * (dynamic_cast<PdfPagesDialog*>(dlg))->getZoom();
+	return page->getWidth() * PdfPagesDialog::getZoom();
 }
 
 auto PdfElementView::getContentHeight() -> int
 {
-	return page->getHeight() * (dynamic_cast<PdfPagesDialog*>(dlg))->getZoom();
+	return page->getHeight() * PdfPagesDialog::getZoom();
 }
 

--- a/src/gui/dialog/backgroundSelect/PdfElementView.h
+++ b/src/gui/dialog/backgroundSelect/PdfElementView.h
@@ -42,7 +42,7 @@ protected:
 	virtual int getContentHeight();
 
 public:
-	bool isUsed();
+	bool isUsed() const;
 	void setUsed(bool used);
 	void setHideUnused();
 

--- a/src/gui/dialog/backgroundSelect/PdfPagesDialog.cpp
+++ b/src/gui/dialog/backgroundSelect/PdfPagesDialog.cpp
@@ -30,7 +30,7 @@ PdfPagesDialog::PdfPagesDialog(GladeSearchpath* gladeSearchPath, Document* doc, 
 		if (p->getBackgroundType().isPdfPage())
 		{
 			int pdfPage = p->getPdfPageNr();
-			if (pdfPage >= 0 && pdfPage < (int)elements.size())
+			if (pdfPage >= 0 && pdfPage < static_cast<int>(elements.size()))
 			{
 				(dynamic_cast<PdfElementView*>(elements[p->getPdfPageNr()]))->setUsed(true);
 			}
@@ -48,7 +48,7 @@ PdfPagesDialog::~PdfPagesDialog() = default;
 void PdfPagesDialog::updateOkButton()
 {
 	bool valid = false;
-	if (selected >= 0 && selected < (int)elements.size())
+	if (selected >= 0 && selected < static_cast<int>(elements.size()))
 	{
 		BaseElementView* p = this->elements[this->selected];
 		valid = gtk_widget_get_visible(p->getWidget());

--- a/src/gui/dialog/backgroundSelect/PdfPagesDialog.cpp
+++ b/src/gui/dialog/backgroundSelect/PdfPagesDialog.cpp
@@ -32,7 +32,7 @@ PdfPagesDialog::PdfPagesDialog(GladeSearchpath* gladeSearchPath, Document* doc, 
 			int pdfPage = p->getPdfPageNr();
 			if (pdfPage >= 0 && pdfPage < (int)elements.size())
 			{
-				((PdfElementView*)elements[p->getPdfPageNr()])->setUsed(true);
+				(dynamic_cast<PdfElementView*>(elements[p->getPdfPageNr()]))->setUsed(true);
 			}
 		}
 	}
@@ -68,7 +68,7 @@ void PdfPagesDialog::onlyNotUsedCallback(GtkToggleButton* tb, PdfPagesDialog* dl
 	{
 		for (BaseElementView* p : dlg->elements)
 		{
-			auto* pv = (PdfElementView*) p;
+			auto* pv = dynamic_cast<PdfElementView*>(p);
 			pv->setHideUnused();
 		}
 	}
@@ -103,7 +103,7 @@ void PdfPagesDialog::show(GtkWindow* parent)
 	int unused = 0;
 	for (BaseElementView* p : elements)
 	{
-		auto* pv = (PdfElementView*) p;
+		auto* pv = dynamic_cast<PdfElementView*>(p);
 		if (!pv->isUsed())
 		{
 			unused++;

--- a/src/gui/dialog/backgroundSelect/PdfPagesDialog.h
+++ b/src/gui/dialog/backgroundSelect/PdfPagesDialog.h
@@ -25,7 +25,7 @@ public:
 public:
 	virtual void show(GtkWindow* parent);
 	void updateOkButton();
-	double getZoom();
+	static double getZoom();
 	int getSelectedPage();
 
 private:

--- a/src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp
+++ b/src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp
@@ -223,7 +223,7 @@ void ToolbarAdapter::toolitemDragDataGet(GtkWidget* widget, GdkDragContext* cont
 	adapter->removeFromToolbar(data->item, adapter->toolbarName, data->id);
 
 	gtk_selection_data_set(selection_data, ToolbarDragDropHelper::atomToolItem, 0,
-						   (const guchar*) data, sizeof(ToolItemDragDropData));
+	                       reinterpret_cast<const guchar*>(data), sizeof(ToolItemDragDropData));
 }
 
 /**
@@ -235,7 +235,7 @@ auto ToolbarAdapter::toolbarDragMotionCb(GtkToolbar* toolbar, GdkDragContext* co
 	GdkAtom target = gtk_drag_dest_find_target(GTK_WIDGET(toolbar), context, nullptr);
 	if (target != ToolbarDragDropHelper::atomToolItem)
 	{
-		gdk_drag_status(context, (GdkDragAction) 0, time);
+		gdk_drag_status(context, static_cast<GdkDragAction>(0), time);
 		return false;
 	}
 

--- a/src/gui/dialog/toolbarCustomize/ToolbarAdapter.h
+++ b/src/gui/dialog/toolbarCustomize/ToolbarAdapter.h
@@ -62,6 +62,6 @@ private:
 	string toolbarName;
 	MainWindow* window;
 
-	GtkToolItem* spacerItem;
+	GtkToolItem* spacerItem{};
 	ToolMenuHandler* toolHandler;
 };

--- a/src/gui/dialog/toolbarCustomize/ToolbarCustomizeDialog.cpp
+++ b/src/gui/dialog/toolbarCustomize/ToolbarCustomizeDialog.cpp
@@ -114,8 +114,8 @@ void ToolbarCustomizeDialog::toolitemDragDataGetSeparator(GtkWidget* widget, Gdk
 	ToolItemDragDropData* it = ToolitemDragDrop::ToolItemDragDropData_new(nullptr);
 	it->type = TOOL_ITEM_SEPARATOR;
 
-	gtk_selection_data_set(selection_data, ToolbarDragDropHelper::atomToolItem, 0,
-						   (const guchar*) it, sizeof(ToolItemDragDropData));
+	gtk_selection_data_set(selection_data, ToolbarDragDropHelper::atomToolItem, 0, reinterpret_cast<const guchar*>(it),
+	                       sizeof(ToolItemDragDropData));
 
 	g_free(it);
 }
@@ -152,8 +152,8 @@ void ToolbarCustomizeDialog::toolitemDragDataGet(GtkWidget* widget, GdkDragConte
 
 	ToolItemDragDropData* it = ToolitemDragDrop::ToolItemDragDropData_new(data->item);
 
-	gtk_selection_data_set(selection_data, ToolbarDragDropHelper::atomToolItem, 0,
-						   (const guchar*) it, sizeof(ToolItemDragDropData));
+	gtk_selection_data_set(selection_data, ToolbarDragDropHelper::atomToolItem, 0, reinterpret_cast<const guchar*>(it),
+	                       sizeof(ToolItemDragDropData));
 
 	g_free(it);
 }
@@ -196,8 +196,8 @@ void ToolbarCustomizeDialog::toolitemColorDragDataGet(GtkWidget* widget, GdkDrag
 	it->color = color;
 	it->type = TOOL_ITEM_COLOR;
 
-	gtk_selection_data_set(selection_data, ToolbarDragDropHelper::atomToolItem, 0,
-						   (const guchar*) it, sizeof(ToolItemDragDropData));
+	gtk_selection_data_set(selection_data, ToolbarDragDropHelper::atomToolItem, 0, reinterpret_cast<const guchar*>(it),
+	                       sizeof(ToolItemDragDropData));
 
 	g_free(it);
 }
@@ -249,7 +249,7 @@ void ToolbarCustomizeDialog::freeIconview()
 	GList* children = gtk_container_get_children(GTK_CONTAINER(table));
 	for (GList* l = children; l != nullptr; l = l->next)
 	{
-		auto* w = (GtkWidget*) l->data;
+		auto* w = static_cast<GtkWidget*>(l->data);
 		gtk_container_remove(GTK_CONTAINER(table), w);
 	}
 
@@ -327,7 +327,7 @@ void ToolbarCustomizeDialog::freeColorIconview()
 	GList* children = gtk_container_get_children(GTK_CONTAINER(table));
 	for (GList* l = children; l != nullptr; l = l->next)
 	{
-		auto* w = (GtkWidget*) l->data;
+		auto* w = static_cast<GtkWidget*>(l->data);
 		gtk_container_remove(GTK_CONTAINER(table), w);
 	}
 

--- a/src/gui/dialog/toolbarCustomize/ToolbarDragDropHandler.cpp
+++ b/src/gui/dialog/toolbarCustomize/ToolbarDragDropHandler.cpp
@@ -84,10 +84,5 @@ void ToolbarDragDropHandler::configure()
 
 auto ToolbarDragDropHandler::isInDragAndDrop() -> bool
 {
-	if (this->toolbars == nullptr)
-	{
-		return false;
-	}
-
-	return true;
+	return this->toolbars != nullptr;
 }

--- a/src/gui/dialog/toolbarCustomize/ToolbarDragDropHelper.cpp
+++ b/src/gui/dialog/toolbarCustomize/ToolbarDragDropHelper.cpp
@@ -15,13 +15,14 @@ auto ToolbarDragDropHelper::getImagePixbuf(GtkImage* image) -> GdkPixbuf*
 	switch (gtk_image_get_storage_type(image))
 	{
 	case GTK_IMAGE_PIXBUF:
-		return (GdkPixbuf*) g_object_ref(gtk_image_get_pixbuf(image));
+		return static_cast<GdkPixbuf*>(g_object_ref(gtk_image_get_pixbuf(image)));
 
 	case GTK_IMAGE_ICON_NAME:
 	{
 		const gchar* iconName = nullptr;
 		gtk_image_get_icon_name(image, &iconName, nullptr);
-		return gtk_icon_theme_load_icon(gtk_icon_theme_get_default(), iconName, 22, (GtkIconLookupFlags) 0, nullptr);
+		return gtk_icon_theme_load_icon(gtk_icon_theme_get_default(), iconName, 22, static_cast<GtkIconLookupFlags>(0),
+		                                nullptr);
 	}
 
 	default:

--- a/src/gui/inputdevices/AbstractInputHandler.cpp
+++ b/src/gui/inputdevices/AbstractInputHandler.cpp
@@ -19,7 +19,7 @@ void AbstractInputHandler::block(bool block)
 	this->onBlock();
 }
 
-auto AbstractInputHandler::isBlocked() -> bool
+auto AbstractInputHandler::isBlocked() const -> bool
 {
 	return this->blocked;
 }
@@ -30,9 +30,8 @@ auto AbstractInputHandler::handle(InputEvent* event) -> bool
 	{
 		this->inputContext->getXournal()->view->getCursor()->setInputDeviceClass(event->deviceClass);
 		return this->handleImpl(event);
-	} else {
-		return true;
 	}
+	    return true;
 }
 
 /**

--- a/src/gui/inputdevices/AbstractInputHandler.cpp
+++ b/src/gui/inputdevices/AbstractInputHandler.cpp
@@ -31,7 +31,7 @@ auto AbstractInputHandler::handle(InputEvent* event) -> bool
 		this->inputContext->getXournal()->view->getCursor()->setInputDeviceClass(event->deviceClass);
 		return this->handleImpl(event);
 	}
-	    return true;
+	return true;
 }
 
 /**

--- a/src/gui/inputdevices/AbstractInputHandler.h
+++ b/src/gui/inputdevices/AbstractInputHandler.h
@@ -44,7 +44,7 @@ public:
 	virtual ~AbstractInputHandler();
 
 	void block(bool block);
-	bool isBlocked();
+	bool isBlocked() const;
 	virtual void onBlock();
 	bool handle(InputEvent* event);
 	virtual bool handleImpl(InputEvent* event) = 0;

--- a/src/gui/inputdevices/HandRecognition.cpp
+++ b/src/gui/inputdevices/HandRecognition.cpp
@@ -66,7 +66,7 @@ void HandRecognition::reload()
 	touch.getString("method", disableMethod);
 	if (disableMethod == "X11")
 	{
-		if (x11Session == false)
+		if (!x11Session)
 		{
 			g_warning("X11 Touch workaround is selected, but no X11 Session running!");
 			enabled = false;

--- a/src/gui/inputdevices/HandRecognition.cpp
+++ b/src/gui/inputdevices/HandRecognition.cpp
@@ -129,7 +129,7 @@ auto HandRecognition::enableTimeout(HandRecognition* self) -> bool
 
 	int nextTime = now - self->lastPenAction + self->disableTimeout;
 
-	g_timeout_add(nextTime, (GSourceFunc)enableTimeout, self);
+	g_timeout_add(nextTime, reinterpret_cast<GSourceFunc>(enableTimeout), self);
 
 	// Do not call again, a new time is scheduled
 	return false;
@@ -146,7 +146,7 @@ void HandRecognition::penEvent()
 	{
 		touchState = false;
 		disableTouch();
-		g_timeout_add(disableTimeout, (GSourceFunc)enableTimeout, this);
+		g_timeout_add(disableTimeout, reinterpret_cast<GSourceFunc>(enableTimeout), this);
 	}
 }
 

--- a/src/gui/inputdevices/InputContext.cpp
+++ b/src/gui/inputdevices/InputContext.cpp
@@ -130,7 +130,7 @@ auto InputContext::handle(GdkEvent* sourceEvent) -> bool
 			return this->touchDrawingHandler->handle(event);
 		}
 
-		    return this->touchHandler->handle(event);
+		return this->touchHandler->handle(event);
 	}
 
 	// handle keyboard

--- a/src/gui/inputdevices/InputContext.cpp
+++ b/src/gui/inputdevices/InputContext.cpp
@@ -128,10 +128,9 @@ auto InputContext::handle(GdkEvent* sourceEvent) -> bool
 		if (this->touchWorkaroundEnabled)
 		{
 			return this->touchDrawingHandler->handle(event);
-		} else
-		{
-			return this->touchHandler->handle(event);
 		}
+
+		    return this->touchHandler->handle(event);
 	}
 
 	// handle keyboard

--- a/src/gui/inputdevices/InputEvents.cpp
+++ b/src/gui/inputdevices/InputEvents.cpp
@@ -9,7 +9,7 @@ InputEvent::~InputEvent()
 	gdk_event_free(this->sourceEvent);
 }
 
-auto InputEvent::copy() -> InputEvent*
+auto InputEvent::copy() const -> InputEvent*
 {
 	auto inputEvent = new InputEvent();
 

--- a/src/gui/inputdevices/InputEvents.h
+++ b/src/gui/inputdevices/InputEvents.h
@@ -69,7 +69,7 @@ public:
 
 	~InputEvent();
 
-	InputEvent* copy();
+	InputEvent* copy() const;
 };
 
 class InputEvents

--- a/src/gui/inputdevices/KeyboardInputHandler.cpp
+++ b/src/gui/inputdevices/KeyboardInputHandler.cpp
@@ -49,7 +49,8 @@ auto KeyboardInputHandler::handleImpl(InputEvent* event) -> bool
 			{
 				selection->moveSelection(-d, 0);
 				return true;
-			} else if (keyEvent->keyval == GDK_KEY_Down)
+			}
+			if (keyEvent->keyval == GDK_KEY_Down)
 			{
 				selection->moveSelection(0, -d);
 				return true;
@@ -59,5 +60,5 @@ auto KeyboardInputHandler::handleImpl(InputEvent* event) -> bool
 		return xournal->view->onKeyPressEvent(keyEvent);
 	}
 
-	    return inputContext->getView()->onKeyReleaseEvent(keyEvent);
+	return inputContext->getView()->onKeyReleaseEvent(keyEvent);
 }

--- a/src/gui/inputdevices/KeyboardInputHandler.cpp
+++ b/src/gui/inputdevices/KeyboardInputHandler.cpp
@@ -39,11 +39,13 @@ auto KeyboardInputHandler::handleImpl(InputEvent* event) -> bool
 			{
 				selection->moveSelection(d, 0);
 				return true;
-			} else if (keyEvent->keyval == GDK_KEY_Up)
+			}
+			if (keyEvent->keyval == GDK_KEY_Up)
 			{
 				selection->moveSelection(0, d);
 				return true;
-			} else if (keyEvent->keyval == GDK_KEY_Right)
+			}
+			if (keyEvent->keyval == GDK_KEY_Right)
 			{
 				selection->moveSelection(-d, 0);
 				return true;
@@ -55,8 +57,7 @@ auto KeyboardInputHandler::handleImpl(InputEvent* event) -> bool
 		}
 
 		return xournal->view->onKeyPressEvent(keyEvent);
-	} else
-	{
-		return inputContext->getView()->onKeyReleaseEvent(keyEvent);
 	}
+
+	    return inputContext->getView()->onKeyReleaseEvent(keyEvent);
 }

--- a/src/gui/inputdevices/KeyboardInputHandler.cpp
+++ b/src/gui/inputdevices/KeyboardInputHandler.cpp
@@ -14,7 +14,7 @@ KeyboardInputHandler::~KeyboardInputHandler() = default;
 
 auto KeyboardInputHandler::handleImpl(InputEvent* event) -> bool
 {
-	auto keyEvent = (GdkEventKey*) event->sourceEvent;
+	auto keyEvent = reinterpret_cast<GdkEventKey*>(event->sourceEvent);
 	GtkXournal* xournal = inputContext->getXournal();
 
 	if (keyEvent->type == GDK_KEY_PRESS)

--- a/src/gui/inputdevices/MouseInputHandler.cpp
+++ b/src/gui/inputdevices/MouseInputHandler.cpp
@@ -71,7 +71,7 @@ auto MouseInputHandler::handleImpl(InputEvent* event) -> bool
 	// If we loose our Grab on the device end the current action
 	if (event->type == GRAB_BROKEN_EVENT && this->deviceClassPressed)
 	{
-		// TODO: We may need to update pressed state manually here
+		// TODO(fabian): We may need to update pressed state manually here
 		this->actionEnd(event);
 		return true;
 	}

--- a/src/gui/inputdevices/PenInputHandler.cpp
+++ b/src/gui/inputdevices/PenInputHandler.cpp
@@ -155,12 +155,12 @@ auto PenInputHandler::actionStart(InputEvent* event) -> bool
 		}
 
 
-		    xournal->view->clearSelection();
-			if (changeTool(event))
-			{
-				// Do not handle event in any further way to make click only deselect selection
-				return true;
-			}
+		xournal->view->clearSelection();
+		if (changeTool(event))
+		{
+			// Do not handle event in any further way to make click only deselect selection
+			return true;
+		}
 	}
 
 	// Forward event to page
@@ -300,7 +300,7 @@ auto PenInputHandler::actionMotion(InputEvent* event) -> bool
 		return currentPage->onMotionNotifyEvent(pos);
 	}
 
-	    return false;
+	return false;
 }
 
 auto PenInputHandler::actionEnd(InputEvent* event) -> bool

--- a/src/gui/inputdevices/PenInputHandler.cpp
+++ b/src/gui/inputdevices/PenInputHandler.cpp
@@ -153,15 +153,14 @@ auto PenInputHandler::actionStart(InputEvent* event) -> bool
 			// Only modify selection and do not forward event to page
 			return true;
 		}
-		else
-		{
-			xournal->view->clearSelection();
+
+
+		    xournal->view->clearSelection();
 			if (changeTool(event))
 			{
 				// Do not handle event in any further way to make click only deselect selection
 				return true;
 			}
-		}
 	}
 
 	// Forward event to page
@@ -215,7 +214,7 @@ auto PenInputHandler::actionMotion(InputEvent* event) -> bool
 		}
 		return false;
 	}
-	else if (xournal->selection)
+	if (xournal->selection)
 	{
 		EditSelection* selection = xournal->selection;
 		XojPageView* view = selection->getView();
@@ -299,10 +298,9 @@ auto PenInputHandler::actionMotion(InputEvent* event) -> bool
 		// Relay the event to the page
 		PositionInputData pos = getInputDataRelativeToCurrentPage(currentPage, event);
 		return currentPage->onMotionNotifyEvent(pos);
-	} else
-	{
-		return false;
 	}
+
+	    return false;
 }
 
 auto PenInputHandler::actionEnd(InputEvent* event) -> bool

--- a/src/gui/inputdevices/PenInputHandler.cpp
+++ b/src/gui/inputdevices/PenInputHandler.cpp
@@ -61,7 +61,8 @@ void PenInputHandler::handleScrollEvent(InputEvent* event)
 	// see github Gnome/evince@1adce5486b10e763bed869
 
 	// GTK handles event compression/filtering differently between versions - this may be needed on certain hardware/GTK combinations.
-	if (std::abs((double)(this->scrollStartX - event->absoluteX)) < 0.1 && std::abs((double)(this->scrollStartY - event->absoluteY)) < 0.1 )
+	if (std::abs((this->scrollStartX - event->absoluteX)) < 0.1 &&
+	    std::abs((this->scrollStartY - event->absoluteY)) < 0.1)
 	{
 		return;
 	}
@@ -287,8 +288,8 @@ auto PenInputHandler::actionMotion(InputEvent* event) -> bool
 		// Enforce input to stay within page
 		pos.x = std::max(0.0, pos.x);
 		pos.y = std::max(0.0, pos.y);
-		pos.x = std::min(pos.x, (double) sequenceStartPage->getDisplayWidth());
-		pos.y = std::min(pos.y, (double) sequenceStartPage->getDisplayHeight());
+		pos.x = std::min(pos.x, static_cast<double>(sequenceStartPage->getDisplayWidth()));
+		pos.y = std::min(pos.y, static_cast<double>(sequenceStartPage->getDisplayHeight()));
 
 		return sequenceStartPage->onMotionNotifyEvent(pos);
 	}
@@ -428,7 +429,7 @@ void PenInputHandler::actionLeaveWindow(InputEvent* event)
 		{
 			int offsetX = 0, offsetY = 0;
 
-			// TODO: make offset dependent on how big the distance between pen and view is
+			// TODO(fabian): make offset dependent on how big the distance between pen and view is
 			if (eventX < WIDGET_SCROLL_BORDER)
 			{
 				offsetX = -10;
@@ -462,7 +463,7 @@ void PenInputHandler::actionLeaveWindow(InputEvent* event)
 				});
 
 				//sleep for half a second until we scroll again
-				g_usleep((gulong) (0.5 * G_USEC_PER_SEC));
+				g_usleep(static_cast<gulong>(0.5 * G_USEC_PER_SEC));
 			}
 		});
 

--- a/src/gui/inputdevices/StylusInputHandler.cpp
+++ b/src/gui/inputdevices/StylusInputHandler.cpp
@@ -105,7 +105,7 @@ auto StylusInputHandler::handleImpl(InputEvent* event) -> bool
 	// If we loose our Grab on the device end the current action
 	if (event->type == GRAB_BROKEN_EVENT && this->deviceClassPressed)
 	{
-		// TODO: We may need to update pressed state manually here
+		// TODO(fabian): We may need to update pressed state manually here
 		this->actionEnd(event);
 		return true;
 	}

--- a/src/gui/inputdevices/StylusInputHandler.cpp
+++ b/src/gui/inputdevices/StylusInputHandler.cpp
@@ -31,7 +31,8 @@ auto StylusInputHandler::handleImpl(InputEvent* event) -> bool
 		{
 			this->actionStart(event);
 			return true;
-		} else if (this->inputRunning)
+		}
+		if (this->inputRunning)
 		{
 			// TPCButton is disabled and modifier button was pressed
 			this->actionEnd(event);
@@ -89,7 +90,8 @@ auto StylusInputHandler::handleImpl(InputEvent* event) -> bool
 		{
 			this->actionEnd(event);
 			return true;
-		} else if (this->inputRunning)
+		}
+		if (this->inputRunning)
 		{
 			// TPCButton is disabled and modifier button was released
 			this->actionEnd(event);

--- a/src/gui/inputdevices/TouchInputHandler.cpp
+++ b/src/gui/inputdevices/TouchInputHandler.cpp
@@ -147,7 +147,7 @@ void TouchInputHandler::zoomStart()
 	ZoomControl* zoomControl = this->inputContext->getView()->getControl()->getZoomControl();
 
 	// Disable zoom fit as we are zooming currently
-	// TODO this should happen internally!!!
+	// TODO(fabian): this should happen internally!!!
 	if (zoomControl->isZoomFitMode())
 	{
 		zoomControl->setZoomFitMode(false);

--- a/src/gui/inputdevices/TouchInputHandler.cpp
+++ b/src/gui/inputdevices/TouchInputHandler.cpp
@@ -4,7 +4,7 @@
 
 #include "TouchInputHandler.h"
 #include "InputContext.h"
-#include "math.h"
+#include <cmath>
 
 TouchInputHandler::TouchInputHandler(InputContext* inputContext) : AbstractInputHandler(inputContext)
 {

--- a/src/gui/inputdevices/TouchInputHandler.cpp
+++ b/src/gui/inputdevices/TouchInputHandler.cpp
@@ -4,6 +4,7 @@
 
 #include "TouchInputHandler.h"
 #include "InputContext.h"
+#include "math.h"
 
 TouchInputHandler::TouchInputHandler(InputContext* inputContext) : AbstractInputHandler(inputContext)
 {
@@ -95,8 +96,8 @@ void TouchInputHandler::sequenceStart(InputEvent* event)
 
 void TouchInputHandler::scrollMotion(InputEvent* event)
 {
-	double offsetX;
-	double offsetY;
+	double offsetX = NAN;
+	double offsetY = NAN;
 
 	// Will only be called if there is a single sequence (zooming handles two sequences)
 	if (event->sequence == this->primarySequence)

--- a/src/gui/inputdevices/old/InputSequence.cpp
+++ b/src/gui/inputdevices/old/InputSequence.cpp
@@ -409,7 +409,7 @@ auto InputSequence::getInputDataRelativeToCurrentPage(XojPageView* page) -> Posi
 {
 	GtkXournal* xournal = inputHandler->getXournal();
 
-	PositionInputData pos;
+	PositionInputData pos{};
 	pos.x = x - page->getX() - xournal->x;
 	pos.y = y - page->getY() - xournal->y;
 	pos.pressure = Point::NO_PRESSURE;

--- a/src/gui/inputdevices/old/InputSequence.cpp
+++ b/src/gui/inputdevices/old/InputSequence.cpp
@@ -176,7 +176,7 @@ auto InputSequence::actionMoved(guint32 time) -> bool
 		}
 		return false;
 	}
-	else if (xournal->selection)
+	if (xournal->selection)
 	{
 		EditSelection* selection = xournal->selection;
 		XojPageView* view = selection->getView();
@@ -267,7 +267,7 @@ auto InputSequence::actionStart(guint32 time) -> bool
 
 		return true;
 	}
-	else if (xournal->selection)
+	if (xournal->selection)
 	{
 		EditSelection* selection = xournal->selection;
 
@@ -288,14 +288,13 @@ auto InputSequence::actionStart(guint32 time) -> bool
 			xournal->selection->mouseDown(selType, pos.x, pos.y);
 			return true;
 		}
-		else
-		{
-			xournal->view->clearSelection();
+
+
+		    xournal->view->clearSelection();
 			if (changeTool())
 			{
 				return true;
 			}
-		}
 	}
 
 	XojPageView* pv = getPageAtCurrentPosition();
@@ -431,14 +430,7 @@ auto InputSequence::getInputDataRelativeToCurrentPage(XojPageView* page) -> Posi
  */
 void InputSequence::checkCanStartInput()
 {
-	if (inputHandler->startInput(this))
-	{
-		inputRunning = true;
-	}
-	else
-	{
-		inputRunning = false;
-	}
+	inputRunning = inputHandler->startInput(this);
 }
 
 /**

--- a/src/gui/inputdevices/old/InputSequence.cpp
+++ b/src/gui/inputdevices/old/InputSequence.cpp
@@ -290,11 +290,11 @@ auto InputSequence::actionStart(guint32 time) -> bool
 		}
 
 
-		    xournal->view->clearSelection();
-			if (changeTool())
-			{
-				return true;
-			}
+		xournal->view->clearSelection();
+		if (changeTool())
+		{
+			return true;
+		}
 	}
 
 	XojPageView* pv = getPageAtCurrentPosition();

--- a/src/gui/inputdevices/old/InputSequence.cpp
+++ b/src/gui/inputdevices/old/InputSequence.cpp
@@ -68,7 +68,7 @@ void InputSequence::setAxes(gdouble* axes)
 void InputSequence::copyAxes(GdkEvent* event)
 {
 	clearAxes();
-	setAxes((gdouble*)g_memdup(event->motion.axes, sizeof(gdouble) * gdk_device_get_n_axes(device)));
+	setAxes(static_cast<gdouble*>(g_memdup(event->motion.axes, sizeof(gdouble) * gdk_device_get_n_axes(device))));
 }
 
 /**
@@ -328,7 +328,7 @@ auto InputSequence::checkStillRunning() -> bool
 		return true;
 	}
 
-	auto mask = (GdkModifierType) 0;
+	auto mask = static_cast<GdkModifierType>(0);
 	GdkWindow* window = gtk_widget_get_window(GTK_WIDGET(inputHandler->getXournal()));
 	gdk_device_get_state(device, window, nullptr, &mask);
 

--- a/src/gui/inputdevices/old/InputSequence.h
+++ b/src/gui/inputdevices/old/InputSequence.h
@@ -232,7 +232,5 @@ private:
 	/**
 	 * event time
 	 */
-	guint32 eventTime;
-	
-	
+	guint32 eventTime{};
 };

--- a/src/gui/inputdevices/old/NewGtkInputDevice.cpp
+++ b/src/gui/inputdevices/old/NewGtkInputDevice.cpp
@@ -7,6 +7,7 @@
 #include "gui/PageView.h"
 #include "gui/scroll/ScrollHandling.h"
 #include "gui/XournalView.h"
+#include "math.h"
 #include "util/DeviceListHelper.h"
 #include "model/Point.h"
 
@@ -264,7 +265,7 @@ auto NewGtkInputDevice::eventHandler(GdkEvent* event) -> bool
 	input->setDevice(sourceDevice);
 	input->clearAxes();
 
-	gdouble x, y;
+	gdouble x = NAN, y = NAN;
 	if (gdk_event_get_coords(event, &x, &y))
 	{
 		scrollHandling->translate(x, y);

--- a/src/gui/inputdevices/old/NewGtkInputDevice.cpp
+++ b/src/gui/inputdevices/old/NewGtkInputDevice.cpp
@@ -7,7 +7,7 @@
 #include "gui/PageView.h"
 #include "gui/scroll/ScrollHandling.h"
 #include "gui/XournalView.h"
-#include "math.h"
+#include <cmath>
 #include "util/DeviceListHelper.h"
 #include "model/Point.h"
 
@@ -79,15 +79,15 @@ auto NewGtkInputDevice::startInput(InputSequence* input) -> bool
 		inputRunning = input;
 		return true;
 	}
-	else
-	{
-		if (inputRunning->checkStillRunning())
+
+
+	    if (inputRunning->checkStillRunning())
 		{
 			g_warning("Input was not stopped correctly!");
 			inputRunning = input;
 			return true;
 		}
-	}
+
 
 	return false;
 }
@@ -165,12 +165,12 @@ auto NewGtkInputDevice::eventKeyPressHandler(GdkEventKey* event) -> bool
 			selection->moveSelection(d, 0);
 			return true;
 		}
-		else if (event->keyval == GDK_KEY_Up)
+		if (event->keyval == GDK_KEY_Up)
 		{
 			selection->moveSelection(0, d);
 			return true;
 		}
-		else if (event->keyval == GDK_KEY_Right)
+		if (event->keyval == GDK_KEY_Right)
 		{
 			selection->moveSelection(-d, 0);
 			return true;
@@ -234,7 +234,7 @@ auto NewGtkInputDevice::eventHandler(GdkEvent* event) -> bool
 		g_hash_table_remove(touchInputList, sequence);
 		return true;
 	}
-	else if (event->type == GDK_LEAVE_NOTIFY)
+	if (event->type == GDK_LEAVE_NOTIFY)
 	{
 		g_hash_table_remove(pointerInputList, sourceDevice);
 		return true;

--- a/src/gui/inputdevices/old/NewGtkInputDevice.cpp
+++ b/src/gui/inputdevices/old/NewGtkInputDevice.cpp
@@ -81,12 +81,12 @@ auto NewGtkInputDevice::startInput(InputSequence* input) -> bool
 	}
 
 
-	    if (inputRunning->checkStillRunning())
-		{
-			g_warning("Input was not stopped correctly!");
-			inputRunning = input;
-			return true;
-		}
+	if (inputRunning->checkStillRunning())
+	{
+		g_warning("Input was not stopped correctly!");
+		inputRunning = input;
+		return true;
+	}
 
 
 	return false;
@@ -175,7 +175,7 @@ auto NewGtkInputDevice::eventKeyPressHandler(GdkEventKey* event) -> bool
 			selection->moveSelection(-d, 0);
 			return true;
 		}
-		else if (event->keyval == GDK_KEY_Down)
+		if (event->keyval == GDK_KEY_Down)
 		{
 			selection->moveSelection(0, -d);
 			return true;

--- a/src/gui/inputdevices/old/NewGtkInputDevice.cpp
+++ b/src/gui/inputdevices/old/NewGtkInputDevice.cpp
@@ -16,8 +16,10 @@ NewGtkInputDevice::NewGtkInputDevice(GtkWidget* widget, XournalView* view, Scrol
  : AbstractInputDevice(widget, view),
    scrollHandling(scrollHandling)
 {
-	pointerInputList = g_hash_table_new_full(nullptr, nullptr, nullptr, (GDestroyNotify) InputSequence::free);
-	touchInputList = g_hash_table_new_full(nullptr, nullptr, nullptr, (GDestroyNotify) InputSequence::free);
+	pointerInputList =
+	        g_hash_table_new_full(nullptr, nullptr, nullptr, reinterpret_cast<GDestroyNotify>(InputSequence::free));
+	touchInputList =
+	        g_hash_table_new_full(nullptr, nullptr, nullptr, reinterpret_cast<GDestroyNotify>(InputSequence::free));
 
 	ignoreTouch = !view->getControl()->getSettings()->isTouchWorkaround();
 }
@@ -222,11 +224,11 @@ auto NewGtkInputDevice::eventHandler(GdkEvent* event) -> bool
 
 	if (event->type == GDK_TOUCH_END || event->type == GDK_TOUCH_CANCEL)
 	{
-		auto* input = (InputSequence*) g_hash_table_lookup(touchInputList, sequence);
+		auto* input = static_cast<InputSequence*>(g_hash_table_lookup(touchInputList, sequence));
 
 		if (input != nullptr)
 		{
-			input->actionEnd(((GdkEventTouch *)event)->time);
+			input->actionEnd((reinterpret_cast<GdkEventTouch*>(event))->time);
 		}
 
 		g_hash_table_remove(touchInputList, sequence);
@@ -241,7 +243,7 @@ auto NewGtkInputDevice::eventHandler(GdkEvent* event) -> bool
 	InputSequence* input = nullptr;
 	if (sequence == nullptr)
 	{
-		input = (InputSequence*) g_hash_table_lookup(pointerInputList, sourceDevice);
+		input = static_cast<InputSequence*>(g_hash_table_lookup(pointerInputList, sourceDevice));
 
 		if (input == nullptr)
 		{
@@ -251,7 +253,7 @@ auto NewGtkInputDevice::eventHandler(GdkEvent* event) -> bool
 	}
 	else
 	{
-		input = (InputSequence*) g_hash_table_lookup(touchInputList, sequence);
+		input = static_cast<InputSequence*>(g_hash_table_lookup(touchInputList, sequence));
 
 		if (input == nullptr)
 		{
@@ -283,7 +285,7 @@ auto NewGtkInputDevice::eventHandler(GdkEvent* event) -> bool
 		input->setButton(button, gdk_event_get_time(event) );
 	}
 
-	auto state = (GdkModifierType) 0;
+	auto state = static_cast<GdkModifierType>(0);
 	if (gdk_event_get_state(event, &state))
 	{
 		input->setState(state);
@@ -292,7 +294,9 @@ auto NewGtkInputDevice::eventHandler(GdkEvent* event) -> bool
 	if (event->type == GDK_MOTION_NOTIFY || event->type == GDK_TOUCH_UPDATE)
 	{
 		input->copyAxes(event);
-		guint32 time = event->type == GDK_MOTION_NOTIFY ? ((GdkEventMotion *)event)->time : ((GdkEventTouch *)event)->time;	// or call gdk_event_get_time(event)
+		guint32 time = event->type == GDK_MOTION_NOTIFY ?
+		                       (reinterpret_cast<GdkEventMotion*>(event))->time :
+		                       (reinterpret_cast<GdkEventTouch*>(event))->time;  // or call gdk_event_get_time(event)
 		input->actionMoved(time);
 
 		XournalppCursor* cursor = view->getControl()->getWindow()->getXournal()->getCursor();
@@ -304,13 +308,15 @@ auto NewGtkInputDevice::eventHandler(GdkEvent* event) -> bool
 	else if (event->type == GDK_BUTTON_PRESS || event->type == GDK_TOUCH_BEGIN)
 	{
 		input->copyAxes(event);
-		guint32 time = event->type == GDK_BUTTON_PRESS ? ((GdkEventButton *)event)->time : ((GdkEventTouch *)event)->time;  //or call gdk_event_get_time()
+		guint32 time = event->type == GDK_BUTTON_PRESS ?
+		                       (reinterpret_cast<GdkEventButton*>(event))->time :
+		                       (reinterpret_cast<GdkEventTouch*>(event))->time;  //or call gdk_event_get_time()
 		input->actionStart(time);
 	}
 	else if (event->type == GDK_BUTTON_RELEASE)
 	{
 		input->copyAxes(event);
-		input->actionEnd( ((GdkEventButton *)event)->time );
+		input->actionEnd((reinterpret_cast<GdkEventButton*>(event))->time);
 	}
 
 	return true;

--- a/src/gui/inputdevices/touchdisable/TouchDisableGdk.cpp
+++ b/src/gui/inputdevices/touchdisable/TouchDisableGdk.cpp
@@ -6,7 +6,8 @@
 #include <gui/XournalView.h>
 #include "TouchDisableGdk.h"
 
-TouchDisableGdk::TouchDisableGdk(GtkWidget* widget) : TouchDisableInterface(), widget(widget)
+TouchDisableGdk::TouchDisableGdk(GtkWidget* widget)
+ : widget(widget)
 {
 }
 

--- a/src/gui/sidebar/indextree/SidebarIndexPage.cpp
+++ b/src/gui/sidebar/indextree/SidebarIndexPage.cpp
@@ -206,7 +206,7 @@ auto SidebarIndexPage::treeSearchFunction(GtkTreeModel* model, gint column, cons
 	        g_timeout_add_seconds_full(G_PRIORITY_DEFAULT_IDLE, 2, (GSourceFunc) searchTimeoutFunc, sidebar, nullptr);
 
 	// Source: Pidgin
-	gchar* text;
+	gchar* text = nullptr;
 	gtk_tree_model_get(model, iter, DOCUMENT_LINKS_COLUMN_NAME, &text, -1);
 	if (text == nullptr)
 	{

--- a/src/gui/sidebar/indextree/SidebarIndexPage.cpp
+++ b/src/gui/sidebar/indextree/SidebarIndexPage.cpp
@@ -381,16 +381,16 @@ auto SidebarIndexPage::selectPageNr(size_t page, size_t pdfPage, GtkTreeIter* pa
 		}
 
 
-		    g_object_unref(link);
+		g_object_unref(link);
 
-			if (selectPageNr(page, pdfPage, &iter))
-			{
-				g_object_unref(model);
-				return true;
-			}
+		if (selectPageNr(page, pdfPage, &iter))
+		{
+			g_object_unref(model);
+			return true;
+		}
 
 
-		        valid = gtk_tree_model_iter_next(model, &iter);
+		valid = gtk_tree_model_iter_next(model, &iter);
 	}
 
 	g_object_unref(model);

--- a/src/gui/sidebar/indextree/SidebarIndexPage.cpp
+++ b/src/gui/sidebar/indextree/SidebarIndexPage.cpp
@@ -17,7 +17,8 @@ SidebarIndexPage::SidebarIndexPage(Control* control, SidebarToolbar* toolbar)
 	gtk_tree_view_set_enable_search(GTK_TREE_VIEW(treeViewBookmarks), true);
 	gtk_tree_view_set_search_column(GTK_TREE_VIEW(treeViewBookmarks), DOCUMENT_LINKS_COLUMN_NAME);
 	gtk_tree_view_set_search_equal_func(GTK_TREE_VIEW(treeViewBookmarks),
-	                                    (GtkTreeViewSearchEqualFunc) treeSearchFunction, this, nullptr);
+	                                    reinterpret_cast<GtkTreeViewSearchEqualFunc>(treeSearchFunction), this,
+	                                    nullptr);
 
 	this->scrollBookmarks = gtk_scrolled_window_new(nullptr, nullptr);
 	g_object_ref(this->scrollBookmarks);
@@ -35,8 +36,8 @@ SidebarIndexPage::SidebarIndexPage(Control* control, SidebarToolbar* toolbar)
 	gtk_tree_view_column_set_expand(GTK_TREE_VIEW_COLUMN(column), true);
 	gtk_tree_view_append_column(GTK_TREE_VIEW(treeViewBookmarks), column);
 
-	auto* renderer =
-	        (GtkCellRenderer*) g_object_new(GTK_TYPE_CELL_RENDERER_TEXT, "ellipsize", PANGO_ELLIPSIZE_END, nullptr);
+	auto* renderer = static_cast<GtkCellRenderer*>(
+	        g_object_new(GTK_TYPE_CELL_RENDERER_TEXT, "ellipsize", PANGO_ELLIPSIZE_END, nullptr));
 	gtk_tree_view_column_pack_start(GTK_TREE_VIEW_COLUMN(column), renderer, true);
 	gtk_tree_view_column_set_attributes(GTK_TREE_VIEW_COLUMN(column), renderer, "markup", DOCUMENT_LINKS_COLUMN_NAME,
 	                                    nullptr);
@@ -202,8 +203,8 @@ auto SidebarIndexPage::treeSearchFunction(GtkTreeModel* model, gint column, cons
 		g_source_remove(sidebar->searchTimeout);
 		sidebar->searchTimeout = 0;
 	}
-	sidebar->searchTimeout =
-	        g_timeout_add_seconds_full(G_PRIORITY_DEFAULT_IDLE, 2, (GSourceFunc) searchTimeoutFunc, sidebar, nullptr);
+	sidebar->searchTimeout = g_timeout_add_seconds_full(
+	        G_PRIORITY_DEFAULT_IDLE, 2, reinterpret_cast<GSourceFunc>(searchTimeoutFunc), sidebar, nullptr);
 
 	// Source: Pidgin
 	gchar* text = nullptr;

--- a/src/gui/sidebar/indextree/SidebarIndexPage.cpp
+++ b/src/gui/sidebar/indextree/SidebarIndexPage.cpp
@@ -379,20 +379,18 @@ auto SidebarIndexPage::selectPageNr(size_t page, size_t pdfPage, GtkTreeIter* pa
 			g_object_unref(model);
 			return true;
 		}
-		else
-		{
-			g_object_unref(link);
+
+
+		    g_object_unref(link);
 
 			if (selectPageNr(page, pdfPage, &iter))
 			{
 				g_object_unref(model);
 				return true;
 			}
-			else
-			{
-				valid = gtk_tree_model_iter_next(model, &iter);
-			}
-		}
+
+
+		        valid = gtk_tree_model_iter_next(model, &iter);
 	}
 
 	g_object_unref(model);

--- a/src/gui/sidebar/previews/base/SidebarLayout.cpp
+++ b/src/gui/sidebar/previews/base/SidebarLayout.cpp
@@ -12,7 +12,7 @@ SidebarLayout::~SidebarLayout() = default;
 class SidebarRow
 {
 public:
-	SidebarRow(int width)
+	explicit SidebarRow(int width)
 	{
 		this->width = width;
 		this->currentWidth = 0;

--- a/src/gui/sidebar/previews/base/SidebarLayout.cpp
+++ b/src/gui/sidebar/previews/base/SidebarLayout.cpp
@@ -23,10 +23,10 @@ public:
 		clear();
 	}
 
-public:
+
 	auto isSpaceFor(SidebarPreviewBaseEntry* p) -> bool
 	{
-		if (this->list.size() == 0)
+		if (this->list.empty())
 		{
 			return true;
 		}
@@ -55,7 +55,7 @@ public:
 		return this->list.size();
 	}
 
-	auto getWidth() -> int
+	auto getWidth() const -> int
 	{
 		return this->currentWidth;
 	}

--- a/src/gui/sidebar/previews/base/SidebarLayout.h
+++ b/src/gui/sidebar/previews/base/SidebarLayout.h
@@ -27,7 +27,7 @@ public:
 	/**
 	 * Layouts the sidebar
 	 */
-	void layout(SidebarPreviewBase* sidebar);
+	static void layout(SidebarPreviewBase* sidebar);
 
 private:
 };

--- a/src/gui/sidebar/previews/base/SidebarPreviewBase.cpp
+++ b/src/gui/sidebar/previews/base/SidebarPreviewBase.cpp
@@ -82,7 +82,7 @@ void SidebarPreviewBase::sizeChanged(GtkWidget* widget, GtkAllocation* allocatio
 	}
 }
 
-auto SidebarPreviewBase::getZoom() -> double
+auto SidebarPreviewBase::getZoom() const -> double
 {
 	return this->zoom;
 }
@@ -94,7 +94,7 @@ auto SidebarPreviewBase::getCache() -> PdfCache*
 
 void SidebarPreviewBase::layout()
 {
-	this->layoutmanager->layout(this);
+	SidebarLayout::layout(this);
 }
 
 auto SidebarPreviewBase::hasData() -> bool

--- a/src/gui/sidebar/previews/base/SidebarPreviewBase.cpp
+++ b/src/gui/sidebar/previews/base/SidebarPreviewBase.cpp
@@ -150,7 +150,7 @@ auto SidebarPreviewBase::scrollToPreview(SidebarPreviewBase* sidebar) -> bool
 
 		if (x == -1)
 		{
-			g_idle_add((GSourceFunc) scrollToPreview, sidebar);
+			g_idle_add(reinterpret_cast<GSourceFunc>(scrollToPreview), sidebar);
 			return false;
 		}
 

--- a/src/gui/sidebar/previews/base/SidebarPreviewBase.h
+++ b/src/gui/sidebar/previews/base/SidebarPreviewBase.h
@@ -55,7 +55,7 @@ public:
 	/**
 	 * Gets the zoom factor for the previews
 	 */
-	double getZoom();
+	double getZoom() const;
 
 	/**
 	 * Gets the PDF cache for preview rendering

--- a/src/gui/sidebar/previews/base/SidebarPreviewBaseEntry.h
+++ b/src/gui/sidebar/previews/base/SidebarPreviewBaseEntry.h
@@ -86,7 +86,7 @@ protected:
 	/**
 	 * Mutex
 	 */
-	GMutex drawingMutex;
+	GMutex drawingMutex{};
 
 	/**
 	 * The Widget which is used for drawing

--- a/src/gui/sidebar/previews/layer/SidebarPreviewLayerEntry.cpp
+++ b/src/gui/sidebar/previews/layer/SidebarPreviewLayerEntry.cpp
@@ -84,7 +84,7 @@ auto SidebarPreviewLayerEntry::getHeight() -> int
 	return getWidgetHeight() + toolbarHeight;
 }
 
-auto SidebarPreviewLayerEntry::getLayer() -> int
+auto SidebarPreviewLayerEntry::getLayer() const -> int
 {
 	return layer;
 }

--- a/src/gui/sidebar/previews/layer/SidebarPreviewLayerEntry.cpp
+++ b/src/gui/sidebar/previews/layer/SidebarPreviewLayerEntry.cpp
@@ -66,12 +66,12 @@ void SidebarPreviewLayerEntry::checkboxToggled()
 	}
 
 	bool check = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(cbVisible));
-	((SidebarPreviewLayers*)sidebar)->layerVisibilityChanged(layer + 1, check);
+	(dynamic_cast<SidebarPreviewLayers*>(sidebar))->layerVisibilityChanged(layer + 1, check);
 }
 
 void SidebarPreviewLayerEntry::mouseButtonPressCallback()
 {
-	((SidebarPreviewLayers*)sidebar)->layerSelected(index);
+	(dynamic_cast<SidebarPreviewLayers*>(sidebar))->layerSelected(index);
 }
 
 auto SidebarPreviewLayerEntry::getRenderType() -> PreviewRenderType

--- a/src/gui/sidebar/previews/layer/SidebarPreviewLayerEntry.h
+++ b/src/gui/sidebar/previews/layer/SidebarPreviewLayerEntry.h
@@ -34,7 +34,7 @@ public:
 	/**
 	 * @return The layer to be rendered
 	 */
-	int getLayer();
+	int getLayer() const;
 
 	virtual GtkWidget* getWidget();
 

--- a/src/gui/sidebar/previews/layer/SidebarPreviewLayers.cpp
+++ b/src/gui/sidebar/previews/layer/SidebarPreviewLayers.cpp
@@ -153,7 +153,7 @@ void SidebarPreviewLayers::layerVisibilityChanged()
 
 	for (int i = 0; i < (int)this->previews.size(); i++)
 	{
-		auto* sp = (SidebarPreviewLayerEntry*) this->previews[this->previews.size() - i - 1];
+		auto* sp = dynamic_cast<SidebarPreviewLayerEntry*>(this->previews[this->previews.size() - i - 1]);
 		sp->setVisibleCheckbox(p->isLayerVisible(i));
 	}
 }

--- a/src/gui/sidebar/previews/layer/SidebarPreviewLayers.cpp
+++ b/src/gui/sidebar/previews/layer/SidebarPreviewLayers.cpp
@@ -151,7 +151,7 @@ void SidebarPreviewLayers::layerVisibilityChanged()
 		return;
 	}
 
-	for (int i = 0; i < (int)this->previews.size(); i++)
+	for (int i = 0; i < static_cast<int>(this->previews.size()); i++)
 	{
 		auto* sp = dynamic_cast<SidebarPreviewLayerEntry*>(this->previews[this->previews.size() - i - 1]);
 		sp->setVisibleCheckbox(p->isLayerVisible(i));
@@ -207,7 +207,7 @@ void SidebarPreviewLayers::updateSelectedLayer()
 	}
 
 	this->toolbar->setHidden(false);
-	this->toolbar->setButtonEnabled((SidebarActions)actions);
+	this->toolbar->setButtonEnabled(static_cast<SidebarActions>(actions));
 }
 
 void SidebarPreviewLayers::layerSelected(size_t layerIndex)

--- a/src/gui/sidebar/previews/page/SidebarPreviewPages.cpp
+++ b/src/gui/sidebar/previews/page/SidebarPreviewPages.cpp
@@ -287,17 +287,17 @@ void SidebarPreviewPages::pageSelected(size_t page)
 		scrollToPreview(this);
 
 		int actions = 0;
-		if (page != 0 && this->previews.size() != 0)
+		if (page != 0 && !this->previews.empty())
 		{
 			actions |= SIDEBAR_ACTION_MOVE_UP;
 		}
 
-		if (page != this->previews.size() - 1 && this->previews.size() != 0)
+		if (page != this->previews.size() - 1 && !this->previews.empty())
 		{
 			actions |= SIDEBAR_ACTION_MOVE_DOWN;
 		}
 
-		if (this->previews.size() != 0)
+		if (!this->previews.empty())
 		{
 			actions |= SIDEBAR_ACTION_COPY;
 		}

--- a/src/gui/sidebar/previews/page/SidebarPreviewPages.cpp
+++ b/src/gui/sidebar/previews/page/SidebarPreviewPages.cpp
@@ -308,7 +308,7 @@ void SidebarPreviewPages::pageSelected(size_t page)
 		}
 
 		this->toolbar->setHidden(false);
-		this->toolbar->setButtonEnabled((SidebarActions)actions);
+		this->toolbar->setButtonEnabled(static_cast<SidebarActions>(actions));
 	}
 }
 

--- a/src/gui/toolbarMenubar/AbstractItem.cpp
+++ b/src/gui/toolbarMenubar/AbstractItem.cpp
@@ -177,7 +177,7 @@ void AbstractItem::enable(bool enabled)
 {
 }
 
-auto AbstractItem::isEnabled() -> bool
+auto AbstractItem::isEnabled() const -> bool
 {
 	return this->enabled;
 }

--- a/src/gui/toolbarMenubar/AbstractItem.h
+++ b/src/gui/toolbarMenubar/AbstractItem.h
@@ -37,7 +37,7 @@ public:
 	virtual string getId();
 
 	void setTmpDisabled(bool disabled);
-	bool isEnabled();
+	bool isEnabled() const;
 
 	ActionType getActionType();
 

--- a/src/gui/toolbarMenubar/AbstractToolItem.cpp
+++ b/src/gui/toolbarMenubar/AbstractToolItem.cpp
@@ -50,7 +50,7 @@ void AbstractToolItem::toolButtonCallback(GtkToolButton* toolbutton, AbstractToo
 		}
 
 		// don't allow deselect this button
-		if (item->toolToggleOnlyEnable && selected == false)
+		if (item->toolToggleOnlyEnable && !selected)
 		{
 			gtk_toggle_tool_button_set_active(GTK_TOGGLE_TOOL_BUTTON(toolbutton), true);
 			return;
@@ -107,7 +107,7 @@ void AbstractToolItem::setPopupMenu(GtkWidget* popupMenu)
 	this->popupMenu = popupMenu;
 }
 
-auto AbstractToolItem::isUsed() -> bool
+auto AbstractToolItem::isUsed() const -> bool
 {
 	return used;
 }

--- a/src/gui/toolbarMenubar/AbstractToolItem.h
+++ b/src/gui/toolbarMenubar/AbstractToolItem.h
@@ -25,7 +25,7 @@ public:
 	virtual GtkToolItem* createTmpItem(bool horizontal);
 	void setPopupMenu(GtkWidget* popupMenu);
 
-	bool isUsed();
+	bool isUsed() const;
 	void setUsed(bool used);
 
 	static void toolButtonCallback(GtkToolButton* toolbutton, AbstractToolItem* item);

--- a/src/gui/toolbarMenubar/ColorToolItem.cpp
+++ b/src/gui/toolbarMenubar/ColorToolItem.cpp
@@ -158,9 +158,9 @@ void ColorToolItem::showColorchooser()
 	{
 		GdkRGBA color;
 		gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(dialog), &color);
-		this->color = (((int)(color.red * 255)) & 0xff) << 16 |
-				(((int)(color.green * 255)) & 0xff) << 8 |
-				(((int)(color.blue * 255)) & 0xff);
+		this->color = ((static_cast<int>(color.red * 255)) & 0xff) << 16 |
+		              ((static_cast<int>(color.green * 255)) & 0xff) << 8 |
+		              ((static_cast<int>(color.blue * 255)) & 0xff);
 	}
 
 	gtk_widget_destroy(dialog);

--- a/src/gui/toolbarMenubar/ColorToolItem.cpp
+++ b/src/gui/toolbarMenubar/ColorToolItem.cpp
@@ -104,7 +104,7 @@ void ColorToolItem::enableColor(int color)
 	}
 }
 
-auto ColorToolItem::getColor() -> int
+auto ColorToolItem::getColor() const -> int
 {
 	return this->color;
 }
@@ -123,7 +123,7 @@ auto ColorToolItem::getId() -> string
 	return id;
 }
 
-auto ColorToolItem::colorEqualsMoreOreLess(int color) -> bool
+auto ColorToolItem::colorEqualsMoreOreLess(int color) const -> bool
 {
 	if (color == -1)
 	{
@@ -138,11 +138,7 @@ auto ColorToolItem::colorEqualsMoreOreLess(int color) -> bool
 	int g2 = (this->color & 0xff00) >> 8;
 	int b2 = (this->color & 0xff);
 
-	if (std::abs(r1 - r2) < 10 && std::abs(g1 - g2) < 10 && std::abs(b1 - b2) < 10)
-	{
-		return true;
-	}
-	return false;
+	return std::abs(r1 - r2) < 10 && std::abs(g1 - g2) < 10 && std::abs(b1 - b2) < 10;
 }
 
 /**

--- a/src/gui/toolbarMenubar/ColorToolItem.h
+++ b/src/gui/toolbarMenubar/ColorToolItem.h
@@ -28,7 +28,7 @@ public:
 public:
 	virtual void actionSelected(ActionGroup group, ActionType action);
 	void enableColor(int color);
-	bool colorEqualsMoreOreLess(int color);
+	bool colorEqualsMoreOreLess(int color) const;
 	virtual void activated(GdkEvent* event, GtkMenuItem* menuitem, GtkToolButton* toolbutton);
 
 	virtual string getToolDisplayName();
@@ -36,7 +36,7 @@ public:
 
 	virtual string getId();
 
-	int getColor();
+	int getColor() const;
 
 	/**
 	 * Enable / Disable the tool item

--- a/src/gui/toolbarMenubar/FontButton.h
+++ b/src/gui/toolbarMenubar/FontButton.h
@@ -36,7 +36,7 @@ protected:
 	virtual GtkToolItem* createTmpItem(bool horizontal);
 	virtual GtkToolItem* newItem();
 
-	GtkWidget* newFontButton();
+	static GtkWidget* newFontButton();
 	static void setFontFontButton(GtkWidget* fontButton, XojFont& font);
 
 	virtual GtkWidget* getNewToolIcon();

--- a/src/gui/toolbarMenubar/ToolButton.cpp
+++ b/src/gui/toolbarMenubar/ToolButton.cpp
@@ -75,7 +75,7 @@ void ToolButton::updateDescription(const string& description)
 
 auto ToolButton::newItem() -> GtkToolItem*
 {
-	GtkToolItem* it;
+	GtkToolItem* it = nullptr;
 
 	if (group != GROUP_NOGROUP)
 	{

--- a/src/gui/toolbarMenubar/ToolButton.cpp
+++ b/src/gui/toolbarMenubar/ToolButton.cpp
@@ -38,7 +38,7 @@ auto ToolButton::registerPopupMenuEntry(const string& name, const string& iconNa
 	}
 
 	GtkWidget* menuItem = nullptr;
-	if (iconName == "")
+	if (iconName.empty())
 	{
 		menuItem = gtk_check_menu_item_new_with_label(name.c_str());
 	}

--- a/src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp
+++ b/src/gui/toolbarMenubar/ToolDrawCombocontrol.cpp
@@ -17,7 +17,7 @@ public:
 	{
 	}
 
-public:
+
 	string name;
 	string icon;
 	ActionType type;

--- a/src/gui/toolbarMenubar/ToolMenuHandler.cpp
+++ b/src/gui/toolbarMenubar/ToolMenuHandler.cpp
@@ -298,7 +298,7 @@ void ToolMenuHandler::signalConnectCallback(GtkBuilder* builder, GObject* object
 		const gchar* handlerName, GObject* connectObject, GConnectFlags flags, ToolMenuHandler* self)
 {
 	string actionName = handlerName;
-	string groupName = "";
+	string groupName = groupName;
 
 	size_t pos = actionName.find(':');
 	if (pos != string::npos)
@@ -316,7 +316,7 @@ void ToolMenuHandler::signalConnectCallback(GtkBuilder* builder, GObject* object
 		return;
 	}
 
-	if (groupName != "")
+	if (!groupName.empty())
 	{
 		group = ActionGroup_fromString(groupName);
 	}

--- a/src/gui/toolbarMenubar/ToolMenuHandler.cpp
+++ b/src/gui/toolbarMenubar/ToolMenuHandler.cpp
@@ -223,13 +223,13 @@ void ToolMenuHandler::removeColorToolItem(AbstractToolItem* it)
 			break;
 		}
 	}
-	delete (ColorToolItem*) it;
+	delete dynamic_cast<ColorToolItem*>(it);
 }
 
 void ToolMenuHandler::addColorToolItem(AbstractToolItem* it)
 {
 	g_return_if_fail(it != nullptr);
-	this->toolbarColorItems.push_back((ColorToolItem*) it);
+	this->toolbarColorItems.push_back(dynamic_cast<ColorToolItem*>(it));
 }
 
 void ToolMenuHandler::setTmpDisabled(bool disabled)

--- a/src/gui/toolbarMenubar/ToolMenuHandler.cpp
+++ b/src/gui/toolbarMenubar/ToolMenuHandler.cpp
@@ -510,7 +510,8 @@ void ToolMenuHandler::initToolItems()
 
 
 	// now connect all Glade Signals
-	gtk_builder_connect_signals_full(gui->getBuilder(), (GtkBuilderConnectFunc)signalConnectCallback, this);
+	gtk_builder_connect_signals_full(gui->getBuilder(), reinterpret_cast<GtkBuilderConnectFunc>(signalConnectCallback),
+	                                 this);
 }
 
 void ToolMenuHandler::setFontButtonFont(XojFont& font)

--- a/src/gui/toolbarMenubar/ToolMenuHandler.cpp
+++ b/src/gui/toolbarMenubar/ToolMenuHandler.cpp
@@ -298,7 +298,7 @@ void ToolMenuHandler::signalConnectCallback(GtkBuilder* builder, GObject* object
 		const gchar* handlerName, GObject* connectObject, GConnectFlags flags, ToolMenuHandler* self)
 {
 	string actionName = handlerName;
-	string groupName = groupName;
+	string groupName{};
 
 	size_t pos = actionName.find(':');
 	if (pos != string::npos)

--- a/src/gui/toolbarMenubar/ToolMenuHandler.h
+++ b/src/gui/toolbarMenubar/ToolMenuHandler.h
@@ -41,7 +41,7 @@ public:
 
 public:
 	void freeDynamicToolbarItems();
-	void unloadToolbar(GtkWidget* tBunload);
+	static void unloadToolbar(GtkWidget* toolbar);
 
 	void load(ToolbarData* d, GtkWidget* toolbar, const char* toolbarName, bool horizontal);
 

--- a/src/gui/toolbarMenubar/ToolPageLayer.cpp
+++ b/src/gui/toolbarMenubar/ToolPageLayer.cpp
@@ -129,7 +129,7 @@ void ToolPageLayer::layerMenuClicked(GtkWidget* menu)
 
 	if (!gtk_check_menu_item_get_active(GTK_CHECK_MENU_ITEM(menu)))
 	{
-		if (layerId == (int)lc->getCurrentLayerId())
+		if (layerId == static_cast<int>(lc->getCurrentLayerId()))
 		{
 			// This is the current layer, don't allow to deselect it
 			inMenuUpdate = true;

--- a/src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp
+++ b/src/gui/toolbarMenubar/ToolSelectCombocontrol.cpp
@@ -93,7 +93,7 @@ void ToolSelectCombocontrol::selected(ActionGroup group, ActionType action)
 
 auto ToolSelectCombocontrol::newItem() -> GtkToolItem*
 {
-	GtkToolItem* it;
+	GtkToolItem* it = nullptr;
 
 	labelWidget = gtk_label_new(_("Select Rectangle"));
 	iconWidget = gtk_image_new_from_icon_name("rect-select", GTK_ICON_SIZE_SMALL_TOOLBAR);

--- a/src/gui/toolbarMenubar/ToolZoomSlider.cpp
+++ b/src/gui/toolbarMenubar/ToolZoomSlider.cpp
@@ -62,7 +62,7 @@ auto ToolZoomSlider::sliderHoverScroll(GtkWidget* range, GdkEventScroll* event, 
 
 auto ToolZoomSlider::sliderFormatValue(GtkRange* range, gdouble value, ToolZoomSlider* self) -> gchar*
 {
-	return g_strdup_printf("%d%%", (int) (100 * scaleFuncInv(value)));
+	return g_strdup_printf("%d%%", static_cast<int>(100 * scaleFuncInv(value)));
 }
 
 void ToolZoomSlider::zoomChanged()

--- a/src/gui/toolbarMenubar/model/ToolbarColorNames.cpp
+++ b/src/gui/toolbarMenubar/model/ToolbarColorNames.cpp
@@ -105,7 +105,7 @@ auto ToolbarColorNames::getColorName(int color) -> string
 		return colorName;
 	}
 
-	char* value = (char*) g_hash_table_lookup(this->predefinedColorNames, &color);
+	char* value = static_cast<char*>(g_hash_table_lookup(this->predefinedColorNames, &color));
 	if (value)
 	{
 		return value;

--- a/src/gui/toolbarMenubar/model/ToolbarColorNames.cpp
+++ b/src/gui/toolbarMenubar/model/ToolbarColorNames.cpp
@@ -57,7 +57,7 @@ void ToolbarColorNames::saveFile(const string& file)
 	gsize len = 0;
 	char* data = g_key_file_to_data(this->config, &len, nullptr);
 
-	FILE* fp = g_fopen(file.c_str(), "wb");
+	FILE* fp = g_fopen(file.c_str(), "wbe");
 	if (!fp)
 	{
 		g_error("Could not save color file «%s»", file.c_str());

--- a/src/gui/toolbarMenubar/model/ToolbarData.cpp
+++ b/src/gui/toolbarMenubar/model/ToolbarData.cpp
@@ -113,7 +113,7 @@ void ToolbarData::saveToKeyFile(GKeyFile* config)
 
 	for (ToolbarEntry* e : this->contents)
 	{
-		string line = line;
+		string line{};
 
 		for (ToolbarItem* it : e->getItems())
 		{

--- a/src/gui/toolbarMenubar/model/ToolbarData.cpp
+++ b/src/gui/toolbarMenubar/model/ToolbarData.cpp
@@ -61,7 +61,7 @@ void ToolbarData::setId(string id)
 	this->id = std::move(id);
 }
 
-auto ToolbarData::isPredefined() -> bool
+auto ToolbarData::isPredefined() const -> bool
 {
 	return this->predefined;
 }
@@ -113,7 +113,7 @@ void ToolbarData::saveToKeyFile(GKeyFile* config)
 
 	for (ToolbarEntry* e : this->contents)
 	{
-		string line = "";
+		string line = line;
 
 		for (ToolbarItem* it : e->getItems())
 		{

--- a/src/gui/toolbarMenubar/model/ToolbarData.h
+++ b/src/gui/toolbarMenubar/model/ToolbarData.h
@@ -29,7 +29,7 @@ public:
 	void setName(string name);
 	string getId();
 	void setId(string id);
-	bool isPredefined();
+	bool isPredefined() const;
 
 	void load(GKeyFile* config, const char* group);
 	void saveToKeyFile(GKeyFile* config);

--- a/src/gui/toolbarMenubar/model/ToolbarEntry.cpp
+++ b/src/gui/toolbarMenubar/model/ToolbarEntry.cpp
@@ -70,7 +70,7 @@ auto ToolbarEntry::removeItemById(int id) -> bool
 auto ToolbarEntry::insertItem(string item, int position) -> int
 {
 	auto* it = new ToolbarItem(std::move(item));
-	if (position >= (int)entries.size())
+	if (position >= static_cast<int>(entries.size()))
 	{
 		entries.push_back(it);
 		return it->getId();

--- a/src/gui/toolbarMenubar/model/ToolbarItem.cpp
+++ b/src/gui/toolbarMenubar/model/ToolbarItem.cpp
@@ -39,7 +39,7 @@ auto ToolbarItem::operator==(ToolbarItem& other) -> bool
 	return this->name == other.name;
 }
 
-auto ToolbarItem::getId() -> int
+auto ToolbarItem::getId() const -> int
 {
 	return this->id;
 }

--- a/src/gui/toolbarMenubar/model/ToolbarItem.h
+++ b/src/gui/toolbarMenubar/model/ToolbarItem.h
@@ -29,7 +29,7 @@ public:
 
 	bool operator==(ToolbarItem& other);
 
-	int getId();
+	int getId() const;
 
 private:
 	string name;

--- a/src/gui/widgets/SpinPageAdapter.cpp
+++ b/src/gui/widgets/SpinPageAdapter.cpp
@@ -48,7 +48,7 @@ auto SpinPageAdapter::getWidget() -> GtkWidget*
 	return this->widget;
 }
 
-auto SpinPageAdapter::getPage() -> int
+auto SpinPageAdapter::getPage() const -> int
 {
 	return this->page;
 }

--- a/src/gui/widgets/SpinPageAdapter.cpp
+++ b/src/gui/widgets/SpinPageAdapter.cpp
@@ -29,7 +29,7 @@ auto SpinPageAdapter::pageNrSpinChangedTimerCallback(SpinPageAdapter* adapter) -
 void SpinPageAdapter::pageNrSpinChangedCallback(GtkSpinButton* spinbutton, SpinPageAdapter* adapter)
 {
 	// Nothing changed.
-	if (gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(spinbutton)) == (long) adapter->page)
+	if (gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(spinbutton)) == static_cast<long>(adapter->page))
 	{
 		return;
 	}
@@ -40,7 +40,7 @@ void SpinPageAdapter::pageNrSpinChangedCallback(GtkSpinButton* spinbutton, SpinP
 	}
 
 	// Give the spin button some time to realease, if we don't do he will send new events...
-	adapter->lastTimeoutId = g_timeout_add(100, (GSourceFunc) pageNrSpinChangedTimerCallback, adapter);
+	adapter->lastTimeoutId = g_timeout_add(100, reinterpret_cast<GSourceFunc>(pageNrSpinChangedTimerCallback), adapter);
 }
 
 auto SpinPageAdapter::getWidget() -> GtkWidget*

--- a/src/gui/widgets/SpinPageAdapter.h
+++ b/src/gui/widgets/SpinPageAdapter.h
@@ -27,7 +27,7 @@ public:
 public:
 	GtkWidget* getWidget();
 
-	int getPage();
+	int getPage() const;
 	void setPage(size_t page);
 	void setMinMaxPage(size_t min, size_t max);
 

--- a/src/gui/widgets/XournalWidget.cpp
+++ b/src/gui/widgets/XournalWidget.cpp
@@ -40,7 +40,7 @@ auto gtk_xournal_get_type(void) -> GType
 		                                           // base finalize
 		                                           nullptr,
 		                                           // class initialize
-		                                           (GClassInitFunc) gtk_xournal_class_init,
+		                                           reinterpret_cast<GClassInitFunc>(gtk_xournal_class_init),
 		                                           // class finalize
 		                                           nullptr,
 		                                           // class data,
@@ -50,14 +50,12 @@ auto gtk_xournal_get_type(void) -> GType
 		                                           // n_preallocs
 		                                           0,
 		                                           // instance init
-		                                           (GInstanceInitFunc) gtk_xournal_init,
+		                                           reinterpret_cast<GInstanceInitFunc>(gtk_xournal_init),
 		                                           // value table
 		                                           (const GTypeValueTable*) nullptr};
 
-		gtk_xournal_type = g_type_register_static(GTK_TYPE_WIDGET,
-		                                          "GtkXournal",
-		                                          &gtk_xournal_info,
-		                                          (GTypeFlags) 0);
+		gtk_xournal_type =
+		        g_type_register_static(GTK_TYPE_WIDGET, "GtkXournal", &gtk_xournal_info, static_cast<GTypeFlags>(0));
 	}
 
 	return gtk_xournal_type;
@@ -101,7 +99,7 @@ static void gtk_xournal_class_init(GtkXournalClass* klass)
 {
 	GtkWidgetClass* widget_class = nullptr;
 
-	widget_class = (GtkWidgetClass*) klass;
+	widget_class = reinterpret_cast<GtkWidgetClass*>(klass);
 
 	widget_class->realize = gtk_xournal_realize;
 	widget_class->get_preferred_width = gtk_xournal_get_preferred_width;
@@ -124,10 +122,10 @@ auto gtk_xournal_get_visible_area(GtkWidget* widget, XojPageView* p) -> Rectangl
 	GtkAdjustment* hadj = xournal->scrollHandling->getHorizontal();
 
 	GdkRectangle r2;
-	r2.x = (int)gtk_adjustment_get_value(hadj);
-	r2.y = (int)gtk_adjustment_get_value(vadj);
-	r2.width = (int)gtk_adjustment_get_page_size(hadj);
-	r2.height = (int)gtk_adjustment_get_page_size(vadj);
+	r2.x = static_cast<int>(gtk_adjustment_get_value(hadj));
+	r2.y = static_cast<int>(gtk_adjustment_get_value(vadj));
+	r2.width = static_cast<int>(gtk_adjustment_get_page_size(hadj));
+	r2.height = static_cast<int>(gtk_adjustment_get_page_size(vadj));
 
 	GdkRectangle r1;
 	r1.x = p->getX();

--- a/src/gui/widgets/XournalWidget.cpp
+++ b/src/gui/widgets/XournalWidget.cpp
@@ -8,6 +8,7 @@
 #include "gui/scroll/ScrollHandling.h"
 #include "gui/Shadow.h"
 #include "gui/XournalView.h"
+#include "math.h"
 
 #include <config-debug.h>
 #include <Rectangle.h>
@@ -98,7 +99,7 @@ auto gtk_xournal_new_deprecated(XournalView* view, ScrollHandling* scrollHandlin
 
 static void gtk_xournal_class_init(GtkXournalClass* klass)
 {
-	GtkWidgetClass* widget_class;
+	GtkWidgetClass* widget_class = nullptr;
 
 	widget_class = (GtkWidgetClass*) klass;
 
@@ -204,7 +205,7 @@ static void gtk_xournal_size_allocate(GtkWidget* widget, GtkAllocation* allocati
 static void gtk_xournal_realize(GtkWidget* widget)
 {
 	GdkWindowAttr attributes;
-	guint attributes_mask;
+	guint attributes_mask = 0;
 
 	g_return_if_fail(widget != nullptr);
 	g_return_if_fail(GTK_IS_XOURNAL(widget));
@@ -295,7 +296,7 @@ static auto gtk_xournal_draw(GtkWidget* widget, cairo_t* cr) -> gboolean
 
 	GtkXournal* xournal = GTK_XOURNAL(widget);
 
-	double x1, x2, y1, y2;
+	double x1 = NAN, x2 = NAN, y1 = NAN, y2 = NAN;
 
 	cairo_clip_extents(cr, &x1, &y1, &x2, &y2);
 

--- a/src/gui/widgets/XournalWidget.cpp
+++ b/src/gui/widgets/XournalWidget.cpp
@@ -8,7 +8,7 @@
 #include "gui/scroll/ScrollHandling.h"
 #include "gui/Shadow.h"
 #include "gui/XournalView.h"
-#include "math.h"
+#include <cmath>
 
 #include <config-debug.h>
 #include <Rectangle.h>

--- a/src/gui/widgets/ZoomCallib.cpp
+++ b/src/gui/widgets/ZoomCallib.cpp
@@ -34,7 +34,7 @@ auto zoomcallib_new() -> GtkWidget*
 
 static void zoomcallib_class_init(ZoomCallibClass* klass)
 {
-	GtkWidgetClass* widget_class;
+	GtkWidgetClass* widget_class = nullptr;
 
 	widget_class = (GtkWidgetClass*) klass;
 
@@ -79,7 +79,7 @@ static void zoomcallib_size_allocate(GtkWidget* widget, GtkAllocation* allocatio
 static void zoomcallib_realize(GtkWidget* widget)
 {
 	GdkWindowAttr attributes;
-	guint attributes_mask;
+	guint attributes_mask = 0;
 	GtkAllocation allocation;
 
 	g_return_if_fail(widget != nullptr);
@@ -139,7 +139,7 @@ static auto zoomcallib_draw(GtkWidget* widget, cairo_t* cr) -> gboolean
 	gdouble x = 2;
 	for (int i = 0; x < allocation.width; x += hafCm, ++i)
 	{
-		int y;
+		int y = 0;
 		if (i % 2 == 0)
 		{
 			cairo_set_source_rgb(cr, 0, 0, 0);

--- a/src/gui/widgets/ZoomCallib.cpp
+++ b/src/gui/widgets/ZoomCallib.cpp
@@ -36,7 +36,7 @@ static void zoomcallib_class_init(ZoomCallibClass* klass)
 {
 	GtkWidgetClass* widget_class = nullptr;
 
-	widget_class = (GtkWidgetClass*) klass;
+	widget_class = reinterpret_cast<GtkWidgetClass*>(klass);
 
 	widget_class->realize = zoomcallib_realize;
 	widget_class->size_allocate = zoomcallib_size_allocate;

--- a/src/gui/widgets/ZoomCallib.h
+++ b/src/gui/widgets/ZoomCallib.h
@@ -37,7 +37,7 @@ struct _ZoomCallibClass
 };
 
 GType zoomcallib_get_type(void);
-void zoomcallib_set_val(ZoomCallib* cpu, gint val);
+void zoomcallib_set_val(ZoomCallib* callib, gint val);
 GtkWidget* zoomcallib_new();
 
 G_END_DECLS

--- a/src/gui/widgets/gtkmenutooltogglebutton.cpp
+++ b/src/gui/widgets/gtkmenutooltogglebutton.cpp
@@ -350,7 +350,7 @@ static auto arrow_button_button_press_event_cb(GtkWidget* widget,
 	}
 
 
-	    return false;
+	return false;
 }
 
 static void gtk_menu_tool_toggle_button_init(GtkMenuToolToggleButton* button)

--- a/src/gui/widgets/gtkmenutooltogglebutton.cpp
+++ b/src/gui/widgets/gtkmenutooltogglebutton.cpp
@@ -348,10 +348,9 @@ static auto arrow_button_button_press_event_cb(GtkWidget* widget,
 
 		return true;
 	}
-	else
-	{
-		return false;
-	}
+
+
+	    return false;
 }
 
 static void gtk_menu_tool_toggle_button_init(GtkMenuToolToggleButton* button)

--- a/src/gui/widgets/gtkmenutooltogglebutton.cpp
+++ b/src/gui/widgets/gtkmenutooltogglebutton.cpp
@@ -177,9 +177,9 @@ static void gtk_menu_tool_toggle_button_get_property(GObject* object,
 static void gtk_menu_tool_toggle_button_class_init(GtkMenuToolToggleButtonClass*
                                                    klass)
 {
-	auto* object_class = (GObjectClass*) klass;
-	auto* widget_class = (GtkWidgetClass*) klass;
-	auto* toolitem_class = (GtkToolItemClass*) klass;
+	auto* object_class = reinterpret_cast<GObjectClass*>(klass);
+	auto* widget_class = reinterpret_cast<GtkWidgetClass*>(klass);
+	auto* toolitem_class = reinterpret_cast<GtkToolItemClass*>(klass);
 
 	object_class->set_property = gtk_menu_tool_toggle_button_set_property;
 	object_class->get_property = gtk_menu_tool_toggle_button_get_property;
@@ -205,10 +205,9 @@ static void gtk_menu_tool_toggle_button_class_init(GtkMenuToolToggleButtonClass*
 	                                  G_STRUCT_OFFSET(GtkMenuToolToggleButtonClass, show_menu), nullptr, nullptr,
 	                                  g_cclosure_marshal_VOID__VOID, G_TYPE_NONE, 0);
 
-	GParamSpec* pspec = g_param_spec_object("menu", "Menu",
-	                                        "The dropdown menu",
-	                                        GTK_TYPE_MENU,
-	                                        (GParamFlags)(G_PARAM_READWRITE|G_PARAM_STATIC_NAME|G_PARAM_STATIC_NICK|G_PARAM_STATIC_BLURB));
+	GParamSpec* pspec = g_param_spec_object("menu", "Menu", "The dropdown menu", GTK_TYPE_MENU,
+	                                        static_cast<GParamFlags>(G_PARAM_READWRITE | G_PARAM_STATIC_NAME |
+	                                                                 G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB));
 	g_object_class_install_property(object_class, PROP_MENU, pspec);
 
 	g_type_class_add_private(object_class, sizeof(GtkMenuToolToggleButtonPrivate));
@@ -314,7 +313,7 @@ static void popup_menu_under_arrow(GtkMenuToolToggleButton* button,
 		return;
 	}
 
-	gtk_menu_popup(priv->menu, nullptr, nullptr, (GtkMenuPositionFunc) menu_position_func, button,
+	gtk_menu_popup(priv->menu, nullptr, nullptr, reinterpret_cast<GtkMenuPositionFunc>(menu_position_func), button,
 	               event ? event->button : 0, event ? event->time : gtk_get_current_event_time());
 }
 

--- a/src/gui/widgets/gtkmenutooltogglebutton.cpp
+++ b/src/gui/widgets/gtkmenutooltogglebutton.cpp
@@ -63,7 +63,7 @@ static void gtk_menu_tool_toggle_button_construct_contents(
 
 	GtkOrientation orientation = gtk_tool_item_get_orientation(GTK_TOOL_ITEM (button));
 
-	GtkWidget* box;
+	GtkWidget* box = nullptr;
 	if (orientation == GTK_ORIENTATION_HORIZONTAL)
 	{
 		box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
@@ -93,7 +93,7 @@ static void gtk_menu_tool_toggle_button_construct_contents(
 
 	if (priv->box)
 	{
-		gchar* tmp;
+		gchar* tmp = nullptr;
 
 		/* Transfer a possible tooltip to the new box */
 		g_object_get(priv->box, "tooltip-markup", &tmp, nullptr);
@@ -498,7 +498,7 @@ static void menu_detacher(GtkWidget* widget, GtkMenu* menu)
 void gtk_menu_tool_toggle_button_set_menu(GtkMenuToolToggleButton* button,
                                           GtkWidget* menu)
 {
-	GtkMenuToolToggleButtonPrivate* priv;
+	GtkMenuToolToggleButtonPrivate* priv = nullptr;
 
 	g_return_if_fail (GTK_IS_MENU_TOOL_TOGGLE_BUTTON (button));
 	g_return_if_fail(GTK_IS_MENU(menu) || menu == nullptr);

--- a/src/model/BackgroundImage.cpp
+++ b/src/model/BackgroundImage.cpp
@@ -62,12 +62,12 @@ void BackgroundImage::free()
 
 void BackgroundImage::loadFile(const string& filename, GError** error)
 {
-	this->img = std::make_shared<Content>(std::move(filename), error);
+	this->img = std::make_shared<Content>(filename, error);
 }
 
 void BackgroundImage::loadFile(GInputStream* stream, const string& filename, GError** error)
 {
-	this->img = std::make_shared<Content>(stream, std::move(filename), error);
+	this->img = std::make_shared<Content>(stream, filename, error);
 }
 
 auto BackgroundImage::getCloneId() -> int

--- a/src/model/Document.cpp
+++ b/src/model/Document.cpp
@@ -142,14 +142,13 @@ auto Document::createSaveFolder(Path lastSavePath) -> Path
 	{
 		return filename.getParentPath();
 	}
-	else if (!pdfFilename.isEmpty())
+	if (!pdfFilename.isEmpty())
 	{
 		return pdfFilename.getParentPath();
 	}
-	else
-	{
-		return lastSavePath;
-	}
+
+
+	    return lastSavePath;
 }
 
 auto Document::createSaveFilename(DocumentType type, const string& defaultSaveName) -> Path
@@ -161,15 +160,15 @@ auto Document::createSaveFilename(DocumentType type, const string& defaultSaveNa
 		p.clearExtensions();
 		return p;
 	}
-	else if (!pdfFilename.isEmpty())
+	if (!pdfFilename.isEmpty())
 	{
 		Path p = pdfFilename.getFilename();
 		p.clearExtensions();
 		return p;
 	}
-	else
-	{
-		time_t curtime = time(nullptr);
+
+
+	    time_t curtime = time(nullptr);
 		char stime[128];
 		strftime(stime, sizeof(stime), defaultSaveName.c_str(), localtime(&curtime));
 
@@ -177,7 +176,6 @@ auto Document::createSaveFilename(DocumentType type, const string& defaultSaveNa
 		Path p = stime;
 		p.clearExtensions();
 		return p;
-	}
 }
 
 
@@ -220,7 +218,7 @@ auto Document::isPdfDocumentLoaded() -> bool
 	return pdfDocument.isLoaded();
 }
 
-auto Document::isAttachPdf() -> bool
+auto Document::isAttachPdf() const -> bool
 {
 	return this->attachPdf;
 }
@@ -513,7 +511,7 @@ void Document::setCreateBackupOnSave(bool backup)
 	this->createBackupOnSave = backup;
 }
 
-auto Document::shouldCreateBackupOnSave() -> bool
+auto Document::shouldCreateBackupOnSave() const -> bool
 {
 	return this->createBackupOnSave;
 }

--- a/src/model/Document.cpp
+++ b/src/model/Document.cpp
@@ -148,7 +148,7 @@ auto Document::createSaveFolder(Path lastSavePath) -> Path
 	}
 
 
-	    return lastSavePath;
+	return lastSavePath;
 }
 
 auto Document::createSaveFilename(DocumentType type, const string& defaultSaveName) -> Path
@@ -168,14 +168,14 @@ auto Document::createSaveFilename(DocumentType type, const string& defaultSaveNa
 	}
 
 
-	    time_t curtime = time(nullptr);
-		char stime[128];
-		strftime(stime, sizeof(stime), defaultSaveName.c_str(), localtime(&curtime));
+	time_t curtime = time(nullptr);
+	char stime[128];
+	strftime(stime, sizeof(stime), defaultSaveName.c_str(), localtime(&curtime));
 
-		// Remove the extension, file format is handled by the filter combo box
-		Path p = stime;
-		p.clearExtensions();
-		return p;
+	// Remove the extension, file format is handled by the filter combo box
+	Path p = stime;
+	p.clearExtensions();
+	return p;
 }
 
 

--- a/src/model/Document.cpp
+++ b/src/model/Document.cpp
@@ -28,7 +28,8 @@ void Document::freeTreeContentModel()
 {
 	if (this->contentsModel)
 	{
-		gtk_tree_model_foreach(this->contentsModel, (GtkTreeModelForeachFunc) freeTreeContentEntry, this);
+		gtk_tree_model_foreach(this->contentsModel, reinterpret_cast<GtkTreeModelForeachFunc>(freeTreeContentEntry),
+		                       this);
 
 		g_object_unref(this->contentsModel);
 		this->contentsModel = nullptr;
@@ -291,7 +292,8 @@ void Document::buildContentsModel()
 		return;
 	}
 
-	this->contentsModel = (GtkTreeModel*) gtk_tree_store_new(4, G_TYPE_STRING, G_TYPE_OBJECT, G_TYPE_BOOLEAN, G_TYPE_STRING);
+	this->contentsModel = reinterpret_cast<GtkTreeModel*>(
+	        gtk_tree_store_new(4, G_TYPE_STRING, G_TYPE_OBJECT, G_TYPE_BOOLEAN, G_TYPE_STRING));
 	buildTreeContentsModel(nullptr, iter);
 	delete iter;
 }
@@ -329,7 +331,7 @@ void Document::updateIndexPageNumbers()
 {
 	if (this->contentsModel != nullptr)
 	{
-		gtk_tree_model_foreach(this->contentsModel, (GtkTreeModelForeachFunc) fillPageLabels, this);
+		gtk_tree_model_foreach(this->contentsModel, reinterpret_cast<GtkTreeModelForeachFunc>(fillPageLabels), this);
 	}
 }
 

--- a/src/model/Document.h
+++ b/src/model/Document.h
@@ -51,9 +51,9 @@ public:
 	PageRef getPage(size_t page);
 	void deletePage(size_t pNr);
 
-	void setPageSize(PageRef p, double width, double height);
-	double getPageWidth(PageRef p);
-	double getPageHeight(PageRef p);
+	static void setPageSize(PageRef p, double width, double height);
+	static double getPageWidth(PageRef p);
+	static double getPageHeight(PageRef p);
 
 	size_t indexOf(const PageRef& page);
 
@@ -78,11 +78,11 @@ public:
 	GtkTreeModel* getContentsModel();
 
 	void setCreateBackupOnSave(bool backup);
-	bool shouldCreateBackupOnSave();
+	bool shouldCreateBackupOnSave() const;
 
 	void clearDocument(bool destroy = false);
 
-	bool isAttachPdf();
+	bool isAttachPdf() const;
 
 	cairo_surface_t* getPreview();
 	void setPreview(cairo_surface_t* preview);
@@ -98,7 +98,7 @@ private:
 
 	void buildTreeContentsModel(GtkTreeIter* parent, XojPdfBookmarkIterator* iter);
 	void updateIndexPageNumbers();
-	static bool fillPageLabels(GtkTreeModel* tree_model, GtkTreePath* path, GtkTreeIter* iter, Document* doc);
+	static bool fillPageLabels(GtkTreeModel* treeModel, GtkTreePath* path, GtkTreeIter* iter, Document* doc);
 
 private:
 	DocumentHandler* handler = nullptr;

--- a/src/model/Document.h
+++ b/src/model/Document.h
@@ -139,5 +139,5 @@ private:
 	/**
 	 * The lock of the document
 	 */
-	GMutex documentLock;
+	GMutex documentLock{};
 };

--- a/src/model/Element.cpp
+++ b/src/model/Element.cpp
@@ -3,7 +3,7 @@
 #include <serializing/ObjectInputStream.h>
 #include <serializing/ObjectOutputStream.h>
 
-#include "math.h"
+#include <cmath>
 
 Element::Element(ElementType type)
  : type(type)
@@ -140,7 +140,7 @@ auto Element::rescaleOnlyAspectRatio() -> bool
 	return false;
 }
 
-void Element::serializeElement(ObjectOutputStream& out)
+void Element::serializeElement(ObjectOutputStream& out) const
 {
 	out.writeObject("Element");
 

--- a/src/model/Element.cpp
+++ b/src/model/Element.cpp
@@ -3,6 +3,8 @@
 #include <serializing/ObjectInputStream.h>
 #include <serializing/ObjectOutputStream.h>
 
+#include "math.h"
+
 Element::Element(ElementType type)
  : type(type)
 {
@@ -100,8 +102,8 @@ auto Element::intersectsArea(const GdkRectangle* src) -> bool
 
 auto Element::intersectsArea(double x, double y, double width, double height) -> bool
 {
-	double dest_x, dest_y;
-	double dest_w, dest_h;
+	double dest_x = NAN, dest_y = NAN;
+	double dest_w = NAN, dest_h = NAN;
 
 	dest_x = std::max(getX(), x);
 	dest_y = std::max(getY(), y);

--- a/src/model/Element.h
+++ b/src/model/Element.h
@@ -77,7 +77,7 @@ private:
 protected:
 	virtual void calcSize() = 0;
 
-	void serializeElement(ObjectOutputStream& out);
+	void serializeElement(ObjectOutputStream& out) const;
 	void readSerializedElement(ObjectInputStream& in);
 
 protected:

--- a/src/model/Font.cpp
+++ b/src/model/Font.cpp
@@ -19,7 +19,7 @@ void XojFont::setName(string name)
 	this->name = std::move(name);
 }
 
-auto XojFont::getSize() -> double
+auto XojFont::getSize() const -> double
 {
 	return size;
 }

--- a/src/model/Font.h
+++ b/src/model/Font.h
@@ -26,7 +26,7 @@ public:
 	string getName();
 	void setName(string name);
 
-	double getSize();
+	double getSize() const;
 	void setSize(double size);
 
 	void operator=(const XojFont& font);

--- a/src/model/Image.cpp
+++ b/src/model/Image.cpp
@@ -93,7 +93,8 @@ auto Image::getImage() -> cairo_surface_t*
 	if (this->image == nullptr && this->data.length())
 	{
 		this->read = 0;
-		this->image = cairo_image_surface_create_from_png_stream((cairo_read_func_t) &cairoReadFunction, this);
+		this->image = cairo_image_surface_create_from_png_stream(
+		        reinterpret_cast<cairo_read_func_t>(&cairoReadFunction), this);
 	}
 
 	return this->image;

--- a/src/model/Layer.cpp
+++ b/src/model/Layer.cpp
@@ -73,7 +73,7 @@ void Layer::insertElement(Element* e, int pos)
 	}
 
 	// If the element should be inserted at the top
-	if (pos >= (int)this->elements.size())
+	if (pos >= static_cast<int>(this->elements.size()))
 	{
 		this->elements.push_back(e);
 	}

--- a/src/model/Layer.cpp
+++ b/src/model/Layer.cpp
@@ -125,7 +125,7 @@ auto Layer::isAnnotated() -> bool
 /**
  * @return true if the layer is visible
  */
-auto Layer::isVisible() -> bool
+auto Layer::isVisible() const -> bool
 {
 	return visible;
 }

--- a/src/model/Layer.h
+++ b/src/model/Layer.h
@@ -58,7 +58,7 @@ public:
 	/**
 	 * @return true if the layer is visible
 	 */
-	bool isVisible();
+	bool isVisible() const;
 
 	/**
 	 * @param visible true if the layer is visible

--- a/src/model/LineStyle.cpp
+++ b/src/model/LineStyle.cpp
@@ -20,7 +20,10 @@ LineStyle::~LineStyle()
 
 void LineStyle::operator=(const LineStyle& other)
 {
-	if (this == &other) return;
+	if (this == &other)
+	{
+		return;
+	}
 	const double* dashes = nullptr;
 	int dashCount = 0;
 

--- a/src/model/LineStyle.cpp
+++ b/src/model/LineStyle.cpp
@@ -45,7 +45,7 @@ void LineStyle::readSerialized(ObjectInputStream& in)
 	g_free(this->dashes);
 	this->dashes = nullptr;
 	this->dashCount = 0;
-	in.readData((void**) &this->dashes, &this->dashCount);
+	in.readData(reinterpret_cast<void**>(&this->dashes), &this->dashCount);
 
 	in.endObject();
 }
@@ -80,7 +80,7 @@ void LineStyle::setDashes(const double* dashes, int dashCount)
 		return;
 	}
 
-	this->dashes = (double*)g_malloc(dashCount * sizeof(double));
+	this->dashes = static_cast<double*>(g_malloc(dashCount * sizeof(double)));
 	this->dashCount = dashCount;
 
 	memcpy(this->dashes, dashes, this->dashCount * sizeof(double));

--- a/src/model/LinkDestination.cpp
+++ b/src/model/LinkDestination.cpp
@@ -33,7 +33,7 @@ static void link_dest_dispose(GObject* object)
 
 static void link_dest_class_init(XojLinkDestClass* linkClass)
 {
-	GObjectClass* g_object_class;
+	GObjectClass* g_object_class = nullptr;
 
 	parent_class = g_type_class_peek_parent(linkClass);
 

--- a/src/model/LinkDestination.cpp
+++ b/src/model/LinkDestination.cpp
@@ -62,7 +62,7 @@ LinkDestination::LinkDestination()
 
 LinkDestination::~LinkDestination() = default;
 
-auto LinkDestination::getPdfPage() -> size_t
+auto LinkDestination::getPdfPage() const -> size_t
 {
 	return this->page;
 }
@@ -77,37 +77,37 @@ void LinkDestination::setExpand(bool expand)
 	this->expand = expand;
 }
 
-auto LinkDestination::getExpand() -> bool
+auto LinkDestination::getExpand() const -> bool
 {
 	return this->expand;
 }
 
-auto LinkDestination::shouldChangeLeft() -> bool
+auto LinkDestination::shouldChangeLeft() const -> bool
 {
 	return changeLeft;
 }
 
-auto LinkDestination::shouldChangeZoom() -> bool
+auto LinkDestination::shouldChangeZoom() const -> bool
 {
 	return changeZoom;
 }
 
-auto LinkDestination::shouldChangeTop() -> bool
+auto LinkDestination::shouldChangeTop() const -> bool
 {
 	return changeTop;
 }
 
-auto LinkDestination::getZoom() -> double
+auto LinkDestination::getZoom() const -> double
 {
 	return zoom;
 }
 
-auto LinkDestination::getLeft() -> double
+auto LinkDestination::getLeft() const -> double
 {
 	return left;
 }
 
-auto LinkDestination::getTop() -> double
+auto LinkDestination::getTop() const -> double
 {
 	return top;
 }

--- a/src/model/LinkDestination.h
+++ b/src/model/LinkDestination.h
@@ -25,19 +25,19 @@ public:
 	virtual ~LinkDestination();
 
 public:
-	size_t getPdfPage();
+	size_t getPdfPage() const;
 	void setPdfPage(size_t page);
 
 	void setExpand(bool expand);
-	bool getExpand();
+	bool getExpand() const;
 
-	bool shouldChangeLeft();
-	bool shouldChangeZoom();
-	bool shouldChangeTop();
+	bool shouldChangeLeft() const;
+	bool shouldChangeZoom() const;
+	bool shouldChangeTop() const;
 
-	double getZoom();
-	double getLeft();
-	double getTop();
+	double getZoom() const;
+	double getLeft() const;
+	double getTop() const;
 
 	void setChangeLeft(double left);
 	void setChangeZoom(double zoom);

--- a/src/model/PageRef.cpp
+++ b/src/model/PageRef.cpp
@@ -78,7 +78,7 @@ auto PageRef::clone() -> PageRef
 	}
 
 
-	    return PageRef(this->page->clone());
+	return PageRef(this->page->clone());
 }
 
 auto PageRef::isValid() -> bool

--- a/src/model/PageRef.cpp
+++ b/src/model/PageRef.cpp
@@ -76,10 +76,9 @@ auto PageRef::clone() -> PageRef
 	{
 		return PageRef(nullptr);
 	}
-	else
-	{
-		return PageRef(this->page->clone());
-	}
+
+
+	    return PageRef(this->page->clone());
 }
 
 auto PageRef::isValid() -> bool

--- a/src/model/PageType.cpp
+++ b/src/model/PageType.cpp
@@ -29,7 +29,7 @@ auto PageType::operator==(const PageType& other) const -> bool
 /**
  * PDF background
  */
-auto PageType::isPdfPage() -> bool
+auto PageType::isPdfPage() const -> bool
 {
 	return this->format == PageTypeFormat::Pdf;
 }
@@ -37,7 +37,7 @@ auto PageType::isPdfPage() -> bool
 /**
  * Image Background
  */
-auto PageType::isImagePage() -> bool
+auto PageType::isImagePage() const -> bool
 {
 	return this->format == PageTypeFormat::Image;
 }
@@ -45,7 +45,7 @@ auto PageType::isImagePage() -> bool
 /**
  * Special background
  */
-auto PageType::isSpecial() -> bool
+auto PageType::isSpecial() const -> bool
 {
 	return this->format == PageTypeFormat::Pdf || this->format == PageTypeFormat::Image ||
 	       this->format == PageTypeFormat::Copy;

--- a/src/model/PageType.h
+++ b/src/model/PageType.h
@@ -44,17 +44,17 @@ public:
 	/**
 	 * PDF background
 	 */
-	bool isPdfPage();
+	bool isPdfPage() const;
 
 	/**
 	 * Image Background
 	 */
-	bool isImagePage();
+	bool isImagePage() const;
 
 	/**
 	 * Special background
 	 */
-	bool isSpecial();
+	bool isSpecial() const;
 
 public:
 	/**

--- a/src/model/Point.cpp
+++ b/src/model/Point.cpp
@@ -20,12 +20,12 @@ auto Point::lineLengthTo(const Point& p) const -> double
 	return std::hypot(this->x - p.x, this->y - p.y);
 }
 
-auto Point::slopeTo(const Point& p) -> double
+auto Point::slopeTo(const Point& p) const -> double
 {
 	return std::atan2(this->x - p.x, this->y - p.y);
 }
 
-auto Point::lineTo(const Point& p, double length) -> Point
+auto Point::lineTo(const Point& p, double length) const -> Point
 {
 	double factor = lineLengthTo(p);
 	factor = length / factor;
@@ -40,7 +40,7 @@ auto Point::lineTo(const Point& p, double length) -> Point
 	return Point(x, y);
 }
 
-auto Point::equalsPos(const Point& p) -> bool
+auto Point::equalsPos(const Point& p) const -> bool
 {
 	return this->x == p.x && this->y == p.y;
 }

--- a/src/model/Point.h
+++ b/src/model/Point.h
@@ -54,7 +54,7 @@ public:
 	 * @brief The slope to another point.
 	 * @param p The other point.
 	 */
-	double slopeTo(const Point& p);
+	double slopeTo(const Point& p) const;
 
 	/**
 	 * @brief Compute new Point in the direction from this to another Point.
@@ -62,14 +62,14 @@ public:
 	 * @param length The line length or vector length.
 	 * @return The new Point.
 	 */
-	Point lineTo(const Point& p, double length);
+	Point lineTo(const Point& p, double length) const;
 
 	/**
 	 * @brief Compare if this Point has the same position as another Point.
 	 * @param p The other Point.
 	 * @return True if the coordinates are equal. False otherwise.
 	 */
-	bool equalsPos(const Point& p);
+	bool equalsPos(const Point& p) const;
 
 public:
 	/**

--- a/src/model/Stroke.cpp
+++ b/src/model/Stroke.cpp
@@ -452,7 +452,10 @@ void Stroke::calcSize()
 
 	for (auto&& p: points)
 	{
-		if (hasPressure) halfThick = p.z / 2.0;
+		if (hasPressure)
+		{
+			halfThick = p.z / 2.0;
+		}
 
 		minX = std::min(minX, p.x - halfThick);
 		minY = std::min(minY, p.y - halfThick);

--- a/src/model/Stroke.cpp
+++ b/src/model/Stroke.cpp
@@ -69,13 +69,13 @@ void Stroke::readSerialized(ObjectInputStream& in)
 
 	this->width = in.readDouble();
 
-	this->toolType = (StrokeTool) in.readInt();
+	this->toolType = static_cast<StrokeTool>(in.readInt());
 
 	this->fill = in.readInt();
 
 	Point* p{};
 	int count{};
-	in.readData((void**) &p, &count);
+	in.readData(reinterpret_cast<void**>(&p), &count);
 	this->points = std::vector<Point>{p, p + count};
 	g_free(p);
 	this->lineStyle.readSerialized(in);

--- a/src/model/Stroke.h
+++ b/src/model/Stroke.h
@@ -83,8 +83,8 @@ public:
 	const LineStyle& getLineStyle() const;
 	void setLineStyle(const LineStyle& style);
 
-	bool intersects(double x, double y, double halfSize) override;
-	bool intersects(double x, double y, double halfSize, double* gap) override;
+	bool intersects(double x, double y, double halfEraserSize) override;
+	bool intersects(double x, double y, double halfEraserSize, double* gap) override;
 
 	void setPressure(const vector<double>& pressure);
 	void setLastPressure(double pressure);

--- a/src/model/StrokeStyle.cpp
+++ b/src/model/StrokeStyle.cpp
@@ -10,12 +10,12 @@ const double dashLinePattern[] = { 6, 3 };
 const double dashDotLinePattern[] = { 6, 3, 0.5, 3 };
 const double dotLinePattern[] = { 0.5, 3 };
 
-#define PARSE_STYLE(name, def) \
-	if (strcmp(style, name) == 0) \
-	{ \
-		LineStyle style; \
-		style.setDashes(def, sizeof(def) / sizeof(def[0])); \
-		return style; \
+#define PARSE_STYLE(name, def)                                \
+	if (strcmp(style, name) == 0)                             \
+	{                                                         \
+		LineStyle style;                                      \
+		style.setDashes(def, sizeof(def) / sizeof((def)[0])); \
+		return style;                                         \
 	}
 
 auto StrokeStyle::parseStyle(const char* style) -> LineStyle
@@ -45,7 +45,7 @@ auto StrokeStyle::parseStyle(const char* style) -> LineStyle
 		dash.push_back(val);
 	}
 
-	if (dash.size() == 0)
+	if (dash.empty())
 	{
 		return LineStyle();
 	}
@@ -63,10 +63,10 @@ auto StrokeStyle::parseStyle(const char* style) -> LineStyle
 	return ls;
 }
 
-#define FORMAT_STYLE(name, def) \
-	if (count == (sizeof(def) / sizeof(def[0])) && memcmp(dashes, def, count * sizeof(def[0])) == 0) \
-	{ \
-		return name; \
+#define FORMAT_STYLE(name, def)                                                                          \
+	if (count == (sizeof(def) / sizeof((def)[0])) && memcmp(dashes, def, count * sizeof((def)[0])) == 0) \
+	{                                                                                                    \
+		return name;                                                                                     \
 	}
 
 auto StrokeStyle::formatStyle(const double* dashes, int count) -> string

--- a/src/model/StrokeStyle.cpp
+++ b/src/model/StrokeStyle.cpp
@@ -51,13 +51,13 @@ auto StrokeStyle::parseStyle(const char* style) -> LineStyle
 	}
 
 	auto* dashesArr = new double[dash.size()];
-	for (int i = 0; i < (int)dash.size(); i++)
+	for (int i = 0; i < static_cast<int>(dash.size()); i++)
 	{
 		dashesArr[i] = dash[i];
 	}
 
 	LineStyle ls;
-	ls.setDashes(dashesArr, (int)dash.size());
+	ls.setDashes(dashesArr, static_cast<int>(dash.size()));
 	delete[] dashesArr;
 
 	return ls;

--- a/src/model/TexImage.cpp
+++ b/src/model/TexImage.cpp
@@ -141,12 +141,13 @@ void TexImage::loadBinaryData()
 	if (type[1] == 'P' && type[2] == 'N' && type[3] == 'G')
 	{
 		this->read = 0;
-		this->image = cairo_image_surface_create_from_png_stream((cairo_read_func_t) &cairoReadFunction, this);
+		this->image = cairo_image_surface_create_from_png_stream(
+		        reinterpret_cast<cairo_read_func_t>(&cairoReadFunction), this);
 	}
 	else if (type[1] == 'P' && type[2] == 'D' && type[3] == 'F')
 	{
-		this->pdf = poppler_document_new_from_data((char*) this->binaryData.c_str(), this->binaryData.length(), nullptr,
-		                                           nullptr);
+		this->pdf = poppler_document_new_from_data(const_cast<char*>(this->binaryData.c_str()),
+		                                           this->binaryData.length(), nullptr, nullptr);
 	}
 	else
 	{
@@ -239,7 +240,7 @@ void TexImage::readSerialized(ObjectInputStream& in)
 
 	char* data = nullptr;
 	int len = 0;
-	in.readData((void**)&data, &len);
+	in.readData(reinterpret_cast<void**>(&data), &len);
 
 	this->binaryData = string(data, len);
 

--- a/src/model/TexImage.cpp
+++ b/src/model/TexImage.cpp
@@ -115,7 +115,7 @@ auto TexImage::getText() -> string
 
 auto TexImage::getImage() -> cairo_surface_t*
 {
-	if (this->image == nullptr && this->parsedBinaryData == false)
+	if (this->image == nullptr && !this->parsedBinaryData)
 	{
 		loadBinaryData();
 	}
@@ -164,7 +164,7 @@ void TexImage::loadBinaryData()
  */
 auto TexImage::getPdf() -> PopplerDocument*
 {
-	if (this->pdf == nullptr && this->parsedBinaryData == false)
+	if (this->pdf == nullptr && !this->parsedBinaryData)
 	{
 		loadBinaryData();
 	}

--- a/src/model/Text.cpp
+++ b/src/model/Text.cpp
@@ -98,7 +98,7 @@ void Text::rotate(double x0, double y0, double xo, double yo, double th)
 {
 }
 
-auto Text::isInEditing() -> bool
+auto Text::isInEditing() const -> bool
 {
 	return this->inEditing;
 }

--- a/src/model/Text.h
+++ b/src/model/Text.h
@@ -34,7 +34,7 @@ public:
 	void setHeight(double height);
 
 	void setInEditing(bool inEditing);
-	bool isInEditing();
+	bool isInEditing() const;
 
 	void scale(double x0, double y0, double fx, double fy) override;
 	void rotate(double x0, double y0, double xo, double yo, double th) override;
@@ -46,8 +46,8 @@ public:
 	 */
 	Element* clone() override;
 
-	bool intersects(double x, double y, double halfSize) override;
-	bool intersects(double x, double y, double halfSize, double* gap) override;
+	bool intersects(double x, double y, double halfEraserSize) override;
+	bool intersects(double x, double y, double halfEraserSize, double* gap) override;
 
 public:
 	// Serialize interface

--- a/src/model/XojPage.cpp
+++ b/src/model/XojPage.cpp
@@ -173,7 +173,7 @@ void XojPage::setBackgroundColor(int color)
 	this->backgroundColor = color;
 }
 
-auto XojPage::getBackgroundColor() -> int
+auto XojPage::getBackgroundColor() const -> int
 {
 	return this->backgroundColor;
 }
@@ -194,7 +194,7 @@ auto XojPage::getHeight() const -> double
 	return this->height;
 }
 
-auto XojPage::getPdfPageNr() -> size_t
+auto XojPage::getPdfPageNr() const -> size_t
 {
 	return this->pdfBackgroundPage;
 }
@@ -211,7 +211,7 @@ auto XojPage::isAnnotated() -> bool
 	return false;
 }
 
-void XojPage::setBackgroundType(PageType bgType)
+void XojPage::setBackgroundType(const PageType& bgType)
 {
 	this->bgType = bgType;
 

--- a/src/model/XojPage.cpp
+++ b/src/model/XojPage.cpp
@@ -62,7 +62,7 @@ void XojPage::addLayer(Layer* layer)
 
 void XojPage::insertLayer(Layer* layer, int index)
 {
-	if (index >= (int)this->layer.size())
+	if (index >= static_cast<int>(this->layer.size()))
 	{
 		addLayer(layer);
 		return;
@@ -127,7 +127,7 @@ void XojPage::setLayerVisible(int layerId, bool visible)
 	}
 
 	layerId--;
-	if (layerId >= (int)this->layer.size())
+	if (layerId >= static_cast<int>(this->layer.size()))
 	{
 		return;
 	}
@@ -148,7 +148,7 @@ auto XojPage::isLayerVisible(int layerId) -> bool
 	}
 
 	layerId--;
-	if (layerId >= (int)this->layer.size())
+	if (layerId >= static_cast<int>(this->layer.size()))
 	{
 		return false;
 	}

--- a/src/model/XojPage.h
+++ b/src/model/XojPage.h
@@ -44,7 +44,7 @@ public:
 	// Also set the size over doc->setPageSize!
 	void setBackgroundPdfPageNr(size_t page);
 
-	void setBackgroundType(PageType bgType);
+	void setBackgroundType(const PageType& bgType);
 	PageType getBackgroundType();
 
 	/**
@@ -55,18 +55,18 @@ public:
 	double getWidth() const;
 	double getHeight() const;
 
-	size_t getPdfPageNr();
+	size_t getPdfPageNr() const;
 
 	bool isAnnotated();
 
 	void setBackgroundColor(int color);
-	int getBackgroundColor();
+	int getBackgroundColor() const;
 
 	vector<Layer*>* getLayers();
 	size_t getLayerCount();
 	int getSelectedLayerId();
 	void setSelectedLayerId(int id);
-	bool isLayerVisible(Layer* layer);
+	static bool isLayerVisible(Layer* layer);
 	bool isLayerVisible(int layerId);
 
 	Layer* getSelectedLayer();

--- a/src/model/eraser/EraseableStroke.cpp
+++ b/src/model/eraser/EraseableStroke.cpp
@@ -40,7 +40,7 @@ void EraseableStroke::draw(cairo_t* cr)
 
 	for (GList* l = tmpCopy->data; l != nullptr; l = l->next)
 	{
-		auto* part = (EraseableStrokePart*) l->data;
+		auto* part = static_cast<EraseableStrokePart*>(l->data);
 		if (part->getWidth() == Point::NO_PRESSURE)
 		{
 			cairo_set_line_width(cr, w);
@@ -51,13 +51,13 @@ void EraseableStroke::draw(cairo_t* cr)
 		}
 
 		GList* pl = part->getPoints();
-		auto* p = (Point*) pl->data;
+		auto* p = static_cast<Point*>(pl->data);
 		cairo_move_to(cr, p->x, p->y);
 
 		pl = pl->next;
 		for (; pl != nullptr; pl = pl->next)
 		{
-			auto* p = (Point*) pl->data;
+			auto* p = static_cast<Point*>(pl->data);
 			cairo_line_to(cr, p->x, p->y);
 		}
 		cairo_stroke(cr);
@@ -83,7 +83,7 @@ auto EraseableStroke::erase(double x, double y, double halfEraserSize, Range* ra
 
 	for (GList* l = tmpCopy->data; l != nullptr;)
 	{
-		auto* p = (EraseableStrokePart*) l->data;
+		auto* p = static_cast<EraseableStrokePart*>(l->data);
 		l = l->next;
 		erase(x, y, halfEraserSize, p, tmpCopy);
 	}
@@ -121,8 +121,8 @@ void EraseableStroke::erase(double x, double y, double halfEraserSize, Eraseable
 
 	Point eraser(x, y);
 
-	auto* a = (Point*) g_list_first(part->points)->data;
-	auto* b = (Point*) g_list_last(part->points)->data;
+	auto* a = static_cast<Point*>(g_list_first(part->points)->data);
+	auto* b = static_cast<Point*>(g_list_last(part->points)->data);
 
 	if (eraser.lineLengthTo(*a) < halfEraserSize * 1.2 && eraser.lineLengthTo(*b) < halfEraserSize * 1.2)
 	{
@@ -239,7 +239,7 @@ auto EraseableStroke::erasePart(double x, double y, double halfEraserSize, Erase
 	 */
 	for (GList* l = part->getPoints(); l != nullptr;)
 	{
-		auto* p = (Point*) l->data;
+		auto* p = static_cast<Point*>(l->data);
 		l = l->next;
 		if (p->x >= x1 && p->y >= y1 && p->x <= x2 && p->y <= y2)
 		{
@@ -259,7 +259,7 @@ auto EraseableStroke::erasePart(double x, double y, double halfEraserSize, Erase
 	 */
 	for (GList* l = g_list_last(part->getPoints()); l != nullptr;)
 	{
-		auto* p = (Point*) l->data;
+		auto* p = static_cast<Point*>(l->data);
 		l = l->prev;
 		if (p->x >= x1 && p->y >= y1 && p->x <= x2 && p->y <= y2)
 		{
@@ -283,7 +283,7 @@ auto EraseableStroke::erasePart(double x, double y, double halfEraserSize, Erase
 
 	for (GList* l = part->points; l != nullptr;)
 	{
-		auto* p = (Point*) l->data;
+		auto* p = static_cast<Point*>(l->data);
 		l = l->next;
 		if (p->x >= x1 && p->y >= y1 && p->x <= x2 && p->y <= y2)
 		{
@@ -312,7 +312,7 @@ auto EraseableStroke::erasePart(double x, double y, double halfEraserSize, Erase
 	part->points = nullptr;
 	if (lists)
 	{
-		part->points = (GList*) lists->data;
+		part->points = static_cast<GList*>(lists->data);
 		lists = g_list_delete_link(lists, lists);
 
 		int pos = g_list_index(list->data, part) + 1;
@@ -321,7 +321,7 @@ auto EraseableStroke::erasePart(double x, double y, double halfEraserSize, Erase
 		for (GList* l = lists; l != nullptr; l = l->next)
 		{
 			auto* newPart = new EraseableStrokePart(part->width);
-			newPart->points = (GList*) l->data;
+			newPart->points = static_cast<GList*>(l->data);
 			list->data = g_list_insert(list->data, newPart, pos++);
 		}
 
@@ -345,15 +345,15 @@ auto EraseableStroke::getStroke(Stroke* original) -> GList*
 	Point lastPoint(NAN, NAN);
 	for (GList* l = this->parts->data; l != nullptr; l = l->next)
 	{
-		auto* p = (EraseableStrokePart*) l->data;
+		auto* p = static_cast<EraseableStrokePart*>(l->data);
 		GList* points = p->getPoints();
 		if (g_list_length(points) < 2)
 		{
 			continue;
 		}
 
-		Point a = *((Point*) g_list_first(points)->data);
-		Point b = *((Point*) g_list_last(points)->data);
+		Point a = *(static_cast<Point*>(g_list_first(points)->data));
+		Point b = *(static_cast<Point*>(g_list_last(points)->data));
 		a.z = p->width;
 
 		if (!lastPoint.equalsPos(a) || s == nullptr)

--- a/src/model/eraser/EraseableStroke.h
+++ b/src/model/eraser/EraseableStroke.h
@@ -45,7 +45,7 @@ private:
 	void addRepaintRect(double x, double y, double width, double height);
 
 private:
-	GMutex partLock;
+	GMutex partLock{};
 	PartList* parts = nullptr;
 
 	Range* repaintRect = nullptr;

--- a/src/model/eraser/EraseableStroke.h
+++ b/src/model/eraser/EraseableStroke.h
@@ -39,8 +39,8 @@ public:
 
 private:
 	void erase(double x, double y, double halfEraserSize, EraseableStrokePart* part, PartList* list);
-	bool erasePart(double x, double y, double halfEraserSize, EraseableStrokePart* part,
-				   PartList* list, bool* deleteStrokeAfter);
+	static bool erasePart(double x, double y, double halfEraserSize, EraseableStrokePart* part, PartList* list,
+	                      bool* deleteStrokeAfter);
 
 	void addRepaintRect(double x, double y, double width, double height);
 

--- a/src/model/eraser/EraseableStrokePart.cpp
+++ b/src/model/eraser/EraseableStrokePart.cpp
@@ -77,22 +77,22 @@ auto EraseableStrokePart::clone() -> EraseableStrokePart*
 	return part;
 }
 
-auto EraseableStrokePart::getX() -> double
+auto EraseableStrokePart::getX() const -> double
 {
 	return this->x;
 }
 
-auto EraseableStrokePart::getY() -> double
+auto EraseableStrokePart::getY() const -> double
 {
 	return this->y;
 }
 
-auto EraseableStrokePart::getElementWidth() -> double
+auto EraseableStrokePart::getElementWidth() const -> double
 {
 	return this->elementWidth;
 }
 
-auto EraseableStrokePart::getElementHeight() -> double
+auto EraseableStrokePart::getElementHeight() const -> double
 {
 	return this->elementHeight;
 }
@@ -104,7 +104,7 @@ void EraseableStrokePart::addPoint(Point p)
 	this->points = g_list_append(this->points, new Point(p));
 }
 
-auto EraseableStrokePart::getWidth() -> double
+auto EraseableStrokePart::getWidth() const -> double
 {
 	return this->width;
 }

--- a/src/model/eraser/EraseableStrokePart.cpp
+++ b/src/model/eraser/EraseableStrokePart.cpp
@@ -24,7 +24,7 @@ EraseableStrokePart::~EraseableStrokePart()
 {
 	for (GList* l = this->points; l != nullptr; l = l->next)
 	{
-		auto* p = (Point*) l->data;
+		auto* p = static_cast<Point*>(l->data);
 		delete p;
 	}
 	g_list_free(this->points);
@@ -42,14 +42,14 @@ void EraseableStrokePart::calcSize()
 		return;
 	}
 
-	double x1 = ((Point*) g_list_first(this->points)->data)->x;
-	double y1 = ((Point*) g_list_first(this->points)->data)->y;
-	double x2 = ((Point*) g_list_first(this->points)->data)->x;
-	double y2 = ((Point*) g_list_first(this->points)->data)->y;
+	double x1 = (static_cast<Point*>(g_list_first(this->points)->data))->x;
+	double y1 = (static_cast<Point*>(g_list_first(this->points)->data))->y;
+	double x2 = (static_cast<Point*>(g_list_first(this->points)->data))->x;
+	double y2 = (static_cast<Point*>(g_list_first(this->points)->data))->y;
 
 	for (GList* l = this->points; l != nullptr; l = l->next)
 	{
-		auto* p = (Point*) l->data;
+		auto* p = static_cast<Point*>(l->data);
 		x1 = std::min(x1, p->x);
 		x2 = std::max(x2, p->x);
 		y1 = std::min(y1, p->y);
@@ -68,7 +68,7 @@ auto EraseableStrokePart::clone() -> EraseableStrokePart*
 
 	for (GList* l = this->points; l != nullptr; l = l->next)
 	{
-		auto* p = (Point*) l->data;
+		auto* p = static_cast<Point*>(l->data);
 		part->addPoint(*p);
 	}
 
@@ -118,7 +118,7 @@ void EraseableStrokePart::clearSplitData()
 {
 	for (GList* l = this->points->next; l->next != nullptr;)
 	{
-		auto* p = (Point*) l->data;
+		auto* p = static_cast<Point*>(l->data);
 		delete p;
 		GList* link = l;
 		l = l->next;
@@ -136,8 +136,8 @@ void EraseableStrokePart::splitFor(double halfEraserSize)
 
 	this->splitSize = halfEraserSize;
 
-	auto* a = (Point*) g_list_first(this->points)->data;
-	auto* b = (Point*) g_list_last(this->points)->data;
+	auto* a = static_cast<Point*>(g_list_first(this->points)->data);
+	auto* b = static_cast<Point*>(g_list_last(this->points)->data);
 
 	// nothing to do, the size is enough small
 	if (a->lineLengthTo(*b) <= halfEraserSize)

--- a/src/model/eraser/EraseableStrokePart.h
+++ b/src/model/eraser/EraseableStrokePart.h
@@ -26,7 +26,7 @@ private:
 
 public:
 	void addPoint(Point p);
-	double getWidth();
+	double getWidth() const;
 
 	GList* getPoints();
 
@@ -38,10 +38,10 @@ public:
 	void calcSize();
 
 public:
-	double getX();
-	double getY();
-	double getElementWidth();
-	double getElementHeight();
+	double getX() const;
+	double getY() const;
+	double getElementWidth() const;
+	double getElementHeight() const;
 
 	static void printDebugStrokeParts();
 

--- a/src/model/eraser/PartList.cpp
+++ b/src/model/eraser/PartList.cpp
@@ -8,7 +8,7 @@ PartList::~PartList()
 {
 	for (GList* l = this->data; l != nullptr; l = l->next)
 	{
-		auto* p = (EraseableStrokePart*) l->data;
+		auto* p = static_cast<EraseableStrokePart*>(l->data);
 		delete p;
 	}
 	g_list_free(this->data);
@@ -25,7 +25,7 @@ auto PartList::clone() -> PartList*
 	auto* list = new PartList();
 	for (GList* l = this->data; l != nullptr; l = l->next)
 	{
-		auto* p = (EraseableStrokePart*) l->data;
+		auto* p = static_cast<EraseableStrokePart*>(l->data);
 		list->data = g_list_append(list->data, p->clone());
 	}
 

--- a/src/pdf/base/XojCairoPdfExport.cpp
+++ b/src/pdf/base/XojCairoPdfExport.cpp
@@ -74,7 +74,7 @@ void XojCairoPdfExport::exportPage(size_t page)
 
 auto XojCairoPdfExport::createPdf(Path file, PageRangeVector& range) -> bool
 {
-	if (range.size() == 0)
+	if (range.empty())
 	{
 		this->lastError = _("No pages to export!");
 		return false;

--- a/src/pdf/base/XojCairoPdfExport.cpp
+++ b/src/pdf/base/XojCairoPdfExport.cpp
@@ -101,7 +101,7 @@ auto XojCairoPdfExport::createPdf(Path file, PageRangeVector& range) -> bool
 	{
 		for (int i = e->getFirst(); i <= e->getLast(); i++)
 		{
-			if (i < 0 || i > (int)doc->getPageCount())
+			if (i < 0 || i > static_cast<int>(doc->getPageCount()))
 			{
 				continue;
 			}

--- a/src/pdf/popplerapi/PopplerGlibAction.cpp
+++ b/src/pdf/popplerapi/PopplerGlibAction.cpp
@@ -28,7 +28,7 @@ auto PopplerGlibAction::getDestination() -> XojLinkDest*
 	// every other action is not supported in Xournal
 	if (action->type == POPPLER_ACTION_GOTO_DEST)
 	{
-		auto* actionDest = (PopplerActionGotoDest*) action;
+		auto* actionDest = reinterpret_cast<PopplerActionGotoDest*>(action);
 		PopplerDest* pDest = actionDest->dest;
 
 		if (pDest == nullptr)
@@ -129,5 +129,5 @@ void PopplerGlibAction::linkFromDest(LinkDestination* link, PopplerDest* pDest)
 
 auto PopplerGlibAction::getTitle() -> string
 {
-	return ((PopplerActionAny*)action)->title;
+	return (reinterpret_cast<PopplerActionAny*>(action))->title;
 }

--- a/src/pdf/popplerapi/PopplerGlibDocument.cpp
+++ b/src/pdf/popplerapi/PopplerGlibDocument.cpp
@@ -33,7 +33,7 @@ void PopplerGlibDocument::assign(XojPdfDocumentInterface* doc)
 		g_object_unref(document);
 	}
 
-	document = ((PopplerGlibDocument*)doc)->document;
+	document = (dynamic_cast<PopplerGlibDocument*>(doc))->document;
 	if (document)
 	{
 		g_object_ref(document);
@@ -42,7 +42,7 @@ void PopplerGlibDocument::assign(XojPdfDocumentInterface* doc)
 
 auto PopplerGlibDocument::equals(XojPdfDocumentInterface* doc) -> bool
 {
-	return document == ((PopplerGlibDocument*)doc)->document;
+	return document == (dynamic_cast<PopplerGlibDocument*>(doc))->document;
 }
 
 auto PopplerGlibDocument::save(Path filename, GError** error) -> bool

--- a/src/pdf/popplerapi/PopplerGlibPage.cpp
+++ b/src/pdf/popplerapi/PopplerGlibPage.cpp
@@ -85,7 +85,7 @@ auto PopplerGlibPage::findText(string& text) -> vector<XojPdfRectangle>
 
 	for (GList* l = matches; l && l->data; l = g_list_next(l))
 	{
-		auto* rect = (PopplerRectangle*) l->data;
+		auto* rect = static_cast<PopplerRectangle*>(l->data);
 
 		findings.emplace_back(rect->x1, height - rect->y1, rect->x2, height - rect->y2);
 

--- a/src/undo/AddUndoAction.cpp
+++ b/src/undo/AddUndoAction.cpp
@@ -20,7 +20,7 @@ AddUndoAction::~AddUndoAction()
 {
 	for (GList* l = this->elements; l != nullptr; l = l->next)
 	{
-		auto e = (PageLayerPosEntry<Element>*) l->data;
+		auto e = static_cast<PageLayerPosEntry<Element>*>(l->data);
 		if (!undone)
 		{
 			//The element will be deleted when the layer is removed.
@@ -34,8 +34,8 @@ AddUndoAction::~AddUndoAction()
 
 void AddUndoAction::addElement(Layer* layer, Element* e, int pos)
 {
-	this->elements = g_list_insert_sorted(this->elements, new PageLayerPosEntry<Element> (layer, e, pos),
-										  (GCompareFunc) PageLayerPosEntry<Element>::cmp);
+	this->elements = g_list_insert_sorted(this->elements, new PageLayerPosEntry<Element>(layer, e, pos),
+	                                      reinterpret_cast<GCompareFunc>(PageLayerPosEntry<Element>::cmp));
 }
 
 auto AddUndoAction::redo(Control*) -> bool
@@ -50,7 +50,7 @@ auto AddUndoAction::redo(Control*) -> bool
 
 	for (GList* l = this->elements; l != nullptr; l = l->next)
 	{
-		auto e = (PageLayerPosEntry<Element>*) l->data;
+		auto e = static_cast<PageLayerPosEntry<Element>*>(l->data);
 		e->layer->insertElement(e->element, e->pos);
 		this->page->fireElementChanged(e->element);
 	}
@@ -71,7 +71,7 @@ auto AddUndoAction::undo(Control*) -> bool
 
 	for (GList* l = this->elements; l != nullptr; l = l->next)
 	{
-		auto e = (PageLayerPosEntry<Element>*) l->data;
+		auto e = static_cast<PageLayerPosEntry<Element>*>(l->data);
 		e->layer->removeElement(e->element, false);
 		this->page->fireElementChanged(e->element);
 	}
@@ -95,11 +95,11 @@ auto AddUndoAction::getText() -> string
 
 		if (this->elements != nullptr)
 		{
-			ElementType type = ((PageLayerPosEntry<Element>*) this->elements->data)->element->getType();
+			ElementType type = (static_cast<PageLayerPosEntry<Element>*>(this->elements->data))->element->getType();
 
 			for (GList* l = this->elements->next; l != nullptr; l = l->next)
 			{
-				auto e = (PageLayerPosEntry<Element>*) l->data;
+				auto e = static_cast<PageLayerPosEntry<Element>*>(l->data);
 				if (type != e->element->getType())
 				{
 					text += " ";

--- a/src/undo/DeleteUndoAction.cpp
+++ b/src/undo/DeleteUndoAction.cpp
@@ -19,7 +19,7 @@ DeleteUndoAction::~DeleteUndoAction()
 {
 	for (GList* l = this->elements; l != nullptr; l = l->next)
 	{
-		auto e = (PageLayerPosEntry<Element>*) l->data;
+		auto e = static_cast<PageLayerPosEntry<Element>*>(l->data);
 		if (!undone)
 		{
 			delete e->element;
@@ -31,8 +31,8 @@ DeleteUndoAction::~DeleteUndoAction()
 
 void DeleteUndoAction::addElement(Layer* layer, Element* e, int pos)
 {
-	this->elements = g_list_insert_sorted(this->elements, new PageLayerPosEntry<Element> (layer, e, pos),
-										  (GCompareFunc) PageLayerPosEntry<Element>::cmp);
+	this->elements = g_list_insert_sorted(this->elements, new PageLayerPosEntry<Element>(layer, e, pos),
+	                                      reinterpret_cast<GCompareFunc>(PageLayerPosEntry<Element>::cmp));
 }
 
 auto DeleteUndoAction::undo(Control*) -> bool
@@ -47,7 +47,7 @@ auto DeleteUndoAction::undo(Control*) -> bool
 
 	for (GList* l = this->elements; l != nullptr; l = l->next)
 	{
-		auto e = (PageLayerPosEntry<Element>*) l->data;
+		auto e = static_cast<PageLayerPosEntry<Element>*>(l->data);
 		e->layer->insertElement(e->element, e->pos);
 		this->page->fireElementChanged(e->element);
 	}
@@ -68,7 +68,7 @@ auto DeleteUndoAction::redo(Control*) -> bool
 
 	for (GList* l = this->elements; l != nullptr; l = l->next)
 	{
-		auto e = (PageLayerPosEntry<Element>*) l->data;
+		auto e = static_cast<PageLayerPosEntry<Element>*>(l->data);
 		e->layer->removeElement(e->element, false);
 		this->page->fireElementChanged(e->element);
 	}
@@ -89,11 +89,11 @@ auto DeleteUndoAction::getText() -> string
 
 	if (this->elements != nullptr)
 	{
-		ElementType type = ((PageLayerPosEntry<Element>*) this->elements->data)->element->getType();
+		ElementType type = (static_cast<PageLayerPosEntry<Element>*>(this->elements->data))->element->getType();
 
 		for (GList* l = this->elements->next; l != nullptr; l = l->next)
 		{
-			auto e = (PageLayerPosEntry<Element>*) l->data;
+			auto e = static_cast<PageLayerPosEntry<Element>*>(l->data);
 			if (type != e->element->getType())
 			{
 				text += " ";

--- a/src/undo/EraseUndoAction.cpp
+++ b/src/undo/EraseUndoAction.cpp
@@ -19,7 +19,7 @@ EraseUndoAction::~EraseUndoAction()
 {
 	for (GList* l = this->original; l != nullptr; l = l->next)
 	{
-		auto* e = (PageLayerPosEntry<Stroke>*) l->data;
+		auto* e = static_cast<PageLayerPosEntry<Stroke>*>(l->data);
 		if (!undone)
 		{
 			delete e->element;
@@ -31,7 +31,7 @@ EraseUndoAction::~EraseUndoAction()
 
 	for (GList* l = this->edited; l != nullptr; l = l->next)
 	{
-		auto* e = (PageLayerPosEntry<Stroke>*) l->data;
+		auto* e = static_cast<PageLayerPosEntry<Stroke>*>(l->data);
 		if (undone)
 		{
 			delete e->element;
@@ -44,21 +44,21 @@ EraseUndoAction::~EraseUndoAction()
 
 void EraseUndoAction::addOriginal(Layer* layer, Stroke* element, int pos)
 {
-	this->original = g_list_insert_sorted(this->original, new PageLayerPosEntry<Stroke> (layer, element, pos),
-										  (GCompareFunc) PageLayerPosEntry<Stroke>::cmp);
+	this->original = g_list_insert_sorted(this->original, new PageLayerPosEntry<Stroke>(layer, element, pos),
+	                                      reinterpret_cast<GCompareFunc>(PageLayerPosEntry<Stroke>::cmp));
 }
 
 void EraseUndoAction::addEdited(Layer* layer, Stroke* element, int pos)
 {
-	this->edited = g_list_insert_sorted(this->edited, new PageLayerPosEntry<Stroke> (layer, element, pos),
-										(GCompareFunc) PageLayerPosEntry<Stroke>::cmp);
+	this->edited = g_list_insert_sorted(this->edited, new PageLayerPosEntry<Stroke>(layer, element, pos),
+	                                    reinterpret_cast<GCompareFunc>(PageLayerPosEntry<Stroke>::cmp));
 }
 
 void EraseUndoAction::removeEdited(Stroke* element)
 {
 	for (GList* l = this->edited; l != nullptr; l = l->next)
 	{
-		auto* p = (PageLayerPosEntry<Stroke>*) l->data;
+		auto* p = static_cast<PageLayerPosEntry<Stroke>*>(l->data);
 		if (p->element == element)
 		{
 			this->edited = g_list_delete_link(this->edited, l);
@@ -73,7 +73,7 @@ void EraseUndoAction::finalize()
 {
 	for (GList* l = this->original; l != nullptr;)
 	{
-		auto* p = (PageLayerPosEntry<Stroke>*) l->data;
+		auto* p = static_cast<PageLayerPosEntry<Stroke>*>(l->data);
 		GList* del = l;
 		l = l->next;
 
@@ -93,7 +93,7 @@ void EraseUndoAction::finalize()
 			GList* stroke = e->getStroke(p->element);
 			for (GList* ls = stroke; ls != nullptr; ls = ls->next)
 			{
-				auto* copy = (Stroke*) ls->data;
+				auto* copy = static_cast<Stroke*>(ls->data);
 				p->layer->insertElement(copy, pos);
 				this->addEdited(p->layer, copy, pos);
 				pos++;
@@ -117,7 +117,7 @@ auto EraseUndoAction::undo(Control* control) -> bool
 {
 	for (GList* l = this->edited; l != nullptr; l = l->next)
 	{
-		auto* e = (PageLayerPosEntry<Stroke>*) l->data;
+		auto* e = static_cast<PageLayerPosEntry<Stroke>*>(l->data);
 
 		e->layer->removeElement(e->element, false);
 		this->page->fireElementChanged(e->element);
@@ -125,7 +125,7 @@ auto EraseUndoAction::undo(Control* control) -> bool
 
 	for (GList* l = this->original; l != nullptr; l = l->next)
 	{
-		auto* e = (PageLayerPosEntry<Stroke>*) l->data;
+		auto* e = static_cast<PageLayerPosEntry<Stroke>*>(l->data);
 
 		e->layer->insertElement(e->element, e->pos);
 		this->page->fireElementChanged(e->element);
@@ -139,7 +139,7 @@ auto EraseUndoAction::redo(Control* control) -> bool
 {
 	for (GList* l = this->original; l != nullptr; l = l->next)
 	{
-		auto* e = (PageLayerPosEntry<Stroke>*) l->data;
+		auto* e = static_cast<PageLayerPosEntry<Stroke>*>(l->data);
 
 		e->layer->removeElement(e->element, false);
 		this->page->fireElementChanged(e->element);
@@ -147,7 +147,7 @@ auto EraseUndoAction::redo(Control* control) -> bool
 
 	for (GList* l = this->edited; l != nullptr; l = l->next)
 	{
-		auto* e = (PageLayerPosEntry<Stroke>*) l->data;
+		auto* e = static_cast<PageLayerPosEntry<Stroke>*>(l->data);
 
 		e->layer->insertElement(e->element, e->pos);
 		this->page->fireElementChanged(e->element);

--- a/src/undo/GroupUndoAction.cpp
+++ b/src/undo/GroupUndoAction.cpp
@@ -77,7 +77,7 @@ auto GroupUndoAction::undo(Control* control) -> bool
 
 auto GroupUndoAction::getText() -> string
 {
-	if (actions.size() == 0)
+	if (actions.empty())
 	{
 		return "!! NOTHING !!";
 	}

--- a/src/undo/InsertDeletePageUndoAction.cpp
+++ b/src/undo/InsertDeletePageUndoAction.cpp
@@ -26,10 +26,9 @@ auto InsertDeletePageUndoAction::undo(Control* control) -> bool
 	{
 		return deletePage(control);
 	}
-	else
-	{
-		return insertPage(control);
-	}
+
+
+	    return insertPage(control);
 }
 
 auto InsertDeletePageUndoAction::redo(Control* control) -> bool
@@ -38,10 +37,9 @@ auto InsertDeletePageUndoAction::redo(Control* control) -> bool
 	{
 		return insertPage(control);
 	}
-	else
-	{
-		return deletePage(control);
-	}
+
+
+	    return deletePage(control);
 }
 
 auto InsertDeletePageUndoAction::insertPage(Control* control) -> bool
@@ -108,8 +106,7 @@ auto InsertDeletePageUndoAction::getText() -> string
 	{
 		return _("Page inserted");
 	}
-	else
-	{
-		return _("Page deleted");
-	}
+
+
+	    return _("Page deleted");
 }

--- a/src/undo/InsertDeletePageUndoAction.cpp
+++ b/src/undo/InsertDeletePageUndoAction.cpp
@@ -28,7 +28,7 @@ auto InsertDeletePageUndoAction::undo(Control* control) -> bool
 	}
 
 
-	    return insertPage(control);
+	return insertPage(control);
 }
 
 auto InsertDeletePageUndoAction::redo(Control* control) -> bool
@@ -39,7 +39,7 @@ auto InsertDeletePageUndoAction::redo(Control* control) -> bool
 	}
 
 
-	    return deletePage(control);
+	return deletePage(control);
 }
 
 auto InsertDeletePageUndoAction::insertPage(Control* control) -> bool
@@ -108,5 +108,5 @@ auto InsertDeletePageUndoAction::getText() -> string
 	}
 
 
-	    return _("Page deleted");
+	return _("Page deleted");
 }

--- a/src/undo/InsertUndoAction.cpp
+++ b/src/undo/InsertUndoAction.cpp
@@ -33,7 +33,7 @@ auto InsertUndoAction::getText() -> string
 	{
 		return _("Draw stroke");
 	}
-	else if (element->getType() == ELEMENT_TEXT)
+	if (element->getType() == ELEMENT_TEXT)
 	{
 		return _("Write text");
 	}

--- a/src/undo/InsertUndoAction.cpp
+++ b/src/undo/InsertUndoAction.cpp
@@ -37,7 +37,7 @@ auto InsertUndoAction::getText() -> string
 	{
 		return _("Write text");
 	}
-	else if (element->getType() == ELEMENT_IMAGE)
+	if (element->getType() == ELEMENT_IMAGE)
 	{
 		return _("Insert image");
 	}

--- a/src/undo/MoveUndoAction.cpp
+++ b/src/undo/MoveUndoAction.cpp
@@ -88,7 +88,10 @@ void MoveUndoAction::switchLayer(vector<Element*>* entries, Layer* oldLayer, Lay
 
 void MoveUndoAction::repaint()
 {
-	if (this->elements.empty()) return;
+	if (this->elements.empty())
+	{
+		return;
+	}
 
 	this->page->firePageChanged();
 

--- a/src/undo/RotateUndoAction.cpp
+++ b/src/undo/RotateUndoAction.cpp
@@ -40,7 +40,10 @@ auto RotateUndoAction::redo(Control* control) -> bool
 
 void RotateUndoAction::applyRotation(double rotation)
 {
-	if (this->elements.empty()) return;
+	if (this->elements.empty())
+	{
+		return;
+	}
 
 	Range r(elements.front()->getX(), elements.front()->getY());
 

--- a/src/undo/ScaleUndoAction.cpp
+++ b/src/undo/ScaleUndoAction.cpp
@@ -39,7 +39,10 @@ auto ScaleUndoAction::redo(Control* control) -> bool
 
 void ScaleUndoAction::applyScale(double fx, double fy)
 {
-	if (this->elements.empty()) return;
+	if (this->elements.empty())
+	{
+		return;
+	}
 
 	Range r(elements.front()->getX(), elements.front()->getY());
 

--- a/src/util/DeviceListHelper.cpp
+++ b/src/util/DeviceListHelper.cpp
@@ -117,11 +117,11 @@ auto InputDevice::getType() const -> string
 	{
 		return _("mouse");
 	}
-	else if (source == GDK_SOURCE_PEN)
+	if (source == GDK_SOURCE_PEN)
 	{
 		return _("pen");
 	}
-	else if (source == GDK_SOURCE_ERASER)
+	if (source == GDK_SOURCE_ERASER)
 	{
 		return _("eraser");
 	}

--- a/src/util/DeviceListHelper.cpp
+++ b/src/util/DeviceListHelper.cpp
@@ -125,7 +125,7 @@ auto InputDevice::getType() const -> string
 	{
 		return _("eraser");
 	}
-	else if (source == GDK_SOURCE_CURSOR)
+	if (source == GDK_SOURCE_CURSOR)
 	{
 		return _("cursor");
 	}

--- a/src/util/DeviceListHelper.cpp
+++ b/src/util/DeviceListHelper.cpp
@@ -60,7 +60,7 @@ auto DeviceListHelper::getDeviceList(Settings* settings, bool ignoreTouchDevices
 		        deviceList.end());
 	}
 
-	GList* pointerSlaves;
+	GList* pointerSlaves = nullptr;
 	// TODO remove after completely switching to gtk 3.20 or use c++17 if constexpr (predicate){...} else{...} ...
 #if (GDK_MAJOR_VERSION >= 3 && GDK_MINOR_VERSION >= 22)
 	GdkDisplay* display = gdk_display_get_default();

--- a/src/util/DeviceListHelper.cpp
+++ b/src/util/DeviceListHelper.cpp
@@ -24,7 +24,7 @@ void addDevicesToList(std::vector<InputDevice>& deviceList, GList* devList, bool
 {
 	while (devList != nullptr)
 	{
-		auto dev = (GdkDevice*) devList->data;
+		auto dev = static_cast<GdkDevice*>(devList->data);
 		if (GDK_SOURCE_KEYBOARD == gdk_device_get_source(dev))
 		{
 			// Skip keyboard
@@ -61,7 +61,7 @@ auto DeviceListHelper::getDeviceList(Settings* settings, bool ignoreTouchDevices
 	}
 
 	GList* pointerSlaves = nullptr;
-	// TODO remove after completely switching to gtk 3.20 or use c++17 if constexpr (predicate){...} else{...} ...
+	// TODO(fabian): remove after completely switching to gtk 3.20 or use c++17 if constexpr (predicate){...} else{...} ...
 #if (GDK_MAJOR_VERSION >= 3 && GDK_MINOR_VERSION >= 22)
 	GdkDisplay* display = gdk_display_get_default();
 	GdkSeat* defaultSeat = gdk_display_get_default_seat(display);

--- a/src/util/GtkColorWrapper.cpp
+++ b/src/util/GtkColorWrapper.cpp
@@ -24,7 +24,7 @@ GtkColorWrapper::~GtkColorWrapper() = default;
 /**
  * Apply the color to a cairo interface with "cairo_set_source_rgb"
  */
-void GtkColorWrapper::apply(cairo_t* cr)
+void GtkColorWrapper::apply(cairo_t* cr) const
 {
 	cairo_set_source_rgb(cr, red / 65536.0, green / 65536.0, blue / 65536.0);
 }
@@ -32,7 +32,7 @@ void GtkColorWrapper::apply(cairo_t* cr)
 /**
  * Apply the color to a cairo interface with "cairo_set_source_rgba" and a specified alpha value
  */
-void GtkColorWrapper::applyWithAlpha(cairo_t* cr, double alpha)
+void GtkColorWrapper::applyWithAlpha(cairo_t* cr, double alpha) const
 {
 	cairo_set_source_rgba(cr, red / 65536.0, green / 65536.0, blue / 65536.0, alpha);
 }

--- a/src/util/GtkColorWrapper.h
+++ b/src/util/GtkColorWrapper.h
@@ -28,12 +28,12 @@ public:
 	/**
 	 * Apply the color to a cairo interface with "cairo_set_source_rgb"
 	 */
-	void apply(cairo_t* cr);
+	void apply(cairo_t* cr) const;
 
 	/**
 	 * Apply the color to a cairo interface with "cairo_set_source_rgba" and a specified alpha value
 	 */
-	void applyWithAlpha(cairo_t* cr, double alpha);
+	void applyWithAlpha(cairo_t* cr, double alpha) const;
 
 public:
 	/**

--- a/src/util/OutputStream.h
+++ b/src/util/OutputStream.h
@@ -23,7 +23,7 @@ public:
 	virtual ~OutputStream();
 
 public:
-	virtual void write(const char* data);
+	virtual void write(const char* str);
 	virtual void write(const char* data, int len) = 0;
 	virtual void write(const string& str);
 

--- a/src/util/PageRange.cpp
+++ b/src/util/PageRange.cpp
@@ -52,7 +52,7 @@ auto PageRange::parse(const char* str) -> PageRangeVector
 		}
 		else
 		{
-			start = (int) strtol(p, &next, 10);
+			start = static_cast<int>(strtol(p, &next, 10));
 			if (start < 1)
 			{
 				start = 1;
@@ -70,7 +70,7 @@ auto PageRange::parse(const char* str) -> PageRangeVector
 		if (*p == '-')
 		{
 			p++;
-			end = (int) strtol(p, &next, 10);
+			end = static_cast<int>(strtol(p, &next, 10));
 			if (next == p) // a half-open range like 2-
 			{
 				end = 0;

--- a/src/util/PageRange.cpp
+++ b/src/util/PageRange.cpp
@@ -11,12 +11,12 @@ PageRangeEntry::PageRangeEntry(int first, int last)
 
 PageRangeEntry::~PageRangeEntry() = default;
 
-auto PageRangeEntry::getLast() -> int
+auto PageRangeEntry::getLast() const -> int
 {
 	return this->last;
 }
 
-auto PageRangeEntry::getFirst() -> int
+auto PageRangeEntry::getFirst() const -> int
 {
 	return this->first;
 }

--- a/src/util/PageRange.cpp
+++ b/src/util/PageRange.cpp
@@ -35,7 +35,7 @@ auto PageRange::parse(const char* str) -> PageRangeVector
 		return data;
 	}
 
-	int start, end;
+	int start = 0, end = 0;
 	char* next = nullptr;
 	const char* p = str;
 	while (*p)

--- a/src/util/PageRange.h
+++ b/src/util/PageRange.h
@@ -20,8 +20,8 @@ public:
 	virtual ~PageRangeEntry();
 
 public:
-	int getLast();
-	int getFirst();
+	int getLast() const;
+	int getFirst() const;
 
 private:
 	int first;

--- a/src/util/Path.cpp
+++ b/src/util/Path.cpp
@@ -110,7 +110,7 @@ auto Path::exists() const -> bool
 	return g_file_test(path.c_str(), G_FILE_TEST_EXISTS);
 }
 
-auto Path::deleteFile() -> bool
+auto Path::deleteFile() const -> bool
 {
 	return g_unlink(c_str()) == 0;
 }

--- a/src/util/Path.h
+++ b/src/util/Path.h
@@ -47,7 +47,7 @@ public:
 	 *
 	 * @return true if the file existed and is deleted, false if an error occurred
 	 */
-	bool deleteFile();
+	bool deleteFile() const;
 
 	bool operator==(const Path& other) const;
 

--- a/src/util/PathUtil.cpp
+++ b/src/util/PathUtil.cpp
@@ -40,7 +40,7 @@ auto PathUtil::readString(string& output, Path& path, bool showErrorToUser) -> b
 
 auto PathUtil::copy(const Path& src, const Path& dest) -> bool
 {
-	std::array<char, 16 * 1024> buffer;  // 16k
+	std::array<char, 16 * 1024> buffer{};  // 16k
 
 	FILE* fpRead = g_fopen(src.c_str(), "rb");
 	if (!fpRead)

--- a/src/util/PathUtil.cpp
+++ b/src/util/PathUtil.cpp
@@ -26,29 +26,28 @@ auto PathUtil::readString(string& output, Path& path, bool showErrorToUser) -> b
 		g_free(contents);
 		return true;
 	}
-	else
-	{
-		if (showErrorToUser)
+
+
+	    if (showErrorToUser)
 		{
 			XojMsgBox::showErrorToUser(nullptr, error->message);
 		}
 
 		g_error_free(error);
 		return false;
-	}
 }
 
 auto PathUtil::copy(const Path& src, const Path& dest) -> bool
 {
 	std::array<char, 16 * 1024> buffer{};  // 16k
 
-	FILE* fpRead = g_fopen(src.c_str(), "rb");
+	FILE* fpRead = g_fopen(src.c_str(), "rbe");
 	if (!fpRead)
 	{
 		return false;
 	}
 
-	FILE* fpWrite = g_fopen(dest.c_str(), "wb");
+	FILE* fpWrite = g_fopen(dest.c_str(), "wbe");
 	if (!fpWrite)
 	{
 		fclose(fpRead);

--- a/src/util/PathUtil.cpp
+++ b/src/util/PathUtil.cpp
@@ -28,13 +28,13 @@ auto PathUtil::readString(string& output, Path& path, bool showErrorToUser) -> b
 	}
 
 
-	    if (showErrorToUser)
-		{
-			XojMsgBox::showErrorToUser(nullptr, error->message);
-		}
+	if (showErrorToUser)
+	{
+		XojMsgBox::showErrorToUser(nullptr, error->message);
+	}
 
-		g_error_free(error);
-		return false;
+	g_error_free(error);
+	return false;
 }
 
 auto PathUtil::copy(const Path& src, const Path& dest) -> bool

--- a/src/util/PlaceholderString.cpp
+++ b/src/util/PlaceholderString.cpp
@@ -20,7 +20,7 @@ public:
  */
 class PlaceholderElementString : public PlaceholderElement{
 public:
-	PlaceholderElementString(std::string text)
+	explicit PlaceholderElementString(std::string text)
 	 : text(std::move(text))
 	{
 	}
@@ -41,7 +41,7 @@ private:
  */
 class PlaceholderElementInt : public PlaceholderElement{
 public:
-	PlaceholderElementInt(int64_t value)
+	explicit PlaceholderElementInt(int64_t value)
 	 : value(value)
 	{
 	}
@@ -112,7 +112,7 @@ auto PlaceholderString::formatPart(std::string format) -> std::string
 	// Placeholder index starting at 1, vector at 0
 	index--;
 
-	if (index < 0 || index >= (int)data.size())
+	if (index < 0 || index >= static_cast<int>(data.size()))
 	{
 		std::string notFound = "{";
 		notFound += std::to_string(index + 1);

--- a/src/util/PlaceholderString.cpp
+++ b/src/util/PlaceholderString.cpp
@@ -98,7 +98,7 @@ auto PlaceholderString::formatPart(std::string format) -> std::string
 		format = format.substr(0, comma);
 	}
 
-	int index;
+	int index = 0;
 	try
 	{
 		index = std::stoi(format);

--- a/src/util/PlaceholderString.cpp
+++ b/src/util/PlaceholderString.cpp
@@ -11,7 +11,7 @@ class PlaceholderElement {
 public:
 	virtual ~PlaceholderElement() = default;
 
-public:
+
 	virtual auto format(std::string format) -> std::string = 0;
 };
 
@@ -25,7 +25,7 @@ public:
 	{
 	}
 
-public:
+
 	auto format(std::string format) -> std::string override
 	{
 		return text;
@@ -46,7 +46,7 @@ public:
 	{
 	}
 
-public:
+
 	auto format(std::string format) -> std::string override
 	{
 		return std::to_string(value);
@@ -127,7 +127,7 @@ auto PlaceholderString::formatPart(std::string format) -> std::string
 
 void PlaceholderString::process()
 {
-	if (processed != "")
+	if (!processed.empty())
 	{
 		// Already processed
 		return;

--- a/src/util/Rectangle.cpp
+++ b/src/util/Rectangle.cpp
@@ -1,7 +1,7 @@
 #include "Rectangle.h"
 
 #include "Range.h"
-#include "math.h"
+#include <cmath>
 
 Rectangle::Rectangle() = default;
 
@@ -79,12 +79,12 @@ void Rectangle::add(const Rectangle &other)
 	add(other.x, other.y, other.width, other.height);
 }
 
-auto Rectangle::translated(double dx, double dy) -> Rectangle
+auto Rectangle::translated(double dx, double dy) const -> Rectangle
 {
 	return Rectangle(this->x + dx, this->y + dy, this->width, this->height);
 }
 
-auto Rectangle::intersect(const Rectangle& other) -> Rectangle
+auto Rectangle::intersect(const Rectangle& other) const -> Rectangle
 {
 	double x1 = std::max(this->x, other.x);
 	double y1 = std::max(this->y, other.y);

--- a/src/util/Rectangle.cpp
+++ b/src/util/Rectangle.cpp
@@ -1,6 +1,7 @@
 #include "Rectangle.h"
 
 #include "Range.h"
+#include "math.h"
 
 Rectangle::Rectangle() = default;
 
@@ -24,8 +25,8 @@ Rectangle::~Rectangle() = default;
 
 auto Rectangle::intersects(const Rectangle& other, Rectangle* dest) const -> bool
 {
-	double destX, destY;
-	double destW, destH;
+	double destX = NAN, destY = NAN;
+	double destW = NAN, destH = NAN;
 
 	bool returnVal = false;
 

--- a/src/util/Rectangle.h
+++ b/src/util/Rectangle.h
@@ -44,14 +44,14 @@ public:
 	 * by the function arguments
 	 *
 	 */
-	Rectangle translated(double dx, double dy);
+	Rectangle translated(double dx, double dy) const;
 
 	/**
 	 * Same as the above, provided for convenience
 	 */
 	void add(const Rectangle &other);
 
-	Rectangle intersect(const Rectangle &other);
+	Rectangle intersect(const Rectangle& other) const;
 
 	Rectangle& operator*=(double factor);
 

--- a/src/util/Stacktrace.cpp
+++ b/src/util/Stacktrace.cpp
@@ -69,7 +69,7 @@ std::string Stacktrace::getExePath()
 #else
 auto Stacktrace::getExePath() -> std::string
 {
-	std::array<char, PATH_MAX> result;
+	std::array<char, PATH_MAX> result{};
 	ssize_t count = readlink("/proc/self/exe", result.data(), PATH_MAX);
 	return std::string(result.data(), (count > 0) ? count : 0);
 }
@@ -77,8 +77,8 @@ auto Stacktrace::getExePath() -> std::string
 
 void Stacktrace::printStracktrace(std::ostream& stream)
 {
-	std::array<void*, 32> trace;
-	std::array<char, 2048> buff;
+	std::array<void*, 32> trace{};
+	std::array<char, 2048> buff{};
 
 	int trace_size = backtrace(trace.data(), trace.size());
 	char** messages = backtrace_symbols(trace.data(), trace_size);
@@ -90,7 +90,7 @@ void Stacktrace::printStracktrace(std::ostream& stream)
 	{
 		stream << "[bt] #" << i << " " << messages[i] << endl;
 
-		std::array<char, 1024> syscom;
+		std::array<char, 1024> syscom{};
 
 		sprintf(syscom.data(), "addr2line %p -e %s", trace[i], exeName.c_str());
 		FILE* fProc = popen(syscom.data(), "r");

--- a/src/util/Util.cpp
+++ b/src/util/Util.cpp
@@ -172,7 +172,7 @@ auto Util::paintBackgroundWhite(GtkWidget* widget, cairo_t* cr, void*) -> gboole
 
 void Util::writeCoordinateString(OutputStream* out, double xVal, double yVal)
 {
-	std::array<char, G_ASCII_DTOSTR_BUF_SIZE> coordString;
+	std::array<char, G_ASCII_DTOSTR_BUF_SIZE> coordString{};
 	g_ascii_formatd(coordString.data(), G_ASCII_DTOSTR_BUF_SIZE, Util::PRECISION_FORMAT_STRING, xVal);
 	out->write(coordString.data());
 	out->write(" ");

--- a/src/util/Util.cpp
+++ b/src/util/Util.cpp
@@ -38,7 +38,8 @@ static auto execInUiThreadCallback(CallbackUiData* cb) -> bool
  */
 void Util::execInUiThread(std::function<void()>&& callback)
 {
-	gdk_threads_add_idle((GSourceFunc) execInUiThreadCallback, new CallbackUiData(std::move(callback)));
+	gdk_threads_add_idle(reinterpret_cast<GSourceFunc>(execInUiThreadCallback),
+	                     new CallbackUiData(std::move(callback)));
 }
 
 auto Util::rgb_to_GdkRGBA(const uint32_t color) -> GdkRGBA

--- a/src/util/XojPreviewExtractor.cpp
+++ b/src/util/XojPreviewExtractor.cpp
@@ -131,7 +131,8 @@ auto XojPreviewExtractor::readFile(const Path& file) -> PreviewExtractResult
 
 		gzclose(fp);
 		return result;
-	} else if (!zipFp)
+	}
+	if (!zipFp)
 	{
 		return PREVIEW_RESULT_COULD_NOT_OPEN_FILE;
 	}

--- a/src/util/XojPreviewExtractor.cpp
+++ b/src/util/XojPreviewExtractor.cpp
@@ -158,7 +158,7 @@ auto XojPreviewExtractor::readFile(const Path& file) -> PreviewExtractResult
 		return PREVIEW_RESULT_ERROR_READING_PREVIEW;
 	}
 
-	data = (unsigned char *)g_malloc(thumbStat.size);
+	data = static_cast<unsigned char*>(g_malloc(thumbStat.size));
 	zip_uint64_t readBytes = 0;
 	while (readBytes < dataLen)
 	{

--- a/src/util/XojPreviewExtractor.cpp
+++ b/src/util/XojPreviewExtractor.cpp
@@ -124,7 +124,7 @@ auto XojPreviewExtractor::readFile(const Path& file) -> PreviewExtractResult
 		// The <preview> Tag is within the first 179 Bytes
 		// The Preview should end within the first 8k
 
-		std::array<char, BUF_SIZE> buffer;
+		std::array<char, BUF_SIZE> buffer{};
 		int readLen = gzread(fp, buffer.data(), BUF_SIZE);
 
 		PreviewExtractResult result = readPreview(buffer.data(), readLen);

--- a/src/util/audio/DeviceInfo.h
+++ b/src/util/audio/DeviceInfo.h
@@ -30,8 +30,8 @@ public:
 
 private:
 	const string deviceName;
-	const PaDeviceIndex index;
-	const bool selected;
-	const int inputChannels;
-	const int outputChannels;
+	const PaDeviceIndex index{};
+	const bool selected{};
+	const int inputChannels{};
+	const int outputChannels{};
 };

--- a/src/util/audio/PortAudioConsumer.cpp
+++ b/src/util/audio/PortAudioConsumer.cpp
@@ -79,7 +79,7 @@ auto PortAudioConsumer::startPlaying() -> bool
 		return false;
 	}
 
-	if ((unsigned int) device->maxOutputChannels() < channels)
+	if (static_cast<unsigned int>(device->maxOutputChannels()) < channels)
 	{
 		this->audioQueue->signalEndOfStream();
 		g_warning("Output device has not enough channels to play audio file. (Requires at least 2 channels)");
@@ -125,7 +125,8 @@ auto PortAudioConsumer::playCallback(const void* inputBuffer, void* outputBuffer
 	if (outputBuffer != nullptr)
 	{
 		size_t outputBufferLength = 0;
-		this->audioQueue->pop(((float*) outputBuffer), outputBufferLength, framesPerBuffer * this->outputChannels);
+		this->audioQueue->pop((static_cast<float*>(outputBuffer)), outputBufferLength,
+		                      framesPerBuffer * this->outputChannels);
 
 		// Fill buffer to requested length if necessary
 
@@ -137,7 +138,7 @@ auto PortAudioConsumer::playCallback(const void* inputBuffer, void* outputBuffer
 				g_warning("PortAudioConsumer: Not enough audio samples available to fill requested frame");
 			}
 
-			auto outputBufferImpl = (float*) outputBuffer;
+			auto outputBufferImpl = static_cast<float*>(outputBuffer);
 
 			if (outputBufferLength > this->outputChannels)
 			{

--- a/src/util/audio/PortAudioConsumer.cpp
+++ b/src/util/audio/PortAudioConsumer.cpp
@@ -1,6 +1,6 @@
 #include "PortAudioConsumer.h"
 #include "AudioPlayer.h"
-#include "math.h"
+#include <cmath>
 
 PortAudioConsumer::PortAudioConsumer(AudioPlayer* audioPlayer, AudioQueue<float>* audioQueue) : sys(portaudio::System::instance()), audioPlayer(audioPlayer), audioQueue(audioQueue)
 {
@@ -164,10 +164,9 @@ auto PortAudioConsumer::playCallback(const void* inputBuffer, void* outputBuffer
 			this->audioPlayer->disableAudioPlaybackButtons();
 			return paComplete;
 		}
-		else
-		{
-			return paContinue;
-		}
+
+
+		    return paContinue;
 	}
 
 	// The output buffer is no longer available - Abort!

--- a/src/util/audio/PortAudioConsumer.cpp
+++ b/src/util/audio/PortAudioConsumer.cpp
@@ -1,5 +1,6 @@
 #include "PortAudioConsumer.h"
 #include "AudioPlayer.h"
+#include "math.h"
 
 PortAudioConsumer::PortAudioConsumer(AudioPlayer* audioPlayer, AudioQueue<float>* audioQueue) : sys(portaudio::System::instance()), audioPlayer(audioPlayer), audioQueue(audioQueue)
 {
@@ -56,8 +57,8 @@ auto PortAudioConsumer::startPlaying() -> bool
 		this->outputStream->abort();
 	}
 
-	double sampleRate;
-	unsigned int channels;
+	double sampleRate = NAN;
+	unsigned int channels = 0;
 	this->audioQueue->getAudioAttributes(sampleRate, channels);
 
 	if (sampleRate == -1)
@@ -123,7 +124,7 @@ auto PortAudioConsumer::playCallback(const void* inputBuffer, void* outputBuffer
 
 	if (outputBuffer != nullptr)
 	{
-		size_t outputBufferLength;
+		size_t outputBufferLength = 0;
 		this->audioQueue->pop(((float*) outputBuffer), outputBufferLength, framesPerBuffer * this->outputChannels);
 
 		// Fill buffer to requested length if necessary

--- a/src/util/audio/PortAudioConsumer.cpp
+++ b/src/util/audio/PortAudioConsumer.cpp
@@ -166,7 +166,7 @@ auto PortAudioConsumer::playCallback(const void* inputBuffer, void* outputBuffer
 		}
 
 
-		    return paContinue;
+		return paContinue;
 	}
 
 	// The output buffer is no longer available - Abort!

--- a/src/util/audio/VorbisConsumer.cpp
+++ b/src/util/audio/VorbisConsumer.cpp
@@ -1,4 +1,6 @@
 #include <cmath>
+
+#include "math.h"
 #include "VorbisConsumer.h"
 
 VorbisConsumer::VorbisConsumer(Settings* settings, AudioQueue<float>* audioQueue)
@@ -11,8 +13,8 @@ VorbisConsumer::~VorbisConsumer() = default;
 
 auto VorbisConsumer::start(const string& filename) -> bool
 {
-	double sampleRate;
-	unsigned int channels;
+	double sampleRate = NAN;
+	unsigned int channels = 0;
 	this->audioQueue->getAudioAttributes(sampleRate, channels);
 
 	if (sampleRate == -1)
@@ -39,7 +41,7 @@ auto VorbisConsumer::start(const string& filename) -> bool
 				std::unique_lock<std::mutex> lock(audioQueue->syncMutex());
 
 		        std::vector<float> buffer(64 * channels);
-		        size_t bufferLength;
+		        size_t bufferLength = 0;
 		        double audioGain = this->settings->getAudioGain();
 
 		        while (!(this->stopConsumer || (audioQueue->hasStreamEnded() && audioQueue->empty())))

--- a/src/util/audio/VorbisConsumer.cpp
+++ b/src/util/audio/VorbisConsumer.cpp
@@ -1,6 +1,6 @@
 #include <cmath>
 
-#include "math.h"
+#include <cmath>
 #include "VorbisConsumer.h"
 
 VorbisConsumer::VorbisConsumer(Settings* settings, AudioQueue<float>* audioQueue)
@@ -9,7 +9,6 @@ VorbisConsumer::VorbisConsumer(Settings* settings, AudioQueue<float>* audioQueue
 {
 }
 
-VorbisConsumer::~VorbisConsumer() = default;
 
 auto VorbisConsumer::start(const string& filename) -> bool
 {

--- a/src/util/audio/VorbisConsumer.h
+++ b/src/util/audio/VorbisConsumer.h
@@ -27,7 +27,7 @@ class VorbisConsumer
 {
 public:
 	explicit VorbisConsumer(Settings* settings, AudioQueue<float>* audioQueue);
-	~VorbisConsumer();
+	~VorbisConsumer() = default;
 
 public:
 	bool start(const string& filename);

--- a/src/util/audio/VorbisProducer.cpp
+++ b/src/util/audio/VorbisProducer.cpp
@@ -5,7 +5,6 @@ VorbisProducer::VorbisProducer(AudioQueue<float>* audioQueue) : audioQueue(audio
 {
 }
 
-VorbisProducer::~VorbisProducer() = default;
 
 auto VorbisProducer::start(const std::string& filename, unsigned int timestamp) -> bool
 {

--- a/src/util/audio/VorbisProducer.h
+++ b/src/util/audio/VorbisProducer.h
@@ -25,7 +25,7 @@ class VorbisProducer
 {
 public:
 	explicit VorbisProducer(AudioQueue<float>* audioQueue);
-	~VorbisProducer();
+	~VorbisProducer() = default;
 
 public:
 	bool start(const string& filename, unsigned int timestamp);

--- a/src/util/audio/VorbisProducer.h
+++ b/src/util/audio/VorbisProducer.h
@@ -38,7 +38,7 @@ private:
 
 protected:
 	bool stopProducer = false;
-	SF_INFO sfInfo;
+	SF_INFO sfInfo{};
 	SNDFILE_tag* sfFile = nullptr;
 
 	AudioQueue<float>* audioQueue = nullptr;

--- a/src/util/pixbuf-utils.cpp
+++ b/src/util/pixbuf-utils.cpp
@@ -51,7 +51,7 @@ const cairo_user_data_key_t format_key = { 0 };
 
 auto f_image_surface_create(cairo_format_t format, int width, int height) -> cairo_surface_t*
 {
-	int size;
+	int size = 0;
 
 	switch (format)
 	{
@@ -113,7 +113,7 @@ auto f_pixbuf_to_cairo_surface(GdkPixbuf* pixbuf) -> cairo_surface_t*
 	int gdk_rowstride = gdk_pixbuf_get_rowstride(pixbuf);
 	int n_channels = gdk_pixbuf_get_n_channels(pixbuf);
 
-	cairo_format_t format;
+	cairo_format_t format{};
 	if (n_channels == 3)
 	{
 		format = CAIRO_FORMAT_RGB24;
@@ -153,7 +153,7 @@ auto f_pixbuf_to_cairo_surface(GdkPixbuf* pixbuf) -> cairo_surface_t*
 		else
 		{
 			guchar* end = p + 4 * width;
-			guint t1, t2, t3;
+			guint t1 = 0, t2 = 0, t3 = 0;
 
 #define MULT(d,c,a,t) G_STMT_START { t = c * a + 0x7f; d = ((t >> 8) + t) >> 8; } G_STMT_END
 

--- a/src/util/pixbuf-utils.cpp
+++ b/src/util/pixbuf-utils.cpp
@@ -155,7 +155,13 @@ auto f_pixbuf_to_cairo_surface(GdkPixbuf* pixbuf) -> cairo_surface_t*
 			guchar* end = p + 4 * width;
 			guint t1 = 0, t2 = 0, t3 = 0;
 
-#define MULT(d,c,a,t) G_STMT_START { t = c * a + 0x7f; d = ((t >> 8) + t) >> 8; } G_STMT_END
+#define MULT(d, c, a, t)               \
+	G_STMT_START                       \
+	{                                  \
+		(t) = (c) * (a) + 0x7f;        \
+		(d) = (((t) >> 8) + (t)) >> 8; \
+	}                                  \
+	G_STMT_END
 
 			while (p < end)
 			{

--- a/src/util/serializing/BinObjectEncoding.cpp
+++ b/src/util/serializing/BinObjectEncoding.cpp
@@ -6,5 +6,5 @@ BinObjectEncoding::~BinObjectEncoding() = default;
 
 void BinObjectEncoding::addData(const void* data, int len)
 {
-	g_string_append_len(this->data, (const char*) data, len);
+	g_string_append_len(this->data, static_cast<const char*>(data), len);
 }

--- a/src/util/serializing/HexObjectEncoding.cpp
+++ b/src/util/serializing/HexObjectEncoding.cpp
@@ -8,7 +8,7 @@ HexObjectEncoding::~HexObjectEncoding() = default;
 
 void HexObjectEncoding::addData(const void* data, int len)
 {
-	char* buffer = (char*) g_malloc(len * 2);
+	char* buffer = static_cast<char*>(g_malloc(len * 2));
 
 	for (int i = 0; i < len; i++)
 	{

--- a/src/util/serializing/ObjectEncoding.cpp
+++ b/src/util/serializing/ObjectEncoding.cpp
@@ -7,7 +7,7 @@ ObjectEncoding::ObjectEncoding()
 
 ObjectEncoding::~ObjectEncoding() = default;
 
-void ObjectEncoding::addStr(const char* str)
+void ObjectEncoding::addStr(const char* str) const
 {
 	g_string_append(this->data, str);
 }

--- a/src/util/serializing/ObjectEncoding.h
+++ b/src/util/serializing/ObjectEncoding.h
@@ -20,7 +20,7 @@ public:
 	virtual ~ObjectEncoding();
 
 public:
-	void addStr(const char* str);
+	void addStr(const char* str) const;
 	virtual void addData(const void* data, int len) = 0;
 
 	GString* getData();

--- a/src/util/serializing/ObjectInputStream.cpp
+++ b/src/util/serializing/ObjectInputStream.cpp
@@ -89,7 +89,7 @@ auto ObjectInputStream::readInt() -> int
 		throw InputStreamException("End reached, but try to read an integer", __FILE__, __LINE__);
 	}
 
-	int i = *((int*) (this->str->str + this->pos));
+	int i = *(reinterpret_cast<int*>(this->str->str + this->pos));
 	this->pos += sizeof(int);
 	return i;
 }
@@ -103,7 +103,7 @@ auto ObjectInputStream::readDouble() -> double
 		throw InputStreamException("End reached, but try to read an double", __FILE__, __LINE__);
 	}
 
-	double d = *((double*) (this->str->str + this->pos));
+	double d = *(reinterpret_cast<double*>(this->str->str + this->pos));
 	this->pos += sizeof(double);
 	return d;
 }
@@ -117,7 +117,7 @@ auto ObjectInputStream::readSizeT() -> size_t
 		throw InputStreamException("End reached, but try to read an integer", __FILE__, __LINE__);
 	}
 
-	size_t st = *((size_t*) (this->str->str + this->pos));
+	size_t st = *(reinterpret_cast<size_t*>(this->str->str + this->pos));
 	this->pos += sizeof(size_t);
 	return st;
 }
@@ -131,7 +131,7 @@ auto ObjectInputStream::readString() -> string
 		throw InputStreamException("End reached, but try to read an string", __FILE__, __LINE__);
 	}
 
-	int len = *((int*) (this->str->str + this->pos));
+	int len = *(reinterpret_cast<int*>(this->str->str + this->pos));
 	this->pos += sizeof(int);
 
 	if (this->pos + len >= this->str->len)
@@ -153,10 +153,10 @@ void ObjectInputStream::readData(void** data, int* length)
 		throw InputStreamException("End reached, but try to read data", __FILE__, __LINE__);
 	}
 
-	int len = *((int*) (this->str->str + this->pos));
+	int len = *(reinterpret_cast<int*>(this->str->str + this->pos));
 	this->pos += sizeof(int);
 
-	int width = *((int*) (this->str->str + this->pos));
+	int width = *(reinterpret_cast<int*>(this->str->str + this->pos));
 	this->pos += sizeof(int);
 
 	if (this->pos + (len * width) >= this->str->len)
@@ -220,7 +220,7 @@ auto ObjectInputStream::readImage() -> cairo_surface_t*
 		throw InputStreamException("End reached, but try to read an image", __FILE__, __LINE__);
 	}
 
-	int len = *((int*) (this->str->str + this->pos));
+	int len = *(reinterpret_cast<int*>(this->str->str + this->pos));
 	//this->pos += sizeof(int);
 	//totally not equivalent!
 	this->pos += sizeof(gsize);
@@ -232,7 +232,8 @@ auto ObjectInputStream::readImage() -> cairo_surface_t*
 
 	PngDatasource source(this->str->str + this->pos, len);
 	//cairo_surface_t * img = cairo_image_surface_create_from_png_stream((cairo_read_func_t) cairoReadFunction, &source);
-	cairo_surface_t* img = cairo_image_surface_create_from_png_stream((cairo_read_func_t) &cairoReadFunction, &source);
+	cairo_surface_t* img = cairo_image_surface_create_from_png_stream(
+	        reinterpret_cast<cairo_read_func_t>(&cairoReadFunction), &source);
 
 	this->pos += len;
 

--- a/src/util/serializing/ObjectInputStream.h
+++ b/src/util/serializing/ObjectInputStream.h
@@ -42,7 +42,7 @@ public:
 private:
 	void checkType(char type);
 
-	string getType(char type);
+	static string getType(char type);
 
 private:
 	GString* str = nullptr;

--- a/src/util/serializing/ObjectOutputStream.cpp
+++ b/src/util/serializing/ObjectOutputStream.cpp
@@ -75,7 +75,7 @@ void ObjectOutputStream::writeData(const void* data, int len, int width)
 
 static auto cairoWriteFunction(GString* string, const unsigned char* data, unsigned int length) -> cairo_status_t
 {
-	g_string_append_len(string, (const gchar*) data, length);
+	g_string_append_len(string, reinterpret_cast<const gchar*>(data), length);
 	return CAIRO_STATUS_SUCCESS;
 }
 
@@ -83,7 +83,7 @@ void ObjectOutputStream::writeImage(cairo_surface_t* img)
 {
 	GString* imgStr = g_string_sized_new(102400);
 
-	cairo_surface_write_to_png_stream(img, (cairo_write_func_t) &cairoWriteFunction, imgStr);
+	cairo_surface_write_to_png_stream(img, reinterpret_cast<cairo_write_func_t>(&cairoWriteFunction), imgStr);
 
 	this->encoder->addStr("_m");
 	this->encoder->addData(&imgStr->len, sizeof(gsize));

--- a/src/view/DocumentView.cpp
+++ b/src/view/DocumentView.cpp
@@ -66,7 +66,8 @@ void DocumentView::applyColor(cairo_t* cr, int c, int alpha)
 	cairo_set_source_rgba(cr, r, g, b, alpha / 255.0);
 }
 
-void DocumentView::drawStroke(cairo_t* cr, Stroke* s, int startPoint, double scaleFactor, bool changeSource, bool noAlpha)
+void DocumentView::drawStroke(cairo_t* cr, Stroke* s, int startPoint, double scaleFactor, bool changeSource,
+                              bool noAlpha) const
 {
 	if (s->getPointCount() < 2)
 	{
@@ -168,7 +169,7 @@ void DocumentView::drawTexImage(cairo_t* cr, TexImage* texImage)
 	cairo_set_matrix(cr, &defaultMatrix);
 }
 
-void DocumentView::drawElement(cairo_t* cr, Element* e)
+void DocumentView::drawElement(cairo_t* cr, Element* e) const
 {
 	if (e->getType() == ELEMENT_STROKE)
 	{

--- a/src/view/DocumentView.cpp
+++ b/src/view/DocumentView.cpp
@@ -172,19 +172,19 @@ void DocumentView::drawElement(cairo_t* cr, Element* e)
 {
 	if (e->getType() == ELEMENT_STROKE)
 	{
-		drawStroke(cr, (Stroke*) e);
+		drawStroke(cr, dynamic_cast<Stroke*>(e));
 	}
 	else if (e->getType() == ELEMENT_TEXT)
 	{
-		drawText(cr, (Text*) e);
+		drawText(cr, dynamic_cast<Text*>(e));
 	}
 	else if (e->getType() == ELEMENT_IMAGE)
 	{
-		drawImage(cr, (Image*) e);
+		drawImage(cr, dynamic_cast<Image*>(e));
 	}
 	else if (e->getType() == ELEMENT_TEXIMAGE)
 	{
-		drawTexImage(cr, (TexImage*) e);
+		drawTexImage(cr, dynamic_cast<TexImage*>(e));
 	}
 }
 

--- a/src/view/DocumentView.h
+++ b/src/view/DocumentView.h
@@ -45,8 +45,8 @@ public:
 	void drawPage(PageRef page, cairo_t* cr, bool dontRenderEditingStroke, bool hideBackground = false);
 
 
-
-	void drawStroke(cairo_t* cr, Stroke* s, int startPoint = 0, double scaleFactor = 1, bool changeSource = true, bool noAlpha = false);
+	void drawStroke(cairo_t* cr, Stroke* s, int startPoint = 0, double scaleFactor = 1, bool changeSource = true,
+	                bool noAlpha = false) const;
 
 	static void applyColor(cairo_t* cr, Stroke* s);
 	static void applyColor(cairo_t* cr, int c, int alpha = 255);
@@ -94,11 +94,11 @@ public:
 	void finializeDrawing();
 
 private:
-	void drawText(cairo_t* cr, Text* t);
-	void drawImage(cairo_t* cr, Image* i);
-	void drawTexImage(cairo_t* cr, TexImage* texImage);
+	static void drawText(cairo_t* cr, Text* t);
+	static void drawImage(cairo_t* cr, Image* i);
+	static void drawTexImage(cairo_t* cr, TexImage* texImage);
 
-	void drawElement(cairo_t* cr, Element* e);
+	void drawElement(cairo_t* cr, Element* e) const;
 
 	void paintBackgroundImage();
 

--- a/src/view/StrokeView.cpp
+++ b/src/view/StrokeView.cpp
@@ -14,7 +14,6 @@ StrokeView::StrokeView(cairo_t* cr, Stroke* s, int startPoint, double scaleFacto
 {
 }
 
-StrokeView::~StrokeView() = default;
 
 void StrokeView::drawFillStroke()
 {

--- a/src/view/StrokeView.h
+++ b/src/view/StrokeView.h
@@ -19,7 +19,7 @@ class StrokeView
 {
 public:
 	StrokeView(cairo_t* cr, Stroke* s, int startPoint, double scaleFactor, bool noAlpha);
-	~StrokeView();
+	~StrokeView() = default;
 
 public:
 	void paint(bool dontRenderEditingStroke);
@@ -33,7 +33,7 @@ public:
 private:
 	void drawFillStroke();
 	void applyDashed(double offset);
-	void drawEraseableStroke(cairo_t* cr, Stroke* s);
+	static void drawEraseableStroke(cairo_t* cr, Stroke* s);
 
 	/**
 	 * No pressure sensitivity, one line is drawn

--- a/src/view/TextView.cpp
+++ b/src/view/TextView.cpp
@@ -86,12 +86,12 @@ auto TextView::findText(Text* t, string& search) -> vector<XojPdfRectangle>
 			XojPdfRectangle mark;
 			PangoRectangle rect = { 0 };
 			pango_layout_index_to_pos(layout, pos, &rect);
-			mark.x1 = ((double) rect.x) / PANGO_SCALE + t->getX();
-			mark.y1 = ((double) rect.y) / PANGO_SCALE + t->getY();
+			mark.x1 = (static_cast<double>(rect.x)) / PANGO_SCALE + t->getX();
+			mark.y1 = (static_cast<double>(rect.y)) / PANGO_SCALE + t->getY();
 
 			pango_layout_index_to_pos(layout, pos + srch.length(), &rect);
-			mark.x2 = ((double) rect.x + rect.width) / PANGO_SCALE + t->getX();
-			mark.y2 = ((double) rect.y + rect.height) / PANGO_SCALE + t->getY();
+			mark.x2 = (static_cast<double>(rect.x) + rect.width) / PANGO_SCALE + t->getX();
+			mark.y2 = (static_cast<double>(rect.y) + rect.height) / PANGO_SCALE + t->getY();
 
 			list.push_back(mark);
 		}
@@ -116,8 +116,8 @@ void TextView::calcSize(Text* t, double& width, double& height)
 	int w = 0;
 	int h = 0;
 	pango_layout_get_size(layout, &w, &h);
-	width = ((double) w) / PANGO_SCALE;
-	height = ((double) h) / PANGO_SCALE;
+	width = (static_cast<double>(w)) / PANGO_SCALE;
+	height = (static_cast<double>(h)) / PANGO_SCALE;
 	g_object_unref(layout);
 
 	cairo_surface_destroy(surface);

--- a/src/view/TextView.h
+++ b/src/view/TextView.h
@@ -39,7 +39,7 @@ public:
 	/**
 	 * Searches text within a Text model, returns XojPopplerRectangle, have to been freed
 	 */
-	static vector<XojPdfRectangle> findText(Text* t, string& text);
+	static vector<XojPdfRectangle> findText(Text* t, string& search);
 
 	/**
 	 * Initialize a Pango layout

--- a/src/view/background/BackgroundConfig.cpp
+++ b/src/view/background/BackgroundConfig.cpp
@@ -32,7 +32,7 @@ auto BackgroundConfig::loadValue(const string& key, string& value) -> bool
 	return false;
 }
 
-auto BackgroundConfig::loadValue(string key, int& value) -> bool
+auto BackgroundConfig::loadValue(const string& key, int& value) -> bool
 {
 	string str;
 	if (loadValue(key, str))
@@ -44,7 +44,7 @@ auto BackgroundConfig::loadValue(string key, int& value) -> bool
 	return false;
 }
 
-auto BackgroundConfig::loadValue(string key, double& value) -> bool
+auto BackgroundConfig::loadValue(const string& key, double& value) -> bool
 {
 	string str;
 	if (loadValue(key, str))
@@ -56,7 +56,7 @@ auto BackgroundConfig::loadValue(string key, double& value) -> bool
 	return false;
 }
 
-auto BackgroundConfig::loadValueHex(string key, int& value) -> bool
+auto BackgroundConfig::loadValueHex(const string& key, int& value) -> bool
 {
 	string str;
 	if (loadValue(key, str))

--- a/src/view/background/BackgroundConfig.cpp
+++ b/src/view/background/BackgroundConfig.cpp
@@ -35,7 +35,7 @@ auto BackgroundConfig::loadValue(const string& key, string& value) -> bool
 auto BackgroundConfig::loadValue(string key, int& value) -> bool
 {
 	string str;
-	if (loadValue(std::move(key), str))
+	if (loadValue(key, str))
 	{
 		value = std::stoul(str, nullptr, 10);
 		return true;
@@ -47,7 +47,7 @@ auto BackgroundConfig::loadValue(string key, int& value) -> bool
 auto BackgroundConfig::loadValue(string key, double& value) -> bool
 {
 	string str;
-	if (loadValue(std::move(key), str))
+	if (loadValue(key, str))
 	{
 		value = std::stoul(str, nullptr, 10);
 		return true;
@@ -59,7 +59,7 @@ auto BackgroundConfig::loadValue(string key, double& value) -> bool
 auto BackgroundConfig::loadValueHex(string key, int& value) -> bool
 {
 	string str;
-	if (loadValue(std::move(key), str))
+	if (loadValue(key, str))
 	{
 		value = std::stoul(str, nullptr, 16);
 		return true;

--- a/src/view/background/BackgroundConfig.h
+++ b/src/view/background/BackgroundConfig.h
@@ -24,9 +24,9 @@ public:
 
 public:
 	bool loadValue(const string& key, string& value);
-	bool loadValue(string key, int& value);
-	bool loadValue(string key, double& value);
-	bool loadValueHex(string key, int& value);
+	bool loadValue(const string& key, int& value);
+	bool loadValue(const string& key, double& value);
+	bool loadValueHex(const string& key, int& value);
 
 private:
 	map<string, string> data;

--- a/src/view/background/LineBackgroundPainter.cpp
+++ b/src/view/background/LineBackgroundPainter.cpp
@@ -38,7 +38,7 @@ void LineBackgroundPainter::paintBackgroundRuled()
 	Util::cairo_set_source_rgbi(cr, this->foregroundColor1);
 	cairo_set_line_width(cr, lineWidth * lineWidthFactor);
 
-	int numLines = (int) ((height - headerSize - footerSize) / (roulingSize + lineWidth * lineWidthFactor));
+	int numLines = static_cast<int>((height - headerSize - footerSize) / (roulingSize + lineWidth * lineWidthFactor));
 
 	double offset = headerSize;
 

--- a/src/view/background/StavesBackgroundPainter.cpp
+++ b/src/view/background/StavesBackgroundPainter.cpp
@@ -20,7 +20,7 @@ void StavesBackgroundPainter::paint()
 	double lineSize = 4 * staveDistance + 5 * lineWidth * lineWidthFactor + lineDistance;
 	double offset = headerSize;
 
-	int numStaves = (int) ((height - headerSize - footerSize + lineDistance) / (lineSize));
+	int numStaves = static_cast<int>((height - headerSize - footerSize + lineDistance) / (lineSize));
 
 	for (int line = 0; line < numStaves; line++)
 	{


### PR DESCRIPTION
Applied nearly every check, currently defined in our .clang-tidy file.

Currently missing: 
- fixups due subsequent calls to clang-tidy.
- not automatically fixable warnings.
- readability-identifier-naming, because it has not been discussed yet.