### PR TITLE
Allow the user to disable cursor blinking.

### DIFF
--- a/src/gui/TextEditor.h
+++ b/src/gui/TextEditor.h
@@ -105,6 +105,7 @@ private:
     double markPosX = 0;
     double markPosY = 0;
 
+    bool cursorBlink = true;
     int cursorBlinkTime = 0;
     int cursorBlinkTimeout = 0;
     int blinkTimeout = 0;  // handler id


### PR DESCRIPTION
This uses the same setting which is also used by the built-in text entry widget.