### PR TITLE
snapping for selections and vertical space

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Xournal++ features:
 - Page Template definitions
 - Shape drawing (line, arrow, circle, rect, splines)
 - Shape resizing and rotation
-- Rotation snapping every 45 degrees
+- Rotation snapping every 15 degrees
 - Rect snapping to grid
 - Audio recording and playback alongside with handwritten notes
 - Multi Language Support, Like English, German (Deutsch), Italian (Italiano)...

--- a/desktop/com.github.xournalpp.xournalpp.appdata.xml
+++ b/desktop/com.github.xournalpp.xournalpp.appdata.xml
@@ -12,37 +12,37 @@
   <summary xml:lang="pl">Notatki odręczne</summary>
   <developer_name>Xournalpp Developers</developer_name>
   <description>
-   <p>
+    <p>
     Xournal++ is a hand note taking software written in C++ with the target of
     flexibility, functionality and speed. Stroke recognizer and other parts are
     based on Xournal Code, which you can find at sourceforge. It supports Linux
     (e.g. Ubuntu, Debian, Arch, SUSE), macOS and Windows 10. Supports pen input
     from devices such as Wacom Tablets.
    </p>
-   <p>Xournal++ features:</p>
-   <ul>
-     <li>Support for Pen preassure, e.g. Wacom Tablet</li>
-     <li>Support for annotating PDFs</li>
-     <li>Fill shape functionality</li>
-     <li>PDF Export (with and without paper style)</li>
-     <li>PNG Export (with and without transparent background)</li>
-     <li>Allow to map different tools / colors etc. to stylus buttons / mouse buttons</li>
-     <li>Sidebar with Page Previews with advanced page sorting, PDF Bookmarks and Layers</li>
-     <li>Enhanced support for image insertion</li>
-     <li>Eraser with multiple configurations</li>
-     <li>Significantly reduced memory usage and code to detect memory leaks compared to Xournal</li>
-     <li>LaTeX support (requires a working LaTeX install)</li>
-     <li>Bug reporting, autosave, and auto backup tools</li>
-     <li>Customizeable toolbar, with multiple configurations, e.g. to optimize toolbar for portrait/landscape</li>
-     <li>Page Template definitions</li>
-     <li>Shape drawing (line, arrow, circle, rect)</li>
-     <li>Shape resizing and rotation</li>
-     <li>Rotation snapping every 45 degrees</li>
-     <li>Rect snapping to grid</li>
-     <li>Audio recording and playback alongside with handwritten notes</li>
-     <li>Multi Language Support, Like English, German (Deutsch), Italian (Italiano)...</li>
-     <li>Plugins using LUA Scripting</li>
-   </ul>
+    <p>Xournal++ features:</p>
+    <ul>
+      <li>Support for Pen preassure, e.g. Wacom Tablet</li>
+      <li>Support for annotating PDFs</li>
+      <li>Fill shape functionality</li>
+      <li>PDF Export (with and without paper style)</li>
+      <li>PNG Export (with and without transparent background)</li>
+      <li>Allow to map different tools / colors etc. to stylus buttons / mouse buttons</li>
+      <li>Sidebar with Page Previews with advanced page sorting, PDF Bookmarks and Layers</li>
+      <li>Enhanced support for image insertion</li>
+      <li>Eraser with multiple configurations</li>
+      <li>Significantly reduced memory usage and code to detect memory leaks compared to Xournal</li>
+      <li>LaTeX support (requires a working LaTeX install)</li>
+      <li>Bug reporting, autosave, and auto backup tools</li>
+      <li>Customizeable toolbar, with multiple configurations, e.g. to optimize toolbar for portrait/landscape</li>
+      <li>Page Template definitions</li>
+      <li>Shape drawing (line, arrow, circle, rect)</li>
+      <li>Shape resizing and rotation</li>
+      <li>Rotation snapping every 15 degrees</li>
+      <li>Rect snapping to grid</li>
+      <li>Audio recording and playback alongside with handwritten notes</li>
+      <li>Multi Language Support, Like English, German (Deutsch), Italian (Italiano)...</li>
+      <li>Plugins using LUA Scripting</li>
+    </ul>
   </description>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0</project_license>
@@ -74,19 +74,19 @@
     <mimetype>application/x-xopt</mimetype>
   </mimetypes>
   <update_contact>webmaster_AT_huberulrich.de</update_contact>
-  <content_rating type="oars-1.0"/>
+  <content_rating type="oars-1.0" />
   <releases>
     <!-- Could be automated more:
 	 `git tag -l | grep "^[0-9]*\.[0-9]*\.[0-9]*$`"
     -->
-    <release date="2020-02-02" version="1.0.17"/>
-    <release date="2019-11-10" version="1.0.16"/>
-    <release date="2019-10-15" version="1.0.15"/>
-    <release date="2019-10-12" version="1.0.14"/>
-    <release date="2019-05-26" version="1.0.12"/>
-    <release date="2019-04-01" version="1.0.10"/>
-    <release date="2019-02-16" version="1.0.8"/>
-    <release date="2019-01-19" version="1.0.7"/>
-    <release date="2018-12-30" version="1.0.5"/>
+    <release date="2020-02-02" version="1.0.17" />
+    <release date="2019-11-10" version="1.0.16" />
+    <release date="2019-10-15" version="1.0.15" />
+    <release date="2019-10-12" version="1.0.14" />
+    <release date="2019-05-26" version="1.0.12" />
+    <release date="2019-04-01" version="1.0.10" />
+    <release date="2019-02-16" version="1.0.8" />
+    <release date="2019-01-19" version="1.0.7" />
+    <release date="2018-12-30" version="1.0.5" />
   </releases>
 </component>

--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -2642,10 +2642,9 @@ void Control::clipboardPasteXournal(ObjectInputStream& in) {
         y = std::max(0.0, y - selection->getHeight() / 2);
 
         // calculate difference between current selection position and destination
-        auto dx = selection->getXOnView() - x;
-        auto dy = selection->getYOnView() - y;
+        auto dx = x - selection->getXOnView();
+        auto dy = y - selection->getYOnView();
 
-        // for some reason selection moving is inverted (x -= dx,...), intended?
         selection->moveSelection(dx, dy);
         // update all Elements (same procedure as moving a element selection by hand and releasing the mouse button)
         selection->mouseUp();

--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -163,6 +163,9 @@ void Settings::loadDefault() {
     this->doActionOnStrokeFiltered = false;
     this->trySelectOnStrokeFiltered = false;
 
+    this->snapRecognizedShapesEnabled = false;
+    this->restoreLineWidthEnabled = false;
+
     this->inTransaction = false;
 }
 
@@ -459,6 +462,10 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur) {
         this->latexSettings.globalTemplatePath = fs::u8path(v);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("latexSettings.genCmd")) == 0) {
         this->latexSettings.genCmd = reinterpret_cast<char*>(value);
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("snapRecognizedShapesEnabled")) == 0) {
+        this->snapRecognizedShapesEnabled = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("restoreLineWidthEnabled")) == 0) {
+        this->restoreLineWidthEnabled = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
     }
 
     xmlFree(name);
