### PR TITLE
Latex tool enhancements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,6 +264,10 @@ install (DIRECTORY plugins
 		DESTINATION "share/xournalpp"
 		COMPONENT xournalpp
 )
+install (DIRECTORY resources
+        DESTINATION "share/xournalpp"
+        COMPONENT xournalpp
+)
 
 # Install desktop shortcuts for Linux
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")

--- a/resources/default_template.tex
+++ b/resources/default_template.tex
@@ -8,6 +8,10 @@
 \usepackage{ifthen}
 \newlength{\pheight}
 
+% Color support
+\usepackage{xcolor}
+\definecolor{xpp_font_color}{HTML}{%%XPP_TEXT_COLOR%%}
+
 % User input
 \def\preview{\(
   \displaystyle
@@ -21,5 +25,5 @@
   \ifthenelse{\pheight=0}{\GenericError{}{xournalpp:blankformula}{}{}}
 
   % Render the user input
-  \preview
+  \textcolor{xpp_font_color}{\preview}
 \end{document}

--- a/resources/default_template.tex
+++ b/resources/default_template.tex
@@ -1,0 +1,25 @@
+\documentclass[varwidth=true, crop, border=5pt]{standalone}
+
+% Packages
+\usepackage{amsmath}
+\usepackage{amssymb}
+
+% Blank formula checking
+\usepackage{ifthen}
+\newlength{\pheight}
+
+% User input
+\def\preview{\(
+  \displaystyle
+  %%XPP_TOOL_INPUT%%
+  \)
+}
+
+\begin{document}
+  % Check if the formula is empty
+  \settoheight{\pheight}{\preview}
+  \ifthenelse{\pheight=0}{\GenericError{}{xournalpp:blankformula}{}{}}
+
+  % Render the user input
+  \preview
+\end{document}

--- a/resources/default_template.tex
+++ b/resources/default_template.tex
@@ -4,6 +4,9 @@
 \usepackage{amsmath}
 \usepackage{amssymb}
 
+% for storing in memory verbatim content to be reused later
+\usepackage{scontents}
+
 % Blank formula checking
 \usepackage{ifthen}
 \newlength{\pheight}
@@ -13,17 +16,18 @@
 \definecolor{xpp_font_color}{HTML}{%%XPP_TEXT_COLOR%%}
 
 % User input
-\def\preview{\(
-  \displaystyle
-  %%XPP_TOOL_INPUT%%
-  \)
-}
+\begin{scontents}[store-env=preview]
+	\( 
+	\displaystyle
+    %%XPP_TOOL_INPUT%%
+	\)
+\end{scontents}
 
 \begin{document}
   % Check if the formula is empty
-  \settoheight{\pheight}{\preview}
+  \settoheight{\pheight}{\getstored[1]{preview}}
   \ifthenelse{\pheight=0}{\GenericError{}{xournalpp:blankformula}{}{}}
 
   % Render the user input
-  \textcolor{xpp_font_color}{\preview}
+  \textcolor{xpp_font_color}{\getstored[1]{preview}}
 \end{document}

--- a/src/control/LatexController.cpp
+++ b/src/control/LatexController.cpp
@@ -36,19 +36,25 @@ LatexController::~LatexController() { this->control = nullptr; }
  * Find the tex executable, return false if not found
  */
 auto LatexController::findTexDependencies() -> LatexController::FindDependencyStatus {
-    std::ifstream is(this->settings.globalTemplatePath.string(), std::ios_base::binary);
-    if (!is.is_open()) {
-        g_message("%s", this->settings.globalTemplatePath.string().c_str());
-        string msg = _("Global template file does not exist. Please check your settings.");
-        return LatexController::FindDependencyStatus(false, msg);
-    }
-    this->latexTemplate = std::string(std::istreambuf_iterator<char>(is), {});
-    if (!is.good()) {
-        string msg = _("Failed to read global template file. Please check your settings.");
-        return LatexController::FindDependencyStatus(false, msg);
-    }
+    std::string templatePathName = this->settings.globalTemplatePath.string();
+    if (fs::is_regular_file(fs::status(templatePathName))) {
+        std::ifstream is(templatePathName, std::ios_base::binary);
+        if (!is.is_open()) {
+            g_message("%s", templatePathName.c_str());
+            string msg = _("Global template file does not exist. Please check your settings.");
+            return LatexController::FindDependencyStatus(false, msg);
+        }
+        this->latexTemplate = std::string(std::istreambuf_iterator<char>(is), {});
+        if (!is.good()) {
+            string msg = _("Failed to read global template file. Please check your settings.");
+            return LatexController::FindDependencyStatus(false, msg);
+        }
 
-    return LatexController::FindDependencyStatus(true, "");
+        return LatexController::FindDependencyStatus(true, "");
+    } else {
+        string msg = _("Global template file is not a regular file. Please check your settings. ");
+        return LatexController::FindDependencyStatus(false, msg);
+    }
 }
 
 /**

--- a/src/control/LatexController.h
+++ b/src/control/LatexController.h
@@ -22,6 +22,7 @@
 
 #include "control/settings/LatexSettings.h"
 #include "gui/dialog/LatexDialog.h"
+#include "latex/LatexGenerator.h"
 #include "model/PageRef.h"
 #include "model/Text.h"
 
@@ -78,16 +79,6 @@ private:
     void deleteOldImage();
 
     /**
-     * Run the LaTeX command asynchronously to generate a preview for the given
-     * LaTeX string. Note that this method can only be called when the preview
-     * is not updating.
-     *
-     * @return The PID of the spawned process, or nullptr if the .tex file could
-     * not be written or the command failed to start.
-     */
-    std::unique_ptr<GPid> runCommandAsync(const string& texString);
-
-    /**
      * Asynchronously runs the LaTeX command and then updates the TeX image with
      * the given LaTeX string. If the preview is already being updated, then
      * this method will be a no-op.
@@ -113,7 +104,7 @@ private:
      * If the Latex text has changed since the last update, triggerPreviewUpdate
      * will be called again.
      */
-    static void onPdfRenderComplete(GPid pid, gint returnCode, LatexController* self);
+    static void onPdfRenderComplete(GObject* procObj, GAsyncResult* res, LatexController* self);
 
     void setUpdating(bool newValue);
 
@@ -223,4 +214,6 @@ private:
      * when a new render is created
      */
     std::unique_ptr<TexImage> temporaryRender;
+
+    LatexGenerator generator;
 };

--- a/src/control/LatexController.h
+++ b/src/control/LatexController.h
@@ -118,12 +118,6 @@ private:
     void setUpdating(bool newValue);
 
     /**
-     * Convert the given PDF Document to a TexImage and set the formula to the
-     * given formula.
-     */
-    std::unique_ptr<TexImage> convertDocumentToImage(PopplerDocument* doc, string formula) const;
-
-    /**
      * Load the preview PDF from disk and create a TexImage object.
      */
     std::unique_ptr<TexImage> loadRendered(string renderedTex);

--- a/src/control/LatexController.h
+++ b/src/control/LatexController.h
@@ -20,6 +20,7 @@
 
 #include <poppler.h>
 
+#include "control/settings/LatexSettings.h"
 #include "gui/dialog/LatexDialog.h"
 #include "model/PageRef.h"
 #include "model/Text.h"
@@ -134,6 +135,12 @@ private:
 
 private:
     Control* control = nullptr;
+    LatexSettings const& settings;
+
+    /**
+     * The contents of the latex template, loaded from disk.
+     */
+    std::string latexTemplate;
 
     /**
      * LaTex editor dialog

--- a/src/control/LatexController.h
+++ b/src/control/LatexController.h
@@ -214,11 +214,9 @@ private:
     Path texTmpDir;
 
     /**
-     * Previously existing TexImage
+     * The element that is currently being edited.
      */
-    TexImage* selectedTexImage = nullptr;
-
-    Text* selectedText = nullptr;
+    Element* selectedElem = nullptr;
 
     /**
      * The controller owns the rendered preview in order to be able to delete it

--- a/src/control/XournalMain.cpp
+++ b/src/control/XournalMain.cpp
@@ -372,6 +372,13 @@ auto XournalMain::run(int argc, char* argv[]) -> int {
         gtk_icon_theme_prepend_search_path(gtk_icon_theme_get_default(), icon.c_str());
     }
 
+    auto& globalLatexTemplatePath = control->getSettings()->latexSettings.globalTemplatePath;
+    if (globalLatexTemplatePath.empty()) {
+        globalLatexTemplatePath = fs::u8path(findResourcePath("resources/")) / "default_template.tex";
+        g_message("Using default latex template in %s", globalLatexTemplatePath.u8string().c_str());
+        control->getSettings()->save();
+    }
+
     auto* win = new MainWindow(gladePath, control);
     control->initWindow(win);
 

--- a/src/control/latex/LatexGenerator.cpp
+++ b/src/control/latex/LatexGenerator.cpp
@@ -1,0 +1,87 @@
+#include "LatexGenerator.h"
+
+#include <iomanip>
+#include <iterator>
+#include <regex>
+#include <sstream>
+
+#include <glib.h>
+
+#include "i18n.h"
+
+LatexGenerator::LatexGenerator(const LatexSettings& settings): settings(settings) {}
+
+auto LatexGenerator::templateSub(const std::string& input, const std::string& templ, const uint32_t textColor)
+        -> std::string {
+    const static std::regex substRe("%%XPP_((TOOL_INPUT)|(TEXT_COLOR))%%");
+    std::string output;
+    output.reserve(templ.length());
+    int templatePos = 0;
+    for (std::sregex_iterator it(templ.begin(), templ.end(), substRe); it != std::sregex_iterator{}; it++) {
+        std::smatch match = *it;
+        std::string matchStr = match[1];
+        std::string repl;
+        // Performance can be optimized here by precomputing hashes
+        if (matchStr == "TOOL_INPUT") {
+            repl = input;
+        } else if (matchStr == "TEXT_COLOR") {
+            std::ostringstream s;
+            s.imbue(std::locale::classic());
+            s << std::hex << std::setfill('0') << std::setw(6) << std::right << (textColor & 0xFFFFFFU);
+            repl = s.str();
+        }
+        output.append(templ, templatePos, match.position() - templatePos);
+        output.append(repl);
+        templatePos = match.position() + match.length();
+    }
+    output.append(templ, templatePos);
+    return output;
+}
+
+auto LatexGenerator::asyncRun(const Path& texDir, const std::string& texFileContents) -> Result {
+    std::string cmd = this->settings.genCmd;
+    GError* err = nullptr;
+    const auto&& fail = [&](GenError&& res) -> Result {
+        g_error_free(err);
+        return res;
+    };
+
+    std::string texFilePath = (texDir / "tex.tex").c_str();
+    for (auto i = cmd.find(u8"{}"); i != std::string::npos; i = cmd.find(u8"{}", i + texFilePath.length())) {
+        cmd.replace(i, 2, texFilePath);
+    }
+    // Windows note: g_shell_parse_argv assumes POSIX paths, so Windows paths need to be escaped.
+    gchar** argv = nullptr;
+    if (!g_shell_parse_argv(cmd.c_str(), nullptr, &argv, &err)) {
+        return fail({FS(_F("Failed to parse LaTeX generator command: {1}") % err->message)});
+    }
+    gchar* prog = argv[0];
+    if (!prog || !(prog = g_find_program_in_path(prog))) {
+        GenError res{FS(_F("Failed to find LaTeX generator program in PATH: {1}") % argv[0])};
+        g_strfreev(argv);
+        g_error_free(err);
+        return res;
+    }
+    g_free(argv[0]);
+    argv[0] = prog;
+
+    if (!g_file_set_contents(texFilePath.c_str(), texFileContents.c_str(), texFileContents.length(), &err)) {
+        return fail({FS(_F("Could not save .tex file: {1}") % err->message)});
+    }
+
+    auto flags = static_cast<GSubprocessFlags>(G_SUBPROCESS_FLAGS_STDOUT_SILENCE | G_SUBPROCESS_FLAGS_STDERR_SILENCE);
+    GSubprocessLauncher* launcher = g_subprocess_launcher_new(flags);
+    g_subprocess_launcher_set_cwd(launcher, texDir.c_str());
+    auto* proc = g_subprocess_launcher_spawnv(launcher, argv, &err);
+
+    std::string progName(prog);
+    g_strfreev(argv);
+    g_object_unref(launcher);
+
+    if (proc) {
+        return {proc};
+    } else {
+        return fail(
+                {FS(_F("Could not start {1}: {2} (exit code: {3})") % progName.c_str() % err->message % err->code)});
+    }
+}

--- a/src/control/latex/LatexGenerator.h
+++ b/src/control/latex/LatexGenerator.h
@@ -1,0 +1,52 @@
+/*
+ * Xournal++
+ *
+ * Latex file generator
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+#include <string>
+#include <variant>
+
+#include <gio/gio.h>
+#include <poppler.h>
+
+#include "control/settings/LatexSettings.h"
+
+#include "Path.h"
+
+class LatexGenerator {
+public:
+    LatexGenerator(const LatexSettings& settings);
+    LatexGenerator(const LatexGenerator&) = delete;
+    LatexGenerator& operator=(const LatexGenerator&) = delete;
+    LatexGenerator(const LatexGenerator&&) = delete;
+    LatexGenerator&& operator=(const LatexGenerator&&) = delete;
+    virtual ~LatexGenerator() = default;
+
+    struct GenError {
+        std::string message;
+    };
+    using Result = std::variant<GSubprocess*, GenError>;
+
+    /**
+     * Run the LaTeX command asynchronously to generate a preview for the given
+     * LaTeX file. The contents of the LaTeX file will be written to "tex.tex"
+     * in the given directory.
+     */
+    Result asyncRun(const Path& texDir, const std::string& texFileContents);
+
+    /**
+     * Instantiate the LaTeX template.
+     */
+    static std::string templateSub(const string& input, const string& templ, const uint32_t textColor);
+
+private:
+    const LatexSettings& settings;
+};

