### PR TITLE
1.0.x - fix page layout update after inserting a new page

### DIFF
--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -1444,13 +1444,7 @@ void Control::insertPage(const PageRef& page, size_t position)
 
 	getCursor()->updateCursor();
 
-	int visibleHeight = 0;
-	scrollHandler->isPageVisible(position, &visibleHeight);
-
-	if (visibleHeight < 10)
-	{
-		Util::execInUiThread([=]() { scrollHandler->scrollToPage(position); });
-	}
+    scrollHandler->scrollToPage(position);
 	firePageSelected(position);
 
 	updateDeletePageButton();

--- a/src/gui/XournalView.cpp
+++ b/src/gui/XournalView.cpp
@@ -638,7 +638,7 @@ HandRecognition* XournalView::getHandRecognition()
 }
 
 /**
- * @returnScrollbars
+ * @return Scrollbars
  */
 ScrollHandling* XournalView::getScrollHandling()
 {
@@ -839,8 +839,12 @@ void XournalView::pageInserted(size_t page)
 	this->viewPages[page] = pageView;
 
 	Layout* layout = gtk_xournal_get_layout(this->widget);
-	layout->recalculate();
-	layout->updateVisibility();
+    // recalculate the layout width and height amd layout the pages with the updated layout size
+    layout->recalculate();
+    layout->layoutPages(layout->getMinimalWidth(), layout->getMinimalHeight());
+
+    // check which pages are visible and select the most visible page
+    layout->updateVisibility();
 }
 
 double XournalView::getZoom()

--- a/src/gui/scroll/ScrollHandlingGtk.cpp
+++ b/src/gui/scroll/ScrollHandlingGtk.cpp
@@ -17,7 +17,15 @@ ScrollHandlingGtk::~ScrollHandlingGtk()
 void ScrollHandlingGtk::setLayoutSize(int width, int height)
 {
 	XOJ_CHECK_TYPE(ScrollHandlingGtk);
-
+    
+	// after a page has been inserted the layout size must be updated immediately,
+    // otherwise it comes down to a race deciding if scrolling happens normally or not
+    if (gtk_adjustment_get_upper(getHorizontal()) < width) {
+        gtk_adjustment_set_upper(getHorizontal(), width);
+    }
+    if (gtk_adjustment_get_upper(getVertical()) < height) {
+        gtk_adjustment_set_upper(getVertical(), height);
+    }
 	gtk_widget_queue_resize(xournal);
 }
 


### PR DESCRIPTION
backport of 23aee5dd847d10204b62fd8b406c91888b114a9e

I did this by updating my local 1.0.x branch (via 
```term
git checkout 1.0.x
git fetch upstream
git merge upstream/1.0.x
git push origin 1.0.x
```
and then I cherry-picked via 
```term
git cherry-pick -x 23aee5dd847d10204b62fd8b406c91888b114a9e
```
and resolved all conflicts. 

Is that the way that is done in general? To solve the merge conflicts was tedious, since the git patched the incoming changes mostly at the wrong line numbers.

Anyway I managed to solve all conflicts. I tested out the back-ported fix and it worked fine.