### PR TITLE
Changed the units on grid snapping to be relative to the squares in the graph paper....

### DIFF
--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -22,8 +22,6 @@
     com = xmlNewComment((const xmlChar*)(var)); \
     xmlAddPrevSibling(xmlNode, com);
 
-constexpr auto DEFAULT_GRID_SIZE = 14.17;
-
 constexpr char const* BUTTON_NAMES[] = {"middle", "right", "eraser", "touch", "default", "stylus", "stylus2"};
 
 Settings::Settings(Path filename): filename(std::move(filename)) { loadDefault(); }

--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -1104,10 +1104,10 @@ void Settings::setSnapGridTolerance(double tolerance) {
 auto Settings::getSnapGridTolerance() const -> double { return this->snapGridTolerance; }
 auto Settings::getSnapGridSize() const -> double { return this->snapGridSize; };
 void Settings::setSnapGridSize(double gridSize) {
-    if (this->snapGridSize == gridSize/14.17) {
+    if (this->snapGridSize == gridSize) {
         return;
     }
-    this->snapGridSize = gridSize*14.17;
+    this->snapGridSize = gridSize;
     save();
 }
 

--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -1104,10 +1104,10 @@ void Settings::setSnapGridTolerance(double tolerance) {
 auto Settings::getSnapGridTolerance() const -> double { return this->snapGridTolerance; }
 auto Settings::getSnapGridSize() const -> double { return this->snapGridSize; };
 void Settings::setSnapGridSize(double gridSize) {
-    if (this->snapGridSize == gridSize) {
+    if (this->snapGridSize == gridSize/14.17) {
         return;
     }
-    this->snapGridSize = gridSize;
+    this->snapGridSize = gridSize*14.17;
     save();
 }
 

--- a/src/control/settings/Settings.h
+++ b/src/control/settings/Settings.h
@@ -23,6 +23,8 @@
 
 #include "Path.h"
 
+constexpr auto DEFAULT_GRID_SIZE = 14.17;
+
 enum AttributeType {
     ATTRIBUTE_TYPE_NONE,
     ATTRIBUTE_TYPE_STRING,

--- a/src/gui/dialog/SettingsDialog.cpp
+++ b/src/gui/dialog/SettingsDialog.cpp
@@ -575,7 +575,7 @@ void SettingsDialog::save() {
             static_cast<double>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spSnapRotationTolerance")))));
     settings->setSnapGridTolerance(
             static_cast<double>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spSnapGridTolerance")))));
-    settings->setSnapGridSize(static_cast<double>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spSnapGridSize")))));
+    settings->setSnapGridSize(static_cast<double>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spSnapGridSize")))*14.17));
 
     int selectedInputDeviceIndex = gtk_combo_box_get_active(GTK_COMBO_BOX(get("cbAudioInputDevice"))) - 1;
     if (selectedInputDeviceIndex >= 0 && selectedInputDeviceIndex < static_cast<int>(this->audioInputDevices.size())) {

--- a/src/gui/dialog/SettingsDialog.cpp
+++ b/src/gui/dialog/SettingsDialog.cpp
@@ -225,7 +225,7 @@ void SettingsDialog::load() {
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spSnapGridTolerance), settings->getSnapGridTolerance());
 
     GtkWidget* spSnapGridSize = get("spSnapGridSize");
-    gtk_spin_button_set_value(GTK_SPIN_BUTTON(spSnapGridSize), settings->getSnapGridSize() / 14.17);
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(spSnapGridSize), settings->getSnapGridSize() / DEFAULT_GRID_SIZE);
 
     GtkWidget* spZoomStep = get("spZoomStep");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spZoomStep), settings->getZoomStep());
@@ -576,7 +576,7 @@ void SettingsDialog::save() {
     settings->setSnapGridTolerance(
             static_cast<double>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spSnapGridTolerance")))));
     settings->setSnapGridSize(
-            static_cast<double>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spSnapGridSize"))) * 14.17));
+            static_cast<double>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spSnapGridSize"))) * DEFAULT_GRID_SIZE));
 
     int selectedInputDeviceIndex = gtk_combo_box_get_active(GTK_COMBO_BOX(get("cbAudioInputDevice"))) - 1;
     if (selectedInputDeviceIndex >= 0 && selectedInputDeviceIndex < static_cast<int>(this->audioInputDevices.size())) {

--- a/src/gui/dialog/SettingsDialog.cpp
+++ b/src/gui/dialog/SettingsDialog.cpp
@@ -225,7 +225,7 @@ void SettingsDialog::load() {
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spSnapGridTolerance), settings->getSnapGridTolerance());
 
     GtkWidget* spSnapGridSize = get("spSnapGridSize");
-    gtk_spin_button_set_value(GTK_SPIN_BUTTON(spSnapGridSize), settings->getSnapGridSize()/14.17);
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(spSnapGridSize), settings->getSnapGridSize() / 14.17);
 
     GtkWidget* spZoomStep = get("spZoomStep");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spZoomStep), settings->getZoomStep());
@@ -575,7 +575,8 @@ void SettingsDialog::save() {
             static_cast<double>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spSnapRotationTolerance")))));
     settings->setSnapGridTolerance(
             static_cast<double>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spSnapGridTolerance")))));
-    settings->setSnapGridSize(static_cast<double>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spSnapGridSize")))*14.17));
+    settings->setSnapGridSize(
+            static_cast<double>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spSnapGridSize"))) * 14.17));
 
     int selectedInputDeviceIndex = gtk_combo_box_get_active(GTK_COMBO_BOX(get("cbAudioInputDevice"))) - 1;
     if (selectedInputDeviceIndex >= 0 && selectedInputDeviceIndex < static_cast<int>(this->audioInputDevices.size())) {

--- a/src/gui/dialog/SettingsDialog.cpp
+++ b/src/gui/dialog/SettingsDialog.cpp
@@ -225,7 +225,7 @@ void SettingsDialog::load() {
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spSnapGridTolerance), settings->getSnapGridTolerance());
 
     GtkWidget* spSnapGridSize = get("spSnapGridSize");
-    gtk_spin_button_set_value(GTK_SPIN_BUTTON(spSnapGridSize), settings->getSnapGridSize());
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(spSnapGridSize), settings->getSnapGridSize()/14.17);
 
     GtkWidget* spZoomStep = get("spZoomStep");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spZoomStep), settings->getZoomStep());

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -44,9 +44,9 @@
     <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentSnapGridSize">
-    <property name="lower">0.10000000000000001</property>
-    <property name="upper">50</property>
-    <property name="value">14.17</property>
+    <property name="lower">0.01</property>
+    <property name="upper">20</property>
+    <property name="value">1</property>
     <property name="step_increment">0.01</property>
     <property name="page_increment">10</property>
   </object>
@@ -3374,7 +3374,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                             <property name="adjustment">adjustmentSnapGridSize</property>
                                             <property name="climb_rate">0.01</property>
                                             <property name="digits">2</property>
-                                            <property name="value">14.17</property>
+                                            <property name="value">1.00</property>
                                           </object>
                                           <packing>
                                             <property name="left_attach">1</property>


### PR DESCRIPTION
Hi,
Thanks to Fabian, we have a beautiful new way to select the grid size.  I wasn't quite happy with it though, because it was in basic units, and I wanted it in units relative to the size of the squares on the graph paper.  Thanks for a very useful program!
Rob