### PR TITLE
MacOS: Update the build environment to gtk 3.24.23 - switch to macports

### DIFF
--- a/mac-setup/Readme.md
+++ b/mac-setup/Readme.md
@@ -1,0 +1,17 @@
+# How to build for MacOS
+
+The MacOS build will build most prerequisites via macports. Some updated versions are installed via the manual configure/make/make install. The build environment is located in $HOME/gtk/inst for historical reasons. You need to have Apple XCode installed.
+
+```
+cd mac-setup
+./installmacports.sh
+./cleanmacports.sh
+./build-gettext.sh
+./build-mac-integration.sh
+```
+
+Then your build environment is ready and you can create the app bundle
+
+```
+./complete-build.sh $HOME/gtk
+```

--- a/mac-setup/build-app.sh
+++ b/mac-setup/build-app.sh
@@ -72,6 +72,9 @@ for locale in */ ; do
   fi
 done
 
+## Fix the calling script in the bundle
+sed -i '' '/export DYLD_LIB.*/d' ./Xournal++.app/Contents/MacOS/xournalpp
+
 echo "Create zip"
 zip -r Xournal++.zip Xournal++.app
 

--- a/mac-setup/build-gettext.sh
+++ b/mac-setup/build-gettext.sh
@@ -1,0 +1,23 @@
+export PATH="/usr/bin:/bin"
+
+gettextversion=0.21
+rm -rf ./gettext
+curl -L https://ftp.gnu.org/pub/gnu/gettext/gettext-$gettextversion.tar.xz -o gettext.tar.xy
+tar -xJf ./gettext.tar.xy
+rm ./gettext.tar.xy
+mv gettext-$gettextversion gettext
+cd gettext
+./configure --prefix=$HOME/gtk/inst \
+  --disable-csharp \
+  --disable-java \
+  --disable-native-java \
+  --disable-openmp \
+  --without-emacs \
+  --with-included-gettext \
+  --with-included-glib \
+  --with-included-libcroco \
+  --with-included-libunistring \
+  --with-included-libxml
+
+make -j8
+make install

--- a/mac-setup/cleanmacports.sh
+++ b/mac-setup/cleanmacports.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -xve
+
+# Cleanup the macports build environment
+
+
+# Copyright (C) 2020 Friedrich Beckmann
+# Released under GNU General Public License, either version 3
+# or any later option
+
+topdir=$HOME/gtk
+
+# This is the installation directory which will be used as macports prefix
+# and as pspp configure prefix.
+bundleinstall=$topdir/inst
+
+export PATH=$bundleinstall/bin:$bundleinstall/sbin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin
+
+for i in  {1..10}; do port -N uninstall leaves || true ; done
+
+rm -rf $bundleinstall/var/macports
+rm -rf $topdir/macports-ports

--- a/mac-setup/installmacports.sh
+++ b/mac-setup/installmacports.sh
@@ -1,0 +1,102 @@
+#!/bin/bash -xve
+
+# Install macports and all dependencies for xournalpp in $HOME/gtk/inst
+# macports is all recompiled because it uses the quartz backend instead of x11
+
+portindexversion=8e06b840b02731c3ef712f4aa6c4ff138a64a604
+
+# Copyright (C) 2020 Friedrich Beckmann
+# Released under GNU General Public License, either version 3
+# or any later option
+
+echo `date`
+
+# Check if we are on MacOS
+if ! test `uname` = "Darwin"; then
+    echo "This only works on MacOS"
+    exit
+fi
+
+# Check if XCode is installed - Assume clang indicates xcode.
+if ! test -f /usr/bin/clang; then
+    echo "/usr/bin/clang not found - please install XCode CLT"
+    exit
+fi
+
+topdir=$HOME/gtk
+
+# This is the installation directory which will be used as macports prefix
+# and as pspp configure prefix.
+bundleinstall=$topdir/inst
+
+export PATH=$bundleinstall/bin:$bundleinstall/sbin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin
+
+# Target macports install directory for the pspp bundle
+if test -d $bundleinstall; then
+    echo "Found existing macports directory $bundleinstall - continue"
+else
+    echo "Creating Macports installation in $bundleinstall"
+    mkdir -p $bundleinstall
+    # Install macports
+    rm -rf /tmp/macports
+    mkdir /tmp/macports
+    pushd /tmp/macports
+    macportsversion=2.6.3
+    curl https://distfiles.macports.org/MacPorts/MacPorts-$macportsversion.tar.gz -O
+    tar xvzf Macports-$macportsversion.tar.gz
+    cd Macports-$macportsversion
+    ./configure --prefix=$bundleinstall \
+                --with-applications-dir=$bundleinstall/Applications \
+                --with-no-root-privileges
+    make
+    make install
+    popd
+    rm -rf /tmp/macports
+    # Modify the default variants to use quartz
+    echo "-x11 +no_x11 +quartz" > $bundleinstall/etc/macports/variants.conf
+    # Make the build compatible with previous OSX Versions
+    # echo "macosx_deployment_target 10.7" >> $bundleinstall/etc/macports/macports.conf
+    # dbus tries to install startup items which are under superuser account
+    echo "startupitem_install no"  >> $bundleinstall/etc/macports/macports.conf
+    echo "buildfromsource always" >> $bundleinstall/etc/macports/macports.conf
+    # Activate step failed due to bsdtar problem 
+    echo "hfscompression no"  >> $bundleinstall/etc/macports/macports.conf
+    # Fix the macports version for reproducible builds
+    pushd $topdir
+    git clone --single-branch https://github.com/macports/macports-ports.git
+    cd macports-ports
+    git checkout $portindexversion
+    portindex
+    popd
+    echo "file://$topdir/macports-ports" > $bundleinstall/etc/macports/sources.conf
+    echo "rsync://rsync.macports.org/macports/release/tarballs/ports.tar [default]" >> $bundleinstall/etc/macports/sources.conf
+fi
+
+echo `date`
+# Install the packages for pspp
+port -v selfupdate
+port upgrade outdated || true
+# Install the build dependencies
+
+
+buildports="pkgconfig  \
+  gtk3 \
+  gtk-doc \
+  adwaita-icon-theme \
+  cmake \
+  automake \
+  cppunit \
+  autoconf \
+  poppler \
+  libzip \
+  portaudio \
+  libsndfile"
+
+port -N install $buildports
+port -N setrequested $buildports
+
+# gtk-mac-integration needs gettext 0.20 but macports has still 0.19
+# so you need to uninstall gettext via macports and install it via the script
+# build-gettext.sh
+
+port -Nf uninstall gettext


### PR DESCRIPTION
The MacOS build does not recognize the Wacom pen due to a problem
which is fixed in gtk 3.24.23. I did not manage to create the
build environment with jhbuild so I switched to macports. The Readme
explains how to create the build environment. The gtk-mac-integration
and the gtk-mac-bundler is still used, i.e. this build produces an
application bundle which runs standalone.

See: https://github.com/xournalpp/xournalpp/issues/1772