--- a/src/control/settings/LatexSettings.cpp
+++ b/src/control/settings/LatexSettings.cpp
@@ -1,0 +1,1 @@
+#include "LatexSettings.h"

--- a/src/control/settings/LatexSettings.h
+++ b/src/control/settings/LatexSettings.h
@@ -1,0 +1,24 @@
+/*
+ * Xournal++
+ *
+ * Latex settings
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+#include <string>
+
+#include "filesystem.h"
+
+class LatexSettings {
+public:
+    bool autoCheckDependencies{true};
+    fs::path globalTemplatePath{};
+    std::string kpsewhichCmd{"kpsewhich"};
+    std::string genCmd{"pdflatex -interaction=nonstopmode"};
+};

--- a/src/control/settings/LatexSettings.h
+++ b/src/control/settings/LatexSettings.h
@@ -19,6 +19,5 @@ class LatexSettings {
 public:
     bool autoCheckDependencies{true};
     fs::path globalTemplatePath{};
-    std::string kpsewhichCmd{"kpsewhich"};
-    std::string genCmd{"pdflatex -interaction=nonstopmode"};
+    std::string genCmd{"pdflatex -interaction=nonstopmode '{}'"};
 };

--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -455,8 +455,6 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur) {
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("latexSettings.globalTemplatePath")) == 0) {
         std::string v(reinterpret_cast<char*>(value));
         this->latexSettings.globalTemplatePath = fs::u8path(v);
-    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("latexSettings.kpsewhichCmd")) == 0) {
-        this->latexSettings.kpsewhichCmd = reinterpret_cast<char*>(value);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("latexSettings.genCmd")) == 0) {
         this->latexSettings.genCmd = reinterpret_cast<char*>(value);
     }
@@ -836,7 +834,6 @@ void Settings::save() {
     // wchar_t instead of char
     fs::path& p = latexSettings.globalTemplatePath;
     xmlNode = saveProperty("latexSettings.globalTemplatePath", p.empty() ? "" : p.u8string().c_str(), root);
-    WRITE_STRING_PROP(latexSettings.kpsewhichCmd);
     WRITE_STRING_PROP(latexSettings.genCmd);
 
     xmlNodePtr xmlFont = nullptr;

--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -450,6 +450,15 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur) {
         this->doActionOnStrokeFiltered = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("trySelectOnStrokeFiltered")) == 0) {
         this->trySelectOnStrokeFiltered = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("latexSettings.autoCheckDependencies")) == 0) {
+        this->latexSettings.autoCheckDependencies = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("latexSettings.globalTemplatePath")) == 0) {
+        std::string v(reinterpret_cast<char*>(value));
+        this->latexSettings.globalTemplatePath = fs::u8path(v);
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("latexSettings.kpsewhichCmd")) == 0) {
+        this->latexSettings.kpsewhichCmd = reinterpret_cast<char*>(value);
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("latexSettings.genCmd")) == 0) {
+        this->latexSettings.genCmd = reinterpret_cast<char*>(value);
     }
 
     xmlFree(name);
@@ -820,6 +829,15 @@ void Settings::save() {
     WRITE_BOOL_PROP(newInputSystemEnabled);
     WRITE_BOOL_PROP(inputSystemTPCButton);
     WRITE_BOOL_PROP(inputSystemDrawOutsideWindow);
+
+    WRITE_BOOL_PROP(latexSettings.autoCheckDependencies);
+    // Inline WRITE_STRING_PROP(latexSettings.globalTemplatePath) since it
+    // breaks on Windows due to the native character representation being
+    // wchar_t instead of char
+    fs::path& p = latexSettings.globalTemplatePath;
+    xmlNode = saveProperty("latexSettings.globalTemplatePath", p.empty() ? "" : p.u8string().c_str(), root);
+    WRITE_STRING_PROP(latexSettings.kpsewhichCmd);
+    WRITE_STRING_PROP(latexSettings.genCmd);
 
     xmlNodePtr xmlFont = nullptr;
     xmlFont = xmlNewChild(root, nullptr, reinterpret_cast<const xmlChar*>("property"), nullptr);

--- a/src/control/settings/Settings.h
+++ b/src/control/settings/Settings.h
@@ -21,6 +21,7 @@
 #include "control/Tool.h"
 #include "model/Font.h"
 
+#include "LatexSettings.h"
 #include "Path.h"
 
 constexpr auto DEFAULT_GRID_SIZE = 14.17;
@@ -507,6 +508,8 @@ public:
      * Stop transaction and save settings
      */
     void transactionEnd();
