### PR TITLE
Add "Show toolbars" menu toggle item bound to F9

### DIFF
--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -62,6 +62,8 @@ void Settings::loadDefault() {
     this->showSidebar = true;
     this->sidebarWidth = 150;
 
+    this->showToolbar = true;
+
     this->sidebarOnRight = false;
 
     this->scrollbarOnLeft = false;
@@ -311,6 +313,8 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur) {
         this->mainWndHeight = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("maximized")) == 0) {
         this->maximized = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("showToolbar")) == 0) {
+        this->showToolbar = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("showSidebar")) == 0) {
         this->showSidebar = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("sidebarWidth")) == 0) {
@@ -716,6 +720,8 @@ void Settings::save() {
     WRITE_INT_PROP(mainWndWidth);
     WRITE_INT_PROP(mainWndHeight);
     WRITE_BOOL_PROP(maximized);
+
+    WRITE_BOOL_PROP(showToolbar);
 
     WRITE_BOOL_PROP(showSidebar);
     WRITE_INT_PROP(sidebarWidth);
@@ -1410,6 +1416,16 @@ void Settings::setSidebarVisible(bool visible) {
         return;
     }
     this->showSidebar = visible;
+    save();
+}
+
+auto Settings::isToolbarVisible() const -> bool { return this->showToolbar; }
+
+void Settings::setToolbarVisible(bool visible) {
+    if (this->showToolbar == visible) {
+        return;
+    }
+    this->showToolbar = visible;
     save();
 }
 

--- a/src/control/settings/Settings.h
+++ b/src/control/settings/Settings.h
@@ -179,6 +179,9 @@ public:
     bool isSidebarVisible() const;
     void setSidebarVisible(bool visible);
 
+    bool isToolbarVisible() const;
+    void setToolbarVisible(bool visible);
+
     int getSidebarWidth() const;
     void setSidebarWidth(int width);
 
@@ -473,6 +476,11 @@ private:
      *  If the sidebar is visible
      */
     bool showSidebar{};
+
+    /**
+     *  If the sidebar is visible
+     */
+    bool showToolbar{};
 
     /**
      *  The Width of the Sidebar

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -92,8 +92,13 @@ MainWindow::MainWindow(GladeSearchpath* gladeSearchPath, Control* control):
 
     createToolbarAndMenu();
 
+    setToolbarVisible(control->getSettings()->isToolbarVisible());
+
     GtkWidget* menuViewSidebarVisible = get("menuViewSidebarVisible");
     g_signal_connect(menuViewSidebarVisible, "toggled", G_CALLBACK(viewShowSidebar), this);
+
+    GtkWidget* menuViewToolbarsVisible = get("menuViewToolbarsVisible");
+    g_signal_connect(menuViewToolbarsVisible, "toggled", G_CALLBACK(viewShowToolbar), this);
 
     updateScrollbarSidebarPosition();
 
@@ -376,6 +381,14 @@ void MainWindow::viewShowSidebar(GtkCheckMenuItem* checkmenuitem, MainWindow* wi
     win->setSidebarVisible(a);
 }
 
+void MainWindow::viewShowToolbar(GtkCheckMenuItem* checkmenuitem, MainWindow* win) {
+    bool showToolbar = gtk_check_menu_item_get_active(checkmenuitem);
+    if (win->control->getSettings()->isToolbarVisible() == showToolbar) {
+        return;
+    }
+    win->setToolbarVisible(showToolbar);
+}
+
 auto MainWindow::getControl() -> Control* { return control; }
 
 void MainWindow::updateScrollbarSidebarPosition() {
@@ -479,6 +492,18 @@ void MainWindow::setSidebarVisible(bool visible) {
     }
 
     GtkWidget* w = get("menuViewSidebarVisible");
+    gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(w), visible);
+}
+
+void MainWindow::setToolbarVisible(bool visible) {
+    Settings* settings = control->getSettings();
+
+    settings->setToolbarVisible(visible);
+    for (int i = 0; i < TOOLBAR_DEFINITIONS_LEN; i++) {
+        gtk_widget_set_visible(this->toolbarWidgets[i], visible);
+    }
+
+    GtkWidget* w = get("menuViewToolbarsVisible");
     gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(w), visible);
 }
 

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -69,6 +69,7 @@ public:
     XournalView* getXournal();
 
     void setSidebarVisible(bool visible);
+    void setToolbarVisible(bool visible);
 
     Control* getControl();
 
@@ -121,6 +122,11 @@ private:
      * Sidebar show / hidden
      */
     static void viewShowSidebar(GtkCheckMenuItem* checkmenuitem, MainWindow* win);
+
+    /**
+     * Toolbar show / hidden
+     */
+    static void viewShowToolbar(GtkCheckMenuItem* checkmenuitem, MainWindow* win);
 
     /**
      * Window close Button is pressed

--- a/ui/main.glade
+++ b/ui/main.glade
@@ -505,6 +505,22 @@
                           </object>
                         </child>
                         <child>
+                          <object class="GtkCheckMenuItem" id="menuViewToolbarsVisible">
+                            <property name="name">menuViewToolbarsVisible</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">Show toolbars</property>
+                            <property name="use_underline">True</property>
+                            <accelerator key="F9" signal="activate"/>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkSeparatorMenuItem" id="menuViewToolbarsVisibleSeparator">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                          </object>
+                        </child>
+                        <child>
                           <object class="GtkMenuItem" id="menuitemLayout">
                             <property name="name">menuitemLayout</property>
                             <property name="visible">True</property>


### PR DESCRIPTION
# Purpose

This is a suggested fix for #2074 to hide toolbars as easily as other screen furniture. It is based on the toggle menu item for hiding the sidebar and bound to the F9 accelerator.

# Queries 

- I have cached the currently visible toolbar as `ToolbarData* lastToolbar`. I don't know the implications of storing that (e.g. could it become invalidated?) or where it should best be kept. Could just store the id if necessary.
- Unlike the `show sidebar` I haven't created a persistent setting for hidden toolbars
- It's kind of odd that menu accelerators no longer work if you hide menus
- I think it would be neater to have _Zen Mode_ to disable toolbars/menu/side-bar in one step
- If this is accepted, we can also remove the `Empty Toolbar` toolbar type which I find a bit weird