### PR TITLE
Hotfix for #1660

### DIFF
--- a/src/gui/Layout.cpp
+++ b/src/gui/Layout.cpp
@@ -26,9 +26,11 @@ constexpr size_t const XOURNAL_PADDING_BETWEEN = 15;
 
 
 Layout::Layout(XournalView* view, ScrollHandling* scrollHandling): view(view), scrollHandling(scrollHandling) {
-    g_signal_connect(scrollHandling->getHorizontal(), "value-changed", G_CALLBACK(horizontalScrollChanged), this);
+    this->hadjHandler = g_signal_connect(scrollHandling->getHorizontal(), "value-changed",
+                                         G_CALLBACK(horizontalScrollChanged), this);
 
-    g_signal_connect(scrollHandling->getVertical(), "value-changed", G_CALLBACK(verticalScrollChanged), this);
+    this->vadjHandler =
+            g_signal_connect(scrollHandling->getVertical(), "value-changed", G_CALLBACK(verticalScrollChanged), this);
 
 
     lastScrollHorizontal = gtk_adjustment_get_value(scrollHandling->getHorizontal());
@@ -36,15 +38,19 @@ Layout::Layout(XournalView* view, ScrollHandling* scrollHandling): view(view), s
 }
 
 void Layout::horizontalScrollChanged(GtkAdjustment* adjustment, Layout* layout) {
+    g_signal_handler_block(layout->scrollHandling->getHorizontal(), layout->hadjHandler);
     Layout::checkScroll(adjustment, layout->lastScrollHorizontal);
     layout->updateVisibility();
     layout->scrollHandling->scrollChanged();
+    g_signal_handler_unblock(layout->scrollHandling->getHorizontal(), layout->hadjHandler);
 }
 
 void Layout::verticalScrollChanged(GtkAdjustment* adjustment, Layout* layout) {
+    g_signal_handler_block(layout->scrollHandling->getVertical(), layout->vadjHandler);
     Layout::checkScroll(adjustment, layout->lastScrollVertical);
     layout->updateVisibility();
     layout->scrollHandling->scrollChanged();
+    g_signal_handler_unblock(layout->scrollHandling->getVertical(), layout->vadjHandler);
 }
 
 Layout::~Layout() = default;

--- a/src/gui/Layout.h
+++ b/src/gui/Layout.h
@@ -125,6 +125,9 @@ private:
     double lastScrollHorizontal = -1;
     double lastScrollVertical = -1;
 
+    guint hadjHandler = -1;
+    guint vadjHandler = -1;
+
     /**
      * The last width and height of the widget
      */


### PR DESCRIPTION
Fixes #1660. The scroll now jumps awkwardly instead of crashing, but it's better than crashing. ¯\\\_(ツ)\_/¯

Merging if CI passes.