### PR TITLE
[WIP] Lua Plugin for Handwriting recognition

### DIFF
--- a/plugins/HandwritingRecognition/Dialog.glade
+++ b/plugins/HandwritingRecognition/Dialog.glade
@@ -1,0 +1,558 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.2 -->
+<interface>
+  <requires lib="gtk+" version="3.20"/>
+  <object class="GtkDialog" id="dialog1">
+    <property name="can_focus">False</property>
+    <property name="title" translatable="yes">Text recognition tool: Settings</property>
+    <property name="resizable">False</property>
+    <property name="destroy_with_parent">True</property>
+    <property name="type_hint">dialog</property>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
+    <child internal-child="vbox">
+      <object class="GtkBox" id="mainBox">
+        <property name="can_focus">False</property>
+        <property name="margin_left">18</property>
+        <property name="margin_right">18</property>
+        <property name="margin_top">18</property>
+        <property name="margin_bottom">18</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">18</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox" id="actionButtonBox">
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton" id="btOk">
+                <property name="label" translatable="yes">Ok</property>
+                <property name="name">btn_ok</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="contentBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">18</property>
+            <child>
+              <object class="GtkFrame">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label_xalign">0</property>
+                <property name="shadow_type">none</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkImage" id="icon_selection">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="pixel_size">60</property>
+                        <property name="icon_name">text-x-generic</property>
+                        <property name="icon_size">6</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="orientation">vertical</property>
+                        <property name="spacing">6</property>
+                        <child>
+                          <object class="GtkRadioButton" id="rd_1">
+                            <property name="label" translatable="yes">on the selected layer</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="halign">start</property>
+                            <property name="draw_indicator">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkRadioButton" id="rd_2">
+                            <property name="label" translatable="yes">from the selection tool</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="halign">start</property>
+                            <property name="draw_indicator">True</property>
+                            <property name="group">rd_1</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">3</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+                <child type="label">
+                  <object class="GtkLabel" id="lbl_selection">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Recognize handwritten text</property>
+                    <attributes>
+                      <attribute name="font-desc" value="Sans Bold 10"/>
+                    </attributes>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFrame">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label_xalign">0</property>
+                <property name="shadow_type">none</property>
+                <child>
+                  <object class="GtkGrid" id="optionsGrid">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="row_spacing">6</property>
+                    <property name="column_spacing">12</property>
+                    <child>
+                      <object class="GtkLabel" id="lblChoice">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="tooltip_text" translatable="yes">The number of different suggestions returned for the recognized text.</property>
+                        <property name="halign">end</property>
+                        <property name="label" translatable="yes">Number of returns</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkComboBoxText" id="choiceEntries">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="has_entry">True</property>
+                        <property name="active_id">3</property>
+                        <items>
+                          <item id="1" translatable="yes">1</item>
+                          <item id="2" translatable="yes">2</item>
+                          <item id="3" translatable="yes">3</item>
+                          <item id="4" translatable="yes">4</item>
+                          <item id="5" translatable="yes">5</item>
+                          <item id="6" translatable="yes">6</item>
+                          <item id="7" translatable="yes">7</item>
+                          <item id="8" translatable="yes">8</item>
+                          <item id="9" translatable="yes">9</item>
+                          <item id="10" translatable="yes">10</item>
+                        </items>
+                        <child internal-child="entry">
+                          <object class="GtkEntry" id="choice">
+                            <property name="can_focus">True</property>
+                            <property name="text" translatable="yes">3</property>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkComboBoxText" id="languageEntries">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="has_entry">True</property>
+                        <property name="active_id">en</property>
+                        <items>
+                          <item id="af" translatable="yes">Afrikaans</item>
+                          <item id="sq" translatable="yes">Albanian</item>
+                          <item id="eu" translatable="yes">Basque</item>
+                          <item id="be" translatable="yes">Belarusian</item>
+                          <item id="bg" translatable="yes">Bulgarian</item>
+                          <item id="ca" translatable="yes">Catalan</item>
+                          <item id="zh_CN" translatable="yes">Chinese (Simplified)</item>
+                          <item id="zh_TW" translatable="yes">Chinese (Traditional)</item>
+                          <item id="hr" translatable="yes">Croatian</item>
+                          <item id="cs" translatable="yes">Czech</item>
+                          <item id="da" translatable="yes">Danish</item>
+                          <item id="nl" translatable="yes">Dutch</item>
+                          <item id="en" translatable="yes">English</item>
+                          <item id="et" translatable="yes">Estonian</item>
+                          <item id="fil" translatable="yes">Filipino</item>
+                          <item id="fi" translatable="yes">Finnish</item>
+                          <item id="fr" translatable="yes">French</item>
+                          <item id="gl" translatable="yes">Galician</item>
+                          <item id="de" translatable="yes">German</item>
+                          <item id="el" translatable="yes">Greek</item>
+                          <item id="ht" translatable="yes">Haitian</item>
+                          <item id="hi" translatable="yes">Hindi</item>
+                          <item id="hu" translatable="yes">Hungarian</item>
+                          <item id="is" translatable="yes">Icelandic</item>
+                          <item id="id" translatable="yes">Indonesian</item>
+                          <item id="ga" translatable="yes">Irish</item>
+                          <item id="it" translatable="yes">Italian</item>
+                          <item id="ja" translatable="yes">Japanese</item>
+                          <item id="ko" translatable="yes">Korean</item>
+                          <item id="la" translatable="yes">Latin</item>
+                          <item id="lv" translatable="yes">Latvian</item>
+                          <item id="lt" translatable="yes">Lithuanian</item>
+                          <item id="mk" translatable="yes">Macedonian</item>
+                          <item id="ms" translatable="yes">Malay</item>
+                          <item id="no" translatable="yes">Norwegian</item>
+                          <item id="pl" translatable="yes">Polish</item>
+                          <item id="pt_BR" translatable="yes">Portuguese (Brazil)</item>
+                          <item id="pt_PT" translatable="yes">Portuguese (Portugal)</item>
+                          <item id="ro" translatable="yes">Romanian</item>
+                          <item id="ru" translatable="yes">Russian</item>
+                          <item id="sr" translatable="yes">Serbian</item>
+                          <item id="Slovenian" translatable="yes">Slovak</item>
+                          <item id="es" translatable="yes">Spanish</item>
+                          <item id="sw" translatable="yes">Swahili</item>
+                          <item id="sv" translatable="yes">Swedish</item>
+                          <item id="th" translatable="yes">Thai</item>
+                          <item id="tr" translatable="yes">Turkish</item>
+                          <item id="yk" translatable="yes">Ukrainian</item>
+                          <item id="vi" translatable="yes">Vietnamese</item>
+                          <item id="cy" translatable="yes">Welsh</item>
+                        </items>
+                        <child internal-child="entry">
+                          <object class="GtkEntry" id="language">
+                            <property name="can_focus">True</property>
+                            <property name="text" translatable="yes">English</property>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="lblLanguage">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">end</property>
+                        <property name="label" translatable="yes">Language</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">0</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+                <child type="label">
+                  <object class="GtkLabel" id="lbl_options">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Further options</property>
+                    <attributes>
+                      <attribute name="font-desc" value="Sans Bold 10"/>
+                    </attributes>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFrame">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label_xalign">0</property>
+                <property name="shadow_type">none</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">center</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkImage" id="icon_warning">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="pixel_size">30</property>
+                        <property name="icon_name">dialog-warning-symbolic</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="lbl_warning">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">When pressing Ok, the selected handwritten data will be sent 
+to a google server for text recognition. 
+Do not use this functionality if you have privacy concerns.</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+                <child type="label">
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
+  <object class="GtkDialog" id="dialog2">
+    <property name="can_focus">False</property>
+    <property name="title" translatable="yes">Text recognition tool: Results</property>
+    <property name="destroy_with_parent">True</property>
+    <property name="type_hint">dialog</property>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
+    <child internal-child="vbox">
+      <object class="GtkBox">
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox">
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton" id="btBack">
+                <property name="label">gtk-go-back</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="btClipboard">
+                <property name="label" translatable="yes">Copy to Clipboard</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="btSave">
+                <property name="label">gtk-save</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="btDone">
+                <property name="label" translatable="yes">Done</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">3</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="margin_left">18</property>
+            <property name="margin_right">18</property>
+            <property name="margin_top">18</property>
+            <property name="margin_bottom">18</property>
+            <property name="spacing">12</property>
+            <child>
+              <object class="GtkNotebook" id="nb">
+                <property name="width_request">500</property>
+                <property name="height_request">200</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="hexpand">True</property>
+                <property name="vexpand">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkGrid">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="row_spacing">6</property>
+                <property name="column_spacing">6</property>
+                <child>
+                  <object class="GtkFileChooserButton" id="pickFolder">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="action">select-folder</property>
+                    <property name="title" translatable="yes"/>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkEntry" id="txtFilename">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="text" translatable="yes">Untitled.txt</property>
+                    <property name="placeholder_text" translatable="yes">(Choose file)</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="lblFilename">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="label" translatable="yes">Name</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="lblSave">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="label" translatable="yes">Save in Folder</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="checkOverwrite">
+                    <property name="label" translatable="yes">Overwrite</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">2</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/plugins/HandwritingRecognition/fetch.lua
+++ b/plugins/HandwritingRecognition/fetch.lua
@@ -1,0 +1,49 @@
+require("socket")
+local https = require("ssl.https")
+local ltn12 = require("ltn12")
+local json = require("json")
+
+function sendRequest(ink, lang, width, height)
+  local path = "https://www.google.com/inputtools/request?ime=handwriting&app=mobilesearch&cs=1&oe=UTF-8"
+  
+  local tbl = {
+    options = "enable_pre_space",
+    requests = {
+       {
+        writing_guide = {
+          writing_area_width = width,
+          writing_area_height = height
+        },
+        ink = ink,
+        language = lang
+      }
+    }
+  }
+
+  local payload = json.encode(tbl)
+
+  local response_body = { }
+
+  local res, code, response_headers, status = https.request
+  {
+    url = path,
+    method = "POST",
+    headers =
+    {
+      ["Content-Type"] = "application/json",
+      ["Content-Length"] = payload:len()
+    },
+    source = ltn12.source.string(payload),
+    sink = ltn12.sink.table(response_body)
+  }
+  local response = json.decode(response_body[1])
+  if (response[1]=="SUCCESS") then
+    local alternatives = response[2][1][2]
+    -- return lua table containing all alternatives
+    return alternatives
+  else
+    -- return error message
+    return { response[1] }
+  end
+end
+

