### PR TITLE
fix attached mode pdf saving

### DIFF
--- a/src/control/xojfile/SaveHandler.cpp
+++ b/src/control/xojfile/SaveHandler.cpp
@@ -218,8 +218,10 @@ void SaveHandler::visitPage(XmlNode* root, PageRef p, Document* doc, int id) {
 
             if (doc->isAttachPdf()) {
                 background->setAttrib("domain", "attach");
-                Path filename = Path(doc->getFilename().str() + ".bg.pdf");
-                background->setAttrib("filename", filename.str());
+                Path filename = doc->getFilename();
+                filename.clearExtensions();
+                filename += ".xopp.bg.pdf";
+                background->setAttrib("filename", "bg.pdf");
 
                 GError* error = nullptr;
                 doc->getPdfDocument().save(filename, &error);

--- a/src/model/Document.cpp
+++ b/src/model/Document.cpp
@@ -127,7 +127,8 @@ auto Document::createSaveFilename(DocumentType type, const string& defaultSaveNa
     }
     if (!pdfFilename.isEmpty()) {
         Path p = pdfFilename.getFilename();
-        p.clearExtensions();
+        std::string ext = this->attachPdf ? ".pdf" : "";
+        p.clearExtensions(ext);
         return p;
     }
 


### PR DESCRIPTION
This commit makes it possible to move pdf+xopp files into a new folder, without running into the problem that (by default) the absolute path to the pdf is saved in the xopp file. 
All you need to do is to choose "Annotate pdf" in the menu, check the "attach file to the journal" option on the bottom left of the file dialog and then save the xopp-file. If you name your xopp file `foo.xopp`, a copy of the pdf will be saved with the name `foo.xopp.bg.pdf` . You can then move both files simultaneously to another directory. You can also rename both files simultaneously to `bar.xopp` and `bar.xopp.bg.pdf`, just make sure that they only differ by the ".bg.pdf"-ending.

In the save file dialog I have stripped the suggested name for the xopp-file from the .pdf ending in "attach file to the journal" mode, since the xopp-file should only have .xopp as an ending in this mode.
