### PR TITLE
fixed bug in `Util::toUri`, which prevented the generation of a URI.

### DIFF
--- a/src/model/Document.cpp
+++ b/src/model/Document.cpp
@@ -291,19 +291,20 @@ auto Document::readPdf(const fs::path& filename, bool initPages, bool attachToDo
             return false;
         }
     } else {
-        if (!pdfDocument.load(filename.c_str(), password, &popplerError)) {
-            lastError = FS(_F("Document not loaded! ({1}), {2}") % filename.string() % popplerError->message);
-            g_error_free(popplerError);
+        if (!pdfDocument.load(filename, password, &popplerError)) {
+            if (popplerError) {
+                lastError = FS(_F("Document not loaded! ({1}), {2}") % filename.string() % popplerError->message);
+                g_error_free(popplerError);
+            } else {
+                lastError = FS(_F("Document not loaded! ({1}), {2}") % filename.string() % "");
+            }
             unlock();
-
             return false;
         }
     }
 
-
     this->pdfFilepath = filename;
     this->attachPdf = attachToDocument;
-
     lastError = "";
 
     if (initPages) {


### PR DESCRIPTION
This happened, when the `fs::path` object is relative.
fixes #2226 