### PR TITLE
Fix MacOS 10.13 compatibility issues (build and CI)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/find" "${PROJECT_SOURCE_DIR}/
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+set_directory_properties(PROPERTIES EP_BASE "${PROJECT_BINARY_DIR}/external")
 
 add_definitions(-D_USE_MATH_DEFINES)
 
@@ -77,7 +78,7 @@ macro(add_includes_ldflags LDFLAGS INCLUDES)
 endmacro (add_includes_ldflags LDFLAGS INCLUDES)
 
 find_package(CXX17 REQUIRED COMPONENTS optional)
-find_package(Filesystem REQUIRED COMPONENTS Boost Final Experimental)
+find_package(Filesystem REQUIRED COMPONENTS ghc Final Experimental)
 
 # libexec
 if (WIN32)
@@ -319,6 +320,7 @@ message("
 Configuration:
 	Compiler:                   ${CMAKE_CXX_COMPILER}
 	CppUnit enabled:            ${ENABLE_CPPUNIT}
+	Filesystem library:         ${CXX_FILESYSTEM_NAMESPACE}
 ")
 
 option(CMAKE_DEBUG_INCLUDES_LDFLAGS "List include dirs and ldflags for xournalpp target" OFF)

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -43,7 +43,7 @@ stages:
             name: 'VersionRelease'
             displayName: 'Set Version Information for Release'
             workingDirectory: ./build
-            condition: and(ne(variables['Build.Reason'], 'Schedule'), ne(variables['runForRelease'], 'False')) # Run for non-scheduled (release)
+            condition: or(eq(variables['Build.Reason'], 'IndividualCI'), ne(variables['runForRelease'], 'False')) # Run for non-scheduled (release)
   - stage: Release
     jobs:
       - job: 'Ubuntu'

--- a/azure-pipelines/steps/build_mac.yml
+++ b/azure-pipelines/steps/build_mac.yml
@@ -34,16 +34,6 @@ steps:
       unzip ninja-mac.zip -d /Users/git-bin/gtk/inst/bin
     displayName: 'Get Ninja'
   - bash: |
-      set -e
-      # Using SourceForge instead of bintray due to boostorg/boost#299
-      curl -L -o boost_1_72_0.tar.gz https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.tar.gz/download
-      tar -xzf boost_1_72_0.tar.gz
-      cd boost_1_72_0
-      ./bootstrap.sh --prefix=/usr/local/boost-1.72.0
-      sudo ./b2 cxxflags="-std=c++17" --with-system --with-filesystem variant=release link=static threading=multi install
-      export DYLD_LIBRARY_PATH=/usr/local/boost-1.72.0/lib:$DYLD_LIBRARY_PATH
-    displayName: 'Build boost'
-  - bash: |
       export PATH="$HOME/.local/bin:/Users/git-bin/gtk/inst/bin:$PATH"
       cmake -GNinja -DCMAKE_INSTALL_PREFIX:PATH=/Users/git-bin/gtk/inst .. -DCMAKE_BUILD_TYPE=${{ parameters.build_type }} ${{ parameters.cmake_flags }}
       # Make sure pot is up to date with sources (maybe translation pipeline is currently running)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -84,6 +84,7 @@ unset (xournalpp_SOURCES_RECURSE)
 add_library (xournalpp-core OBJECT ${xournalpp_SOURCES})
 add_dependencies (xournalpp-core util)
 target_compile_features (xournalpp-core PUBLIC ${PROJECT_CXX_FEATURES})
+target_link_libraries(xournalpp-core util)
 
 ## xournalpp main program ##
 add_executable (xournalpp

--- a/src/gui/Layout.cpp
+++ b/src/gui/Layout.cpp
@@ -109,7 +109,7 @@ void Layout::updateVisibility() {
     }
 
     if (mostPageNr) {
-        this->view->getControl()->firePageSelected(mostPageNr.value());
+        this->view->getControl()->firePageSelected(*mostPageNr);
     }
 }
 


### PR DESCRIPTION
This PR fixes the MacOS builds. Although the issues have actually been present since the forced move to MacOS 10.15 due to the Azure Pipelines update, they had not been exposed until we also updated the regular CI runner to check backwards compatibility with 10.13.

* Switch from Boost filesystem to https://github.com/gulrak/filesystem, which is mostly compliant with C++17 filesystem. Note that the supplementary filesystem library is only used if `std::filesystem` is not supported. The new library will be downloaded automatically by CMake at compile time.
* Fix some backwards compatibility issues.