### PR TITLE
Fix issue #1867.

### DIFF
--- a/src/gui/Layout.cpp
+++ b/src/gui/Layout.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <numeric>
+#include <optional>
 
 #include "control/Control.h"
 #include "gui/scroll/ScrollHandling.h"
@@ -68,7 +69,7 @@ void Layout::updateVisibility() {
     int y1 = 0;
 
     // Data to select page based on visibility
-    size_t mostPageNr = 0;
+    std::optional<size_t> mostPageNr;
     double mostPagePercent = 0;
 
     for (size_t row = 0; row < this->heightRows.size(); ++row) {
@@ -107,7 +108,9 @@ void Layout::updateVisibility() {
         x1 = 0;
     }
 
-    this->view->getControl()->firePageSelected(mostPageNr);
+    if (mostPageNr) {
+        this->view->getControl()->firePageSelected(mostPageNr.value());
+    }
 }
 
 auto Layout::getVisibleRect() -> Rectangle<double> {


### PR DESCRIPTION
When moving to the last page of the following PDF document, https://dx.doi.org/10.1109/TSE.1985.232210,
xournal++ hangs (segfaults). You can try to move to the last page either by scrolling
or by setting the page number in the spinpage box, the result will be the same.

After some debugging, I narrowed it down to the latest statement of Layout::updateVisibility():
this->view->getControl()->firePageSelected(mostPageNr). For some reason, this was triggering an
infinite storm of events.

My solution was to avoid firing the page selected event by checking if any change indeed occurred
in the layout. I used the variable mostPageNr to detect if there was any change: if it wasn't
changed by the updateVisibility()'s algorithm, the value would be the same as of its initilization.
By not calling firePageSelected if not change has happened, this issue was partially handled.

However, when scrolling, there was some issues, as if scrolling was malfunctioning. I had the
same issue with another PDF document (https://www.dropbox.com/s/f5f22fvgldcm2gm/Learning%20to%20program%20%3D%20learning%20to%20construct%20mechanisms%20and%20explanations.pdf?dl=0).
When looking at the change I did in Layout::updateVisibility(), I noticed that the page number
for 'mostPageNr' was off by one. After fixing this, I could scroll without problems to the
last page of the document (and actually in any PDF document).