### PR TITLE
Minor touchups for C++17

### DIFF
--- a/src/control/AudioController.cpp
+++ b/src/control/AudioController.cpp
@@ -1,5 +1,7 @@
 #include "AudioController.h"
 
+#include <cinttypes>
+
 #include "Util.h"
 #include "XojMsgBox.h"
 #include "i18n.h"
@@ -16,8 +18,8 @@ auto AudioController::startRecording() -> bool {
         time_t secs = time(nullptr);
         tm* t = localtime(&secs);
         // This prints the date and time in ISO format.
-        sprintf(buffer.data(), "%04d-%02d-%02d_%02d-%02d-%02d", t->tm_year + 1900, t->tm_mon + 1, t->tm_mday,
-                t->tm_hour, t->tm_min, t->tm_sec);
+        snprintf(buffer.data(), buffer.size(), "%04d-%02d-%02d_%02d-%02d-%02d", t->tm_year + 1900, t->tm_mon + 1,
+                 t->tm_mday, t->tm_hour, t->tm_min, t->tm_sec);
         string data(buffer.data());
         data += ".ogg";
 

--- a/src/control/settings/PageTemplateSettings.cpp
+++ b/src/control/settings/PageTemplateSettings.cpp
@@ -1,5 +1,6 @@
 #include "PageTemplateSettings.h"
 
+#include <cinttypes>
 #include <sstream>
 
 #include "control/pagetype/PageTypeHandler.h"
@@ -114,7 +115,7 @@ auto PageTemplateSettings::toString() const -> string {
     }
 
     char buffer[64];
-    sprintf(buffer, "#%06x", uint32_t{this->backgroundColor});
+    snprintf(buffer, sizeof(buffer), "#%06" PRIx32, uint32_t{this->backgroundColor});
     str += string("backgroundColor=") + buffer + "\n";
 
     return str;

--- a/src/control/xojfile/SaveHandler.cpp
+++ b/src/control/xojfile/SaveHandler.cpp
@@ -1,5 +1,7 @@
 #include "SaveHandler.h"
 
+#include <cinttypes>
+
 #include <config.h>
 
 #include "control/jobs/ProgressListener.h"
@@ -83,9 +85,9 @@ void SaveHandler::writeHeader() {
 }
 
 auto SaveHandler::getColorStr(Color c, unsigned char alpha) -> string {
-    char* str = g_strdup_printf("#%08x", uint32_t(c) << 8U | alpha);
-    string color = str;
-    g_free(str);
+    char str[10];
+    sprintf(str, "#%08" PRIx32, uint32_t(c) << 8U | alpha);
+    string color(str);
     return color;
 }
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -162,7 +162,7 @@ void MainWindow::rebindAcceleratorsMenuItem(GtkWidget* widget, gpointer user_dat
     if (GTK_IS_MENU_ITEM(widget)) {
         GtkAccelGroup* newAccelGroup = reinterpret_cast<GtkAccelGroup*>(user_data);
         GList* menuAccelClosures = gtk_widget_list_accel_closures(widget);
-        for (GList* l = menuAccelClosures; l != NULL; l = l->next) {
+        for (GList* l = menuAccelClosures; l != nullptr; l = l->next) {
             GClosure* closure = reinterpret_cast<GClosure*>(l->data);
             GtkAccelGroup* accelGroup = gtk_accel_group_from_accel_closure(closure);
             GtkAccelKey* key = gtk_accel_group_find(accelGroup, isKeyForClosure, closure);
@@ -171,7 +171,7 @@ void MainWindow::rebindAcceleratorsMenuItem(GtkWidget* widget, gpointer user_dat
             // gtk_widget_get_name(widget));
 
             gtk_accel_group_connect(newAccelGroup, key->accel_key, key->accel_mods, GtkAccelFlags(0),
-                                    g_cclosure_new_swap(G_CALLBACK(MainWindow::invokeMenu), widget, NULL));
+                                    g_cclosure_new_swap(G_CALLBACK(MainWindow::invokeMenu), widget, nullptr));
         }
 
         MainWindow::rebindAcceleratorsSubMenu(widget, newAccelGroup);

--- a/src/gui/toolbarMenubar/ColorToolItem.cpp
+++ b/src/gui/toolbarMenubar/ColorToolItem.cpp
@@ -1,5 +1,7 @@
 #include "ColorToolItem.h"
 
+#include <cinttypes>
+
 #include <config.h>
 
 #include "control/ToolEnums.h"
@@ -79,7 +81,7 @@ auto ColorToolItem::getId() -> string {
     }
 
     char buffer[64];
-    sprintf(buffer, "COLOR(0x%06x)", uint32_t{this->color});
+    snprintf(buffer, sizeof(buffer), "COLOR(0x%06" PRIx32 ")", uint32_t{this->color});
     string id = buffer;
 
     return id;

--- a/src/gui/toolbarMenubar/model/ToolbarColorNames.cpp
+++ b/src/gui/toolbarMenubar/model/ToolbarColorNames.cpp
@@ -1,5 +1,6 @@
 #include "ToolbarColorNames.h"
 
+#include <cinttypes>
 #include <fstream>
 
 #include <glib/gstdio.h>
@@ -12,9 +13,7 @@ ToolbarColorNames::ToolbarColorNames() {
     initPredefinedColors();
 }
 
-ToolbarColorNames::~ToolbarColorNames() {
-    g_key_file_free(this->config);
-}
+ToolbarColorNames::~ToolbarColorNames() { g_key_file_free(this->config); }
 
 static ToolbarColorNames* instance = nullptr;
 
@@ -61,14 +60,14 @@ void ToolbarColorNames::addColor(Color color, const std::string& name, bool pred
         this->predefinedColorNames[color] = name;
     } else {
         char colorHex[16];
-        sprintf(colorHex, "%06x", uint32_t{color});
+        snprintf(colorHex, sizeof(colorHex), "%06" PRIx32, uint32_t{color});
         g_key_file_set_string(this->config, "custom", colorHex, name.c_str());
     }
 }
 
 auto ToolbarColorNames::getColorName(Color color) -> std::string {
     char colorHex[16];
-    sprintf(colorHex, "%06x", uint32_t{color});
+    snprintf(colorHex, sizeof(colorHex), "%06" PRIx32, uint32_t{color});
 
     std::string colorName;
     char* name = g_key_file_get_string(this->config, "custom", colorHex, nullptr);

--- a/src/util/Stacktrace.cpp
+++ b/src/util/Stacktrace.cpp
@@ -87,7 +87,7 @@ void Stacktrace::printStracktrace(std::ostream& stream) {
 
         std::array<char, 1024> syscom{};
 
-        sprintf(syscom.data(), "addr2line %p -e %s", trace[i], exeName.c_str());
+        snprintf(syscom.data(), syscom.size(), "addr2line %p -e %s", trace[i], exeName.c_str());
         FILE* fProc = popen(syscom.data(), "r");
         while (fgets(buff.data(), buff.size(), fProc) != nullptr) {
             stream << buff.data();

--- a/src/util/logger/Logger.cpp
+++ b/src/util/logger/Logger.cpp
@@ -6,12 +6,11 @@
 
 #ifdef DEV_CALL_LOG
 
+#include <cstdio>
 #include <fstream>
 #include <iostream>
 #include <sstream>
 #include <string>
-
-#include <stdio.h>
 
 #ifdef _WIN32
 
@@ -41,7 +40,7 @@ inline std::string NowTime() {
     tm r;
     strftime(buffer, sizeof(buffer), "%X", localtime_r(&tv.tv_sec, &r));
     char result[100];
-    sprintf(result, "%s.%06ld", buffer, (long)tv.tv_usec);
+    snprintf(result, sizeof(result), "%s.%06ld", buffer, (long)tv.tv_usec);
     return result;
 }
 

--- a/src/util/serializing/HexObjectEncoding.cpp
+++ b/src/util/serializing/HexObjectEncoding.cpp
@@ -1,5 +1,6 @@
 #include "HexObjectEncoding.h"
 
+#include <cinttypes>
 #include <cstdio>
 
 HexObjectEncoding::HexObjectEncoding() = default;
@@ -10,8 +11,8 @@ void HexObjectEncoding::addData(const void* data, int len) {
     char* buffer = static_cast<char*>(g_malloc(len * 2));
 
     for (int i = 0; i < len; i++) {
-        int x = static_cast<uint8_t const*>(data)[i];
-        sprintf(&buffer[i * 2], "%02x", x);
+        uint8_t x = static_cast<uint8_t const*>(data)[i];
+        sprintf(&buffer[i * 2], "%02" PRIx8, x);
     }
 
     g_string_append_len(this->data, buffer, len * 2);

--- a/test/util/I18nTest.cpp
+++ b/test/util/I18nTest.cpp
@@ -9,12 +9,12 @@
  * @license GNU GPLv2 or later
  */
 
+#include <cstdlib>
 #include <ctime>
 
 #include <config-test.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include <i18n.h>
-#include <stdlib.h>
 
 using namespace std;
 

--- a/test/util/StringUtilsTest.cpp
+++ b/test/util/StringUtilsTest.cpp
@@ -9,12 +9,12 @@
  * @license GNU GPLv2 or later
  */
 
+#include <cstdlib>
 #include <ctime>
 
 #include <StringUtils.h>
 #include <config-test.h>
 #include <cppunit/extensions/HelperMacros.h>
-#include <stdlib.h>
 
 using namespace std;
 

--- a/test/util/XojPreviewExtractorTest.cpp
+++ b/test/util/XojPreviewExtractorTest.cpp
@@ -9,12 +9,12 @@
  * @license GNU GPLv2 or later
  */
 
+#include <cstdlib>
 #include <ctime>
 
 #include <XojPreviewExtractor.h>
 #include <config-test.h>
 #include <cppunit/extensions/HelperMacros.h>
-#include <stdlib.h>
 
 using namespace std;
 

--- a/windows-setup/xournalpp_launcher.cpp
+++ b/windows-setup/xournalpp_launcher.cpp
@@ -10,9 +10,8 @@
  * @license GNU GPLv2 or later
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-
+#include <cstdio>
+#include <cstdlib>
 #include <string>
 using std::string;
 
@@ -23,90 +22,78 @@ using std::string;
 #include <unistd.h>
 #endif
 
-string escapeString(const char* str)
-{
-	string escaped;
+string escapeString(const char* str) {
+    string escaped;
 
-	while (*str)
-	{
-		char c = *str;
+    while (*str) {
+        char c = *str;
 
-		if (c == '"')
-		{
-			escaped += "\\\"";
-		}
-		else
-		{
-			escaped += c;
-		}
+        if (c == '"') {
+            escaped += "\\\"";
+        } else {
+            escaped += c;
+        }
 
-		str++;
-	}
+        str++;
+    }
 
-	return escaped;
+    return escaped;
 }
 
-int main(int argc, char* argv[])
-{
-	string exePath;
+int main(int argc, char* argv[]) {
+    string exePath;
 
 #ifdef _WIN32
-	char szFileName[MAX_PATH + 1];
-	GetModuleFileNameA(nullptr, szFileName, MAX_PATH + 1);
-	exePath = szFileName;
+    char szFileName[MAX_PATH + 1];
+    GetModuleFileNameA(nullptr, szFileName, MAX_PATH + 1);
+    exePath = szFileName;
 #else
-	char result[1024];
-	ssize_t count = readlink("/proc/self/exe", result, 1024);
-	exePath = string(result, (count > 0) ? count : 0);
+    char result[1024];
+    ssize_t count = readlink("/proc/self/exe", result, 1024);
+    exePath = string(result, (count > 0) ? count : 0);
 #endif
 
-	int slashPos = 0;
+    int slashPos = 0;
 
-	for(int i = exePath.size(); i > 0; i--)
-	{
-		if (exePath[i] == '/' || exePath[i] == '\\')
-		{
-			slashPos = i;
-			break;
-		}
-	}
+    for (int i = exePath.size(); i > 0; i--) {
+        if (exePath[i] == '/' || exePath[i] == '\\') {
+            slashPos = i;
+            break;
+        }
+    }
 
-	string folder = exePath.substr(0, slashPos);
+    string folder = exePath.substr(0, slashPos);
 
-	chdir(folder.c_str());
+    chdir(folder.c_str());
 
-	string command = "xournalpp_bin.exe";
+    string command = "xournalpp_bin.exe";
 
-	for (int i = 1; i < argc; i++)
-	{
-		MessageBoxA(nullptr, argv[i], "Debug IN", 0);
+    for (int i = 1; i < argc; i++) {
+        MessageBoxA(nullptr, argv[i], "Debug IN", 0);
 
-		command += " \"";
-		command += escapeString(argv[i]);
-		command += "\"";
-	}
+        command += " \"";
+        command += escapeString(argv[i]);
+        command += "\"";
+    }
 
 
 #ifdef _WIN32
-	STARTUPINFO info = {};
-	PROCESS_INFORMATION processInfo;
-	char* cmd = new char[command.size() + 1];
-	strncpy(cmd, command.c_str(), command.size());
-	cmd[command.size()] = 0;
-	//	MessageBoxA(nullptr, cmd, "Debug", 0);
-	if (CreateProcessA(nullptr, cmd, nullptr, nullptr, true, 0, nullptr, folder.c_str(), &info, &processInfo))
-	{
-		WaitForSingleObject(processInfo.hProcess, INFINITE);
-		CloseHandle(processInfo.hProcess);
-		CloseHandle(processInfo.hThread);
-	}
-	
-	delete cmd;
+    STARTUPINFO info = {};
+    PROCESS_INFORMATION processInfo;
+    char* cmd = new char[command.size() + 1];
+    strncpy(cmd, command.c_str(), command.size());
+    cmd[command.size()] = 0;
+    //	MessageBoxA(nullptr, cmd, "Debug", 0);
+    if (CreateProcessA(nullptr, cmd, nullptr, nullptr, true, 0, nullptr, folder.c_str(), &info, &processInfo)) {
+        WaitForSingleObject(processInfo.hProcess, INFINITE);
+        CloseHandle(processInfo.hProcess);
+        CloseHandle(processInfo.hThread);
+    }
+
+    delete cmd;
 #else
-	system(command.c_str());
+    system(command.c_str());
 #endif
 
-	return 0;
+    return 0;
 }
-
-


### PR DESCRIPTION
I made the following changes:

- Changes some C headers to C++ headers,
- `NULL` changed to `nullptr`
- `sprintf` changed to `snprintf` (not in every occurrence, but some where I deemed it OK)
- Changed `%x` format specifiers of `sprintf` with `PRIuxN` where appropriate (where `uintN_t` was used).
- Removed a use of `g_strdup_printf` thus avoiding the dynamic allocation.