### PR TITLE
Fix page layout update

### DIFF
--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -1224,18 +1224,18 @@ void Control::insertNewPage(size_t position) { pageBackgroundChangeController->i
 
 void Control::insertPage(const PageRef& page, size_t position) {
     this->doc->lock();
-    this->doc->insertPage(page, position);
+    this->doc->insertPage(page, position);  // insert the new page to the document and update page numbers
     this->doc->unlock();
+
+    // notify document listeners about the inserted page; this creates the new XojViewPage, recalculates the layout
+    // and creates a preview page in the sidebar
     firePageInserted(position);
 
     getCursor()->updateCursor();
 
-    int visibleHeight = 0;
-    scrollHandler->isPageVisible(position, &visibleHeight);
-
-    if (visibleHeight < 10) {
-        Util::execInUiThread([=]() { scrollHandler->scrollToPage(position); });
-    }
+    // make the inserted page fully visible (or at least as much from the top which fits on the screen),
+    // and make the page appear selected
+    scrollHandler->scrollToPage(position);
     firePageSelected(position);
 
     updateDeletePageButton();

--- a/src/gui/Layout.h
+++ b/src/gui/Layout.h
@@ -111,6 +111,10 @@ protected:
 private:
     static void checkScroll(GtkAdjustment* adjustment, double& lastScroll);
 
+    /**
+     * Calls either the ScrollHandlingGtk or (when the Touch Workaround is enabled) the ScrollHandlingXournalpp
+     * method to set the layout size by updating the horizontal and vertical GtkAdjustments
+     */
     void setLayoutSize(int width, int height);
 
 private:

--- a/src/gui/XournalView.cpp
+++ b/src/gui/XournalView.cpp
@@ -471,7 +471,7 @@ auto XournalView::getVisibleRect(XojPageView* redrawable) -> Rectangle<double>* 
 auto XournalView::getHandRecognition() -> HandRecognition* { return handRecognition; }
 
 /**
- * @returnScrollbars
+ * @return Scrollbars
  */
 auto XournalView::getScrollHandling() -> ScrollHandling* { return scrollHandling; }
 
@@ -567,7 +567,12 @@ void XournalView::pageInserted(size_t page) {
     viewPages.insert(begin(viewPages) + page, pageView);
 
     Layout* layout = gtk_xournal_get_layout(this->widget);
+
+    // recalculate the layout width and height amd layout the pages with the updated layout size
     layout->recalculate();
+    layout->layoutPages(layout->getMinimalWidth(), layout->getMinimalHeight());
+
+    // check which pages are visible and select the most visible page
     layout->updateVisibility();
 }
 
@@ -651,6 +656,9 @@ void XournalView::repaintSelection(bool evenWithoutSelection) {
     gtk_widget_queue_draw(this->widget);
 }
 
+/**
+ * Recalculates the layout height and width for the XournalView widget
+ */
 void XournalView::layoutPages() {
     Layout* layout = gtk_xournal_get_layout(this->widget);
     layout->recalculate();

--- a/src/gui/XournalView.h
+++ b/src/gui/XournalView.h
@@ -116,7 +116,7 @@ public:
     HandRecognition* getHandRecognition();
 
     /**
-     * @returnScrollbars
+     * @return Scrollbars
      */
     ScrollHandling* getScrollHandling();
 

--- a/src/gui/scroll/ScrollHandlingGtk.cpp
+++ b/src/gui/scroll/ScrollHandlingGtk.cpp
@@ -8,7 +8,17 @@ ScrollHandlingGtk::ScrollHandlingGtk(GtkScrollable* scrollable):
 
 ScrollHandlingGtk::~ScrollHandlingGtk() = default;
 
-void ScrollHandlingGtk::setLayoutSize(int width, int height) { gtk_widget_queue_resize(xournal); }
+void ScrollHandlingGtk::setLayoutSize(int width, int height) {
+    // after a page has been inserted the layout size must be updated immediately,
+    // otherwise it comes down to a race deciding if scrolling happens normally or not
+    if (gtk_adjustment_get_upper(getHorizontal()) < width) {
+        gtk_adjustment_set_upper(getHorizontal(), width);
+    }
+    if (gtk_adjustment_get_upper(getVertical()) < height) {
+        gtk_adjustment_set_upper(getVertical(), height);
+    }
+    gtk_widget_queue_resize(xournal);
+}
 
 auto ScrollHandlingGtk::getPreferredWidth() -> int { return layout->getMinimalWidth(); }
 

--- a/src/gui/widgets/XournalWidget.cpp
+++ b/src/gui/widgets/XournalWidget.cpp
@@ -171,6 +171,9 @@ static void gtk_xournal_get_preferred_height(GtkWidget* widget, gint* minimal_he
     *minimal_height = *natural_height = xournal->scrollHandling->getPreferredHeight();
 }
 
+/**
+ * This method is called while scrolling or after the XournalWidget size has changed
+ */
 static void gtk_xournal_size_allocate(GtkWidget* widget, GtkAllocation* allocation) {
     g_return_if_fail(widget != nullptr);
     g_return_if_fail(GTK_IS_XOURNAL(widget));
@@ -185,6 +188,7 @@ static void gtk_xournal_size_allocate(GtkWidget* widget, GtkAllocation* allocati
 
     GtkXournal* xournal = GTK_XOURNAL(widget);
 
+    // layout the pages in the XournalWidget
     xournal->layout->layoutPages(allocation->width, allocation->height);
 }
 


### PR DESCRIPTION
Try once more to fix the page layout updating. I had to open a new PR, because I messed up the old one (#2312).

This PR should fix #2289 and #1926 about focus shift to the beginning of the document after inserting a page. It may also fix the freeze from #2211 and #2144 when inserting a blank page in a pdf document.

The page layout now gets updated immediately after inserting the page. That only happens after some time (usually too late) without this fix. It also removes an unnecessary call to firePageSelected, since this action is called from scrollToPage anyway.