### PR TITLE
Add feature to create new xopp file from cli

### DIFF
--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -1896,7 +1896,7 @@ void Control::showSettings() {
     delete dlg;
 }
 
-auto Control::newFile(string pageTemplate) -> bool {
+auto Control::newFile(string pageTemplate, Path fileName) -> bool {
     if (!this->close(true)) {
         return false;
     }
@@ -1905,6 +1905,9 @@ auto Control::newFile(string pageTemplate) -> bool {
 
     this->doc->lock();
     *doc = newDoc;
+    if (!fileName.isEmpty()) {
+        this->doc->setFilename(fileName);
+    };
     this->doc->unlock();
 
     addDefaultPage(std::move(pageTemplate));

--- a/src/control/Control.h
+++ b/src/control/Control.h
@@ -69,7 +69,7 @@ public:
 
 public:
     // Menu File
-    bool newFile(string pageTemplate = "");
+    bool newFile(string pageTemplate = "", Path fileName = "");
     bool openFile(Path filename = "", int scrollToPage = -1, bool forceOpen = false);
     bool annotatePdf(Path filename, bool attachPdf, bool attachToDocument);
     void print();

--- a/src/control/XournalMain.cpp
+++ b/src/control/XournalMain.cpp
@@ -390,7 +390,11 @@ auto XournalMain::run(int argc, char* argv[]) -> int {
         g_object_unref(file);
 
         if (!p.isEmpty()) {
-            opened = control->openFile(p, openAtPageNumber);
+            if (g_file_test(optFilename[0], G_FILE_TEST_EXISTS)) {
+                opened = control->openFile(p, openAtPageNumber);
+            } else {
+                opened = control->newFile("", optFilename[0]);
+            }
         } else {
             string msg = _("Sorry, Xournal++ cannot open remote files at the moment.\n"
                            "You have to copy the file to a local directory.");


### PR DESCRIPTION
This pull request resolves #1872  .

I chose to create a new file by default when the filename does not yet exist, as this is the standard behaviour for most command-line-tools I know (e.g. vim). However, I realized that inkscape and gimp through an error if the file does not yet exist. Thus, I'm sure what the best solution is. Using a flag like `--new` to explicitly request a new file would also be an easy addition to this pull request