### PR TITLE
Fixed several memory leaks after the use of gtk_file_chooser

### DIFF
--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -2277,25 +2277,17 @@ auto Control::showSaveDialog() -> bool {
             return false;
         }
 
-        auto fileTmp = fs::path(gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog)));
+        auto fileTmp = Util::fromGtkFilename(gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog)));
         Util::clearExtensions(fileTmp);
         fileTmp += ".xopp";
-        fs::path currentFolder(gtk_file_chooser_get_current_folder(GTK_FILE_CHOOSER(dialog)));
-
         // Since we add the extension after the OK button, we have to check manually on existing files
-        if (askToReplace(currentFolder / fileTmp)) {
+        if (askToReplace(fileTmp)) {
             break;
         }
     }
 
-    char* name = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog));
-
-    string filename = name;
-    char* folder = gtk_file_chooser_get_current_folder_uri(GTK_FILE_CHOOSER(dialog));
-    settings->setLastSavePath(folder);
-    g_free(folder);
-    g_free(name);
-
+    auto filename = Util::fromGtkFilename(gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog)));
+    settings->setLastSavePath(filename.parent_path());
     gtk_widget_destroy(dialog);
 
     this->doc->lock();

--- a/src/control/jobs/BaseExportJob.cpp
+++ b/src/control/jobs/BaseExportJob.cpp
@@ -67,14 +67,15 @@ auto BaseExportJob::showFilechooser() -> bool {
             gtk_widget_destroy(dialog);
             return false;
         }
-
-        string uri(gtk_file_chooser_get_uri(GTK_FILE_CHOOSER(dialog)));
-        this->filepath = fs::u8path(gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog)));
+        auto uri = [](char* uri) {
+            std::string ret{uri};
+            g_free(uri);
+            return ret;
+        }(gtk_file_chooser_get_uri(GTK_FILE_CHOOSER(dialog)));
+        this->filepath = Util::fromGtkFilename(gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog)));
         Util::clearExtensions(this->filepath);
-        fs::path currentFolder = fs::u8path(gtk_file_chooser_get_current_folder(GTK_FILE_CHOOSER(dialog)));
-
         // Since we add the extension after the OK button, we have to check manually on existing files
-        if (isUriValid(uri) && control->askToReplace(currentFolder / filepath)) {
+        if (isUriValid(uri) && control->askToReplace(filepath)) {
             break;
         }
     }

--- a/src/control/stockdlg/ImageOpenDlg.cpp
+++ b/src/control/stockdlg/ImageOpenDlg.cpp
@@ -1,6 +1,7 @@
 #include "ImageOpenDlg.h"
 
 #include <config.h>
+#include <util/PathUtil.h>
 
 #include "control/settings/Settings.h"
 
@@ -44,17 +45,14 @@ auto ImageOpenDlg::show(GtkWindow* win, Settings* settings, bool localOnly, bool
         *attach = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(cbAttach));
     }
 
-    char* folder = gtk_file_chooser_get_current_folder_uri(GTK_FILE_CHOOSER(dialog));
 
     // e.g. from last used files, there is no folder selected
     // in this case do not store the folder
-    if (folder != nullptr) {
+    if (auto folder = Util::fromGtkFilename(gtk_file_chooser_get_current_folder(GTK_FILE_CHOOSER(dialog)));
+        !folder.empty()) {
         settings->setLastImagePath(folder);
-        g_free(folder);
     }
-
     gtk_widget_destroy(dialog);
-
     return file;
 }
 

--- a/src/control/stockdlg/XojOpenDlg.cpp
+++ b/src/control/stockdlg/XojOpenDlg.cpp
@@ -75,9 +75,8 @@ auto XojOpenDlg::runDialog() -> fs::path {
         return fs::path{};
     }
 
-    fs::path file(gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog)));
+    auto file = Util::fromGtkFilename(gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog)));
     settings->setLastOpenPath(file.parent_path());
-
     return file;
 }
 
