### PR TITLE
Prevent crash on invalid recent files entries

### DIFF
--- a/src/util/Path.cpp
+++ b/src/util/Path.cpp
@@ -166,6 +166,9 @@ auto Path::fromUri(const string& uri) -> Path {
     }
 
     gchar* filename = g_filename_from_uri(uri.c_str(), nullptr, nullptr);
+    if (filename == nullptr) {
+        return {};
+    }
     Path p(filename);
     g_free(filename);
 

--- a/test/util/PathTest.cpp
+++ b/test/util/PathTest.cpp
@@ -37,7 +37,9 @@ public:
     void tearDown() {}
 
     void testUnsupportedUri() {
-        Path b = Path::fromUri("http://localhost/test.txt");
+        Path a = Path::fromUri("http://localhost/test.txt");
+        CPPUNIT_ASSERT_EQUAL(true, a.isEmpty());
+        Path b = Path::fromUri("file://invalid");
         CPPUNIT_ASSERT_EQUAL(true, b.isEmpty());
     }
 


### PR DESCRIPTION
If `Path::fromUri` is passed an invalid location, `g_filename_from_uri` will return NULL, which will cause xournal++ to crash. 

The error below happened when attempting to start xournal++. The crash happens from what appears to be an invalid recent files entry from VMware (`file://[nfs-vm2] WIN10-WKS-14/WIN10-WKS-14.vmx`).
```
terminate called after throwing an instance of 'std::logic_error'
  what():  basic_string::_M_construct null not valid

Thread 1 "xournalpp" received signal SIGABRT, Aborted.
__GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
50	../sysdeps/unix/sysv/linux/raise.c: No such file or directory.
(gdb) bt
#0  0x00007ffff64d33eb in __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
#1  0x00007ffff64b2899 in __GI_abort () at abort.c:79
#2  0x00007ffff67365f6 in  () at /lib/x86_64-linux-gnu/libstdc++.so.6
#3  0x00007ffff67429ec in  () at /lib/x86_64-linux-gnu/libstdc++.so.6
#4  0x00007ffff6742a47 in  () at /lib/x86_64-linux-gnu/libstdc++.so.6
#5  0x00007ffff6742ca9 in  () at /lib/x86_64-linux-gnu/libstdc++.so.6
#6  0x00007ffff6738da4 in std::__throw_logic_error(char const*) () at /lib/x86_64-linux-gnu/libstdc++.so.6
#7  0x0000555555732f76 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<char const*>(char const*, char const*, std::forward_iterator_tag)
    (this=0x7fffffffd5d0, __beg=0x0, __end=0xffffffffffffffff <error: Cannot access memory at address 0xffffffffffffffff>) at /usr/include/c++/9/bits/basic_string.tcc:212
#8  0x0000555555732ecc in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct_aux<char const*>(char const*, char const*, std::__false_type)
    (this=0x7fffffffd5d0, __beg=0x0, __end=0xffffffffffffffff <error: Cannot access memory at address 0xffffffffffffffff>) at /usr/include/c++/9/bits/basic_string.h:247
#9  0x0000555555732e8b in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<char const*>(char const*, char const*)
    (this=0x7fffffffd5d0, __beg=0x0, __end=0xffffffffffffffff <error: Cannot access memory at address 0xffffffffffffffff>) at /usr/include/c++/9/bits/basic_string.h:266
#10 0x0000555555732e35 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string<std::allocator<char> >(char const*, std::allocator<char> const&)
    (this=0x7fffffffd5d0, __s=0x0, __a=...) at /usr/include/c++/9/bits/basic_string.h:527
#11 0x00005555558b4d59 in Path::Path(char const*) (this=0x7fffffffd5d0, path=0x0) at /home/iczero/opt/xournalpp/src/util/Path.cpp:12
#12 0x00005555558b5eee in Path::fromUri(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (uri="file://[nfs-vm2] WIN10-WKS-14/WIN10-WKS-14.vmx")
    at /home/iczero/opt/xournalpp/src/util/Path.cpp:169
#13 0x000055555575b2ac in RecentManager::filterRecent(_GList*, bool) (items=0x555555b49680 = {...}, xoj=true) at /home/iczero/opt/xournalpp/src/control/RecentManager.cpp:128
#14 0x000055555575c2ec in RecentManager::updateMenu() (this=0x555555a412a0) at /home/iczero/opt/xournalpp/src/control/RecentManager.cpp:202
#15 0x000055555575ab82 in RecentManager::RecentManager() (this=0x555555a412a0) at /home/iczero/opt/xournalpp/src/control/RecentManager.cpp:23
#16 0x0000555555739991 in Control::Control(GladeSearchpath*) (this=0x555555a34c50, gladeSearchPath=0x5555559f3140) at /home/iczero/opt/xournalpp/src/control/Control.cpp:73
#17 0x0000555555769966 in XournalMain::run(int, char**) (this=0x5555559ab9d0, argc=1, argv=0x7fffffffdc18) at /home/iczero/opt/xournalpp/src/control/XournalMain.cpp:320
#18 0x0000555555732622 in main(int, char**) (argc=1, argv=0x7fffffffdc18) at /home/iczero/opt/xournalpp/src/Xournalpp.cpp:32
```