### PR TITLE
Make sure translations are built before installation (workaround)

### DIFF
--- a/appimagecraft.yml
+++ b/appimagecraft.yml
@@ -4,6 +4,14 @@ project:
   name: com.github.xournalpp.xournalpp
   version_command: git describe --tags
 
+scripts:
+  pre_build:
+    - mkdir translations-build
+    - cd translations-build
+    - cmake "${PROJECT_ROOT}"
+    - make translations
+    - cd ..
+
 build:
   cmake:
 


### PR DESCRIPTION
An appimagecraft-only workaround that ensures the translations are updated before the actual build.

Not an alternative to #1617 but actually a hack that only fixes problems related to appimagecraft builds on clean Git repository checkouts. I strongly recommend going for #1617, if possible.
This PR is safe to merge, as it won't affect any build pipelines, and it's future proof in that it is unnecessary but won't harm after merging #1617.

CC #1448.