### PR TITLE
1.0.x - update dependencies in debian/control, fix typo in package_description

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,8 +8,34 @@ Homepage: https://github.com/xournalpp/xournalpp/
 
 Package: xournalpp
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}
-Description: Xournal++ is a handwriting Notetaking software with PDF annotation support. Supports Pen input like Wacom Tablets.
-
-
-
+Depends: libglib2.0-0 (>= 2.32), libgtk-3-0 (>= 3.18), libpoppler-glib8 (>= 0.41.0), libxml2 (>= 2.0.0), libportaudiocpp0 (>= 12), libsndfile1 (>= 1.0.25), liblua5.3-0, libzip4 (>= 1.0.1) | libzip5, zlib1g, libc6
+Suggests: texlive-base, texlive-latex-extra
+Description: Xournal++ - Open source hand note-taking program
+ Xournal++ is a hand note taking software written in C++ with the target of 
+ flexibility, functionality and speed. Stroke recognizer and other parts are 
+ based on Xournal Code, which you can find at sourceforge. 
+ It supports Linux (e.g. Ubuntu, Debian, Arch, SUSE), macOS and Windows 10. 
+ Supports pen input from devices such as Wacom Tablets.
+ .
+ Xournal++ features:
+ .
+  - Support for Pen pressure, e.g. Wacom Tablet
+  - Support for annotating PDFs
+  - Fill shape functionality
+  - PDF Export (with and without paper style)
+  - PNG Export (with and without transparent background)
+  - Allows maping different tools/colors etc. to stylus/mouse buttons
+  - Sidebar with Page Previews with page sorting, PDF Bookmarks and Layers
+  - Enhanced support for image insertion
+  - Eraser with multiple configurations
+  - LaTeX support (requires a working LaTeX install)
+  - Bug reporting, autosave, and auto backup tools
+  - Customizeable toolbar, with multiple configurations
+  - Page Template definitions
+  - Shape drawing (line, arrow, circle, rect)
+  - Shape resizing and rotation
+  - Rotation snapping every 45 degrees
+  - Rect snapping to grid
+  - Audio recording and playback alongside with handwritten notes
+  - Multi Language Support, English, German, Italian ...
+  - Plugins using LUA Scripting

--- a/debian/package_description
+++ b/debian/package_description
@@ -6,7 +6,7 @@ Supports pen input from devices such as Wacom Tablets.
 
 Xournal++ features:
 
- - Support for Pen preassure, e.g. Wacom Tablet
+ - Support for Pen pressure, e.g. Wacom Tablet
  - Support for annotating PDFs
  - Fill shape functionality
  - PDF Export (with and without paper style)


### PR DESCRIPTION
- Copied dependencies from official .deb package of 1.0.19 to debian/control (otherwise, the PPA package could not be installed in Ubuntu 18.04, as some of the automatically generated dependencies were missing from the repositories)
- Updated suggests and description in debian/control
- fixed typo in description - preassure --> pressure

This is ready for merge.