### PR TITLE
Preserve PDF outline information in exported PDF

### DIFF
--- a/src/pdf/base/XojCairoPdfExport.h
+++ b/src/pdf/base/XojCairoPdfExport.h
@@ -33,6 +33,17 @@ public:
 
 private:
     bool startPdf(const Path& file);
+#if CAIRO_VERSION >= CAIRO_VERSION_ENCODE(1, 16, 0)
+    /**
+     * Populate the outline of the generated PDF using the outline of the
+     * background PDF.
+     *
+     * This requires features available only in cairo 1.16 or newer.
+     *
+     * @param tocModel The Document's content model. Does nothing if set to null.
+     */
+    void populatePdfOutline(GtkTreeModel* tocModel);
+#endif
     void endPdf();
     void exportPage(size_t page);
 


### PR DESCRIPTION
Fixes #1740. This feature is only available with Cairo 1.16 or newer; it will be automatically enabled if supported. Ubuntu 19.04 has Cairo 1.16, as well as the popular rolling releases (e.g. ArchLinux, Solus).

Merging in 3 days if no objections.