### PR TITLE
Allow "tapping" when using the Select Rectangle and Select Region tools

### DIFF
--- a/src/control/tools/Selection.cpp
+++ b/src/control/tools/Selection.cpp
@@ -84,6 +84,8 @@ void RectSelection::currentPos(double x, double y) {
 
     this->ex = x;
     this->ey = y;
+
+    this->userTapped = false;
 }
 
 void RectSelection::paint(cairo_t* cr, GdkRectangle* rect, double zoom) {
@@ -165,6 +167,8 @@ void RegionSelect::currentPos(double x, double y) {
 
     // at least three points needed
     if (this->points && this->points->next && this->points->next->next) {
+
+        this->userTapped = false;
 
         auto* r0 = static_cast<RegionPoint*>(this->points->data);
         double ax = r0->x;

--- a/src/control/tools/Selection.h
+++ b/src/control/tools/Selection.h
@@ -25,6 +25,7 @@ class Selection: public ShapeContainer {
 public:
     Selection(Redrawable* view);
     virtual ~Selection();
+    bool userTapped = true;
 
 public:
     virtual bool finalize(PageRef page) = 0;

--- a/src/control/tools/Selection.h
+++ b/src/control/tools/Selection.h
@@ -25,12 +25,12 @@ class Selection: public ShapeContainer {
 public:
     Selection(Redrawable* view);
     virtual ~Selection();
-    bool userTapped = true;
 
 public:
     virtual bool finalize(PageRef page) = 0;
     virtual void paint(cairo_t* cr, GdkRectangle* rect, double zoom) = 0;
     virtual void currentPos(double x, double y) = 0;
+    virtual bool userTapped(double zoom) = 0;
 
 private:
 protected:
@@ -56,12 +56,14 @@ public:
     virtual void paint(cairo_t* cr, GdkRectangle* rect, double zoom);
     virtual void currentPos(double x, double y);
     virtual bool contains(double x, double y);
+    virtual bool userTapped(double zoom);
 
 private:
     double sx;
     double sy;
     double ex;
     double ey;
+    double maxDist = 0;
 
     /**
      * In zoom coordinates
@@ -82,6 +84,7 @@ public:
     virtual void paint(cairo_t* cr, GdkRectangle* rect, double zoom);
     virtual void currentPos(double x, double y);
     virtual bool contains(double x, double y);
+    virtual bool userTapped(double zoom);
 
 private:
     GList* points;

--- a/src/gui/PageView.cpp
+++ b/src/gui/PageView.cpp
@@ -534,6 +534,11 @@ auto XojPageView::onButtonReleaseEvent(const PositionInputData& pos) -> bool {
             delete this->selection;
             this->selection = nullptr;
         } else {
+            if (this->selection->userTapped) {
+                double zoom = xournal->getZoom();
+                SelectObject select(this);
+                select.at(pos.x / zoom, pos.y / zoom);
+            }
             delete this->selection;
             this->selection = nullptr;
 

--- a/src/gui/PageView.cpp
+++ b/src/gui/PageView.cpp
@@ -534,8 +534,8 @@ auto XojPageView::onButtonReleaseEvent(const PositionInputData& pos) -> bool {
             delete this->selection;
             this->selection = nullptr;
         } else {
-            if (this->selection->userTapped) {
-                double zoom = xournal->getZoom();
+            double zoom = xournal->getZoom();
+            if (this->selection->userTapped(zoom)) {
                 SelectObject select(this);
                 select.at(pos.x / zoom, pos.y / zoom);
             }


### PR DESCRIPTION
This PR implements the following feature: when using the Select Rectangle or Select Region tools, clicking on an object (without dragging to create the rectangle or the selection region) selects the object. This is similar to the experimental feature "Tapping" that allows the selection of an object when drawing.
I find this particularly useful as it allows me to use a single selection tool (I associate Select Rectangle to the middle mouse button) both to select multiple objects (dragging a rect around them) or a single one (with a single click).