@@ -146,16 +145,12 @@ auto XojOpenDlg::showOpenDialog(bool pdf, bool& attachPdf) -> fs::path {
 }
 
 void XojOpenDlg::updatePreviewCallback(GtkFileChooser* fileChooser, void* userData) {
-    gchar* filename = gtk_file_chooser_get_preview_filename(fileChooser);
+    auto filepath = Util::fromGtkFilename(gtk_file_chooser_get_preview_filename(fileChooser));
 
-    if (!filename) {
+    if (filepath.empty()) {
         gtk_file_chooser_set_preview_widget_active(fileChooser, false);
         return;
     }
-
-    fs::path filepath = filename;
-    g_free(filename);
-    filename = nullptr;
 
     if (!Util::hasXournalFileExt(filepath)) {
         gtk_file_chooser_set_preview_widget_active(fileChooser, false);

--- a/src/gui/dialog/LatexSettingsPanel.cpp
+++ b/src/gui/dialog/LatexSettingsPanel.cpp
@@ -34,13 +34,7 @@ void LatexSettingsPanel::load(const LatexSettings& settings) {
 
 void LatexSettingsPanel::save(LatexSettings& settings) {
     settings.autoCheckDependencies = gtk_toggle_button_get_active(this->cbAutoDepCheck);
-    gchar* templPath = gtk_file_chooser_get_filename(this->globalTemplateChooser);
-    if (templPath) {
-        settings.globalTemplatePath = fs::u8path(templPath);
-        g_free(templPath);
-    } else {
-        settings.globalTemplatePath = "";
-    }
+    settings.globalTemplatePath = Util::fromGtkFilename(gtk_file_chooser_get_filename(this->globalTemplateChooser));
     settings.genCmd = gtk_entry_get_text(GTK_ENTRY(this->get("latexSettingsGenCmd")));
 }
 

--- a/src/gui/dialog/PageTemplateDialog.cpp
+++ b/src/gui/dialog/PageTemplateDialog.cpp
@@ -3,8 +3,6 @@
 #include <fstream>
 #include <sstream>
 
-#include <config.h>
-
 #include "control/pagetype/PageTypeHandler.h"
 #include "control/stockdlg/XojOpenDlg.h"
 #include "gui/dialog/FormatDialog.h"
@@ -111,21 +109,12 @@ void PageTemplateDialog::saveToFile() {
         return;
     }
 
-    char* name = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog));
-
-    string filename = name;
-    char* folder = gtk_file_chooser_get_current_folder_uri(GTK_FILE_CHOOSER(dialog));
-    settings->setLastSavePath(folder);
-    g_free(folder);
-    g_free(name);
-
+    auto filepath = Util::fromGtkFilename(gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog)));
+    settings->setLastSavePath(filepath.parent_path());
     gtk_widget_destroy(dialog);
 
-
-    ofstream out;
-    out.open(filename.c_str());
+    std::ofstream out{filepath};
     out << model.toString();
