### PR TITLE
Fixed possible PortAudio integration bugs

### DIFF
--- a/azure-pipelines/steps/build_linux.yml
+++ b/azure-pipelines/steps/build_linux.yml
@@ -11,8 +11,8 @@ steps:
       mkdir build
     displayName: 'Create build directory'
   - bash: |
-      export CXX=g++-8
-      export CC=gcc-8
+      export CXX=g++-9
+      export CC=gcc-9
       cmake -GNinja .. -DCMAKE_BUILD_TYPE=${{ parameters.build_type}} ${{ parameters.cmake_flags }}
       # Make sure pot is up to date with sources (maybe translation pipeline is currently running)
       cmake --build . --target pot

--- a/azure-pipelines/steps/install_deps_ubuntu.yml
+++ b/azure-pipelines/steps/install_deps_ubuntu.yml
@@ -11,9 +11,11 @@ steps:
       sudo add-apt-repository ppa:ubuntu-toolchain-r/test
       sudo apt-get update
       sudo apt install gcc g++
-      sudo apt install gcc-8 g++-8
+      sudo apt install gcc-9 g++-9
+      sudo apt install libstdc++-9-dev
       sudo apt-get install -y cmake ninja-build libcppunit-dev libgtk-3-dev libpoppler-glib-dev portaudio19-dev libsndfile-dev liblua5.3-dev libzip-dev
       g++ --version
-      export CXX=g++-8
-      export CC=gcc-8
+      g++-9 --version
+      export CXX=g++-9
+      export CC=gcc-9
     displayName: 'Install dependencies'

--- a/azure-pipelines/translation.yml
+++ b/azure-pipelines/translation.yml
@@ -22,8 +22,8 @@ stages:
         mkdir build
       displayName: 'Create build directory'
     - bash: |
-        export CXX=g++-8
-        export CC=gcc-8
+        export CXX=g++-9
+        export CC=gcc-9
         cmake ..
         cmake --build . --target pot
       workingDirectory: ./build

--- a/src/control/AudioController.cpp
+++ b/src/control/AudioController.cpp
@@ -4,23 +4,6 @@
 #include <i18n.h>
 #include <XojMsgBox.h>
 
