### PR TITLE
Add option to change primary foreground color to journal menu

### DIFF
--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -10,6 +10,7 @@
 #include <gio/gio.h>
 #include <glib/gstdio.h>
 #include <gtk/gtk.h>
+#include <view/background/BackgroundConfig.h>
 
 #include "gui/TextEditor.h"
 #include "gui/XournalView.h"
@@ -1402,7 +1403,12 @@ void Control::changePageForegroundColor() {
     dlg.show(GTK_WINDOW(this->win->getWindow()));
 
     if (auto optColor = dlg.getSelectedColor(); optColor) {
-        p->setForegroundColor(*optColor);
+        PageType pageType = p->getBackgroundType();
+        auto *backgroundConfig = new BackgroundConfig(pageType.config);
+        backgroundConfig->setValueHex("f1", ((uint32_t) *optColor) - 0xff000000);
+        pageType.config = backgroundConfig->toString();
+        p->setBackgroundType(pageType);
+
         firePageChanged(pNr);
     }
 }

--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -486,6 +486,9 @@ void Control::actionPerformed(ActionType type, ActionGroup group, GdkEvent* even
         case ACTION_PAPER_BACKGROUND_COLOR:
             changePageBackgroundColor();
             break;
+        case ACTION_PAPER_FOREGROUND_COLOR:
+            changePageForegroundColor();
+            break;
 
             // Menu Tools
         case ACTION_TOOL_PEN:
@@ -1374,6 +1377,32 @@ void Control::changePageBackgroundColor() {
 
     if (auto optColor = dlg.getSelectedColor(); optColor) {
         p->setBackgroundColor(*optColor);
+        firePageChanged(pNr);
+    }
+}
+
+void Control::changePageForegroundColor() {
+    int pNr = getCurrentPageNo();
+    this->doc->lock();
+    auto const& p = this->doc->getPage(pNr);
+    this->doc->unlock();
+
+    if (!p) {
+        return;
+    }
+
+    clearSelectionEndText();
+
+    PageType bg = p->getBackgroundType();
+    if (bg.isSpecial()) {
+        return;
+    }
+
+    SelectBackgroundColorDialog dlg(this);
+    dlg.show(GTK_WINDOW(this->win->getWindow()));
+
+    if (auto optColor = dlg.getSelectedColor(); optColor) {
+        p->setForegroundColor(*optColor);
         firePageChanged(pNr);
     }
 }

--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -1403,11 +1403,7 @@ void Control::changePageForegroundColor() {
     dlg.show(GTK_WINDOW(this->win->getWindow()));
 
     if (auto optColor = dlg.getSelectedColor(); optColor) {
-        PageType pageType = p->getBackgroundType();
-        auto* backgroundConfig = new BackgroundConfig(pageType.config);
-        backgroundConfig->setValueHex("f1", ((uint32_t)*optColor) - 0xff000000);
-        pageType.config = backgroundConfig->toString();
-        p->setBackgroundType(pageType);
+        p->setForegroundColor(((uint32_t)*optColor) - 0xff000000);
 
         firePageChanged(pNr);
     }

--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -1404,8 +1404,8 @@ void Control::changePageForegroundColor() {
 
     if (auto optColor = dlg.getSelectedColor(); optColor) {
         PageType pageType = p->getBackgroundType();
-        auto *backgroundConfig = new BackgroundConfig(pageType.config);
-        backgroundConfig->setValueHex("f1", ((uint32_t) *optColor) - 0xff000000);
+        auto* backgroundConfig = new BackgroundConfig(pageType.config);
+        backgroundConfig->setValueHex("f1", ((uint32_t)*optColor) - 0xff000000);
         pageType.config = backgroundConfig->toString();
         p->setBackgroundType(pageType);
 

--- a/src/control/Control.h
+++ b/src/control/Control.h
@@ -172,6 +172,7 @@ public:
     void paperTemplate();
     void paperFormat();
     void changePageBackgroundColor();
+    void changePageForegroundColor();
     void updateBackgroundSizeButton();
 
     void endDragDropToolbar();

--- a/src/enums/ActionType.enum.h
+++ b/src/enums/ActionType.enum.h
@@ -73,6 +73,7 @@ enum ActionType {
     ACTION_DELETE_LAYER,
     ACTION_PAPER_FORMAT,
     ACTION_PAPER_BACKGROUND_COLOR,
+    ACTION_PAPER_FOREGROUND_COLOR,
 
     // Menu Tools
     // Has to be in the same order as in Tool.h: ToolType!

--- a/src/enums/generateConvert.php
+++ b/src/enums/generateConvert.php
@@ -80,13 +80,13 @@ function writeCppFile($output, $name, $values) {
 
 	fwrite($fp, "\n\n");
 
-	fwrite($fp, "// ** This needs to be copied to the header\n");
-	fwrite($fp, $name . " " . $name . "_fromString(string value);\n");
-	fwrite($fp, "string " . $name . "_toString($name value);\n");
+	//fwrite($fp, "// ** This needs to be copied to the header\n");
+	//fwrite($fp, $name . " " . $name . "_fromString(const string& value);\n");
+	//fwrite($fp, "string " . $name . "_toString($name value);\n");
 
 	fwrite($fp, "\n\n");
 
-	fwrite($fp, $name . " " . $name . "_fromString(string value)\n");
+	fwrite($fp, "auto " . $name . "_fromString(const string& value) -> $name\n");
 	fwrite($fp, "{\n");
 	
 	foreach ($values as $v) {

--- a/src/enums/generated/ActionGroup.generated.cpp
+++ b/src/enums/generated/ActionGroup.generated.cpp
@@ -2,276 +2,220 @@
 // ** use generateConvert.php to update this file **
 
 
+#include <string>
 
 #include "../ActionGroup.enum.h"
-
-#include <string>
 using std::string;
 #include <glib.h>
 
 
+auto ActionGroup_fromString(const string& value) -> ActionGroup {
+    if (value == "GROUP_NOGROUP") {
+        return GROUP_NOGROUP;
+    }
 
+    if (value == "GROUP_TOOL") {
+        return GROUP_TOOL;
+    }
 
-auto ActionGroup_fromString(const string& value) -> ActionGroup
-{
-	if (value == "GROUP_NOGROUP")
-	{
-		return GROUP_NOGROUP;
-	}
+    if (value == "GROUP_COLOR") {
+        return GROUP_COLOR;
+    }
 
-	if (value == "GROUP_TOOL")
-	{
-		return GROUP_TOOL;
-	}
+    if (value == "GROUP_SIZE") {
+        return GROUP_SIZE;
+    }
 
-	if (value == "GROUP_COLOR")
-	{
-		return GROUP_COLOR;
-	}
+    if (value == "GROUP_ERASER_MODE") {
+        return GROUP_ERASER_MODE;
+    }
 
-	if (value == "GROUP_SIZE")
-	{
-		return GROUP_SIZE;
-	}
+    if (value == "GROUP_ERASER_SIZE") {
+        return GROUP_ERASER_SIZE;
+    }
 
-	if (value == "GROUP_ERASER_MODE")
-	{
-		return GROUP_ERASER_MODE;
-	}
+    if (value == "GROUP_PEN_SIZE") {
+        return GROUP_PEN_SIZE;
+    }
 
-	if (value == "GROUP_ERASER_SIZE")
-	{
-		return GROUP_ERASER_SIZE;
-	}
+    if (value == "GROUP_PEN_FILL") {
+        return GROUP_PEN_FILL;
+    }
 
-	if (value == "GROUP_PEN_SIZE")
-	{
-		return GROUP_PEN_SIZE;
-	}
+    if (value == "GROUP_HILIGHTER_SIZE") {
+        return GROUP_HILIGHTER_SIZE;
+    }
 
-	if (value == "GROUP_PEN_FILL")
-	{
-		return GROUP_PEN_FILL;
-	}
+    if (value == "GROUP_HILIGHTER_FILL") {
+        return GROUP_HILIGHTER_FILL;
+    }
 
-	if (value == "GROUP_HILIGHTER_SIZE")
-	{
-		return GROUP_HILIGHTER_SIZE;
-	}
+    if (value == "GROUP_TOGGLE_GROUP") {
+        return GROUP_TOGGLE_GROUP;
+    }
 
-	if (value == "GROUP_HILIGHTER_FILL")
-	{
-		return GROUP_HILIGHTER_FILL;
-	}
+    if (value == "GROUP_PAIRED_PAGES") {
+        return GROUP_PAIRED_PAGES;
+    }
 
-	if (value == "GROUP_TOGGLE_GROUP")
-	{
-		return GROUP_TOGGLE_GROUP;
-	}
+    if (value == "GROUP_PRESENTATION_MODE") {
+        return GROUP_PRESENTATION_MODE;
+    }
 
-	if (value == "GROUP_PAIRED_PAGES")
-	{
-		return GROUP_PAIRED_PAGES;
-	}
+    if (value == "GROUP_FULLSCREEN") {
+        return GROUP_FULLSCREEN;
+    }
 
-	if (value == "GROUP_PRESENTATION_MODE")
-	{
-		return GROUP_PRESENTATION_MODE;
-	}
+    if (value == "GROUP_RULER") {
+        return GROUP_RULER;
+    }
 
-	if (value == "GROUP_FULLSCREEN")
-	{
-		return GROUP_FULLSCREEN;
-	}
+    if (value == "GROUP_LINE_STYLE") {
+        return GROUP_LINE_STYLE;
+    }
 
-	if (value == "GROUP_RULER")
-	{
-		return GROUP_RULER;
-	}
+    if (value == "GROUP_AUDIO") {
+        return GROUP_AUDIO;
+    }
 
-	if (value == "GROUP_LINE_STYLE")
-	{
-		return GROUP_LINE_STYLE;
-	}
+    if (value == "GROUP_SNAPPING") {
+        return GROUP_SNAPPING;
+    }
 
-	if (value == "GROUP_AUDIO")
-	{
-		return GROUP_AUDIO;
-	}
+    if (value == "GROUP_GRID_SNAPPING") {
+        return GROUP_GRID_SNAPPING;
+    }
 
-	if (value == "GROUP_SNAPPING")
-	{
-		return GROUP_SNAPPING;
-	}
+    if (value == "GROUP_FILL") {
+        return GROUP_FILL;
+    }
 
-	if (value == "GROUP_GRID_SNAPPING")
-	{
-		return GROUP_GRID_SNAPPING;
-	}
+    if (value == "GROUP_FIXED_ROW_OR_COLS") {
+        return GROUP_FIXED_ROW_OR_COLS;
+    }
 
-	if (value == "GROUP_FILL")
-	{
-		return GROUP_FILL;
-	}
+    if (value == "GROUP_LAYOUT_HORIZONTAL") {
+        return GROUP_LAYOUT_HORIZONTAL;
+    }
 
-	if (value == "GROUP_FIXED_ROW_OR_COLS")
-	{
-		return GROUP_FIXED_ROW_OR_COLS;
-	}
+    if (value == "GROUP_LAYOUT_LR") {
+        return GROUP_LAYOUT_LR;
+    }
 
-	if (value == "GROUP_LAYOUT_HORIZONTAL")
-	{
-		return GROUP_LAYOUT_HORIZONTAL;
-	}
+    if (value == "GROUP_LAYOUT_TB") {
+        return GROUP_LAYOUT_TB;
+    }
 
-	if (value == "GROUP_LAYOUT_LR")
-	{
-		return GROUP_LAYOUT_LR;
-	}
+    if (value == "GROUP_ZOOM_FIT") {
+        return GROUP_ZOOM_FIT;
+    }
 
-	if (value == "GROUP_LAYOUT_TB")
-	{
-		return GROUP_LAYOUT_TB;
-	}
-
-	if (value == "GROUP_ZOOM_FIT")
-	{
-		return GROUP_ZOOM_FIT;
-	}
-
-	g_error("Invalid enum value for ActionGroup: «%s»", value.c_str());
-	return GROUP_NOGROUP;
+    g_error("Invalid enum value for ActionGroup: «%s»", value.c_str());
+    return GROUP_NOGROUP;
 }
 
 
+string ActionGroup_toString(ActionGroup value) {
+    if (value == GROUP_NOGROUP) {
+        return "GROUP_NOGROUP";
+    }
 
-string ActionGroup_toString(ActionGroup value)
-{
-	if (value == GROUP_NOGROUP)
-	{
-		return "GROUP_NOGROUP";
-	}
+    if (value == GROUP_TOOL) {
+        return "GROUP_TOOL";
+    }
 
-	if (value == GROUP_TOOL)
-	{
-		return "GROUP_TOOL";
-	}
+    if (value == GROUP_COLOR) {
+        return "GROUP_COLOR";
+    }
 
-	if (value == GROUP_COLOR)
-	{
-		return "GROUP_COLOR";
-	}
+    if (value == GROUP_SIZE) {
+        return "GROUP_SIZE";
+    }
 
-	if (value == GROUP_SIZE)
-	{
-		return "GROUP_SIZE";
-	}
+    if (value == GROUP_ERASER_MODE) {
+        return "GROUP_ERASER_MODE";
+    }
 
-	if (value == GROUP_ERASER_MODE)
-	{
-		return "GROUP_ERASER_MODE";
-	}
+    if (value == GROUP_ERASER_SIZE) {
+        return "GROUP_ERASER_SIZE";
+    }
 
-	if (value == GROUP_ERASER_SIZE)
-	{
-		return "GROUP_ERASER_SIZE";
-	}
+    if (value == GROUP_PEN_SIZE) {
+        return "GROUP_PEN_SIZE";
+    }
 
-	if (value == GROUP_PEN_SIZE)
-	{
-		return "GROUP_PEN_SIZE";
-	}
+    if (value == GROUP_PEN_FILL) {
+        return "GROUP_PEN_FILL";
+    }
 
-	if (value == GROUP_PEN_FILL)
-	{
-		return "GROUP_PEN_FILL";
-	}
+    if (value == GROUP_HILIGHTER_SIZE) {
+        return "GROUP_HILIGHTER_SIZE";
+    }
 
-	if (value == GROUP_HILIGHTER_SIZE)
-	{
-		return "GROUP_HILIGHTER_SIZE";
-	}
+    if (value == GROUP_HILIGHTER_FILL) {
+        return "GROUP_HILIGHTER_FILL";
+    }
 
-	if (value == GROUP_HILIGHTER_FILL)
-	{
-		return "GROUP_HILIGHTER_FILL";
-	}
+    if (value == GROUP_TOGGLE_GROUP) {
+        return "GROUP_TOGGLE_GROUP";
+    }
 
-	if (value == GROUP_TOGGLE_GROUP)
-	{
-		return "GROUP_TOGGLE_GROUP";
-	}
+    if (value == GROUP_PAIRED_PAGES) {
+        return "GROUP_PAIRED_PAGES";
+    }
 
-	if (value == GROUP_PAIRED_PAGES)
-	{
-		return "GROUP_PAIRED_PAGES";
-	}
+    if (value == GROUP_PRESENTATION_MODE) {
+        return "GROUP_PRESENTATION_MODE";
+    }
 
-	if (value == GROUP_PRESENTATION_MODE)
-	{
-		return "GROUP_PRESENTATION_MODE";
-	}
+    if (value == GROUP_FULLSCREEN) {
+        return "GROUP_FULLSCREEN";
+    }
 
-	if (value == GROUP_FULLSCREEN)
-	{
-		return "GROUP_FULLSCREEN";
-	}
+    if (value == GROUP_RULER) {
+        return "GROUP_RULER";
+    }
 
-	if (value == GROUP_RULER)
-	{
-		return "GROUP_RULER";
-	}
+    if (value == GROUP_LINE_STYLE) {
+        return "GROUP_LINE_STYLE";
+    }
 
-	if (value == GROUP_LINE_STYLE)
-	{
-		return "GROUP_LINE_STYLE";
-	}
+    if (value == GROUP_AUDIO) {
+        return "GROUP_AUDIO";
+    }
 
-	if (value == GROUP_AUDIO)
-	{
-		return "GROUP_AUDIO";
-	}
+    if (value == GROUP_SNAPPING) {
+        return "GROUP_SNAPPING";
+    }
 
-	if (value == GROUP_SNAPPING)
-	{
-		return "GROUP_SNAPPING";
-	}
+    if (value == GROUP_GRID_SNAPPING) {
+        return "GROUP_GRID_SNAPPING";
+    }
 
-	if (value == GROUP_GRID_SNAPPING)
-	{
-		return "GROUP_GRID_SNAPPING";
-	}
+    if (value == GROUP_FILL) {
+        return "GROUP_FILL";
+    }
 
-	if (value == GROUP_FILL)
-	{
-		return "GROUP_FILL";
-	}
+    if (value == GROUP_FIXED_ROW_OR_COLS) {
+        return "GROUP_FIXED_ROW_OR_COLS";
+    }
 
-	if (value == GROUP_FIXED_ROW_OR_COLS)
-	{
-		return "GROUP_FIXED_ROW_OR_COLS";
-	}
+    if (value == GROUP_LAYOUT_HORIZONTAL) {
+        return "GROUP_LAYOUT_HORIZONTAL";
+    }
 
-	if (value == GROUP_LAYOUT_HORIZONTAL)
-	{
-		return "GROUP_LAYOUT_HORIZONTAL";
-	}
+    if (value == GROUP_LAYOUT_LR) {
+        return "GROUP_LAYOUT_LR";
+    }
 
-	if (value == GROUP_LAYOUT_LR)
-	{
-		return "GROUP_LAYOUT_LR";
-	}
+    if (value == GROUP_LAYOUT_TB) {
+        return "GROUP_LAYOUT_TB";
+    }
 
-	if (value == GROUP_LAYOUT_TB)
-	{
-		return "GROUP_LAYOUT_TB";
-	}
+    if (value == GROUP_ZOOM_FIT) {
+        return "GROUP_ZOOM_FIT";
+    }
 
-	if (value == GROUP_ZOOM_FIT)
-	{
-		return "GROUP_ZOOM_FIT";
-	}
-
-	g_error("Invalid enum value for ActionGroup: %i", value);
-	return "";
+    g_error("Invalid enum value for ActionGroup: %i", value);
+    return "";
 }

--- a/src/enums/generated/ActionGroup.generated.cpp
+++ b/src/enums/generated/ActionGroup.generated.cpp
@@ -2,223 +2,276 @@
 // ** use generateConvert.php to update this file **
 
 
-#include <string>
 
 #include "../ActionGroup.enum.h"
+
+#include <string>
 using std::string;
 #include <glib.h>
 
 
-// ** This needs to be copied to the header
 
 
-auto ActionGroup_fromString(const string& value) -> ActionGroup {
-    if (value == "GROUP_NOGROUP") {
-        return GROUP_NOGROUP;
-    }
+auto ActionGroup_fromString(const string& value) -> ActionGroup
+{
+	if (value == "GROUP_NOGROUP")
+	{
+		return GROUP_NOGROUP;
+	}
 
-    if (value == "GROUP_TOOL") {
-        return GROUP_TOOL;
-    }
+	if (value == "GROUP_TOOL")
+	{
+		return GROUP_TOOL;
+	}
 
-    if (value == "GROUP_COLOR") {
-        return GROUP_COLOR;
-    }
+	if (value == "GROUP_COLOR")
+	{
+		return GROUP_COLOR;
+	}
 
-    if (value == "GROUP_SIZE") {
-        return GROUP_SIZE;
-    }
+	if (value == "GROUP_SIZE")
+	{
+		return GROUP_SIZE;
+	}
 
-    if (value == "GROUP_ERASER_MODE") {
-        return GROUP_ERASER_MODE;
-    }
+	if (value == "GROUP_ERASER_MODE")
+	{
+		return GROUP_ERASER_MODE;
+	}
 
-    if (value == "GROUP_ERASER_SIZE") {
-        return GROUP_ERASER_SIZE;
-    }
+	if (value == "GROUP_ERASER_SIZE")
+	{
+		return GROUP_ERASER_SIZE;
+	}
 
-    if (value == "GROUP_PEN_SIZE") {
-        return GROUP_PEN_SIZE;
-    }
+	if (value == "GROUP_PEN_SIZE")
+	{
+		return GROUP_PEN_SIZE;
+	}
 
-    if (value == "GROUP_PEN_FILL") {
-        return GROUP_PEN_FILL;
-    }
+	if (value == "GROUP_PEN_FILL")
+	{
+		return GROUP_PEN_FILL;
+	}
 
-    if (value == "GROUP_HILIGHTER_SIZE") {
-        return GROUP_HILIGHTER_SIZE;
-    }
+	if (value == "GROUP_HILIGHTER_SIZE")
+	{
+		return GROUP_HILIGHTER_SIZE;
+	}
 
-    if (value == "GROUP_HILIGHTER_FILL") {
-        return GROUP_HILIGHTER_FILL;
-    }
+	if (value == "GROUP_HILIGHTER_FILL")
+	{
+		return GROUP_HILIGHTER_FILL;
+	}
 
-    if (value == "GROUP_TOGGLE_GROUP") {
-        return GROUP_TOGGLE_GROUP;
-    }
+	if (value == "GROUP_TOGGLE_GROUP")
+	{
+		return GROUP_TOGGLE_GROUP;
+	}
 
-    if (value == "GROUP_PAIRED_PAGES") {
-        return GROUP_PAIRED_PAGES;
-    }
+	if (value == "GROUP_PAIRED_PAGES")
+	{
+		return GROUP_PAIRED_PAGES;
+	}
 
-    if (value == "GROUP_PRESENTATION_MODE") {
-        return GROUP_PRESENTATION_MODE;
-    }
+	if (value == "GROUP_PRESENTATION_MODE")
+	{
+		return GROUP_PRESENTATION_MODE;
+	}
 
-    if (value == "GROUP_FULLSCREEN") {
-        return GROUP_FULLSCREEN;
-    }
+	if (value == "GROUP_FULLSCREEN")
+	{
+		return GROUP_FULLSCREEN;
+	}
 
-    if (value == "GROUP_RULER") {
-        return GROUP_RULER;
-    }
+	if (value == "GROUP_RULER")
+	{
+		return GROUP_RULER;
+	}
 
-    if (value == "GROUP_LINE_STYLE") {
-        return GROUP_LINE_STYLE;
-    }
+	if (value == "GROUP_LINE_STYLE")
+	{
+		return GROUP_LINE_STYLE;
+	}
 
-    if (value == "GROUP_AUDIO") {
-        return GROUP_AUDIO;
-    }
+	if (value == "GROUP_AUDIO")
+	{
+		return GROUP_AUDIO;
+	}
 
-    if (value == "GROUP_SNAPPING") {
-        return GROUP_SNAPPING;
-    }
+	if (value == "GROUP_SNAPPING")
+	{
+		return GROUP_SNAPPING;
+	}
 
-    if (value == "GROUP_GRID_SNAPPING") {
-        return GROUP_GRID_SNAPPING;
-    }
+	if (value == "GROUP_GRID_SNAPPING")
+	{
+		return GROUP_GRID_SNAPPING;
+	}
 
-    if (value == "GROUP_FILL") {
-        return GROUP_FILL;
-    }
+	if (value == "GROUP_FILL")
+	{
+		return GROUP_FILL;
+	}
 
-    if (value == "GROUP_FIXED_ROW_OR_COLS") {
-        return GROUP_FIXED_ROW_OR_COLS;
-    }
+	if (value == "GROUP_FIXED_ROW_OR_COLS")
+	{
+		return GROUP_FIXED_ROW_OR_COLS;
+	}
 
-    if (value == "GROUP_LAYOUT_HORIZONTAL") {
-        return GROUP_LAYOUT_HORIZONTAL;
-    }
+	if (value == "GROUP_LAYOUT_HORIZONTAL")
+	{
+		return GROUP_LAYOUT_HORIZONTAL;
+	}
 
-    if (value == "GROUP_LAYOUT_LR") {
-        return GROUP_LAYOUT_LR;
-    }
+	if (value == "GROUP_LAYOUT_LR")
+	{
+		return GROUP_LAYOUT_LR;
+	}
 
-    if (value == "GROUP_LAYOUT_TB") {
-        return GROUP_LAYOUT_TB;
-    }
+	if (value == "GROUP_LAYOUT_TB")
+	{
+		return GROUP_LAYOUT_TB;
+	}
 
-    if (value == "GROUP_ZOOM_FIT") {
-        return GROUP_ZOOM_FIT;
-    }
+	if (value == "GROUP_ZOOM_FIT")
+	{
+		return GROUP_ZOOM_FIT;
+	}
 
-    g_error("Invalid enum value for ActionGroup: «%s»", value.c_str());
-    return GROUP_NOGROUP;
+	g_error("Invalid enum value for ActionGroup: «%s»", value.c_str());
+	return GROUP_NOGROUP;
 }
 
 
-auto ActionGroup_toString(ActionGroup value) -> string {
-    if (value == GROUP_NOGROUP) {
-        return "GROUP_NOGROUP";
-    }
 
-    if (value == GROUP_TOOL) {
-        return "GROUP_TOOL";
-    }
+string ActionGroup_toString(ActionGroup value)
+{
+	if (value == GROUP_NOGROUP)
+	{
+		return "GROUP_NOGROUP";
+	}
 
-    if (value == GROUP_COLOR) {
-        return "GROUP_COLOR";
-    }
+	if (value == GROUP_TOOL)
+	{
+		return "GROUP_TOOL";
+	}
 
-    if (value == GROUP_SIZE) {
-        return "GROUP_SIZE";
-    }
+	if (value == GROUP_COLOR)
+	{
+		return "GROUP_COLOR";
+	}
 
-    if (value == GROUP_ERASER_MODE) {
-        return "GROUP_ERASER_MODE";
-    }
+	if (value == GROUP_SIZE)
+	{
+		return "GROUP_SIZE";
+	}
 
-    if (value == GROUP_ERASER_SIZE) {
-        return "GROUP_ERASER_SIZE";
-    }
+	if (value == GROUP_ERASER_MODE)
+	{
+		return "GROUP_ERASER_MODE";
+	}
 
-    if (value == GROUP_PEN_SIZE) {
-        return "GROUP_PEN_SIZE";
-    }
+	if (value == GROUP_ERASER_SIZE)
+	{
+		return "GROUP_ERASER_SIZE";
+	}
 
-    if (value == GROUP_PEN_FILL) {
-        return "GROUP_PEN_FILL";
-    }
+	if (value == GROUP_PEN_SIZE)
+	{
+		return "GROUP_PEN_SIZE";
+	}
 
-    if (value == GROUP_HILIGHTER_SIZE) {
-        return "GROUP_HILIGHTER_SIZE";
-    }
+	if (value == GROUP_PEN_FILL)
+	{
+		return "GROUP_PEN_FILL";
+	}
 
-    if (value == GROUP_HILIGHTER_FILL) {
-        return "GROUP_HILIGHTER_FILL";
-    }
+	if (value == GROUP_HILIGHTER_SIZE)
+	{
+		return "GROUP_HILIGHTER_SIZE";
+	}
 
-    if (value == GROUP_TOGGLE_GROUP) {
-        return "GROUP_TOGGLE_GROUP";
-    }
+	if (value == GROUP_HILIGHTER_FILL)
+	{
+		return "GROUP_HILIGHTER_FILL";
+	}
 
-    if (value == GROUP_PAIRED_PAGES) {
-        return "GROUP_PAIRED_PAGES";
-    }
+	if (value == GROUP_TOGGLE_GROUP)
+	{
+		return "GROUP_TOGGLE_GROUP";
+	}
 
-    if (value == GROUP_PRESENTATION_MODE) {
-        return "GROUP_PRESENTATION_MODE";
-    }
+	if (value == GROUP_PAIRED_PAGES)
+	{
+		return "GROUP_PAIRED_PAGES";
+	}
 
-    if (value == GROUP_FULLSCREEN) {
-        return "GROUP_FULLSCREEN";
-    }
+	if (value == GROUP_PRESENTATION_MODE)
+	{
+		return "GROUP_PRESENTATION_MODE";
+	}
 
-    if (value == GROUP_RULER) {
-        return "GROUP_RULER";
-    }
+	if (value == GROUP_FULLSCREEN)
+	{
+		return "GROUP_FULLSCREEN";
+	}
 
-    if (value == GROUP_LINE_STYLE) {
-        return "GROUP_LINE_STYLE";
-    }
+	if (value == GROUP_RULER)
+	{
+		return "GROUP_RULER";
+	}
 
-    if (value == GROUP_AUDIO) {
-        return "GROUP_AUDIO";
-    }
+	if (value == GROUP_LINE_STYLE)
+	{
+		return "GROUP_LINE_STYLE";
+	}
 
-    if (value == GROUP_SNAPPING) {
-        return "GROUP_SNAPPING";
-    }
+	if (value == GROUP_AUDIO)
+	{
+		return "GROUP_AUDIO";
+	}
 
-    if (value == GROUP_GRID_SNAPPING) {
-        return "GROUP_GRID_SNAPPING";
-    }
+	if (value == GROUP_SNAPPING)
+	{
+		return "GROUP_SNAPPING";
+	}
 
-    if (value == GROUP_FILL) {
-        return "GROUP_FILL";
-    }
+	if (value == GROUP_GRID_SNAPPING)
+	{
+		return "GROUP_GRID_SNAPPING";
+	}
 
-    if (value == GROUP_FIXED_ROW_OR_COLS) {
-        return "GROUP_FIXED_ROW_OR_COLS";
-    }
+	if (value == GROUP_FILL)
+	{
+		return "GROUP_FILL";
+	}
 
-    if (value == GROUP_LAYOUT_HORIZONTAL) {
-        return "GROUP_LAYOUT_HORIZONTAL";
-    }
+	if (value == GROUP_FIXED_ROW_OR_COLS)
+	{
+		return "GROUP_FIXED_ROW_OR_COLS";
+	}
 
-    if (value == GROUP_LAYOUT_LR) {
-        return "GROUP_LAYOUT_LR";
-    }
+	if (value == GROUP_LAYOUT_HORIZONTAL)
+	{
+		return "GROUP_LAYOUT_HORIZONTAL";
+	}
 
-    if (value == GROUP_LAYOUT_TB) {
-        return "GROUP_LAYOUT_TB";
-    }
+	if (value == GROUP_LAYOUT_LR)
+	{
+		return "GROUP_LAYOUT_LR";
+	}
 
-    if (value == GROUP_ZOOM_FIT) {
-        return "GROUP_ZOOM_FIT";
-    }
+	if (value == GROUP_LAYOUT_TB)
+	{
+		return "GROUP_LAYOUT_TB";
+	}
 
-    g_error("Invalid enum value for ActionGroup: %i", value);
-    return "";
+	if (value == GROUP_ZOOM_FIT)
+	{
+		return "GROUP_ZOOM_FIT";
+	}
+
+	g_error("Invalid enum value for ActionGroup: %i", value);
+	return "";
 }

--- a/src/enums/generated/ActionType.generated.cpp
+++ b/src/enums/generated/ActionType.generated.cpp
@@ -166,9 +166,15 @@ auto ActionType_fromString(const string& value) -> ActionType {
         return ACTION_PAPER_BACKGROUND_COLOR;
     }
 
-    if (value == "ACTION_TOOL_PEN") {
-        return ACTION_TOOL_PEN;
-    }
+	if (value == "ACTION_PAPER_FOREGROUND_COLOR")
+	{
+		return ACTION_PAPER_FOREGROUND_COLOR;
+	}
+
+	if (value == "ACTION_TOOL_PEN")
+	{
+		return ACTION_TOOL_PEN;
+	}
 
     if (value == "ACTION_TOOL_ERASER") {
         return ACTION_TOOL_ERASER;
@@ -745,9 +751,15 @@ auto ActionType_toString(ActionType value) -> string {
         return "ACTION_PAPER_BACKGROUND_COLOR";
     }
 
-    if (value == ACTION_TOOL_PEN) {
-        return "ACTION_TOOL_PEN";
-    }
+	if (value == ACTION_PAPER_FOREGROUND_COLOR)
+	{
+		return "ACTION_PAPER_FOREGROUND_COLOR";
+	}
+
+	if (value == ACTION_TOOL_PEN)
+	{
+		return "ACTION_TOOL_PEN";
+	}
 
     if (value == ACTION_TOOL_ERASER) {
         return "ACTION_TOOL_ERASER";

--- a/src/enums/generated/ActionType.generated.cpp
+++ b/src/enums/generated/ActionType.generated.cpp
@@ -166,15 +166,13 @@ auto ActionType_fromString(const string& value) -> ActionType {
         return ACTION_PAPER_BACKGROUND_COLOR;
     }
 
-	if (value == "ACTION_PAPER_FOREGROUND_COLOR")
-	{
-		return ACTION_PAPER_FOREGROUND_COLOR;
-	}
+    if (value == "ACTION_PAPER_FOREGROUND_COLOR") {
+        return ACTION_PAPER_FOREGROUND_COLOR;
+    }
 
-	if (value == "ACTION_TOOL_PEN")
-	{
-		return ACTION_TOOL_PEN;
-	}
+    if (value == "ACTION_TOOL_PEN") {
+        return ACTION_TOOL_PEN;
+    }
 
     if (value == "ACTION_TOOL_ERASER") {
         return ACTION_TOOL_ERASER;
@@ -751,15 +749,13 @@ auto ActionType_toString(ActionType value) -> string {
         return "ACTION_PAPER_BACKGROUND_COLOR";
     }
 
-	if (value == ACTION_PAPER_FOREGROUND_COLOR)
-	{
-		return "ACTION_PAPER_FOREGROUND_COLOR";
-	}
+    if (value == ACTION_PAPER_FOREGROUND_COLOR) {
+        return "ACTION_PAPER_FOREGROUND_COLOR";
+    }
 
-	if (value == ACTION_TOOL_PEN)
-	{
-		return "ACTION_TOOL_PEN";
-	}
+    if (value == ACTION_TOOL_PEN) {
+        return "ACTION_TOOL_PEN";
+    }
 
     if (value == ACTION_TOOL_ERASER) {
         return "ACTION_TOOL_ERASER";

--- a/src/model/XojPage.cpp
+++ b/src/model/XojPage.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <iterator>
 #include <utility>
+#include <view/background/BackgroundConfig.h>
 
 #include "BackgroundImage.h"
 #include "Document.h"
@@ -119,6 +120,16 @@ void XojPage::setBackgroundPdfPageNr(size_t page) {
 void XojPage::setBackgroundColor(Color color) { this->backgroundColor = color; }
 
 auto XojPage::getBackgroundColor() const -> Color { return this->backgroundColor; }
+
+void XojPage::setForegroundColor(Color color) {
+    PageType pageType = this->getBackgroundType();
+
+    auto backgroundConfig = BackgroundConfig(pageType.config);
+    backgroundConfig.setValueHex("f1", color);
+    pageType.config = backgroundConfig.toString();
+
+    this->setBackgroundType(pageType);
+}
 
 void XojPage::setSize(double width, double height) {
     this->width = width;

--- a/src/model/XojPage.cpp
+++ b/src/model/XojPage.cpp
@@ -120,6 +120,10 @@ void XojPage::setBackgroundColor(Color color) { this->backgroundColor = color; }
 
 auto XojPage::getBackgroundColor() const -> Color { return this->backgroundColor; }
 
+void XojPage::setForegroundColor(Color color) {this->foregroundColor = color; }
+
+auto XojPage::getForegroundColor() const -> Color {return this->foregroundColor; };
+
 void XojPage::setSize(double width, double height) {
     this->width = width;
     this->height = height;

--- a/src/model/XojPage.cpp
+++ b/src/model/XojPage.cpp
@@ -120,10 +120,6 @@ void XojPage::setBackgroundColor(Color color) { this->backgroundColor = color; }
 
 auto XojPage::getBackgroundColor() const -> Color { return this->backgroundColor; }
 
-void XojPage::setForegroundColor(Color color) {this->foregroundColor = color; }
-
-auto XojPage::getForegroundColor() const -> Color {return this->foregroundColor; };
-
 void XojPage::setSize(double width, double height) {
     this->width = width;
     this->height = height;

--- a/src/model/XojPage.h
+++ b/src/model/XojPage.h
@@ -59,6 +59,8 @@ public:
     void setBackgroundColor(Color color);
     Color getBackgroundColor() const;
 
+    void setForegroundColor(Color color);
+
     vector<Layer*>* getLayers();
     size_t getLayerCount();
     int getSelectedLayerId();

--- a/src/model/XojPage.h
+++ b/src/model/XojPage.h
@@ -59,9 +59,6 @@ public:
     void setBackgroundColor(Color color);
     Color getBackgroundColor() const;
 
-    void setForegroundColor(Color color);
-    Color getForegroundColor() const;
-
     vector<Layer*>* getLayers();
     size_t getLayerCount();
     int getSelectedLayerId();
@@ -115,7 +112,6 @@ private:
      * The background color if the background type is plain
      */
     Color backgroundColor{0xffffffU};
-    Color foregroundColor;
 
     /**
      * Background visible

--- a/src/model/XojPage.h
+++ b/src/model/XojPage.h
@@ -59,6 +59,9 @@ public:
     void setBackgroundColor(Color color);
     Color getBackgroundColor() const;
 
+    void setForegroundColor(Color color);
+    Color getForegroundColor() const;
+
     vector<Layer*>* getLayers();
     size_t getLayerCount();
     int getSelectedLayerId();
@@ -112,6 +115,7 @@ private:
      * The background color if the background type is plain
      */
     Color backgroundColor{0xffffffU};
+    Color foregroundColor;
 
     /**
      * Background visible

--- a/src/view/background/BackgroundConfig.cpp
+++ b/src/view/background/BackgroundConfig.cpp
@@ -1,6 +1,7 @@
 #include "BackgroundConfig.h"
 
 #include <utility>
+#include <sstream>
 
 #include "StringUtils.h"
 
@@ -65,4 +66,34 @@ auto BackgroundConfig::loadValueHex(const string& key, uint32_t& value) -> bool 
     }
 
     return false;
+}
+
+bool BackgroundConfig::setValue(const string &key, string value) {
+    this->data[key] = value;
+
+    return true;
+}
+
+bool BackgroundConfig::setValueHex(const string &key, uint32_t value) {
+    char output[6];
+
+    sprintf(output, "%X", value);
+
+    this->setValue(key, output);
+    return true;
+}
+
+string BackgroundConfig::toString() {
+    map<string, string>::iterator it;
+
+    //string output = (char *) malloc(64);
+
+    string output;
+
+    for ( it = this->data.begin(); it != this->data.end(); it++ ) {
+        if (it != this->data.begin()) output += ',';
+        output += it->first + '=' + it->second;
+    }
+
+    return output;
 }

--- a/src/view/background/BackgroundConfig.cpp
+++ b/src/view/background/BackgroundConfig.cpp
@@ -1,7 +1,7 @@
 #include "BackgroundConfig.h"
 
-#include <utility>
 #include <sstream>
+#include <utility>
 
 #include "StringUtils.h"
 
@@ -68,13 +68,13 @@ auto BackgroundConfig::loadValueHex(const string& key, uint32_t& value) -> bool 
     return false;
 }
 
-bool BackgroundConfig::setValue(const string &key, string value) {
+bool BackgroundConfig::setValue(const string& key, string value) {
     this->data[key] = value;
 
     return true;
 }
 
-bool BackgroundConfig::setValueHex(const string &key, uint32_t value) {
+bool BackgroundConfig::setValueHex(const string& key, uint32_t value) {
     char output[6];
 
     sprintf(output, "%X", value);
@@ -86,12 +86,13 @@ bool BackgroundConfig::setValueHex(const string &key, uint32_t value) {
 string BackgroundConfig::toString() {
     map<string, string>::iterator it;
 
-    //string output = (char *) malloc(64);
+    // string output = (char *) malloc(64);
 
     string output;
 
-    for ( it = this->data.begin(); it != this->data.end(); it++ ) {
-        if (it != this->data.begin()) output += ',';
+    for (it = this->data.begin(); it != this->data.end(); it++) {
+        if (it != this->data.begin())
+            output += ',';
         output += it->first + '=' + it->second;
     }
 

--- a/src/view/background/BackgroundConfig.cpp
+++ b/src/view/background/BackgroundConfig.cpp
@@ -75,9 +75,10 @@ bool BackgroundConfig::setValue(const string& key, string value) {
 }
 
 bool BackgroundConfig::setValueHex(const string& key, uint32_t value) {
-    char output[6];
+    // Allocate a new string with length 6 + termination char
+    char output[7];
 
-    sprintf(output, "%X", value);
+    snprintf(output, 7, "%X", value);
 
     this->setValue(key, output);
     return true;

--- a/src/view/background/BackgroundConfig.h
+++ b/src/view/background/BackgroundConfig.h
@@ -29,6 +29,11 @@ public:
     bool loadValueHex(const string& key, int& value);
     bool loadValueHex(const string& key, uint32_t& value);
 
+    bool setValue(const string& key, string value);
+    bool setValueHex(const string& key, uint32_t value);
+
+    string toString();
+
 private:
     map<string, string> data;
 };

--- a/src/view/background/GraphBackgroundPainter.cpp
+++ b/src/view/background/GraphBackgroundPainter.cpp
@@ -38,7 +38,7 @@ void GraphBackgroundPainter::paint() {
 }
 
 void GraphBackgroundPainter::paintBackgroundGraph() {
-    Util::cairo_set_source_rgbi(cr, this->foregroundColor1);
+    Util::cairo_set_source_rgbi(cr, this->page->getForegroundColor());
 
     cairo_set_line_width(cr, lineWidth * lineWidthFactor);
     double marginTopBottom = margin1;

--- a/src/view/background/GraphBackgroundPainter.cpp
+++ b/src/view/background/GraphBackgroundPainter.cpp
@@ -8,19 +8,6 @@ GraphBackgroundPainter::GraphBackgroundPainter() = default;
 
 GraphBackgroundPainter::~GraphBackgroundPainter() = default;
 
-/**
- * Set the Graph line color to a lower contrast alternative if a black background is used
- */
-void GraphBackgroundPainter::updateGraphColor() {
-    Color backgroundColor = this->page->getBackgroundColor();
-
-    auto greyscale = [](Color color) {
-        return ((0xffU & uint32_t(color)) + (0xffU & (uint32_t(color) >> 8U)) + (0xffU & (uint32_t(color) >> 16U))) / 3;
-    };
-
-    this->foregroundColor1 = greyscale(backgroundColor) < 0x80U ? 0x202020U : 0xBDBDBDU;
-}
-
 void GraphBackgroundPainter::resetConfig() {
     this->foregroundColor1 = 0xBDBDBDU;
     this->lineWidth = 0.5;
@@ -32,13 +19,12 @@ void GraphBackgroundPainter::resetConfig() {
 auto GraphBackgroundPainter::getUnitSize() -> double { return this->drawRaster1; }
 
 void GraphBackgroundPainter::paint() {
-    this->updateGraphColor();
     paintBackgroundColor();
     paintBackgroundGraph();
 }
 
 void GraphBackgroundPainter::paintBackgroundGraph() {
-    Util::cairo_set_source_rgbi(cr, this->page->getForegroundColor());
+    Util::cairo_set_source_rgbi(cr, this->foregroundColor1);
 
     cairo_set_line_width(cr, lineWidth * lineWidthFactor);
     double marginTopBottom = margin1;

--- a/ui/main.glade
+++ b/ui/main.glade
@@ -1233,7 +1233,16 @@
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">Paper b_ackground</property>
-                            <property name="use_underline">True</property>
+                            <property name="use-underline">True</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkMenuItem" id="menuJournalPaperForeground">
+                            <property name="name">menuJournalPaperBackground</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">Paper Foreground</property>
+                            <signal name="activate" handler="ACTION_PAPER_FOREGROUND_COLOR" swapped="no"/>
                           </object>
                         </child>
                       </object>
@@ -2072,7 +2081,7 @@
                             <property name="can_focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
-                              <placeholder />
+                              <placeholder/>
                             </child>
                           </object>
                           <packing>
@@ -2175,8 +2184,8 @@
                                   </packing>
                                 </child>
                                 <style>
-                                  <class name="raised" />
-                                  <class name="linked" />
+                                  <class name="raised"/>
+                                  <class name="linked"/>
                                 </style>
                               </object>
                               <packing>
@@ -2200,7 +2209,7 @@
                                   </object>
                                 </child>
                                 <style>
-                                  <class name="raised" />
+                                  <class name="raised"/>
                                 </style>
                               </object>
                               <packing>
@@ -2231,7 +2240,7 @@
                         <property name="can_focus">False</property>
                         <property name="orientation">vertical</property>
                         <child>
-                          <placeholder />
+                          <placeholder/>
                         </child>
                       </object>
                       <packing>
@@ -2374,8 +2383,8 @@
                               </packing>
                             </child>
                             <style>
-                              <class name="linked" />
-                              <class name="raised" />
+                              <class name="linked"/>
+                              <class name="raised"/>
                             </style>
                           </object>
                         </child>
@@ -2425,7 +2434,7 @@
                               </object>
                             </child>
                             <style>
-                              <class name="raised" />
+                              <class name="raised"/>
                             </style>
                           </object>
                         </child>

--- a/ui/pagetemplates.ini
+++ b/ui/pagetemplates.ini
@@ -49,9 +49,9 @@ format=graph
 config=m1=40,rm=1
 
 
-[XournalppRedTest]
-name=Red dotted
-name[de]=Rot gepunktet
-format=dotted
-config=f1=FF0000
+#[XournalppRedTest]
+#name=Red dotted
+#name[de]=Rot gepunktet
+#format=dotted
+#config=f1=FF0000
 

--- a/ui/pagetemplates.ini
+++ b/ui/pagetemplates.ini
@@ -49,9 +49,9 @@ format=graph
 config=m1=40,rm=1
 
 
-#[XournalppRedTest]
-#name=Red dotted
-#name[de]=Rot gepunktet
-#format=dotted
-#config=f1=FF0000
+[XournalppRedTest]
+name=Red dotted
+name[de]=Rot gepunktet
+format=dotted
+config=f1=FF0000
 


### PR DESCRIPTION
This adds the ability to set config options in the BackgroundConfig class using the ```setValue``` and ```setValueHex``` methods. Using this, the page foreground color can dynamically be changed by updating the config string of the PageType of the XojPage.
This PR only adds the ability to change the primary foreground color. It doesn't add the ability to change the secondary foreground color. I don't believe showing the ability to change the secondary foreground color for all views would be a good idea since most backgrounds only have one foreground color.
Relevant issues: #2350, #1853
I would also ignore #2352 if this were accepted as I don't believe having user configurable foreground colors and "alternative dark bg colors" are very user friendly.