### PR TITLE
Remove Y adjustment in XournalView::scrollTo

### DIFF
--- a/src/gui/XournalView.cpp
+++ b/src/gui/XournalView.cpp
@@ -391,7 +391,7 @@ void XournalView::scrollTo(size_t pageNo, double yDocument) {
     Layout* layout = gtk_xournal_get_layout(this->widget);
 
     int x = v->getX();
-    int y = v->getY() + std::lround(yDocument);
+    int y = v->getY();
     int width = v->getDisplayWidth();
     int height = v->getDisplayHeight();
 


### PR DESCRIPTION
This fixes the page scrolling units issue for me.

I'm honestly not clear on what the `yDocument` variable was supposed to represent, and why it was always added to the y dimension of new page positions. At least in my testing, this patch makes all "go to page" operations align the viewer with the *top* of the new page, rather than "sort of" the bottom. 

Closes #1764 
