### PR TITLE
Move config directory to .config/xournalpp

### DIFF
--- a/src/control/XournalMain.cpp
+++ b/src/control/XournalMain.cpp
@@ -290,7 +290,7 @@ auto XournalMain::exportPdf(const char* input, const char* output) -> int {
 }
 
 auto XournalMain::run(int argc, char* argv[]) -> int {
-    g_set_prgname("com.github.xournalpp.xournalpp");
+    g_set_prgname("xournalpp");
     this->initLocalisation();
     MigrateResult migrateResult = this->migrateSettings();
 


### PR DESCRIPTION
Really short PR to resolve #1999 

Tested by running the app locally, got the dialog that the config directory was moved to ~/.config/xournalpp, and verified that any settings changes were reflected in this new config file location and not the old one.