### PR TITLE
Update WindowsBuild.md

### DIFF
--- a/readme/WindowsBuild.md
+++ b/readme/WindowsBuild.md
@@ -67,8 +67,13 @@ cd build/
 cmake ..
 cmake --build .
 ```
+## Modify Path Environment Variable
 
-You can run Xournal++ with
+Add `C:\msys64\mingw64\bin` and `C:\msys64\usr\bin` to the top of 
+your PATH environment variable in the Windows Advanced system 
+settings (assuming default installation folder for MSYS2). 
+
+You can now run Xournal++ with
 ```bash
 ./src/xournalpp.exe
 ```

--- a/readme/WindowsBuild.md
+++ b/readme/WindowsBuild.md
@@ -29,7 +29,8 @@ pacman -S mingw-w64-x86_64-toolchain \
           mingw-w64-x86_64-cmake \
           mingw-w64-x86_64-ninja \
           patch \
-          mingw-w64-x86_64-cppunit
+          mingw-w64-x86_64-cppunit \
+          make
 ```
 -> press enter multiple times / confirm all default values
 


### PR DESCRIPTION
`make` is required to build the portaudio library (creating a `make.exe` copy of `mingw32-make.exe` doesn't work)