### PR TITLE
Fix Adding Pages wont scroll to new page

### DIFF
--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -1229,7 +1229,7 @@ void Control::insertPage(const PageRef& page, size_t position) {
     int visibleHeight = 0;
     scrollHandler->isPageVisible(position, &visibleHeight);
 
-    if (visibleHeight < 10) {
+    if (visibleHeight < 100) {
         Util::execInUiThread([=]() { scrollHandler->scrollToPage(position); });
     }
     firePageSelected(position);

--- a/src/gui/XournalView.cpp
+++ b/src/gui/XournalView.cpp
@@ -567,7 +567,10 @@ void XournalView::pageInserted(size_t page) {
     viewPages.insert(begin(viewPages) + page, pageView);
 
     Layout* layout = gtk_xournal_get_layout(this->widget);
+    GtkAllocation allocation;
+    gtk_widget_get_allocation(this->widget, &allocation);
     layout->recalculate();
+    layout->layoutPages(allocation.width, allocation.height);
     layout->updateVisibility();
 }
 


### PR DESCRIPTION
Should fix #2016
Todo inherited from https://developer.gnome.org/gtk3/stable/GtkScrollable.html#GtkScrollablePolicy :

> All scrollable widgets should do the following:
 - [ ] When a parent widget sets the scrollable child widget’s adjustments, the widget should populate the adjustments’ “lower”, “upper”, “step-increment”, “page-increment” and “page-size” properties and connect to the “value-changed” signal.
>
- [x] Because its preferred size is the size for a fully expanded widget, the scrollable widget must be able to cope with underallocations. This means that it must accept any value passed to its GtkWidgetClass.size_allocate() function.
>
- [ ] When the parent allocates space to the scrollable child widget, the widget should update the adjustments’ properties with new values.
>
- [x] When any of the adjustments emits the “value-changed” signal, the scrollable widget should scroll its contents.
