### PR TITLE
Clear PDF cache when document changes

### DIFF
--- a/src/control/PdfCache.h
+++ b/src/control/PdfCache.h
@@ -35,10 +35,10 @@ private:
 
 public:
     void render(cairo_t* cr, const XojPdfPageSPtr& popplerPage, double zoom);
+    void clearCache();
 
 private:
     void setZoom(double zoom);
-    void clearCache();
     cairo_surface_t* lookup(const XojPdfPageSPtr& popplerPage);
     void cache(XojPdfPageSPtr popplerPage, cairo_surface_t* img);
 

--- a/src/gui/XournalView.cpp
+++ b/src/gui/XournalView.cpp
@@ -699,6 +699,9 @@ void XournalView::documentChanged(DocumentChangeType type) {
     }
     viewPages.clear();
 
+    delete this->cache;
+    this->cache = new PdfCache(control->getSettings()->getPdfPageCacheSize());
+
     Document* doc = control->getDocument();
     doc->lock();
 

--- a/src/gui/XournalView.cpp
+++ b/src/gui/XournalView.cpp
@@ -699,8 +699,7 @@ void XournalView::documentChanged(DocumentChangeType type) {
     }
     viewPages.clear();
 
-    delete this->cache;
-    this->cache = new PdfCache(control->getSettings()->getPdfPageCacheSize());
+    this->cache->clearCache();
 
     Document* doc = control->getDocument();
     doc->lock();

--- a/src/gui/sidebar/previews/base/SidebarPreviewBase.cpp
+++ b/src/gui/sidebar/previews/base/SidebarPreviewBase.cpp
@@ -84,6 +84,7 @@ auto SidebarPreviewBase::getWidget() -> GtkWidget* { return this->scrollPreview;
 
 void SidebarPreviewBase::documentChanged(DocumentChangeType type) {
     if (type == DOCUMENT_CHANGE_COMPLETE || type == DOCUMENT_CHANGE_CLEARED) {
+        this->cache->clearCache();
         updatePreviews();
     }
 }


### PR DESCRIPTION
This prevent previous PDF pages being rendered instead of new PDF ones.

Fixes #1964