### PR TITLE
Implement Pen/Highlighter Cursor correct size

### DIFF
--- a/src/gui/XournalppCursor.cpp
+++ b/src/gui/XournalppCursor.cpp
@@ -424,7 +424,7 @@ auto XournalppCursor::createHighlighterOrPenCursor(int size, double alpha) -> Gd
 
     cairo_set_source_rgba(cr, r, g, b, alpha);
     double cursorSize = control->getToolHandler()->getThickness() * control->getZoomControl()->getZoom();
-    cairo_arc(cr, centerX, centerY, cursorSize/2., 0, 2. * M_PI);
+    cairo_arc(cr, centerX, centerY, cursorSize / 2., 0, 2. * M_PI);
     cairo_fill(cr);
     cairo_destroy(cr);
     GdkPixbuf* pixbuf = xoj_pixbuf_get_from_surface(crCursor, 0, 0, width, height);

--- a/src/gui/XournalppCursor.cpp
+++ b/src/gui/XournalppCursor.cpp
@@ -421,9 +421,10 @@ auto XournalppCursor::createHighlighterOrPenCursor(int size, double alpha) -> Gd
         cairo_stroke(cr);
     }
 
+
     cairo_set_source_rgba(cr, r, g, b, alpha);
-    // Correct the offset of the coloured dot for big-cursor mode
-    cairo_rectangle(cr, centerX, centerY, size, size);
+    double cursorSize = control->getToolHandler()->getThickness() * control->getZoomControl()->getZoom();
+    cairo_arc(cr, centerX, centerY, cursorSize/2., 0, 2. * M_PI);
     cairo_fill(cr);
     cairo_destroy(cr);
     GdkPixbuf* pixbuf = xoj_pixbuf_get_from_surface(crCursor, 0, 0, width, height);


### PR DESCRIPTION
This Commit changes the Pen/Highlighter Cursor to have the form of a
circle (via `cairo_arc`) and also uses the set size to give a correct
impression on how big the line one is about to draw is.

This PR would resolve #1513. Note that it would make my previous PR #1941 obsolete.