### PR TITLE
Windows CI quickfix

### DIFF
--- a/azure-pipelines/steps/build_windows.yml
+++ b/azure-pipelines/steps/build_windows.yml
@@ -5,21 +5,27 @@ parameters:
   cmake_flags: ''
 
 steps:
-  - task: DownloadPipelineArtifact@2
-    inputs:
-      buildType: 'specific'
-      project: 'ce85de88-4b71-44a0-8a57-2707c0b9a6e7'
-      definition: '8'
-      buildVersionToDownload: 'latest'
-      targetPath: 'C:\'
-      artifact: 'msys'
-  - task: ExtractFiles@1
-    inputs:
-      archiveFilePatterns: 'C:\msys.7z'
-      destinationFolder: 'C:\'
-      cleanDestinationFolder: false
+  # Copy of msys2-blob as a temporary fix for Windows CI
   - script: |
-      set PATH=%PATH%;C:\msys64\usr\bin;C:\msys64\mingw64\bin"
+      set PATH=C:\msys64\usr\bin;C:\msys64\mingw64\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem
+      pacman --noconfirm -S mingw-w64-x86_64-ninja mingw-w64-x86_64-cppunit mingw-w64-x86_64-poppler mingw-w64-x86_64-gtk3 mingw-w64-x86_64-libsndfile mingw-w64-x86_64-libzip mingw-w64-x86_64-lua
+    env:
+      MSYS2_ARCH: x86_64
+      MSYSTEM: MINGW64
+      CHERE_INVOKING: yes
+    displayName: 'Install dependencies on Windows'
+  - script: |
+      set PATH="C:\msys64\usr\bin;C:\msys64\mingw64\bin;%PATH%"
+      C:\msys64\usr\bin\bash -lc "./build-portaudio.sh"
+    workingDirectory: ./windows-setup
+    env:
+      MSYS2_ARCH: x86_64
+      MSYSTEM: MINGW64
+      CHERE_INVOKING: yes
+    displayName: 'Build Portaudio'
+  # End msys setup
+  - script: |
+      set PATH="C:\msys64\usr\bin;C:\msys64\mingw64\bin;%PATH%"
       C:\msys64\usr\bin\bash -lc "mkdir build"
     env:
       MSYS2_ARCH: x86_64
@@ -27,7 +33,7 @@ steps:
       CHERE_INVOKING: yes
     displayName: 'Create build directory'
   - script: |
-      set PATH=%PATH%;C:\msys64\usr\bin;C:\msys64\mingw64\bin"
+      set PATH="C:\msys64\usr\bin;C:\msys64\mingw64\bin;%PATH%"
       C:\msys64\usr\bin\bash -lc "cmake -GNinja .. -DCMAKE_BUILD_TYPE=${{ parameters.build_type}} ${{ parameters.cmake_flags }}"
       rem Make sure pot is up to date with sources (maybe translation pipeline is currently running)
       C:\msys64\usr\bin\bash -lc "cmake --build . --target pot"

--- a/readme/WindowsBuild.md
+++ b/readme/WindowsBuild.md
@@ -27,11 +27,8 @@ pacman -S git
 ```bash
 pacman -S mingw-w64-x86_64-toolchain \
           mingw-w64-x86_64-cmake \
-          mingw-w64-x86_64-make \
           mingw-w64-x86_64-ninja \
           patch \
-          make \
-          tar \
           mingw-w64-x86_64-cppunit
 ```
 -> press enter multiple times / confirm all default values
@@ -42,7 +39,8 @@ pacman -S mingw-w64-x86_64-toolchain \
 pacman -S mingw-w64-x86_64-poppler \
           mingw-w64-x86_64-gtk3 \
           mingw-w64-x86_64-libsndfile \
-          mingw-w64-x86_64-libzip
+          mingw-w64-x86_64-libzip \
+          mingw-w64-x86_64-lua
 ```
 -> press enter multiple times / confirm all default values
 
@@ -58,13 +56,6 @@ cd xournalpp/
 Build/Install portaudio with
 ```bash
 windows-setup/build-portaudio.sh
-```
-
-### Install Lua
-
-Build/Install lua with
-```bash
-windows-setup/build-lua.sh
 ```
 
 ## Build Xournal++


### PR DESCRIPTION
Delete the existing msys64 installation before building. This is a temporary hack until we figure out a better solution.