### PR TITLE
Fix Debian build

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -3,5 +3,5 @@
 	dh $@
 
 override_dh_auto_build:
-	make translations all
+	dh_auto_build -- translations all
 


### PR DESCRIPTION
The fix for building translations added in #1602 breaks the build in a clean source tree.

```
$ git clone https://github.com/xournalpp/xournalpp.git
$ cd xournalapp/
# Generate .orig.tar.gz so debuild does not complain
$ dh_make -s --createorig -p xournalapp_1.0.6
$ debuild
[..]
   debian/rules override_dh_auto_build
make[1]: Entering directory '/tmp/git3/xournalpp'
make translations all
make[2]: Entering directory '/tmp/git3/xournalpp'
make[2]: *** No rule to make target 'translations'.  Stop.
make[2]: Leaving directory '/tmp/git3/xournalpp' 
```

This fixes the command as described in the [Debian New Maintainers Guide](https://www.debian.org/doc/manuals/maint-guide/dreq.en.html#customrules):
>  If the Makefile in the source for gentoo requires you to specify build as its target to build it [52], you create an override_dh_auto_build target to enable this.
> ```
> override_dh_auto_build:
>        dh_auto_build -- build
> ```