### PR TITLE
Zoom + Pen fix

### DIFF
--- a/src/gui/inputdevices/AbstractInputHandler.cpp
+++ b/src/gui/inputdevices/AbstractInputHandler.cpp
@@ -16,7 +16,14 @@ AbstractInputHandler::~AbstractInputHandler() = default;
 void AbstractInputHandler::block(bool block)
 {
 	this->blocked = block;
-	this->onBlock();
+	if(block == false)
+	{
+		this->onUnblock();
+	}
+	else 
+	{
+		this->onBlock();
+	}
 }
 
 auto AbstractInputHandler::isBlocked() const -> bool
@@ -91,5 +98,9 @@ auto AbstractInputHandler::getInputDataRelativeToCurrentPage(XojPageView* page, 
 }
 
 void AbstractInputHandler::onBlock()
+{
+}
+
+void AbstractInputHandler::onUnblock()
 {
 }

--- a/src/gui/inputdevices/AbstractInputHandler.h
+++ b/src/gui/inputdevices/AbstractInputHandler.h
@@ -46,6 +46,7 @@ public:
 	void block(bool block);
 	bool isBlocked() const;
 	virtual void onBlock();
+	virtual void onUnblock();
 	bool handle(InputEvent* event);
 	virtual bool handleImpl(InputEvent* event) = 0;
 };

--- a/src/gui/inputdevices/HandRecognition.cpp
+++ b/src/gui/inputdevices/HandRecognition.cpp
@@ -145,7 +145,10 @@ void HandRecognition::penEvent()
 	if (touchState)
 	{
 		touchState = false;
-		disableTouch();
+		if (enabled)
+		{
+			disableTouch();
+		}
 		g_timeout_add(disableTimeout, reinterpret_cast<GSourceFunc>(enableTimeout), this);
 	}
 }
@@ -159,7 +162,7 @@ void HandRecognition::enableTouch()
 	{
 		inputContext->unblockDevice(InputContext::TOUCHSCREEN);
 	}
-	if (touchImpl)
+	if (touchImpl && enabled)
 	{
 		touchImpl->enableTouch();
 	}
@@ -185,11 +188,6 @@ void HandRecognition::disableTouch()
  */
 void HandRecognition::event(GdkDevice* device)
 {
-	if (!enabled)
-	{
-		return;
-	}
-
 	GdkInputSource dev = gdk_device_get_source(device);
 
 	if (dev == GDK_SOURCE_PEN || dev == GDK_SOURCE_ERASER)
@@ -203,11 +201,6 @@ void HandRecognition::event(GdkDevice* device)
  */
 void HandRecognition::event(InputDeviceClass device)
 {
-	if (!enabled)
-	{
-		return;
-	}
-
 	if (device == INPUT_DEVICE_PEN || device == INPUT_DEVICE_ERASER)
 	{
 		penEvent();

--- a/src/gui/inputdevices/InputContext.h
+++ b/src/gui/inputdevices/InputContext.h
@@ -39,10 +39,10 @@ class InputContext
 
 private:
 	StylusInputHandler* stylusHandler;
-	TouchInputHandler* touchHandler;
 	MouseInputHandler* mouseHandler;
 	TouchDrawingInputHandler* touchDrawingHandler;
 	KeyboardInputHandler* keyboardHandler;
+	TouchInputHandler* touchHandler;
 
 	GtkWidget* widget = nullptr;
 	XournalView* view;

--- a/src/gui/inputdevices/TouchInputHandler.cpp
+++ b/src/gui/inputdevices/TouchInputHandler.cpp
@@ -196,3 +196,23 @@ void TouchInputHandler::zoomEnd()
 	ZoomControl* zoomControl = this->inputContext->getView()->getControl()->getZoomControl();
 	zoomControl->endZoomSequence();
 }
+
+void TouchInputHandler::onUnblock()
+{
+	this->primarySequence = nullptr;
+	this->secondarySequence = nullptr;
+
+	this->startZoomDistance = 0.0;
+	this->lastZoomScrollCenterX = 0.0;
+	this->lastZoomScrollCenterY = 0.0;
+
+	this->priLastAbsX = -1.0;
+	this->priLastAbsY = -1.0;
+	this->secLastAbsX = -1.0;
+	this->secLastAbsY = -1.0;
+
+	this->priLastRelX = -1.0;
+	this->priLastRelY = -1.0;
+	this->secLastRelX = -1.0;
+	this->secLastRelY = -1.0;
+}

--- a/src/gui/inputdevices/TouchInputHandler.h
+++ b/src/gui/inputdevices/TouchInputHandler.h
@@ -49,6 +49,7 @@ public:
 	~TouchInputHandler() override = default;
 
 	bool handleImpl(InputEvent* event) override;
+	void onUnblock();
 
 };
 


### PR DESCRIPTION
Fix for issue #1668

I decided to call the reset method of the TouchInputHandler from HandRecognition, so it also works without the internal hand recognition turned on.