### PR TITLE
Fix crash when exporting single pages

### DIFF
--- a/src/gui/dialog/ExportDialog.cpp
+++ b/src/gui/dialog/ExportDialog.cpp
@@ -46,7 +46,7 @@ auto ExportDialog::getRange() -> PageRangeVector {
     }
     if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(rdRangeCurrent))) {
         PageRangeVector range;
-        range.push_back(new PageRangeEntry(this->currentPage, this->currentPage));
+        range.push_back(new PageRangeEntry(this->currentPage - 1, this->currentPage - 1));
         return range;
     }
 

--- a/src/pdf/base/XojCairoPdfExport.cpp
+++ b/src/pdf/base/XojCairoPdfExport.cpp
@@ -133,7 +133,7 @@ auto XojCairoPdfExport::createPdf(Path file, PageRangeVector& range) -> bool {
 
     int c = 0;
     for (PageRangeEntry* e: range) {
-        for (int i = e->getFirst() - 1; i <= e->getLast() - 1; i++) {
+        for (int i = e->getFirst(); i <= e->getLast(); i++) {
             if (i < 0 || i > static_cast<int>(doc->getPageCount())) {
                 continue;
             }

--- a/src/pdf/base/XojCairoPdfExport.cpp
+++ b/src/pdf/base/XojCairoPdfExport.cpp
@@ -134,7 +134,7 @@ auto XojCairoPdfExport::createPdf(Path file, PageRangeVector& range) -> bool {
     int c = 0;
     for (PageRangeEntry* e: range) {
         for (int i = e->getFirst(); i <= e->getLast(); i++) {
-            if (i < 0 || i > static_cast<int>(doc->getPageCount())) {
+            if (i < 0 || i >= static_cast<int>(doc->getPageCount())) {
                 continue;
             }
 

--- a/src/pdf/base/XojCairoPdfExport.cpp
+++ b/src/pdf/base/XojCairoPdfExport.cpp
@@ -133,7 +133,7 @@ auto XojCairoPdfExport::createPdf(Path file, PageRangeVector& range) -> bool {
 
     int c = 0;
     for (PageRangeEntry* e: range) {
-        for (int i = e->getFirst(); i <= e->getLast(); i++) {
+        for (int i = e->getFirst() - 1; i <= e->getLast() - 1; i++) {
             if (i < 0 || i > static_cast<int>(doc->getPageCount())) {
                 continue;
             }


### PR DESCRIPTION
When choosing to export a custom page range (either a single page or multiple ones) xournalpp has been crashing every time because indices were out of range.