### PR TITLE
fix  bug #2038

### DIFF
--- a/src/pdf/base/XojCairoPdfExport.cpp
+++ b/src/pdf/base/XojCairoPdfExport.cpp
@@ -31,7 +31,7 @@ auto XojCairoPdfExport::startPdf(const Path& file) -> bool {
     this->cr = cairo_create(surface);
 
 #if CAIRO_VERSION >= CAIRO_VERSION_ENCODE(1, 16, 0)
-    cairo_pdf_surface_set_metadata(surface, CAIRO_PDF_METADATA_TITLE, doc->getFilename().c_str());
+    cairo_pdf_surface_set_metadata(surface, CAIRO_PDF_METADATA_TITLE, doc->getFilename().getFilename().c_str());
     GtkTreeModel* tocModel = doc->getContentsModel();
     this->populatePdfOutline(tocModel);
 #endif


### PR DESCRIPTION
As suggested by the bug reporter, the pdf title will now be without path, just the filename.