### PR TITLE
fixup borders from empty toolbars

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -500,7 +500,10 @@ void MainWindow::setToolbarVisible(bool visible) {
 
     settings->setToolbarVisible(visible);
     for (int i = 0; i < TOOLBAR_DEFINITIONS_LEN; i++) {
-        gtk_widget_set_visible(this->toolbarWidgets[i], visible);
+        auto widget = this->toolbarWidgets[i];
+        if (!visible || GTK_IS_CONTAINER(widget) && gtk_container_get_children(GTK_CONTAINER(widget))) {
+            gtk_widget_set_visible(widget, visible);
+        }
     }
 
     GtkWidget* w = get("menuViewToolbarsVisible");


### PR DESCRIPTION
Fixes #2291 by only setting those toolbar widgets visible, which have at least one child.