-    out.close();
 }
 
 void PageTemplateDialog::loadFromFile() {

--- a/src/gui/dialog/SettingsDialog.cpp
+++ b/src/gui/dialog/SettingsDialog.cpp
@@ -560,6 +560,7 @@ void SettingsDialog::save() {
     settings->setMenubarVisible(getCheckbox("cbHideMenubarStartup"));
 
     settings->setDefaultSaveName(gtk_entry_get_text(GTK_ENTRY(get("txtDefaultSaveName"))));
+    // Todo(fabian): use Util::fromGtkFilename!
     char* uri = gtk_file_chooser_get_uri(GTK_FILE_CHOOSER(get("fcAudioPath")));
     if (uri != nullptr) {
         settings->setAudioFolder(uri);

--- a/src/util/PathUtil.cpp
+++ b/src/util/PathUtil.cpp
@@ -95,7 +95,6 @@ auto Util::toUri(const fs::path& path) -> std::optional<std::string> {
     return {std::move(uriString)};
 }
 
-#ifndef BUILD_THUMBNAILER
 auto Util::fromGFile(GFile* file) -> fs::path {
     char* p = g_file_get_path(file);
     auto ret = p ? fs::u8path(p) : fs::path{};
@@ -103,8 +102,7 @@ auto Util::fromGFile(GFile* file) -> fs::path {
     return ret;
 }
 
-auto Util::toGFile(const fs::path path) -> GFile* { return g_file_new_for_path(path.u8string().c_str()); }
-#endif
+auto Util::toGFile(fs::path const& path) -> GFile* { return g_file_new_for_path(path.u8string().c_str()); }
 
 
 void Util::openFileWithDefaultApplication(const fs::path& filename) {

--- a/src/util/PathUtil.h
+++ b/src/util/PathUtil.h
@@ -26,17 +26,17 @@ namespace Util {
  *
  * @return contents if the file was read, std::nullopt if not
  */
-std::optional<std::string> readString(fs::path const& path, bool showErrorToUser = true);
+[[maybe_unused]] [[nodiscard]] std::optional<std::string> readString(fs::path const& path, bool showErrorToUser = true);
 
 /**
  * Get escaped path, all " and \ are escaped
  */
-std::string getEscapedPath(const fs::path& path);
+[[maybe_unused]] [[nodiscard]] std::string getEscapedPath(const fs::path& path);
 
 /**
  * @return true if this file has .xopp or .xoj extension
  */
-bool hasXournalFileExt(const fs::path& path);
+[[maybe_unused]] [[nodiscard]] bool hasXournalFileExt(const fs::path& path);
 
 /**
  * Clear the the last known xournal extension (last .xoj, .xopp etc.)
@@ -47,38 +47,43 @@ bool hasXournalFileExt(const fs::path& path);
 void clearExtensions(fs::path& path, const std::string& ext = "");
 
 // Uri must be ASCII-encoded!
-std::optional<fs::path> fromUri(const std::string& uri);
+[[maybe_unused]] [[nodiscard]] std::optional<fs::path> fromUri(const std::string& uri);
 
-std::optional<std::string> toUri(const fs::path& path);
+[[maybe_unused]] [[nodiscard]] std::optional<std::string> toUri(const fs::path& path);
 
 
-#ifndef BUILD_THUMBNAILER
-fs::path fromGFile(GFile* file);
+[[maybe_unused]] [[nodiscard]] fs::path fromGFile(GFile* file);
+[[maybe_unused]] [[nodiscard]] GFile* toGFile(fs::path const& path);
 
-GFile* toGFile(const fs::path);
-#endif
-
+[[maybe_unused]] [[nodiscard]] inline fs::path fromGtkFilename(char* path) {
+    if (path == nullptr) {
+        return {};
+    }
+    auto ret = fs::path{path};
+    g_free(path);
+    return ret;
+}
 
 void openFileWithDefaultApplication(const fs::path& filename);
 void openFileWithFilebrowser(const fs::path& filename);
 
-bool isChildOrEquivalent(fs::path const& path, fs::path const& base);
+[[maybe_unused]] [[nodiscard]] bool isChildOrEquivalent(fs::path const& path, fs::path const& base);
 
-bool safeRenameFile(fs::path const& from, fs::path const& to);
+[[maybe_unused]] bool safeRenameFile(fs::path const& from, fs::path const& to);
 
-fs::path ensureFolderExists(const fs::path& p);
+[[maybe_unused]] fs::path ensureFolderExists(const fs::path& p);
 
 
 /**
  * Return the configuration folder path (may not be guaranteed to exist).
  */
-fs::path getConfigFolder();
-fs::path getConfigSubfolder(const fs::path& subfolder = "");
-fs::path getCacheSubfolder(const fs::path& subfolder = "");
-fs::path getDataSubfolder(const fs::path& subfolder = "");
-fs::path getConfigFile(const fs::path& relativeFileName = "");
-fs::path getCacheFile(const fs::path& relativeFileName = "");
-fs::path getTmpDirSubfolder(const fs::path& subfolder = "");
-fs::path getAutosaveFilepath();
+[[maybe_unused]] [[nodiscard]] fs::path getConfigFolder();
+[[maybe_unused]] [[nodiscard]] fs::path getConfigSubfolder(const fs::path& subfolder = "");
+[[maybe_unused]] [[nodiscard]] fs::path getCacheSubfolder(const fs::path& subfolder = "");
+[[maybe_unused]] [[nodiscard]] fs::path getDataSubfolder(const fs::path& subfolder = "");
+[[maybe_unused]] [[nodiscard]] fs::path getConfigFile(const fs::path& relativeFileName = "");
+[[maybe_unused]] [[nodiscard]] fs::path getCacheFile(const fs::path& relativeFileName = "");
+[[maybe_unused]] [[nodiscard]] fs::path getTmpDirSubfolder(const fs::path& subfolder = "");
+[[maybe_unused]] [[nodiscard]] fs::path getAutosaveFilepath();
 
 }  // namespace Util


### PR DESCRIPTION
For that a new utility function has been introduced `Util::fromGtkFilename`
Which parses an owned char* to an fs::path and deletes the char*