-AudioController::AudioController(Settings* settings, Control* control)
-{
-	this->settings = settings;
-	this->control = control;
-	this->audioRecorder = new AudioRecorder(settings);
-	this->audioPlayer = new AudioPlayer(control, settings);
-}
-
-AudioController::~AudioController()
-{
-	delete this->audioRecorder;
-	this->audioRecorder = nullptr;
-
-	delete this->audioPlayer;
-	this->audioPlayer = nullptr;
-}
-
 auto AudioController::startRecording() -> bool
 {
 	if (!this->isRecording())
@@ -88,56 +71,56 @@ auto AudioController::startPlayback(const string& filename, unsigned int timesta
 	bool status = this->audioPlayer->start(filename, timestamp);
 	if (status)
 	{
-		this->control->getWindow()->getToolMenuHandler()->enableAudioPlaybackButtons();
+		this->control.getWindow()->getToolMenuHandler()->enableAudioPlaybackButtons();
 	}
 	return status;
 }
 
 void AudioController::pausePlayback()
 {
-	this->control->getWindow()->getToolMenuHandler()->setAudioPlaybackPaused(true);
+	this->control.getWindow()->getToolMenuHandler()->setAudioPlaybackPaused(true);
 
 	this->audioPlayer->pause();
 }
 
 void AudioController::seekForwards()
 {
-	this->audioPlayer->seek(this->settings->getDefaultSeekTime());
+	this->audioPlayer->seek(this->settings.getDefaultSeekTime());
 }
 
 void AudioController::seekBackwards()
 {
-	this->audioPlayer->seek(-1 * this->settings->getDefaultSeekTime());
+	this->audioPlayer->seek(-1 * this->settings.getDefaultSeekTime());
 }
 
 void AudioController::continuePlayback()
 {
-	this->control->getWindow()->getToolMenuHandler()->setAudioPlaybackPaused(false);
+	this->control.getWindow()->getToolMenuHandler()->setAudioPlaybackPaused(false);
 
 	this->audioPlayer->play();
 }
 
 void AudioController::stopPlayback()
 {
-	this->control->getWindow()->getToolMenuHandler()->disableAudioPlaybackButtons();
+	this->control.getWindow()->getToolMenuHandler()->disableAudioPlaybackButtons();
 	this->audioPlayer->stop();
 }
 
-auto AudioController::getAudioFilename() -> string
+auto AudioController::getAudioFilename() const -> string const&
 {
 	return this->audioFilename;
 }
 
-auto AudioController::getAudioFolder() -> Path
+auto AudioController::getAudioFolder() const -> Path
 {
-	string af = this->settings->getAudioFolder();
+	string const& af = this->settings.getAudioFolder();
 
 	if (af.length() < 8)
 	{
 		string msg = _("Audio folder not set! Recording won't work!\nPlease set the "
 					   "recording folder under \"Preferences > Audio recording\"");
 		g_warning("%s", msg.c_str());
-		XojMsgBox::showErrorToUser(this->control->getGtkWindow(), msg);
+		XojMsgBox::showErrorToUser(this->control.getGtkWindow(), msg);
 		return Path("");
 	}
 
@@ -149,12 +132,12 @@ auto AudioController::getStartTime() const -> size_t
 	return this->timestamp;
 }
 
-auto AudioController::getOutputDevices() -> vector<DeviceInfo>
+auto AudioController::getOutputDevices() const -> vector<DeviceInfo>
 {
 	return this->audioPlayer->getOutputDevices();
 }
 
-auto AudioController::getInputDevices() -> vector<DeviceInfo>
+auto AudioController::getInputDevices() const -> vector<DeviceInfo>
 {
 	return this->audioRecorder->getInputDevices();
 }

--- a/src/util/audio/AudioPlayer.cpp
+++ b/src/util/audio/AudioPlayer.cpp
@@ -1,25 +1,10 @@
-#include <control/Control.h>
 #include "AudioPlayer.h"
 
-AudioPlayer::AudioPlayer(Control* control, Settings* settings) : control(control), settings(settings)
-{
-	this->audioQueue = new AudioQueue<float>();
-	this->portAudioConsumer = new PortAudioConsumer(this, this->audioQueue);
-	this->vorbisProducer = new VorbisProducer(this->audioQueue);
-}
+#include "control/Control.h"
 
 AudioPlayer::~AudioPlayer()
 {
 	this->stop();
-
-	delete this->portAudioConsumer;
-	this->portAudioConsumer = nullptr;
-
-	delete this->vorbisProducer;
-	this->vorbisProducer = nullptr;
-
-	delete this->audioQueue;
-	this->audioQueue = nullptr;
 }
 
 auto AudioPlayer::start(const string& filename, unsigned int timestamp) -> bool
@@ -66,7 +51,7 @@ void AudioPlayer::disableAudioPlaybackButtons()
 {
 	if (this->audioQueue->hasStreamEnded())
 	{
-		this->control->getWindow()->disableAudioPlaybackButtons();
+		this->control.getWindow()->disableAudioPlaybackButtons();
 	}
 }
 
@@ -92,12 +77,10 @@ void AudioPlayer::seek(int seconds)
 
 auto AudioPlayer::getOutputDevices() -> vector<DeviceInfo>
 {
-	std::list<DeviceInfo> deviceList = this->portAudioConsumer->getOutputDevices();
-	return vector<DeviceInfo>{std::make_move_iterator(std::begin(deviceList)),
-							  std::make_move_iterator(std::end(deviceList))};
+	return this->portAudioConsumer->getOutputDevices();
 }
 
-auto AudioPlayer::getSettings() -> Settings*
+auto AudioPlayer::getSettings() -> Settings&
 {
 	return this->settings;
 }

--- a/src/util/audio/AudioPlayer.h
+++ b/src/util/audio/AudioPlayer.h
@@ -17,13 +17,18 @@
 #include "PortAudioConsumer.h"
 #include "VorbisProducer.h"
 
-#include <control/settings/Settings.h>
-#include <control/Control.h>
+#include "control/settings/Settings.h"
+#include "control/Control.h"
 
-class AudioPlayer
+class AudioPlayer final
 {
 public:
-	explicit AudioPlayer(Control* control, Settings* settings);
+	explicit AudioPlayer(Control& control, Settings& settings)
+	 : control(control)
+	 , settings(settings)
+	{
+	}
+
 	~AudioPlayer();
 	bool start(const string& filename, unsigned int timestamp = 0);
 	bool isPlaying();
@@ -34,15 +39,14 @@ public:
 
 	vector<DeviceInfo> getOutputDevices();
 
-	Settings* getSettings();
+	Settings& getSettings();
 	void disableAudioPlaybackButtons();
-private:
-protected:
-	Settings* settings = nullptr;
-	Control* control = nullptr;
 
-	AudioQueue<float>* audioQueue = nullptr;
-	PortAudioConsumer* portAudioConsumer = nullptr;
-	VorbisProducer* vorbisProducer = nullptr;
-	std::thread stopThread;
+private:
+	Control& control;
+	Settings& settings;
+
+	std::unique_ptr<AudioQueue<float>> audioQueue = std::make_unique<AudioQueue<float>>();
+	std::unique_ptr<PortAudioConsumer> portAudioConsumer = std::make_unique<PortAudioConsumer>(*this, *audioQueue);
+	std::unique_ptr<VorbisProducer> vorbisProducer = std::make_unique<VorbisProducer>(*audioQueue);
 };

--- a/src/util/audio/AudioQueue.h
+++ b/src/util/audio/AudioQueue.h
@@ -11,22 +11,17 @@
 
 #pragma once
 
-#include <XournalType.h>
-
-#include <vector>
-#include <deque>
-#include <mutex>
 #include <algorithm>
+#include <cassert>
 #include <condition_variable>
+#include <deque>
+#include <limits>
+#include <mutex>
+#include <vector>
 
 template <typename T>
-class AudioQueue : protected std::deque<T>
+class AudioQueue
 {
-public:
-	AudioQueue() = default;
-
-	~AudioQueue() = default;
-
 public:
 	void reset()
 	{
@@ -34,7 +29,7 @@ public:
 		this->popNotified = false;
 		this->pushNotified = false;
 		this->streamEnd = false;
-		this->clear();
+		internalQueue.clear();
 
 		this->sampleRate = -1;
 		this->channels = 0;
@@ -43,119 +38,127 @@ public:
 	bool empty()
 	{
 		std::lock_guard<std::mutex> lock(internalLock);
-		return std::deque<T>::empty();
+		return internalQueue.empty();
 	}
 
 	size_t size()
 	{
 		std::lock_guard<std::mutex> lock(internalLock);
-		return std::deque<T>::size();
+		return internalQueue.size();
 	}
 
-	void push(T* samples, size_t nSamples)
+	template <typename Iter>
+	void emplace(Iter begI, Iter endI)
 	{
-		{
-			std::lock_guard<std::mutex> lock(internalLock);
-			for (size_t i = 0; i < nSamples; i++)
-			{
-				this->push_front(samples[i]);
-			}
-		}
-
-		this->popNotified = false;
+		std::lock_guard<std::mutex> lock(internalLock);
+		std::move(begI, endI, std::front_inserter(internalQueue));
 
 		this->pushNotified = true;
 		this->pushLockCondition.notify_one();
 	}
 
-	void pop(T* returnBuffer, size_t& returnBufferLength, size_t nSamples)
+	template <typename InsertIter>
+	InsertIter pop(InsertIter insertIter, size_t nSamples)
 	{
+		std::lock_guard<std::mutex> lock(internalLock);
+
 		if (this->channels == 0)
 		{
-			returnBufferLength = 0;
-
 			this->popNotified = true;
 			this->popLockCondition.notify_one();
-
-			return;
+			return insertIter;
 		}
 
-		{
-			std::lock_guard<std::mutex> lock(internalLock);
-			returnBufferLength =
-			        std::min<size_t>(nSamples, std::deque<T>::size() - std::deque<T>::size() % this->channels);
-			for (size_t i = 0; i < returnBufferLength; i++)
-			{
-				returnBuffer[i] = this->back();
-				this->pop_back();
-			}
-		}
 
-		this->pushNotified = false;
+		auto queueSize = internalQueue.size();
+		auto returnBufferLength = std::min<size_t>(nSamples, queueSize - queueSize % this->channels);
+		auto begI = rbegin(internalQueue);
+		auto endI = std::next(begI, returnBufferLength);
+
+		auto ret = std::move(begI, endI, insertIter);
+		internalQueue.erase(endI.base(), begI.base());
 
 		this->popNotified = true;
 		this->popLockCondition.notify_one();
+		return ret;
 	}
 
 	void signalEndOfStream()
 	{
+		std::lock_guard<std::mutex> lock(internalLock);
 		this->streamEnd = true;
 		this->pushNotified = true;
-		this->pushLockCondition.notify_one();
 		this->popNotified = true;
+		this->pushLockCondition.notify_one();
 		this->popLockCondition.notify_one();
 	}
 
 	void waitForProducer(std::unique_lock<std::mutex>& lock)
 	{
-		while (!this->pushNotified)
+		//static_assert(lock.mutex() == &this->queueLock);
+		assert(lock.mutex() == &this->queueLock);
+		while (!this->pushNotified && !hasStreamEnded())
 		{
 			this->pushLockCondition.wait(lock);
 		}
+		this->pushNotified = false;
 	}
 
 	void waitForConsumer(std::unique_lock<std::mutex>& lock)
 	{
-		while (!this->popNotified)
+		//static_assert(lock.mutex() == &this->queueLock);
+		assert(lock.mutex() == &this->queueLock);
+		while (!this->popNotified && !hasStreamEnded())
 		{
 			this->popLockCondition.wait(lock);
 		}
+		this->popNotified = false;
 	}
 
 	bool hasStreamEnded()
 	{
+		std::lock_guard<std::mutex> lock(internalLock);
 		return this->streamEnd;
 	}
 
-	std::mutex& syncMutex()
+	[[nodiscard]] std::unique_lock<std::mutex> aquire_lock()
 	{
-		return this->queueLock;
+		std::unique_lock retLock{this->queueLock, std::defer_lock};
+		std::lock(retLock, this->internalLock);
+		std::lock_guard{this->internalLock, std::adopt_lock};
+		return retLock;
 	}
 
-	void setAudioAttributes(double sampleRate, unsigned int channels)
+	void setAudioAttributes(double lSampleRate, unsigned int lChannels)
 	{
 		std::lock_guard<std::mutex> lock(internalLock);
-		this->sampleRate = sampleRate;
-		this->channels = channels;
+		this->sampleRate = lSampleRate;
+		this->channels = lChannels;
 	}
 
-	void getAudioAttributes(double &sampleRate, unsigned int &channels)
+	/**
+	 * @return std::pair<double, int>,
+	 * std::pair<double, int>::first is the sample rate and std::pair<double, int>::second the channel count.
+	 */
+	[[nodiscard]] std::pair<double, int> getAudioAttributes()
 	{
 		std::lock_guard<std::mutex> lock(internalLock);
-		sampleRate = this->sampleRate;
-		channels = this->channels;
+		return {this->sampleRate, static_cast<int>(this->channels)};
 	}
 
 private:
-protected:
 	std::mutex queueLock;
 	std::mutex internalLock;
-	bool streamEnd = false;
-	std::condition_variable pushLockCondition;
-	bool pushNotified = false;
-	std::condition_variable popLockCondition;
-	bool popNotified = false;
 
-	double sampleRate = -1;
-	unsigned int channels = 0;
+	std::deque<T> internalQueue;
+
+	std::condition_variable pushLockCondition;
+	std::condition_variable popLockCondition;
+
+	double sampleRate{std::numeric_limits<double>::quiet_NaN()};
+	unsigned int channels{0};
+
+	bool streamEnd{false};
+	bool pushNotified{false};
+	bool popNotified{false};
 };

--- a/src/util/audio/AudioRecorder.cpp
+++ b/src/util/audio/AudioRecorder.cpp
@@ -2,26 +2,9 @@
 
 #include "AudioRecorder.h"
 
-AudioRecorder::AudioRecorder(Settings* settings)
-		: settings(settings)
-{
-	this->audioQueue = new AudioQueue<float>();
-	this->portAudioProducer = new PortAudioProducer(settings, this->audioQueue);
-	this->vorbisConsumer = new VorbisConsumer(settings, this->audioQueue);
-}
-
 AudioRecorder::~AudioRecorder()
 {
 	this->stop();
-
-	delete this->portAudioProducer;
-	this->portAudioProducer = nullptr;
-
-	delete this->vorbisConsumer;
-	this->vorbisConsumer = nullptr;
-
-	delete this->audioQueue;
-	this->audioQueue = nullptr;
 }
 
 auto AudioRecorder::start(const string& filename) -> bool
@@ -47,14 +30,12 @@ void AudioRecorder::stop()
 	this->audioQueue->reset();
 }
 
-auto AudioRecorder::isRecording() -> bool
+auto AudioRecorder::isRecording() const -> bool
 {
 	return this->portAudioProducer->isRecording();
 }
 
-auto AudioRecorder::getInputDevices() -> std::vector<DeviceInfo>
+auto AudioRecorder::getInputDevices() const -> std::vector<DeviceInfo>
 {
-	std::list<DeviceInfo> deviceList = this->portAudioProducer->getInputDevices();
-	return vector<DeviceInfo>{std::make_move_iterator(std::begin(deviceList)),
-							  std::make_move_iterator(std::end(deviceList))};
+	return this->portAudioProducer->getInputDevices();
 }

--- a/src/util/audio/AudioRecorder.h
+++ b/src/util/audio/AudioRecorder.h
@@ -11,31 +11,33 @@
 
 #pragma once
 
-#include <XournalType.h>
+#include "XournalType.h"
 
 #include "AudioQueue.h"
 #include "PortAudioProducer.h"
 #include "VorbisConsumer.h"
 
-#include <control/settings/Settings.h>
+#include "control/settings/Settings.h"
 
-class AudioRecorder
+#include <memory>
+
+struct AudioRecorder
 {
-public:
-	explicit AudioRecorder(Settings* settings);
+	explicit AudioRecorder(Settings& settings)
+	 : settings(settings)
+	{
+	}
 	~AudioRecorder();
 
-public:
 	bool start(const string& filename);
 	void stop();
-	bool isRecording();
-	vector<DeviceInfo> getInputDevices();
+	bool isRecording() const;
+	vector<DeviceInfo> getInputDevices() const;
 
 private:
-protected:
-	Settings* settings = nullptr;
+	Settings& settings;
 
-	AudioQueue<float>* audioQueue = nullptr;
-	PortAudioProducer* portAudioProducer = nullptr;
-	VorbisConsumer* vorbisConsumer = nullptr;
+	std::unique_ptr<AudioQueue<float>> audioQueue = std::make_unique<AudioQueue<float>>();
+	std::unique_ptr<PortAudioProducer> portAudioProducer = std::make_unique<PortAudioProducer>(settings, *audioQueue);
+	std::unique_ptr<VorbisConsumer> vorbisConsumer = std::make_unique<VorbisConsumer>(settings, *audioQueue);
 };

--- a/src/util/audio/PortAudioConsumer.h
+++ b/src/util/audio/PortAudioConsumer.h
@@ -16,7 +16,7 @@
 #include "DeviceInfo.h"
 #include "AudioQueue.h"
 
-#include <control/settings/Settings.h>
+#include "control/settings/Settings.h"
 
 #include <portaudiocpp/PortAudioCpp.hxx>
 
@@ -24,31 +24,29 @@
 
 class AudioPlayer;
 
-class PortAudioConsumer
+class PortAudioConsumer final
 {
 public:
-	explicit PortAudioConsumer(AudioPlayer* audioPlayer, AudioQueue<float>* audioQueue);
-	~PortAudioConsumer();
+	explicit PortAudioConsumer(AudioPlayer& audioPlayer, AudioQueue<float>& audioQueue)
+	 : audioPlayer(audioPlayer)
+	 , audioQueue(audioQueue)
+	{
+	}
 
-public:
-	std::list<DeviceInfo> getOutputDevices();
-	DeviceInfo getSelectedOutputDevice();
-	bool isPlaying();
+	std::vector<DeviceInfo> getOutputDevices() const;
+	DeviceInfo getSelectedOutputDevice() const;
+	bool isPlaying() const;
 	bool startPlaying();
 	int playCallback(const void* inputBuffer, void* outputBuffer, unsigned long framesPerBuffer,
 	                 const PaStreamCallbackTimeInfo* timeInfo, PaStreamCallbackFlags statusFlags);
 	void stopPlaying();
 
 private:
-protected:
-	constexpr static auto framesPerBuffer{64U};
+	portaudio::System& sys{portaudio::System::instance()};
+	AudioPlayer& audioPlayer;
+	AudioQueue<float>& audioQueue;
 
-	portaudio::AutoSystem autoSys;
-	portaudio::System& sys;
-	AudioPlayer* audioPlayer;
-	AudioQueue<float>* audioQueue = nullptr;
+	std::unique_ptr<portaudio::MemFunCallbackStream<PortAudioConsumer>> outputStream;
 
 	int outputChannels = 0;
-
-	portaudio::MemFunCallbackStream<PortAudioConsumer>* outputStream = nullptr;
 };

--- a/src/util/audio/PortAudioProducer.h
+++ b/src/util/audio/PortAudioProducer.h
@@ -25,14 +25,15 @@
 class PortAudioProducer
 {
 public:
-	explicit PortAudioProducer(Settings* settings, AudioQueue<float>* audioQueue);
-	~PortAudioProducer();
+	PortAudioProducer(Settings& settings, AudioQueue<float>& audioQueue)
+	 : settings(settings)
+	 , audioQueue(audioQueue){};
 
-	std::list<DeviceInfo> getInputDevices();
+	std::vector<DeviceInfo> getInputDevices() const;
 
-	DeviceInfo getSelectedInputDevice();
+	DeviceInfo getSelectedInputDevice() const;
 
-	bool isRecording();
+	bool isRecording() const;
 
 	bool startRecording();
 
@@ -42,15 +43,12 @@ public:
 	void stopRecording();
 
 private:
-protected:
-	constexpr static auto framesPerBuffer{64U};
+	portaudio::System& sys{portaudio::System::instance()};
+	Settings& settings;
 
-	portaudio::AutoSystem autoSys;
-	portaudio::System& sys;
-	Settings* settings;
-	AudioQueue<float>* audioQueue;
+	AudioQueue<float>& audioQueue;
+
+	std::unique_ptr<portaudio::MemFunCallbackStream<PortAudioProducer>> inputStream;
 
 	int inputChannels = 0;
-
-	portaudio::MemFunCallbackStream<PortAudioProducer>* inputStream = nullptr;
 };

--- a/src/util/audio/VorbisConsumer.h
+++ b/src/util/audio/VorbisConsumer.h
@@ -11,23 +11,26 @@
 
 #pragma once
 
-#include <XournalType.h>
-#include <control/settings/Settings.h>
+#include "control/settings/Settings.h"
 
 #include "AudioQueue.h"
 #include "DeviceInfo.h"
 
-#include <sndfile.h>
-
+#include <atomic>
 #include <thread>
 #include <utility>
 #include <fstream>
 
-class VorbisConsumer
+#include <sndfile.h>
+
+class VorbisConsumer final
 {
 public:
-	explicit VorbisConsumer(Settings* settings, AudioQueue<float>* audioQueue);
-	~VorbisConsumer() = default;
+	explicit VorbisConsumer(Settings& settings, AudioQueue<float>& audioQueue)
+	 : settings(settings)
+	 , audioQueue(audioQueue)
+	{
+	}
 
 public:
 	bool start(const string& filename);
@@ -35,10 +38,9 @@ public:
 	void stop();
 
 private:
-protected:
-	bool stopConsumer = false;
+	Settings& settings;
+	AudioQueue<float>& audioQueue;
 
-	Settings* settings = nullptr;
-	AudioQueue<float>* audioQueue = nullptr;
-	std::thread* consumerThread = nullptr;
+	std::thread consumerThread{};
+	std::atomic<bool> stopConsumer{false};
 };

--- a/src/util/audio/VorbisProducer.h
+++ b/src/util/audio/VorbisProducer.h
@@ -11,38 +11,31 @@
 
 #pragma once
 
-#include <XournalType.h>
-
 #include "AudioQueue.h"
 #include "DeviceInfo.h"
 
-#include <sndfile.h>
-
+#include <atomic>
 #include <thread>
 #include <utility>
 
-class VorbisProducer
-{
-public:
-	explicit VorbisProducer(AudioQueue<float>* audioQueue);
-	~VorbisProducer() = default;
+#include <sndfile.h>
 
-public:
-	bool start(const string& filename, unsigned int timestamp);
+struct VorbisProducer final
+{
+	explicit VorbisProducer(AudioQueue<float>& audioQueue)
+	 : audioQueue(audioQueue)
+	{
+	}
+
+	bool start(const std::string& filename, unsigned int timestamp);
 	void abort();
 	void stop();
 	void seek(int seconds);
 
 private:
-	const int sample_buffer_size = 16384;
+	AudioQueue<float>& audioQueue;
+	std::thread producerThread{};
 
-protected:
-	bool stopProducer = false;
-	SF_INFO sfInfo{};
-	SNDFILE_tag* sfFile = nullptr;
-
-	AudioQueue<float>* audioQueue = nullptr;
-	std::thread* producerThread = nullptr;
-
-	int seekSeconds = 0;
+	std::atomic<bool> stopProducer{false};
+	std::atomic<int> seekSeconds{0};
 };


### PR DESCRIPTION
While fixing clang-tidy warnings, I found possible bugs I fixed:
- The AudioQueue's threads could be unaware of changes done in other threads, 
because those changes were done non atomic or not in a fixed memory ordering ensured by a mutex/lock.
- Same for VorbisConsumer and VorbisProducer
- Fixed possible ressource leak of the "SNDFILE_tag" - ressource
- Fixed memory leaks of undeleted std::thread's 
--
- Refactored all touched files. 