### PR TITLE
Check if folder exists in ensure folder exists

### DIFF
--- a/src/util/PathUtil.cpp
+++ b/src/util/PathUtil.cpp
@@ -198,7 +198,7 @@ auto Util::getTmpDirSubfolder(const fs::path& subfolder) -> fs::path {
 }
 
 auto Util::ensureFolderExists(const fs::path& p) -> fs::path {
-    if (!fs::create_directories(p)) {
+    if (!fs::exists(p) && !fs::create_directories(p)) {
         Util::execInUiThread([=]() {
             string msg = FS(_F("Could not create folder: {1}") % p.string());
             g_warning("%s", msg.c_str());


### PR DESCRIPTION
std::filesystem::create_directories returns false if no folders were created which can be the case if the folder already exists (which will be most of the time). This simply adds a check beforehand to ensure no errors are presented if none occured.