### PR TITLE
Fix translation target

### DIFF
--- a/po/CMakeLists.txt
+++ b/po/CMakeLists.txt
@@ -20,7 +20,7 @@ if (XGETTEXT_FOUND)
       "${PROJECT_SOURCE_DIR}/ui/*.glade"
   )
 
-  gettext_create_translations ("${potfile}")
+  gettext_create_translations ("${potfile}" ALL NOUPDATE)
 
 else (XGETTEXT_FOUND)
   message (ERROR "Gettext not found!")


### PR DESCRIPTION
Fixes #1596. Supersedes #1617.

Apparently, the `gettext_create_translations` function has a parameter called `NOUPDATE` that generates the `.po` file in the build directory rather than updating it in place. 

In hindsight, we could've saved a lot more time if we had taken a closer look at that `cmake/find/Gettext.cmake`.

We can probably remove some of the translation build commands in the CI config to catch packaging/translation errors in the future.