### PR TITLE
Rebind accelerators when the menubar is hidden

### DIFF
--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -313,6 +313,8 @@ void Control::initWindow(MainWindow* win) {
 
     this->pluginController->registerMenu();
 
+    win->rebindMenubarAccelerators();
+
     fireActionSelected(GROUP_SNAPPING, settings->isSnapRotation() ? ACTION_ROTATION_SNAPPING : ACTION_NONE);
     fireActionSelected(GROUP_GRID_SNAPPING, settings->isSnapGrid() ? ACTION_GRID_SNAPPING : ACTION_NONE);
 }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -35,7 +35,7 @@
 #include "util/DeviceListHelper.h"
 
 MainWindow::MainWindow(GladeSearchpath* gladeSearchPath, Control* control):
-        GladeGui(gladeSearchPath, "main.glade", "mainWindow"), ignoreNextHideEvent(false) {
+        GladeGui(gladeSearchPath, "main.glade", "mainWindow") {
     this->control = control;
     this->toolbarWidgets = new GtkWidget*[TOOLBAR_DEFINITIONS_LEN];
     this->toolbarSelectMenu = new MainWindowToolbarMenu(this);
@@ -150,6 +150,54 @@ MainWindow::MainWindow(GladeSearchpath* gladeSearchPath, Control* control):
 #endif
 }
 
+gboolean MainWindow::isKeyForClosure(GtkAccelKey* key, GClosure* closure, gpointer data) { return closure == data; }
+
+gboolean MainWindow::invokeMenu(GtkWidget* widget) {
+    // g_warning("invoke_menu %s", gtk_widget_get_name(widget));
+    gtk_widget_activate(widget);
+    return TRUE;
+}
+
+void MainWindow::rebindAcceleratorsMenuItem(GtkWidget* widget, gpointer user_data) {
+    if (GTK_IS_MENU_ITEM(widget)) {
+        GtkAccelGroup* newAccelGroup = reinterpret_cast<GtkAccelGroup*>(user_data);
+        GList* menuAccelClosures = gtk_widget_list_accel_closures(widget);
+        for (GList* l = menuAccelClosures; l != NULL; l = l->next) {
+            GClosure* closure = reinterpret_cast<GClosure*>(l->data);
+            GtkAccelGroup* accelGroup = gtk_accel_group_from_accel_closure(closure);
+            GtkAccelKey* key = gtk_accel_group_find(accelGroup, isKeyForClosure, closure);
+
+            // g_warning("Rebind %s : %s", gtk_accelerator_get_label(key->accel_key, key->accel_mods),
+            // gtk_widget_get_name(widget));
+
+            gtk_accel_group_connect(newAccelGroup, key->accel_key, key->accel_mods, GtkAccelFlags(0),
+                                    g_cclosure_new_swap(G_CALLBACK(MainWindow::invokeMenu), widget, NULL));
+        }
+
+        MainWindow::rebindAcceleratorsSubMenu(widget, newAccelGroup);
+    }
+}
+
+void MainWindow::rebindAcceleratorsSubMenu(GtkWidget* widget, gpointer user_data) {
+    if (GTK_IS_MENU_ITEM(widget)) {
+        GtkMenuItem* menuItem = reinterpret_cast<GtkMenuItem*>(widget);
+        GtkWidget* subMenu = gtk_menu_item_get_submenu(menuItem);
+        if (GTK_IS_CONTAINER(subMenu)) {
+            gtk_container_foreach(reinterpret_cast<GtkContainer*>(subMenu), rebindAcceleratorsMenuItem, user_data);
+        }
+    }
+}
+
+// When the Menubar is hidden, accelerators no longer work so rebind them to the MainWindow
+// It should be called after all plugins have been initialised so that their injected menu items are captured
+void MainWindow::rebindMenubarAccelerators() {
+    this->globalAccelGroup = gtk_accel_group_new();
+    gtk_window_add_accel_group(GTK_WINDOW(this->getWindow()), this->globalAccelGroup);
+
+    GtkMenuBar* menuBar = (GtkMenuBar*)this->get("mainMenubar");
+    gtk_container_foreach(reinterpret_cast<GtkContainer*>(menuBar), rebindAcceleratorsSubMenu, this->globalAccelGroup);
+}
+
 MainWindow::~MainWindow() {
     for (int i = 0; i < TOOLBAR_DEFINITIONS_LEN; i++) {
         g_object_unref(this->toolbarWidgets[i]);
@@ -181,17 +229,11 @@ const char* TOP_WIDGETS[] = {"tbTop1", "tbTop2", "mainContainerBox", nullptr};
 
 
 void MainWindow::toggleMenuBar(MainWindow* win) {
-    if (win->ignoreNextHideEvent) {
-        win->ignoreNextHideEvent = false;
-        return;
-    }
-
     GtkWidget* menu = win->get("mainMenubar");
     if (gtk_widget_is_visible(menu)) {
         gtk_widget_hide(menu);
     } else {
         gtk_widget_show(menu);
-        win->ignoreNextHideEvent = true;
     }
 }
 
@@ -274,11 +316,6 @@ void MainWindow::initHideMenu() {
         // Menu found, allow to hide it
         g_signal_connect(menuItem, "activate",
                          G_CALLBACK(+[](GtkMenuItem* menuitem, MainWindow* self) { toggleMenuBar(self); }), this);
-
-        GtkAccelGroup* accelGroup = gtk_accel_group_new();
-        gtk_accel_group_connect(accelGroup, GDK_KEY_F10, static_cast<GdkModifierType>(0), GTK_ACCEL_VISIBLE,
-                                g_cclosure_new_swap(G_CALLBACK(toggleMenuBar), this, nullptr));
-        gtk_window_add_accel_group(GTK_WINDOW(getWindow()), accelGroup);
     }
 
     // Hide menubar at startup if specified in settings

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -28,7 +28,6 @@ class ToolbarModel;
 class XournalView;
 class MainWindowToolbarMenu;
 
-
 class MainWindow: public GladeGui, public LayerCtrlListener {
 public:
     MainWindow(GladeSearchpath* gladeSearchPath, Control* control);
@@ -104,6 +103,8 @@ public:
      */
     void setTouchscreenScrollingForDeviceMapping();
 
+    void rebindMenubarAccelerators();
+
 private:
     void initXournalWidget();
 
@@ -114,7 +115,10 @@ private:
     static void toggleMenuBar(MainWindow* win);
 
     void createToolbarAndMenu();
-
+    static void rebindAcceleratorsMenuItem(GtkWidget* widget, gpointer user_data);
+    static void rebindAcceleratorsSubMenu(GtkWidget* widget, gpointer user_data);
+    static gboolean isKeyForClosure(GtkAccelKey* key, GClosure* closure, gpointer data);
+    static gboolean invokeMenu(GtkWidget* widget);
 
     static void buttonCloseSidebarClicked(GtkButton* button, MainWindow* win);
 
@@ -171,9 +175,5 @@ private:
     GtkWidget** toolbarWidgets;
 
     MainWindowToolbarMenu* toolbarSelectMenu;
-
-    /**
-     * Workaround for double hide menubar event
-     */
-    bool ignoreNextHideEvent;
+    GtkAccelGroup* globalAccelGroup;
 };

--- a/src/gui/XournalView.cpp
+++ b/src/gui/XournalView.cpp
@@ -136,7 +136,7 @@ auto XournalView::onKeyPressEvent(GdkEventKey* event) -> bool {
     }
 
     // Esc leaves fullscreen mode
-    if (event->keyval == GDK_KEY_Escape || event->keyval == GDK_KEY_F11) {
+    if (event->keyval == GDK_KEY_Escape) {
         if (control->isFullscreen()) {
             control->setFullscreen(false);
             return true;


### PR DESCRIPTION
## Problem

Fix for #2082 and #1002 and progress towards user defined keymaps #919 for @rolandlo to test.

Keyboard accelerators for things like copy/paste/fullscreen/tools are bound by the menubar definition in glade. When the menubar is hidden, they no longer work.

## Implementation

There is no way to use the menubar programmatically when hidden and no other way I could find to hide it that preserved the accelerators so the only path I could see was to manually rebind them when the menubar is hidden. We can't have menubar and manual accelerators bound at the same time so they have to be toggled on/off when the menubar is reshown.

This means we have duplication of the accelerator definitions in glade and `initGlobalAccelerators` that must be kept in sync. If we removed the accelerators from glade then we would lose the UI integration that displays the short-cut key. If implementing user-defined key bindings then I think we would be forced to remove the glade accelerators and manually create UI labels to show the user's chosen short-cut.

I have reused the `actionPerformed` infrastructure where possible. This does mean providing dummy information for the parameters we don't have like the gtk event and the button being pressed which is currently fine but a future developer might change the action implementations to use these parameters causing a problem.

It looks like we could almost auto generate these bindings by parsing the glade file but it would make assumptions about how the accelerators are implemented that could easily be broken so lambdas makes it flexible to provide any necessary behaviour.

References:

https://stackoverflow.com/questions/19707775/accelerators-stop-responding-when-menubar-gets-hidden

## Testing

I have tested the accelerators with/without the menubar and it looks ok. 

I found one conflict with `f11` and `XournalView::onKeyPressEvent` which caused double toggling. I have removed it and it looks ok. Areas to examine would be any other view states that might manually handle key events.

## Remaining

I haven't changed the current `MainWindow::initHideMenu` which manually rebinds f10. I think I can remove it and make everything consistent.