@@ -825,10 +832,12 @@ void Settings::save() {
     WRITE_INT_PROP(strokeFilterIgnoreTime);
     WRITE_DOUBLE_PROP(strokeFilterIgnoreLength);
     WRITE_INT_PROP(strokeFilterSuccessiveTime);
-
     WRITE_BOOL_PROP(strokeFilterEnabled);
     WRITE_BOOL_PROP(doActionOnStrokeFiltered);
     WRITE_BOOL_PROP(trySelectOnStrokeFiltered);
+
+    WRITE_BOOL_PROP(snapRecognizedShapesEnabled);
+    WRITE_BOOL_PROP(restoreLineWidthEnabled);
 
     WRITE_INT_PROP(numIgnoredStylusEvents);
 
@@ -1663,6 +1672,15 @@ auto Settings::getDoActionOnStrokeFiltered() const -> bool { return this->doActi
 void Settings::setTrySelectOnStrokeFiltered(bool enabled) { this->trySelectOnStrokeFiltered = enabled; }
 
 auto Settings::getTrySelectOnStrokeFiltered() const -> bool { return this->trySelectOnStrokeFiltered; }
+
+void Settings::setSnapRecognizedShapesEnabled(bool enabled) { this->snapRecognizedShapesEnabled = enabled; }
+
+auto Settings::getSnapRecognizedShapesEnabled() const -> bool { return this->snapRecognizedShapesEnabled; }
+
+
+void Settings::setRestoreLineWidthEnabled(bool enabled) { this->restoreLineWidthEnabled = enabled; }
+
+auto Settings::getRestoreLineWidthEnabled() const -> bool { return this->restoreLineWidthEnabled; }
 
 
 void Settings::setIgnoredStylusEvents(int numEvents) {

--- a/src/control/settings/Settings.h
+++ b/src/control/settings/Settings.h
@@ -400,7 +400,6 @@ public:
      */
     bool getStrokeFilterEnabled() const;
 
-
     /**
      * get strokeFilter settings
      */
@@ -431,6 +430,28 @@ public:
      * Get TrySelectOnStrokeFilter enabled
      */
     bool getTrySelectOnStrokeFiltered() const;
+
+
+    /**
+     * Set snap recognized shapes enabled
+     */
+    void setSnapRecognizedShapesEnabled(bool enabled);
+
+    /**
+     * Get snap recognized shapes enabled
+     */
+    bool getSnapRecognizedShapesEnabled() const;
+
+    /**
+     * Set line width restoring for resized edit selctions enabled
+     */
+    void setRestoreLineWidthEnabled(bool enabled);
+
+    /**
+     * Get line width restoring enabled
+     */
+    bool getRestoreLineWidthEnabled() const;
+
 
 public:
     // Custom settings
@@ -826,6 +847,16 @@ private:
     bool strokeFilterEnabled{};
     bool doActionOnStrokeFiltered{};
     bool trySelectOnStrokeFiltered{};
+
+    /**
+     * Whether snapping for recognized shapes is enabled
+     */
+    bool snapRecognizedShapesEnabled{};
+
+    /**
+     * Whether the line width should be preserved in a resizing operation
+     */
+    bool restoreLineWidthEnabled{};
 
     /**
      * How many stylus events since hitting the screen should be ignored before actually starting the action. If set to

--- a/src/control/shaperecognizer/CircleRecognizer.cpp
+++ b/src/control/shaperecognizer/CircleRecognizer.cpp
@@ -13,8 +13,8 @@
  */
 auto CircleRecognizer::makeCircleShape(Stroke* originalStroke, Inertia& inertia) -> Stroke* {
     int npts = static_cast<int>(2 * inertia.rad());
-    if (npts < 12) {
-        npts = 12;  // min. number of points
+    if (npts < 24) {
+        npts = 24;  // min. number of points
     }
 
     auto* s = new Stroke();

--- a/src/control/tools/EditSelection.h
+++ b/src/control/tools/EditSelection.h
@@ -89,6 +89,11 @@ public:
     double getHeight() const;
 
     /**
+     * Get the bounding rectangle in document coordinates (multiple with zoom)
+     */
+    Rectangle<double> getRect() const;
+
+    /**
      * Get the source page (where the selection was done)
      */
     PageRef getSourcePage();
@@ -200,7 +205,7 @@ public:
     /**
      * Handles mouse input for moving and resizing, coordinates are relative to "view"
      */
-    void mouseMove(double x, double y);
+    void mouseMove(double x, double y, bool alt);
 
     /**
      * If the selection should moved (or rescaled)
@@ -252,6 +257,16 @@ private:
      */
     void translateToView(XojPageView* v);
 
+    /**
+     * Updates rotation matrix
+     */
+    void updateMatrix();
+
+    /**
+     * scales and shifts to update bounding boxes
+     */
+    void scaleShift(double fx, double fy, bool changeLeft, bool changeTop);
+
 private:  // DATA
     /**
      * Support rotation
@@ -268,7 +283,7 @@ private:  // DATA
     /**
      * Use to translate to rotated selection
      */
-    _cairo_matrix cmatrix{};
+    cairo_matrix_t cmatrix{};
 
     /**
      * The size
@@ -277,11 +292,19 @@ private:  // DATA
     double height{};
 
     /**
+     * The size and dimensions for snapping
+     */
+    Rectangle<double> snappedBounds{};
+
+
+    /**
      * Mouse coordinates for moving / resizing
      */
     CursorSelectionType mouseDownType;
     double relMousePosX{};
     double relMousePosY{};
+    double relMousePosRotX{};
+    double relMousePosRotY{};
 
     /**
      * If both scale axes should have the same scale factor, e.g. for Text

--- a/src/control/tools/EditSelectionContents.h
+++ b/src/control/tools/EditSelectionContents.h
@@ -35,7 +35,7 @@ class DeleteUndoAction;
 
 class EditSelectionContents: public ElementContainer, public Serializeable {
 public:
-    EditSelectionContents(double x, double y, double width, double height, const PageRef& sourcePage,
+    EditSelectionContents(Rectangle<double> bounds, Rectangle<double> snappedBounds, const PageRef& sourcePage,
                           Layer* sourceLayer, XojPageView* sourceView);
     virtual ~EditSelectionContents();
 
@@ -93,11 +93,11 @@ public:
     /**
      * Finish the editing
      */
-    void finalizeSelection(double x, double y, double width, double height, bool aspectRatio, Layer* layer,
+    void finalizeSelection(Rectangle<double> bounds, Rectangle<double> snappedBounds, bool aspectRatio, Layer* layer,
                            const PageRef& targetPage, XojPageView* targetView, UndoRedoHandler* undo);
 
-    void updateContent(double x, double y, double rotation, double width, double height, bool aspectRatio, Layer* layer,
-                       const PageRef& targetPage, XojPageView* targetView, UndoRedoHandler* undo,
+    void updateContent(Rectangle<double> bounds, Rectangle<double> snappedBounds, double rotation, bool aspectRatio,
+                       Layer* layer, const PageRef& targetPage, XojPageView* targetView, UndoRedoHandler* undo,
                        CursorSelectionType type);
 
 private:
@@ -149,16 +149,12 @@ public:
 
 private:
     /**
-     * The original size to calculate the zoom factor for reascaling the items
+     * The original dimensions to calculate the zoom factor for reascaling the items and the offset for moving the
+     * selection
      */
-    double originalWidth, originalHeight;
-    double lastWidth, lastHeight;
-
-    /**
-     * The original position, to calculate the offset for moving the objects
-     */
-    double originalX, originalY;
-    double lastX, lastY;
+    Rectangle<double> originalBounds;
+    Rectangle<double> lastBounds;
+    Rectangle<double> lastSnappedBounds;
 
     /**
      * The given rotation. Original rotation should always be zero (double)
@@ -169,8 +165,13 @@ private:
     /**
      * The offset to the original selection
      */
-    double relativeX;
-    double relativeY;
+    double relativeX = -9999999999;
+    double relativeY = -9999999999;
+
+    /**
+     * The setting for whether line width is restored after resizing operation (checked at creation time)
+     */
+    bool restoreLineWidth;
 
     /**
      * The selected element (the only one which are handled by this instance)
@@ -186,12 +187,12 @@ private:
     /**
      * The rendered elements
      */
-    cairo_surface_t* crBuffer;
+    cairo_surface_t* crBuffer = nullptr;
 
     /**
      * The source id for the rescaling task
      */
-    int rescaleId;
+    int rescaleId = 0;
 
     /**
      * Source Page for Undo operations

--- a/src/control/tools/SnapToGridInputHandler.cpp
+++ b/src/control/tools/SnapToGridInputHandler.cpp
@@ -5,10 +5,23 @@
 
 SnapToGridInputHandler::SnapToGridInputHandler(Settings* settings): settings(settings) {}
 
+double SnapToGridInputHandler::snapVertically(double y, bool alt) {
+    if (alt != settings->isSnapGrid()) {
+        return Snapping::snapVertically(y, settings->getSnapGridSize(), settings->getSnapGridTolerance());
+    }
+    return y;
+}
+
+double SnapToGridInputHandler::snapHorizontally(double x, bool alt) {
+    if (alt != settings->isSnapGrid()) {
+        return Snapping::snapHorizontally(x, settings->getSnapGridSize(), settings->getSnapGridTolerance());
+    }
+    return x;
+}
+
 Point SnapToGridInputHandler::snapToGrid(Point const& pos, bool alt) {
     if (alt != settings->isSnapGrid()) {
-        return Snapping::snapToGrid(pos, settings->getSnapGridSize(),
-                                    settings->getSnapGridTolerance());  // grid size is not yet in the settings
+        return Snapping::snapToGrid(pos, settings->getSnapGridSize(), settings->getSnapGridTolerance());
     }
     return pos;
 }

--- a/src/control/tools/SnapToGridInputHandler.h
+++ b/src/control/tools/SnapToGridInputHandler.h
@@ -24,6 +24,22 @@ protected:
 
 public:
     /**
+     * @brief If a value is near enough to the y-coordinate of a grid point, it returns the nearest y-coordinate of the
+     * grid point. Otherwise the original value itself.
+     * @param y the value
+     * @param alt indicates whether snapping mode is altered (via the Alt key)
+     */
+    [[nodiscard]] double snapVertically(double y, bool alt);
+
+    /**
+     * @brief If a value is near enough to the x-coordinate of a grid point, it returns the nearest x-coordinate of the
+     * grid point. Otherwise the original value itself.
+     * @param x the value
+     * @param alt indicates whether snapping mode is altered (via the Alt key)
+     */
+    [[nodiscard]] double snapHorizontally(double x, bool alt);
+
+    /**
      * @brief If a points distance to the nearest grid point is under a certain tolerance, it returns the nearest
      * grid point. Otherwise the original Point itself.
      * @param pos the position

--- a/src/control/tools/StrokeHandler.h
+++ b/src/control/tools/StrokeHandler.h
@@ -14,6 +14,7 @@
 #include "view/DocumentView.h"
 
 #include "InputHandler.h"
+#include "SnapToGridInputHandler.h"
 
 class ShapeRecognizer;
 
@@ -50,6 +51,8 @@ protected:
 
 protected:
     Point buttonDownPoint;  // used for tapSelect and filtering - never snapped to grid.
+    SnapToGridInputHandler snappingHandler;
+
 private:
     /**
      * The masking surface

--- a/src/control/tools/VerticalToolHandler.cpp
+++ b/src/control/tools/VerticalToolHandler.cpp
@@ -7,8 +7,12 @@
 #include "undo/UndoRedoHandler.h"
 #include "view/DocumentView.h"
 
-VerticalToolHandler::VerticalToolHandler(Redrawable* view, const PageRef& page, double y, double zoom):
-        view(view), page(page), layer(this->page->getSelectedLayer()), startY(y), endY(y) {
+VerticalToolHandler::VerticalToolHandler(Redrawable* view, const PageRef& page, Settings* settings, double y,
+                                         double zoom):
+        view(view), page(page), layer(this->page->getSelectedLayer()), snappingHandler(settings) {
+    double ySnapped = snappingHandler.snapVertically(y, false);
+    this->startY = ySnapped;
+    this->endY = ySnapped;
     for (Element* e: *this->layer->getElements()) {
         if (e->getY() >= y) {
             this->elements.push_back(e);
@@ -76,12 +80,13 @@ void VerticalToolHandler::paint(cairo_t* cr, GdkRectangle* rect, double zoom) {
 }
 
 void VerticalToolHandler::currentPos(double x, double y) {
-    if (this->endY == y) {
+    double ySnapped = snappingHandler.snapVertically(y, false);
+    if (this->endY == ySnapped) {
         return;
     }
-    double y1 = std::min(this->endY, y);
+    double y1 = std::min(this->endY, ySnapped);
 
-    this->endY = y;
+    this->endY = ySnapped;
 
     this->view->repaintRect(0, y1, this->page->getWidth(), this->page->getHeight());
 }

--- a/src/control/tools/VerticalToolHandler.h
+++ b/src/control/tools/VerticalToolHandler.h
@@ -21,11 +21,12 @@
 #include "undo/MoveUndoAction.h"
 #include "view/ElementContainer.h"
 
+#include "SnapToGridInputHandler.h"
 #include "XournalType.h"
 
 class VerticalToolHandler: public ElementContainer {
 public:
-    VerticalToolHandler(Redrawable* view, const PageRef& page, double y, double zoom);
+    VerticalToolHandler(Redrawable* view, const PageRef& page, Settings* settings, double y, double zoom);
     ~VerticalToolHandler() override;
 
     void paint(cairo_t* cr, GdkRectangle* rect, double zoom);
@@ -50,4 +51,9 @@ private:
      * When we create a new page
      */
     double jumpY = 0;
+
+    /**
+     * The handler for snapping points
+     */
+    SnapToGridInputHandler snappingHandler;
 };

--- a/src/gui/PageView.cpp
+++ b/src/gui/PageView.cpp
@@ -317,7 +317,7 @@ auto XojPageView::onButtonPressEvent(const PositionInputData& pos) -> bool {
         this->eraser->erase(x, y);
         this->inEraser = true;
     } else if (h->getToolType() == TOOL_VERTICAL_SPACE) {
-        this->verticalSpace = new VerticalToolHandler(this, this->page, y, zoom);
+        this->verticalSpace = new VerticalToolHandler(this, this->page, this->settings, y, zoom);
     } else if (h->getToolType() == TOOL_SELECT_RECT || h->getToolType() == TOOL_SELECT_REGION ||
                h->getToolType() == TOOL_PLAY_OBJECT || h->getToolType() == TOOL_SELECT_OBJECT) {
         if (h->getToolType() == TOOL_SELECT_RECT) {

--- a/src/gui/XournalppCursor.h
+++ b/src/gui/XournalppCursor.h
@@ -38,6 +38,7 @@ public:
     void setInsidePage(bool insidePage);
     void activateDrawDirCursor(bool enable, bool shift = false, bool ctrl = false);
     void setInputDeviceClass(InputDeviceClass inputDevice);
+    void setRotationAngle(double angle);
 
 private:
     void setCursor(int id);
@@ -46,6 +47,7 @@ private:
 
     GdkCursor* getEraserCursor();
     GdkCursor* getHighlighterCursor();
+    GdkCursor* getResizeCursor(double deltaAngle);
 
     GdkCursor* createHighlighterOrPenCursor(int size, double alpha);
     GdkCursor* createCustomDrawDirCursor(int size, bool shift, bool ctrl);
@@ -70,4 +72,7 @@ private:
     guint currentCursor = 0;        // enum AVAILABLECURSORS
     gulong currentCursorFlavour{};  // for different flavours of a cursor (i.e. drawdir, pen and hilighter custom
                                     // cursors)
+
+    // for resizing rotated selections
+    double angle = 0;
 };

--- a/src/gui/dialog/SettingsDialog.cpp
+++ b/src/gui/dialog/SettingsDialog.cpp
@@ -216,6 +216,8 @@ void SettingsDialog::load() {
     loadCheckbox("cbStrokeFilterEnabled", settings->getStrokeFilterEnabled());
     loadCheckbox("cbDoActionOnStrokeFiltered", settings->getDoActionOnStrokeFiltered());
     loadCheckbox("cbTrySelectOnStrokeFiltered", settings->getTrySelectOnStrokeFiltered());
+    loadCheckbox("cbSnapRecognizedShapesEnabled", settings->getSnapRecognizedShapesEnabled());
+    loadCheckbox("cbRestoreLineWidthEnabled", settings->getRestoreLineWidthEnabled());
     loadCheckbox("cbDarkTheme", settings->isDarkTheme());
     loadCheckbox("cbHideHorizontalScrollbar", settings->getScrollbarHideType() & SCROLLBAR_HIDE_HORIZONTAL);
     loadCheckbox("cbHideVerticalScrollbar", settings->getScrollbarHideType() & SCROLLBAR_HIDE_VERTICAL);
@@ -496,6 +498,8 @@ void SettingsDialog::save() {
     settings->setStrokeFilterEnabled(getCheckbox("cbStrokeFilterEnabled"));
     settings->setDoActionOnStrokeFiltered(getCheckbox("cbDoActionOnStrokeFiltered"));
     settings->setTrySelectOnStrokeFiltered(getCheckbox("cbTrySelectOnStrokeFiltered"));
+    settings->setSnapRecognizedShapesEnabled(getCheckbox("cbSnapRecognizedShapesEnabled"));
+    settings->setRestoreLineWidthEnabled(getCheckbox("cbRestoreLineWidthEnabled"));
     settings->setDarkTheme(getCheckbox("cbDarkTheme"));
     settings->setTouchWorkaround(getCheckbox("cbTouchWorkaround"));
     settings->setExperimentalInputSystemEnabled(getCheckbox("cbNewInputSystem"));

--- a/src/gui/inputdevices/KeyboardInputHandler.cpp
+++ b/src/gui/inputdevices/KeyboardInputHandler.cpp
@@ -31,19 +31,19 @@ auto KeyboardInputHandler::handleImpl(InputEvent const& event) -> bool {
             }
 
             if (keyEvent->keyval == GDK_KEY_Left) {
-                selection->moveSelection(d, 0);
-                return true;
-            }
-            if (keyEvent->keyval == GDK_KEY_Up) {
-                selection->moveSelection(0, d);
-                return true;
-            }
-            if (keyEvent->keyval == GDK_KEY_Right) {
                 selection->moveSelection(-d, 0);
                 return true;
             }
-            if (keyEvent->keyval == GDK_KEY_Down) {
+            if (keyEvent->keyval == GDK_KEY_Up) {
                 selection->moveSelection(0, -d);
+                return true;
+            }
+            if (keyEvent->keyval == GDK_KEY_Right) {
+                selection->moveSelection(d, 0);
+                return true;
+            }
+            if (keyEvent->keyval == GDK_KEY_Down) {
+                selection->moveSelection(0, d);
                 return true;
             }
         }

--- a/src/gui/inputdevices/PenInputHandler.cpp
+++ b/src/gui/inputdevices/PenInputHandler.cpp
@@ -185,7 +185,7 @@ auto PenInputHandler::actionMotion(InputEvent const& event) -> bool {
         PositionInputData pos = this->getInputDataRelativeToCurrentPage(view, event);
 
         if (xournal->selection->isMoving()) {
-            selection->mouseMove(pos.x, pos.y);
+            selection->mouseMove(pos.x, pos.y, pos.isAltDown());
         } else {
             CursorSelectionType selType = selection->getSelectionTypeForPos(pos.x, pos.y, xournal->view->getZoom());
             xournal->view->getCursor()->setMouseSelectionType(selType);

--- a/src/gui/inputdevices/old/InputSequence.cpp
+++ b/src/gui/inputdevices/old/InputSequence.cpp
@@ -162,7 +162,7 @@ auto InputSequence::actionMoved(guint32 time) -> bool {
         PositionInputData pos = getInputDataRelativeToCurrentPage(view);
 
         if (xournal->selection->isMoving()) {
-            selection->mouseMove(pos.x, pos.y);
+            selection->mouseMove(pos.x, pos.y, pos.isAltDown());
         } else {
             CursorSelectionType selType = selection->getSelectionTypeForPos(pos.x, pos.y, xournal->view->getZoom());
             xournal->view->getCursor()->setMouseSelectionType(selType);

--- a/src/gui/inputdevices/old/NewGtkInputDevice.cpp
+++ b/src/gui/inputdevices/old/NewGtkInputDevice.cpp
@@ -126,19 +126,19 @@ auto NewGtkInputDevice::eventKeyPressHandler(GdkEventKey* event) -> bool {
         }
 
         if (event->keyval == GDK_KEY_Left) {
-            selection->moveSelection(d, 0);
-            return true;
-        }
-        if (event->keyval == GDK_KEY_Up) {
-            selection->moveSelection(0, d);
-            return true;
-        }
-        if (event->keyval == GDK_KEY_Right) {
             selection->moveSelection(-d, 0);
             return true;
         }
-        if (event->keyval == GDK_KEY_Down) {
+        if (event->keyval == GDK_KEY_Up) {
             selection->moveSelection(0, -d);
+            return true;
+        }
+        if (event->keyval == GDK_KEY_Right) {
+            selection->moveSelection(d, 0);
+            return true;
+        }
+        if (event->keyval == GDK_KEY_Down) {
+            selection->moveSelection(0, d);
             return true;
         }
     }

--- a/src/model/Element.cpp
+++ b/src/model/Element.cpp
@@ -11,11 +11,17 @@ Element::~Element() = default;
 
 auto Element::getType() const -> ElementType { return this->type; }
 
-void Element::setX(double x) { this->x = x; }
+void Element::setX(double x) {
+    this->x = x;
+    this->sizeCalculated = false;
+}
 
-void Element::setY(double y) { this->y = y; }
+void Element::setY(double y) {
+    this->y = y;
+    this->sizeCalculated = false;
+}
 
-auto Element::getX() -> double {
+auto Element::getX() const -> double {
     if (!this->sizeCalculated) {
         this->sizeCalculated = true;
         calcSize();
@@ -23,20 +29,28 @@ auto Element::getX() -> double {
     return x;
 }
 
-auto Element::getY() -> double {
+auto Element::getY() const -> double {
     if (!this->sizeCalculated) {
         this->sizeCalculated = true;
         calcSize();
     }
     return y;
 }
+auto Element::getSnappedBounds() const -> Rectangle<double> {
+    if (!this->sizeCalculated) {
+        this->sizeCalculated = true;
+        calcSize();
+    }
+    return this->snappedBounds;
+}
 
 void Element::move(double dx, double dy) {
     this->x += dx;
     this->y += dy;
+    this->snappedBounds = this->snappedBounds.translated(dx, dy);
 }
 
-auto Element::getElementWidth() -> double {
+auto Element::getElementWidth() const -> double {
     if (!this->sizeCalculated) {
         this->sizeCalculated = true;
         calcSize();
@@ -44,7 +58,7 @@ auto Element::getElementWidth() -> double {
     return this->width;
 }
 
-auto Element::getElementHeight() -> double {
+auto Element::getElementHeight() const -> double {
     if (!this->sizeCalculated) {
         this->sizeCalculated = true;
         calcSize();
@@ -52,7 +66,7 @@ auto Element::getElementHeight() -> double {
     return this->height;
 }
 
-auto Element::boundingRect() -> Rectangle<double> {
+auto Element::boundingRect() const -> Rectangle<double> {
     return Rectangle<double>(getX(), getY(), getElementWidth(), getElementHeight());
 }
 

--- a/src/model/Element.h
+++ b/src/model/Element.h
@@ -43,20 +43,22 @@ public:
 
     void setX(double x);
     void setY(double y);
-    double getX();
-    double getY();
+    double getX() const;
+    double getY() const;
 
     virtual void move(double dx, double dy);
-    virtual void scale(double x0, double y0, double fx, double fy) = 0;
-    virtual void rotate(double x0, double y0, double xo, double yo, double th) = 0;
+    virtual void scale(double x0, double y0, double fx, double fy, double rotation, bool restoreLineWidth) = 0;
+    virtual void rotate(double x0, double y0, double th) = 0;
 
     void setColor(Color color);
     Color getColor() const;
 
-    double getElementWidth();
-    double getElementHeight();
+    double getElementWidth() const;
+    double getElementHeight() const;
 
-    Rectangle<double> boundingRect();
+    Rectangle<double> getSnappedBounds() const;
+
+    Rectangle<double> boundingRect() const;
 
     virtual bool intersectsArea(const GdkRectangle* src);
     virtual bool intersectsArea(double x, double y, double width, double height);
@@ -72,21 +74,24 @@ public:
 
 private:
 protected:
-    virtual void calcSize() = 0;
+    virtual void calcSize() const = 0;
 
     void serializeElement(ObjectOutputStream& out) const;
     void readSerializedElement(ObjectInputStream& in);
 
 protected:
     // If the size has been calculated
-    bool sizeCalculated = false;
+    mutable bool sizeCalculated = false;
 
-    double width = 0;
-    double height = 0;
+    mutable double width = 0;
+    mutable double height = 0;
 
     // The position on the screen
-    double x = 0;
-    double y = 0;
+    mutable double x = 0;
+    mutable double y = 0;
+
+    // The position and dimensions on the screen used for snapping
+    mutable Rectangle<double> snappedBounds{};
 
 private:
     /**

--- a/src/model/Font.cpp
+++ b/src/model/Font.cpp
@@ -9,7 +9,7 @@ XojFont::XojFont() = default;
 
 XojFont::~XojFont() = default;
 
-auto XojFont::getName() -> string { return this->name; }
+auto XojFont::getName() const -> string { return this->name; }
 
 void XojFont::setName(string name) { this->name = std::move(name); }
 

--- a/src/model/Font.h
+++ b/src/model/Font.h
@@ -26,7 +26,7 @@ public:
     virtual ~XojFont();
 
 public:
-    string getName();
+    string getName() const;
     void setName(string name);
 
     double getSize() const;

--- a/src/model/Image.h
+++ b/src/model/Image.h
@@ -31,8 +31,8 @@ public:
     void setImage(GdkPixbuf* img);
     cairo_surface_t* getImage();
 
-    virtual void scale(double x0, double y0, double fx, double fy);
-    virtual void rotate(double x0, double y0, double xo, double yo, double th);
+    virtual void scale(double x0, double y0, double fx, double fy, double rotation, bool restoreLineWidth);
+    virtual void rotate(double x0, double y0, double th);
 
     /**
      * @overwrite
@@ -45,7 +45,7 @@ public:
     void readSerialized(ObjectInputStream& in);
 
 private:
-    virtual void calcSize();
+    void calcSize() const override;
 
     static cairo_status_t cairoReadFunction(Image* image, unsigned char* data, unsigned int length);
 

--- a/src/model/Snapping.cpp
+++ b/src/model/Snapping.cpp
@@ -6,6 +6,16 @@ namespace Snapping {
 
 [[nodiscard]] inline double roundToMultiple(double val, double multiple) { return val - std::remainder(val, multiple); }
 [[nodiscard]] inline double distance(Point const& a, Point const& b) { return std::hypot(b.x - a.x, b.y - a.y); }
+double snapVertically(double y, double gridSize, double tolerance) {
+    double ySnapped = roundToMultiple(y, gridSize);
+    return abs(ySnapped - y) < tolerance * gridSize ? ySnapped : y;
+}
+
+double snapHorizontally(double x, double gridSize, double tolerance) {
+    double xSnapped = roundToMultiple(x, gridSize);
+    return abs(xSnapped - x) < tolerance * gridSize ? xSnapped : x;
+}
+
 Point snapToGrid(Point const& pos, double gridSize, double tolerance) {
     double abs_tolerance = (gridSize / sqrt(2)) * tolerance;
     Point ret{roundToMultiple(pos.x, gridSize), roundToMultiple(pos.y, gridSize), pos.z};
@@ -13,8 +23,8 @@ Point snapToGrid(Point const& pos, double gridSize, double tolerance) {
 }
 
 double snapAngle(double radian, double tolerance) {
-    auto snapped = roundToMultiple(radian, M_PI_4);
-    double abs_tolerance = (M_PI_4 / 2) * tolerance;
+    auto snapped = roundToMultiple(radian, M_PI_4 / 3.0);
+    double abs_tolerance = (M_PI_4 / 6.0) * tolerance;
     return std::abs(snapped - radian) < abs_tolerance ? snapped : radian;
 }
 

--- a/src/model/Snapping.h
+++ b/src/model/Snapping.h
@@ -15,6 +15,24 @@
 namespace Snapping {
 
 /**
+ * @brief If a value is near enough to the y-coordinate of a grid point, it returns the nearest y-coordinate of the
+ * grid point. Otherwise the original value itself.
+ * @param y the value
+ * @param gridSize the distance to each snapping point
+ * @param tolerance the tolerance as a fraction of a half grid diagonal (assumed to be between 0 and 1)
+ */
+[[nodiscard]] double snapVertically(double y, double gridSize, double tolerance);
+
+/**
+ * @brief If a value is near enough to the x-coordinate of a grid point, it returns the nearest x-coordinate of the
+ * grid point. Otherwise the original value itself.
+ * @param x the value
+ * @param gridSize the distance to each snapping point
+ * @param tolerance the tolerance as a fraction of a half grid diagonal (assumed to be between 0 and 1)
+ */
+[[nodiscard]] double snapHorizontally(double x, double gridSize, double tolerance);
+
+/**
  * @brief If a points distance to the nearest grid point is under a certain tolerance, it returns the nearest
  * grid point. Otherwise the original Point itself.
  * @param pos the position

--- a/src/model/Stroke.cpp
+++ b/src/model/Stroke.cpp
@@ -168,40 +168,32 @@ void Stroke::move(double dx, double dy) {
     this->sizeCalculated = false;
 }
 
-void Stroke::rotate(double x0, double y0, double xo, double yo, double th) {
+void Stroke::rotate(double x0, double y0, double th) {
+    cairo_matrix_t rotMatrix;
+    cairo_matrix_init_identity(&rotMatrix);
+    cairo_matrix_translate(&rotMatrix, x0, y0);
+    cairo_matrix_rotate(&rotMatrix, th);
+    cairo_matrix_translate(&rotMatrix, -x0, -y0);
+
     for (auto&& p: points) {
-        p.x -= x0;  // move to origin
-        p.y -= y0;
-        double offset = 0.7;  // __DBL_EPSILON__;
-        p.x -= xo - offset;   // center to origin
-        p.y -= yo - offset;
-
-        double x1 = p.x * cos(th) - p.y * sin(th);
-        double y1 = p.y * cos(th) + p.x * sin(th);
-        p.x = x1;
-        p.y = y1;
-
-        p.x += x0;  // restore the position
-        p.y += y0;
-
-        p.x += xo - offset;  // center it
-        p.y += yo - offset;
+        cairo_matrix_transform_point(&rotMatrix, &p.x, &p.y);
     }
     // Width and Height will likely be changed after this operation
     calcSize();
 }
 
-void Stroke::scale(double x0, double y0, double fx, double fy) {
-    double fz = sqrt(fx * fy);
+void Stroke::scale(double x0, double y0, double fx, double fy, double rotation, bool restoreLineWidth) {
+    double fz = (restoreLineWidth) ? 1 : sqrt(fx * fy);
+    cairo_matrix_t scaleMatrix;
+    cairo_matrix_init_identity(&scaleMatrix);
+    cairo_matrix_translate(&scaleMatrix, x0, y0);
+    cairo_matrix_rotate(&scaleMatrix, rotation);
+    cairo_matrix_scale(&scaleMatrix, fx, fy);
+    cairo_matrix_rotate(&scaleMatrix, -rotation);
+    cairo_matrix_translate(&scaleMatrix, -x0, -y0);
 
     for (auto&& p: points) {
-        p.x -= x0;
-        p.x *= fx;
-        p.x += x0;
-
-        p.y -= y0;
-        p.y *= fy;
-        p.y += y0;
+        cairo_matrix_transform_point(&scaleMatrix, &p.x, &p.y);
 
         if (p.z != Point::NO_PRESSURE) {
             p.z *= fz;
@@ -338,7 +330,7 @@ auto Stroke::intersects(double x, double y, double halfEraserSize, double* gap) 
  * the whole page (performance reason).
  * Also used for Selected Bounding box.
  */
-void Stroke::calcSize() {
+void Stroke::calcSize() const {
     if (this->points.empty()) {
         Element::x = 0;
         Element::y = 0;
@@ -346,12 +338,20 @@ void Stroke::calcSize() {
         // The size of the rectangle, not the size of the pen!
         Element::width = 0;
         Element::height = 0;
+
+        // used for snapping
+        Element::snappedBounds = Rectangle<double>{};
     }
 
     double minX = DBL_MAX;
     double maxX = DBL_MIN;
     double minY = DBL_MAX;
     double maxY = DBL_MIN;
+
+    double minSnapX = DBL_MAX;
+    double maxSnapX = DBL_MIN;
+    double minSnapY = DBL_MAX;
+    double maxSnapY = DBL_MIN;
 
     bool hasPressure = points[0].z != Point::NO_PRESSURE;
     double halfThick = this->width / 2.0;  //  accommodate for pen width
@@ -366,12 +366,20 @@ void Stroke::calcSize() {
 
         maxX = std::max(maxX, p.x + halfThick);
         maxY = std::max(maxY, p.y + halfThick);
+
+        minSnapX = std::min(minSnapX, p.x);
+        minSnapY = std::min(minSnapY, p.y);
+
+        maxSnapX = std::max(maxSnapX, p.x);
+        maxSnapY = std::max(maxSnapY, p.y);
     }
 
-    Element::x = minX - 2;
-    Element::y = minY - 2;
-    Element::width = maxX - minX + 4;
-    Element::height = maxY - minY + 4;
+    Element::x = minX;
+    Element::y = minY;
+    Element::width = maxX - minX;
+    Element::height = maxY - minY;
+
+    Element::snappedBounds = Rectangle<double>(minSnapX, minSnapY, maxSnapX - minSnapX, maxSnapY - minSnapY);
 }
 
 auto Stroke::getEraseable() -> EraseableStroke* { return this->eraseable; }

--- a/src/model/Stroke.h
+++ b/src/model/Stroke.h
@@ -91,8 +91,8 @@ public:
     double getAvgPressure() const;
 
     void move(double dx, double dy) override;
-    void scale(double x0, double y0, double fx, double fy) override;
-    void rotate(double x0, double y0, double xo, double yo, double th) override;
+    void scale(double x0, double y0, double fx, double fy, double rotation, bool restoreLineWidth) override;
+    void rotate(double x0, double y0, double th) override;
 
     bool isInSelection(ShapeContainer* container) override;
 
@@ -107,7 +107,7 @@ public:
     void readSerialized(ObjectInputStream& in) override;
 
 protected:
-    void calcSize() override;
+    void calcSize() const override;
 
 private:
     // The stroke width cannot be inherited from Element

--- a/src/model/TexImage.cpp
+++ b/src/model/TexImage.cpp
@@ -35,9 +35,15 @@ auto TexImage::clone() -> Element* {
     return img;
 }
 
-void TexImage::setWidth(double width) { this->width = width; }
+void TexImage::setWidth(double width) {
+    this->width = width;
+    this->calcSize();
+}
 
-void TexImage::setHeight(double height) { this->height = height; }
+void TexImage::setHeight(double height) {
+    this->height = height;
+    this->calcSize();
+}
 
 auto TexImage::cairoReadFunction(TexImage* image, unsigned char* data, unsigned int length) -> cairo_status_t {
     for (unsigned int i = 0; i < length; i++, image->read++) {
@@ -91,15 +97,18 @@ auto TexImage::getImage() -> cairo_surface_t* { return this->image; }
 
 auto TexImage::getPdf() -> PopplerDocument* { return this->pdf; }
 
-void TexImage::scale(double x0, double y0, double fx, double fy) {
+void TexImage::scale(double x0, double y0, double fx, double fy, double rotation,
+                     bool) {  // line width scaling option is not used
+
     this->x = (this->x - x0) * fx + x0;
     this->y = (this->y - y0) * fy + y0;
 
     this->width *= fx;
     this->height *= fy;
+    this->calcSize();
 }
 
-void TexImage::rotate(double x0, double y0, double xo, double yo, double th) {
+void TexImage::rotate(double x0, double y0, double th) {
     // Rotation for TexImages not yet implemented
 }
 
@@ -135,6 +144,10 @@ void TexImage::readSerialized(ObjectInputStream& in) {
     this->loadData(std::string(data, len), nullptr);
 
     in.endObject();
+    this->calcSize();
 }
 
-void TexImage::calcSize() {}
+void TexImage::calcSize() const {
+    this->snappedBounds = Rectangle<double>(this->x, this->y, this->width, this->height);
+    this->sizeCalculated = true;
+}

--- a/src/model/TexImage.h
+++ b/src/model/TexImage.h
@@ -51,8 +51,8 @@ public:
      */
     PopplerDocument* getPdf();
 
-    virtual void scale(double x0, double y0, double fx, double fy);
-    virtual void rotate(double x0, double y0, double xo, double yo, double th);
+    virtual void scale(double x0, double y0, double fx, double fy, double rotation, bool restoreLineWidth);
+    virtual void rotate(double x0, double y0, double th);
 
     // text tag to alow latex
     void setText(string text);
@@ -71,7 +71,7 @@ public:
     void readSerialized(ObjectInputStream& in);
 
 private:
-    virtual void calcSize();
+    void calcSize() const override;
 
     static cairo_status_t cairoReadFunction(TexImage* image, unsigned char* data, unsigned int length);
 

--- a/src/model/Text.cpp
+++ b/src/model/Text.cpp
@@ -23,15 +23,20 @@ auto Text::clone() -> Element* {
     text->x = this->x;
     text->y = this->y;
     text->cloneAudioData(this);
+    this->updateSnapping();
 
     return text;
 }
 
 auto Text::getFont() -> XojFont& { return font; }
 
-void Text::setFont(XojFont& font) { this->font = font; }
+void Text::setFont(const XojFont& font) { this->font = font; }
 
-auto Text::getText() -> string { return this->text; }
+auto Text::getFontSize() const -> double { return font.getSize(); }
+
+auto Text::getFontName() const -> string { return font.getName(); }
+
+auto Text::getText() const -> string { return this->text; }
 
 void Text::setText(string text) {
     this->text = std::move(text);
@@ -39,15 +44,25 @@ void Text::setText(string text) {
     calcSize();
 }
 
-void Text::calcSize() { TextView::calcSize(this, this->width, this->height); }
+void Text::calcSize() const {
+    TextView::calcSize(this, this->width, this->height);
+    this->updateSnapping();
+}
 
-void Text::setWidth(double width) { this->width = width; }
+void Text::setWidth(double width) {
+    this->width = width;
+    this->updateSnapping();
+}
 
-void Text::setHeight(double height) { this->height = height; }
+void Text::setHeight(double height) {
+    this->height = height;
+    this->updateSnapping();
+}
 
 void Text::setInEditing(bool inEditing) { this->inEditing = inEditing; }
 
-void Text::scale(double x0, double y0, double fx, double fy) {
+void Text::scale(double x0, double y0, double fx, double fy, double rotation,
+                 bool) {  // line width scaling option is not used
     // only proportional scale allowed...
     if (fx != fy) {
         g_warning("rescale font with fx != fy not supported: %lf / %lf", fx, fy);
@@ -64,10 +79,10 @@ void Text::scale(double x0, double y0, double fx, double fy) {
     double size = this->font.getSize() * fx;
     this->font.setSize(size);
 
-    this->sizeCalculated = false;
+    calcSize();
 }
 
-void Text::rotate(double x0, double y0, double xo, double yo, double th) {}
+void Text::rotate(double x0, double y0, double th) {}
 
 auto Text::isInEditing() const -> bool { return this->inEditing; }
 
@@ -108,4 +123,8 @@ void Text::readSerialized(ObjectInputStream& in) {
     font.readSerialized(in);
 
     in.endObject();
+}
+
+void Text::updateSnapping() const {
+    this->snappedBounds = Rectangle<double>(this->x, this->y, this->width, this->height);
 }

--- a/src/model/Text.h
+++ b/src/model/Text.h
@@ -23,10 +23,12 @@ public:
     ~Text() override;
 
 public:
-    void setFont(XojFont& font);
+    void setFont(const XojFont& font);
     XojFont& getFont();
+    double getFontSize() const;  // same result as getFont()->getSize(), but const
+    string getFontName() const;  // same result as getFont()->getName(), but const
 
-    string getText();
+    string getText() const;
     void setText(string text);
 
     void setWidth(double width);
@@ -35,8 +37,8 @@ public:
     void setInEditing(bool inEditing);
     bool isInEditing() const;
 
-    void scale(double x0, double y0, double fx, double fy) override;
-    void rotate(double x0, double y0, double xo, double yo, double th) override;
+    void scale(double x0, double y0, double fx, double fy, double rotation, bool restoreLineWidth) override;
+    void rotate(double x0, double y0, double th) override;
 
     bool rescaleOnlyAspectRatio() override;
 
@@ -54,7 +56,8 @@ public:
     void readSerialized(ObjectInputStream& in) override;
 
 protected:
-    void calcSize() override;
+    void calcSize() const override;
+    void updateSnapping() const;
 
 private:
     XojFont font;

--- a/src/undo/MoveUndoAction.cpp
+++ b/src/undo/MoveUndoAction.cpp
@@ -1,7 +1,6 @@
 #include "MoveUndoAction.h"
 
 #include "control/tools/EditSelection.h"
-#include "control/tools/VerticalToolHandler.h"
 #include "gui/Redrawable.h"
 #include "model/Element.h"
 #include "model/Layer.h"

--- a/src/undo/RotateUndoAction.cpp
+++ b/src/undo/RotateUndoAction.cpp
@@ -6,15 +6,13 @@
 #include "Range.h"
 #include "i18n.h"
 
-RotateUndoAction::RotateUndoAction(const PageRef& page, vector<Element*>* elements, double x0, double y0, double xo,
-                                   double yo, double rotation):
+RotateUndoAction::RotateUndoAction(const PageRef& page, vector<Element*>* elements, double x0, double y0,
+                                   double rotation):
         UndoAction("RotateUndoAction") {
     this->page = page;
     this->elements = *elements;
     this->x0 = x0;
     this->y0 = y0;
-    this->xo = xo;
-    this->yo = yo;
     this->rotation = rotation;
 }
 
@@ -42,7 +40,7 @@ void RotateUndoAction::applyRotation(double rotation) {
     for (Element* e: this->elements) {
         r.addPoint(e->getX(), e->getY());
         r.addPoint(e->getX() + e->getElementWidth(), e->getY() + e->getElementHeight());
-        e->rotate(this->x0, this->y0, this->xo, this->yo, rotation);
+        e->rotate(this->x0, this->y0, rotation);
         r.addPoint(e->getX(), e->getY());
         r.addPoint(e->getX() + e->getElementWidth(), e->getY() + e->getElementHeight());
     }

--- a/src/undo/RotateUndoAction.h
+++ b/src/undo/RotateUndoAction.h
@@ -15,8 +15,7 @@
 
 class RotateUndoAction: public UndoAction {
 public:
-    RotateUndoAction(const PageRef& page, vector<Element*>* elements, double x0, double y0, double xo, double yo,
-                     double rotation);
+    RotateUndoAction(const PageRef& page, vector<Element*>* elements, double x0, double y0, double rotation);
     virtual ~RotateUndoAction();
 
 public:
@@ -32,7 +31,5 @@ private:
 
     double x0;
     double y0;
-    double xo;
-    double yo;
     double rotation = 0;
 };

--- a/src/undo/ScaleUndoAction.cpp
+++ b/src/undo/ScaleUndoAction.cpp
@@ -7,7 +7,7 @@
 #include "i18n.h"
 
 ScaleUndoAction::ScaleUndoAction(const PageRef& page, vector<Element*>* elements, double x0, double y0, double fx,
-                                 double fy):
+                                 double fy, double rotation, bool restoreLineWidth):
         UndoAction("ScaleUndoAction") {
     this->page = page;
     this->elements = *elements;
@@ -15,23 +15,25 @@ ScaleUndoAction::ScaleUndoAction(const PageRef& page, vector<Element*>* elements
     this->y0 = y0;
     this->fx = fx;
     this->fy = fy;
+    this->rotation = rotation;
+    this->restoreLineWidth = restoreLineWidth;
 }
 
 ScaleUndoAction::~ScaleUndoAction() { this->page = nullptr; }
 
 auto ScaleUndoAction::undo(Control* control) -> bool {
-    applyScale(1 / this->fx, 1 / this->fy);
+    applyScale(1 / this->fx, 1 / this->fy, restoreLineWidth);
     this->undone = true;
     return true;
 }
 
 auto ScaleUndoAction::redo(Control* control) -> bool {
-    applyScale(this->fx, this->fy);
+    applyScale(this->fx, this->fy, restoreLineWidth);
     this->undone = false;
     return true;
 }
 
-void ScaleUndoAction::applyScale(double fx, double fy) {
+void ScaleUndoAction::applyScale(double fx, double fy, bool restoreLineWidth) {
     if (this->elements.empty()) {
         return;
     }
@@ -41,7 +43,7 @@ void ScaleUndoAction::applyScale(double fx, double fy) {
     for (Element* e: this->elements) {
         r.addPoint(e->getX(), e->getY());
         r.addPoint(e->getX() + e->getElementWidth(), e->getY() + e->getElementHeight());
-        e->scale(this->x0, this->y0, fx, fy);
+        e->scale(this->x0, this->y0, fx, fy, this->rotation, restoreLineWidth);
         r.addPoint(e->getX(), e->getY());
         r.addPoint(e->getX() + e->getElementWidth(), e->getY() + e->getElementHeight());
     }

--- a/src/undo/ScaleUndoAction.h
+++ b/src/undo/ScaleUndoAction.h
@@ -15,7 +15,8 @@
 
 class ScaleUndoAction: public UndoAction {
 public:
-    ScaleUndoAction(const PageRef& page, vector<Element*>* elements, double x0, double y0, double fx, double fy);
+    ScaleUndoAction(const PageRef& page, vector<Element*>* elements, double x0, double y0, double fx, double fy,
+                    double rotation, bool restoreLineWidth);
     virtual ~ScaleUndoAction();
 
 public:
@@ -24,7 +25,7 @@ public:
     virtual string getText();
 
 private:
-    void applyScale(double fx, double fy);
+    void applyScale(double fx, double fy, bool restoreLineWidth);
 
 private:
     vector<Element*> elements;
@@ -33,4 +34,6 @@ private:
     double y0;
     double fx;
     double fy;
+    double rotation;
+    bool restoreLineWidth;
 };

--- a/src/util/Rectangle.h
+++ b/src/util/Rectangle.h
@@ -51,7 +51,8 @@ public:
      * Computes the union of this and the other rectangle
      */
     void unite(const Rectangle& other) {
-        assert(other.width > 0 && other.height > 0 && "Rectangle not normalized");
+        // assert(other.width > 0 && other.height > 0 && "Rectangle not normalized"); (does not need to be valid for
+        // snappedBounds)
         this->x = std::min(this->x, other.x);
         this->y = std::min(this->y, other.y);
         this->width = std::max(this->x + this->width, other.x + other.width) - this->x;

--- a/src/view/TextView.cpp
+++ b/src/view/TextView.cpp
@@ -15,7 +15,7 @@ static int textDpi = 72;
 
 void TextView::setDpi(int dpi) { textDpi = dpi; }
 
-auto TextView::initPango(cairo_t* cr, Text* t) -> PangoLayout* {
+auto TextView::initPango(cairo_t* cr, const Text* t) -> PangoLayout* {
     PangoLayout* layout = pango_cairo_create_layout(cr);
 
     // Additional Feature: add autowrap and text field size for
@@ -30,16 +30,16 @@ auto TextView::initPango(cairo_t* cr, Text* t) -> PangoLayout* {
     return layout;
 }
 
-void TextView::updatePangoFont(PangoLayout* layout, Text* t) {
-    PangoFontDescription* desc = pango_font_description_from_string(t->getFont().getName().c_str());
-    // pango_font_description_set_absolute_size(desc, t->getFont().getSize() * PANGO_SCALE);
-    pango_font_description_set_size(desc, t->getFont().getSize() * PANGO_SCALE);
+void TextView::updatePangoFont(PangoLayout* layout, const Text* t) {
+    PangoFontDescription* desc = pango_font_description_from_string(t->getFontName().c_str());
+    // pango_font_description_set_absolute_size(desc, t->getFontSize() * PANGO_SCALE);
+    pango_font_description_set_size(desc, t->getFontSize() * PANGO_SCALE);
 
     pango_layout_set_font_description(layout, desc);
     pango_font_description_free(desc);
 }
 
-void TextView::drawText(cairo_t* cr, Text* t) {
+void TextView::drawText(cairo_t* cr, const Text* t) {
     cairo_save(cr);
 
     cairo_translate(cr, t->getX(), t->getY());
@@ -55,7 +55,7 @@ void TextView::drawText(cairo_t* cr, Text* t) {
     cairo_restore(cr);
 }
 
-auto TextView::findText(Text* t, string& search) -> vector<XojPdfRectangle> {
+auto TextView::findText(const Text* t, string& search) -> vector<XojPdfRectangle> {
     cairo_surface_t* surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, 1, 1);
     cairo_t* cr = cairo_create(surface);
 
@@ -95,7 +95,7 @@ auto TextView::findText(Text* t, string& search) -> vector<XojPdfRectangle> {
     return list;
 }
 
-void TextView::calcSize(Text* t, double& width, double& height) {
+void TextView::calcSize(const Text* t, double& width, double& height) {
     cairo_surface_t* surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, 1, 1);
     cairo_t* cr = cairo_create(surface);
 

--- a/src/view/TextView.h
+++ b/src/view/TextView.h
@@ -28,25 +28,25 @@ public:
     /**
      * Calculates the size of a Text model
      */
-    static void calcSize(Text* t, double& width, double& height);
+    static void calcSize(const Text* t, double& width, double& height);
 
     /**
      * Draws a Text modle to a cairo surface
      */
-    static void drawText(cairo_t* cr, Text* t);
+    static void drawText(cairo_t* cr, const Text* t);
 
     /**
      * Searches text within a Text model, returns XojPopplerRectangle, have to been freed
      */
-    static vector<XojPdfRectangle> findText(Text* t, string& search);
+    static vector<XojPdfRectangle> findText(const Text* t, string& search);
 
     /**
      * Initialize a Pango layout
      */
-    static PangoLayout* initPango(cairo_t* cr, Text* t);
+    static PangoLayout* initPango(cairo_t* cr, const Text* t);
 
     /**
      * Sets the font name from Text model
      */
-    static void updatePangoFont(PangoLayout* layout, Text* t);
+    static void updatePangoFont(PangoLayout* layout, const Text* t);
 };

--- a/test/control/LoadHandlerTest.cpp
+++ b/test/control/LoadHandlerTest.cpp
@@ -372,7 +372,7 @@ public:
                     auto tA = dynamic_cast<Text*>(a);
                     auto tB = dynamic_cast<Text*>(b);
                     CPPUNIT_ASSERT_EQUAL(tA->getText(), tB->getText());
-                    CPPUNIT_ASSERT_EQUAL(tA->getFont().getSize(), tB->getFont().getSize());
+                    CPPUNIT_ASSERT_EQUAL(tA->getFontSize(), tB->getFontSize());
                     break;
                 }
                 default:

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.22.1 -->
 <interface>
-  <requires lib="gtk+" version="3.18"/>
+  <requires lib="gtk+" version="3.18" />
   <object class="GtkAdjustment" id="adjustmentAudioGain">
     <property name="upper">10</property>
     <property name="value">1</property>
@@ -139,9 +139,9 @@
     <property name="icon">pixmaps/com.github.xournalpp.xournalpp.svg</property>
     <property name="type_hint">normal</property>
     <property name="gravity">center</property>
-    <signal name="close" handler="gtk_widget_hide" swapped="no"/>
+    <signal name="close" handler="gtk_widget_hide" swapped="no" />
     <child type="titlebar">
-      <placeholder/>
+      <placeholder />
     </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox3">
@@ -749,7 +749,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                 <property name="can_focus">False</property>
                                 <property name="orientation">vertical</property>
                                 <child>
-                                  <placeholder/>
+                                  <placeholder />
                                 </child>
                               </object>
                               <packing>
@@ -973,7 +973,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                                     <property name="visible">True</property>
                                                     <property name="can_focus">False</property>
                                                     <child>
-                                                      <placeholder/>
+                                                      <placeholder />
                                                     </child>
                                                   </object>
                                                 </child>
@@ -1011,7 +1011,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                                     <property name="visible">True</property>
                                                     <property name="can_focus">False</property>
                                                     <child>
-                                                      <placeholder/>
+                                                      <placeholder />
                                                     </child>
                                                   </object>
                                                 </child>
@@ -1328,7 +1328,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                                     <property name="visible">True</property>
                                                     <property name="can_focus">False</property>
                                                     <child>
-                                                      <placeholder/>
+                                                      <placeholder />
                                                     </child>
                                                   </object>
                                                 </child>
@@ -1366,7 +1366,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                                     <property name="visible">True</property>
                                                     <property name="can_focus">False</property>
                                                     <child>
-                                                      <placeholder/>
+                                                      <placeholder />
                                                     </child>
                                                   </object>
                                                 </child>
@@ -1404,7 +1404,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                                     <property name="visible">True</property>
                                                     <property name="can_focus">False</property>
                                                     <child>
-                                                      <placeholder/>
+                                                      <placeholder />
                                                     </child>
                                                   </object>
                                                 </child>
@@ -1533,7 +1533,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <child>
-                                              <placeholder/>
+                                              <placeholder />
                                             </child>
                                           </object>
                                           <packing>
@@ -1691,7 +1691,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                                   </packing>
                                                 </child>
                                                 <child>
-                                                  <placeholder/>
+                                                  <placeholder />
                                                 </child>
                                               </object>
                                               <packing>
@@ -1742,77 +1742,77 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                                             <property name="row_spacing">5</property>
                                                             <property name="column_spacing">5</property>
                                                             <child>
-                                                            <object class="GtkLabel" id="label52">
-                                                            <property name="visible">True</property>
-                                                            <property name="can_focus">False</property>
-                                                            <property name="label" translatable="yes">Enable</property>
-                                                            <property name="xalign">0</property>
-                                                            </object>
-                                                            <packing>
-                                                            <property name="left_attach">0</property>
-                                                            <property name="top_attach">0</property>
-                                                            </packing>
+                                                              <object class="GtkLabel" id="label52">
+                                                                <property name="visible">True</property>
+                                                                <property name="can_focus">False</property>
+                                                                <property name="label" translatable="yes">Enable</property>
+                                                                <property name="xalign">0</property>
+                                                              </object>
+                                                              <packing>
+                                                                <property name="left_attach">0</property>
+                                                                <property name="top_attach">0</property>
+                                                              </packing>
                                                             </child>
                                                             <child>
-                                                            <object class="GtkLabel" id="label53">
-                                                            <property name="visible">True</property>
-                                                            <property name="can_focus">False</property>
-                                                            <property name="label" translatable="yes">Disable</property>
-                                                            </object>
-                                                            <packing>
-                                                            <property name="left_attach">0</property>
-                                                            <property name="top_attach">1</property>
-                                                            </packing>
+                                                              <object class="GtkLabel" id="label53">
+                                                                <property name="visible">True</property>
+                                                                <property name="can_focus">False</property>
+                                                                <property name="label" translatable="yes">Disable</property>
+                                                              </object>
+                                                              <packing>
+                                                                <property name="left_attach">0</property>
+                                                                <property name="top_attach">1</property>
+                                                              </packing>
                                                             </child>
                                                             <child>
-                                                            <object class="GtkEntry" id="txtEnableTouchCommand">
-                                                            <property name="name">txtEnableTouchCommand</property>
-                                                            <property name="visible">True</property>
-                                                            <property name="can_focus">True</property>
-                                                            <property name="hexpand">True</property>
-                                                            </object>
-                                                            <packing>
-                                                            <property name="left_attach">1</property>
-                                                            <property name="top_attach">0</property>
-                                                            </packing>
+                                                              <object class="GtkEntry" id="txtEnableTouchCommand">
+                                                                <property name="name">txtEnableTouchCommand</property>
+                                                                <property name="visible">True</property>
+                                                                <property name="can_focus">True</property>
+                                                                <property name="hexpand">True</property>
+                                                              </object>
+                                                              <packing>
+                                                                <property name="left_attach">1</property>
+                                                                <property name="top_attach">0</property>
+                                                              </packing>
                                                             </child>
                                                             <child>
-                                                            <object class="GtkEntry" id="txtDisableTouchCommand">
-                                                            <property name="name">txtDisableTouchCommand</property>
-                                                            <property name="visible">True</property>
-                                                            <property name="can_focus">True</property>
-                                                            <property name="hexpand">True</property>
-                                                            </object>
-                                                            <packing>
-                                                            <property name="left_attach">1</property>
-                                                            <property name="top_attach">1</property>
-                                                            </packing>
+                                                              <object class="GtkEntry" id="txtDisableTouchCommand">
+                                                                <property name="name">txtDisableTouchCommand</property>
+                                                                <property name="visible">True</property>
+                                                                <property name="can_focus">True</property>
+                                                                <property name="hexpand">True</property>
+                                                              </object>
+                                                              <packing>
+                                                                <property name="left_attach">1</property>
+                                                                <property name="top_attach">1</property>
+                                                              </packing>
                                                             </child>
                                                             <child>
-                                                            <object class="GtkButton" id="btTestEnable">
-                                                            <property name="label" translatable="yes">Test</property>
-                                                            <property name="name">btTestEnable</property>
-                                                            <property name="visible">True</property>
-                                                            <property name="can_focus">True</property>
-                                                            <property name="receives_default">True</property>
-                                                            </object>
-                                                            <packing>
-                                                            <property name="left_attach">2</property>
-                                                            <property name="top_attach">0</property>
-                                                            </packing>
+                                                              <object class="GtkButton" id="btTestEnable">
+                                                                <property name="label" translatable="yes">Test</property>
+                                                                <property name="name">btTestEnable</property>
+                                                                <property name="visible">True</property>
+                                                                <property name="can_focus">True</property>
+                                                                <property name="receives_default">True</property>
+                                                              </object>
+                                                              <packing>
+                                                                <property name="left_attach">2</property>
+                                                                <property name="top_attach">0</property>
+                                                              </packing>
                                                             </child>
                                                             <child>
-                                                            <object class="GtkButton" id="btTestDisable">
-                                                            <property name="label" translatable="yes">Test</property>
-                                                            <property name="name">btTestDisable</property>
-                                                            <property name="visible">True</property>
-                                                            <property name="can_focus">True</property>
-                                                            <property name="receives_default">True</property>
-                                                            </object>
-                                                            <packing>
-                                                            <property name="left_attach">2</property>
-                                                            <property name="top_attach">1</property>
-                                                            </packing>
+                                                              <object class="GtkButton" id="btTestDisable">
+                                                                <property name="label" translatable="yes">Test</property>
+                                                                <property name="name">btTestDisable</property>
+                                                                <property name="visible">True</property>
+                                                                <property name="can_focus">True</property>
+                                                                <property name="receives_default">True</property>
+                                                              </object>
+                                                              <packing>
+                                                                <property name="left_attach">2</property>
+                                                                <property name="top_attach">1</property>
+                                                              </packing>
                                                             </child>
                                                           </object>
                                                           <packing>
@@ -2519,7 +2519,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                               </packing>
                                             </child>
                                             <child>
-                                              <placeholder/>
+                                              <placeholder />
                                             </child>
                                           </object>
                                           <packing>
@@ -3104,7 +3104,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                                 <property name="can_focus">False</property>
                                                 <property name="orientation">vertical</property>
                                                 <child>
-                                                  <placeholder/>
+                                                  <placeholder />
                                                 </child>
                                               </object>
                                               <packing>
@@ -3435,93 +3435,122 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                     <property name="left_padding">12</property>
                                     <property name="right_padding">12</property>
                                     <child>
-                                      <object class="GtkGrid" id="sid148">
+                                      <object class="GtkBox" id="box51">
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
-                                        <property name="row_spacing">5</property>
-                                        <property name="column_spacing">5</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="spacing">6</property>
                                         <child>
-                                          <object class="GtkLabel" id="lbSnapRotationTolerance">
-                                            <property name="name">lbSnapRotationTolerance</property>
+                                          <object class="GtkGrid" id="sid148">
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Rotation snapping tolerance</property>
-                                            <property name="xalign">0</property>
+                                            <property name="row_spacing">5</property>
+                                            <property name="column_spacing">5</property>
+                                            <child>
+                                              <object class="GtkLabel" id="lbSnapRotationTolerance">
+                                                <property name="name">lbSnapRotationTolerance</property>
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="label" translatable="yes">Rotation snapping tolerance</property>
+                                                <property name="xalign">0</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left_attach">0</property>
+                                                <property name="top_attach">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel" id="lbSnapGridTolerance">
+                                                <property name="name">lbSnapGridTolerance</property>
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="label" translatable="yes">Grid snapping tolerance</property>
+                                                <property name="xalign">0</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left_attach">0</property>
+                                                <property name="top_attach">1</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSpinButton" id="spSnapRotationTolerance">
+                                                <property name="name">spSnapRotationTolerance</property>
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="adjustment">adjustmentSnapRotationTolerance</property>
+                                                <property name="climb_rate">0.050000000000000003</property>
+                                                <property name="digits">2</property>
+                                                <property name="value">0.20000000000000001</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left_attach">1</property>
+                                                <property name="top_attach">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSpinButton" id="spSnapGridTolerance">
+                                                <property name="name">spSnapGridTolerance</property>
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="adjustment">adjustmentSnapGridTolerance</property>
+                                                <property name="climb_rate">0.050000000000000003</property>
+                                                <property name="digits">2</property>
+                                                <property name="value">0.25</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left_attach">1</property>
+                                                <property name="top_attach">1</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel" id="lbSnapGridSize">
+                                                <property name="name">lbSnapGridSize</property>
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="label" translatable="yes">Grid size</property>
+                                                <property name="xalign">0</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left_attach">0</property>
+                                                <property name="top_attach">2</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSpinButton" id="spSnapGridSize">
+                                                <property name="name">spSnapGridSize</property>
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="adjustment">adjustmentSnapGridSize</property>
+                                                <property name="climb_rate">0.01</property>
+                                                <property name="digits">2</property>
+                                                <property name="value">1</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left_attach">1</property>
+                                                <property name="top_attach">2</property>
+                                              </packing>
+                                            </child>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">0</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkLabel" id="lbSnapGridTolerance">
-                                            <property name="name">lbSnapGridTolerance</property>
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Grid snapping tolerance</property>
-                                            <property name="xalign">0</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left_attach">0</property>
-                                            <property name="top_attach">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSpinButton" id="spSnapRotationTolerance">
-                                            <property name="name">spSnapRotationTolerance</property>
+                                          <object class="GtkCheckButton" id="cbSnapRecognizedShapesEnabled">
+                                            <property name="label" translatable="yes">Use snapping for recognized shapes</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
-                                            <property name="adjustment">adjustmentSnapRotationTolerance</property>
-                                            <property name="climb_rate">0.050000000000000003</property>
-                                            <property name="digits">2</property>
-                                            <property name="value">0.20000000000000001</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSpinButton" id="spSnapGridTolerance">
-                                            <property name="name">spSnapGridTolerance</property>
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="adjustment">adjustmentSnapGridTolerance</property>
-                                            <property name="climb_rate">0.050000000000000003</property>
-                                            <property name="digits">2</property>
-                                            <property name="value">0.25</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkLabel" id="lbSnapGridSize">
-                                            <property name="name">lbSnapGridSize</property>
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Grid size</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="tooltip_text" translatable="yes">If activated, shapes that have been recognized by the shape recognizer will be snapped to the grid automatically. This may lead to unexpected results if you have the shape recognizer turned on while writing.</property>
                                             <property name="xalign">0</property>
+                                            <property name="draw_indicator">True</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">0</property>
-                                            <property name="top_attach">2</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSpinButton" id="spSnapGridSize">
-                                            <property name="name">spSnapGridSize</property>
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="adjustment">adjustmentSnapGridSize</property>
-                                            <property name="climb_rate">0.01</property>
-                                            <property name="digits">2</property>
-                                            <property name="value">1</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">2</property>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
                                           </packing>
                                         </child>
                                       </object>
@@ -3627,7 +3656,57 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                               </packing>
                             </child>
                             <child>
-                              <placeholder/>
+                              <object class="GtkFrame" id="sid 155">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="margin_left">4</property>
+                                <property name="margin_top">3</property>
+                                <property name="margin_bottom">3</property>
+                                <property name="border_width">2</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
+                                <child>
+                                  <object class="GtkAlignment">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="left_padding">12</property>
+                                    <child>
+                                      <object class="GtkGrid">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <child>
+                                          <object class="GtkCheckButton" id="cbRestoreLineWidthEnabled">
+                                            <property name="label" translatable="yes">Preserve line width</property>
+                                            <property name="name">cbRestoreLineWidthEnabled</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="tooltip_markup" translatable="yes">After resizing a selection, the line width of all strokes will be the same as before the resizing operation. </property>
+                                            <property name="margin_bottom">2</property>
+                                            <property name="xalign">0</property>
+                                            <property name="draw_indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">0</property>
+                                            <property name="top_attach">0</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label">
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="label" translatable="yes">Resizing</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">4</property>
+                              </packing>
                             </child>
                             <child>
                               <object class="GtkFrame" id="sid154">
@@ -3914,7 +3993,7 @@ It must be short in time and length and we can't have ignored another stroke rec
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <child>
-                                              <placeholder/>
+                                              <placeholder />
                                             </child>
                                           </object>
                                           <packing>
@@ -3924,7 +4003,7 @@ It must be short in time and length and we can't have ignored another stroke rec
                                           </packing>
                                         </child>
                                         <child>
-                                          <placeholder/>
+                                          <placeholder />
                                         </child>
                                       </object>
                                     </child>
@@ -4431,7 +4510,7 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                 <property name="can_focus">False</property>
                 <property name="orientation">vertical</property>
                 <child>
-                  <placeholder/>
+                  <placeholder />
                 </child>
               </object>
               <packing>


### PR DESCRIPTION
This first commit implements snapping for moving selections, addressing issue #807 (and the duplicate #1972). The selection is snapped according to the the nearest corner of the reduced bounding box (discarding padding and stroke width). This still needs some fixes (in particular for scaling/rotating objects and for selections which do not merely consist of strokes) and improvements.

I do plan to add snapping for vertical space (mentioned in issue #807).