### PR TITLE
Debian packaging improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -346,7 +346,7 @@ set (CPACK_DEBIAN_PACKAGE_HOMEPAGE ${PACKAGE_URL})
 set (CPACK_DEBIAN_PACKAGE_MAINTAINER "Andreas Butti <andreasbutti@gmail.com>")
 set (CPACK_DEBIAN_PACKAGE_SECTION "graphics")
 set (CPACK_DEBIAN_PACKAGE_DEPENDS
-		"libglib2.0-0 (>= 2.32), libgtk-3-0 (>= 3.18), libpoppler-glib8 (>= 0.41.0), libxml2 (>= 2.0.0), libportaudiocpp0 (>= 12), libsndfile1 (>= 1.0.25), liblua5.3-0, libzip4 (>= 1.0.1) | libzip5, zlib1g")
+		"libglib2.0-0 (>= 2.32), libgtk-3-0 (>= 3.18), libpoppler-glib8 (>= 0.41.0), libxml2 (>= 2.0.0), libportaudiocpp0 (>= 12), libsndfile1 (>= 1.0.25), liblua5.3-0, libzip4 (>= 1.0.1) | libzip5, zlib1g, libc6")
 set (CPACK_DEBIAN_PACKAGE_SUGGESTS "texlive-base, texlive-latex-extra")  # Latex tool
 # Use debian's arch scheme; we only care about x86/amd64 for now but feel free to add more
 if (${PACKAGE_ARCH} STREQUAL "x86_64")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,6 +336,35 @@ endif (CMAKE_DEBUG_INCLUDES_LDFLAGS)
 set (CPACK_OUTPUT_FILE_PREFIX packages)
 set (CPACK_PACKAGE_NAME "${PROJECT_PACKAGE}")
 set (CPACK_PACKAGE_DESCRIPTION_SUMMARY "Xournal++ - Open source hand note-taking program")
