### PR TITLE
snap to grid and user tapping for splines

### DIFF
--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -95,10 +95,10 @@ void Settings::loadDefault() {
     this->drawDirModsEnabled = false;
 
     this->snapRotation = true;
-    this->snapRotationTolerance = 0.20;
+    this->snapRotationTolerance = 0.30;
 
     this->snapGrid = true;
-    this->snapGridTolerance = 0.25;
+    this->snapGridTolerance = 0.50;
 
     this->touchWorkaround = false;
 

--- a/src/control/tools/ArrowHandler.cpp
+++ b/src/control/tools/ArrowHandler.cpp
@@ -18,19 +18,15 @@ void ArrowHandler::drawShape(Point& c, const PositionInputData& pos) {
      * Snap first point to grid (if enabled)
      */
     bool altDown = pos.isAltDown();
-    if (!altDown && xournal->getControl()->getSettings()->isSnapGrid()) {
-        Point firstPoint = stroke->getPoint(0);
-        snapToGrid(firstPoint.x, firstPoint.y);
-        stroke->setFirstPoint(firstPoint.x, firstPoint.y);
-    }
+
+    Point firstPoint = snappingHandler.snapToGrid(stroke->getPoint(0), altDown);
+    stroke->setFirstPoint(firstPoint.x, firstPoint.y);
 
 
     int count = stroke->getPointCount();
     if (count < 1) {
         stroke->addPoint(c);
     } else {
-        Point p = stroke->getPoint(0);
-
         // disable this to see such a cool "serrate brush" effect
         if (count > 4) {
             // remove previous points
@@ -40,90 +36,20 @@ void ArrowHandler::drawShape(Point& c, const PositionInputData& pos) {
             stroke->deletePoint(1);
         }
 
-        if (!altDown && xournal->getControl()->getSettings()->isSnapGrid()) {
-            snapToGrid(c.x, c.y);
-        }
+        c = snappingHandler.snap(c, firstPoint, altDown);
 
         // We've now computed the line points for the arrow
         // so we just have to build the head
 
         // set up the size of the arrowhead to be 7x the thickness of the line
-        double dist = sqrt(pow(c.x - p.x, 2.0) + pow(c.y - p.y, 2.0));
         double arrowDist = xournal->getControl()->getToolHandler()->getThickness() * 7.0;
 
-        double angle = atan2((c.y - p.y), (c.x - p.x));
         // an appropriate delta is Pi/3 radians for an arrow shape
         double delta = M_PI / 6.0;
-
-        if (altDown || !xournal->getControl()->getSettings()->isSnapRotation()) {
-            stroke->addPoint(c);
-            stroke->addPoint(Point(c.x - arrowDist * cos(angle + delta), c.y - arrowDist * sin(angle + delta)));
-            stroke->addPoint(c);
-            stroke->addPoint(Point(c.x - arrowDist * cos(angle - delta), c.y - arrowDist * sin(angle - delta)));
-        } else {
-            double epsilon = xournal->getControl()->getSettings()->getSnapRotationTolerance();
-            if (std::abs(angle) < epsilon) {
-                angle = 0;
-                stroke->addPoint(Point(c.x, p.y));
-                stroke->addPoint(Point(c.x - arrowDist * cos(angle + delta), p.y - arrowDist * sin(angle + delta)));
-                stroke->addPoint(Point(c.x, p.y));
-                stroke->addPoint(Point(c.x - arrowDist * cos(angle - delta), p.y - arrowDist * sin(angle - delta)));
-            } else if (std::abs(angle - M_PI / 4.0) < epsilon) {
-                angle = M_PI / 4.0;
-                stroke->addPoint(Point(dist / sqrt(2.0) + p.x, dist / sqrt(2.0) + p.y));
-                stroke->addPoint(Point(dist / sqrt(2.0) + p.x - arrowDist * cos(angle + delta),
-                                       dist / sqrt(2.0) + p.y - arrowDist * sin(angle + delta)));
-                stroke->addPoint(Point(dist / sqrt(2.0) + p.x, dist / sqrt(2.0) + p.y));
-                stroke->addPoint(Point(dist / sqrt(2.0) + p.x - arrowDist * cos(angle - delta),
-                                       dist / sqrt(2.0) + p.y - arrowDist * sin(angle - delta)));
-            } else if (std::abs(angle - 3.0 * M_PI / 4.0) < epsilon) {
-                angle = 3.0 * M_PI / 4.0;
-                stroke->addPoint(Point(-dist / sqrt(2.0) + p.x, dist / sqrt(2.0) + p.y));
-                stroke->addPoint(Point(-dist / sqrt(2.0) + p.x - arrowDist * cos(angle + delta),
-                                       dist / sqrt(2.0) + p.y - arrowDist * sin(angle + delta)));
-                stroke->addPoint(Point(-dist / sqrt(2.0) + p.x, dist / sqrt(2.0) + p.y));
-                stroke->addPoint(Point(-dist / sqrt(2.0) + p.x - arrowDist * cos(angle - delta),
-                                       dist / sqrt(2.0) + p.y - arrowDist * sin(angle - delta)));
-            } else if (std::abs(angle + M_PI / 4.0) < epsilon) {
-                angle = M_PI / 4.0;
-                stroke->addPoint(Point(dist / sqrt(2.0) + p.x, -dist / sqrt(2.0) + p.y));
-                stroke->addPoint(Point(dist / sqrt(2.0) + p.x - arrowDist * cos(angle + delta),
-                                       -dist / sqrt(2.0) + p.y + arrowDist * sin(angle + delta)));
-                stroke->addPoint(Point(dist / sqrt(2.0) + p.x, -dist / sqrt(2.0) + p.y));
-                stroke->addPoint(Point(dist / sqrt(2.0) + p.x - arrowDist * cos(angle - delta),
-                                       -dist / sqrt(2.0) + p.y + arrowDist * sin(angle - delta)));
-            } else if (std::abs(angle + 3.0 * M_PI / 4.0) < epsilon) {
-                angle = 3.0 * M_PI / 4.0;
-                stroke->addPoint(Point(-dist / sqrt(2.0) + p.x, -dist / sqrt(2.0) + p.y));
-                stroke->addPoint(Point(-dist / sqrt(2.0) + p.x - arrowDist * cos(angle + delta),
-                                       -dist / sqrt(2.0) + p.y + arrowDist * sin(angle + delta)));
-                stroke->addPoint(Point(-dist / sqrt(2.0) + p.x, -dist / sqrt(2.0) + p.y));
-                stroke->addPoint(Point(-dist / sqrt(2.0) + p.x - arrowDist * cos(angle - delta),
-                                       -dist / sqrt(2.0) + p.y + arrowDist * sin(angle - delta)));
-            } else if (std::abs(std::abs(angle) - M_PI) < epsilon) {
-                angle = -M_PI;
-                stroke->addPoint(Point(c.x, p.y));
-                stroke->addPoint(Point(c.x - arrowDist * cos(angle + delta), p.y - arrowDist * sin(angle + delta)));
-                stroke->addPoint(Point(c.x, p.y));
-                stroke->addPoint(Point(c.x - arrowDist * cos(angle - delta), p.y - arrowDist * sin(angle - delta)));
-            } else if (std::abs(angle - M_PI / 2.0) < epsilon) {
-                angle = M_PI / 2.0;
-                stroke->addPoint(Point(p.x, c.y));
-                stroke->addPoint(Point(p.x - arrowDist * cos(angle + delta), c.y - arrowDist * sin(angle + delta)));
-                stroke->addPoint(Point(p.x, c.y));
-                stroke->addPoint(Point(p.x - arrowDist * cos(angle - delta), c.y - arrowDist * sin(angle - delta)));
-            } else if (std::abs(angle + M_PI / 2.0) < epsilon) {
-                angle = -M_PI / 2.0;
-                stroke->addPoint(Point(p.x, c.y));
-                stroke->addPoint(Point(p.x - arrowDist * cos(angle + delta), c.y - arrowDist * sin(angle + delta)));
-                stroke->addPoint(Point(p.x, c.y));
-                stroke->addPoint(Point(p.x - arrowDist * cos(angle - delta), c.y - arrowDist * sin(angle - delta)));
-            } else {
-                stroke->addPoint(c);
-                stroke->addPoint(Point(c.x - arrowDist * cos(angle + delta), c.y - arrowDist * sin(angle + delta)));
-                stroke->addPoint(c);
-                stroke->addPoint(Point(c.x - arrowDist * cos(angle - delta), c.y - arrowDist * sin(angle - delta)));
-            }
-        }
+        double angle = atan2(c.y - firstPoint.y, c.x - firstPoint.x);
+        stroke->addPoint(c);
+        stroke->addPoint(Point(c.x - arrowDist * cos(angle + delta), c.y - arrowDist * sin(angle + delta)));
+        stroke->addPoint(c);
+        stroke->addPoint(Point(c.x - arrowDist * cos(angle - delta), c.y - arrowDist * sin(angle - delta)));
     }
 }

--- a/src/control/tools/BaseStrokeHandler.cpp
+++ b/src/control/tools/BaseStrokeHandler.cpp
@@ -15,57 +15,10 @@ guint32 BaseStrokeHandler::lastStrokeTime;  // persist for next stroke
 
 BaseStrokeHandler::BaseStrokeHandler(XournalView* xournal, XojPageView* redrawable, const PageRef& page, bool flipShift,
                                      bool flipControl):
-        InputHandler(xournal, redrawable, page) {
-    this->flipShift = flipShift;
-    this->flipControl = flipControl;
-}
-
-void BaseStrokeHandler::snapToGrid(double& x, double& y) {
-    if (!xournal->getControl()->getSettings()->isSnapGrid()) {
-        return;
-    }
-
-    /**
-     * Snap points to a grid:
-     * If x/y coordinates are under a certain tolerance,
-     * fix the point to the grid intersection value
-     */
-    double gridSize = 14.17 / 4.0;
-
-    double t = xournal->getControl()->getSettings()->getSnapGridTolerance();
-    double tolerance = (gridSize / 2) - (1 / t);
-
-    double xRem = fmod(x, gridSize);
-    double yRem = fmod(y, gridSize);
-
-    bool snapX = false;
-    bool snapY = false;
-
-    double tmpX = 0;
-    double tmpY = 0;
-
-    if (xRem < tolerance) {
-        tmpX = x - xRem;
-        snapX = true;
-    }
-    if (xRem > gridSize - tolerance) {
-        tmpX = x + (gridSize - xRem);
-        snapX = true;
-    }
-    if (yRem < tolerance) {
-        tmpY = y - yRem;
-        snapY = true;
-    }
-    if (yRem > gridSize - tolerance) {
-        tmpY = y + (gridSize - yRem);
-        snapY = true;
-    }
-
-    if (snapX && snapY) {
-        x = tmpX;
-        y = tmpY;
-    }
-}
+        InputHandler(xournal, redrawable, page),
+        snappingHandler(xournal->getControl()->getSettings()),
+        flipShift(flipShift),
+        flipControl(flipControl) {}
 
 BaseStrokeHandler::~BaseStrokeHandler() = default;
 

--- a/src/control/tools/BaseStrokeHandler.h
+++ b/src/control/tools/BaseStrokeHandler.h
@@ -12,9 +12,11 @@
 #pragma once
 
 #include "model/Point.h"
+#include "model/Snapping.h"
 #include "view/DocumentView.h"
 
 #include "InputHandler.h"
+#include "SnapToGridInputHandler.h"
 
 enum DIRSET_MODIFIERS { NONE = 0, SET = 1, SHIFT = 1 << 1, CONTROL = 1 << 2 };
 
@@ -47,7 +49,6 @@ private:
     static guint32 lastStrokeTime;  // persist across strokes - allow us to not ignore persistent dotting.
 
 protected:
-    void snapToGrid(double& x, double& y);
     /**
      * modifyModifiersByDrawDir
      * @brief 	Toggle shift and control modifiers depending on initial drawing direction.
@@ -61,4 +62,5 @@ protected:
                             // derived classes such as CircleHandler.
     bool modShift = false;
     bool modControl = false;
+    SnapToGridInputHandler snappingHandler;
 };

--- a/src/control/tools/CircleHandler.cpp
+++ b/src/control/tools/CircleHandler.cpp
@@ -20,10 +20,7 @@ void CircleHandler::drawShape(Point& c, const PositionInputData& pos) {
     /**
      * Snap point to grid (if enabled - Alt key pressed will toggle)
      */
-    Settings* settings = xournal->getControl()->getSettings();
-    if (pos.isAltDown() != settings->isSnapGrid()) {
-        snapToGrid(c.x, c.y);
-    }
+    c = snappingHandler.snapToGrid(c, pos.isAltDown());
 
     if (!this->started)  // initialize first point
     {
@@ -38,6 +35,7 @@ void CircleHandler::drawShape(Point& c, const PositionInputData& pos) {
         this->modShift = pos.isShiftDown();
         this->modControl = pos.isControlDown();
 
+        Settings* settings = xournal->getControl()->getSettings();
         if (settings->getDrawDirModsEnabled())  // change modifiers based on draw dir
         {
             this->modifyModifiersByDrawDir(width, height, true);

--- a/src/control/tools/CoordinateSystemHandler.cpp
+++ b/src/control/tools/CoordinateSystemHandler.cpp
@@ -23,10 +23,7 @@ void CoordinateSystemHandler::drawShape(Point& c, const PositionInputData& pos) 
     /**
      * Snap point to grid (if enabled)
      */
-    Settings* settings = xournal->getControl()->getSettings();
-    if (pos.isAltDown() != settings->isSnapGrid()) {
-        snapToGrid(c.x, c.y);
-    }
+    c = snappingHandler.snapToGrid(c, pos.isAltDown());
 
     if (!this->started)  // initialize first point
     {
@@ -42,6 +39,7 @@ void CoordinateSystemHandler::drawShape(Point& c, const PositionInputData& pos) 
         this->modShift = pos.isShiftDown();
         this->modControl = pos.isControlDown();
 
+        Settings* settings = xournal->getControl()->getSettings();
         if (settings->getDrawDirModsEnabled())  // change modifiers based on draw dir
         {
             this->modifyModifiersByDrawDir(width, height, true);

--- a/src/control/tools/EditSelection.h
+++ b/src/control/tools/EditSelection.h
@@ -18,9 +18,11 @@
 #include "control/Tool.h"
 #include "model/Font.h"
 #include "model/PageRef.h"
+#include "model/Snapping.h"
 #include "view/ElementContainer.h"
 
 #include "CursorSelectionType.h"
+#include "SnapToGridInputHandler.h"
 #include "XournalType.h"
 
 class UndoRedoHandler;
@@ -50,8 +52,6 @@ private:
      * Calculate the size from the element list
      */
     void calcSizeFromElements(vector<Element*> elements);
-
-    void snapRotation();
 
 public:
     /**
@@ -320,4 +320,9 @@ private:  // HANDLER
      * Undo redo handler
      */
     UndoRedoHandler* undo{};
+
+    /**
+     * The handler for snapping points
+     */
+    SnapToGridInputHandler snappingHandler;
 };

--- a/src/control/tools/RectangleHandler.cpp
+++ b/src/control/tools/RectangleHandler.cpp
@@ -18,10 +18,7 @@ void RectangleHandler::drawShape(Point& c, const PositionInputData& pos) {
     /**
      * Snap point to grid (if enabled)
      */
-    Settings* settings = xournal->getControl()->getSettings();
-    if (pos.isAltDown() != settings->isSnapGrid()) {
-        snapToGrid(c.x, c.y);
-    }
+    c = snappingHandler.snapToGrid(c, pos.isAltDown());
 
     if (!this->started)  // initialize first point
     {
@@ -36,6 +33,7 @@ void RectangleHandler::drawShape(Point& c, const PositionInputData& pos) {
         this->modShift = pos.isShiftDown();
         this->modControl = pos.isControlDown();
 
+        Settings* settings = xournal->getControl()->getSettings();
         if (settings->getDrawDirModsEnabled())  // change modifiers based on draw dir
         {
             this->modifyModifiersByDrawDir(width, height, true);

--- a/src/control/tools/RulerHandler.cpp
+++ b/src/control/tools/RulerHandler.cpp
@@ -11,77 +11,21 @@ RulerHandler::RulerHandler(XournalView* xournal, XojPageView* redrawable, const 
 
 RulerHandler::~RulerHandler() = default;
 
-
-void RulerHandler::snapRotation(double& x, double& y) {
-    Point firstPoint = stroke->getPoint(0);
-
-    // snap to a grid - get the angle of the points
-    // if it's near 0, pi/4, 3pi/4, pi, or the negatives
-    // within epsilon, fix it to that value.
-
-    double dist = sqrt(pow(x - firstPoint.x, 2.0) + pow(y - firstPoint.y, 2.0));
-    double angle = atan2((y - firstPoint.y), (x - firstPoint.x));
-    double epsilon = xournal->getControl()->getSettings()->getSnapRotationTolerance();
-
-    if (std::abs(angle) < epsilon) {
-        x = dist + firstPoint.x;
-        y = firstPoint.y;
-    } else if (std::abs(angle - M_PI / 4.0) < epsilon) {
-        x = dist / sqrt(2.0) + firstPoint.x;
-        y = dist / sqrt(2.0) + firstPoint.y;
-    } else if (std::abs(angle - 3.0 * M_PI / 4.0) < epsilon) {
-        x = -dist / sqrt(2.0) + firstPoint.x;
-        y = dist / sqrt(2.0) + firstPoint.y;
-    } else if (std::abs(angle + M_PI / 4.0) < epsilon) {
-        x = dist / sqrt(2.0) + firstPoint.x;
-        y = -dist / sqrt(2.0) + firstPoint.y;
-    } else if (std::abs(angle + 3.0 * M_PI / 4.0) < epsilon) {
-        x = -dist / sqrt(2.0) + firstPoint.x;
-        y = -dist / sqrt(2.0) + firstPoint.y;
-    } else if (std::abs(std::abs(angle) - M_PI) < epsilon) {
-        x = -dist + firstPoint.x;
-        y = firstPoint.y;
-    } else if (std::abs(angle - M_PI / 2.0) < epsilon) {
-        x = firstPoint.x;
-        y = dist + firstPoint.y;
-    } else if (std::abs(angle + M_PI / 2.0) < epsilon) {
-        x = firstPoint.x;
-        y = -dist + firstPoint.y;
-    }
-}
-
-
 void RulerHandler::drawShape(Point& currentPoint, const PositionInputData& pos) {
     this->currPoint = currentPoint;  // in case redrawn by keypress event in base class.
-
-    double x = currentPoint.x;
-    double y = currentPoint.y;
 
     /**
      * Snap first point to grid (if enabled)
      */
     bool altDown = pos.isAltDown();
-    if (!altDown && xournal->getControl()->getSettings()->isSnapGrid()) {
-        Point firstPoint = stroke->getPoint(0);
-        snapToGrid(firstPoint.x, firstPoint.y);
-        stroke->setFirstPoint(firstPoint.x, firstPoint.y);
-    }
 
+    Point firstPoint = snappingHandler.snapToGrid(stroke->getPoint(0), altDown);
+    stroke->setFirstPoint(firstPoint.x, firstPoint.y);
 
     if (stroke->getPointCount() < 2) {
         stroke->addPoint(currentPoint);
-    } else if (altDown) {
-        x = currentPoint.x;
-        y = currentPoint.y;
     } else {
-        if (xournal->getControl()->getSettings()->isSnapRotation()) {
-            snapRotation(x, y);
-        }
-
-        if (xournal->getControl()->getSettings()->isSnapGrid()) {
-            snapToGrid(x, y);
-        }
+        Point secondPoint = snappingHandler.snap(currentPoint, firstPoint, altDown);
+        stroke->setLastPoint(secondPoint.x, secondPoint.y);
     }
-
-    stroke->setLastPoint(x, y);
 }

--- a/src/control/tools/RulerHandler.h
+++ b/src/control/tools/RulerHandler.h
@@ -20,7 +20,6 @@ public:
 
 private:
     virtual void drawShape(Point& currentPoint, const PositionInputData& pos);
-    void snapRotation(double& x, double& y);
 
 private:
 };

--- a/src/control/tools/SnapToGridInputHandler.cpp
+++ b/src/control/tools/SnapToGridInputHandler.cpp
@@ -1,0 +1,32 @@
+#include "SnapToGridInputHandler.h"
+
+#include "model/Snapping.h"
+
+SnapToGridInputHandler::SnapToGridInputHandler(Settings* settings): settings(settings) {}
+
+Point SnapToGridInputHandler::snapToGrid(Point const& pos, bool alt) {
+    if (alt != settings->isSnapGrid()) {
+        return Snapping::snapToGrid(pos, DEFAULT_GRID_SIZE,
+                                    settings->getSnapGridTolerance());  // grid size is not yet in the settings
+    }
+    return pos;
+}
+
+double SnapToGridInputHandler::snapAngle(double radian, bool alt) {
+    if (alt != settings->isSnapRotation()) {
+        return Snapping::snapAngle(radian, settings->getSnapRotationTolerance());
+    }
+    return radian;
+}
+
+Point SnapToGridInputHandler::snapRotation(Point const& pos, Point const& center, bool alt) {
+    if (alt != settings->isSnapRotation()) {
+        return Snapping::snapRotation(pos, center, settings->getSnapRotationTolerance());
+    }
+    return pos;
+}
+
+Point SnapToGridInputHandler::snap(Point const& pos, Point const& center, bool alt) {
+    Point rotationSnappedPoint{snapRotation(pos, center, alt)};
+    return snapToGrid(rotationSnappedPoint, alt);
+}

--- a/src/control/tools/SnapToGridInputHandler.h
+++ b/src/control/tools/SnapToGridInputHandler.h
@@ -1,0 +1,57 @@
+/*
+ * Xournal++
+ *
+ * Snapping methods which take account of the settings
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+#pragma once
+
+#include "control/settings/Settings.h"
+#include "model/Point.h"
+
+class SnapToGridInputHandler final {
+
+public:
+    SnapToGridInputHandler(Settings* settings);
+
+protected:
+    const Settings* settings;
+
+public:
+    /**
+     * @brief If a points distance to the nearest grid point is under a certain tolerance, it returns the nearest
+     * grid point. Otherwise the original Point itself.
+     * @param pos the position
+     * @param alt indicates whether snapping mode is altered (via the Alt key)
+     */
+    [[nodiscard]] Point snapToGrid(Point const& pos, bool alt);
+
+    /**
+     * @brief if the angles distance to a multiple quarter of PI is under a certain tolerance, it returns the latter.
+     * Otherwise the original angle.
+     * @param radian the angle (in radian)
+     * @param alt indicates whether snapping mode is altered (via the Alt key)
+     */
+    [[nodiscard]] double snapAngle(double radian, bool alt);
+
+    /**
+     * @brief Snaps the angle between the horizontal axis and the line between the given point and center
+     * and returns the point rotated accordingly
+     * @param pos the coordinate of the point
+     * @param center the center of rotation
+     * @param alt indicates whether snapping mode is altered (via the Alt key)
+     */
+    [[nodiscard]] Point snapRotation(Point const& pos, Point const& center, bool alt);
+
+    /**
+     * @brief Does rotation snapping followed by snapping to grid
+     * @param pos the coordinate of the point
+     * @param center the center of rotation
+     * @param alt indicates whether snapping mode is altered (via the Alt key)
+     */
+    [[nodiscard]] Point snap(Point const& pos, Point const& center, bool alt);
+};

--- a/src/control/tools/SplineHandler.h
+++ b/src/control/tools/SplineHandler.h
@@ -12,10 +12,12 @@
 #pragma once
 
 #include "model/Point.h"
+#include "model/Snapping.h"
 #include "model/SplineSegment.h"
 #include "view/DocumentView.h"
 
 #include "InputHandler.h"
+#include "SnapToGridInputHandler.h"
 
 /**
  * @brief A class to handle splines
@@ -50,10 +52,16 @@ private:
     void updateStroke();
     Rectangle<double> computeRepaintRectangle() const;
 
+    // to filter out short strokes (usually the user tapping on the page to select it)
+    guint32 startStrokeTime{};
+    static guint32 lastStrokeTime;  // persist across strokes - allow us to not ignore persistent dotting.
+
+
 private:
     std::vector<Point> knots{};
     std::vector<Point> tangents{};
     bool isButtonPressed = false;
+    SnapToGridInputHandler snappingHandler;
 
 public:
     void addKnot(const Point& p);
@@ -65,4 +73,6 @@ public:
 protected:
     DocumentView view;
     Point currPoint;
+    Point buttonDownPoint;  // used for tapSelect and filtering - never snapped to grid. See startPoint defined in
+                            // derived classes such as CircleHandler.
 };

--- a/src/model/Snapping.cpp
+++ b/src/model/Snapping.cpp
@@ -1,0 +1,29 @@
+#include "Snapping.h"
+
+#include <cmath>
+
+namespace Snapping {
+
+[[nodiscard]] inline double roundToMultiple(double val, double multiple) { return val - std::remainder(val, multiple); }
+[[nodiscard]] inline double distance(Point const& a, Point const& b) { return std::hypot(b.x - a.x, b.y - a.y); }
+Point snapToGrid(Point const& pos, double gridSize, double tolerance) {
+    double abs_tolerance = (gridSize / sqrt(2)) * tolerance;
+    Point ret{roundToMultiple(pos.x, gridSize), roundToMultiple(pos.y, gridSize), pos.z};
+    return distance(ret, pos) < abs_tolerance ? ret : pos;
+}
+
+double snapAngle(double radian, double tolerance) {
+    auto snapped = roundToMultiple(radian, M_PI_4);
+    double abs_tolerance = (M_PI_4 / 2) * tolerance;
+    return std::abs(snapped - radian) < abs_tolerance ? snapped : radian;
+}
+
+Point snapRotation(Point const& pos, Point const& center, double tolerance) {
+    auto const dist = distance(pos, center);
+    auto const angle = std::atan2(pos.y - center.y, pos.x - center.x);
+    auto const snappedAngle = snapAngle(angle, tolerance);
+    return {center.x + dist * std::cos(snappedAngle),  //
+            center.y + dist * std::sin(snappedAngle), pos.z};
+}
+
+}  // namespace Snapping

--- a/src/model/Snapping.h
+++ b/src/model/Snapping.h
@@ -1,0 +1,44 @@
+/*
+ * Xournal++
+ *
+ * Snapping methods
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+#pragma once
+
+#include "Point.h"
+
+constexpr auto DEFAULT_GRID_SIZE = 14.17 / 4;
+
+namespace Snapping {
+
+/**
+ * @brief If a points distance to the nearest grid point is under a certain tolerance, it returns the nearest
+ * grid point. Otherwise the original Point itself.
+ * @param pos the position
+ * @param gridSize the distance to each snapping point
+ * @param tolerance the tolerance as a fraction of a half grid diagonal (assumed to be between 0 and 1)
+ */
+[[nodiscard]] Point snapToGrid(Point const& pos, double gridSize, double tolerance);
+
+/**
+ * @brief if the angles distance to a multiple quarter of PI is under a certain tolerance, it returns the latter.
+ * Otherwise the original angle.
+ * @param radian the angle (in radian)
+ * @param tolerance the tolerance as a fraction of M_PI/8 (assumed to be between 0 and 1)
+ */
+[[nodiscard]] double snapAngle(double radian, double tolerance);
+
+/**
+ * @brief Snaps the angle between the horizontal axis and the line between the given point and center
+ * and returns the point rotated accordingly
+ * @param pos the coordinate of the point
+ * @param center the center of rotation
+ * @param tolerance the tolerance as a fraction of M_PI/8 (assumed to be between 0 and 1)
+ */
+[[nodiscard]] Point snapRotation(Point const& pos, Point const& center, double tolerance);
+}  // namespace Snapping

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -44,17 +44,17 @@
     <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentSnapGridTolerance">
-    <property name="lower">0.20000000000000001</property>
-    <property name="upper">10</property>
-    <property name="value">0.25</property>
-    <property name="step_increment">0.05000000000000001</property>
+    <property name="lower">0.10000000000000001</property>
+    <property name="upper">1</property>
+    <property name="value">0.5</property>
+    <property name="step_increment">0.050000000000000003</property>
     <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentSnapRotationTolerance">
     <property name="lower">0.10000000000000001</property>
-    <property name="upper">0.5</property>
-    <property name="value">0.20000000000000001</property>
-    <property name="step_increment">0.05000000000000001</property>
+    <property name="upper">1</property>
+    <property name="value">0.29999999999999999</property>
+    <property name="step_increment">0.050000000000000003</property>
     <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentStrokeIgnoreLength">


### PR DESCRIPTION
With this commit all knots of the spline are snapped to grid if the corresponding setting is activated.
I reused the snapToGrid code from BaseStrokeHandler.cpp. There was probably a better way of doing it, but I don't know what is the best way. Hence I just copied this function to the SplineHandler.

Now I will take care of user tapping.
