### PR TITLE
Modernize formatting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,56 +1,152 @@
 ---
-BasedOnStyle: WebKit
-
+Language:        Cpp
+# BasedOnStyle:  Google
 AccessModifierOffset: -4
 AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: false
 AlignConsecutiveAssignments: false
 AlignConsecutiveDeclarations: false
 AlignEscapedNewlines: Left
 AlignOperands: true
 AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: None
-AllowShortIfStatementsOnASingleLine: true
-AllowShortLoopsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: true
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: false
-AlwaysBreakTemplateDeclarations: true
+AlwaysBreakTemplateDeclarations: Yes
 BinPackArguments: true
 BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
 BreakBeforeBinaryOperators: None
-BreakBeforeBraces: Allman
-BreakBeforeTernaryOperators: false
-#BreakConstructorInitializers: BeforeColon
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
 BreakInheritanceList: AfterColon
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: AfterColon
+BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: true
 ColumnLimit: 120
-CompactNamespaces: true
-ConstructorInitializerAllOnOneLineOrOnePerLine: false
-ConstructorInitializerIndentWidth: 1
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 8
 ContinuationIndentWidth: 8
 Cpp11BracedListStyle: true
+#DeriveLineEnding: true #cf-10
 DerivePointerAlignment: false
 DisableFormat: false
-ExperimentalAutoDetectBinPacking: true
+ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true
-IncludeBlocks: Preserve
-IndentCaseLabels: false
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks: Regroup
+IncludeCategories:
+#std headers
+  - Regex:           '^<[^\/.]*>'
+    Priority:        1
+  #    SortPriority:    0 #cf-10
+  - Regex:           '^<[^\/]*.h(?:|.{2})>'
+    Priority:        3
+  #    SortPriority:    0 #cf-10
+  - Regex:           '^<.*\.h(?:|.{2})>'
+    Priority:        2
+  #    SortPriority:    0 #cf-10
+  - Regex:           '^<.*'
+    Priority:        4
+  #    SortPriority:    0 #cf-10
+  - Regex:           '^"[^\/]*"'
+    Priority:        6
+  #    SortPriority:    0 #cf-10
+  - Regex:           '.*'
+    Priority:        5
+#    SortPriority:    0 #cf-10
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+#IncludeIsMainSourceRegex: '' #cf-10
+IndentCaseLabels: true
+#IndentGotoLabels: true #cf-10
 IndentPPDirectives: None
 IndentWidth: 4
 IndentWrappedFunctionNames: true
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
 KeepEmptyLinesAtTheStartOfBlocks: true
-Language: Cpp
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 2
 NamespaceIndentation: None
-PenaltyReturnTypeOnItsOwnLine: 10000
+ObjCBinPackProtocolList: Never
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Left
-ReflowComments: false #true
-SortIncludes: false #true
-SortUsingDeclarations: false #true
-SpaceAfterCStyleCast: true
+RawStringFormats:
+  - Language:        Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+  - Language:        TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+ReflowComments: true
+SortIncludes: true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
 SpaceAfterTemplateKeyword: true
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeCpp11BracedList: false
@@ -58,17 +154,21 @@ SpaceBeforeCtorInitializerColon: false
 SpaceBeforeInheritanceColon: false
 SpaceBeforeParens: ControlStatements
 SpaceBeforeRangeBasedForLoopColon: false
+#SpaceInEmptyBlock: false #cf-10
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 2
 SpacesInAngles: false
-SpacesInCStyleCastParentheses: false
+#SpacesInConditionalStatement: false #cf-10
 SpacesInContainerLiterals: false
+SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard: Cpp11
-
-TabWidth: 4
-
-UseTab: ForIndentation
-
+#SpaceBeforeSquareBrackets: false #cf-10
+Standard: Auto
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        4
+#UseCRLF:         false #cf-10
+UseTab:          Never
 ...

--- a/azure-pipelines/clang-format-applied.yml
+++ b/azure-pipelines/clang-format-applied.yml
@@ -22,9 +22,9 @@ stages:
     steps:
     - bash: |
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-        sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main"
+        sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main"
         sudo apt-get update
-        sudo apt-get install -y clang-format-8
+        sudo apt-get install -y clang-format-9
       displayName: 'Install clang-format'
     - bash: |
         # Checkout the master branch as we require it to get the list of modified files

--- a/azure-pipelines/util/format_diff_lines.pl
+++ b/azure-pipelines/util/format_diff_lines.pl
@@ -13,7 +13,7 @@ my @hunks;
 # Current file
 my $current_file;
 
-my @CLANG_FMT_CMDS = ("clang-format", "clang-format-8");
+my @CLANG_FMT_CMDS = ("clang-format", "clang-format-9");
 my $clang_format_cmd = "";
 for my $c (@CLANG_FMT_CMDS) {
 	if (`$c --version`) {


### PR DESCRIPTION
Hello there,
I modernized the formatting in our .clang-format file.
Currently it's hardly aligned on googles style, as we discussed.
But I also did some changes, wanted by @LittleHuba and a bit of personal preference influenced it.

Please take a look and give fast feedback, I want to merge it tomorrow. And format all files accordingly so the pr-freeze can finally come to an end.

Aditionally I want to merge all current merge requests before.