### PR TITLE
Added more infos about installation on Debian to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,9 +177,9 @@ of some popular Linux distros and platforms.
 
 ### Debian
 
-[Stable releases](https://github.com/xournalpp/xournalpp/releases) and
-_unstable_, [automated nightly releases](https://github.com/xournalpp/xournalpp/releases/tag/nightly)
-for Debian can be found on Debian.
+There are [Stable releases](https://github.com/xournalpp/xournalpp/releases) and
+_unstable_ [automated nightly releases](https://github.com/xournalpp/xournalpp/releases/tag/nightly)
+for Debian.
 
 ### Ubuntu and derivatives
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ only compatible with the _specific version of Debian or Ubuntu_ indicated by the
 file name. For example, if you are on Ubuntu 20.04, the binary whose name
 contains `Ubuntu-xenial` is _only_ compatible with Ubuntu 18.04. If your system
 is not one of the specific Debian or Ubuntu versions that are supported by the
-official binaries, we recommend you use either the PPA, the Flatpak, or the
+official binaries, we recommend you use either the PPA (Ubuntu only), the Flatpak, or the
 AppImage.
 
 There is also an _unstable_, [automated nightly

--- a/README.md
+++ b/README.md
@@ -175,6 +175,12 @@ includes the very latest features and bug fixes.
 With the help of the community, Xournal++ is also available on official repositories
 of some popular Linux distros and platforms.
 
+### Debian
+
+[Stable releases](https://github.com/xournalpp/xournalpp/releases) and
+_unstable_, [automated nightly releases](https://github.com/xournalpp/xournalpp/releases/tag/nightly)
+for Debian can be found on Debian.
+
 ### Ubuntu and derivatives
 
 An _unstable_, nightly release is available for Ubuntu-based distributions via the following PPA:


### PR DESCRIPTION
See #2231

The current version may lead to the idea, the PPA should also be used by Debian users, which is not the case (https://github.com/xournalpp/xournalpp/issues/2231#issuecomment-691574344).
This PR adds more infos to the README by marking PPA as Ubuntu only in a hint targeted to Debian/Ubuntu users and adding a short paragraph for Debian users linking to the GitHub releases page.