### PR TITLE
Image Insert Crash Resolved

### DIFF
--- a/src/control/stockdlg/ImageOpenDlg.cpp
+++ b/src/control/stockdlg/ImageOpenDlg.cpp
@@ -24,7 +24,7 @@ auto ImageOpenDlg::show(GtkWindow* win, Settings* settings, bool localOnly, bool
 	}
 
 	GtkWidget* cbAttach = nullptr;
-	if (*attach)
+	if (attach)
 	{
 		cbAttach = gtk_check_button_new_with_label(_("Attach file to the journal"));
 		gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(cbAttach), false);


### PR DESCRIPTION
Resolved the application crash while adding an image to the document as reported in #1648
Fixes #1648