### PR TITLE
Add option to ignore the first events of the stylus when touching the screen.

### DIFF
--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -137,6 +137,8 @@ void Settings::loadDefault() {
     this->pluginEnabled = "";
     this->pluginDisabled = "";
 
+    this->numIgnoredStylusEvents = 0;
+
     this->newInputSystemEnabled = true;
     this->inputSystemTPCButton = false;
     this->inputSystemDrawOutsideWindow = true;
@@ -408,6 +410,9 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur) {
         this->audioInputDevice = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("audioOutputDevice")) == 0) {
         this->audioOutputDevice = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("numIgnoredStylusEvents")) == 0) {
+        this->numIgnoredStylusEvents =
+                std::max<int>(g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10), 0);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("newInputSystemEnabled")) == 0) {
         this->newInputSystemEnabled = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("inputSystemTPCButton")) == 0) {
@@ -778,6 +783,8 @@ void Settings::save() {
     WRITE_BOOL_PROP(strokeFilterEnabled);
     WRITE_BOOL_PROP(doActionOnStrokeFiltered);
     WRITE_BOOL_PROP(trySelectOnStrokeFiltered);
+
+    WRITE_INT_PROP(numIgnoredStylusEvents);
 
     WRITE_BOOL_PROP(newInputSystemEnabled);
     WRITE_BOOL_PROP(inputSystemTPCButton);
@@ -1548,6 +1555,17 @@ auto Settings::getDoActionOnStrokeFiltered() const -> bool { return this->doActi
 void Settings::setTrySelectOnStrokeFiltered(bool enabled) { this->trySelectOnStrokeFiltered = enabled; }
 
 auto Settings::getTrySelectOnStrokeFiltered() const -> bool { return this->trySelectOnStrokeFiltered; }
+
+
+void Settings::setIgnoredStylusEvents(int numEvents) {
+    if (this->numIgnoredStylusEvents == numEvents) {
+        return;
+    }
+    this->numIgnoredStylusEvents = std::max<int>(numEvents, 0);
+    save();
+}
+
+auto Settings::getIgnoredStylusEvents() const -> int { return this->numIgnoredStylusEvents; }
 
 
 void Settings::setExperimentalInputSystemEnabled(bool systemEnabled) {

--- a/src/control/settings/Settings.h
+++ b/src/control/settings/Settings.h
@@ -370,6 +370,15 @@ public:
     string const& getPluginDisabled() const;
     void setPluginDisabled(const string& pluginDisabled);
 
+    /**
+     * Sets #numIgnoredStylusEvents. If given a negative value writes 0 instead.
+     */
+    void setIgnoredStylusEvents(int numEvents);
+    /**
+     * Returns #numIgnoredStylusEvents.
+     */
+    int getIgnoredStylusEvents() const;
+
     bool getExperimentalInputSystemEnabled() const;
     void setExperimentalInputSystemEnabled(bool systemEnabled);
 
@@ -820,6 +829,12 @@ private:
     bool strokeFilterEnabled{};
     bool doActionOnStrokeFiltered{};
     bool trySelectOnStrokeFiltered{};
+
+    /**
+     * How many stylus events since hitting the screen should be ignored before actually starting the action. If set to
+     * 0, no event will be ignored. Should not be negative.
+     */
+    int numIgnoredStylusEvents{};
 
     /**
      * Whether the new experimental input system is activated

--- a/src/gui/dialog/SettingsDialog.cpp
+++ b/src/gui/dialog/SettingsDialog.cpp
@@ -34,6 +34,12 @@ SettingsDialog::SettingsDialog(GladeSearchpath* gladeSearchPath, Settings* setti
                      }),
                      this);
 
+    g_signal_connect(get("cbIgnoreFirstStylusEvents"), "toggled",
+                     G_CALLBACK(+[](GtkToggleButton* togglebutton, SettingsDialog* self) {
+                         self->enableWithCheckbox("cbIgnoreFirstStylusEvents", "spNumIgnoredStylusEvents");
+                     }),
+                     this);
+
 
     g_signal_connect(get("btTestEnable"), "clicked", G_CALLBACK(+[](GtkButton* bt, SettingsDialog* self) {
                          Util::systemWithMessage(gtk_entry_get_text(GTK_ENTRY(self->get("txtEnableTouchCommand"))));
@@ -202,6 +208,7 @@ void SettingsDialog::load() {
     loadCheckbox("cbHideVerticalScrollbar", settings->getScrollbarHideType() & SCROLLBAR_HIDE_VERTICAL);
     loadCheckbox("cbDisableScrollbarFadeout", settings->isScrollbarFadeoutDisabled());
     loadCheckbox("cbTouchWorkaround", settings->isTouchWorkaround());
+    loadCheckbox("cbIgnoreFirstStylusEvents", settings->getIgnoredStylusEvents() != 0);  // 0 means disabled, >0 enabled
     loadCheckbox("cbNewInputSystem", settings->getExperimentalInputSystemEnabled());
     loadCheckbox("cbInputSystemTPCButton", settings->getInputSystemTPCButtonEnabled());
     loadCheckbox("cbInputSystemDrawOutsideWindow", settings->getInputSystemDrawOutsideWindowEnabled());
@@ -215,6 +222,13 @@ void SettingsDialog::load() {
 
     GtkWidget* spAutosaveTimeout = get("spAutosaveTimeout");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spAutosaveTimeout), settings->getAutosaveTimeout());
+
+    GtkWidget* spNumIgnoredStylusEvents = get("spNumIgnoredStylusEvents");
+    if (settings->getIgnoredStylusEvents() == 0) {  // 0 means checkbox disabled, the spinButton's value should be >= 1
+        gtk_spin_button_set_value(GTK_SPIN_BUTTON(spNumIgnoredStylusEvents), 1);
+    } else {
+        gtk_spin_button_set_value(GTK_SPIN_BUTTON(spNumIgnoredStylusEvents), settings->getIgnoredStylusEvents());
+    }
 
     GtkWidget* spPairsOffset = get("spPairsOffset");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spPairsOffset), settings->getPairsOffset());
@@ -298,6 +312,7 @@ void SettingsDialog::load() {
     loadCheckbox("cbHideMenubarStartup", settings->isMenubarVisible());
 
     enableWithCheckbox("cbAutosave", "boxAutosave");
+    enableWithCheckbox("cbIgnoreFirstStylusEvents", "spNumIgnoredStylusEvents");
     enableWithCheckbox("cbAddVerticalSpace", "spAddVerticalSpace");
     enableWithCheckbox("cbAddHorizontalSpace", "spAddHorizontalSpace");
     enableWithCheckbox("cbDrawDirModsEnabled", "spDrawDirModsRadius");
@@ -489,6 +504,14 @@ void SettingsDialog::save() {
     GtkWidget* spAutosaveTimeout = get("spAutosaveTimeout");
     int autosaveTimeout = gtk_spin_button_get_value(GTK_SPIN_BUTTON(spAutosaveTimeout));
     settings->setAutosaveTimeout(autosaveTimeout);
+
+    if (getCheckbox("cbIgnoreFirstStylusEvents")) {
+        GtkWidget* spNumIgnoredStylusEvents = get("spNumIgnoredStylusEvents");
+        int numIgnoredStylusEvents = gtk_spin_button_get_value(GTK_SPIN_BUTTON(spNumIgnoredStylusEvents));
+        settings->setIgnoredStylusEvents(numIgnoredStylusEvents);
+    } else {
+        settings->setIgnoredStylusEvents(0);  // This means nothing will be ignored
+    }
 
     GtkWidget* spPairsOffset = get("spPairsOffset");
     int numPairsOffset = gtk_spin_button_get_value(GTK_SPIN_BUTTON(spPairsOffset));

--- a/src/gui/dialog/SettingsDialog.cpp
+++ b/src/gui/dialog/SettingsDialog.cpp
@@ -208,7 +208,8 @@ void SettingsDialog::load() {
     loadCheckbox("cbHideVerticalScrollbar", settings->getScrollbarHideType() & SCROLLBAR_HIDE_VERTICAL);
     loadCheckbox("cbDisableScrollbarFadeout", settings->isScrollbarFadeoutDisabled());
     loadCheckbox("cbTouchWorkaround", settings->isTouchWorkaround());
-    loadCheckbox("cbIgnoreFirstStylusEvents", settings->getIgnoredStylusEvents() != 0);  // 0 means disabled, >0 enabled
+    const bool ignoreStylusEventsEnabled = settings->getIgnoredStylusEvents() != 0;  // 0 means disabled, >0 enabled
+    loadCheckbox("cbIgnoreFirstStylusEvents", ignoreStylusEventsEnabled);
     loadCheckbox("cbNewInputSystem", settings->getExperimentalInputSystemEnabled());
     loadCheckbox("cbInputSystemTPCButton", settings->getInputSystemTPCButtonEnabled());
     loadCheckbox("cbInputSystemDrawOutsideWindow", settings->getInputSystemDrawOutsideWindowEnabled());
@@ -224,7 +225,7 @@ void SettingsDialog::load() {
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spAutosaveTimeout), settings->getAutosaveTimeout());
 
     GtkWidget* spNumIgnoredStylusEvents = get("spNumIgnoredStylusEvents");
-    if (settings->getIgnoredStylusEvents() == 0) {  // 0 means checkbox disabled, the spinButton's value should be >= 1
+    if (!ignoreStylusEventsEnabled) {  // The spinButton's value should be >= 1
         gtk_spin_button_set_value(GTK_SPIN_BUTTON(spNumIgnoredStylusEvents), 1);
     } else {
         gtk_spin_button_set_value(GTK_SPIN_BUTTON(spNumIgnoredStylusEvents), settings->getIgnoredStylusEvents());

--- a/src/gui/inputdevices/StylusInputHandler.cpp
+++ b/src/gui/inputdevices/StylusInputHandler.cpp
@@ -26,7 +26,13 @@ auto StylusInputHandler::handleImpl(InputEvent const& event) -> bool {
     if (event.type == BUTTON_PRESS_EVENT) {
 
         if (event.button == 1 || this->inputContext->getSettings()->getInputSystemTPCButtonEnabled()) {
-            this->actionStart(event);
+            this->eventsToIgnore = this->inputContext->getSettings()->getIgnoredStylusEvents();
+            if (this->eventsToIgnore > 0) {
+                this->eventsToIgnore--;  // This is already the first ignored event
+            } else {
+                this->eventsToIgnore = -1;
+                this->actionStart(event);
+            }
             return true;
         }
         if (this->inputRunning) {
@@ -49,7 +55,16 @@ auto StylusInputHandler::handleImpl(InputEvent const& event) -> bool {
     // Trigger motion action when pen/mouse is pressed and moved
     if (event.type == MOTION_EVENT)  // mouse or pen moved
     {
-        this->actionMotion(event);
+        if (this->eventsToIgnore >= 0) {
+            if (this->eventsToIgnore == 0) {
+                this->eventsToIgnore = -1;
+                this->actionStart(event);
+            } else {
+                this->eventsToIgnore--;
+            }
+        } else {
+            this->actionMotion(event);
+        }
         XournalppCursor* cursor = xournal->view->getCursor();
         cursor->setInvisible(false);
         cursor->updateCursor();
@@ -77,7 +92,9 @@ auto StylusInputHandler::handleImpl(InputEvent const& event) -> bool {
     // Trigger end of action if pen tip leaves screen or mouse button is released
     if (event.type == BUTTON_RELEASE_EVENT) {
         if (event.button == 1 || this->inputContext->getSettings()->getInputSystemTPCButtonEnabled()) {
-            this->actionEnd(event);
+            if (this->inputRunning) {
+                this->actionEnd(event);
+            }
             return true;
         }
         if (this->inputRunning) {
@@ -110,7 +127,9 @@ void StylusInputHandler::setPressedState(InputEvent const& event) {
     {
         switch (event.button) {
             case 1:
-                this->deviceClassPressed = true;
+                if (!this->eventsToIgnore >= 0) {
+                    this->deviceClassPressed = true;
+                }
                 break;
             case 2:
                 this->modifier2 = true;

--- a/src/gui/inputdevices/StylusInputHandler.cpp
+++ b/src/gui/inputdevices/StylusInputHandler.cpp
@@ -55,13 +55,11 @@ auto StylusInputHandler::handleImpl(InputEvent const& event) -> bool {
     // Trigger motion action when pen/mouse is pressed and moved
     if (event.type == MOTION_EVENT)  // mouse or pen moved
     {
-        if (this->eventsToIgnore >= 0) {
-            if (this->eventsToIgnore == 0) {
-                this->eventsToIgnore = -1;
-                this->actionStart(event);
-            } else {
-                this->eventsToIgnore--;
-            }
+        if (this->eventsToIgnore > 0) {
+            this->eventsToIgnore--;
+        } else if (this->eventsToIgnore == 0) {
+            this->eventsToIgnore = -1;
+            this->actionStart(event);
         } else {
             this->actionMotion(event);
         }
@@ -92,8 +90,10 @@ auto StylusInputHandler::handleImpl(InputEvent const& event) -> bool {
     // Trigger end of action if pen tip leaves screen or mouse button is released
     if (event.type == BUTTON_RELEASE_EVENT) {
         if (event.button == 1 || this->inputContext->getSettings()->getInputSystemTPCButtonEnabled()) {
-            if (this->inputRunning) {
+            if (this->eventsToIgnore < 0) {
                 this->actionEnd(event);
+            } else {
+                this->eventsToIgnore = -1;
             }
             return true;
         }
@@ -127,7 +127,7 @@ void StylusInputHandler::setPressedState(InputEvent const& event) {
     {
         switch (event.button) {
             case 1:
-                if (!this->eventsToIgnore >= 0) {
+                if (this->inputContext->getSettings()->getIgnoredStylusEvents() <= 0) {
                     this->deviceClassPressed = true;
                 }
                 break;
@@ -139,8 +139,11 @@ void StylusInputHandler::setPressedState(InputEvent const& event) {
             default:
                 break;
         }
-    }
-    if (event.type == BUTTON_RELEASE_EVENT)  // mouse button released or pen not touching surface anymore
+    } else if (event.type == MOTION_EVENT) {
+        if (this->eventsToIgnore == 0) {
+            this->deviceClassPressed = true;
+        }
+    } else if (event.type == BUTTON_RELEASE_EVENT)  // mouse button released or pen not touching surface anymore
     {
         switch (event.button) {
             case 1:

--- a/src/gui/inputdevices/StylusInputHandler.h
+++ b/src/gui/inputdevices/StylusInputHandler.h
@@ -28,5 +28,16 @@ public:
     bool changeTool(InputEvent const& event) override;
 
 private:
+    /**
+     * How many events since hitting the screen with the stylus are still left to be ignored before actually starting
+     * the action. Will first be set according to the user's setting on every button-1-press-event. Will be evaluated
+     * and then decreased by one (until -1) on every button-1-press-event and motion-event.\n
+     * If >0: Ignore the event\n
+     * If 0: Start the action\n
+     * If -1: Action already started, handle the event normally
+     */
+    int eventsToIgnore = 0;
+
+private:
     void setPressedState(InputEvent const& event);
 };

--- a/src/gui/inputdevices/StylusInputHandler.h
+++ b/src/gui/inputdevices/StylusInputHandler.h
@@ -30,13 +30,13 @@ public:
 private:
     /**
      * How many events since hitting the screen with the stylus are still left to be ignored before actually starting
-     * the action. Will first be set according to the user's setting on every button-1-press-event. Will be evaluated
-     * and then decreased by one (until -1) on every button-1-press-event and motion-event.\n
-     * If >0: Ignore the event\n
-     * If 0: Start the action\n
-     * If -1: Action already started, handle the event normally
+     * the action. Set according to the user's setting on every button-1-press-event. Will be evaluated and then
+     * decreased by one (down to -1) on every button-1-press-event and motion-event. Set to -1 on button-1-release.\n
+     * If >0: Ignore the (button-1-press- or motion-) event\n
+     * If 0: Start the action (on the next button-1-press- or motion-event)\n
+     * If -1: Stylus not touching or action already started, handle the event normally
      */
-    int eventsToIgnore = 0;
+    int eventsToIgnore = -1;
 
 private:
     void setPressedState(InputEvent const& event);

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -20,6 +20,13 @@
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
   </object>
+  <object class="GtkAdjustment" id="adjustmentIgnoreStylusEvents">
+    <property name="lower">1</property>
+    <property name="upper">1000</property>
+    <property name="value">1</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
   <object class="GtkAdjustment" id="adjustmentPairsOffset">
     <property name="upper">100</property>
     <property name="step_increment">1</property>
@@ -1144,6 +1151,114 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                               </packing>
                             </child>
                             <child>
+                              <object class="GtkFrame" id="sid183">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
+                                <child>
+                                  <object class="GtkAlignment" id="sid184">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="bottom_padding">8</property>
+                                    <property name="left_padding">12</property>
+                                    <property name="right_padding">12</property>
+                                    <child>
+                                      <object class="GtkBox" id="sid185">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                          <object class="GtkLabel" id="sid186">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="label" translatable="yes">&lt;i&gt;With some setup, pen strokes have artifacts at their beginning. This can be avoided by ignoring the first few events/stroke-points when the pen touches the screen.&lt;/i&gt;</property>
+                                            <property name="use_markup">True</property>
+                                            <property name="wrap">True</property>
+                                            <property name="width_chars">85</property>
+                                            <property name="max_width_chars">85</property>
+                                            <property name="xalign">0</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkBox" id="sid187">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <child>
+                                              <object class="GtkCheckButton" id="cbIgnoreFirstStylusEvents">
+                                                <property name="label" translatable="yes">Ignore the first</property>
+                                                <property name="name">cbSettingIgnoreFirstStylusEvents</property>
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="receives_default">False</property>
+                                                <property name="xalign">0</property>
+                                                <property name="draw_indicator">True</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSpinButton" id="spNumIgnoredStylusEvents">
+                                                <property name="name">spNrOfIgnoredFirstStylusEvents</property>
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="text" translatable="yes">1</property>
+                                                <property name="adjustment">adjustmentIgnoreStylusEvents</property>
+                                                <property name="value">1</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="padding">10</property>
+                                                <property name="position">1</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel" id="lbIgnoreFirstStylusEvents">
+                                                <property name="name">lbIgnoreFirstStylusEvents</property>
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="label" translatable="yes">events</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">2</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label">
+                                  <object class="GtkLabel" id="sid188">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="label" translatable="yes">Artifact workaround</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                            <child>
                               <object class="GtkFrame" id="sid38">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
@@ -1306,7 +1421,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">1</property>
+                                <property name="position">2</property>
                               </packing>
                             </child>
                           </object>


### PR DESCRIPTION
Add option to ignore the first events of the stylus when touching the screen to avoid artifacts at the beginnings of strokes. The number of ignored events can be set in the preferences.

I had this problem on Kubuntu 18.04: When the stylus is pressed on the screen, the accuracy and update rate of its recognized position increases. Because of the lower precision before, when hitting the screen the cursor might jump from its previous position to the more precise point (this is especially far if the pen tip was in rapid movement right before touching), while beeing recognized as writing. This can result in artifacts that e.g. make handwritten text very hard to read. To work around this, the first events since the triggering event can be ignored.

This works great for me (when ignoring the first 3 events) and should also be a workaround for #1662 and #1821 as they seem to be the same problem.