### PR TITLE
Support "no icon" stylus cursor type #2093

### DIFF
--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -1859,7 +1859,7 @@ void Control::showSettings() {
     int verticalSpaceAmount = settings->getAddVerticalSpaceAmount();
     bool horizontalSpace = settings->getAddHorizontalSpace();
     int horizontalSpaceAmount = settings->getAddHorizontalSpaceAmount();
-    bool bigCursor = settings->isShowBigCursor();
+    StylusCursorType stylusCursorType = settings->getStylusCursorType();
     bool highlightPosition = settings->isHighlightPosition();
 
     auto* dlg = new SettingsDialog(this->gladeSearchPath, settings, this);
@@ -1878,7 +1878,7 @@ void Control::showSettings() {
         scrollHandler->scrollToPage(currentPage);
     }
 
-    if (bigCursor != settings->isShowBigCursor() || highlightPosition != settings->isHighlightPosition()) {
+    if (stylusCursorType != settings->getStylusCursorType() || highlightPosition != settings->isHighlightPosition()) {
         getCursor()->updateCursor();
     }
 

--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -69,7 +69,7 @@ void Settings::loadDefault() {
     this->menubarVisible = true;
 
     this->autoloadPdfXoj = true;
-    this->showBigCursor = false;
+    this->stylusCursorType = STYLUS_CURSOR_DOT;
     this->highlightPosition = false;
     this->cursorHighlightColor = 0x80FFFF00;  // Yellow with 50% opacity
     this->cursorHighlightRadius = 30.0;
@@ -341,8 +341,8 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur) {
         this->presentationMode = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("autoloadPdfXoj")) == 0) {
         this->autoloadPdfXoj = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
-    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("showBigCursor")) == 0) {
-        this->showBigCursor = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("stylusCursorType")) == 0) {
+        this->stylusCursorType = stylusCursorTypeFromString(reinterpret_cast<const char*>(value));
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("highlightPosition")) == 0) {
         this->highlightPosition = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("cursorHighlightColor")) == 0) {
@@ -739,7 +739,9 @@ void Settings::save() {
     WRITE_STRING_PROP(presentationHideElements);
     WRITE_COMMENT("Which gui elements are hidden if you are in Presentation mode, separated by a colon (,)");
 
-    WRITE_BOOL_PROP(showBigCursor);
+    xmlNode = saveProperty("stylusCursorType", stylusCursorTypeToString(this->stylusCursorType), root);
+    WRITE_COMMENT("The cursor icon used with a stylus, allowed values are \"none\", \"dot\", \"big\"");
+
     WRITE_BOOL_PROP(highlightPosition);
     WRITE_UINT_PROP(cursorHighlightColor);
     WRITE_UINT_PROP(cursorHighlightBorderColor);
@@ -1018,15 +1020,15 @@ void Settings::setDrawDirModsRadius(int pixels) {
     save();
 }
 
+auto Settings::getStylusCursorType() const -> StylusCursorType { return this->stylusCursorType; }
 
-auto Settings::isShowBigCursor() const -> bool { return this->showBigCursor; }
-
-void Settings::setShowBigCursor(bool b) {
-    if (this->showBigCursor == b) {
+void Settings::setStylusCursorType(StylusCursorType type) {
+    if (this->stylusCursorType == type) {
         return;
     }
 
-    this->showBigCursor = b;
+    this->stylusCursorType = type;
+
     save();
 }
 

--- a/src/control/settings/Settings.h
+++ b/src/control/settings/Settings.h
@@ -22,73 +22,12 @@
 #include "model/Font.h"
 
 #include "Path.h"
+#include "SettingsEnums.h"
 
 constexpr auto DEFAULT_GRID_SIZE = 14.17;
 
-enum Buttons {
-    BUTTON_ERASER,
-    BUTTON_MIDDLE,
-    BUTTON_RIGHT,
-    BUTTON_TOUCH,
-    BUTTON_DEFAULT,
-    BUTTON_STYLUS,
-    BUTTON_STYLUS2,
-    BUTTON_COUNT
-};
-
-constexpr auto buttonToString(Buttons button) -> const char* {
-    switch (button) {
-        case BUTTON_ERASER:
-            return "eraser";
-        case BUTTON_MIDDLE:
-            return "middle";
-        case BUTTON_RIGHT:
-            return "right";
-        case BUTTON_TOUCH:
-            return "touch";
-        case BUTTON_DEFAULT:
-            return "default";
-        case BUTTON_STYLUS:
-            return "stylus";
-        case BUTTON_STYLUS2:
-            return "stylus2";
-        default:
-            return "unknown";
-    }
-}
-
-enum AttributeType {
-    ATTRIBUTE_TYPE_NONE,
-    ATTRIBUTE_TYPE_STRING,
-    ATTRIBUTE_TYPE_INT,
-    ATTRIBUTE_TYPE_DOUBLE,
-    ATTRIBUTE_TYPE_INT_HEX,
-    ATTRIBUTE_TYPE_BOOLEAN,
-};
-
-// use this as a bit flag
-enum ScrollbarHideType {
-    SCROLLBAR_HIDE_NONE = 0,
-    SCROLLBAR_HIDE_HORIZONTAL = 1 << 1,
-    SCROLLBAR_HIDE_VERTICAL = 1 << 2,
-    SCROLLBAR_HIDE_BOTH = SCROLLBAR_HIDE_HORIZONTAL | SCROLLBAR_HIDE_VERTICAL
-};
-
-/**
- * The user-selectable device types
- */
-enum class InputDeviceTypeOption {
-    Disabled = 0,
-    Mouse = 1,
-    Pen = 2,
-    Eraser = 3,
-    Touchscreen = 4,
-    MouseKeyboardCombo = 5,
-};
-
 class ButtonConfig;
 class InputDevice;
-
 
 class SAttribute {
 public:
@@ -318,8 +257,8 @@ public:
     double getSnapGridSize() const;
     void setSnapGridSize(double gridSize);
 
-    bool isShowBigCursor() const;
-    void setShowBigCursor(bool b);
+    StylusCursorType getStylusCursorType() const;
+    void setStylusCursorType(StylusCursorType stylusCursorType);
 
     bool isHighlightPosition() const;
     void setHighlightPosition(bool highlight);
@@ -546,9 +485,9 @@ private:
     bool sidebarOnRight{};
 
     /**
-     *  Show a better visible cursor for pen
+     *  Type of cursor icon to use with a stylus
      */
-    bool showBigCursor{};
+    StylusCursorType stylusCursorType;
 
     /**
      * Show a colored circle around the cursor

--- a/src/control/settings/SettingsEnums.cpp
+++ b/src/control/settings/SettingsEnums.cpp
@@ -1,0 +1,15 @@
+#include "SettingsEnums.h"
+
+auto stylusCursorTypeFromString(const string& stylusCursorTypeStr) -> StylusCursorType {
+    if (stylusCursorTypeStr == "none") {
+        return STYLUS_CURSOR_NONE;
+    }
+    if (stylusCursorTypeStr == "dot") {
+        return STYLUS_CURSOR_DOT;
+    }
+    if (stylusCursorTypeStr == "big") {
+        return STYLUS_CURSOR_BIG;
+    }
+    g_warning("Settings::Unknown stylus cursor type: %s\n", stylusCursorTypeStr.c_str());
+    return STYLUS_CURSOR_DOT;
+}

--- a/src/control/settings/SettingsEnums.h
+++ b/src/control/settings/SettingsEnums.h
@@ -1,0 +1,99 @@
+/*
+ * Xournal++
+ *
+ * Enum definition used for tools
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "XournalType.h"
+
+enum Buttons {
+    BUTTON_ERASER,
+    BUTTON_MIDDLE,
+    BUTTON_RIGHT,
+    BUTTON_TOUCH,
+    BUTTON_DEFAULT,
+    BUTTON_STYLUS,
+    BUTTON_STYLUS2,
+    BUTTON_COUNT
+};
+
+enum AttributeType {
+    ATTRIBUTE_TYPE_NONE,
+    ATTRIBUTE_TYPE_STRING,
+    ATTRIBUTE_TYPE_INT,
+    ATTRIBUTE_TYPE_DOUBLE,
+    ATTRIBUTE_TYPE_INT_HEX,
+    ATTRIBUTE_TYPE_BOOLEAN,
+};
+
+// use this as a bit flag
+enum ScrollbarHideType {
+    SCROLLBAR_HIDE_NONE = 0,
+    SCROLLBAR_HIDE_HORIZONTAL = 1 << 1,
+    SCROLLBAR_HIDE_VERTICAL = 1 << 2,
+    SCROLLBAR_HIDE_BOTH = SCROLLBAR_HIDE_HORIZONTAL | SCROLLBAR_HIDE_VERTICAL
+};
+
+/**
+ * The user-selectable device types
+ */
+enum class InputDeviceTypeOption {
+    Disabled = 0,
+    Mouse = 1,
+    Pen = 2,
+    Eraser = 3,
+    Touchscreen = 4,
+    MouseKeyboardCombo = 5,
+};
+
+enum StylusCursorType {
+    STYLUS_CURSOR_NONE = 0,
+    STYLUS_CURSOR_DOT = 1,
+    STYLUS_CURSOR_BIG = 2,
+};
+
+constexpr auto buttonToString(Buttons button) -> const char* {
+    switch (button) {
+        case BUTTON_ERASER:
+            return "eraser";
+        case BUTTON_MIDDLE:
+            return "middle";
+        case BUTTON_RIGHT:
+            return "right";
+        case BUTTON_TOUCH:
+            return "touch";
+        case BUTTON_DEFAULT:
+            return "default";
+        case BUTTON_STYLUS:
+            return "stylus";
+        case BUTTON_STYLUS2:
+            return "stylus2";
+        default:
+            return "unknown";
+    }
+}
+
+constexpr auto stylusCursorTypeToString(StylusCursorType stylusCursorType) -> const char* {
+    switch (stylusCursorType) {
+        case STYLUS_CURSOR_NONE:
+            return "none";
+        case STYLUS_CURSOR_DOT:
+            return "dot";
+        case STYLUS_CURSOR_BIG:
+            return "big";
+        default:
+            return "unknown";
+    }
+}
+
+StylusCursorType stylusCursorTypeFromString(const string& stylusCursorTypeStr);

--- a/src/gui/XournalppCursor.cpp
+++ b/src/gui/XournalppCursor.cpp
@@ -344,6 +344,10 @@ auto XournalppCursor::getHighlighterCursor() -> GdkCursor* {
 
 
 auto XournalppCursor::getPenCursor() -> GdkCursor* {
+    if (control->getSettings()->getStylusCursorType() == STYLUS_CURSOR_NONE) {
+        setCursor(CRSR_BLANK_CURSOR);
+        return nullptr;
+    }
     if (this->drawDirActive) {
         return createCustomDrawDirCursor(48, this->drawDirShift, this->drawDirCtrl);
     }
@@ -357,7 +361,7 @@ auto XournalppCursor::createHighlighterOrPenCursor(int size, double alpha) -> Gd
     double r = ((rgb >> 16) & 0xff) / 255.0;
     double g = ((rgb >> 8) & 0xff) / 255.0;
     double b = (rgb & 0xff) / 255.0;
-    bool big = control->getSettings()->isShowBigCursor();
+    bool big = control->getSettings()->getStylusCursorType() == STYLUS_CURSOR_BIG;
     bool bright = control->getSettings()->isHighlightPosition();
     int height = size;
     int width = size;
@@ -484,7 +488,7 @@ void XournalppCursor::setCursor(int cursorID) {
 
 
 auto XournalppCursor::createCustomDrawDirCursor(int size, bool shift, bool ctrl) -> GdkCursor* {
-    bool big = control->getSettings()->isShowBigCursor();
+    bool big = control->getSettings()->getStylusCursorType() == STYLUS_CURSOR_BIG;
     bool bright = control->getSettings()->isHighlightPosition();
 
     int newCursorID = CRSR_DRAWDIRNONE + (shift ? 1 : 0) + (ctrl ? 2 : 0);

--- a/src/gui/dialog/SettingsDialog.h
+++ b/src/gui/dialog/SettingsDialog.h
@@ -37,6 +37,7 @@ public:
      */
     void enableWithCheckbox(const string& checkbox, const string& widget);
     void customHandRecognitionToggled();
+    void customStylusIconTypeChanged();
 
 private:
     void load();

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.2 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.18"/>
   <object class="GtkAdjustment" id="adjustmentAudioGain">
@@ -2273,7 +2273,50 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                         <property name="can_focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
-                                          <object class="GtkGrid">
+                                          <object class="GtkBox">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="spacing">5</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="label" translatable="yes">Cursor icon for pen</property>
+                                                <property name="xalign">0</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkComboBoxText" id="cbStylusCursorType">
+                                                <property name="name">cbStylusCursorType</property>
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="active">0</property>
+                                                <items>
+                                                  <item id="none" translatable="yes" context="stylus cursor uses no icon">No icon</item>
+                                                  <item id="dot" translatable="yes" context="stylus cursor uses a small dot">Small dot icon</item>
+                                                  <item id="big" translatable="yes" context="stylus cursor uses a big pen icon">Big pen icon</item>
+                                                </items>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">1</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkGrid" id="highlightCursorGrid">
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="column_homogeneous">True</property>
@@ -2478,21 +2521,6 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                             <child>
                                               <placeholder/>
                                             </child>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkCheckButton" id="cbBigCursor">
-                                            <property name="label" translatable="yes">Big cursor for pen</property>
-                                            <property name="name">cbBigCursor</property>
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="draw_indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -3489,7 +3517,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                             <property name="adjustment">adjustmentSnapGridSize</property>
                                             <property name="climb_rate">0.01</property>
                                             <property name="digits">2</property>
-                                            <property name="value">1.00</property>
+                                            <property name="value">1</property>
                                           </object>
                                           <packing>
                                             <property name="left_attach">1</property>


### PR DESCRIPTION
# Purpose

Support a "no icon" cursor type for stylus use for a more "like paper and pen" experience with less distraction.

See issue #2093

# Implementation

I have replaced the `showBigCursor` boolean setting with a `stylusCursorType` enum and updated the settings and preference pages.

- Followed the settings config for `scrollbarHideType`
  - used toString/fromString methods to avoid repetition of constants
  - saved the setting as text rather than an int to be readable
  - add an xml comment for the available options
- Followed the ui config for `cbAudioSampleRate`
- Followed the dialog layout for the stylus screen
  - used a frame and full width combo
  - I have copied the alignment
- Replaced use `showBigCursor` cursor with an enum
- Defaulted the enum to the current DOT cursor
- I have run git-clang-format

# Testing

I have tested:
- tool modes: pen, highlight, shapes, stroke-recogniser
- changing the setting and ensuring it is saved/loaded properly

# Queries:

- I haven't done anything to patch older settings files so if someone has chosen "big cursor" settings, it will be reset to a dot
- I would personally define things like combo-box indices and view ids as constants but chose to follow similar code elsewhere to be consistent
- I don't throw any type of error if the xml cursor type setting isn't valid, I just silently default to a dot. Maybe add a log message?
- I have no `.glade` experience so just copying what I see for other settings
- You may have a preferred location of the enum toString/fromString functions I have added in Settings.h
- I didn't think `strcmp` was advisable but it's used elsewhere so I have been consistent
  