### PR TITLE
Fix PDF export crash when outline is empty

### DIFF
--- a/src/pdf/base/XojCairoPdfExport.cpp
+++ b/src/pdf/base/XojCairoPdfExport.cpp
@@ -49,7 +49,11 @@ void XojCairoPdfExport::populatePdfOutline(GtkTreeModel* tocModel) {
     std::stack<std::pair<GtkTreeIter, int>> nodeStack;
 
     GtkTreeIter firstIter = {0};
-    gtk_tree_model_get_iter_first(tocModel, &firstIter);
+    if (!gtk_tree_model_get_iter_first(tocModel, &firstIter)) {
+        // Outline is empty, so do nothing.
+        return;
+    }
+
     nodeStack.push(std::make_pair(firstIter, idCounter));
     while (!nodeStack.empty()) {
         auto [iter, parentId] = nodeStack.top();


### PR DESCRIPTION
Fixes #2236. This PR resolves the exporting issue, while d2665ed resolves a related loading issue (but does not directly fix the bug).

Note: this fixes a regression from 1.0.17.