### PR TITLE
fix crash after selecting object from other  layer

### DIFF
--- a/src/gui/PageViewFindObjectHelper.h
+++ b/src/gui/PageViewFindObjectHelper.h
@@ -35,12 +35,8 @@ public:
         view->xournal->getControl()->clearSelection();
         matchRect = {gint(x - 10), gint(y - 10), 20, 20};
 
-        for (Layer* l: *view->page->getLayers()) {
-            if (view->page->isLayerVisible(l)) {
-                return checkLayer(l);
-            }
-        }
-        return false;
+        Layer* layer = this->view->getPage()->getSelectedLayer();
+        return checkLayer(layer);
     }
 
 protected:


### PR DESCRIPTION
The code used for selecting an object was flawed. Apparently the idea was to allow selecting an object on all visible layers, but in reality only the first visible layer was checked. I think it makes more sense to only allow selecting objects from the currently selected layer. This explains my fix. The PR fixes #2081 and avoids the "selection-crash" examined in #2133.