+set (CPACK_DEBIAN_PACKAGE_DESCRIPTION 
+"Xournal++ is a hand note taking software written in C++ with the target of 
+flexibility, functionality and speed. Stroke recognizer and other parts are 
+based on Xournal Code, which you can find at sourceforge. 
+It supports Linux (e.g. Ubuntu, Debian, Arch, SUSE), macOS and Windows 10. 
+Supports pen input from devices such as Wacom Tablets.
+
+Xournal++ features:
+
+ - Support for Pen preassure, e.g. Wacom Tablet
+ - Support for annotating PDFs
+ - Fill shape functionality
+ - PDF Export (with and without paper style)
+ - PNG Export (with and without transparent background)
+ - Allows maping different tools/colors etc. to stylus/mouse buttons
+ - Sidebar with Page Previews with page sorting, PDF Bookmarks and Layers
+ - Enhanced support for image insertion
+ - Eraser with multiple configurations
+ - LaTeX support (requires a working LaTeX install)
+ - Bug reporting, autosave, and auto backup tools
+ - Customizeable toolbar, with multiple configurations
+ - Page Template definitions
+ - Shape drawing (line, arrow, circle, rect)
+ - Shape resizing and rotation
+ - Rotation snapping every 45 degrees
+ - Rect snapping to grid
+ - Audio recording and playback alongside with handwritten notes
+ - Multi Language Support, English, German, Italian ...
+ - Plugins using LUA Scripting")
 set (CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/LICENSE")
 set (CPACK_PACKAGE_INSTALL_DIRECTORY "Xournal++")
 set (CPACK_PACKAGE_FILE_NAME "xournalpp-${PROJECT_VERSION}-${DISTRO_NAME}-${DISTRO_CODENAME}-${PACKAGE_ARCH}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -382,6 +382,16 @@ if (${PACKAGE_ARCH} STREQUAL "x86_64")
 	set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "amd64")
 endif()
 
+if(CPACK_GENERATOR STREQUAL "DEB")
+	message("Preparing documentation for DEB package")
+	add_custom_target(package_docummentation ALL)
+
+	#Compress changelog and save it as share/doc/xournalpp/changelog.Debian.gz
+	add_custom_command(TARGET package_docummentation PRE_BUILD
+	COMMAND gzip -c -9 -n "${PROJECT_SOURCE_DIR}/debian/changelog" > "changelog.Debian.gz" VERBATIM)
+	install(FILES "${CMAKE_CURRENT_BINARY_DIR}/changelog.Debian.gz" DESTINATION "share/doc/xournalpp/")
+endif()
+
 if (NOT DEFINED CPACK_GENERATOR)
 	set(CPACK_GENERATOR "TGZ")
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,35 +336,7 @@ endif (CMAKE_DEBUG_INCLUDES_LDFLAGS)
 set (CPACK_OUTPUT_FILE_PREFIX packages)
 set (CPACK_PACKAGE_NAME "${PROJECT_PACKAGE}")
 set (CPACK_PACKAGE_DESCRIPTION_SUMMARY "Xournal++ - Open source hand note-taking program")
-set (CPACK_DEBIAN_PACKAGE_DESCRIPTION 
-"Xournal++ is a hand note taking software written in C++ with the target of 
-flexibility, functionality and speed. Stroke recognizer and other parts are 
-based on Xournal Code, which you can find at sourceforge. 
-It supports Linux (e.g. Ubuntu, Debian, Arch, SUSE), macOS and Windows 10. 
-Supports pen input from devices such as Wacom Tablets.
-
-Xournal++ features:
-
- - Support for Pen preassure, e.g. Wacom Tablet
- - Support for annotating PDFs
- - Fill shape functionality
- - PDF Export (with and without paper style)
- - PNG Export (with and without transparent background)
- - Allows maping different tools/colors etc. to stylus/mouse buttons
- - Sidebar with Page Previews with page sorting, PDF Bookmarks and Layers
- - Enhanced support for image insertion
- - Eraser with multiple configurations
- - LaTeX support (requires a working LaTeX install)
- - Bug reporting, autosave, and auto backup tools
- - Customizeable toolbar, with multiple configurations
- - Page Template definitions
- - Shape drawing (line, arrow, circle, rect)
- - Shape resizing and rotation
- - Rotation snapping every 45 degrees
- - Rect snapping to grid
- - Audio recording and playback alongside with handwritten notes
- - Multi Language Support, English, German, Italian ...
- - Plugins using LUA Scripting")
+file(READ "${PROJECT_SOURCE_DIR}/debian/package_description" CPACK_DEBIAN_PACKAGE_DESCRIPTION)
 set (CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/LICENSE")
 set (CPACK_PACKAGE_INSTALL_DIRECTORY "Xournal++")
 set (CPACK_PACKAGE_FILE_NAME "xournalpp-${PROJECT_VERSION}-${DISTRO_NAME}-${DISTRO_CODENAME}-${PACKAGE_ARCH}")

--- a/debian/package_description
+++ b/debian/package_description
@@ -1,0 +1,28 @@
+Xournal++ is a hand note taking software written in C++ with the target of 
+flexibility, functionality and speed. Stroke recognizer and other parts are 
+based on Xournal Code, which you can find at sourceforge. 
+It supports Linux (e.g. Ubuntu, Debian, Arch, SUSE), macOS and Windows 10. 
+Supports pen input from devices such as Wacom Tablets.
+
+Xournal++ features:
+
+ - Support for Pen preassure, e.g. Wacom Tablet
+ - Support for annotating PDFs
+ - Fill shape functionality
+ - PDF Export (with and without paper style)
+ - PNG Export (with and without transparent background)
+ - Allows maping different tools/colors etc. to stylus/mouse buttons
+ - Sidebar with Page Previews with page sorting, PDF Bookmarks and Layers
+ - Enhanced support for image insertion
+ - Eraser with multiple configurations
+ - LaTeX support (requires a working LaTeX install)
+ - Bug reporting, autosave, and auto backup tools
+ - Customizeable toolbar, with multiple configurations
+ - Page Template definitions
+ - Shape drawing (line, arrow, circle, rect)
+ - Shape resizing and rotation
+ - Rotation snapping every 45 degrees
+ - Rect snapping to grid
+ - Audio recording and playback alongside with handwritten notes
+ - Multi Language Support, English, German, Italian ...
+ - Plugins using LUA Scripting


### PR DESCRIPTION
Everything is done according to Debian guidelines and  informations printed by `lintian`

lintian report for currently available packages:
```
E: xournalpp: debian-changelog-file-missing
E: xournalpp: extended-description-is-empty
E: xournalpp: missing-dependency-on-libc needed by usr/bin/xournal-thumbnailer and 1 others
E: xournalpp: no-copyright-file
E: xournalpp: unstripped-binary-or-object usr/bin/xournalpp

W: xournalpp: binary-without-manpage usr/bin/xournal-thumbnailer
W: xournalpp: binary-without-manpage usr/bin/xournalpp
W: xournalpp: script-not-executable usr/share/xournalpp/ui/icons/hicolor/update-icon-cache.sh
W: xournalpp: script-not-executable usr/share/xournalpp/ui/iconsDark/hicolor/update-icon-cache.sh
```
lintian report after these patches:
```
E: xournalpp: latest-changelog-entry-without-new-date
E: xournalpp: no-copyright-file
E: xournalpp: unstripped-binary-or-object usr/bin/xournalpp

W: xournalpp: binary-without-manpage usr/bin/xournalpp
W: xournalpp: binary-without-manpage usr/bin/xournalpp-thumbnailer
W: xournalpp: non-standard-dir-perm usr/ 0775 != 0755
W: xournalpp: non-standard-dir-perm usr/bin/ 0775 != 0755
W: xournalpp: non-standard-dir-perm usr/share/ 0775 != 0755
W: xournalpp: non-standard-dir-perm ... use --no-tag-display-limit to see all (or pipe to a file/program)
W: xournalpp: script-not-executable usr/share/xournalpp/ui/icons/hicolor/update-icon-cache.sh
W: xournalpp: script-not-executable usr/share/xournalpp/ui/iconsDark/hicolor/update-icon-cache.sh
```