### PR TITLE
Move CI to Ubuntu 18.04

### DIFF
--- a/azure-pipelines/clang-format-applied.yml
+++ b/azure-pipelines/clang-format-applied.yml
@@ -17,7 +17,7 @@ stages:
   jobs:
   - job: 'Build_Test'
     pool:
-      vmImage: 'ubuntu-16.04'
+      vmImage: 'ubuntu-18.04'
     displayName: 'Test for correct Clang formatting'
     steps:
     - bash: |

--- a/azure-pipelines/continuous-integration.yml
+++ b/azure-pipelines/continuous-integration.yml
@@ -16,7 +16,7 @@ stages:
     jobs:
       - job: 'Linux'
         pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: 'ubuntu-18.04'
         displayName: 'Test Xournal++ on Linux'
         steps:
           - template: steps/install_deps_ubuntu.yml

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -20,7 +20,7 @@ stages:
     jobs:
       - job: 'Versioning'
         pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: 'ubuntu-18.04'
         displayName: 'Set Build Number'
         steps:
           - bash: |
@@ -48,7 +48,7 @@ stages:
     jobs:
       - job: 'Ubuntu'
         pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: 'ubuntu-18.04'
         displayName: 'Build for Ubuntu'
         condition: always()
         steps:
@@ -74,7 +74,7 @@ stages:
             displayName: 'Publish packages'
       - job: 'Debian'
         pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: 'ubuntu-18.04'
         container:
           image: xournalpp/debian-latest-sudo:latest
         displayName: 'Build for Debian'

--- a/azure-pipelines/steps/install_deps_ubuntu.yml
+++ b/azure-pipelines/steps/install_deps_ubuntu.yml
@@ -3,19 +3,10 @@
 
 parameters:
   build_type: 'Debug'
-  cmake_flags: ''
-  cmake_commands: ''
 
 steps:
   - bash: |
-      sudo add-apt-repository ppa:ubuntu-toolchain-r/test
       sudo apt-get update
-      sudo apt install gcc g++
-      sudo apt install gcc-8 g++-8
-      sudo apt install libstdc++-9-dev
-      sudo apt-get install -y cmake ninja-build libcppunit-dev libgtk-3-dev libpoppler-glib-dev portaudio19-dev libsndfile-dev liblua5.3-dev libzip-dev
+      sudo apt-get install -y gcc-8 g++-8 cmake ninja-build libcppunit-dev libgtk-3-dev libpoppler-glib-dev portaudio19-dev libsndfile-dev liblua5.3-dev libzip-dev
       g++ --version
-      g++-8 --version
-      export CXX=g++-8
-      export CC=gcc-8
     displayName: 'Install dependencies'

--- a/azure-pipelines/translation.yml
+++ b/azure-pipelines/translation.yml
@@ -9,7 +9,7 @@ stages:
   jobs:
   - job: 'Linux'
     pool:
-      vmImage: 'ubuntu-16.04'
+      vmImage: 'ubuntu-18.04'
     displayName: 'Update translation template'
     steps:
     - bash: |


### PR DESCRIPTION
This PR moves CI from Ubuntu 16.04 to 18.04. We are dropping support for 16.04 for `1.1.0` since we are using C++17 (`1.0.x` will be kept on 16.04 as it does not need C++17 features). Also, Ubuntu 20.04 LTS was released today and there's going to be even less of a reason to support 16.04 now.

Fixes #1732.