### PR TITLE
Prepend iconsDark path after setting default path.

### DIFF
--- a/src/control/XournalMain.cpp
+++ b/src/control/XournalMain.cpp
@@ -319,13 +319,14 @@ auto XournalMain::run(int argc, char* argv[]) -> int {
 
     auto* control = new Control(gladePath);
 
+    string icon = gladePath->getFirstSearchPath() + "/icons/";
+    gtk_icon_theme_prepend_search_path(gtk_icon_theme_get_default(), icon.c_str());
+
     if (control->getSettings()->isDarkTheme()) {
         string icon = gladePath->getFirstSearchPath() + "/iconsDark/";
         gtk_icon_theme_prepend_search_path(gtk_icon_theme_get_default(), icon.c_str());
-    }
 
-    string icon = gladePath->getFirstSearchPath() + "/icons/";
-    gtk_icon_theme_prepend_search_path(gtk_icon_theme_get_default(), icon.c_str());
+    }
 
     auto* win = new MainWindow(gladePath, control);
     control->initWindow(win);

--- a/src/control/XournalMain.cpp
+++ b/src/control/XournalMain.cpp
@@ -325,7 +325,6 @@ auto XournalMain::run(int argc, char* argv[]) -> int {
     if (control->getSettings()->isDarkTheme()) {
         string icon = gladePath->getFirstSearchPath() + "/iconsDark/";
         gtk_icon_theme_prepend_search_path(gtk_icon_theme_get_default(), icon.c_str());
-
     }
 
     auto* win = new MainWindow(gladePath, control);


### PR DESCRIPTION
When the "dark theme" option is set, the iconsDark directory should be
the first dir where the icon theme should search for the icon. By
prepending this path after the default icons path has been set, we make
sure that this dir is indeed the first in the list of dirs to look up
icons.

Fixes issue #1746.