### PR TITLE
Fix strokes only appearing after lifting pen

### DIFF
--- a/src/control/ToolHandler.cpp
+++ b/src/control/ToolHandler.cpp
@@ -448,13 +448,7 @@ void ToolHandler::loadSettings() {
 
 void ToolHandler::pointCurrentToolToButtonTool() { this->currentTool = this->buttonSelectedTool; }
 
-void ToolHandler::pointCurrentToolToToolbarTool() {
-    this->currentTool = this->toolbarSelectedTool;
-
-    this->listener->toolColorChanged(false);
-    this->listener->toolSizeChanged();
-    this->fireToolChanged();
-}
+void ToolHandler::pointCurrentToolToToolbarTool() { this->currentTool = this->toolbarSelectedTool; }
 
 auto ToolHandler::getToolThickness(ToolType type) -> const double* { return this->tools[type - TOOL_PEN]->thickness; }
 

--- a/src/gui/inputdevices/PenInputHandler.cpp
+++ b/src/gui/inputdevices/PenInputHandler.cpp
@@ -169,8 +169,6 @@ auto PenInputHandler::actionMotion(InputEvent const& event) -> bool {
     GtkXournal* xournal = this->inputContext->getXournal();
     ToolHandler* toolHandler = this->inputContext->getToolHandler();
 
-    this->changeTool(event);
-
     if (toolHandler->getToolType() == TOOL_HAND) {
         if (this->deviceClassPressed) {
             this->handleScrollEvent(event);


### PR DESCRIPTION
Fixes #2242 

Also fixes strokes not disappearing until lifting the eraser.

The main problem was "changeTool" being called during the motion event,
for some reason firing those events there did cause the stroke to not
appear.

Only removing that call though resulted in the first stroke after
starting the application not appearing before lifting the stroke
(inverting my issue, which already was a big improvement). Also removing
those events then fixed that, too, as well as the eraser issue.

I honestly don't see, why pointCurrentToolToButtonTool and
pointCurrentToolToToolbarTool should be different here and I didn't
experience any issues so far but still, this is more an empirical "fix"
than actually understanding the real issue at hand (still took me hours
to debug).

Of course someone actually familiar with this code base should verify that this change doesn't break anything else. At least for me, drawing in general feels a lot smoother but that might also be my imagination and happiness to have finally fixed my problems with pen input.