### PR TITLE
Drop fs::exists check for recent files

### DIFF
--- a/src/control/RecentManager.cpp
+++ b/src/control/RecentManager.cpp
@@ -130,7 +130,7 @@ auto RecentManager::filterRecent(GList* items, bool xoj) -> GList* {
         auto p = Util::fromUri(uri);
 
         // Skip remote files
-        if (!p || !fs::exists(*p)) {
+        if (!p) {
             continue;
         }
 


### PR DESCRIPTION
Resolves #2225.

Please note that while this solves the "crash and burn" issue Xournal++ encounters when even a simple `fs::exists` failes, in #2225 I also had quite high timeouts – 10s or 30s _for every affected file in recents_.

10s alone is quite a bummer, but it adds up. My case is quite special, but let's assume that one just has a very slow network drive. 10 files that take 3s each for `fs::exists`, that's 30s just to start Xournal++. Maybe we just want to drop `fs::exists` here and only call that when we actually want to open a single file?