### PR TITLE
Implementation of cubic splines

### DIFF
--- a/src/control/tools/SplineHandler.cpp
+++ b/src/control/tools/SplineHandler.cpp
@@ -9,66 +9,91 @@
 #include "undo/InsertUndoAction.h"
 #include "util/cpp14memory.h"
 
-/**
- * @brief A class to handle splines
- *
- * Drawing of a spline is started by a ButtonPressEvent. After every ButtonReleaseEvent,
- * a new knot point is added. The spline is finished through a ButtonDoublePressEvent,
- * the escape key or a ButtonPressEvent near the first knot. The latter event closes the spline.
- *
- * Splines segments can be linear or cubic (as in Inkscape). Join of two cubic segments
- * is supposed to be smooth. As for now only linear splines are implemented.
- */
 SplineHandler::SplineHandler(XournalView* xournal, XojPageView* redrawable, const PageRef& page):
         InputHandler(xournal, redrawable, page) {}
 
 SplineHandler::~SplineHandler() = default;
 
+constexpr double RADIUS_WITHOUT_ZOOM = 10.0;
+constexpr double LINE_WIDTH_WITHOUT_ZOOM = 2.0;
+
 void SplineHandler::draw(cairo_t* cr) {
-    if (!stroke) {
+    if (!stroke || this->knots.empty()) {
         return;
     }
 
     double zoom = xournal->getZoom();
-    double radius = radiusConst / zoom;
+    double radius = RADIUS_WITHOUT_ZOOM / zoom;
     if (xournal->getControl()->getToolHandler()->getDrawingType() != DRAWING_TYPE_SPLINE) {
         g_warning("Drawing type is not spline any longer");
-        finalizeSpline();
-        //        stroke = nullptr;
-        //        xournal->getCursor()->updateCursor();
+        this->finalizeSpline();
+        this->knots.clear();
+        this->tangents.clear();
         return;
     }
 
     int dpiScaleFactor = xournal->getDpiScaleFactor();
     cairo_scale(cr, zoom * dpiScaleFactor, zoom * dpiScaleFactor);
 
-    // draw circles around knot points
-    double lineWidth = 2 / zoom;
-    int pointCount = stroke->getPointCount();
+    double lineWidth = LINE_WIDTH_WITHOUT_ZOOM / zoom;
     cairo_set_line_width(cr, lineWidth);
-    Point firstPoint = stroke->getPoint(0);
-    Point currPoint = stroke->getPoint(pointCount - 1);
-    double dist = currPoint.lineLengthTo(firstPoint);
-    cairo_set_source_rgb(cr, 1, 0, 0);                               // use red color for first knot
-    cairo_move_to(cr, firstPoint.x + radius, firstPoint.y);          // move to start point of circle arc;
-    cairo_arc(cr, firstPoint.x, firstPoint.y, radius, 0, 2 * M_PI);  // draw circle
-    if (dist < radius && pointCount > 3) {  // current point lies within the circle around the first knot
+    const Point& firstKnot = this->knots.front();
+    const Point& lastKnot = this->knots.back();
+    const Point& firstTangent = this->tangents.front();
+    const Point& lastTangent = this->tangents.back();
+    double dist = this->currPoint.lineLengthTo(firstKnot);
+
+    // draw circles around knot points
+    cairo_set_source_rgb(cr, 0.3, 0.3, 0.3);           // use gray color for all knots except first one
+    for (auto p: knots) {                              // circle all knots, circle around first knot will be redrawn
+        cairo_move_to(cr, p.x + radius, p.y);          // move to start point of circle arc;
+        cairo_arc(cr, p.x, p.y, radius, 0, 2 * M_PI);  // draw circle
+    }
+    cairo_stroke(cr);
+    cairo_set_source_rgb(cr, 1, 0, 0);                             // use red color for first knot
+    cairo_move_to(cr, firstKnot.x + radius, firstKnot.y);          // move to start point of circle arc;
+    cairo_arc(cr, firstKnot.x, firstKnot.y, radius, 0, 2 * M_PI);  // draw circle
+    if (dist < radius && this->getKnotCount() > 1) {  // current point lies within the circle around the first knot
         cairo_fill(cr);
     } else {
         cairo_stroke(cr);
     }
 
-    cairo_set_source_rgb(cr, 0.3, 0.3, 0.3);       // use gray color for all knots except first one
-    for (size_t i = 1; i < pointCount - 1; i++) {  // dynamically changing knot is not circled
-        Point p = stroke->getPoint(i);
-        cairo_move_to(cr, p.x + radius, p.y);          // move to start point of circle arc;
-        cairo_arc(cr, p.x, p.y, radius, 0, 2 * M_PI);  // draw circle
+    // draw dynamically changing segment
+    cairo_set_source_rgb(cr, 0.3, 0.3, 0.3);  // use gray color
+    const Point& cp1 = Point(lastKnot.x + lastTangent.x, lastKnot.y + lastTangent.y);
+    const Point& cp2 = (dist < radius && this->getKnotCount() > 1) ?
+                               Point(firstKnot.x - firstTangent.x, firstKnot.y - firstTangent.y) :
+                               this->currPoint;
+    SplineSegment changingSegment = SplineSegment(lastKnot, cp1, cp2, this->currPoint);
+    changingSegment.draw(cr);
+
+    // draw dynamically changing tangent
+    cairo_move_to(cr, lastKnot.x - lastTangent.x, lastKnot.y - lastTangent.y);
+    cairo_line_to(cr, lastKnot.x + lastTangent.x, lastKnot.y + lastTangent.y);
+
+    cairo_stroke(cr);
+
+
+    // draw other tangents
+    cairo_set_source_rgb(cr, 0, 1, 0);
+    for (size_t i = 0; i < this->getKnotCount(); i++) {
+        cairo_move_to(cr, this->knots[i].x - this->tangents[i].x,
+                      this->knots[i].y - this->tangents[i].y);  // draw dynamically changing segment
+        cairo_line_to(cr, this->knots[i].x + this->tangents[i].x, this->knots[i].y + this->tangents[i].y);
     }
     cairo_stroke(cr);
 
-    // draw spline
-    view.drawStroke(cr, stroke, 0);
+    // create stroke and draw spline
+    this->updateStroke();
+    if (this->getKnotCount() > 1) {
+        view.drawStroke(cr, stroke, 0);
+    }
 }
+
+constexpr double SHIFT_AMOUNT = 1.0;
+constexpr double ROTATE_AMOUNT = 5.0;
+constexpr double SCALE_AMOUNT = 1.05;
 
 auto SplineHandler::onKeyEvent(GdkEventKey* event) -> bool {
     if (!stroke ||
@@ -77,107 +102,117 @@ auto SplineHandler::onKeyEvent(GdkEventKey* event) -> bool {
         return false;
     }
 
-    int pointCount = stroke->getPointCount();
-    double zoom = xournal->getZoom();
-    double radius = radiusConst / zoom;
-    double x = stroke->getX() - radius;
-    double y = stroke->getY() - radius;
-    double w = stroke->getElementWidth() + 2 * radius;
-    double h = stroke->getElementHeight() + 2 * radius;
+    Rectangle rect = this->computeRepaintRectangle();
 
     switch (event->keyval) {
         case GDK_KEY_Escape: {
-            if (pointCount > 0) {
-                // remove dynamically changing point at cursor position
-                stroke->deletePoint(pointCount - 1);
-                this->redrawable->rerenderRect(x, y, w, h);
-            }
-            finalizeSpline();
+            this->redrawable->repaintRect(rect.x, rect.y, rect.width, rect.height);
+            this->finalizeSpline();
             return true;
         }
         case GDK_KEY_BackSpace: {
-            if (pointCount > 1) {
-                // delete last non dynammically changing point
-                stroke->deletePoint(pointCount - 2);
+            if (!knots.empty()) {
+                this->deleteLastKnotWithTangent();
+                this->redrawable->repaintRect(rect.x, rect.y, rect.width, rect.height);
+                return true;
             }
             break;
         }
-        case GDK_KEY_Up: {
-            movePoint(0, -1);
-            break;
-        }
-        case GDK_KEY_Down: {
-            movePoint(0, 1);
-            break;
-        }
         case GDK_KEY_Right: {
-            movePoint(1, 0);
-            break;
+            this->movePoint(SHIFT_AMOUNT, 0);
+            this->redrawable->repaintRect(rect.x, rect.y, rect.width + SHIFT_AMOUNT, rect.height);
+            return true;
         }
         case GDK_KEY_Left: {
-            movePoint(-1, 0);
-            break;
+            this->movePoint(-SHIFT_AMOUNT, 0);
+            this->redrawable->repaintRect(rect.x - SHIFT_AMOUNT, rect.y, rect.width, rect.height);
+            return true;
+        }
+        case GDK_KEY_Up: {
+            this->movePoint(0, -SHIFT_AMOUNT);
+            this->redrawable->repaintRect(rect.x, rect.y - SHIFT_AMOUNT, rect.width, rect.height + SHIFT_AMOUNT);
+            return true;
+        }
+        case GDK_KEY_Down: {
+            this->movePoint(0, SHIFT_AMOUNT);
+            this->redrawable->repaintRect(rect.x, rect.y, rect.width, rect.height + SHIFT_AMOUNT);
+            return true;
+        }
+        case GDK_KEY_r:
+        case GDK_KEY_R: {  // r like "rotate"
+            double angle = (event->state & GDK_SHIFT_MASK) ? -ROTATE_AMOUNT : ROTATE_AMOUNT;
+            double xOld = this->tangents.back().x;
+            double yOld = this->tangents.back().y;
+            double xNew = cos(angle * M_PI / 180) * xOld + sin(angle * M_PI / 180) * yOld;
+            double yNew = -sin(angle * M_PI / 180) * xOld + cos(angle * M_PI / 180) * yOld;
+            this->modifyLastTangent(Point(xNew, yNew));
+            this->redrawable->repaintRect(rect.x, rect.y, rect.width, rect.height);
+            return true;
+        }
+        case GDK_KEY_s:
+        case GDK_KEY_S: {  // s like "scale"
+            double xOld = this->tangents.back().x;
+            double yOld = this->tangents.back().y;
+            double length = 2 * sqrt(pow(xOld, 2) + pow(yOld, 2));
+            double factor = 1;
+            if ((event->state & GDK_SHIFT_MASK) && length >= 1) {
+                factor = 1 / SCALE_AMOUNT;
+            } else if (!(event->state & GDK_SHIFT_MASK) && length <= 2000) {
+                factor = SCALE_AMOUNT;
+            }
+            double xNew = xOld * factor;
+            double yNew = yOld * factor;
+            this->modifyLastTangent(Point(xNew, yNew));
+            this->redrawable->repaintRect(rect.x, rect.y, rect.width, rect.height);
+            return true;
         }
     }
-    this->redrawable->rerenderRect(x - 1, y - 1, w + 2, h + 2);
     return false;
 }
 
 auto SplineHandler::onMotionNotifyEvent(const PositionInputData& pos) -> bool {
-    if (!stroke) {
+    if (!stroke || this->knots.empty()) {
         return false;
     }
 
     double zoom = xournal->getZoom();
-    double radius = radiusConst / zoom;
-    int pointCount = stroke->getPointCount();
-
-    Point currentPoint = Point(pos.x / zoom, pos.y / zoom);
-    Rectangle rect = stroke->boundingRect();
-
-    if (pointCount > 0) {
-        if (!validMotion(currentPoint, stroke->getPoint(pointCount - 1))) {
-            return true;
+    Rectangle rect = this->computeRepaintRectangle();
+    if (this->isButtonPressed) {
+        Point newTangent = Point(pos.x / zoom - this->currPoint.x, pos.y / zoom - this->currPoint.y);
+        if (validMotion(newTangent, this->tangents.back())) {
+            this->modifyLastTangent(newTangent);
         }
+    } else {
+        this->currPoint = Point(pos.x / zoom, pos.y / zoom);
     }
 
-    this->redrawable->repaintRect(stroke->getX() - radius, stroke->getY() - radius,
-                                  stroke->getElementWidth() + 2 * radius, stroke->getElementHeight() + 2 * radius);
-
-    drawShape(currentPoint, pos);
-
-    rect.add(stroke->boundingRect());
-    double w = stroke->getWidth();
-
-    redrawable->repaintRect(rect.x - w, rect.y - w, rect.width + 2 * w, rect.height + 2 * w);
+    rect.add(this->computeRepaintRectangle());
+    this->redrawable->repaintRect(rect.x, rect.y, rect.width, rect.height);
 
     return true;
 }
 
-void SplineHandler::onButtonReleaseEvent(const PositionInputData& pos) {
-    if (!stroke) {
-        return;
-    }
-
-    double zoom = xournal->getZoom();
-    double radius = radiusConst / zoom;
-    Point currPoint = Point(pos.x / zoom, pos.y / zoom);
-    Point firstPoint = stroke->getPoint(0);
-    double dist = currPoint.lineLengthTo(firstPoint);
-    int pointCount = stroke->getPointCount();
-    if (dist < radius && pointCount > 1) {
-        stroke->setLastPoint(firstPoint);
-        finalizeSpline();
-    } else {
-        stroke->addPoint(currPoint);
-        this->redrawable->rerenderRect(currPoint.x - radius, currPoint.y - radius, 2 * radius, 2 * radius);
-    }
-}
+void SplineHandler::onButtonReleaseEvent(const PositionInputData& pos) { isButtonPressed = false; }
 
 void SplineHandler::onButtonPressEvent(const PositionInputData& pos) {
+    isButtonPressed = true;
     double zoom = xournal->getZoom();
+    double radius = RADIUS_WITHOUT_ZOOM / zoom;
+    this->currPoint = Point(pos.x / zoom, pos.y / zoom);
     if (!stroke) {
-        createStroke(Point(pos.x / zoom, pos.y / zoom));
+        createStroke(this->currPoint);
+        this->addKnot(this->currPoint);
+        this->redrawable->rerenderRect(this->currPoint.x - radius, this->currPoint.y - radius, 2 * radius, 2 * radius);
+    } else {
+        double dist = this->currPoint.lineLengthTo(this->knots.front());
+        if (dist < radius && !this->knots.empty()) {  // now the spline is closed and finalized
+            this->addKnotWithTangent(this->knots.front(), this->tangents.front());
+            this->finalizeSpline();
+        } else if (validMotion(currPoint, this->knots.back())) {
+            this->addKnot(this->currPoint);
+            this->redrawable->rerenderRect(this->currPoint.x - radius, this->currPoint.y - radius, 2 * radius,
+                                           2 * radius);
+        }
     }
 }
 
@@ -185,15 +220,9 @@ void SplineHandler::onButtonDoublePressEvent(const PositionInputData& pos) { fin
 
 void SplineHandler::movePoint(double dx, double dy) {
     // move last non dynamically changing point
-    int pointCount = stroke->getPointCount();
-    if (pointCount > 1) {
-        Point currPoint = stroke->getPoint(pointCount - 1);
-        Point lastSetPoint = stroke->getPoint(pointCount - 2);
-        lastSetPoint.x += dx;
-        lastSetPoint.y += dy;
-        stroke->deletePointsFrom(pointCount - 2);
-        stroke->addPoint(lastSetPoint);
-        stroke->addPoint(currPoint);
+    if (!this->knots.empty()) {
+        this->knots.back().x += dx;
+        this->knots.back().y += dy;
     }
 }
 
@@ -202,51 +231,106 @@ void SplineHandler::finalizeSpline() {
         return;
     }
 
-    Control* control = xournal->getControl();
+    if (this->getKnotCount() < 2) {  // This is not a valid spline
+        g_warning("Spline incomplete!");
+        Rectangle rect = this->computeRepaintRectangle();
+        this->redrawable->repaintRect(rect.x, rect.y, rect.width, rect.height);
 
-    // This is not a valid stroke
-    if (stroke->getPointCount() < 2) {
-        g_warning("Stroke incomplete!");
         delete stroke;
         stroke = nullptr;
         return;
     }
 
+    this->updateStroke();
+
     stroke->freeUnusedPointItems();
+    Control* control = xournal->getControl();
     control->getLayerController()->ensureLayerExists(page);
 
     Layer* layer = page->getSelectedLayer();
 
     UndoRedoHandler* undo = control->getUndoRedoHandler();
-
-
     undo->addUndoAction(mem::make_unique<InsertUndoAction>(page, layer, stroke));
 
     layer->addElement(stroke);
-    //    page->fireElementChanged(stroke);  --> this would result in a crash if called from draw method
-    double zoom = xournal->getZoom();
-    double radius = radiusConst / zoom;
 
-
-    this->redrawable->rerenderRect(stroke->getX() - radius, stroke->getY() - radius,
-                                   stroke->getElementWidth() + 2 * radius, stroke->getElementHeight() + 2 * radius);
-
+    Rectangle rect = this->computeRepaintRectangle();
+    this->redrawable->rerenderRect(rect.x, rect.y, rect.width, rect.height);
 
     stroke = nullptr;
 
     xournal->getCursor()->updateCursor();
 }
 
-void SplineHandler::drawShape(Point& c, const PositionInputData& pos) {
+void SplineHandler::addKnot(const Point& p) { addKnotWithTangent(p, Point(0, 0)); }
+
+void SplineHandler::addKnotWithTangent(const Point& p, const Point& t) {
+    this->knots.push_back(p);
+    this->tangents.push_back(t);
+}
+
+void SplineHandler::modifyLastTangent(const Point& t) { this->tangents.back() = t; }
+
+void SplineHandler::deleteLastKnotWithTangent() {
+    if (this->getKnotCount() > 1) {
+        this->knots.pop_back();
+        this->tangents.pop_back();
+    }
+}
+
+auto SplineHandler::getKnotCount() const -> int {
+    if (this->knots.size() != this->tangents.size()) {
+        g_warning("number of knots and tangents differ");
+    }
+    return this->knots.size();
+}
+
+void SplineHandler::updateStroke() {
     if (!stroke) {
         return;
     }
-
-    int pointCount = stroke->getPointCount();
-    if (pointCount > 1) {
-        // remove dynamically changing point at (previous) cursor position
-        stroke->deletePoint(pointCount - 1);
+    // create spline segments
+    std::vector<SplineSegment> segments = {};
+    Point cp1, cp2;
+    for (size_t i = 0; i < this->getKnotCount() - 1; i++) {
+        cp1 = Point(this->knots[i].x + this->tangents[i].x, this->knots[i].y + this->tangents[i].y);
+        cp2 = Point(this->knots[i + 1].x - this->tangents[i + 1].x, this->knots[i + 1].y - this->tangents[i + 1].y);
+        segments.push_back(SplineSegment(this->knots[i], cp1, cp2, this->knots[i + 1]));
     }
 
-    stroke->addPoint(c);
+    // convert collection of segments to stroke
+    stroke->deletePointsFrom(0);
+    for (auto s: segments) {
+        for (auto p: s.toPointSequence()) {
+            stroke->addPoint(p);
+        }
+    }
+    if (!segments.empty()) {
+        stroke->addPoint(segments.back().secondKnot);
+    }
+}
+
+auto SplineHandler::computeRepaintRectangle() const -> Rectangle {
+    double zoom = xournal->getZoom();
+    double radius = RADIUS_WITHOUT_ZOOM / zoom;
+    std::vector<double> xCoords = {};
+    std::vector<double> yCoords = {};
+    for (auto p: knots) {
+        xCoords.push_back(p.x);
+        yCoords.push_back(p.y);
+    }
+    for (size_t i = 0; i < this->getKnotCount(); i++) {
+        xCoords.push_back(this->knots[i].x + this->tangents[i].x);
+        xCoords.push_back(this->knots[i].x - this->tangents[i].x);
+        yCoords.push_back(this->knots[i].y + this->tangents[i].y);
+        yCoords.push_back(this->knots[i].y - this->tangents[i].y);
+    }
+    xCoords.push_back(this->currPoint.x);
+    yCoords.push_back(this->currPoint.y);
+
+    double minX = *std::min_element(xCoords.begin(), xCoords.end());
+    double maxX = *std::max_element(xCoords.begin(), xCoords.end());
+    double minY = *std::min_element(yCoords.begin(), yCoords.end());
+    double maxY = *std::max_element(yCoords.begin(), yCoords.end());
+    return Rectangle(minX - radius, minY - radius, maxX - minX + 2 * radius, maxY - minY + 2 * radius);
 }

--- a/src/control/tools/SplineHandler.h
+++ b/src/control/tools/SplineHandler.h
@@ -12,9 +12,24 @@
 #pragma once
 
 #include "model/Point.h"
+#include "model/SplineSegment.h"
 #include "view/DocumentView.h"
 
 #include "InputHandler.h"
+
+/**
+ * @brief A class to handle splines
+ *
+ * Drawing of a spline is started by a ButtonPressEvent. Every ButtonPressEvent gives a new knot.
+ * Click-dragging will set the tangents. After a ButtonReleaseEvent the spline segment is dynamically
+ * drawn and finished after the next ButtonPressEvent.
+ * The spline is completed through a ButtonDoublePressEvent, the escape key or a
+ * ButtonPressEvent near the first knot. The latter event closes the spline.
+ *
+ * Splines segments can be linear or cubic (as in Inkscape). Where there is a nontrivial tangent,
+ * the join is smooth.
+ * The last knot and tangent can be modified using the keyboard.
+ */
 
 class SplineHandler: public InputHandler {
 public:
@@ -30,11 +45,24 @@ public:
     virtual bool onKeyEvent(GdkEventKey* event);
 
 private:
-    virtual void drawShape(Point& currentPoint, const PositionInputData& pos);
     void finalizeSpline();
     void movePoint(double dx, double dy);
+    void updateStroke();
+    Rectangle computeRepaintRectangle() const;
+
+private:
+    std::vector<Point> knots{};
+    std::vector<Point> tangents{};
+    bool isButtonPressed = false;
+
+public:
+    void addKnot(const Point& p);
+    void addKnotWithTangent(const Point& p, const Point& t);
+    void modifyLastTangent(const Point& t);
+    void deleteLastKnotWithTangent();
+    int getKnotCount() const;
 
 protected:
     DocumentView view;
-    const double radiusConst = 10.0;
+    Point currPoint;
 };

--- a/src/model/SplineSegment.cpp
+++ b/src/model/SplineSegment.cpp
@@ -1,0 +1,58 @@
+#include "SplineSegment.h"
+
+SplineSegment::SplineSegment(const Point& p, const Point& q):
+        firstKnot(p), firstControlPoint(p), secondKnot(q), secondControlPoint(q) {}
+
+SplineSegment::SplineSegment(const Point& p, const Point& fp, const Point& sp, const Point& q) {
+    firstKnot = p;
+    firstControlPoint = fp;
+    secondControlPoint = sp;
+    secondKnot = q;
+}
+
+void SplineSegment::draw(cairo_t* cr) const {
+    cairo_move_to(cr, firstKnot.x, firstKnot.y);
+    cairo_curve_to(cr, firstControlPoint.x, firstControlPoint.y, secondControlPoint.x, secondControlPoint.y,
+                   secondKnot.x, secondKnot.y);
+}
+
+auto SplineSegment::toPointSequence() const -> std::list<Point> {
+    if (isFlatEnough()) {
+        return {firstKnot};
+    }
+    auto const& childSegments = subdivide(0.5);
+    auto left_points = childSegments.first.toPointSequence();
+    left_points.splice(end(left_points), childSegments.second.toPointSequence());
+    return left_points;
+}
+
+auto SplineSegment::subdivide(float t) const -> std::pair<SplineSegment, SplineSegment> {
+
+    Point b0 = SplineSegment::linearInterpolate(firstKnot, firstControlPoint, t);  // Same as evaluating a Bezier
+    Point b1 = SplineSegment::linearInterpolate(firstControlPoint, secondControlPoint, t);
+    Point b2 = SplineSegment::linearInterpolate(secondControlPoint, secondKnot, t);
+
+    Point c0 = SplineSegment::linearInterpolate(b0, b1, t);
+    Point c1 = SplineSegment::linearInterpolate(b1, b2, t);
+
+    Point d0 = SplineSegment::linearInterpolate(c0, c1, t);  // This would be the interpolated point
+
+    SplineSegment firstPart = SplineSegment(firstKnot, b0, c0, d0);    // first point of each step
+    SplineSegment secondPart = SplineSegment(d0, c1, b2, secondKnot);  // last point of each step
+    return std::make_pair(firstPart, secondPart);
+}
+
+auto SplineSegment::linearInterpolate(const Point& p, const Point& q, float t) -> Point {
+    return Point(p.x * (1 - t) + q.x * t, p.y * (1 - t) + q.y * t);
+}
+
+constexpr double FLATNESS_TOLERANCE = 1.0001;
+constexpr double MIN_KNOT_DISTANCE = 0.3;
+
+auto SplineSegment::isFlatEnough() const -> bool {
+    double l1 = firstKnot.lineLengthTo(firstControlPoint);
+    double l2 = firstControlPoint.lineLengthTo(secondControlPoint);
+    double l3 = secondControlPoint.lineLengthTo(secondKnot);
+    double l = firstKnot.lineLengthTo(secondKnot);
+    return l1 + l2 + l3 < FLATNESS_TOLERANCE * l || l < MIN_KNOT_DISTANCE;
+}

--- a/src/model/SplineSegment.h
+++ b/src/model/SplineSegment.h
@@ -1,0 +1,108 @@
+/*
+ * Xournal++
+ *
+ * A spline segment
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+#include <list>
+
+#include <gtk/gtk.h>
+
+#include "model/Element.h"
+#include "model/Stroke.h"
+
+#include "Point.h"
+
+
+/**
+ * @brief A class to handle splines segments
+ *
+ * Every spline segment is defined by two knot points and two control points.
+ * This contrasts to the cairo-draw command cairo_curve_to, where everything is relative to the current position of
+ * another knot,
+ */
+
+
+class SplineSegment {
+public:
+    SplineSegment() = default;
+
+    /**
+     * @brief A linear spline segment from two points
+     * @param p the first knot
+     * @param q the second knot
+     */
+    SplineSegment(const Point& p, const Point& q);
+
+    /**
+     * @brief A spline segment from four points
+     * @param p the first knot
+     * @param fp the first control point
+     * @param sp the second control point
+     * @param q the second knot
+     */
+    SplineSegment(const Point& p, const Point& fp, const Point& sp, const Point& q);
+
+    /**
+     * @brief draw the spline segment via the cairo_curve_to command
+     * @param cr the cairo context on which the spline segment ought to be drawn
+     */
+    void draw(cairo_t* cr) const;
+
+    /**
+     * @brief Convert the spline segment to a list of points.
+     * @return A point list which represents the spline segment without the end point.
+     */
+    std::list<Point> toPointSequence() const;
+
+    /**
+     * @brief Subdivide the spline into two parts with respect to parameter t.
+     * @param t the parameter between 0 and 1, which corresponds to the point where the spline is split
+     * @return A pair of two spline segments corresponding to the two parts of the spline
+     */
+    std::pair<SplineSegment, SplineSegment> subdivide(float t) const;
+
+    /**
+     * @brief Interpolate a line segment with respect to parameter t
+     * @param t the parameter between 0 and 1, which corresponds to the point on the line segment
+     * @param p the starting point of the line segment
+     * @param q the end point of the line segment
+     * @return A point on the line segment which corresponds to the parameter value t
+     */
+    static Point linearInterpolate(const Point& p, const Point& q, float t);
+
+    /**
+     * @brief checks if the spline segment is flat enough so that it can be drawn as a straight line
+     * @return true, if the spline segment is flat enough; false otherwise
+     */
+    bool isFlatEnough() const;
+
+
+public:
+    /**
+     * @brief The first knot of the spline segment.
+     */
+    Point firstKnot;
+
+    /**
+     * @brief The second knot of the spline segment.
+     */
+    Point secondKnot;
+
+    /**
+     * @brief The first control point of the spline segment.
+     */
+    Point firstControlPoint;
+
+    /**
+     * @brief The second control point of the spline segment.
+     */
+    Point secondControlPoint;
+};


### PR DESCRIPTION
This commit implements cubic splines. At every knot you can adjust the tangent by click-dragging. The longer the drawn tangent, the stronger its influence. If all tangents are trivial (only click, no click-drag), it will be a linear spline as before.
The last set knot and the last set tangent can be modified using the keyboard (e, s, r, b for extend, shrink, rotate and back rotate).
If the spline is closed the tangent of the first knot will be used for the last knot as well, so the join will be smooth (if the tangent of the first knot is non-trivial).