### PR TITLE
Enable Ctrl-G dialog to be closed by "Enter"

### DIFF
--- a/src/gui/dialog/GotoDialog.cpp
+++ b/src/gui/dialog/GotoDialog.cpp
@@ -16,10 +16,10 @@ auto GotoDialog::getSelectedPage() const -> int
 void GotoDialog::show(GtkWindow* parent)
 {
 	gtk_window_set_transient_for(GTK_WINDOW(this->window), parent);
-    gtk_entry_set_activates_default(GTK_ENTRY(get("spinPage")), TRUE);
+	gtk_entry_set_activates_default(GTK_ENTRY(get("spinPage")), TRUE);
 
 	int returnCode = gtk_dialog_run(GTK_DIALOG(this->window));
-    gtk_widget_hide(this->window);
+	gtk_widget_hide(this->window);
 
 	if (returnCode == GTK_RESPONSE_OK)
 	{

--- a/src/gui/dialog/GotoDialog.cpp
+++ b/src/gui/dialog/GotoDialog.cpp
@@ -16,10 +16,12 @@ auto GotoDialog::getSelectedPage() const -> int
 void GotoDialog::show(GtkWindow* parent)
 {
 	gtk_window_set_transient_for(GTK_WINDOW(this->window), parent);
-	int returnCode = gtk_dialog_run(GTK_DIALOG(this->window));
-	gtk_widget_hide(this->window);
+    gtk_entry_set_activates_default(GTK_ENTRY(get("spinPage")), TRUE);
 
-	if (returnCode == 2)
+	int returnCode = gtk_dialog_run(GTK_DIALOG(this->window));
+    gtk_widget_hide(this->window);
+
+	if (returnCode == GTK_RESPONSE_OK)
 	{
 		this->selectedPage = gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spinPage")));
 	}

--- a/ui/goto.glade
+++ b/ui/goto.glade
@@ -13,7 +13,6 @@
     <property name="border_width">5</property>
     <property name="title" translatable="yes">Go to Page</property>
     <property name="resizable">False</property>
-    <property name="modal">True</property>
     <property name="destroy_with_parent">True</property>
     <property name="type_hint">dialog</property>
     <child>
@@ -32,12 +31,12 @@
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
-              <object class="GtkButton" id="button1">
-                <property name="label">gtk-close</property>
-                <property name="use_action_appearance">False</property>
+              <object class="GtkButton" id="gotocancelbutton">
+                <property name="label">gtk-cancel</property>
+                <property name="name">gotocancelbutton</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
+                <property name="receives_default">False</property>
                 <property name="use_stock">True</property>
               </object>
               <packing>
@@ -47,14 +46,15 @@
               </packing>
             </child>
             <child>
-              <object class="GtkButton" id="button2">
+              <object class="GtkButton" id="gotookbutton">
                 <property name="label">gtk-ok</property>
-                <property name="use_action_appearance">False</property>
+                <property name="name">gotookbutton</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
+                <property name="can_default">True</property>
+                <property name="has_default">True</property>
                 <property name="receives_default">True</property>
                 <property name="use_stock">True</property>
-                <accelerator key="Return" signal="activate"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -114,8 +114,8 @@
       </object>
     </child>
     <action-widgets>
-      <action-widget response="1">button1</action-widget>
-      <action-widget response="2">button2</action-widget>
+      <action-widget response="-6">gotocancelbutton</action-widget>
+      <action-widget response="-5">gotookbutton</action-widget>
     </action-widgets>
   </object>
 </interface>


### PR DESCRIPTION
This fixes bug #975.
Key changes:
- removed the "accelerator" that linked the enter key to the OK button. It appeared this forced the dialog to close before the value in the spin button was handled.
- used `gtk_entry_set_activates_default` to specify that when the Enter key is pressed in the spin box, the default option should be activated.
- included some settings that specified that the OK button was the one to activate by default (i.e. when the Enter key is pressed)

Additional changes:
- the Close button was changed to a Cancel button to be consistent with other dialogs
- Instead of the buttons creating values 1 and 2 (hardcoded), the OK and Close buttons response codes were replaced with the GTK-specified constants. (Unfortunately, this means there are weird -5 and -6 in the `.glade` file, but hopefully no one is manually editing those anyways...)

Two concerns:
- There are a few lines of fiddling I did that I'm not sure are necessary changes. Is it worth going back and finding the smallest sufficient set of changes?
- For some reason, opening and editing the `ui/goto.glade` file in Glade adds `type="action"` in places that seems to break the page. It works as it is now, but if anyone ever edits this `ui/goto.glade` file again, it won't work without manually removing those lines. I assume that's a problem, but I don't know enough about Glade to resolve it.