### PR TITLE
Cut grid size in half; tidied up the togglegrid lua plugin.

### DIFF
--- a/plugins/ToggleGrid/togglegrid.lua
+++ b/plugins/ToggleGrid/togglegrid.lua
@@ -1,16 +1,18 @@
 
 -- Register all Toolbar actions and intialize all UI stuff
 function initUi()
-  app.registerUi({["menu"] = "Grid with snapping On", ["callback"] = "toggleGridOn"});
-  app.registerUi({["menu"] = "Grid with snapping Off", ["callback"] = "toggleGridOff"});
+  app.registerUi({["menu"] = "Toggle Grid Paper", ["callback"] = "toggleGridPaper"});
 end
 
-function toggleGridOn()
-  app.uiActionSelected("GROUP_GRID_SNAPPING", "ACTION_GRID_SNAPPING");
-  app.changeCurrentPageBackground("graph");
-end
+local toggleState = false
 
-function toggleGridOff()
-  app.uiActionSelected("GROUP_GRID_SNAPPING", "ACTION_NONE");
-  app.changeCurrentPageBackground("plain");
+function toggleGridPaper()
+  if toggleState == true then
+    app.uiActionSelected("GROUP_GRID_SNAPPING", "ACTION_GRID_SNAPPING");
+    app.changeCurrentPageBackground("graph");
+  else
+    app.uiActionSelected("GROUP_GRID_SNAPPING", "ACTION_NONE");
+    app.changeCurrentPageBackground("plain");
+  end
+  toggleState = not toggleState
 end

--- a/src/control/tools/BaseStrokeHandler.cpp
+++ b/src/control/tools/BaseStrokeHandler.cpp
@@ -30,7 +30,7 @@ void BaseStrokeHandler::snapToGrid(double& x, double& y) {
      * If x/y coordinates are under a certain tolerance,
      * fix the point to the grid intersection value
      */
-    double gridSize = 14.17;
+    double gridSize = 14.17 / 2.0;
 
     double t = xournal->getControl()->getSettings()->getSnapGridTolerance();
     double tolerance = (gridSize / 2) - (1 / t);

--- a/src/control/tools/BaseStrokeHandler.cpp
+++ b/src/control/tools/BaseStrokeHandler.cpp
@@ -30,7 +30,7 @@ void BaseStrokeHandler::snapToGrid(double& x, double& y) {
      * If x/y coordinates are under a certain tolerance,
      * fix the point to the grid intersection value
      */
-    double gridSize = 14.17 / 2.0;
+    double gridSize = 14.17 / 4.0;
 
     double t = xournal->getControl()->getSettings()->getSnapGridTolerance();
     double tolerance = (gridSize / 2) - (1 / t);


### PR DESCRIPTION
I find the grid size too large.  Since I was the one who originally put it at the same size as the squares on the grid paper, and I found that too large, I'm being bold enough to change it to half that for now.  Really, it would be nice to have an easy way to change it back and forth.

I also looked over the lua plugin examples.  I changed the example so there were not so many menu items.  

I determined that using the plugin API wasn't going to be super easy, so I ditched it for now.  Maybe someone more familiar with glade and gtk can add to the GUI to change the grid size.  It really seems to me that having the gridSize variable set locally in BaseStrokeHandler.cpp is not the best, but it is how I did it last year.  It seems that it should be something that is set in the GUI, and BaseStrokeHandler.cpp should get it from there.

Sorry for making two changes in one pull request.  The first one seemed so trivial, I didn't do a separate one for it.  The second one is probably less important, but it makes things look better.