+
+    LatexSettings latexSettings{};
 
 private:
     /**

--- a/src/control/xml/XmlTexNode.cpp
+++ b/src/control/xml/XmlTexNode.cpp
@@ -1,6 +1,6 @@
 #include "XmlTexNode.h"
 
-XmlTexNode::XmlTexNode(const char* tag, string& binaryData): XmlNode(tag), binaryData(binaryData) {}
+XmlTexNode::XmlTexNode(const char* tag, string&& binaryData): XmlNode(tag), binaryData(binaryData) {}
 
 XmlTexNode::~XmlTexNode() = default;
 

--- a/src/control/xml/XmlTexNode.h
+++ b/src/control/xml/XmlTexNode.h
@@ -15,7 +15,7 @@
 
 class XmlTexNode: public XmlNode {
 public:
-    XmlTexNode(const char* tag, string& binaryData);
+    XmlTexNode(const char* tag, string&& binaryData);
     virtual ~XmlTexNode();
 
 public:
@@ -25,5 +25,5 @@ private:
     /**
      * Binary .PNG or .PDF
      */
-    string& binaryData;
+    string binaryData;
 };

--- a/src/control/xojfile/LoadHandler.cpp
+++ b/src/control/xojfile/LoadHandler.cpp
@@ -689,7 +689,7 @@ void LoadHandler::parseAttachment() {
             break;
         }
         case PARSER_POS_IN_TEXIMAGE: {
-            this->teximage->setBinaryData(imgData);
+            this->teximage->loadData(std::move(imgData), nullptr);
             break;
         }
         default:
