### PR TITLE
Rewrite main to use the gtk3 initialisation instead of the deprecated gtk2 method

### DIFF
--- a/cmake/find/FindFilesystem.cmake
+++ b/cmake/find/FindFilesystem.cmake
@@ -259,7 +259,7 @@ elseif (NOT _found AND "ghc" IN_LIST want_components)
     set (GHC_FILESYSTEM ghcFilesystem_git)
     ExternalProject_Add(${GHC_FILESYSTEM}
       GIT_REPOSITORY "https://github.com/gulrak/filesystem.git"
-      GIT_TAG "v1.3.2"
+      GIT_TAG "v1.3.8"
       LOG_DOWNLOAD 1
       CONFIGURE_COMMAND ""
       BUILD_COMMAND ""

--- a/src/Xournalpp.cpp
+++ b/src/Xournalpp.cpp
@@ -35,12 +35,10 @@ auto main(int argc, char* argv[]) -> int {
 #endif
 
     // Use this two line to test the crash handler...
-    //	int* crash = nullptr;
-    //	*crash = 0;
+    // int* crash = nullptr;
+    // *crash = 0;
 
-    auto* main = new XournalMain();
-    int result = main->run(argc, argv);
-    delete main;
+    int result = XournalMain::run(argc, argv);
 
 #ifdef DEV_CALL_LOG
     Log::closelog();

--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -1,15 +1,10 @@
 #include "Control.h"
 
 #include <ctime>
-#include <fstream>
 #include <memory>
 #include <numeric>
-#include <sstream>
-#include <utility>
 
-#include <gio/gio.h>
 #include <glib/gstdio.h>
-#include <gtk/gtk.h>
 
 #include "gui/TextEditor.h"
 #include "gui/XournalView.h"
@@ -24,21 +19,15 @@
 #include "gui/dialog/ToolbarManageDialog.h"
 #include "gui/dialog/toolbarCustomize/ToolbarDragDropHandler.h"
 #include "gui/inputdevices/HandRecognition.h"
-#include "gui/toolbarMenubar/ToolMenuHandler.h"
 #include "gui/toolbarMenubar/model/ToolbarData.h"
 #include "gui/toolbarMenubar/model/ToolbarModel.h"
 #include "jobs/AutosaveJob.h"
-#include "jobs/BlockingJob.h"
 #include "jobs/CustomExportJob.h"
 #include "jobs/PdfExportJob.h"
 #include "jobs/SaveJob.h"
 #include "layer/LayerController.h"
-#include "model/BackgroundImage.h"
-#include "model/FormatDefinitions.h"
 #include "model/StrokeStyle.h"
-#include "model/XojPage.h"
 #include "pagetype/PageTypeHandler.h"
-#include "pagetype/PageTypeMenu.h"
 #include "plugin/PluginController.h"
 #include "serializing/ObjectInputStream.h"
 #include "settings/ButtonConfig.h"
@@ -48,7 +37,6 @@
 #include "undo/DeleteUndoAction.h"
 #include "undo/InsertDeletePageUndoAction.h"
 #include "undo/InsertUndoAction.h"
-#include "view/DocumentView.h"
 #include "view/TextView.h"
 #include "xojfile/LoadHandler.h"
 
@@ -64,12 +52,11 @@
 #include "Util.h"
 #include "XojMsgBox.h"
 #include "config-dev.h"
-#include "config-features.h"
 #include "config.h"
 #include "i18n.h"
 
 
-Control::Control(GladeSearchpath* gladeSearchPath) {
+Control::Control(GApplication* gtkApp, GladeSearchpath* gladeSearchPath): gtkApp(gtkApp) {
     this->recent = new RecentManager();
     this->undoRedo = new UndoRedoHandler(this);
     this->recent->addListener(this);
@@ -137,9 +124,7 @@ Control::~Control() {
     this->enableAutosave(false);
 
     deleteLastAutosaveFile("");
-
     this->scheduler->stop();
-
     this->changedPages.clear();  // can be removed, will be done by implicit destructor
 
     delete this->pluginController;
@@ -2433,7 +2418,7 @@ void Control::quit(bool allowCancel) {
 
     this->scheduler->removeAllJobs();
     this->scheduler->unlock();
-    gtk_main_quit();
+    g_application_quit(G_APPLICATION(gtkApp));
 }
 
 auto Control::close(const bool allowDestroy, const bool allowCancel) -> bool {

--- a/src/control/Control.h
+++ b/src/control/Control.h
@@ -14,9 +14,9 @@
 #include <string>
 #include <vector>
 
-#include "../gui/dialog/LatexDialog.h"
 #include "gui/MainWindow.h"
 #include "gui/SearchBar.h"
+#include "gui/dialog/LatexDialog.h"
 #include "gui/sidebar/Sidebar.h"
 #include "jobs/ProgressListener.h"
 #include "jobs/XournalScheduler.h"
@@ -62,7 +62,7 @@ class Control:
         public ClipboardListener,
         public ProgressListener {
 public:
-    Control(GladeSearchpath* gladeSearchPath);
+    Control(GApplication* gtkApp, GladeSearchpath* gladeSearchPath);
     virtual ~Control();
 
     void initWindow(MainWindow* win);
@@ -333,11 +333,11 @@ private:
      */
     void applyPreferredLanguage();
 
-    RecentManager* recent;
-    UndoRedoHandler* undoRedo;
-    ZoomControl* zoom;
+    RecentManager* recent = nullptr;
+    UndoRedoHandler* undoRedo = nullptr;
+    ZoomControl* zoom = nullptr;
 
-    Settings* settings;
+    Settings* settings = nullptr;
     MainWindow* win = nullptr;
 
     Document* doc = nullptr;
@@ -356,6 +356,8 @@ private:
     AudioController* audioController;
 
     ToolbarDragDropHandler* dragDropHandler = nullptr;
+
+    GApplication* gtkApp = nullptr;
 
     /**
      * The cursor handler

--- a/src/control/XournalMain.cpp
+++ b/src/control/XournalMain.cpp
@@ -1,9 +1,11 @@
 #include "XournalMain.h"
 
+#include <algorithm>
 #include <memory>
 
 #include <glib/gstdio.h>
 #include <gtk/gtk.h>
+#include <gui/toolbarMenubar/model/ToolbarColorNames.h>
 #include <libintl.h>
 
 #include "control/jobs/ImageExport.h"
@@ -11,7 +13,6 @@
 #include "gui/GladeSearchpath.h"
 #include "gui/MainWindow.h"
 #include "gui/XournalView.h"
-#include "gui/toolbarMenubar/model/ToolbarColorNames.h"
 #include "pdf/base/XojPdfExport.h"
 #include "pdf/base/XojPdfExportFactory.h"
 #include "undo/EmergencySaveRestore.h"
@@ -30,15 +31,33 @@
 #if __linux__
 #include <libgen.h>
 #endif
+namespace {
 
-#include <algorithm>  // std::sort
+constexpr auto APP_FLAGS = GApplicationFlags(G_APPLICATION_SEND_ENVIRONMENT | G_APPLICATION_NON_UNIQUE);
 
+/// Configuration migration status.
+enum class MigrateStatus {
+    NotNeeded,  ///< No migration was needed.
+    Success,    ///< Migration was carried out successfully.
+    Failure,    ///< Migration failed. */
+};
 
-XournalMain::XournalMain() = default;
+struct MigrateResult {
+    MigrateStatus status{};
+    std::string message;  ///< Any additional information about the migration status.
+};
 
-XournalMain::~XournalMain() = default;
+auto migrateSettings() -> MigrateResult;
 
-void XournalMain::initLocalisation() {
+void checkForErrorlog();
+void checkForEmergencySave(Control* control);
+
+auto exportPdf(const char* input, const char* output) -> int;
+auto exportImg(const char* input, const char* output) -> int;
+
+void initResourcePath(GladeSearchpath* gladePath, const gchar* relativePathAndFile, bool failIfNotFound = true);
+
+void initLocalisation() {
 #ifdef ENABLE_NLS
 
 #ifdef _WIN32
@@ -61,56 +80,59 @@ void XournalMain::initLocalisation() {
 
 #endif  // ENABLE_NLS
 
-    // Not working on Windows! Working on Linux, but not sure if it's needed
-#ifndef _WIN32
+    // Not working on GNU g++(mingww) forWindows! Only working on Linux/macOS and with msvc
     try {
         std::locale::global(std::locale(""));  // "" - system default locale
     } catch (std::runtime_error& e) {
-        g_warning("XournalMain: System default locale could not be set.\nCaused by: %s", e.what());
+        g_warning("XournalMain: System default locale could not be set.\n - Caused by: %s\n - Note that it is not "
+                  "supported to set the locale using mingw-w64 on windows.\n - This could be solved by compiling "
+                  "xournalpp with msvc",
+                  e.what());
     }
-#endif
     std::cout.imbue(std::locale());
 }
 
-XournalMain::MigrateResult XournalMain::migrateSettings() {
+auto migrateSettings() -> MigrateResult {
     fs::path newConfigPath = Util::getConfigFolder();
 
     if (!fs::exists(newConfigPath)) {
-        std::array<fs::path, 1> oldPaths = {
+        std::array oldPaths = {
+                Util::getConfigFolder().parent_path() /= "com.github.xournalpp.xournalpp",
+                Util::getConfigFolder().parent_path() /= "com.github.xournalpp.xournalpp.exe",
                 fs::u8path(g_get_home_dir()) /= ".xournalpp",
         };
         for (auto const& oldPath: oldPaths) {
             if (!fs::is_directory(oldPath)) {
                 continue;
             }
-            g_message("Migrating configuration from %s to %s", oldPath.c_str(), newConfigPath.c_str());
+            g_message("Migrating configuration from %s to %s", oldPath.string().c_str(),
+                      newConfigPath.string().c_str());
             Util::ensureFolderExists(newConfigPath.parent_path());
             try {
                 fs::copy(oldPath, newConfigPath, fs::copy_options::recursive);
                 constexpr auto msg = "Due to a recent update, Xournal++ has changed where it's configuration files are "
                                      "stored.\nThey have been automatically copied from\n\t{1}\nto\n\t{2}";
-                return {MigrateStatus::Success,
-                        FS(_F(msg) % oldPath.u8string().c_str() % newConfigPath.u8string().c_str())};
+                return {MigrateStatus::Success, FS(_F(msg) % oldPath.u8string() % newConfigPath.u8string())};
             } catch (fs::filesystem_error const& except) {
                 constexpr auto msg =
                         "Due to a recent update, Xournal++ has changed where it's configuration files are "
                         "stored.\nHowever, when attempting to copy\n\t{1}\nto\n\t{2}\nmigration failed:\n{3}";
                 g_message("Migration failed: %s", except.what());
                 return {MigrateStatus::Failure,
-                        FS(_F(msg) % oldPath.u8string().c_str() % newConfigPath.u8string().c_str() % except.what())};
+                        FS(_F(msg) % oldPath.u8string() % newConfigPath.u8string() % except.what())};
             }
         }
     }
     return {MigrateStatus::NotNeeded, ""};
 }
 
-void XournalMain::checkForErrorlog() {
+void checkForErrorlog() {
     fs::path errorDir = Util::getCacheSubfolder(ERRORLOG_DIR);
     if (!fs::exists(errorDir)) {
         return;
     }
 
-    vector<fs::path> errorList;
+    std::vector<fs::path> errorList;
     for (auto const& f: fs::directory_iterator(errorDir)) {
         if (f.is_regular_file() && f.path().stem() == "errorlog") {
             errorList.emplace_back(f);
@@ -127,11 +149,9 @@ void XournalMain::checkForErrorlog() {
                     _("There is an errorlogfile from Xournal++. Please send a Bugreport, so the bug may be fixed.") :
                     _("There are errorlogfiles from Xournal++. Please send a Bugreport, so the bug may be fixed.");
     msg += "\n";
-#if defined(GIT_BRANCH) && defined(GIT_REPO_OWNER)
-    msg += FS(_F("You're using {1}/{2} branch. Send Bugreport will direct you to this repo's issue tracker.") %
-              GIT_REPO_OWNER % GIT_BRANCH);
+    msg += FS(_F("You're using \"{1}/{2}\" branch. Send Bugreport will direct you to this repo's issue tracker.") %
+              GIT_ORIGIN_OWNER % GIT_BRANCH);
     msg += "\n";
-#endif
     msg += FS(_F("The most recent log file name: {1}") % errorList[0].string());
 
     GtkWidget* dialog = gtk_message_dialog_new(nullptr, GTK_DIALOG_MODAL, GTK_MESSAGE_QUESTION, GTK_BUTTONS_NONE, "%s",
@@ -144,6 +164,7 @@ void XournalMain::checkForErrorlog() {
     gtk_dialog_add_button(GTK_DIALOG(dialog), _("Cancel"), 5);
 
     int res = gtk_dialog_run(GTK_DIALOG(dialog));
+    gtk_widget_destroy(dialog);
 
     auto const& errorlogPath = Util::getCacheSubfolder(ERRORLOG_DIR) / errorList[0];
     if (res == 1)  // Send Bugreport
@@ -159,19 +180,17 @@ void XournalMain::checkForErrorlog() {
     } else if (res == 4)  // Delete Logfile
     {
         if (!fs::exists(errorlogPath)) {
-            string msg = FS(_F("Errorlog cannot be deleted. You have to do it manually.\nLogfile: {1}") %
-                            errorlogPath.u8string());
+            msg = FS(_F("Errorlog cannot be deleted. You have to do it manually.\nLogfile: {1}") %
+                     errorlogPath.u8string());
             XojMsgBox::showErrorToUser(nullptr, msg);
         }
     } else if (res == 5)  // Cancel
     {
         // Nothing to do
     }
-
-    gtk_widget_destroy(dialog);
 }
 
-void XournalMain::checkForEmergencySave(Control* control) {
+void checkForEmergencySave(Control* control) {
     auto file = Util::getConfigFile("emergencysave.xopp");
 
     if (!fs::exists(file)) {
@@ -206,13 +225,12 @@ void XournalMain::checkForEmergencySave(Control* control) {
     gtk_widget_destroy(dialog);
 }
 
-auto XournalMain::exportImg(const char* input, const char* output) -> int {
+auto exportImg(const char* input, const char* output) -> int {
     LoadHandler loader;
 
     Document* doc = loader.loadDocument(input);
     if (doc == nullptr) {
         g_error("%s", loader.getLastError().c_str());
-        return -2;
     }
 
     fs::path const path(output);
@@ -224,7 +242,7 @@ auto XournalMain::exportImg(const char* input, const char* output) -> int {
     }
 
     PageRangeVector exportRange;
-    exportRange.push_back(new PageRangeEntry(0, doc->getPageCount() - 1));
+    exportRange.push_back(new PageRangeEntry(0, int(doc->getPageCount() - 1)));
     DummyProgressListener progress;
 
     ImageExport imgExport(doc, path, format, false, exportRange);
@@ -238,7 +256,6 @@ auto XournalMain::exportImg(const char* input, const char* output) -> int {
     string errorMsg = imgExport.getLastErrorMsg();
     if (!errorMsg.empty()) {
         g_message("Error exporting image: %s\n", errorMsg.c_str());
-        return -3;
     }
 
     g_message("%s", _("Image file successfully created"));
@@ -246,13 +263,12 @@ auto XournalMain::exportImg(const char* input, const char* output) -> int {
     return 0;  // no error
 }
 
-auto XournalMain::exportPdf(const char* input, const char* output) -> int {
+auto exportPdf(const char* input, const char* output) -> int {
     LoadHandler loader;
 
     Document* doc = loader.loadDocument(input);
     if (doc == nullptr) {
         g_error("%s", loader.getLastError().c_str());
-        return -2;
     }
 
     GFile* file = g_file_new_for_commandline_arg(output);
@@ -265,9 +281,7 @@ auto XournalMain::exportPdf(const char* input, const char* output) -> int {
 
     if (!pdfe->createPdf(path)) {
         g_error("%s", pdfe->getLastError().c_str());
-
-        delete pdfe;
-        return -3;
+        // delete pdfe; Unreachable. Todo: use std::unique_ptr
     }
     delete pdfe;
 
@@ -276,237 +290,73 @@ auto XournalMain::exportPdf(const char* input, const char* output) -> int {
     return 0;  // no error
 }
 
-auto XournalMain::run(int argc, char* argv[]) -> int {
-    g_set_prgname("com.github.xournalpp.xournalpp");
-    this->initLocalisation();
-    MigrateResult migrateResult = this->migrateSettings();
+struct XournalMainPrivate {
+    XournalMainPrivate() = default;
+    XournalMainPrivate(XournalMainPrivate&&) = delete;
+    XournalMainPrivate(XournalMainPrivate const&) = delete;
+    auto operator=(XournalMainPrivate&&) -> XournalMainPrivate = delete;
+    auto operator=(XournalMainPrivate const&) -> XournalMainPrivate = delete;
 
-    GError* error = nullptr;
-    GOptionContext* context = g_option_context_new("FILE");
+    ~XournalMainPrivate() {
+        g_strfreev(optFilename);
+        g_free(pdfFilename);
+        g_free(imgFilename);
+    }
 
-    gchar** optFilename = nullptr;
-    gchar* pdfFilename = nullptr;
-    gchar* imgFilename = nullptr;
+    gchar** optFilename{};
+    gchar* pdfFilename{};
+    gchar* imgFilename{};
     gboolean showVersion = false;
     int openAtPageNumber = -1;
+    std::unique_ptr<GladeSearchpath> gladePath;
+    std::unique_ptr<Control> control;
+    std::unique_ptr<MainWindow> win;
+};
+using XMPtr = XournalMainPrivate*;
 
-    string create_pdf = _("PDF output filename");
-    string create_img = _("Image output filename (.png / .svg)");
-    string page_jump = _("Jump to Page (first Page: 1)");
-    string audio_folder = _("Absolute path for the audio files playback");
-    string version = _("Get version of xournalpp");
-    GOptionEntry options[] = {{"create-pdf", 'p', 0, G_OPTION_ARG_FILENAME, &pdfFilename, create_pdf.c_str(), nullptr},
-                              {"create-img", 'i', 0, G_OPTION_ARG_FILENAME, &imgFilename, create_img.c_str(), nullptr},
-                              {"page", 'n', 0, G_OPTION_ARG_INT, &openAtPageNumber, page_jump.c_str(), "N"},
-                              {G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_FILENAME_ARRAY, &optFilename, "<input>", nullptr},
-                              {"version", 0, 0, G_OPTION_ARG_NONE, &showVersion, version.c_str(), nullptr},
-                              {nullptr}};
-
-    g_option_context_add_main_entries(context, options, GETTEXT_PACKAGE);
-    // parse options, so we don't need gtk_init, but don't init display (so we have a commandline mode)
-    g_option_context_add_group(context, gtk_get_option_group(false));
-    if (!g_option_context_parse(context, &argc, &argv, &error)) {
-        g_error("%s", error->message);
-        g_error_free(error);
-        gchar* help = g_option_context_get_help(context, true, nullptr);
-        g_message("%s", help);
-        g_free(help);
-        error = nullptr;
-    }
-    g_option_context_free(context);
-
-    if (pdfFilename && optFilename && *optFilename) {
-        return exportPdf(*optFilename, pdfFilename);
-    }
-    if (imgFilename && optFilename && *optFilename) {
-        return exportImg(*optFilename, imgFilename);
-    }
-
-    if (showVersion) {
-        g_printf("%s %s \n", PROJECT_NAME, PROJECT_VERSION);
-        g_printf("└──%s: %d.%d.%d \n", "libgtk", gtk_get_major_version(), gtk_get_minor_version(),
-                 gtk_get_micro_version());
-        return 0;
-    }
-
-    // Checks for input method compatibility
-
+/// Checks for input method compatibility and ensures it
+void ensure_input_model_compatibility() {
     const char* imModule = g_getenv("GTK_IM_MODULE");
     if (imModule != nullptr && strcmp(imModule, "xim") == 0) {
         g_setenv("GTK_IM_MODULE", "ibus", true);
         g_warning("Unsupported input method: xim, changed to: ibus");
     }
-
-    // Init GTK Display
-    gtk_init(&argc, &argv);
-
-    auto* gladePath = new GladeSearchpath();
-    initResourcePath(gladePath, "ui/about.glade");
-    initResourcePath(gladePath, "ui/xournalpp.css",
-                     false);  // will notify user if file not present. Path ui/ already added above.
-
-    // init singleton
-    auto colorNameFile = Util::getConfigFile("colornames.ini");
-    ToolbarColorNames::getInstance().loadFile(colorNameFile);
-
-    auto* control = new Control(gladePath);
-
-    auto icon = gladePath->getFirstSearchPath() / "icons";
-    gtk_icon_theme_prepend_search_path(gtk_icon_theme_get_default(), icon.u8string().c_str());
-
-    if (control->getSettings()->isDarkTheme()) {
-        auto icon = gladePath->getFirstSearchPath() / "iconsDark";
-        gtk_icon_theme_prepend_search_path(gtk_icon_theme_get_default(), icon.u8string().c_str());
-    }
-
-    auto& globalLatexTemplatePath = control->getSettings()->latexSettings.globalTemplatePath;
-    if (globalLatexTemplatePath.empty()) {
-        globalLatexTemplatePath = findResourcePath("resources/") / "default_template.tex";
-        g_message("Using default latex template in %s", globalLatexTemplatePath.string().c_str());
-        control->getSettings()->save();
-    }
-
-    auto* win = new MainWindow(gladePath, control);
-    control->initWindow(win);
-
-    win->show(nullptr);
-    bool opened = false;
-    if (optFilename) {
-        if (g_strv_length(optFilename) != 1) {
-            string msg = _("Sorry, Xournal++ can only open one file at once.\n"
-                           "Others are ignored.");
-            XojMsgBox::showErrorToUser(static_cast<GtkWindow*>(*win), msg);
-        }
-
-        fs::path p = Util::fromGFilename(optFilename[0], false);
-
-        try {
-            if (fs::exists(p)) {
-                opened = control->openFile(p, openAtPageNumber);
-            } else {
-                opened = control->newFile("", p);
-            }
-        } catch (fs::filesystem_error const& e) {
-            string msg = FS(_F("Sorry, Xournal++ cannot open remote files at the moment.\n"
-                               "You have to copy the file to a local directory.") %
-                            p.u8string().c_str() % e.what());
-            XojMsgBox::showErrorToUser(static_cast<GtkWindow*>(*win), msg);
-            opened = control->newFile("", p);
-        }
-    }
-
-    control->getScheduler()->start();
-
-    if (!opened) {
-        control->newFile();
-    }
-
-    checkForErrorlog();
-    checkForEmergencySave(control);
-
-    // There was a timing issue with the layout, see #405
-    control->getWindow()->getXournal()->layoutPages();
-
-    if (migrateResult.status != MigrateStatus::NotNeeded) {
-        Util::execInUiThread([=]() { XojMsgBox::showErrorToUser(control->getGtkWindow(), migrateResult.message); });
-    }
-
-    gtk_main();
-
-    control->saveSettings();
-
-    win->getXournal()->clearSelection();
-
-    control->getScheduler()->stop();
-
-    delete win;
-    delete control;
-    delete gladePath;
-
-    ToolbarColorNames::getInstance().saveFile(colorNameFile);
-    ToolbarColorNames::freeInstance();
-
-    return 0;
 }
 
 /**
  * Find a file in a resource folder, and return the resource folder path
  * Return an empty string, if the folder was not found
  */
-auto XournalMain::findResourcePath(const string& searchFile) -> fs::path {
-    // First check if the files are available relative to the path
-    // So a "portable" installation will be possible
-    fs::path relative1 = searchFile;
+auto findResourcePath(const fs::path& searchFile) -> fs::path {
+    auto search_for = [&searchFile](fs::path start) -> std::optional<fs::path> {
+        constexpr auto* postfix = "share/xournalpp";
+        /// 1. relative install
+        /// 2. windows install
+        /// 3. build dir
+        for (int i = 0; i < 3; ++i, start = start.parent_path()) {
+            if (auto target = start / searchFile; fs::exists(target)) {
+                return target.parent_path();
+            }
 
-    if (fs::exists(relative1)) {
-        return relative1.parent_path();
+            if (auto folder = start / postfix / searchFile; fs::exists(folder)) {
+                return folder.parent_path();
+            }
+        }
+        return std::nullopt;
+    };
+    /*    /// relative execution path
+        if (auto path = search_for(fs::path{}); path) {
+            return *path;
+        }*/
+    /// real execution path
+    if (auto path = search_for(Stacktrace::getExePath().parent_path()); path) {
+        return *path;
     }
-
-    // -----------------------------------------------------------------------
-
-    // Check if we are in the "build" directory, and therefore the resources
-    // are installed two folders back
-    fs::path relative2 = "../..";
-    relative2 /= searchFile;
-
-    if (fs::exists(relative2)) {
-        return relative2.parent_path();
-    }
-
-    // -----------------------------------------------------------------------
-
-    fs::path executableDir = Stacktrace::getExePath();
-    executableDir = executableDir.parent_path();
-
-    // First check if the files are available relative to the executable
-    // So a "portable" installation will be possible
-    fs::path relative3 = executableDir;
-    relative3 /= searchFile;
-
-    if (fs::exists(relative3)) {
-        return relative3.parent_path();
-    }
-
-    // -----------------------------------------------------------------------
-
-    // Check one folder back, for windows portable
-    fs::path relative4 = executableDir;
-    relative4 /= "..";
-    relative4 /= searchFile;
-
-    if (fs::exists(relative4)) {
-        return relative4.parent_path();
-    }
-
-    // -----------------------------------------------------------------------
-
-    // Check if we are in the "build" directory, and therefore the resources
-    // are installed two folders back
-    fs::path relative5 = executableDir;
-    relative5 /= "../..";
-    relative5 /= searchFile;
-
-    if (fs::exists(relative5)) {
-        return relative5.parent_path();
-    }
-
-    // -----------------------------------------------------------------------
-
-    // Check for .../share resources directory relative to binary to support
-    // relocatable installations (such as e.g., AppImages)
-    fs::path relative6 = executableDir;
-    relative6 /= "../share/xournalpp/";
-    relative6 /= searchFile;
-
-    if (fs::exists(relative6)) {
-        return relative6.parent_path();
-    }
-
     // Not found
     return {};
 }
 
-void XournalMain::initResourcePath(GladeSearchpath* gladePath, const gchar* relativePathAndFile, bool failIfNotFound) {
+void initResourcePath(GladeSearchpath* gladePath, const gchar* relativePathAndFile, bool failIfNotFound) {
     auto uiPath = findResourcePath(relativePathAndFile);  // i.e.  relativePathAndFile = "ui/about.glade"
 
     if (!uiPath.empty()) {
@@ -544,7 +394,6 @@ void XournalMain::initResourcePath(GladeSearchpath* gladePath, const gchar* rela
         return;
     }
 
-
     string msg = FS(_F("<span foreground='red' size='x-large'>Missing the needed UI file:\n<b>{1}</b></span>\nCould "
                        "not find them at any location.\n  Not relative\n  Not in the Working Path\n  Not in {2}") %
                     relativePathAndFile % PACKAGE_DATA_DIR);
@@ -558,4 +407,151 @@ void XournalMain::initResourcePath(GladeSearchpath* gladePath, const gchar* rela
     if (failIfNotFound) {
         exit(12);
     }
+}
+
+void on_activate(GApplication*, XMPtr) {}
+
+void on_command_line(GApplication*, GApplicationCommandLine*, XMPtr) {
+    g_message("XournalMain::on_command_line: This should never happen, please file a bugreport with a detailed "
+              "description how to reproduce this message");
+    // Todo: implement this, if someone files the bug report
+}
+
+void on_open_files(GApplication*, gpointer, gint, gchar*, XMPtr) {
+    g_message("XournalMain::on_open_files: This should never happen, please file a bugreport with a detailed "
+              "description how to reproduce this message");
+    // Todo: implement this, if someone files the bug report
+}
+
+void on_startup(GApplication* application, XMPtr app_data) {
+    initLocalisation();
+    ensure_input_model_compatibility();
+    MigrateResult migrateResult = migrateSettings();
+
+    app_data->gladePath = std::make_unique<GladeSearchpath>();
+    initResourcePath(app_data->gladePath.get(), "ui/about.glade");
+    initResourcePath(app_data->gladePath.get(), "ui/xournalpp.css", false);
+
+    // init singleton
+    // ToolbarColorNames::getInstance();
+    app_data->control = std::make_unique<Control>(application, app_data->gladePath.get());
+    {
+        auto icon = app_data->gladePath->getFirstSearchPath() / "icons";
+        gtk_icon_theme_prepend_search_path(gtk_icon_theme_get_default(), icon.u8string().c_str());
+    }
+
+    if (app_data->control->getSettings()->isDarkTheme()) {
+        auto icon = app_data->gladePath->getFirstSearchPath() / "iconsDark";
+        gtk_icon_theme_prepend_search_path(gtk_icon_theme_get_default(), icon.u8string().c_str());
+    }
+
+    auto& globalLatexTemplatePath = app_data->control->getSettings()->latexSettings.globalTemplatePath;
+    if (globalLatexTemplatePath.empty()) {
+        globalLatexTemplatePath = findResourcePath("resources/") / "default_template.tex";
+        g_message("Using default latex template in %s", globalLatexTemplatePath.string().c_str());
+        app_data->control->getSettings()->save();
+    }
+
+    app_data->win = std::make_unique<MainWindow>(app_data->gladePath.get(), app_data->control.get());
+    app_data->control->initWindow(app_data->win.get());
+
+    if (migrateResult.status != MigrateStatus::NotNeeded) {
+        Util::execInUiThread(
+                [=]() { XojMsgBox::showErrorToUser(app_data->control->getGtkWindow(), migrateResult.message); });
+    }
+
+    app_data->win->show(nullptr);
+
+    bool opened = false;
+    if (app_data->optFilename) {
+        if (g_strv_length(app_data->optFilename) != 1) {
+            string msg = _("Sorry, Xournal++ can only open one file at once.\n"
+                           "Others are ignored.");
+            XojMsgBox::showErrorToUser(static_cast<GtkWindow*>(*app_data->win), msg);
+        }
+
+        fs::path p = Util::fromGFilename(app_data->optFilename[0], false);
+
+        try {
+            if (fs::exists(p)) {
+                opened = app_data->control->openFile(p, app_data->openAtPageNumber);
+            } else {
+                opened = app_data->control->newFile("", p);
+            }
+        } catch (fs::filesystem_error const& e) {
+            string msg = FS(_F("Sorry, Xournal++ cannot open remote files at the moment.\n"
+                               "You have to copy the file to a local directory.") %
+                            p.u8string() % e.what());
+            XojMsgBox::showErrorToUser(static_cast<GtkWindow*>(*app_data->win), msg);
+            opened = app_data->control->newFile("", p);
+        }
+    }
+
+    app_data->control->getScheduler()->start();
+
+    if (!opened) {
+        app_data->control->newFile();
+    }
+
+    checkForErrorlog();
+    checkForEmergencySave(app_data->control.get());
+
+    // There is a timing issue with the layout
+    // This fixes it, see #405
+    Util::execInUiThread([=]() { app_data->control->getWindow()->getXournal()->layoutPages(); });
+    gtk_application_add_window(GTK_APPLICATION(application), GTK_WINDOW(app_data->win->getWindow()));
+}
+
+auto on_handle_local_options(GApplication*, GVariantDict*, XMPtr app_data) -> gint {
+    if (app_data->showVersion) {
+        std::cout << PROJECT_NAME << " " << PROJECT_VERSION << std::endl;
+        std::cout << "└──libgtk: " << gtk_get_major_version() << "."  //
+                  << gtk_get_minor_version() << "."                   //
+                  << gtk_get_micro_version() << std::endl;            //
+        return 0;
+    }
+
+    if (app_data->pdfFilename && app_data->optFilename && *app_data->optFilename) {
+        return exportPdf(*app_data->optFilename, app_data->pdfFilename);
+    }
+    if (app_data->imgFilename && app_data->optFilename && *app_data->optFilename) {
+        return exportImg(*app_data->optFilename, app_data->imgFilename);
+    }
+    return -1;
+}
+
+void on_shutdown(GApplication*, XMPtr app_data) {
+    app_data->control->saveSettings();
+    app_data->win->getXournal()->clearSelection();
+    app_data->control->getScheduler()->stop();
+    ToolbarColorNames::getInstance().save();
+}
+
+}  // namespace
+
+auto XournalMain::run(int argc, char** argv) -> int {
+
+    XournalMainPrivate app_data;
+    GtkApplication* app = gtk_application_new("com.github.xournalpp.xournalpp", APP_FLAGS);
+    g_signal_connect(app, "activate", G_CALLBACK(&on_activate), &app_data);
+    g_signal_connect(app, "command-line", G_CALLBACK(&on_command_line), &app_data);
+    g_signal_connect(app, "open", G_CALLBACK(&on_open_files), &app_data);
+    g_signal_connect(app, "startup", G_CALLBACK(&on_startup), &app_data);
+    g_signal_connect(app, "shutdown", G_CALLBACK(&on_shutdown), &app_data);
+    g_signal_connect(app, "handle-local-options", G_CALLBACK(&on_handle_local_options), &app_data);
+
+    std::array options = {GOptionEntry{"create-pdf", 'p', 0, G_OPTION_ARG_FILENAME, &app_data.pdfFilename,
+                                       _("PDF output filename"), nullptr},
+                          GOptionEntry{"create-img", 'i', 0, G_OPTION_ARG_FILENAME, &app_data.imgFilename,
+                                       _("Image output filename (.png / .svg)"), nullptr},
+                          GOptionEntry{"page", 'n', 0, G_OPTION_ARG_INT, &app_data.openAtPageNumber,
+                                       _("Jump to Page (first Page: 1)"), "N"},
+                          GOptionEntry{G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_FILENAME_ARRAY, &app_data.optFilename,
+                                       "<input>", nullptr},
+                          GOptionEntry{"version", 0, 0, G_OPTION_ARG_NONE, &app_data.showVersion,
+                                       _("Get version of xournalpp"), nullptr}};
+    g_application_add_main_option_entries(G_APPLICATION(app), options.data());
+    auto rv = g_application_run(G_APPLICATION(app), argc, argv);
+    g_object_unref(app);
+    return rv;
 }

--- a/src/control/XournalMain.h
+++ b/src/control/XournalMain.h
@@ -22,48 +22,6 @@
 class GladeSearchpath;
 class Control;
 
-class XournalMain {
-public:
-    XournalMain();
-    virtual ~XournalMain();
-
-public:
-    int run(int argc, char* argv[]);
-
-private:
-    static void initLocalisation();
-
-    /**
-     * Configuration migration status.
-     */
-    enum class MigrateStatus {
-        /** No migration was needed. */
-        NotNeeded,
-        /** Migration was carried out successfully. */
-        Success,
-        /** Migration failed. */
-        Failure,
-    };
-
-    struct MigrateResult {
-        MigrateStatus status;
-        /** Any additional information about the migration status. */
-        std::string message;
-    };
-
-    static MigrateResult migrateSettings();
-
-    static void checkForErrorlog();
-    static void checkForEmergencySave(Control* control);
-
-    static int exportPdf(const char* input, const char* output);
-    static int exportImg(const char* input, const char* output);
-
-    void initSettingsPath();
-    void initResourcePath(GladeSearchpath* gladePath);
-    static void initResourcePath(GladeSearchpath* gladePath, const gchar* relativePathAndFile,
-                                 bool failIfNotFound = true);
-    static fs::path findResourcePath(const string& searchFile);
-
-private:
-};
+namespace XournalMain {
+auto run(int argc, char** argv) -> int;
+}

--- a/src/gui/PageView.h
+++ b/src/gui/PageView.h
@@ -182,8 +182,8 @@ private:
 
 private:
     PageRef page;
-    XournalView* xournal;
-    Settings* settings;
+    XournalView* xournal = nullptr;
+    Settings* settings = nullptr;
     EraseHandler* eraser = nullptr;
     InputHandler* inputHandler = nullptr;
 

--- a/src/gui/toolbarMenubar/model/ToolbarColorNames.h
+++ b/src/gui/toolbarMenubar/model/ToolbarColorNames.h
@@ -19,22 +19,24 @@
 
 #include "filesystem.h"
 
-class ToolbarColorNames {
-private:
-    ToolbarColorNames();
-    virtual ~ToolbarColorNames();
+class ToolbarColorNames final {
+    explicit ToolbarColorNames(fs::path path);
 
 public:
     static ToolbarColorNames& getInstance();
-    static void freeInstance();
+
+    ~ToolbarColorNames() noexcept;
+    ToolbarColorNames(ToolbarColorNames const&) = delete;
+    ToolbarColorNames(ToolbarColorNames&&) = delete;
+    ToolbarColorNames& operator=(ToolbarColorNames const&) = delete;
+    ToolbarColorNames& operator=(ToolbarColorNames&&) = delete;
 
 public:
-    void loadFile(fs::path const& file);
-    void saveFile(fs::path const& file);
-
     void addColor(Color color, const std::string& name, bool predefined);
-
     std::string getColorName(Color color);
+
+    void load();
+    void save() const noexcept;
 
 private:
     void initPredefinedColors();
@@ -42,4 +44,5 @@ private:
 private:
     GKeyFile* config;
     std::unordered_map<Color, std::string> predefinedColorNames{};
+    fs::path file;
 };

--- a/src/util/PathUtil.cpp
+++ b/src/util/PathUtil.cpp
@@ -10,8 +10,13 @@
 #include "XojMsgBox.h"
 #include "i18n.h"
 
+#ifdef __APPLE__
+// Fix of ghc::filesystem bug (path::operator/=() won't support string_views)
+constexpr auto const* CONFIG_FOLDER_NAME = "xournalpp";
+#else
 using namespace std::string_view_literals;
 constexpr auto CONFIG_FOLDER_NAME = "xournalpp"sv;
+#endif
 
 /**
  * Read a file to a string

--- a/src/util/PathUtil.cpp
+++ b/src/util/PathUtil.cpp
@@ -10,6 +10,9 @@
 #include "XojMsgBox.h"
 #include "i18n.h"
 
+using namespace std::string_view_literals;
+constexpr auto CONFIG_FOLDER_NAME = "xournalpp"sv;
+
 /**
  * Read a file to a string
  *
@@ -152,8 +155,7 @@ auto Util::getAutosaveFilepath() -> fs::path {
 
 auto Util::getConfigFolder() -> fs::path {
     auto p = fs::u8path(g_get_user_config_dir());
-    p /= g_get_prgname();
-    return p;
+    return (p /= CONFIG_FOLDER_NAME);
 }
 
 auto Util::getConfigSubfolder(const fs::path& subfolder) -> fs::path {
@@ -165,7 +167,7 @@ auto Util::getConfigSubfolder(const fs::path& subfolder) -> fs::path {
 
 auto Util::getCacheSubfolder(const fs::path& subfolder) -> fs::path {
     auto p = fs::u8path(g_get_user_cache_dir());
-    p /= g_get_prgname();
+    p /= CONFIG_FOLDER_NAME;
     p /= subfolder;
 
     return Util::ensureFolderExists(p);
@@ -173,7 +175,7 @@ auto Util::getCacheSubfolder(const fs::path& subfolder) -> fs::path {
 
 auto Util::getDataSubfolder(const fs::path& subfolder) -> fs::path {
     auto p = fs::u8path(g_get_user_data_dir());
-    p /= g_get_prgname();
+    p /= CONFIG_FOLDER_NAME;
     p /= subfolder;
 
     return Util::ensureFolderExists(p);

--- a/src/util/Stacktrace.cpp
+++ b/src/util/Stacktrace.cpp
@@ -68,7 +68,7 @@ fs::path Stacktrace::getExePath() {
 auto Stacktrace::getExePath() -> fs::path {
     std::array<char, PATH_MAX> result{};
     ssize_t count = readlink("/proc/self/exe", result.data(), PATH_MAX);
-    return fs::path{std::string(result.data(), (count > 0) ? count : 0)};
+    return fs::path{std::string(result.data(), std::max(ssize_t{0}, count))};
 }
 #endif
 


### PR DESCRIPTION
Since this is a huge change and this change should be merged into the next release we need to test it well.
Here a suggested list what's to test:

#### Test for Linux:
 - [x] Xournalpp starts (build_dir).
 - [x] Plugins are loaded (build_dir).
 - [x] All commands of the command-line-interface work.
 - [x] All icons are still displayed.
 - [x] everything works after installation

#### Test for Window:
 - [x] All commands of the command-line-interface work.
 - [x] All icons are still displayed.
 - [x] Xournalpp starts.
 - [x] everything works after installation
 - [x] Plugins are loaded

#### Test for Mac:
 - ~~All commands of the command-line-interface work.~~
 - ~~All icons are still displayed.~~
 - ~~Xournalpp starts.~~
 - ~~everything works after installation~~
 - ~~Plugins are loaded~~
 - ~~Append this list if desired.~~


This may fix problems with icons.
It will use the config folder name xournalpp instead of com.github.xournalpp.xournalpp