### PR TITLE
Select the language from settings

### DIFF
--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -2460,7 +2460,13 @@ void Control::closeDocument() {
     this->undoRedoChanged();
 }
 
-void Control::applyPreferredLanguage() { setenv("LANGUAGE", this->settings->getPreferredLocale().c_str(), 1); }
+void Control::applyPreferredLanguage() {
+#ifdef _WIN32
+    _putenv_s("LANGUAGE", this->settings->getPreferredLocale().c_str());
+#else
+    setenv("LANGUAGE", this->settings->getPreferredLocale().c_str(), 1);
+#endif
+}
 
 auto Control::askToReplace(fs::path const& filepath) const -> bool {
     if (fs::exists(filepath)) {

--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -88,6 +88,8 @@ Control::Control(GladeSearchpath* gladeSearchPath) {
     this->settings = new Settings(std::move(name));
     this->settings->load();
 
+    this->applyPreferredLanguage();
+
     TextView::setDpi(settings->getDisplayDpi());
 
     this->pageTypes = new PageTypeHandler(gladeSearchPath);
@@ -2457,6 +2459,8 @@ void Control::closeDocument() {
 
     this->undoRedoChanged();
 }
+
+void Control::applyPreferredLanguage() { setenv("LANGUAGE", this->settings->getPreferredLocale().c_str(), 1); }
 
 auto Control::askToReplace(fs::path const& filepath) const -> bool {
     if (fs::exists(filepath)) {

--- a/src/control/Control.h
+++ b/src/control/Control.h
@@ -326,6 +326,11 @@ private:
      */
     void closeDocument();
 
+    /**
+     * Applies the preferred language to the UI
+     */
+    void applyPreferredLanguage();
+
     RecentManager* recent;
     UndoRedoHandler* undoRedo;
     ZoomControl* zoom;

--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -466,6 +466,8 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur) {
         this->snapRecognizedShapesEnabled = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("restoreLineWidthEnabled")) == 0) {
         this->restoreLineWidthEnabled = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("preferredLocale")) == 0) {
+        this->preferredLocale = reinterpret_cast<char*>(value);
     }
 
     xmlFree(name);
@@ -1684,6 +1686,9 @@ void Settings::setRestoreLineWidthEnabled(bool enabled) { this->restoreLineWidth
 
 auto Settings::getRestoreLineWidthEnabled() const -> bool { return this->restoreLineWidthEnabled; }
 
+auto Settings::setPreferredLocale(std::string const& locale) -> void { this->preferredLocale = locale; }
+
+auto Settings::getPreferredLocale() const -> std::string { return this->preferredLocale; }
 
 void Settings::setIgnoredStylusEvents(int numEvents) {
     if (this->numIgnoredStylusEvents == numEvents) {

--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -845,6 +845,8 @@ void Settings::save() {
     WRITE_BOOL_PROP(inputSystemTPCButton);
     WRITE_BOOL_PROP(inputSystemDrawOutsideWindow);
 
+    WRITE_STRING_PROP(preferredLocale);
+
     WRITE_BOOL_PROP(latexSettings.autoCheckDependencies);
     // Inline WRITE_STRING_PROP(latexSettings.globalTemplatePath) since it
     // breaks on Windows due to the native character representation being

--- a/src/control/settings/Settings.h
+++ b/src/control/settings/Settings.h
@@ -431,7 +431,6 @@ public:
      */
     bool getTrySelectOnStrokeFiltered() const;
 
-
     /**
      * Set snap recognized shapes enabled
      */
@@ -452,6 +451,16 @@ public:
      */
     bool getRestoreLineWidthEnabled() const;
 
+    /**
+     * Set the preferred locale
+     */
+    void setPreferredLocale(std::string const& locale) const;
+
+    /**
+     * Get the preferred locale
+     */
+    std::string getPreferredLocale() const {
+        return "de_DE.UTF-8"; }
 
 public:
     // Custom settings
@@ -882,4 +891,9 @@ private:
      * "Transaction" running, do not save until the end is reached
      */
     bool inTransaction{};
+
+    /** The preferred locale as its language code
+     * e.g. "en_US"
+     */
+    std::string preferredLocale;
 };

--- a/src/control/settings/Settings.h
+++ b/src/control/settings/Settings.h
@@ -454,13 +454,12 @@ public:
     /**
      * Set the preferred locale
      */
-    void setPreferredLocale(std::string const& locale) const;
+    void setPreferredLocale(std::string const& locale);
 
     /**
      * Get the preferred locale
      */
-    std::string getPreferredLocale() const {
-        return "de_DE.UTF-8"; }
+    std::string getPreferredLocale() const;
 
 public:
     // Custom settings

--- a/src/gui/dialog/LanguageConfigGui.cpp
+++ b/src/gui/dialog/LanguageConfigGui.cpp
@@ -1,0 +1,27 @@
+#include "LanguageConfigGui.h"
+#include "i18n.h"
+#include "control/settings/Settings.h"
+
+LanguageConfigGui::LanguageConfigGui(GladeSearchpath* gladeSearchPath, GtkWidget* w, Settings* settings) :
+        GladeGui(gladeSearchPath, "settingsLanguageConfig.glade", "offscreenwindow"), settings(settings) {
+    GtkWidget* dropdown = get("languageSettingsDropdown");
+    gtk_container_remove(GTK_CONTAINER(getWindow()), dropdown);
+    gtk_container_add(GTK_CONTAINER(w), dropdown);
+    gtk_widget_show_all(dropdown);
+};
+
+void LanguageConfigGui::saveSettings() {
+    gint pos = gtk_combo_box_get_active(GTK_COMBO_BOX(get("languageSettingsDropdown")));
+
+    switch (pos) {
+        case 0:
+            settings->setPreferredLocale("en_US.UTF-8");
+            break;
+        case 1:
+            settings->setPreferredLocale("de_DE.UTF-8");
+            break;
+        default:
+            throw "No language selected";
+    }
+    settings->customSettingsChanged();
+}

--- a/src/gui/dialog/LanguageConfigGui.cpp
+++ b/src/gui/dialog/LanguageConfigGui.cpp
@@ -1,27 +1,89 @@
 #include "LanguageConfigGui.h"
-#include "i18n.h"
+
+#include <algorithm>
+
 #include "control/settings/Settings.h"
 
-LanguageConfigGui::LanguageConfigGui(GladeSearchpath* gladeSearchPath, GtkWidget* w, Settings* settings) :
+#include "StringUtils.h"
+#include "XojMsgBox.h"
+#include "config-paths.h"
+#include "config.h"
+#include "filesystem.h"
+#include "i18n.h"
+
+#ifdef _WIN32
+#undef PACKAGE_LOCALE_DIR
+#define PACKAGE_LOCALE_DIR "../share/locale/"
+#endif
+
+#ifdef __APPLE__
+#include "Stacktrace.h"
+#undef PACKAGE_LOCALE_DIR
+const char* PACKAGE_LOCALE_DIR = (Stacktrace::getExePath() / "../Resources/share/locale").c_str();
+#endif
+
+LanguageConfigGui::LanguageConfigGui(GladeSearchpath* gladeSearchPath, GtkWidget* w, Settings* settings):
         GladeGui(gladeSearchPath, "settingsLanguageConfig.glade", "offscreenwindow"), settings(settings) {
-    GtkWidget* dropdown = get("languageSettingsDropdown");
+    auto dropdown = get("languageSettingsDropdown");
     gtk_container_remove(GTK_CONTAINER(getWindow()), dropdown);
     gtk_container_add(GTK_CONTAINER(w), dropdown);
     gtk_widget_show_all(dropdown);
-};
+
+    // Fetch available locales
+    try {
+        fs::path baseLocaleDir(PACKAGE_LOCALE_DIR);
+        for (auto const& d: fs::directory_iterator(baseLocaleDir)) {
+            if (fs::exists(d.path() / "LC_MESSAGES" / (std::string(GETTEXT_PACKAGE) + ".mo"))) {
+                availableLocales.push_back(d.path().filename().u8string());
+            }
+        }
+    } catch (fs::filesystem_error const& e) {
+        g_warning("%s", e.what());
+    }
+    std::sort(availableLocales.begin(), availableLocales.end());
+
+    // No pot file for English
+    if (auto enPos = std::lower_bound(availableLocales.begin(), availableLocales.end(), "en");
+        enPos != availableLocales.end() && !StringUtils::startsWith(*enPos, "en")) {
+        availableLocales.insert(enPos, "en");
+    }
+
+    // Default
+    availableLocales.insert(availableLocales.begin(), _("System Default"));
+
+    auto gtkAvailableLocales = gtk_list_store_new(1, G_TYPE_STRING);
+    for (auto const& i: availableLocales) {
+        GtkTreeIter iter;
+        gtk_list_store_append(gtkAvailableLocales, &iter);
+        gtk_list_store_set(gtkAvailableLocales, &iter, 0, i.c_str(), -1);
+    }
+    gtk_combo_box_set_model(GTK_COMBO_BOX(dropdown), GTK_TREE_MODEL(gtkAvailableLocales));
+
+
+    // Set the current locale if previously selected
+    auto prefPos = availableLocales.begin();
+    if (auto preferred = settings->getPreferredLocale(); !preferred.empty()) {
+        prefPos = std::lower_bound(availableLocales.begin(), availableLocales.end(), preferred);
+        if (*prefPos != preferred) {
+            XojMsgBox::showErrorToUser(nullptr, _("Previously selected language not available anymore!"));
+
+            // Use system default
+            prefPos = availableLocales.begin();
+        }
+    }
+    gtk_combo_box_set_active(GTK_COMBO_BOX(dropdown), prefPos - availableLocales.begin());
+}
+
 
 void LanguageConfigGui::saveSettings() {
     gint pos = gtk_combo_box_get_active(GTK_COMBO_BOX(get("languageSettingsDropdown")));
+    auto pref = (pos == 0) ? "" : availableLocales[pos];
 
-    switch (pos) {
-        case 0:
-            settings->setPreferredLocale("en_US.UTF-8");
-            break;
-        case 1:
-            settings->setPreferredLocale("de_DE.UTF-8");
-            break;
-        default:
-            throw "No language selected";
-    }
+    settings->setPreferredLocale(pref);
     settings->customSettingsChanged();
+#ifdef _WIN32
+    _putenv_s("LANGUAGE", this->settings->getPreferredLocale().c_str());
+#else
+    setenv("LANGUAGE", this->settings->getPreferredLocale().c_str(), 1);
+#endif
 }

--- a/src/gui/dialog/LanguageConfigGui.h
+++ b/src/gui/dialog/LanguageConfigGui.h
@@ -1,0 +1,36 @@
+/*
+ * Xournal++
+ *
+ * The configuration for a language in the Settings Dialog
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+#include <gdk/gdk.h>
+#include <memory>
+#include "gui/GladeGui.h"
+
+class Settings;
+class SettingsDialog;
+
+class LanguageConfigGui: public GladeGui {
+public:
+    LanguageConfigGui(GladeSearchpath* gladeSearchPath, GtkWidget* w, Settings* settings);
+
+public:
+    void loadSettings() {};
+    void saveSettings();
+
+    // Not implemented! This is not a dialog!
+    void show(GtkWindow* parent) override {};
+
+private:
+
+private:
+    Settings* settings;
+};

--- a/src/gui/dialog/LanguageConfigGui.h
+++ b/src/gui/dialog/LanguageConfigGui.h
@@ -11,8 +11,11 @@
 
 #pragma once
 
-#include <gdk/gdk.h>
 #include <memory>
+#include <vector>
+
+#include <gdk/gdk.h>
+
 #include "gui/GladeGui.h"
 
 class Settings;
@@ -23,14 +26,15 @@ public:
     LanguageConfigGui(GladeSearchpath* gladeSearchPath, GtkWidget* w, Settings* settings);
 
 public:
-    void loadSettings() {};
+    void loadSettings(){};
     void saveSettings();
 
     // Not implemented! This is not a dialog!
-    void show(GtkWindow* parent) override {};
+    void show(GtkWindow* parent) override{};
 
 private:
+    std::vector<std::string> availableLocales;
 
-private:
+
     Settings* settings;
 };

--- a/src/gui/dialog/SettingsDialog.cpp
+++ b/src/gui/dialog/SettingsDialog.cpp
@@ -99,6 +99,7 @@ SettingsDialog::SettingsDialog(GladeSearchpath* gladeSearchPath, Settings* setti
     gtk_box_pack_start(GTK_BOX(vbox), callib, false, true, 0);
     gtk_widget_show(callib);
 
+    initLanguageSettings();
     initMouseButtonEvents();
 
     vector<InputDevice> deviceList = DeviceListHelper::getDeviceList(this->settings);
@@ -132,6 +133,10 @@ SettingsDialog::~SettingsDialog() {
 
     // DO NOT delete settings!
     this->settings = nullptr;
+}
+
+void SettingsDialog::initLanguageSettings() {
+    languageConfig = std::make_unique<LanguageConfigGui>(getGladeSearchPath(), get("hboxLanguageSelect"), settings);
 }
 
 void SettingsDialog::initMouseButtonEvents(const char* hbox, int button, bool withDevice) {
@@ -622,6 +627,8 @@ void SettingsDialog::save() {
     for (ButtonConfigGui* bcg: this->buttonConfigs) {
         bcg->saveSettings();
     }
+
+    languageConfig->saveSettings();
 
     SElement& touch = settings->getCustomElement("touch");
     touch.setBool("disableTouch", getCheckbox("cbDisableTouchOnPenNear"));

--- a/src/gui/dialog/SettingsDialog.h
+++ b/src/gui/dialog/SettingsDialog.h
@@ -18,8 +18,10 @@
 
 #include "DeviceClassConfigGui.h"
 #include "LatexSettingsPanel.h"
+#include "LanguageConfigGui.h"
 
 class ButtonConfigGui;
+class LanguageConfigGui;
 
 class SettingsDialog: public GladeGui {
 public:
@@ -50,6 +52,8 @@ private:
     void initMouseButtonEvents();
     void initMouseButtonEvents(const char* hbox, int button, bool withDevice = false);
 
+    void initLanguageSettings();
+
 private:
     Settings* settings = nullptr;
     Control* control = nullptr;
@@ -58,6 +62,7 @@ private:
     vector<DeviceInfo> audioInputDevices;
     vector<DeviceInfo> audioOutputDevices;
 
+    std::unique_ptr<LanguageConfigGui> languageConfig;
     vector<ButtonConfigGui*> buttonConfigs;
     vector<DeviceClassConfigGui*> deviceClassConfigs;
 

--- a/src/gui/dialog/SettingsDialog.h
+++ b/src/gui/dialog/SettingsDialog.h
@@ -17,11 +17,10 @@
 #include "util/audio/DeviceInfo.h"
 
 #include "DeviceClassConfigGui.h"
-#include "LatexSettingsPanel.h"
 #include "LanguageConfigGui.h"
+#include "LatexSettingsPanel.h"
 
 class ButtonConfigGui;
-class LanguageConfigGui;
 
 class SettingsDialog: public GladeGui {
 public:

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.36.0 -->
 <interface>
   <requires lib="gtk+" version="3.18" />
   <object class="GtkAdjustment" id="adjustmentAudioGain">
     <property name="upper">10</property>
     <property name="value">1</property>
-    <property name="step_increment">0.10000000000000001</property>
+    <property name="step_increment">0.1</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentCursorHighlightBorderWidth">
     <property name="upper">30</property>
@@ -58,24 +58,24 @@
     <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentSnapGridTolerance">
-    <property name="lower">0.10000000000000001</property>
+    <property name="lower">0.1</property>
     <property name="upper">1</property>
     <property name="value">0.5</property>
-    <property name="step_increment">0.050000000000000003</property>
+    <property name="step_increment">0.05</property>
     <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentSnapRotationTolerance">
-    <property name="lower">0.10000000000000001</property>
+    <property name="lower">0.1</property>
     <property name="upper">1</property>
-    <property name="value">0.29999999999999999</property>
-    <property name="step_increment">0.050000000000000003</property>
+    <property name="value">0.3</property>
+    <property name="step_increment">0.05</property>
     <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentStrokeIgnoreLength">
-    <property name="lower">0.010000000000000011</property>
+    <property name="lower">0.01000000000000001</property>
     <property name="upper">100</property>
     <property name="value">1</property>
-    <property name="step_increment">0.10000000000000001</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">2</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentStrokeIgnoreTime">
@@ -101,7 +101,7 @@
     <property name="lower">0.5</property>
     <property name="upper">10</property>
     <property name="value">1</property>
-    <property name="step_increment">0.10000000000000001</property>
+    <property name="step_increment">0.1</property>
     <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentVerticalSpace">
@@ -117,14 +117,14 @@
     <property name="step_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentZoomStep">
-    <property name="lower">0.10000000000000001</property>
+    <property name="lower">0.1</property>
     <property name="upper">50</property>
     <property name="value">10</property>
     <property name="step_increment">0.5</property>
     <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentZoomStepScroll">
-    <property name="lower">0.10000000000000001</property>
+    <property name="lower">0.1</property>
     <property name="upper">50</property>
     <property name="value">2</property>
     <property name="step_increment">0.5</property>
@@ -227,7 +227,7 @@
                               <object class="GtkFrame" id="sid04">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="label_xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid05">
                                     <property name="visible">True</property>
@@ -359,7 +359,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                               <object class="GtkFrame" id="sid09">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="label_xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid10">
                                     <property name="visible">True</property>
@@ -534,7 +534,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                               <object class="GtkFrame" id="sid12">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="label_xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid13">
                                     <property name="visible">True</property>
@@ -633,7 +633,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                   <object class="GtkFrame" id="sid79">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="label_xalign">0.0099999997764825821</property>
+                    <property name="label_xalign">0.009999999776482582</property>
                     <child>
                       <object class="GtkAlignment" id="sid80">
                         <property name="visible">True</property>
@@ -713,7 +713,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                   <object class="GtkFrame" id="sid84">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="label_xalign">0.0099999997764825821</property>
+                    <property name="label_xalign">0.009999999776482582</property>
                     <child>
                       <object class="GtkAlignment" id="sid85">
                         <property name="visible">True</property>
@@ -780,7 +780,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                   <object class="GtkFrame" id="sid88">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="label_xalign">0.0099999997764825821</property>
+                    <property name="label_xalign">0.009999999776482582</property>
                     <child>
                       <object class="GtkAlignment" id="sid89">
                         <property name="visible">True</property>
@@ -910,7 +910,6 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="hscrollbar_policy">never</property>
-                    <property name="min_content_height">500</property>
                     <child>
                       <object class="GtkViewport" id="sid18">
                         <property name="visible">True</property>
@@ -925,7 +924,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                               <object class="GtkFrame" id="sid20">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="label_xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid21">
                                     <property name="visible">True</property>
@@ -959,7 +958,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                           <object class="GtkFrame" id="sid23">
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
-                                            <property name="label_xalign">0.0099999997764825821</property>
+                                            <property name="label_xalign">0.009999999776482582</property>
                                             <child>
                                               <object class="GtkAlignment" id="sid24">
                                                 <property name="visible">True</property>
@@ -997,7 +996,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                           <object class="GtkFrame" id="sid26">
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
-                                            <property name="label_xalign">0.0099999997764825821</property>
+                                            <property name="label_xalign">0.009999999776482582</property>
                                             <child>
                                               <object class="GtkAlignment" id="sid27">
                                                 <property name="visible">True</property>
@@ -1104,7 +1103,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                               <object class="GtkFrame" id="sid33">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="label_xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid34">
                                     <property name="visible">True</property>
@@ -1172,7 +1171,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                               <object class="GtkFrame" id="sid183">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="label_xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid184">
                                     <property name="visible">True</property>
@@ -1280,7 +1279,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                               <object class="GtkFrame" id="sid38">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="label_xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid39">
                                     <property name="visible">True</property>
@@ -1314,7 +1313,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                           <object class="GtkFrame" id="sid42">
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
-                                            <property name="label_xalign">0.0099999997764825821</property>
+                                            <property name="label_xalign">0.009999999776482582</property>
                                             <child>
                                               <object class="GtkAlignment" id="sid43">
                                                 <property name="visible">True</property>
@@ -1352,7 +1351,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                           <object class="GtkFrame" id="sid45">
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
-                                            <property name="label_xalign">0.0099999997764825821</property>
+                                            <property name="label_xalign">0.009999999776482582</property>
                                             <child>
                                               <object class="GtkAlignment" id="sid46">
                                                 <property name="visible">True</property>
@@ -1390,7 +1389,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                           <object class="GtkFrame" id="sid48">
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
-                                            <property name="label_xalign">0.0099999997764825821</property>
+                                            <property name="label_xalign">0.009999999776482582</property>
                                             <child>
                                               <object class="GtkAlignment" id="sid49">
                                                 <property name="visible">True</property>
@@ -1497,7 +1496,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                               <object class="GtkFrame" id="sid55">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="label_xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid56">
                                     <property name="visible">True</property>
@@ -1564,7 +1563,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                               <object class="GtkFrame" id="sid60">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="label_xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid61">
                                     <property name="visible">True</property>
@@ -1705,7 +1704,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                                 <property name="name">boxCustomTouchDisableSettings</property>
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
-                                                <property name="label_xalign">0.0099999997764825821</property>
+                                                <property name="label_xalign">0.009999999776482582</property>
                                                 <child>
                                                   <object class="GtkAlignment" id="sid65">
                                                     <property name="visible">True</property>
@@ -1868,7 +1867,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                               <object class="GtkFrame" id="sid69">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="label_xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid70">
                                     <property name="visible">True</property>
@@ -1933,7 +1932,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                               <object class="GtkFrame" id="sid74">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="label_xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid75">
                                     <property name="visible">True</property>
@@ -2053,7 +2052,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                               <object class="GtkFrame" id="sid98">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="label_xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid99">
                                     <property name="visible">True</property>
@@ -2113,7 +2112,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                             <property name="name">colorsFrame</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
-                                            <property name="label_xalign">0.0099999997764825821</property>
+                                            <property name="label_xalign">0.009999999776482582</property>
                                             <child>
                                               <object class="GtkAlignment" id="sid102">
                                                 <property name="visible">True</property>
@@ -2259,7 +2258,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                               <object class="GtkFrame" id="sid105">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="label_xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid106">
                                     <property name="visible">True</property>
@@ -2550,7 +2549,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                               <object class="GtkFrame" id="sid108">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="label_xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid109">
                                     <property name="visible">True</property>
@@ -2617,7 +2616,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                               <object class="GtkFrame" id="sid111">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="label_xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid112">
                                     <property name="visible">True</property>
@@ -2696,7 +2695,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                               <object class="GtkFrame" id="sid114">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="label_xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid115">
                                     <property name="visible">True</property>
@@ -2763,7 +2762,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                               <object class="GtkFrame" id="sid117">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="label_xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid118">
                                     <property name="visible">True</property>
@@ -2915,7 +2914,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                               <object class="GtkFrame" id="sid123">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="label_xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid124">
                                     <property name="visible">True</property>
@@ -3029,7 +3028,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                               <object class="GtkFrame" id="sid129">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="label_xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid130">
                                     <property name="visible">True</property>
@@ -3205,7 +3204,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                               <object class="GtkFrame" id="sid137">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="label_xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid138">
                                     <property name="visible">True</property>
@@ -3361,7 +3360,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                               <object class="GtkFrame" id="sid143">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="label_xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid144">
                                     <property name="visible">True</property>
@@ -3426,7 +3425,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                               <object class="GtkFrame" id="sid146">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="label_xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid147">
                                     <property name="visible">True</property>
@@ -3575,7 +3574,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                               <object class="GtkFrame" id="sid150">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="label_xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid151">
                                     <property name="visible">True</property>
@@ -3712,7 +3711,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                               <object class="GtkFrame" id="sid154">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="label_xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid155">
                                     <property name="visible">True</property>
@@ -3746,7 +3745,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Ignore Time (ms)</property>
-                                            <property name="angle">0.029999999999999999</property>
+                                            <property name="angle">0.03</property>
                                           </object>
                                           <packing>
                                             <property name="left_attach">2</property>
@@ -3845,7 +3844,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                             <property name="receives_default">False</property>
                                             <property name="tooltip_markup" translatable="yes">Try to select object first; if nothing selected then show floating toolbox if enabled.</property>
                                             <property name="xalign">0</property>
-                                            <property name="yalign">0.43999999761581421</property>
+                                            <property name="yalign">0.4399999976158142</property>
                                             <property name="draw_indicator">True</property>
                                           </object>
                                           <packing>
@@ -3875,7 +3874,7 @@ It must be short in time and length and we can't have ignored another stroke rec
                                             <property name="receives_default">False</property>
                                             <property name="tooltip_markup" translatable="yes">Try to select object first; if nothing selected then show floating toolbox if enabled.</property>
                                             <property name="xalign">0</property>
-                                            <property name="yalign">0.43000000715255737</property>
+                                            <property name="yalign">0.4300000071525574</property>
                                             <property name="draw_indicator">True</property>
                                           </object>
                                           <packing>
@@ -3892,7 +3891,7 @@ It must be short in time and length and we can't have ignored another stroke rec
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Action on Tool Tap</property>
-                                    <property name="angle">0.040000000000000001</property>
+                                    <property name="angle">0.04</property>
                                   </object>
                                 </child>
                               </object>
@@ -3957,7 +3956,7 @@ It must be short in time and length and we can't have ignored another stroke rec
                               <object class="GtkFrame" id="sid163">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="label_xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid164">
                                     <property name="visible">True</property>
@@ -4103,7 +4102,7 @@ It must be short in time and length and we can't have ignored another stroke rec
                               <object class="GtkFrame" id="sid169">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="label_xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid170">
                                     <property name="visible">True</property>
@@ -4193,7 +4192,7 @@ It must be short in time and length and we can't have ignored another stroke rec
                               <object class="GtkFrame" id="sid173">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="label_xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid174">
                                     <property name="visible">True</property>
@@ -4210,7 +4209,7 @@ It must be short in time and length and we can't have ignored another stroke rec
                                           <object class="GtkLabel" id="sid176">
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">&lt;i&gt;Specify the audio devices used for recording and playback of audio attachments. 
+                                            <property name="label" translatable="yes">&lt;i&gt;Specify the audio devices used for recording and playback of audio attachments.
 If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as input / output device.&lt;/i&gt;</property>
                                             <property name="use_markup">True</property>
                                             <property name="wrap">True</property>
@@ -4305,7 +4304,7 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                               <object class="GtkFrame" id="sid178">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="label_xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid179">
                                     <property name="visible">True</property>
@@ -4367,7 +4366,7 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
                                             <property name="adjustment">adjustmentAudioGain</property>
-                                            <property name="climb_rate">0.10000000000000001</property>
+                                            <property name="climb_rate">0.1</property>
                                             <property name="digits">2</property>
                                             <property name="numeric">True</property>
                                             <property name="value">1</property>
@@ -4399,7 +4398,7 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                               <object class="GtkFrame" id="sid1">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="label_xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid2">
                                     <property name="visible">True</property>
@@ -4432,7 +4431,7 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                             <property name="can_focus">True</property>
                                             <property name="text" translatable="yes">1,00</property>
                                             <property name="adjustment">adjustmentSeekTime</property>
-                                            <property name="climb_rate">0.10000000000000001</property>
+                                            <property name="climb_rate">0.1</property>
                                             <property name="digits">2</property>
                                             <property name="numeric">True</property>
                                             <property name="value">1</property>
@@ -4514,7 +4513,7 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                 </child>
               </object>
               <packing>
-                <property name="position">10</property>
+                <property name="position">11</property>
               </packing>
             </child>
             <child type="tab">
@@ -4524,7 +4523,141 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                 <property name="label" translatable="yes">LaTeX</property>
               </object>
               <packing>
-                <property name="position">10</property>
+                <property name="position">11</property>
+                <property name="tab_fill">False</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="languageTabBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">5</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkScrolledWindow" id="sid189">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="hscrollbar_policy">never</property>
+                    <child>
+                      <object class="GtkViewport" id="sid190">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="shadow_type">none</property>
+                        <child>
+                          <object class="GtkBox" id="sid191">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="orientation">vertical</property>
+                            <child>
+                              <object class="GtkFrame" id="sid192">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.009999999776482582</property>
+                                <child>
+                                  <object class="GtkAlignment" id="sid193">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="bottom_padding">12</property>
+                                    <property name="left_padding">12</property>
+                                    <property name="right_padding">12</property>
+                                    <child>
+                                      <object class="GtkBox" id="sid194">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                          <object class="GtkLabel" id="label195">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="label" translatable="yes">&lt;i&gt;Select language (requires restart)&lt;/i&gt;</property>
+                                            <property name="use_markup">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkFrame" id="sid195">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="label_xalign">0.009999999776482582</property>
+                                            <child>
+                                              <object class="GtkAlignment" id="sid196">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="bottom_padding">8</property>
+                                                <property name="left_padding">12</property>
+                                                <property name="right_padding">12</property>
+                                                <child>
+                                                  <object class="GtkBox" id="hboxLanguageSelect">
+                                                    <property name="visible">True</property>
+                                                    <property name="can_focus">False</property>
+                                                    <property name="orientation">vertical</property>
+                                                    <child>
+                                                      <placeholder/>
+                                                    </child>
+                                                  </object>
+                                                </child>
+                                              </object>
+                                            </child>
+                                            <child type="label">
+                                              <object class="GtkLabel" id="label196">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="label" translatable="yes">Language</property>
+                                              </object>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label">
+                                  <object class="GtkLabel" id="label193">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="label" translatable="yes">Language Settings</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="position">11</property>
+              </packing>
+            </child>
+            <child type="tab">
+              <object class="GtkLabel" id="languageTabLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Language</property>
+              </object>
+              <packing>
+                <property name="position">11</property>
                 <property name="tab_fill">False</property>
               </packing>
             </child>
@@ -4541,5 +4674,8 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
       <action-widget response="0">btSettingsCancel</action-widget>
       <action-widget response="1">btSettingsOk</action-widget>
     </action-widgets>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
   </object>
 </interface>

--- a/ui/settingsLanguageConfig.glade
+++ b/ui/settingsLanguageConfig.glade
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.36.0 -->
+<interface>
+  <requires lib="gtk+" version="3.22"/>
+  <object class="GtkOffscreenWindow" id="offscreenwindow">
+    <property name="can_focus">False</property>
+    <child>
+      <object class="GtkComboBoxText" id="languageSettingsDropdown">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+      </object>
+    </child>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
+  </object>
+</interface>


### PR DESCRIPTION
If the user hasn't set up locales properly, or wants a different language due to any reason, it would be easiest if they can select their preferred language from a drop-down menu.

This PR:
 - adds a GUI for selecting the language (depicted below)
 - searches  for the available languages by searching any directories in PACKAGE_LOCALE_DIR for xournalpp.mo files
 - writes the selected language to the config
 - automatically sets the previously selected language as the default in the menu

![image](https://user-images.githubusercontent.com/22723953/91615547-2261a180-e984-11ea-896a-e13bbb0c7635.png)
![image](https://user-images.githubusercontent.com/22723953/91615620-46bd7e00-e984-11ea-897e-850095f0e6f2.png)

Currently untested on macOS and working on a few banal translations (as not offering translations for the language settings would be a bit ironic).

Currently available translations:
 - German
 - Russian
 - Spanish
 - French

Should help in cases such as https://github.com/xournalpp/xournalpp/issues/2181.
