### PR TITLE
Preserve element ordering within layer during selection

### DIFF
--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -2673,7 +2673,7 @@ void Control::clipboardPasteXournal(ObjectInputStream& in) {
 
             pasteAddUndoAction->addElement(layer, element.get(), layer->indexOf(element.get()));
             // Todo: unique_ptr
-            selection->addElement(element.release());
+            selection->addElement(element.release(), Layer::InvalidElementIndex);
         }
         undoRedo->addUndoAction(std::move(pasteAddUndoAction));
 

--- a/src/control/tools/EditSelection.cpp
+++ b/src/control/tools/EditSelection.cpp
@@ -41,8 +41,8 @@ EditSelection::EditSelection(UndoRedoHandler* undo, Selection* selection, XojPag
     contstruct(undo, view, view->getPage());
 
     for (Element* e: selection->selectedElements) {
+        addElement(e, this->sourceLayer->indexOf(e));
         this->sourceLayer->removeElement(e, false);
-        addElement(e);
     }
 
     view->rerenderPage();
@@ -56,7 +56,7 @@ EditSelection::EditSelection(UndoRedoHandler* undo, Element* e, XojPageView* vie
 
     contstruct(undo, view, page);
 
-    addElement(e);
+    addElement(e, this->sourceLayer->indexOf(e));
     this->sourceLayer->removeElement(e, false);
 
     view->rerenderElement(e);
@@ -69,7 +69,7 @@ EditSelection::EditSelection(UndoRedoHandler* undo, const vector<Element*>& elem
     contstruct(undo, view, page);
 
     for (Element* e: elements) {
-        addElement(e);
+        addElement(e, this->sourceLayer->indexOf(e));
         this->sourceLayer->removeElement(e, false);
     }
 
@@ -275,9 +275,10 @@ void EditSelection::fillUndoItem(DeleteUndoAction* undo) { this->contents->fillU
 
 /**
  * Add an element to the this selection
+ *
  */
-void EditSelection::addElement(Element* e) {
-    this->contents->addElement(e);
+void EditSelection::addElement(Element* e, Layer::ElementIndex order) {
+    this->contents->addElement(e, order);
 
     if (e->rescaleOnlyAspectRatio()) {
         this->aspectRatio = true;

--- a/src/control/tools/EditSelection.h
+++ b/src/control/tools/EditSelection.h
@@ -153,8 +153,11 @@ public:
 public:
     /**
      * Add an element to the this selection
+     * @param order: specifies the index of the element from the source layer,
+     * in case we want to replace it back where it came from.
+     * 'InvalidLayerIndex' is a special value that says it has no source layer index (e.g, from clipboard)
      */
-    void addElement(Element* e);
+    void addElement(Element* e, Layer::ElementIndex order = Layer::InvalidElementIndex);
 
     /**
      * Returns all containig elements of this selections

--- a/src/control/tools/EditSelectionContents.h
+++ b/src/control/tools/EditSelectionContents.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <map>
 #include <string>
 #include <vector>
 
@@ -73,8 +74,10 @@ public:
 public:
     /**
      * Add an element to the this selection
+     * @param orderInSourceLayer: specifies the index of the element from the source layer,
+     * in case we want to replace it back where it came from.
      */
-    void addElement(Element* e);
+    void addElement(Element* e, Layer::ElementIndex order);
 
     /**
      * Returns all containig elements of this selections
@@ -173,6 +176,11 @@ private:
      * The selected element (the only one which are handled by this instance)
      */
     vector<Element*> selected;
+
+    /**
+     * Mapping of elements in the selection to the indexes from the original selection layer.
+     */
+    std::map<Element*, Layer::ElementIndex> indexWithinLayer;
 
     /**
      * The rendered elements

--- a/src/control/tools/EditSelectionContents.h
+++ b/src/control/tools/EditSelectionContents.h
@@ -11,8 +11,8 @@
 
 #pragma once
 
-#include <map>
-#include <string>
+#include <deque>
+#include <utility>
 #include <vector>
 
 #include "control/Tool.h"
@@ -175,12 +175,13 @@ private:
     /**
      * The selected element (the only one which are handled by this instance)
      */
-    vector<Element*> selected;
+    std::vector<Element*> selected;
 
     /**
      * Mapping of elements in the selection to the indexes from the original selection layer.
+     * Defines a insert order over the selection.
      */
-    std::map<Element*, Layer::ElementIndex> indexWithinLayer;
+    std::deque<std::pair<Element*, Layer::ElementIndex>> insertOrder;
 
     /**
      * The rendered elements

--- a/src/model/Layer.cpp
+++ b/src/model/Layer.cpp
@@ -38,7 +38,7 @@ void Layer::addElement(Element* e) {
     this->elements.push_back(e);
 }
 
-void Layer::insertElement(Element* e, int pos) {
+void Layer::insertElement(Element* e, ElementIndex pos) {
     if (e == nullptr) {
         g_warning("insertElement(nullptr)!");
         Stacktrace::printStracktrace();
@@ -67,17 +67,17 @@ void Layer::insertElement(Element* e, int pos) {
     }
 }
 
-auto Layer::indexOf(Element* e) -> int {
+auto Layer::indexOf(Element* e) -> ElementIndex {
     for (unsigned int i = 0; i < this->elements.size(); i++) {
         if (this->elements[i] == e) {
             return i;
         }
     }
 
-    return -1;
+    return InvalidElementIndex;
 }
 
-auto Layer::removeElement(Element* e, bool free) -> int {
+auto Layer::removeElement(Element* e, bool free) -> ElementIndex {
     for (unsigned int i = 0; i < this->elements.size(); i++) {
         if (e == this->elements[i]) {
             this->elements.erase(this->elements.begin() + i);
@@ -91,7 +91,7 @@ auto Layer::removeElement(Element* e, bool free) -> int {
 
     g_warning("Could not remove element from layer, it's not on the layer!");
     Stacktrace::printStracktrace();
-    return -1;
+    return InvalidElementIndex;
 }
 
 auto Layer::isAnnotated() -> bool { return !this->elements.empty(); }

--- a/src/model/Layer.h
+++ b/src/model/Layer.h
@@ -17,10 +17,14 @@
 #include "Element.h"
 #include "XournalType.h"
 
+
 class Layer {
 public:
     Layer();
     virtual ~Layer();
+
+    using ElementIndex = std::ptrdiff_t;
+    static constexpr auto InvalidElementIndex = static_cast<ElementIndex>(-1);
 
 public:
     /**
@@ -35,17 +39,17 @@ public:
      *
      * @note Performs a check to determine whether the element is already contained in the Layer
      */
-    void insertElement(Element* e, int pos);
+    void insertElement(Element* e, ElementIndex pos);
 
     /**
      * Returns the index of the given Element with respect to the internal list
      */
-    int indexOf(Element* e);
+    ElementIndex indexOf(Element* e);
 
     /**
      * Removes an Element from the Layer and optionally deletes it
      */
-    int removeElement(Element* e, bool free);
+    ElementIndex removeElement(Element* e, bool free);
 
     /**
      * Returns an iterator over the Element%s contained in this Layer


### PR DESCRIPTION
Addresses the bug half of #810. The feature request (bring to front / bring forward / send to back / send backward) still should be resolved.

When selecting elements, the elements are be pulled to the top. The bug this PR addresses was that these elements were not returned to their original order within the layer. 

Happy to take constructive criticism on design choices; it's been a long while since I've worked in C++ on a large project.