### PR TITLE
fix bug for top and bottom resize anchor cursor

### DIFF
--- a/src/gui/XournalppCursor.cpp
+++ b/src/gui/XournalppCursor.cpp
@@ -247,6 +247,7 @@ void XournalppCursor::updateCursor() {
                 case CURSOR_SELECTION_TOP:
                     [[fallthrough]];
                 case CURSOR_SELECTION_BOTTOM:
+                    cursor = getResizeCursor(90);
                 case CURSOR_SELECTION_ROTATE:
                     setCursor(CRSR_EXCHANGE);
                     break;


### PR DESCRIPTION
When rebasing PR #2011 and solving merge conflicts I accidentally deleted a line, which defines the cursor for the resizing cursor while near top and bottom anchor. This is fixed here.