### PR TITLE
Fix MacOS builds

### DIFF
--- a/azure-pipelines/steps/build_mac.yml
+++ b/azure-pipelines/steps/build_mac.yml
@@ -22,7 +22,10 @@ steps:
       mkdir build
     displayName: 'Create Build Directory'
   - bash: |
-      curl -L -o ninja-mac.zip $(curl -s https://api.github.com/repos/ninja-build/ninja/releases/latest | grep "browser_download_url.*mac\.zip" | cut -d : -f 2,3 | tr -d '"')
+      # Ninja >= 1.10.0 binaries depend on Catalina or newer, so use 1.9.0 instead.
+      curl -L -o ninja-mac.zip https://github.com/ninja-build/ninja/releases/download/v1.9.0/ninja-mac.zip
+
+      # curl -L -o ninja-mac.zip $(curl -s https://api.github.com/repos/ninja-build/ninja/releases/latest | grep "browser_download_url.*mac\.zip" | cut -d : -f 2,3 | tr -d '"')
       # Fallback to version 1.9.0 if the previous request fails for some reason
       if [ ! -f ninja-mac.zip ]; then
         curl -L -o ninja-mac.zip https://github.com/ninja-build/ninja/releases/download/v1.9.0/ninja-mac.zip


### PR DESCRIPTION
Latest Ninja requires Catalina or newer, so stick on Ninja 1.9.0 for now.