### PR TITLE
Speedup Document Loading

### DIFF
--- a/src/control/xojfile/LoadHandler.cpp
+++ b/src/control/xojfile/LoadHandler.cpp
@@ -225,6 +225,9 @@ auto LoadHandler::parseXml() -> bool {
 
     g_markup_parse_context_free(context);
 
+    // Add all parsed pages to the document
+    this->doc.addPages(pages.begin(), pages.end());
+
     if (this->pos != PASER_POS_FINISHED && this->lastError.empty()) {
         lastError = _("Document is not complete (maybe the end is cut off?)");
         return false;
@@ -288,7 +291,7 @@ void LoadHandler::parseContents() {
 
         this->page = std::make_unique<XojPage>(width, height);
 
-        this->doc.addPage(this->page);
+        pages.push_back(this->page);
     } else if (strcmp(elementName, "audio") == 0) {
         this->parseAudio();
     } else if (strcmp(elementName, "title") == 0) {

--- a/src/control/xojfile/LoadHandler.h
+++ b/src/control/xojfile/LoadHandler.h
@@ -125,6 +125,7 @@ private:
 
     vector<double> pressureBuffer;
 
+    std::vector<PageRef> pages;
     PageRef page;
     Layer* layer;
     Stroke* stroke;

--- a/src/model/Document.cpp
+++ b/src/model/Document.cpp
@@ -311,7 +311,7 @@ auto Document::readPdf(const Path& filename, bool initPages, bool attachToDocume
             XojPdfPageSPtr page = pdfDocument.getPage(i);
             auto p = std::make_shared<XojPage>(page->getWidth(), page->getHeight());
             p->setBackgroundPdfPageNr(i);
-            addPage(std::move(p));
+            this->pages.emplace_back(std::move(p));
         }
     }
 

--- a/src/model/Document.cpp
+++ b/src/model/Document.cpp
@@ -1,11 +1,11 @@
-#include "Document.h"
-
+#include <algorithm>
 #include <utility>
 
 #include <config.h>
 
 #include "pdf/base/XojPdfAction.h"
 
+#include "Document.h"
 #include "LinkDestination.h"
 #include "Stacktrace.h"
 #include "Util.h"
@@ -85,6 +85,7 @@ void Document::clearDocument(bool destroy) {
     }
 
     this->pages.clear();
+    this->pageIndex.reset();
     freeTreeContentModel();
 
     this->filename = "";
@@ -169,15 +170,15 @@ auto Document::isPdfDocumentLoaded() -> bool { return pdfDocument.isLoaded(); }
 auto Document::isAttachPdf() const -> bool { return this->attachPdf; }
 
 auto Document::findPdfPage(size_t pdfPage) -> size_t {
-    for (size_t i = 0; i < getPageCount(); i++) {
-        PageRef p = this->pages[i];
-        if (p->getBackgroundType().isPdfPage()) {
-            if (p->getPdfPageNr() == pdfPage) {
-                return i;
-            }
-        }
+    // Create a page index if not already indexed.
+    if (!this->pageIndex)
+        indexPdfPages();
+    auto pos = this->pageIndex->find(pdfPage);
+    if (pos == this->pageIndex->end()) {
+        return -1;
+    } else {
+        return pos->second;
     }
-    return -1;
 }
 
 void Document::buildTreeContentsModel(GtkTreeIter* parent, XojPdfBookmarkIterator* iter) {
@@ -214,6 +215,18 @@ void Document::buildTreeContentsModel(GtkTreeIter* parent, XojPdfBookmarkIterato
 
     } while (iter->next());
 }
+
+void Document::indexPdfPages() {
+    auto index = std::make_unique<PageIndex>();
+    for (size_t i = 0; i < this->pages.size(); ++i) {
+        const auto& p = this->pages[i];
+        if (p->getBackgroundType().isPdfPage()) {
+            index->emplace(p->getPdfPageNr(), i);
+        }
+    }
+    this->pageIndex.swap(index);
+}
+
 
 void Document::buildContentsModel() {
     freeTreeContentModel();
@@ -302,6 +315,7 @@ auto Document::readPdf(const Path& filename, bool initPages, bool attachToDocume
         }
     }
 
+    indexPdfPages();
     buildContentsModel();
     updateIndexPageNumbers();
 
@@ -327,18 +341,24 @@ void Document::deletePage(size_t pNr) {
     auto it = this->pages.begin() + pNr;
     this->pages.erase(it);
 
+    // Reset the page index
+    this->pageIndex.reset();
     updateIndexPageNumbers();
 }
 
 void Document::insertPage(const PageRef& p, size_t position) {
     this->pages.insert(this->pages.begin() + position, p);
 
+    // Reset the page index
+    this->pageIndex.reset();
     updateIndexPageNumbers();
 }
 
 void Document::addPage(const PageRef& p) {
     this->pages.push_back(p);
 
+    // Reset the page index
+    this->pageIndex.reset();
     updateIndexPageNumbers();
 }
 
@@ -378,11 +398,9 @@ auto Document::operator=(const Document& doc) -> Document& {
     this->createBackupOnSave = doc.createBackupOnSave;
     this->pdfFilename = doc.pdfFilename;
     this->filename = doc.filename;
+    this->pages = doc.pages;
 
-    for (const PageRef& p: doc.pages) {
-        addPage(p);
-    }
-
+    indexPdfPages();
     buildContentsModel();
     updateIndexPageNumbers();
 

--- a/src/model/Document.cpp
+++ b/src/model/Document.cpp
@@ -1,3 +1,5 @@
+#include "Document.h"
+
 #include <algorithm>
 #include <utility>
 
@@ -5,7 +7,6 @@
 
 #include "pdf/base/XojPdfAction.h"
 
-#include "Document.h"
 #include "LinkDestination.h"
 #include "Stacktrace.h"
 #include "Util.h"

--- a/src/model/Document.h
+++ b/src/model/Document.h
@@ -13,6 +13,8 @@
 
 #pragma once
 
+#include <unordered_map>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -116,6 +118,23 @@ private:
      * The pages in the document
      */
     vector<PageRef> pages;
+
+    /**
+     * Index from pdf page number to document page number
+     */
+    using PageIndex = std::unordered_map<size_t, size_t>;
+
+    /**
+     * The cached page index
+     */
+    std::unique_ptr<PageIndex> pageIndex;
+
+    /**
+     * Creates an index from pdf page number to document page number
+     *
+     * Clears the index first in case it is already exists.
+     */
+    void indexPdfPages();
 
     /**
      * The bookmark contents model

--- a/src/model/Document.h
+++ b/src/model/Document.h
@@ -13,9 +13,9 @@
 
 #pragma once
 
-#include <unordered_map>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "pdf/base/XojPdfBookmarkIterator.h"
@@ -46,7 +46,7 @@ public:
 
     void insertPage(const PageRef& p, size_t position);
     void addPage(const PageRef& p);
-    template<class InputIter>
+    template <class InputIter>
     void addPages(InputIter first, InputIter last);
     PageRef getPage(size_t page);
     void deletePage(size_t pNr);
@@ -159,9 +159,9 @@ private:
     GMutex documentLock{};
 };
 
-template<class InputIter>
+template <class InputIter>
 void Document::addPages(InputIter first, InputIter last) {
-  this->pages.insert(this->pages.end(), first, last);
-  this->pageIndex.reset();
-  updateIndexPageNumbers();
+    this->pages.insert(this->pages.end(), first, last);
+    this->pageIndex.reset();
+    updateIndexPageNumbers();
 }

--- a/src/model/Document.h
+++ b/src/model/Document.h
@@ -46,6 +46,8 @@ public:
 
     void insertPage(const PageRef& p, size_t position);
     void addPage(const PageRef& p);
+    template<class InputIter>
+    void addPages(InputIter first, InputIter last);
     PageRef getPage(size_t page);
     void deletePage(size_t pNr);
 
@@ -156,3 +158,10 @@ private:
      */
     GMutex documentLock{};
 };
+
+template<class InputIter>
+void Document::addPages(InputIter first, InputIter last) {
+  this->pages.insert(this->pages.end(), first, last);
+  this->pageIndex.reset();
+  updateIndexPageNumbers();
+}


### PR DESCRIPTION
This PR speeds up the loading of PDFs and annotated PDFs significantly.

Main changes:
* Introduced an index from pdf page number to document page number, which reduces the lookup times of `Document::findPdgPage()` from `O(n)` to constant time.
  This index is generated on document read and on demand.
  Interactive document changes such as adding/inserting/deleting a page simply invalidate this index to keep the user interface snappy.
  This speeds-up the load-time of PDFs with many labels such as books.
* Changed the `xojfile/LoadHandler` to add pages in a bulk after parsing instead of calling `addPage` once per page while parsing. This required to add a bulk version `addPages`, which is templated and thus visible in the header. I hope that's not against some coding rules. 


Starting point for this PR was the issue #1947.
I tested this on my machine (X1 Yoga Gen 4) with `RelWithDebInfo` and `-march=native -fno-omit-frame-pointer` using clang 10. I also assume that the files were cached by the linux kernel during the following tests.

The _very vague_ baseline of the load time for an annotated version of the 914 page document was ~6 seconds. With these changes, the document loads in ~1 second.

_edit: sentence got chopped off somehow._