### PR TITLE
Add 16kHz sample rate and fix 91kHz CB label.

### DIFF
--- a/src/gui/dialog/SettingsDialog.cpp
+++ b/src/gui/dialog/SettingsDialog.cpp
@@ -391,15 +391,18 @@ void SettingsDialog::load() {
     }
 
     switch (static_cast<int>(settings->getAudioSampleRate())) {
-        case 96100:
-            gtk_combo_box_set_active(GTK_COMBO_BOX(get("cbAudioSampleRate")), 1);
+        case 16000:
+            gtk_combo_box_set_active(GTK_COMBO_BOX(get("cbAudioSampleRate")), 0);
+            break;
+        case 96000:
+            gtk_combo_box_set_active(GTK_COMBO_BOX(get("cbAudioSampleRate")), 2);
             break;
         case 192000:
-            gtk_combo_box_set_active(GTK_COMBO_BOX(get("cbAudioSampleRate")), 2);
+            gtk_combo_box_set_active(GTK_COMBO_BOX(get("cbAudioSampleRate")), 3);
             break;
         case 44100:
         default:
-            gtk_combo_box_set_active(GTK_COMBO_BOX(get("cbAudioSampleRate")), 0);
+            gtk_combo_box_set_active(GTK_COMBO_BOX(get("cbAudioSampleRate")), 1);
             break;
     }
 
@@ -615,13 +618,16 @@ void SettingsDialog::save() {
     }
 
     switch (gtk_combo_box_get_active(GTK_COMBO_BOX(get("cbAudioSampleRate")))) {
-        case 1:
-            settings->setAudioSampleRate(96100.0);
+        case 0:
+            settings->setAudioSampleRate(16000.0);
             break;
         case 2:
+            settings->setAudioSampleRate(96000.0);
+            break;
+        case 3:
             settings->setAudioSampleRate(192000.0);
             break;
-        case 0:
+        case 1:
         default:
             settings->setAudioSampleRate(44100.0);
             break;

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -4243,8 +4243,9 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                             <property name="can_focus">False</property>
                                             <property name="active">0</property>
                                             <items>
+                                              <item id="16000">16000 Hz</item>
                                               <item id="44100">44100 Hz</item>
-                                              <item id="91000">91000 Hz</item>
+                                              <item id="96000">96000 Hz</item>
                                               <item id="192000">192000 Hz</item>
                                             </items>
                                           </object>


### PR DESCRIPTION
This commit implements the change suggested in #2091. It also changes
the unmatched combo box label value "91000" to "96100" to reflect the
integer value that the `load` settings function expects.