### PR TITLE
Automatically switch foreground color based on background color

### DIFF
--- a/src/view/background/BackgroundConfig.cpp
+++ b/src/view/background/BackgroundConfig.cpp
@@ -17,7 +17,7 @@ BackgroundConfig::BackgroundConfig(const string& config) {
 
 BackgroundConfig::~BackgroundConfig() = default;
 
-auto BackgroundConfig::loadValue(const string& key, string& value) -> bool {
+auto BackgroundConfig::loadValue(const string& key, string& value) const -> bool {
     auto it = data.find(key);
     if (it != this->data.end()) {
         value = it->second;
@@ -27,7 +27,7 @@ auto BackgroundConfig::loadValue(const string& key, string& value) -> bool {
     return false;
 }
 
-auto BackgroundConfig::loadValue(const string& key, int& value) -> bool {
+auto BackgroundConfig::loadValue(const string& key, int& value) const -> bool {
     string str;
     if (loadValue(key, str)) {
         value = std::stoul(str, nullptr, 10);
@@ -37,7 +37,7 @@ auto BackgroundConfig::loadValue(const string& key, int& value) -> bool {
     return false;
 }
 
-auto BackgroundConfig::loadValue(const string& key, double& value) -> bool {
+auto BackgroundConfig::loadValue(const string& key, double& value) const -> bool {
     string str;
     if (loadValue(key, str)) {
         value = std::stoul(str, nullptr, 10);
@@ -47,7 +47,7 @@ auto BackgroundConfig::loadValue(const string& key, double& value) -> bool {
     return false;
 }
 
-auto BackgroundConfig::loadValueHex(const string& key, int& value) -> bool {
+auto BackgroundConfig::loadValueHex(const string& key, int& value) const -> bool {
     string str;
     if (loadValue(key, str)) {
         value = std::stoul(str, nullptr, 16);
@@ -57,7 +57,7 @@ auto BackgroundConfig::loadValueHex(const string& key, int& value) -> bool {
     return false;
 }
 
-auto BackgroundConfig::loadValueHex(const string& key, uint32_t& value) -> bool {
+auto BackgroundConfig::loadValueHex(const string& key, uint32_t& value) const -> bool {
     string str;
     if (loadValue(key, str)) {
         value = std::stoul(str, nullptr, 16);

--- a/src/view/background/BackgroundConfig.h
+++ b/src/view/background/BackgroundConfig.h
@@ -23,11 +23,11 @@ public:
     virtual ~BackgroundConfig();
 
 public:
-    bool loadValue(const string& key, string& value);
-    bool loadValue(const string& key, int& value);
-    bool loadValue(const string& key, double& value);
-    bool loadValueHex(const string& key, int& value);
-    bool loadValueHex(const string& key, uint32_t& value);
+    bool loadValue(const string& key, string& value) const;
+    bool loadValue(const string& key, int& value) const;
+    bool loadValue(const string& key, double& value) const;
+    bool loadValueHex(const string& key, int& value) const;
+    bool loadValueHex(const string& key, uint32_t& value) const;
 
 private:
     map<string, string> data;

--- a/src/view/background/BaseBackgroundPainter.cpp
+++ b/src/view/background/BaseBackgroundPainter.cpp
@@ -15,6 +15,36 @@ void BaseBackgroundPainter::resetConfig() {
     // Overwritten from the subclasses
 }
 
+auto BaseBackgroundPainter::alternativeColor(Color color1, Color color2) const -> Color {
+    auto backgroundColor = this->page->getBackgroundColor();
+
+    auto greyscale = [](uint32_t color) {
+        return ((0xff & color) + (0xff & (color >> 8)) + (0xff & (color >> 16))) / 3;
+    };
+
+    return greyscale(backgroundColor) < 0x80 ? color2 : color1;
+}
+
+auto BaseBackgroundPainter::getForegroundColor1() const -> Color {
+    uint32_t temp{};
+
+    const uint32_t foregroundColor = this->config->loadValueHex("f1", temp) ? temp : this->defaultForegroundColor1;
+    const uint32_t altForegroundColor =
+            this->config->loadValueHex("af1", temp) ? temp : this->defaultAlternativeForegroundColor1;
+
+    return this->alternativeColor(foregroundColor, altForegroundColor);
+}
+
+auto BaseBackgroundPainter::getForegroundColor2() const -> Color {
+    uint32_t temp{};
+
+    const uint32_t foregroundColor = this->config->loadValueHex("f2", temp) ? temp : this->defaultForegroundColor2;
+    const uint32_t altForegroundColor =
+            this->config->loadValueHex("af2", temp) ? temp : this->defaultAlternativeForegroundColor2;
+
+    return this->alternativeColor(foregroundColor, altForegroundColor);
+}
+
 void BaseBackgroundPainter::paint(cairo_t* cr, PageRef page, BackgroundConfig* config) {
     this->cr = cr;
     this->page = page;
@@ -23,9 +53,8 @@ void BaseBackgroundPainter::paint(cairo_t* cr, PageRef page, BackgroundConfig* c
     this->width = page->getWidth();
     this->height = page->getHeight();
 
-    uint32_t temp{};
-    this->foregroundColor1 = this->config->loadValueHex("f1", temp) ? temp : this->foregroundColor1;
-    this->foregroundColor2 = this->config->loadValueHex("f2", temp) ? temp : this->foregroundColor2;
+    this->foregroundColor1 = this->getForegroundColor1();
+    this->foregroundColor2 = this->getForegroundColor2();
 
     this->config->loadValue("lw", this->lineWidth);
     this->config->loadValue("r1", this->drawRaster1);

--- a/src/view/background/BaseBackgroundPainter.h
+++ b/src/view/background/BaseBackgroundPainter.h
@@ -40,6 +40,30 @@ public:
 protected:
     void paintBackgroundColor();
 
+    /**
+     * Choose between color1 and color2 based on the page's background brightness.
+     *
+     * @param color1 A color intended for light backgrounds.
+     * @param color2 A color intended for dark backgrounds.
+     *
+     * @return color1 if the page background is light, else, color2.
+     */
+    Color alternativeColor(Color color1, Color color2) const;
+
+    /**
+     * Determines and returns the primary foreground color to use for this page.
+     *
+     * @return the primary foreground color for the page.
+     */
+    Color getForegroundColor1() const;
+
+    /**
+     * Determines and returns the secondary foreground color to use for this page.
+     *
+     * @return the secondary foreground color for the page.
+     */
+    Color getForegroundColor2() const;
+
 private:
 protected:
     BackgroundConfig* config = nullptr;
@@ -52,8 +76,13 @@ protected:
     // Drawing attributes
     // ParserKey=Value
 protected:
-    Color foregroundColor1{0U};
+    Color defaultForegroundColor1{0U};
+    Color defaultAlternativeForegroundColor1{0U};
 
+    Color defaultForegroundColor2{0U};
+    Color defaultAlternativeForegroundColor2{0U};
+
+    Color foregroundColor1{0U};
     Color foregroundColor2{0U};
 
     double lineWidth = 0;

--- a/src/view/background/DottedBackgroundPainter.cpp
+++ b/src/view/background/DottedBackgroundPainter.cpp
@@ -7,7 +7,8 @@ DottedBackgroundPainter::DottedBackgroundPainter() = default;
 DottedBackgroundPainter::~DottedBackgroundPainter() = default;
 
 void DottedBackgroundPainter::resetConfig() {
-    this->foregroundColor1 = 0xBDBDBDU;
+    this->defaultForegroundColor1 = 0xBDBDBDU;
+    this->defaultAlternativeForegroundColor1 = 0x434343U;
     this->lineWidth = 1.5;
     this->drawRaster1 = 14.17;
 }

--- a/src/view/background/GraphBackgroundPainter.cpp
+++ b/src/view/background/GraphBackgroundPainter.cpp
@@ -8,21 +8,9 @@ GraphBackgroundPainter::GraphBackgroundPainter() = default;
 
 GraphBackgroundPainter::~GraphBackgroundPainter() = default;
 
-/**
- * Set the Graph line color to a lower contrast alternative if a black background is used
- */
-void GraphBackgroundPainter::updateGraphColor() {
-    Color backgroundColor = this->page->getBackgroundColor();
-
-    auto greyscale = [](Color color) {
-        return ((0xffU & uint32_t(color)) + (0xffU & (uint32_t(color) >> 8U)) + (0xffU & (uint32_t(color) >> 16U))) / 3;
-    };
-
-    this->foregroundColor1 = greyscale(backgroundColor) < 0x80U ? 0x202020U : 0xBDBDBDU;
-}
-
 void GraphBackgroundPainter::resetConfig() {
-    this->foregroundColor1 = 0xBDBDBDU;
+    this->defaultForegroundColor1 = 0xBDBDBDU;
+    this->defaultAlternativeForegroundColor1 = 0x434343U;
     this->lineWidth = 0.5;
     this->drawRaster1 = 14.17;
     this->margin1 = 0;
@@ -30,8 +18,7 @@ void GraphBackgroundPainter::resetConfig() {
 }
 
 void GraphBackgroundPainter::paint() {
-    this->updateGraphColor();
-    paintBackgroundColor();
+    this->paintBackgroundColor();
     paintBackgroundGraph();
 }
 

--- a/src/view/background/GraphBackgroundPainter.h
+++ b/src/view/background/GraphBackgroundPainter.h
@@ -30,7 +30,4 @@ public:
      * Reset all used configuration values
      */
     virtual void resetConfig();
-
-private:
-    void updateGraphColor();
 };

--- a/src/view/background/IsometricBackgroundPainter.cpp
+++ b/src/view/background/IsometricBackgroundPainter.cpp
@@ -9,7 +9,8 @@ IsometricBackgroundPainter::IsometricBackgroundPainter(bool drawLines): drawLine
 IsometricBackgroundPainter::~IsometricBackgroundPainter() = default;
 
 void IsometricBackgroundPainter::resetConfig() {
-    this->foregroundColor1 = 0xBDBDBDU;
+    this->defaultForegroundColor1 = 0xBDBDBDU;
+    this->defaultAlternativeForegroundColor1 = 0x434343U;
     this->lineWidth = drawLines ? 1.0 : 1.5;
     this->drawRaster1 = 14.17;
 }

--- a/src/view/background/LineBackgroundPainter.cpp
+++ b/src/view/background/LineBackgroundPainter.cpp
@@ -7,8 +7,10 @@ LineBackgroundPainter::LineBackgroundPainter(bool verticalLine): verticalLine(ve
 LineBackgroundPainter::~LineBackgroundPainter() = default;
 
 void LineBackgroundPainter::resetConfig() {
-    this->foregroundColor1 = 0x40A0FFU;
-    this->foregroundColor2 = 0xFF0080U;
+    this->defaultForegroundColor1 = 0x40A0FFU;
+    this->defaultAlternativeForegroundColor1 = 0x434343U;
+    this->defaultForegroundColor2 = 0xFF0080U;
+    this->defaultAlternativeForegroundColor2 = 0x220080U;
     this->lineWidth = 0.5;
 }
 

--- a/src/view/background/StavesBackgroundPainter.cpp
+++ b/src/view/background/StavesBackgroundPainter.cpp
@@ -7,8 +7,10 @@ StavesBackgroundPainter::StavesBackgroundPainter() = default;
 StavesBackgroundPainter::~StavesBackgroundPainter() = default;
 
 void StavesBackgroundPainter::resetConfig() {
-    this->foregroundColor1 = 0x000000U;
-    this->foregroundColor2 = 0xFF0080U;
+    this->defaultForegroundColor1 = 0x000000U;
+    this->defaultAlternativeForegroundColor1 = 0xFFFFFFU;
+    this->defaultForegroundColor2 = 0xFF0080U;
+    this->defaultAlternativeForegroundColor2 = 0x220080U;
     this->lineWidth = 0.5;
 }
 


### PR DESCRIPTION
This adds configurable alternative foreground colors to "pagetemplates.ini" to all views which are used if the background is darker than middle gray. #2055 did this for the graph view, however it also stopped configurable foreground colors from working specifically on that view. This is very similar to #2061, except that the color switching is more generalized.

I'm not exactly sure if this is the best solution though since pagetempletes.ini does simply allow you to add a dark version of the page manually. I'm personally not a fan of manually needing to configure a config file though which is also fairly hidden from the user.

This also prevents the foreground from becoming invisible, e.g. in the staves background, the foreground is a solid black and will become invisible if the same color is used for the background. Since the foreground colors change automatically the foreground will never become invisible with this patch.

Example of changes to backgrounds:
Without PR             |  With PR
:-------------------------:|:-------------------------:
![Dotted without PR](https://user-images.githubusercontent.com/10325589/108593228-e1ff4100-7372-11eb-9c79-b38d91661d2e.png) | ![Dotted with PR](https://user-images.githubusercontent.com/10325589/108593218-d6137f00-7372-11eb-8e89-7d872aabce2a.png)
![Isometric Graph without PR](https://user-images.githubusercontent.com/10325589/108593287-22f75580-7373-11eb-89b3-e85bb9576d3d.png) |  ![Isometric Graph with PR](https://user-images.githubusercontent.com/10325589/108593305-30144480-7373-11eb-9a3b-3dcf131fd2e9.png)
![Staves without PR](https://user-images.githubusercontent.com/10325589/108593359-75d10d00-7373-11eb-89a2-bf6f8e8ffc90.png) | ![Staves with PR](https://user-images.githubusercontent.com/10325589/108593361-7c5f8480-7373-11eb-8204-3205bed3d2a4.png)

However, things don't look perfect with backgrounds with colors others than 100% black or 100% white:

Without PR             |  With PR
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/10325589/108593429-eb3cdd80-7373-11eb-859b-176f1fabb9b5.png) | ![](https://user-images.githubusercontent.com/10325589/108593431-f09a2800-7373-11eb-85b8-fe87bfe2637f.png)

I'm assuming that most people will be either using 100% white or 100% black backgrounds and personally wouldn't mark this a high priority problem. It would however be nice to have a general solution in the future to select acceptable foreground colors when using colored backgrounds.

In the future it might be apt to combine foreground color and background into background templates and have configurable background templates in the settings. However, further discussion is required for this.