--- a/plugins/HandwritingRecognition/fetch.lua
+++ b/plugins/HandwritingRecognition/fetch.lua
@@ -6,7 +6,10 @@ local json = require("json")
 function sendRequest(ink, lang, width, height)
   local path = "https://www.google.com/inputtools/request?ime=handwriting&app=mobilesearch&cs=1&oe=UTF-8"
 
-  if #ink > 150 then 
+  if (not ink) then
+    print("No strokes!")
+    return
+  elseif #ink > 150 then 
     print("Number of strokes N = " .. #ink .. " is greater than 150, the maximal number of strokes that can be processed. Only the first 150 strokes will be used. \n")
     ink = { table.unpack(ink, 1, 150) }
   end

--- a/plugins/HandwritingRecognition/fetch.lua
+++ b/plugins/HandwritingRecognition/fetch.lua
@@ -5,9 +5,13 @@ local json = require("json")
 
 function sendRequest(ink, lang, width, height)
   local path = "https://www.google.com/inputtools/request?ime=handwriting&app=mobilesearch&cs=1&oe=UTF-8"
-  
+
+  if #ink > 150 then 
+    print("Number of strokes N = " .. #ink .. " is greater than 150, the maximal number of strokes that can be processed. Only the first 150 strokes will be used. \n")
+    ink = { table.unpack(ink, 1, 150) }
+  end
+
   local tbl = {
-    options = "enable_pre_space",
     requests = {
        {
         writing_guide = {

--- a/plugins/HandwritingRecognition/json.lua
+++ b/plugins/HandwritingRecognition/json.lua
@@ -1,0 +1,741 @@
+-----------------------------------------------------------------------------
+-- JSON4Lua: JSON encoding / decoding / traversing support for the Lua language.
+-- json Module.
+-- Authors: Craig Mason-Jones, Egor Skriptunoff
+
+-- Version: 1.2.1
+-- 2017-05-10
+
+-- This module is released under the MIT License (MIT).
+-- Please see LICENCE.txt for details:
+-- https://github.com/craigmj/json4lua/blob/master/doc/LICENCE.txt
+--
+-- USAGE:
+-- This module exposes three functions:
+--   json.encode(obj)
+--     Accepts Lua value (table/string/boolean/number/nil/json.null/json.empty) and returns JSON string.
+--   json.decode(s)
+--     Accepts JSON (as string or as loader function) and returns Lua object.
+--   json.traverse(s, callback)
+--     Accepts JSON (as string or as loader function) and user-supplied callback function, returns nothing
+--     Traverses the JSON, sends each item to callback function, no memory-consuming Lua objects are being created.
+
+--
+-- REQUIREMENTS:
+--   Lua 5.1, Lua 5.2, Lua 5.3 or LuaJIT
+--
+-- CHANGELOG
+--   1.2.1   Now you can partially decode JSON while traversing it (callback function should return true).
+--   1.2.0   Some improvements made to be able to use this module on RAM restricted devices:
+--             To read large JSONs, you can now provide "loader function" instead of preloading whole JSON as Lua string.
+--             Added json.traverse() to traverse JSON using callback function (without creating arrays/objects in Lua).
+--             Now, instead of decoding whole JSON, you can decode its arbitrary element (e.g, array or object)
+--                by specifying the position where this element starts.
+--                In order to do that, at first you have to traverse JSON to get all positions you need.
+--           Most of the code rewritten to improve performance.
+--           Decoder now understands extended syntax beyond strict JSON standard:
+--             In arrays:
+--                trailing comma is ignored:            [1,2,3,]     -> [1,2,3]
+--                missing values are nulls:             [,,42,,]     -> [null,null,42,null]
+--             In objects:
+--                missing values are ignored:           {,,"a":42,,} -> {"a":42}
+--                unquoted identifiers are valid keys:  {a$b_5:42}   -> {"a$b_5":42}
+--           Encoder now accepts both 0-based and 1-based Lua arrays (but decoder always converts JSON arrays to 1-based Lua arrays).
+--           Some minor bugs fixed.
+--   1.1.0   Modifications made by Egor Skriptunoff, based on version 1.0.0 taken from
+--              https://github.com/craigmj/json4lua/blob/40fb13b0ec4a70e36f88812848511c5867bed857/json/json.lua.
+--           Added Lua 5.2 and Lua 5.3 compatibility.
+--           Removed Lua 5.0 compatibility.
+--           Introduced json.empty (Lua counterpart for empty JSON object)
+--           Bugs fixed:
+--              Attempt to encode Lua table {[10^9]=0} raises an out-of-memory error.
+--              Zero bytes '\0' in Lua strings are not escaped by encoder.
+--              JSON numbers with capital "E" (as in 1E+100) are not accepted by decoder.
+--              All nulls in a JSON arrays are skipped by decoder, sparse arrays could not be loaded correctly.
+--              UTF-16 surrogate pairs in JSON strings are not recognised by decoder.
+--   1.0.0   Merged Amr Hassan's changes
+--   0.9.30  Changed to MIT Licence.
+--   0.9.20  Introduction of local Lua functions for private functions (removed _ function prefix).
+--           Fixed Lua 5.1 compatibility issues.
+--           Introduced json.null to have null values in associative arrays.
+--           json.encode() performance improvement (more than 50%) through table_concat rather than ..
+--           Introduced decode ability to ignore /**/ comments in the JSON string.
+--   0.9.10  Fix to array encoding / decoding to correctly manage nil/null values in arrays.
+--   0.9.00  First release
+--
+-----------------------------------------------------------------------------
+
+-----------------------------------------------------------------------------
+-- Module declaration
+-----------------------------------------------------------------------------
+local json = {}
+
+do
+   -----------------------------------------------------------------------------
+   -- Imports and dependencies
+   -----------------------------------------------------------------------------
+   local math, string, table = require'math', require'string', require'table'
+   local math_floor, math_max, math_type = math.floor, math.max, math.type or function() end
+   local string_char, string_sub, string_find, string_match, string_gsub, string_format
+      = string.char, string.sub, string.find, string.match, string.gsub, string.format
+   local table_insert, table_remove, table_concat = table.insert, table.remove, table.concat
+   local type, tostring, pairs, assert, error = type, tostring, pairs, assert, error
+   local loadstring = loadstring or load
+
+   -----------------------------------------------------------------------------
+   -- Public functions
+   -----------------------------------------------------------------------------
+   -- function  json.encode(obj)       encodes Lua value to JSON, returns JSON as string.
+   -- function  json.decode(s, pos)    decodes JSON, returns the decoded result as Lua value (may be very memory-consuming).
+
+   --    Both functions json.encode() and json.decode() work with "special" Lua values json.null and json.empty
+   --       special Lua value  json.null    =  JSON value  null
+   --       special Lua value  json.empty   =  JSON value  {}     (empty JSON object)
+   --       regular Lua empty table         =  JSON value  []     (empty JSON array)
+
+   --    Empty JSON objects and JSON nulls require special handling upon sending (encoding).
+   --       Please make sure that you send empty JSON objects as json.empty (instead of empty Lua table).
+   --       Empty Lua tables will be encoded as empty JSON arrays, not as empty JSON objects!
+   --          json.encode( {empt_obj = json.empty, empt_arr = {}} )   -->   {"empt_obj":{},"empt_arr":[]}
+   --       Also make sure you send JSON nulls as json.null (instead of nil).
+   --          json.encode( {correct = json.null, incorrect = nil} )   -->   {"correct":null}
+
+   --    Empty JSON objects and JSON nulls require special handling upon receiving (decoding).
+   --       After receiving the result of decoding, every Lua table returned (including nested tables) should firstly
+   --       be compared with special Lua values json.empty/json.null prior to making operations on these values.
+   --       If you don't need to distinguish between empty JSON objects and empty JSON arrays,
+   --       json.empty may be replaced with newly created regular empty Lua table.
+   --          v = (v == json.empty) and {} or v
+   --       If you don't need special handling of JSON nulls, you may replace json.null with nil to make them disappear.
+   --          if v == json.null then v = nil end
+
+   -- Function  json.traverse(s, callback, pos)  traverses JSON using user-supplied callback function, returns nothing.
+   --    Traverse is useful to reduce memory usage: no memory-consuming objects are being created in Lua while traversing.
+   --    Each item found inside JSON will be sent to callback function passing the following arguments:
+   --    (path, json_type, value, pos, pos_last)
+   --       path      is array of nested JSON identifiers/indices, "path" is empty for root JSON element
+   --       json_type is one of "null"/"boolean"/"number"/"string"/"array"/"object"
+   --       value     is defined when json_type is "null"/"boolean"/"number"/"string", value == nil for "object"/"array"
+   --       pos       is 1-based index of first character of current JSON element
+   --       pos_last  is 1-based index of last character of current JSON element (defined only when "value" ~= nil)
+   -- "path" table reference is the same on each callback invocation, but its content differs every time.
+   --    Do not modify "path" array inside your callback function, use it as read-only.
+   --    Do not save reference to "path" for future use (create shallow table copy instead).
+   -- callback function should return a value, when it is invoked with argument "value" == nil
+   --    a truthy value means user wants to decode this JSON object/array and create its Lua counterpart (this may be memory-consuming)
+   --    a falsy value (or no value returned) means user wants to traverse through this JSON object/array
+   --    (returned value is ignored when callback function is invoked with value ~= nil)
+
+   -- Traverse examples:
+
+   --    json.traverse([[ 42 ]], callback)
+   --    will invoke callback 1 time:
+   --                 path        json_type  value           pos  pos_last
+   --                 ----------  ---------  --------------  ---  --------
+   --       callback( {},         "number",  42,             2,   3   )
+   --
+   --    json.traverse([[ {"a":true, "b":null, "c":["one","two"], "d":{ "e":{}, "f":[] } } ]], callback)
+   --    will invoke callback 9 times:
+   --                 path        json_type  value           pos  pos_last
+   --                 ----------  ---------  --------------  ---  --------
+   --       callback( {},         "object",  nil,            2,   nil )
+   --       callback( {"a"},      "boolean", true,           7,   10  )
+   --       callback( {"b"},      "null",    json.null,      17,  20  )   -- special Lua value for JSON null
+   --       callback( {"c"},      "array",   nil,            27,  nil )
+   --       callback( {"c", 1},   "string",  "one",          28,  32  )
+   --       callback( {"c", 2},   "string",  "two",          34,  38  )
+   --       callback( {"d"},      "object",  nil,            46,  nil )
+   --       callback( {"d", "e"}, "object",  nil,            52,  nil )
+   --       callback( {"d", "f"}, "array",   nil,            60,  nil )
+   --
+   --    json.traverse([[ {"a":true, "b":null, "c":["one","two"], "d":{ "e":{}, "f":[] } } ]], callback)
+   --    will invoke callback 9 times if callback returns true when invoked for array "c" and object "e":
+   --                 path        json_type  value           pos  pos_last
+   --                 ----------  ---------  --------------  ---  --------
+   --       callback( {},         "object",  nil,            2,   nil )
+   --       callback( {"a"},      "boolean", true,           7,   10  )
+   --       callback( {"b"},      "null",    json.null,      17,  20  )
+   --       callback( {"c"},      "array",   nil,            27,  nil )  -- this callback returned true (user wants to decode this array)
+   --       callback( {"c"},      "array",   {"one", "two"}, 27,  39  )  -- the next invocation brings the result of decoding
+   --       callback( {"d"},      "object",  nil,            46,  nil )
+   --       callback( {"d", "e"}, "object",  nil,            52,  nil )  -- this callback returned true (user wants to decode this object)
+   --       callback( {"d", "e"}, "object",  json.empty,     52,  53  )  -- the next invocation brings the result of decoding (special Lua value for empty JSON object)
+   --       callback( {"d", "f"}, "array",   nil,            60,  nil )
+
+
+   -- Both decoder functions json.decode(s) and json.traverse(s, callback) can accept JSON (argument s)
+   --    as a "loader function" instead of a string.
+   --    This function will be called repeatedly to return next parts (substrings) of JSON.
+   --    An empty string, nil, or no value returned from "loader function" means the end of JSON.
+   --    This may be useful for low-memory devices or for traversing huge JSON files.
+
+
+   --- The json.null table allows one to specify a null value in an associative array (which is otherwise
+   -- discarded if you set the value with 'nil' in Lua. Simply set t = { first=json.null }
+   local null = {"This Lua table is used to designate JSON null value, compare your values with json.null to determine JSON nulls"}
+   json.null = setmetatable(null, {
+      __tostring = function() return 'null' end
+   })
+
+   --- The json.empty table allows one to specify an empty JSON object.
+   -- To encode empty JSON array use usual empty Lua table.
+   -- Example: t = { empty_object=json.empty, empty_array={} }
+   local empty = {}
+   json.empty = setmetatable(empty, {
+      __tostring = function() return '{}' end,
+      __newindex = function() error("json.empty is an read-only Lua table", 2) end
+   })
+
+   -----------------------------------------------------------------------------
+   -- Private functions
+   -----------------------------------------------------------------------------
+   local decode
+   local decode_scanArray
+   local decode_scanConstant
+   local decode_scanNumber
+   local decode_scanObject
+   local decode_scanString
+   local decode_scanIdentifier
+   local decode_scanWhitespace
+   local encodeString
+   local isArray
+   local isEncodable
+   local isConvertibleToString
+   local isRegularNumber
+
+   -----------------------------------------------------------------------------
+   -- PUBLIC FUNCTIONS
+   -----------------------------------------------------------------------------
+   --- Encodes an arbitrary Lua object / variable.
+   -- @param   obj     Lua value (table/string/boolean/number/nil/json.null/json.empty) to be JSON-encoded.
+   -- @return  string  String containing the JSON encoding.
+   function json.encode(obj)
+      -- Handle nil and null values
+      if obj == nil or obj == null then
+         return 'null'
+      end
+
+      -- Handle empty JSON object
+      if obj == empty then
+         return '{}'
+      end
+
+      local obj_type = type(obj)
+
+      -- Handle strings
+      if obj_type == 'string' then
+         return '"'..encodeString(obj)..'"'
+      end
+
+      -- Handle booleans
+      if obj_type == 'boolean' then
+         return tostring(obj)
+      end
+
+      -- Handle numbers
+      if obj_type == 'number' then
+         assert(isRegularNumber(obj), 'numeric values Inf and NaN are unsupported')
+         return math_type(obj) == 'integer' and tostring(obj) or string_format('%.17g', obj)
+      end
+
+      -- Handle tables
+      if obj_type == 'table' then
+         local rval = {}
+         -- Consider arrays separately
+         local bArray, maxCount = isArray(obj)
+         if bArray then
+            for i = obj[0] ~= nil and 0 or 1, maxCount do
+               table_insert(rval, json.encode(obj[i]))
+            end
+         else  -- An object, not an array
+            for i, j in pairs(obj) do
+               if isConvertibleToString(i) and isEncodable(j) then
+                  table_insert(rval, '"'..encodeString(i)..'":'..json.encode(j))
+               end
+            end
+         end
+         if bArray then
+            return '['..table_concat(rval, ',')..']'
+         else
+            return '{'..table_concat(rval, ',')..'}'
+         end
+      end
+
+      error('Unable to JSON-encode Lua value of unsupported type "'..obj_type..'": '..tostring(obj))
+   end
+
+   local function create_state(s)
+      -- Argument s may be "whole JSON string" or "JSON loader function"
+      -- Returns "state" object which holds current state of reading long JSON:
+      --    part = current part (substring of long JSON string)
+      --    disp = number of bytes before current part inside long JSON
+      --    more = function to load next substring (more == nil if all substrings are already read)
+      local state = {disp = 0}
+      if type(s) == "string" then
+         -- s is whole JSON string
+         state.part = s
+      else
+         -- s is loader function
+         state.part = ""
+         state.more = s
+      end
+      return state
+   end
+
+   --- Decodes a JSON string and returns the decoded value as a Lua data structure / value.
+   -- @param   s           The string to scan (or "loader function" for getting next substring).
+   -- @param   pos         (optional) The position inside s to start scan, default = 1.
+   -- @return  Lua object  The object that was scanned, as a Lua table / string / number / boolean / json.null / json.empty.
+   function json.decode(s, pos)
+      return (decode(create_state(s), pos or 1))
+   end
+
+   --- Traverses a JSON string, sends everything to user-supplied callback function, returns nothing
+   -- @param   s           The string to scan (or "loader function" for getting next substring).
+   -- @param   callback    The user-supplied callback function which accepts arguments (path, json_type, value, pos, pos_last).
+   -- @param   pos         (optional) The position inside s to start scan, default = 1.
+   function json.traverse(s, callback, pos)
+      decode(create_state(s), pos or 1, {path = {}, callback = callback})
+   end
+
+   local function read_ahead(state, startPos)
+      -- Make sure there are at least 32 bytes read ahead
+      local endPos = startPos + 31
+      local part = state.part  -- current part (substring of "whole JSON" string)
+      local disp = state.disp  -- number of bytes before current part inside "whole JSON" string
+      local more = state.more  -- function to load next substring
+      assert(startPos > disp)
+      while more and disp + #part < endPos do
+         --  (disp + 1) ... (disp + #part)  -  we already have this segment now
+         --  startPos   ... endPos          -  we need to have this segment
+         local next_substr = more()
+         if not next_substr or next_substr == "" then
+            more = nil
+         else
+            disp, part = disp + #part, string_sub(part, startPos - disp)
+            disp, part = disp - #part, part..next_substr
+         end
+      end
+      state.disp, state.part, state.more = disp, part, more
+   end
+
+   local function get_word(state, startPos, length)
+      -- 1 <= length <= 32
+      if state.more then read_ahead(state, startPos) end
+      local idx = startPos - state.disp
+      return string_sub(state.part, idx, idx + length - 1)
+   end
+
+   local function skip_until_word(state, startPos, word)
+      -- #word < 30
+      -- returns position after that word (nil if not found)
+      repeat
+         if state.more then read_ahead(state, startPos) end
+         local part, disp = state.part, state.disp
+         local b, e = string_find(part, word, startPos - disp, true)
+         if b then
+            return disp + e + 1
+         end
+         startPos = disp + #part + 2 - #word
+      until not state.more
+   end
+
+   local function match_with_pattern(state, startPos, pattern, operation)
+      -- pattern must be
+      --    "^[some set of chars]+"
+      -- returns
+      --    matched_string, endPos   for operation "read"   (matched_string == "" if no match found)
+      --    endPos                   for operation "skip"
+      if operation == "read" then
+         local t = {}
+         repeat
+            if state.more then read_ahead(state, startPos) end
+            local part, disp = state.part, state.disp
+            local str = string_match(part, pattern, startPos - disp)
+            if str then
+               table_insert(t, str)
+               startPos = startPos + #str
+            end
+         until not str or startPos <= disp + #part
+         return table_concat(t), startPos
+      elseif operation == "skip" then
+         repeat
+            if state.more then read_ahead(state, startPos) end
+            local part, disp = state.part, state.disp
+            local b, e = string_find(part, pattern, startPos - disp)
+            if b then
+               startPos = startPos + e - b + 1
+            end
+         until not b or startPos <= disp + #part
+         return startPos
+      else
+         error("Wrong operation name")
+      end
+   end
+
+   --- Decodes a JSON string and returns the decoded value as a Lua data structure / value.
+   -- @param   state             The state of JSON reader.
+   -- @param   startPos          Starting position where the JSON string is located.
+   -- @param   traverse          (optional) table with fields "path" and "callback" for traversing JSON.
+   -- @param   decode_key        (optional) boolean flag for decoding key inside JSON object.
+   -- @return  Lua_object,int    The object that was scanned, as a Lua table / string / number / boolean / json.null / json.empty,
+   --                            and the position of the first character after the scanned JSON object.
+   function decode(state, startPos, traverse, decode_key)
+      local curChar, value, nextPos
+      startPos, curChar = decode_scanWhitespace(state, startPos)
+      if curChar == '{' and not decode_key then
+         -- Object
+         if traverse and traverse.callback(traverse.path, "object", nil, startPos, nil) then
+            -- user wants to decode this JSON object (and get it as Lua value) while traversing
+            local object, endPos = decode_scanObject(state, startPos)
+            traverse.callback(traverse.path, "object", object, startPos, endPos - 1)
+            return false, endPos
+         end
+         return decode_scanObject(state, startPos, traverse)
+      elseif curChar == '[' and not decode_key then
+         -- Array
+         if traverse and traverse.callback(traverse.path, "array", nil, startPos, nil) then
+            -- user wants to decode this JSON array (and get it as Lua value) while traversing
+            local array, endPos = decode_scanArray(state, startPos)
+            traverse.callback(traverse.path, "array", array, startPos, endPos - 1)
+            return false, endPos
+         end
+         return decode_scanArray(state, startPos, traverse)
+      elseif curChar == '"' then
+         -- String
+         value, nextPos = decode_scanString(state, startPos)
+         if traverse then
+            traverse.callback(traverse.path, "string", value, startPos, nextPos - 1)
+         end
+      elseif decode_key then
+         -- Unquoted string as key name
+         return decode_scanIdentifier(state, startPos)
+      elseif string_find(curChar, "^[%d%-]") then
+         -- Number
+         value, nextPos = decode_scanNumber(state, startPos)
+         if traverse then
+            traverse.callback(traverse.path, "number", value, startPos, nextPos - 1)
+         end
+      else
+         -- Otherwise, it must be a constant
+         value, nextPos = decode_scanConstant(state, startPos)
+         if traverse then
+            traverse.callback(traverse.path, value == null and "null" or "boolean", value, startPos, nextPos - 1)
+         end
+      end
+      return value, nextPos
+   end
+
+   -----------------------------------------------------------------------------
+   -- Internal, PRIVATE functions.
+   -- Following a Python-like convention, I have prefixed all these 'PRIVATE'
+   -- functions with an underscore.
+   -----------------------------------------------------------------------------
+
+   --- Scans an array from JSON into a Lua object
+   -- startPos begins at the start of the array.
+   -- Returns the array and the next starting position
+   -- @param   state       The state of JSON reader.
+   -- @param   startPos    The starting position for the scan.
+   -- @param   traverse    (optional) table with fields "path" and "callback" for traversing JSON.
+   -- @return  table,int   The scanned array as a table, and the position of the next character to scan.
+   function decode_scanArray(state, startPos, traverse)
+      local array = not traverse and {}  -- The return value
+      local elem_index, elem_ready, object = 1
+      startPos = startPos + 1
+      -- Infinite loop for array elements
+      while true do
+         repeat
+            local curChar
+            startPos, curChar = decode_scanWhitespace(state, startPos)
+            if curChar == ']' then
+               return array, startPos + 1
+            elseif curChar == ',' then
+               if not elem_ready then
+                  -- missing value in JSON array
+                  if traverse then
+                     table_insert(traverse.path, elem_index)
+                     traverse.callback(traverse.path, "null", null, startPos, startPos - 1)  -- empty substring: pos_last = pos - 1
+                     table_remove(traverse.path)
+                  else
+                     array[elem_index] = null
+                  end
+               end
+               elem_ready = false
+               elem_index = elem_index + 1
+               startPos = startPos + 1
+            end
+         until curChar ~= ','
+         if elem_ready then
+            error('Comma is missing in JSON array at position '..startPos)
+         end
+         if traverse then
+            table_insert(traverse.path, elem_index)
+         end
+         object, startPos = decode(state, startPos, traverse)
+         if traverse then
+            table_remove(traverse.path)
+         else
+            array[elem_index] = object
+         end
+         elem_ready = true
+      end
+   end
+
+   --- Scans for given constants: true, false or null
+   -- Returns the appropriate Lua type, and the position of the next character to read.
+   -- @param  state        The state of JSON reader.
+   -- @param  startPos     The position in the string at which to start scanning.
+   -- @return object, int  The object (true, false or json.null) and the position at which the next character should be scanned.
+   function decode_scanConstant(state, startPos)
+      local w5 = get_word(state, startPos, 5)
+      local w4 = string_sub(w5, 1, 4)
+      if w5 == "false" then
+         return false, startPos + 5
+      elseif w4 == "true" then
+         return true, startPos + 4
+      elseif w4 == "null" then
+         return null, startPos + 4
+      end
+      error('Failed to parse JSON at position '..startPos)
+   end
+
+   --- Scans a number from the JSON encoded string.
+   -- (in fact, also is able to scan numeric +- eqns, which is not in the JSON spec.)
+   -- Returns the number, and the position of the next character after the number.
+   -- @param   state        The state of JSON reader.
+   -- @param   startPos     The position at which to start scanning.
+   -- @return  number,int   The extracted number and the position of the next character to scan.
+   function decode_scanNumber(state, startPos)
+      local stringValue, endPos = match_with_pattern(state, startPos, '^[%+%-%d%.eE]+', "read")
+      local stringEval = loadstring('return '..stringValue)
+      if not stringEval then
+         error('Failed to scan number '..stringValue..' in JSON string at position '..startPos)
+      end
+      return stringEval(), endPos
+   end
+
+   --- Scans a JSON object into a Lua object.
+   -- startPos begins at the start of the object.
+   -- Returns the object and the next starting position.
+   -- @param   state       The state of JSON reader.
+   -- @param   startPos    The starting position of the scan.
+   -- @param   traverse    (optional) table with fields "path" and "callback" for traversing JSON
+   -- @return  table,int   The scanned object as a table and the position of the next character to scan.
+   function decode_scanObject(state, startPos, traverse)
+      local object, elem_ready = not traverse and empty
+      startPos = startPos + 1
+      while true do
+         repeat
+            local curChar
+            startPos, curChar = decode_scanWhitespace(state, startPos)
+            if curChar == '}' then
+               return object, startPos + 1
+            elseif curChar == ',' then
+               startPos = startPos + 1
+               elem_ready = false
+            end
+         until curChar ~= ','
+         if elem_ready then
+            error('Comma is missing in JSON object at '..startPos)
+         end
+         -- Scan the key as string or unquoted identifier such as in {"a":1,b:2}
+         local key, value
+         key, startPos = decode(state, startPos, nil, true)
+         local colon
+         startPos, colon = decode_scanWhitespace(state, startPos)
+         if colon ~= ':' then
+            error('JSON object key-value assignment mal-formed at '..startPos)
+         end
+         startPos = decode_scanWhitespace(state, startPos + 1)
+         if traverse then
+            table_insert(traverse.path, key)
+         end
+         value, startPos = decode(state, startPos, traverse)
+         if traverse then
+            table_remove(traverse.path)
+         else
+            if object == empty then
+               object = {}
+            end
+            object[key] = value
+         end
+         elem_ready = true
+      end  -- infinite loop while key-value pairs are found
+   end
+
+   --- Scans JSON string for an identifier (unquoted key name inside object)
+   -- Returns the string extracted as a Lua string, and the position after the closing quote.
+   -- @param  state        The state of JSON reader.
+   -- @param  startPos     The starting position of the scan.
+   -- @return string,int   The extracted string as a Lua string, and the next character to parse.
+   function decode_scanIdentifier(state, startPos)
+      local identifier, idx = match_with_pattern(state, startPos, '^[%w_%-%$]+', "read")
+      if identifier == "" then
+         error('JSON String decoding failed: missing key name at position '..startPos)
+      end
+      return identifier, idx
+   end
+
+   -- START SoniEx2
+   -- Initialize some things used by decode_scanString
+   -- You know, for efficiency
+   local escapeSequences = { t = "\t", f = "\f", r = "\r", n = "\n", b = "\b" }
+   -- END SoniEx2
+
+   --- Scans a JSON string from the opening quote to the end of the string.
+   -- Returns the string extracted as a Lua string, and the position after the closing quote.
+   -- @param  state        The state of JSON reader.
+   -- @param  startPos     The starting position of the scan.
+   -- @return string,int   The extracted string as a Lua string, and the next character to parse.
+   function decode_scanString(state, startPos)
+      local t, idx, surrogate_pair_started, regular_part = {}, startPos + 1
+      while true do
+         regular_part, idx = match_with_pattern(state, idx, '^[^"\\]+', "read")
+         table_insert(t, regular_part)
+         local w6 = get_word(state, idx, 6)
+         local c = string_sub(w6, 1, 1)
+         if c == '"' then
+            return table_concat(t), idx + 1
+         elseif c == '\\' then
+            local esc = string_sub(w6, 2, 2)
+            if esc == "u" then
+               local n = tonumber(string_sub(w6, 3), 16)
+               if not n then
+                  error("String decoding failed: bad Unicode escape "..w6.." at position "..idx)
+               end
+               -- Handling of UTF-16 surrogate pairs
+               if n >= 0xD800 and n < 0xDC00 then
+                  surrogate_pair_started, n = n
+               elseif n >= 0xDC00 and n < 0xE000 then
+                  n, surrogate_pair_started = surrogate_pair_started and (surrogate_pair_started - 0xD800) * 0x400 + (n - 0xDC00) + 0x10000
+               end
+               if n then
+                  -- Convert unicode codepoint n (0..0x10FFFF) to UTF-8 string
+                  local x
+                  if n < 0x80 then
+                     x = string_char(n % 0x80)
+                  elseif n < 0x800 then
+                     -- [110x xxxx] [10xx xxxx]
+                     x = string_char(0xC0 + (math_floor(n/64) % 0x20), 0x80 + (n % 0x40))
+                  elseif n < 0x10000 then
+                     -- [1110 xxxx] [10xx xxxx] [10xx xxxx]
+                     x = string_char(0xE0 + (math_floor(n/64/64) % 0x10), 0x80 + (math_floor(n/64) % 0x40), 0x80 + (n % 0x40))
+                  else
+                     -- [1111 0xxx] [10xx xxxx] [10xx xxxx] [10xx xxxx]
+                     x = string_char(0xF0 + (math_floor(n/64/64/64) % 8), 0x80 + (math_floor(n/64/64) % 0x40), 0x80 + (math_floor(n/64) % 0x40), 0x80 + (n % 0x40))
+                  end
+                  table_insert(t, x)
+               end
+               idx = idx + 6
+            else
+               table_insert(t, escapeSequences[esc] or esc)
+               idx = idx + 2
+            end
+         else
+            error('String decoding failed: missing closing " for string at position '..startPos)
+         end
+      end
+   end
+
+   --- Scans a JSON string skipping all whitespace from the current start position.
+   -- Returns the position of the first non-whitespace character.
+   -- @param   state      The state of JSON reader.
+   -- @param   startPos   The starting position where we should begin removing whitespace.
+   -- @return  int,char   The first position where non-whitespace was encountered, non-whitespace char.
+   function decode_scanWhitespace(state, startPos)
+      while true do
+         startPos = match_with_pattern(state, startPos, '^[ \n\r\t]+', "skip")
+         local w2 = get_word(state, startPos, 2)
+         if w2 == '/*' then
+            local endPos = skip_until_word(state, startPos + 2, '*/')
+            if not endPos then
+               error("Unterminated comment in JSON string at "..startPos)
+            end
+            startPos = endPos
+         else
+            local next_char = string_sub(w2, 1, 1)
+            if next_char == '' then
+               error('Unexpected end of JSON')
+            end
+            return startPos, next_char
+         end
+      end
+   end
+
+   --- Encodes a string to be JSON-compatible.
+   -- This just involves backslash-escaping of quotes, slashes and control codes
+   -- @param   s        The string to return as a JSON encoded (i.e. backquoted string)
+   -- @return  string   The string appropriately escaped.
+   local escapeList = {
+         ['"']  = '\\"',
+         ['\\'] = '\\\\',
+         ['/']  = '\\/',
+         ['\b'] = '\\b',
+         ['\f'] = '\\f',
+         ['\n'] = '\\n',
+         ['\r'] = '\\r',
+         ['\t'] = '\\t',
+         ['\127'] = '\\u007F'
+   }
+   function encodeString(s)
+      if type(s) == 'number' then
+         s = math_type(s) == 'integer' and tostring(s) or string_format('%.f', s)
+      end
+      return string_gsub(s, ".", function(c) return escapeList[c] or c:byte() < 32 and string_format('\\u%04X', c:byte()) end)
+   end
+
+   -- Determines whether the given Lua type is an array or a table / dictionary.
+   -- We consider any table an array if it has indexes 1..n for its n items, and no other data in the table.
+   -- I think this method is currently a little 'flaky', but can't think of a good way around it yet...
+   -- @param   t                 The table to evaluate as an array
+   -- @return  boolean,number    True if the table can be represented as an array, false otherwise.
+   --                            If true, the second returned value is the maximum number of indexed elements in the array.
+   function isArray(t)
+      -- Next we count all the elements, ensuring that any non-indexed elements are not-encodable
+      -- (with the possible exception of 'n')
+      local maxIndex = 0
+      for k, v in pairs(t) do
+         if type(k) == 'number' and math_floor(k) == k and 0 <= k and k <= 1e6 then  -- k,v is an indexed pair
+            if not isEncodable(v) then  -- All array elements must be encodable
+               return false
+            end
+            maxIndex = math_max(maxIndex, k)
+         elseif not (k == 'n' and v == #t) then  -- if it is n, then n does not hold the number of elements
+            if isConvertibleToString(k) and isEncodable(v) then
+               return false
+            end
+         end -- End of k,v not an indexed pair
+      end  -- End of loop across all pairs
+      return true, maxIndex
+   end
+
+   --- Determines whether the given Lua object / table / value can be JSON encoded.
+   -- The only types that are JSON encodable are: string, boolean, number, nil, table and special tables json.null and json.empty.
+   -- @param   o        The object to examine.
+   -- @return  boolean  True if the object should be JSON encoded, false if it should be ignored.
+   function isEncodable(o)
+      local t = type(o)
+      return t == 'string' or t == 'boolean' or t == 'number' and isRegularNumber(o) or t == 'nil' or t == 'table'
+   end
+
+   --- Determines whether the given Lua object / table / variable can be a JSON key.
+   -- Integer Lua numbers are allowed to be considered as valid string keys in JSON.
+   -- @param   o        The object to examine.
+   -- @return  boolean  True if the object can be converted to a string, false if it should be ignored.
+   function isConvertibleToString(o)
+      local t = type(o)
+      return t == 'string' or t == 'number' and isRegularNumber(o) and (math_type(o) == 'integer' or math_floor(o) == o)
+   end
+
+   local is_Inf_or_NaN = {[tostring(1/0)]=true, [tostring(-1/0)]=true, [tostring(0/0)]=true, [tostring(-(0/0))]=true}
+   --- Determines whether the given Lua number is a regular number or Inf/Nan.
+   -- @param   v        The number to examine.
+   -- @return  boolean  True if the number is a regular number which may be encoded in JSON.
+   function isRegularNumber(v)
+      return not is_Inf_or_NaN[tostring(v)]
+   end
+
+end
+
+return json

--- a/plugins/HandwritingRecognition/plugin.ini
+++ b/plugins/HandwritingRecognition/plugin.ini
@@ -1,0 +1,15 @@
+[about]
+## Author / Copyright notice
+author=Roland Lötscher
+
+description=Issue https://github.com/xournalpp/xournalpp/issues/2152
+
+## If the plugin is packed with Xournal++, use
+## <xournalpp> then it gets the same version number
+version=<xournalpp>
+
+[default]
+enabled=false
+
+[plugin]
+mainfile=recognition.lua

--- a/plugins/HandwritingRecognition/recognition.lua
+++ b/plugins/HandwritingRecognition/recognition.lua
@@ -1,0 +1,131 @@
+-- Register all Toolbar actions and intialize all UI stuff
+function initUi()
+  app.registerUi({["menu"] = "Recognize Handwritten Text", ["callback"] = "recognize"});
+  package.path = package.path .. ";../?.lua;/usr/local/share/lua/5.3/?.lua" -- must currently be customized by the user
+  sourcePath = debug.getinfo(1).source:match("@?(.*/)")
+end
+
+local sel = "Layer"
+
+function recognize()
+  -- Initialize UI
+  local hasLgi, lgi = pcall(require, "lgi")
+  if not hasLgi then
+    app.msgbox("You need to have the Lua lgi-module installed and included in your Lua package path in order to use the GUI for migrating font sizes. \n\n", {[1]="OK"})
+    return
+  end
+
+  --lgi module has been found
+  local Gtk = lgi.require("Gtk", "3.0")
+  local Gdk = lgi.Gdk
+  local assert = lgi.assert
+  local builder = Gtk.Builder()
+  assert(builder:add_from_file(sourcePath .. "Dialog.glade"))
+  local ui = builder.objects
+  local dialog1 = ui.dialog1
+  local dialog2 = ui.dialog2
+  local nb = ui.nb
+
+  -- Connect actions
+  function ui.btOk.on_clicked()
+    local lang = tostring(ui.languageEntries.active_id)
+    local choices = tonumber(ui.choiceEntries.active_id)
+    local strokes = app.getStrokes(sel)
+    ink = {}
+    for i = 1, #strokes do 
+      ink[i] = { strokes[i]["x"], strokes[i]["y"] }
+    end
+    
+    local selectionBox = app.getToolInfo("selection")["boundingBox"]
+    local width, height = selectionBox["width"], selectionBox["height"]
+    require("fetch")
+    alternatives = sendRequest(ink, lang, width, height)
+
+    dialog1:hide()
+    -- Add notebook tabs programmatically
+    numTabs = math.min(choices, #alternatives)
+    for i = 1, numTabs do
+      local tabLabel = "Alternative " .. tostring(i-1)
+      if (i==1) then
+        tabLabel = "Recognized Text"
+      end
+      nb:append_page(Gtk.ScrolledWindow {
+        Gtk.TextView {
+          id = "page" .. tostring(i),
+          buffer = Gtk.TextBuffer { 
+            text = alternatives[i] 
+          },
+          wrap_mode = 'WORD'
+       } 
+      }, 
+      Gtk.Label {label = tabLabel }
+    )      
+    end
+
+    dialog2:show_all()
+  end
+
+  function ui.rd_1.on_toggled()
+    sel = "layer"
+  end
+
+  function ui.rd_2.on_toggled()
+    sel = "selection"
+  end
+
+  function ui.btBack.on_clicked()
+    dialog2:hide()
+    for i = 1, numTabs do
+      nb:remove_page(0)
+    end
+    dialog2:resize(100,100)
+    dialog1:show_all()
+  end
+
+  function ui.btDone.on_clicked()
+    dialog1:destroy()
+    dialog2:destroy()
+  end
+
+  function get_text_view()
+    local currentPage = math.floor(nb:get_current_page()+0.5) -- rounding to an int
+    return nb.child[currentPage+1].child[1]
+  end
+
+  function ui.btClipboard.on_clicked()
+    local textView = get_text_view()
+    local currentText = textView.buffer.text; 
+    local clipboard = textView:get_clipboard(Gdk.SELECTION_CLIPBOARD)
+    clipboard:set_text(currentText,-1)
+  end
+
+  function ui.btSave.on_clicked()
+    local textView = get_text_view()
+    local currentText = textView.buffer.text; 
+
+    local pathseparator = package.config:sub(1,1);
+    local path = ui.pickFolder:get_filename()
+    local name = ui.txtFilename.text
+    local empty = (not name or name=="")
+    local overwrite = ui.checkOverwrite:get_active()
+    if (path and not empty) then
+      local filename = path .. pathseparator .. name
+      if (not overwrite and io.open(filename, "r")) then
+        app.msgbox("File already exists!", {[1] = "OK"})
+      else
+        file = assert(io.open(filename, "w"))
+        file:write(currentText)
+        file:close()
+      end
+    elseif (not path and empty) then
+      app.msgbox("No folder and no name specified!", {[1] = "OK"})
+    elseif (not path and not empty) then
+      app.msgbox("No folder specified!", {[1] = "OK"})
+    elseif (path and empty) then
+      app.msgbox("No name specified!", {[1] = "OK"})      
+    end
+  end
+
+  dialog1:show_all()
+
+end


### PR DESCRIPTION
This is a Lua Plugin that uses the Google IME API for handwriting recognition.

The current initial version only supports recognition of the handwritten text on the selected layer, although the UI shows more options. The language and the number of returns (i.e. the number of alternatives for the recognized text, that are displayed) already work.

This Plugin requires the following lua-modules 
- `lgi `(for creating the UI)
- `socket`,` ssl.https` and `ltn12` (for the `https-request`)

These modules, which can be installed with the `luarocks` package manager, will be searched for in` /usr/local/sahre/lua/5.3/`
If that is the wrong path, the `initUi `function of `recognition.lua` must be modified.