### PR TITLE
Fix MacOS build

### DIFF
--- a/azure-pipelines/continuous-integration.yml
+++ b/azure-pipelines/continuous-integration.yml
@@ -54,7 +54,7 @@ stages:
 
       - job: macOS
         pool:
-          vmImage: 'macOS-10.13'
+          vmImage: 'macOS-10.15'
         displayName: 'Test Xournal++ on MacOS'
         steps:
           - template: steps/build_mac.yml

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -114,14 +114,14 @@ stages:
 
       - job: macOS
         pool:
-          vmImage: 'macOS-10.13'
+          vmImage: 'macOS-10.15'
         displayName: 'Build for macOS'
         condition: always()
         steps:
           - template: steps/build_mac.yml
             parameters:
               build_type: 'RelWithDebInfo'
-              cmake_flags: ''
+              cmake_flags: '-DCMAKE_OSX_DEPLOYMENT_TARGET=10.13'
           - bash: |
               export PATH="$HOME/.local/bin:/Users/git-bin/gtk/inst/bin:$PATH"
               ./build-app.sh /Users/git-bin/gtk

--- a/azure-pipelines/steps/build_mac.yml
+++ b/azure-pipelines/steps/build_mac.yml
@@ -4,7 +4,8 @@ parameters:
 
 steps:
   - bash: |
-      ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall)"
+      # Ignore Homebrew uninstall errors
+      ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall)" || true
     displayName: 'Uninstall brew'
   - bash: |
       cd /Users
@@ -33,7 +34,9 @@ steps:
       unzip ninja-mac.zip -d /Users/git-bin/gtk/inst/bin
     displayName: 'Get Ninja'
   - bash: |
-      curl -L -o boost_1_72_0.tar.gz https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.gz
+      set -e
+      # Using SourceForge instead of bintray due to boostorg/boost#299
+      curl -L -o boost_1_72_0.tar.gz https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.tar.gz/download
       tar -xzf boost_1_72_0.tar.gz
       cd boost_1_72_0
       ./bootstrap.sh --prefix=/usr/local/boost-1.72.0


### PR DESCRIPTION
Working version of #1779. Changes:
* Switch to Catalina image on CI
* Set `macosx-version-min` flag. Currently, we are backwards compatible with 10.13.
* Change Boost source mirror

Merging if build succeeds; we can fix other issues (like pipeline dependencies) later since it's important to stop CI from failing every commit first.