@@ -950,7 +950,7 @@ void LoadHandler::readTexImage(const gchar* base64string, gsize base64stringLen)
         return;
     }
 
-    this->teximage->setBinaryData(parseBase64(const_cast<char*>(base64string), base64stringLen));
+    this->teximage->loadData(parseBase64(const_cast<char*>(base64string), base64stringLen));
 }
 
 /**

--- a/src/control/xojfile/SaveHandler.cpp
+++ b/src/control/xojfile/SaveHandler.cpp
@@ -185,7 +185,7 @@ void SaveHandler::visitLayer(XmlNode* page, Layer* l) {
             image->setAttrib("bottom", i->getY() + i->getElementHeight());
         } else if (e->getType() == ELEMENT_TEXIMAGE) {
             auto* i = dynamic_cast<TexImage*>(e);
-            auto* image = new XmlTexNode("teximage", i->getBinaryData());
+            auto* image = new XmlTexNode("teximage", std::string(i->getBinaryData()));
             layer->addChild(image);
 
             image->setAttrib("text", i->getText().c_str());

--- a/src/gui/dialog/LatexSettingsPanel.cpp
+++ b/src/gui/dialog/LatexSettingsPanel.cpp
@@ -18,7 +18,6 @@ void LatexSettingsPanel::load(const LatexSettings& settings) {
     if (!settings.globalTemplatePath.empty()) {
         gtk_file_chooser_set_filename(this->globalTemplateChooser, settings.globalTemplatePath.u8string().c_str());
     }
-    gtk_entry_set_text(GTK_ENTRY(this->get("latexSettingsKpsewhich")), settings.kpsewhichCmd.c_str());
     gtk_entry_set_text(GTK_ENTRY(this->get("latexSettingsGenCmd")), settings.genCmd.c_str());
 }
 
@@ -31,7 +30,6 @@ void LatexSettingsPanel::save(LatexSettings& settings) {
     } else {
         settings.globalTemplatePath = "";
     }
-    settings.kpsewhichCmd = gtk_entry_get_text(GTK_ENTRY(this->get("latexSettingsKpsewhich")));
     settings.genCmd = gtk_entry_get_text(GTK_ENTRY(this->get("latexSettingsGenCmd")));
 }
 

--- a/src/gui/dialog/LatexSettingsPanel.cpp
+++ b/src/gui/dialog/LatexSettingsPanel.cpp
@@ -26,7 +26,7 @@ void LatexSettingsPanel::save(LatexSettings& settings) {
     settings.autoCheckDependencies = gtk_toggle_button_get_active(this->cbAutoDepCheck);
     gchar* templPath = gtk_file_chooser_get_filename(this->globalTemplateChooser);
     if (templPath) {
-        settings.globalTemplatePath = templPath;
+        settings.globalTemplatePath = fs::u8path(templPath);
         g_free(templPath);
     } else {
         settings.globalTemplatePath = "";

--- a/src/gui/dialog/LatexSettingsPanel.cpp
+++ b/src/gui/dialog/LatexSettingsPanel.cpp
@@ -51,30 +51,34 @@ void LatexSettingsPanel::checkDeps() {
     this->save(settings);
     std::string msg;
 
-    // Assume the file is encoded as UTF-8 (open in binary mode to avoid surprises)
-    std::ifstream is(settings.globalTemplatePath.string(), std::ios_base::binary);
-    if (!is.is_open()) {
-        msg = FS(_F("Unable to open global template file at {1}. Does it exist?") %
-                 settings.globalTemplatePath.u8string().c_str());
-    } else {
-        std::string templ(std::istreambuf_iterator<char>(is), {});
-        std::string sample = LatexGenerator::templateSub("x^2", templ, 0x000000U);
-        const Path tmpDir = Util::getTmpDirSubfolder("tex");
-        auto result = LatexGenerator(settings).asyncRun(tmpDir, sample);
-        if (auto* proc = std::get_if<GSubprocess*>(&result)) {
-            GError* err = nullptr;
-            if (g_subprocess_wait_check(*proc, nullptr, &err)) {
-                msg = _("Sample LaTeX file generated successfully.");
-            } else {
-                msg = FS(_F("Error: {1}. Please check the contents of {2}") % err->message % tmpDir.c_str());
-                g_error_free(err);
+    if (fs::is_regular_file(fs::status(settings.globalTemplatePath.string()))) {
+        // Assume the file is encoded as UTF-8 (open in binary mode to avoid surprises)
+        std::ifstream is(settings.globalTemplatePath.string(), std::ios_base::binary);
+        if (!is.is_open()) {
+            msg = FS(_F("Unable to open global template file at {1}. Does it exist?") %
+                     settings.globalTemplatePath.u8string().c_str());
+        } else {
+            std::string templ(std::istreambuf_iterator<char>(is), {});
+            std::string sample = LatexGenerator::templateSub("x^2", templ, 0x000000U);
+            const Path tmpDir = Util::getTmpDirSubfolder("tex");
+            auto result = LatexGenerator(settings).asyncRun(tmpDir, sample);
+            if (auto* proc = std::get_if<GSubprocess*>(&result)) {
+                GError* err = nullptr;
+                if (g_subprocess_wait_check(*proc, nullptr, &err)) {
+                    msg = _("Sample LaTeX file generated successfully.");
+                } else {
+                    msg = FS(_F("Error: {1}. Please check the contents of {2}") % err->message % tmpDir.c_str());
+                    g_error_free(err);
+                }
+                g_object_unref(*proc);
+            } else if (auto* err = std::get_if<LatexGenerator::GenError>(&result)) {
+                msg = err->message;
             }
-            g_object_unref(*proc);
-        } else if (auto* err = std::get_if<LatexGenerator::GenError>(&result)) {
-            msg = err->message;
         }
+    } else {
+        msg = FS(_F("Error: {1} is not a regular file. Please check your LaTeX template file settings. ") %
+                 settings.globalTemplatePath.u8string().c_str());
     }
-
     GtkWidget* dialog =
             gtk_message_dialog_new(nullptr, GTK_DIALOG_MODAL, GTK_MESSAGE_INFO, GTK_BUTTONS_OK, "%s", msg.c_str());
     gtk_dialog_run(GTK_DIALOG(dialog));

--- a/src/gui/dialog/LatexSettingsPanel.cpp
+++ b/src/gui/dialog/LatexSettingsPanel.cpp
@@ -1,11 +1,22 @@
 #include "LatexSettingsPanel.h"
 
+#include <fstream>
+#include <variant>
+
+#include "control/latex/LatexGenerator.h"
+
+#include "Util.h"
+#include "filesystem.h"
+#include "i18n.h"
+
 LatexSettingsPanel::LatexSettingsPanel(GladeSearchpath* gladeSearchPath):
         GladeGui(gladeSearchPath, "latexSettings.glade", "latexSettingsPanel"),
         cbAutoDepCheck(GTK_TOGGLE_BUTTON(this->get("latexSettingsRunCheck"))),
         globalTemplateChooser(GTK_FILE_CHOOSER(this->get("latexSettingsTemplateFile"))) {
     g_object_ref(this->cbAutoDepCheck);
     g_object_ref(this->globalTemplateChooser);
+    g_signal_connect(this->get("latexSettingsTestBtn"), "clicked",
+                     G_CALLBACK(+[](GtkWidget*, LatexSettingsPanel* self) { self->checkDeps(); }), this);
 }
 
 LatexSettingsPanel::~LatexSettingsPanel() {
@@ -34,3 +45,38 @@ void LatexSettingsPanel::save(LatexSettings& settings) {
 }
 
 void LatexSettingsPanel::show(GtkWindow* parent) {}
+
+void LatexSettingsPanel::checkDeps() {
+    LatexSettings settings;
+    this->save(settings);
+    std::string msg;
+
+    // Assume the file is encoded as UTF-8 (open in binary mode to avoid surprises)
+    std::ifstream is(settings.globalTemplatePath.string(), std::ios_base::binary);
+    if (!is.is_open()) {
+        msg = FS(_F("Unable to open global template file at {1}. Does it exist?") %
+                 settings.globalTemplatePath.u8string().c_str());
+    } else {
+        std::string templ(std::istreambuf_iterator<char>(is), {});
+        std::string sample = LatexGenerator::templateSub("x^2", templ, 0x000000U);
+        const Path tmpDir = Util::getTmpDirSubfolder("tex");
+        auto result = LatexGenerator(settings).asyncRun(tmpDir, sample);
+        if (auto* proc = std::get_if<GSubprocess*>(&result)) {
+            GError* err = nullptr;
+            if (g_subprocess_wait_check(*proc, nullptr, &err)) {
+                msg = _("Sample LaTeX file generated successfully.");
+            } else {
+                msg = FS(_F("Error: {1}. Please check the contents of {2}") % err->message % tmpDir.c_str());
+                g_error_free(err);
+            }
+            g_object_unref(*proc);
+        } else if (auto* err = std::get_if<LatexGenerator::GenError>(&result)) {
+            msg = err->message;
+        }
+    }
+
+    GtkWidget* dialog =
+            gtk_message_dialog_new(nullptr, GTK_DIALOG_MODAL, GTK_MESSAGE_INFO, GTK_BUTTONS_OK, "%s", msg.c_str());
+    gtk_dialog_run(GTK_DIALOG(dialog));
+    gtk_widget_destroy(dialog);
+}

--- a/src/gui/dialog/LatexSettingsPanel.cpp
+++ b/src/gui/dialog/LatexSettingsPanel.cpp
@@ -1,0 +1,38 @@
+#include "LatexSettingsPanel.h"
+
+LatexSettingsPanel::LatexSettingsPanel(GladeSearchpath* gladeSearchPath):
+        GladeGui(gladeSearchPath, "latexSettings.glade", "latexSettingsPanel"),
+        cbAutoDepCheck(GTK_TOGGLE_BUTTON(this->get("latexSettingsRunCheck"))),
+        globalTemplateChooser(GTK_FILE_CHOOSER(this->get("latexSettingsTemplateFile"))) {
+    g_object_ref(this->cbAutoDepCheck);
+    g_object_ref(this->globalTemplateChooser);
+}
+
+LatexSettingsPanel::~LatexSettingsPanel() {
+    g_object_unref(this->cbAutoDepCheck);
+    g_object_unref(this->globalTemplateChooser);
+}
+
+void LatexSettingsPanel::load(const LatexSettings& settings) {
+    gtk_toggle_button_set_active(this->cbAutoDepCheck, settings.autoCheckDependencies);
+    if (!settings.globalTemplatePath.empty()) {
+        gtk_file_chooser_set_filename(this->globalTemplateChooser, settings.globalTemplatePath.u8string().c_str());
+    }
+    gtk_entry_set_text(GTK_ENTRY(this->get("latexSettingsKpsewhich")), settings.kpsewhichCmd.c_str());
+    gtk_entry_set_text(GTK_ENTRY(this->get("latexSettingsGenCmd")), settings.genCmd.c_str());
+}
+
+void LatexSettingsPanel::save(LatexSettings& settings) {
+    settings.autoCheckDependencies = gtk_toggle_button_get_active(this->cbAutoDepCheck);
+    gchar* templPath = gtk_file_chooser_get_filename(this->globalTemplateChooser);
+    if (templPath) {
+        settings.globalTemplatePath = templPath;
+        g_free(templPath);
+    } else {
+        settings.globalTemplatePath = "";
+    }
+    settings.kpsewhichCmd = gtk_entry_get_text(GTK_ENTRY(this->get("latexSettingsKpsewhich")));
+    settings.genCmd = gtk_entry_get_text(GTK_ENTRY(this->get("latexSettingsGenCmd")));
+}
+
+void LatexSettingsPanel::show(GtkWindow* parent) {}

--- a/src/gui/dialog/LatexSettingsPanel.h
+++ b/src/gui/dialog/LatexSettingsPanel.h
@@ -1,0 +1,36 @@
+/*
+ * Xournal++
+ *
+ * Latex settings panel
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+#include <gtk/gtk.h>
+
+#include "control/settings/LatexSettings.h"
+#include "gui/GladeGui.h"
+
+class LatexSettingsPanel: public GladeGui {
+public:
+    LatexSettingsPanel(GladeSearchpath*);
+    LatexSettingsPanel(const LatexSettingsPanel&) = delete;
+    LatexSettingsPanel& operator=(const LatexSettingsPanel&) = delete;
+    LatexSettingsPanel(const LatexSettingsPanel&&) = delete;
+    LatexSettingsPanel& operator=(const LatexSettingsPanel&&) = delete;
+    virtual ~LatexSettingsPanel();
+
+    void show(GtkWindow* parent) override;
+
+    void load(const LatexSettings& settings);
+    void save(LatexSettings& settings);
+
+private:
+    GtkToggleButton* cbAutoDepCheck;
+    GtkFileChooser* globalTemplateChooser;
+};

--- a/src/gui/dialog/LatexSettingsPanel.h
+++ b/src/gui/dialog/LatexSettingsPanel.h
@@ -31,6 +31,8 @@ public:
     void save(LatexSettings& settings);
 
 private:
+    void checkDeps();
+
     GtkToggleButton* cbAutoDepCheck;
     GtkFileChooser* globalTemplateChooser;
 };

--- a/src/gui/dialog/SettingsDialog.cpp
+++ b/src/gui/dialog/SettingsDialog.cpp
@@ -16,7 +16,8 @@ SettingsDialog::SettingsDialog(GladeSearchpath* gladeSearchPath, Settings* setti
         GladeGui(gladeSearchPath, "settings.glade", "settingsDialog"),
         settings(settings),
         control(control),
-        callib(zoomcallib_new()) {
+        callib(zoomcallib_new()),
+        latexPanel(gladeSearchPath) {
     GtkWidget* vbox = get("zoomVBox");
     g_return_if_fail(vbox != nullptr);
 
@@ -109,6 +110,8 @@ SettingsDialog::SettingsDialog(GladeSearchpath* gladeSearchPath, Settings* setti
         gtk_box_pack_end(GTK_BOX(container), label, true, true, 0);
         gtk_widget_show(label);
     }
+
+    gtk_container_add(GTK_CONTAINER(this->get("latexTabBox")), this->latexPanel.get("latexSettingsPanel"));
 }
 
 SettingsDialog::~SettingsDialog() {
@@ -405,6 +408,8 @@ void SettingsDialog::load() {
 
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(get("spAudioGain")), settings->getAudioGain());
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(get("spDefaultSeekTime")), settings->getDefaultSeekTime());
+
+    this->latexPanel.load(settings->latexSettings);
 }
 
 auto SettingsDialog::updateHideString(const string& hidden, bool hideMenubar, bool hideSidebar) -> string {
@@ -634,6 +639,8 @@ void SettingsDialog::save() {
     for (DeviceClassConfigGui* deviceClassConfigGui: this->deviceClassConfigs) {
         deviceClassConfigGui->saveSettings();
     }
+
+    this->latexPanel.save(settings->latexSettings);
 
     settings->transactionEnd();
 

--- a/src/gui/dialog/SettingsDialog.h
+++ b/src/gui/dialog/SettingsDialog.h
@@ -17,6 +17,7 @@
 #include "util/audio/DeviceInfo.h"
 
 #include "DeviceClassConfigGui.h"
+#include "LatexSettingsPanel.h"
 
 class ButtonConfigGui;
 
@@ -58,4 +59,6 @@ private:
 
     vector<ButtonConfigGui*> buttonConfigs;
     vector<DeviceClassConfigGui*> deviceClassConfigs;
+
+    LatexSettingsPanel latexPanel;
 };

--- a/src/model/TexImage.cpp
+++ b/src/model/TexImage.cpp
@@ -73,8 +73,10 @@ auto TexImage::loadData(std::string&& bytes, GError** err) -> bool {
         if (!pdf || poppler_document_get_n_pages(this->pdf) < 1) {
             return false;
         }
-        PopplerPage* page = poppler_document_get_page(this->pdf, 0);
-        poppler_page_get_size(page, &this->width, &this->height);
+        if (!this->width && !this->height) {
+            PopplerPage* page = poppler_document_get_page(this->pdf, 0);
+            poppler_page_get_size(page, &this->width, &this->height);
+        }
     } else if (type == "PNG") {
         this->image = cairo_image_surface_create_from_png_stream(
                 reinterpret_cast<cairo_read_func_t>(&cairoReadFunction), this);

--- a/src/model/TexImage.cpp
+++ b/src/model/TexImage.cpp
@@ -11,9 +11,6 @@ TexImage::TexImage(): Element(ELEMENT_TEXIMAGE) { this->sizeCalculated = true; }
 
 TexImage::~TexImage() { freeImageAndPdf(); }
 
-/**
- * Free image and PDF
- */
 void TexImage::freeImageAndPdf() {
     if (this->image) {
         cairo_surface_destroy(this->image);
@@ -24,30 +21,17 @@ void TexImage::freeImageAndPdf() {
         g_object_unref(this->pdf);
         this->pdf = nullptr;
     }
-
-    this->parsedBinaryData = false;
 }
 
 auto TexImage::clone() -> Element* {
     auto* img = new TexImage();
-
+    img->loadData(std::string(this->binaryData), nullptr);
     img->x = this->x;
     img->y = this->y;
     img->setColor(this->getColor());
     img->width = this->width;
     img->height = this->height;
     img->text = this->text;
-    img->binaryData = this->binaryData;
-
-    if (this->pdf) {
-        img->pdf = this->pdf;
-        g_object_ref(img->pdf);
-    }
-
-    if (this->image) {
-        img->image = cairo_surface_reference(this->image);
-    }
-
     return img;
 }
 
@@ -67,92 +51,47 @@ auto TexImage::cairoReadFunction(TexImage* image, unsigned char* data, unsigned 
 }
 
 /**
- * Sets the binary data, a .PNG image or a .PDF
- */
-void TexImage::setBinaryData(string binaryData) { this->binaryData = std::move(binaryData); }
-
-/**
  * Gets the binary data, a .PNG image or a .PDF
  */
-auto TexImage::getBinaryData() -> string& { return this->binaryData; }
+auto TexImage::getBinaryData() const -> std::string const& { return this->binaryData; }
 
 void TexImage::setText(string text) { this->text = std::move(text); }
 
 auto TexImage::getText() -> string { return this->text; }
 
-auto TexImage::getImage() -> cairo_surface_t* {
-    if (this->image == nullptr && !this->parsedBinaryData) {
-        loadBinaryData();
-    }
-
-    return this->image;
-}
-
-/**
- * Load the binary data, either .PNG or .PDF
- */
-void TexImage::loadBinaryData() {
-    freeImageAndPdf();
-
+auto TexImage::loadData(std::string&& bytes, GError** err) -> bool {
+    this->freeImageAndPdf();
+    this->binaryData = bytes;
     if (this->binaryData.length() < 4) {
-        this->parsedBinaryData = true;
-        return;
+        return false;
     }
 
-    string type = this->binaryData.substr(0, 4);
-
-    if (type[1] == 'P' && type[2] == 'N' && type[3] == 'G') {
-        this->read = 0;
+    const std::string type = binaryData.substr(1, 3);
+    if (type == "PDF") {
+        // Note: binaryData must not be modified while pdf is live.
+        this->pdf = poppler_document_new_from_data(this->binaryData.data(), this->binaryData.size(), nullptr, err);
+        if (!pdf || poppler_document_get_n_pages(this->pdf) < 1) {
+            return false;
+        }
+        PopplerPage* page = poppler_document_get_page(this->pdf, 0);
+        poppler_page_get_size(page, &this->width, &this->height);
+    } else if (type == "PNG") {
         this->image = cairo_image_surface_create_from_png_stream(
                 reinterpret_cast<cairo_read_func_t>(&cairoReadFunction), this);
-    } else if (type[1] == 'P' && type[2] == 'D' && type[3] == 'F') {
-        this->pdf = poppler_document_new_from_data(const_cast<char*>(this->binaryData.c_str()),
-                                                   this->binaryData.length(), nullptr, nullptr);
     } else {
         g_warning("Unknown Latex image type: «%s»", type.c_str());
     }
 
-    this->parsedBinaryData = true;
+    return true;
 }
 
-/**
- * @return The PDF Document, if rendered as .pdf
- *
- * The document needs to be referenced, if it will be hold somewhere
- */
-auto TexImage::getPdf() -> PopplerDocument* {
-    if (this->pdf == nullptr && !this->parsedBinaryData) {
-        loadBinaryData();
-    }
+auto TexImage::getImage() -> cairo_surface_t* { return this->image; }
 
-    return this->pdf;
-}
-
-/**
- * @param pdf The PDF Document, if rendered as .pdf
- *
- * The PDF will be referenced
- */
-void TexImage::setPdf(PopplerDocument* pdf) {
-    if (this->pdf != nullptr) {
-        g_object_unref(this->pdf);
-    }
-
-    this->pdf = pdf;
-
-    if (this->pdf != nullptr) {
-        g_object_ref(this->pdf);
-        this->parsedBinaryData = true;
-    }
-}
+auto TexImage::getPdf() -> PopplerDocument* { return this->pdf; }
 
 void TexImage::scale(double x0, double y0, double fx, double fy) {
-    this->x -= x0;
-    this->x *= fx;
-    this->x += x0;
-    this->y -= y0;
-    this->y *= fy;
-    this->y += y0;
+    this->x = (this->x - x0) * fx + x0;
+    this->y = (this->y - y0) * fy + y0;
 
     this->width *= fx;
     this->height *= fy;
@@ -191,7 +130,7 @@ void TexImage::readSerialized(ObjectInputStream& in) {
     int len = 0;
     in.readData(reinterpret_cast<void**>(&data), &len);
 
-    this->binaryData = string(data, len);
+    this->loadData(std::string(data, len), nullptr);
 
     in.endObject();
 }

--- a/src/model/TexImage.h
+++ b/src/model/TexImage.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -23,6 +24,10 @@
 class TexImage: public Element {
 public:
     TexImage();
+    TexImage(const TexImage&) = delete;
+    TexImage& operator=(const TexImage&) = delete;
+    TexImage(const TexImage&&) = delete;
+    TexImage&& operator=(const TexImage&&) = delete;
     virtual ~TexImage();
 
 public:
@@ -30,33 +35,21 @@ public:
     void setHeight(double height);
 
     /**
-     * Sets the binary data, a .PNG image or a .PDF
+     * Returns the binary data (PDF or PNG (deprecated)).
      */
-    void setBinaryData(string binaryData);
+    const std::string& getBinaryData() const;
 
     /**
-     * Gets the binary data, a .PNG image or a .PDF
-     */
-    string& getBinaryData();
-
-    /**
-     * Get the Image, if rendered as image
+     * @return The image, if render source is PNG. Note: this is deprecated.
      */
     cairo_surface_t* getImage();
 
     /**
-     * @return The PDF Document, if rendered as .pdf
+     * @return The PDF Document, if rendered as a PDF.
      *
      * The document needs to be referenced, if it will be hold somewhere
      */
     PopplerDocument* getPdf();
-
-    /**
-     * @param pdf The PDF Document, if rendered as .pdf
-     *
-     * The PDF will be referenced
-     */
-    void setPdf(PopplerDocument* pdf);
 
     virtual void scale(double x0, double y0, double fx, double fy);
     virtual void rotate(double x0, double y0, double xo, double yo, double th);
@@ -66,6 +59,11 @@ public:
     string getText();
 
     virtual Element* clone();
+
+    /**
+     * @return true if the binary data (PNG or PDF) was loaded successfully.
+     */
+    bool loadData(std::string&& bytes, GError** err = nullptr);
 
 public:
     // Serialize interface
@@ -82,11 +80,6 @@ private:
      */
     void freeImageAndPdf();
 
-    /**
-     * Load the binary data, either .PNG or .PDF
-     */
-    void loadBinaryData();
-
 private:
     /**
      * Tex PDF Document, if rendered as PDF
@@ -94,24 +87,19 @@ private:
     PopplerDocument* pdf = nullptr;
 
     /**
-     * Tex image, if rendered as image
+     * Tex image, if rendered as image. Note: this is deprecated and subject to removal in a later version.
      */
     cairo_surface_t* image = nullptr;
 
     /**
      * PNG Image / PDF Document
      */
-    string binaryData;
+    std::string binaryData;
 
     /**
-     * Flag if the binary data is already parsed
+     * Read position for PNG binaryData (deprecated).
      */
-    bool parsedBinaryData = false;
-
-    /**
-     * Read position in binaryData
-     */
-    string::size_type read = 0;
+    std::string::size_type read = 0;
 
     /**
      * Tex String

--- a/ui/latexSettings.glade
+++ b/ui/latexSettings.glade
@@ -1,0 +1,301 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.2 -->
+<interface>
+  <requires lib="gtk+" version="3.16"/>
+  <object class="GtkFileFilter" id="filefilter1">
+    <mime-types>
+      <mime-type>application/x-latex</mime-type>
+      <mime-type>text/x-tex</mime-type>
+    </mime-types>
+  </object>
+  <object class="GtkScrolledWindow" id="latexSettingsPanel">
+    <property name="visible">True</property>
+    <property name="can_focus">True</property>
+    <property name="shadow_type">in</property>
+    <property name="min_content_height">500</property>
+    <child>
+      <object class="GtkViewport">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkFrame">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label_xalign">0</property>
+                <child>
+                  <object class="GtkAlignment">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="bottom_padding">8</property>
+                    <property name="left_padding">12</property>
+                    <property name="right_padding">12</property>
+                    <child>
+                      <object class="GtkGrid">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <child>
+                          <object class="GtkCheckButton" id="latexSettingsRunCheck">
+                            <property name="label" translatable="yes">Always check LaTeX dependencies before running</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="tooltip_text" translatable="yes">If enabled, check that required LaTeX packages are installed and that the LaTeX commands are available before running the LaTeX tool.</property>
+                            <property name="draw_indicator">True</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">0</property>
+                            <property name="width">2</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child type="label">
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">General LaTeX tool settings</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFrame">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label_xalign">0</property>
+                <child>
+                  <object class="GtkAlignment">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="bottom_padding">8</property>
+                    <property name="left_padding">12</property>
+                    <property name="right_padding">12</property>
+                    <child>
+                      <object class="GtkGrid">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="row_spacing">5</property>
+                        <property name="column_spacing">20</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="tooltip_text" translatable="yes">The LaTeX file to use as a template for the LaTeX tool.</property>
+                            <property name="halign">start</property>
+                            <property name="label" translatable="yes">Global template file path</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="label" translatable="yes">The following strings will be substituted in the global template file when running the LaTeX tool:</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">1</property>
+                            <property name="width">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="label" translatable="yes">%%XPP_TOOL_INPUT%%</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="label" translatable="yes">The math mode formula typed in the LaTeX tool.</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="label" translatable="yes">%%XPP_JOURNAL_TEX%%</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">3</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="label" translatable="yes">The additional *.tex file defined for the journal.</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">3</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkFileChooserButton" id="latexSettingsTemplateFile">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="hexpand">True</property>
+                            <property name="filter">filefilter1</property>
+                            <property name="title" translatable="yes">Choose a global LaTeX template file</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">0</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child type="label">
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Template file settings</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFrame">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label_xalign">0</property>
+                <child>
+                  <object class="GtkAlignment">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="bottom_padding">8</property>
+                    <property name="left_padding">12</property>
+                    <property name="right_padding">12</property>
+                    <child>
+                      <object class="GtkGrid">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="label" translatable="yes">kpsewhich</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="label" translatable="yes">LaTeX generation command</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkEntry" id="latexSettingsKpsewhich">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="hexpand">True</property>
+                            <property name="text" translatable="yes">kpsewhich</property>
+                            <property name="input_purpose">terminal</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkEntry" id="latexSettingsGenCmd">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="hexpand">True</property>
+                            <property name="text" translatable="yes">pdflatex -fno-halt-on-error</property>
+                            <property name="input_purpose">terminal</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkButton" id="latexSettingsTestBtn">
+                            <property name="label" translatable="yes">Test configuration</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="tooltip_text" translatable="yes">Test if the current configuration is valid by running the LaTeX generation command on the global template file with a test formula.</property>
+                            <property name="halign">end</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">2</property>
+                            <property name="width">2</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child type="label">
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">LaTeX executable settings</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/ui/latexSettings.glade
+++ b/ui/latexSettings.glade
@@ -139,7 +139,7 @@
                             <property name="top_attach">2</property>
                           </packing>
                         </child>
-                        <child>
+                        <!-- <child>
                           <object class="GtkLabel">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
@@ -162,7 +162,7 @@
                             <property name="left_attach">1</property>
                             <property name="top_attach">3</property>
                           </packing>
-                        </child>
+                        </child> -->
                         <child>
                           <object class="GtkFileChooserButton" id="latexSettingsTemplateFile">
                             <property name="visible">True</property>

--- a/ui/latexSettings.glade
+++ b/ui/latexSettings.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.2 -->
+<!-- Generated with glade 3.36.0 -->
 <interface>
   <requires lib="gtk+" version="3.16"/>
   <object class="GtkFileFilter" id="filefilter1">
@@ -176,6 +176,30 @@
                             <property name="top_attach">0</property>
                           </packing>
                         </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="label" translatable="yes">%%XPP_TEXT_COLOR%%</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">4</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="label" translatable="yes">The current color of the Text Tool, in hex RGB format.</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">4</property>
+                          </packing>
+                        </child>
                       </object>
                     </child>
                   </object>
@@ -215,35 +239,10 @@
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="halign">start</property>
-                            <property name="label" translatable="yes">kpsewhich</property>
-                          </object>
-                          <packing>
-                            <property name="left_attach">0</property>
-                            <property name="top_attach">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="halign">start</property>
                             <property name="label" translatable="yes">LaTeX generation command</property>
                           </object>
                           <packing>
                             <property name="left_attach">0</property>
-                            <property name="top_attach">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkEntry" id="latexSettingsKpsewhich">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="hexpand">True</property>
-                            <property name="text" translatable="yes">kpsewhich</property>
-                            <property name="input_purpose">terminal</property>
-                          </object>
-                          <packing>
-                            <property name="left_attach">1</property>
                             <property name="top_attach">0</property>
                           </packing>
                         </child>
@@ -252,12 +251,11 @@
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="hexpand">True</property>
-                            <property name="text" translatable="yes">pdflatex -fno-halt-on-error</property>
                             <property name="input_purpose">terminal</property>
                           </object>
                           <packing>
                             <property name="left_attach">1</property>
-                            <property name="top_attach">1</property>
+                            <property name="top_attach">0</property>
                           </packing>
                         </child>
                         <child>
@@ -271,7 +269,7 @@
                           </object>
                           <packing>
                             <property name="left_attach">0</property>
-                            <property name="top_attach">2</property>
+                            <property name="top_attach">1</property>
                             <property name="width">2</property>
                           </packing>
                         </child>

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -3489,7 +3489,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                             <property name="adjustment">adjustmentSnapGridSize</property>
                                             <property name="climb_rate">0.01</property>
                                             <property name="digits">2</property>
-                                            <property name="value">1.00</property>
+                                            <property name="value">1</property>
                                           </object>
                                           <packing>
                                             <property name="left_attach">1</property>
@@ -4393,6 +4393,30 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
               </object>
               <packing>
                 <property name="position">9</property>
+                <property name="tab_fill">False</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="latexTabBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <placeholder/>
+                </child>
+              </object>
+              <packing>
+                <property name="position">10</property>
+              </packing>
+            </child>
+            <child type="tab">
+              <object class="GtkLabel" id="latexTabLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Latex</property>
+              </object>
+              <packing>
+                <property name="position">10</property>
                 <property name="tab_fill">False</property>
               </packing>
             </child>

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -4413,7 +4413,7 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
               <object class="GtkLabel" id="latexTabLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Latex</property>
+                <property name="label" translatable="yes">LaTeX</property>
               </object>
               <packing>
                 <property name="position">10</property>


### PR DESCRIPTION
This PR implements various enhancements for the LaTeX tool, including:
* [x] Configuration settings panel for the LaTeX tool
* [x] Customizable template (global). Closes #1188, #1852.
  * [x] Load and use user-specific template file
  * [ ] Project-specific settings
  * [x] Provide variable for current font color
* [x] ~Multiline LaTeX input, which can support large formulas as well as graphics (e.g. tikz).~
  * Apparently this is already supported by pressing <kbd>Shift</kbd><kbd>Enter</kbd>
* [x] Button to test LaTeX configuration (useful for debugging LaTeX setup/installation)
* [x] ~Switch default PDF generation command from `pdflatex` to `latexmk` by default~ (see https://github.com/xournalpp/xournalpp/pull/1952#issuecomment-631205182)
* [x] Customizable `kpsewhich` and PDF generation commands
  * [x] Remove custom `kpsewhich` setting
  * [ ] Improve error feedback
* [ ] Documentation