### PR TITLE
Change Select Object algorithm to search for closest element

### DIFF
--- a/src/gui/PageViewFindObjectHelper.h
+++ b/src/gui/PageViewFindObjectHelper.h
@@ -13,6 +13,7 @@
 
 // No include needed, this is included after PageView.h
 
+#include <limits>
 #include <optional>
 
 #include "util/audio/AudioPlayer.h"
@@ -44,14 +45,25 @@ public:
 
 protected:
     bool checkLayer(Layer* l) {
+        // Search for Element closest to center of matching rectangle
+        bool found = false;
+        double minDistSq = std::numeric_limits<double>::max();
+        const double mX = matchRect.x + matchRect.width / 2.0;
+        const double mY = matchRect.y + matchRect.height / 2.0;
         for (Element* e: *l->getElements()) {
-            if (e->intersectsArea(&matchRect)) {
+            const double eX = e->getX() + e->getElementWidth() / 2.0;
+            const double eY = e->getY() + e->getElementHeight() / 2.0;
+            const double dx = eX - mX;
+            const double dy = eY - mY;
+            const double distSq = dx * dx + dy * dy;
+            if (e->intersectsArea(&matchRect) && distSq < minDistSq) {
+                minDistSq = distSq;
                 if (this->checkElement(e)) {
-                    return true;
+                    found = true;
                 }
             }
         }
-        return false;
+        return found;
     }
 
     virtual bool checkElement(Element* e) = 0;


### PR DESCRIPTION
Fixes #1718.

The current first-matching-object algorithm has poor UX when attempting to
select from overlapping objects.