### PR TITLE
Make line spacing be the same in export and on screen

### DIFF
--- a/src/view/TextView.cpp
+++ b/src/view/TextView.cpp
@@ -34,6 +34,10 @@ void TextView::updatePangoFont(PangoLayout* layout, const Text* t) {
     PangoFontDescription* desc = pango_font_description_from_string(t->getFontName().c_str());
     pango_font_description_set_absolute_size(desc, t->getFontSize() * PANGO_SCALE);
 
+#if PANGO_VERSION_CHECK(1, 48, 5)  // see https://gitlab.gnome.org/GNOME/pango/-/issues/499
+    pango_layout_set_line_spacing(layout, 1.0);
+#endif
+
     pango_layout_set_font_description(layout, desc);
     pango_font_description_free(desc);
 }


### PR DESCRIPTION
This short PR aims to fix ~two annoying (high priority) bugs and another (yet unreported) minor bug~ the following bug:
- line spacing bug, leading to different results in screen view and pdf export of text elements:#1390,  #2073, #2104 (and #25)

The following bugs, that were previously part of this PR, have already been addressed in #2724
- dpi scaling bug, leading to different text size with different dpi settings: #1118
- search mark bug, leading to search marks that are one character too long (unreported)

The bugs are all easy to reproduce and the results can be compared with the fixed version. For instance take the following zip-file, consisting of a xopp-file with its pdf-export:
[TextLinesOfIncreasingSize.zip](https://github.com/xournalpp/xournalpp/files/5111212/TextLinesOfIncreasingSize.zip)

The columns are written with different font sizes (14.0 pt, 14.1 pt, 14.2 pt, ..., 15.0 pt from left to right). With the PR the screen output and the pdf export look the same: the columns get longer and longer from left to right with every 0.1 pt increase of the font size. With the current (unfixed) version, most columns will have the same height in the screen output. In the pdf export it is the same like in the PR. So clearly the screen output was flawed in the current version of Xournal++, not the pdf export.