### PR TITLE
Extend the Lua Plugin API for page and layer operations

### DIFF
--- a/plugins/LayerActions/main.lua
+++ b/plugins/LayerActions/main.lua
@@ -1,0 +1,72 @@
+-- Register all Toolbar actions and intialize all UI stuff
+function initUi()
+  app.registerUi({["menu"] = "Clone non-background layers to next page", ["callback"] = "clone", ["accelerator"]="<Control><Shift>c"});
+  app.registerUi({["menu"] = "Hide all layers except first layers and backgrounds", ["callback"] = "hide"});
+  app.registerUi({["menu"] = "Add new top layer on each page", ["callback"] = "add"});
+end
+
+function clone()
+  local docStructure = app.getDocumentStructure()
+  local currentPage = docStructure["currentPage"]
+  local nextPage = currentPage + 1
+  local numPages = #docStructure["pages"]
+
+  -- Make sure there is a next page, it has pdf background and no annotations or the annotations can be overwritten
+  if currentPage == numPages then
+    app.msgbox("No next page. ", {[1] = "OK"})
+    return
+  end
+  
+  local bgNextPage = docStructure["pages"][nextPage]["pageTypeFormat"]
+  if bgNextPage ~= ":pdf" then
+    app.msgbox("Next page has no pdf background. ", {[1] = "OK"})
+    return
+  end
+
+  local nextPdfPage = docStructure["pages"][nextPage]["pdfBackgroundPageNo"]
+  print(nextPdfPage)
+
+  local isAnnotated = docStructure["pages"][nextPage]["isAnnotated"]
+  if isAnnotated then
+    local res = app.msgbox("Next page contains annotations that will be lost, when proceeding. ", {[1]="Cancel", [2]="Proceed"})
+    if res == 1 then
+      return
+    end
+  end   
+
+  -- Copy the page, change its background to the background of the next pdf page and delete the old page without cloned layers
+  app.sidebarAction("COPY");
+  app.changeBackgroundPdfPageNr(nextPdfPage, false);
+  app.uiAction({["action"]="ACTION_GOTO_NEXT"})
+  app.uiAction({["action"]="ACTION_DELETE_PAGE"})
+  if currentPage < numPages -1 then
+    app.uiAction({["action"]="ACTION_GOTO_BACK"})
+  end
+end
+
+function hide()
+  local docStructure = app.getDocumentStructure()
+  local page = docStructure["currentPage"]
+  local numPages = #docStructure["pages"]
+
+  for i=1, numPages do
+    app.setCurrentPage(i)
+    app.setCurrentLayer(1, true)  -- makes background layer and layer 1 visible and all other layers invisible
+  end
+  
+  app.setCurrentPage(page)
+end
+
+function add()
+  local docStructure = app.getDocumentStructure()
+  local numPages = #docStructure["pages"]
+  local page = docStructure["currentPage"]
+  
+  for i=1, numPages do
+    app.setCurrentPage(i)
+    app.layerAction("ACTION_GOTO_TOP_LAYER")
+    app.layerAction("ACTION_NEW_LAYER")  
+  end
+  
+  app.setCurrentPage(page)
+end

--- a/plugins/LayerActions/plugin.ini
+++ b/plugins/LayerActions/plugin.ini
@@ -1,0 +1,15 @@
+[about]
+## Author / Copyright notice
+author=Roland Lötscher
+
+description=Actions for cloning, hiding and adding layers
+
+## If the plugin is packed with Xournal++, use
+## <xournalpp> then it gets the same version number
+version=<xournalpp>
+
+[default]
+enabled=false
+
+[plugin]
+mainfile=main.lua

--- a/src/gui/sidebar/Sidebar.cpp
+++ b/src/gui/sidebar/Sidebar.cpp
@@ -151,6 +151,8 @@ void Sidebar::saveSize() {
     this->control->getSettings()->setSidebarWidth(alloc.width);
 }
 
+auto Sidebar::getToolbar() -> SidebarToolbar* { return &this->toolbar; }
+
 auto Sidebar::getControl() -> Control* { return this->control; }
 
 void Sidebar::documentChanged(DocumentChangeType type) {

--- a/src/gui/sidebar/Sidebar.h
+++ b/src/gui/sidebar/Sidebar.h
@@ -68,6 +68,11 @@ public:
      */
     void saveSize();
 
+    /**
+     * Gets the sidebar toolbar
+     */
+    SidebarToolbar* getToolbar();
+
 public:
     // DocumentListener interface
     virtual void documentChanged(DocumentChangeType type);

--- a/src/plugin/luapi_application.h
+++ b/src/plugin/luapi_application.h
@@ -15,7 +15,9 @@
 #include "control/Control.h"
 #include "control/PageBackgroundChangeController.h"
 #include "control/Tool.h"
+#include "control/layer/LayerController.h"
 #include "control/pagetype/PageTypeHandler.h"
+#include "gui/widgets/XournalWidget.h"
 
 #include "StringUtils.h"
 #include "XojMsgBox.h"
@@ -24,6 +26,8 @@ using std::map;
 /**
  * Create a 'Save As' native dialog and return as a string
  * the filepath of the location the user chose to save.
+ *
+ * Example: local filename = app.saveAs()
  */
 static int applib_saveAs(lua_State* L) {
     GtkFileChooserNative* native;
@@ -57,9 +61,8 @@ static int applib_saveAs(lua_State* L) {
 }
 
 /**
- * Example:
- * app.msgbox("Test123", {[1] = "Yes", [2] = "No"})
- * Return 1 for yes, 2 for no in this example
+ * Example: local result = app.msgbox("Test123", {[1] = "Yes", [2] = "No"})
+ * Pops up a message box with two buttons "Yes" and "No" and returns 1 for yes, 2 for no
  */
 static int applib_msgbox(lua_State* L) {
     const char* msg = luaL_checkstring(L, 1);
@@ -89,7 +92,11 @@ static int applib_msgbox(lua_State* L) {
 
 
 /**
- * Allow to register menupoints or toolbar icons, this needs to be called from initUi
+ * Allow to register menupoints, this needs to be called from initUi
+ *
+ * Example: app.registerUi({["menu"] = "HelloWorld", callback="printMessage", accelerator="<Control>a"})
+ * registers a menupoint with name "HelloWorld" executing a function named "printMessage",
+ * which can be triggered via the "<Control>a" keyboard accelerator
  */
 static int applib_registerUi(lua_State* L) {
     Plugin* plugin = Plugin::getPluginFromLua(L);
@@ -149,7 +156,16 @@ static int applib_registerUi(lua_State* L) {
 }
 
 /**
- * Execute an UI action (usually internal called from Toolbar / Menu)
+ * Execute an UI action (usually internally called from Toolbar / Menu)
+ * The argument consists of a Lua table with 3 keys: "action", "group" and "enabled"
+ * The key "group" is currently only used for debugging purpose and can savely be omitted.
+ * The key "enabled" is true by default.
+ *
+ * Example 1: app.uiAction({["action"] = "ACTION_PASTE"})
+ * pastes the clipboard content into the document
+ *
+ * Example 2: app.uiAction({["action"] = "ACTION_TOOL_DRAW_CIRCLE", ["enabled"] = false})
+ * turns off the Circle drawing type
  */
 static int applib_uiAction(lua_State* L) {
     Plugin* plugin = Plugin::getPluginFromLua(L);
@@ -199,7 +215,14 @@ static int applib_uiAction(lua_State* L) {
 }
 
 /**
- * Select UI action
+ * Select UI action (notifies action listeners)
+ * Unless you are sure what you do, use app.uiAction instead!
+ * The problem is that only notifying action listeners does not store these changes in the settings, which may create
+ * confusion
+ *
+ * Example: app.uiActionSelected("GROUP_GRID_SNAPPING", "ACTION_GRID_SNAPPING")
+ * notifies the action listeners that grid snapping is turned on; it is not recorded in the settings,
+ * so better use app.uiAction({["action"] = "ACTION_GRID_SNAPPING") instead
  */
 static int applib_uiActionSelected(lua_State* L) {
     Plugin* plugin = Plugin::getPluginFromLua(L);
@@ -214,7 +237,58 @@ static int applib_uiActionSelected(lua_State* L) {
 }
 
 /**
- * Change page background
+ * Execute action from sidebar menu
+ *
+ * Example: app.sidebar_Action("MOVE_DOWN")
+ * moves down the current page
+ */
+static int applib_sidebarAction(lua_State* L) {
+    // Connect the context menu actions
+    const std::map<std::string, SidebarActions> actionMap = {
+            {"COPY", SIDEBAR_ACTION_COPY},
+            {"DELETE", SIDEBAR_ACTION_DELETE},
+            {"MOVE_UP", SIDEBAR_ACTION_MOVE_UP},
+            {"MOVE_DOWN", SIDEBAR_ACTION_MOVE_DOWN},
+            {"NEW_BEFORE", SIDEBAR_ACTION_NEW_BEFORE},
+            {"NEW_AFTER", SIDEBAR_ACTION_NEW_AFTER},
+    };
+    const char* actionStr = luaL_checkstring(L, 1);
+    if (actionStr == nullptr) {
+        luaL_error(L, "Missing action!");
+    }
+    auto pos = actionMap.find(actionStr);
+    if (pos == actionMap.end()) {
+        luaL_error(L, "Unkonwn action: %s", actionStr);
+    }
+    Plugin* plugin = Plugin::getPluginFromLua(L);
+    SidebarToolbar* toolbar = plugin->getControl()->getSidebar()->getToolbar();
+    toolbar->runAction(pos->second);
+
+    return 1;
+}
+
+/**
+ * Execute action from layer controller
+ *
+ * Example: app.layerAction("ACTION_DELETE_LAYER")
+ * deletes the current layer
+ */
+static int applib_layerAction(lua_State* L) {
+    Plugin* plugin = Plugin::getPluginFromLua(L);
+
+    ActionType action = ActionType_fromString(luaL_checkstring(L, 1));
+
+    Control* ctrl = plugin->getControl();
+    ctrl->getLayerController()->actionPerformed(action);
+
+    return 1;
+}
+
+/**
+ * Change page background of current page
+ *
+ * Example: app.changeCurrentPageBackground("graph")
+ * changes the page background of the current page to graph paper
  */
 static int applib_changeCurrentPageBackground(lua_State* L) {
     PageType pt;
@@ -231,6 +305,12 @@ static int applib_changeCurrentPageBackground(lua_State* L) {
 
 /**
  * Change color of a specified tool or of the current tool
+ *
+ * Example 1: app.changeToolColor({["color"] = 0xff00ff, ["tool"] = "PEN"})
+ * changes the color of the pen tool to violet without applying this change to the current selection
+ *
+ * Example 2: app.changeToolColor({["color"] = 0xff0000, ["selection"] = true })
+ * changes the color of the current tool to red and also applies it to the current selection if there is one
  */
 static int applib_changeToolColor(lua_State* L) {
 
@@ -245,8 +325,8 @@ static int applib_changeToolColor(lua_State* L) {
                                       if omitted, current Tool is used */
     lua_getfield(L, 1, "color");     // an RGB hex code defining the color
     // stack now has following:
-    //    1 = {["color"] = 0xff00ff, ["tool"] = "PEN", ["selection"] = false}
-    //   -3 = false
+    //    1 = {["color"] = 0xff00ff, ["tool"] = "PEN", ["selection"] = true}
+    //   -3 = true
     //   -2 = "pen"
     //   -1 = 0xff0077
 
@@ -305,13 +385,381 @@ static int applib_changeToolColor(lua_State* L) {
     return 1;
 }
 
+/*
+ * Select Background Pdf Page for Current Page
+ * First argument is an integer (page number) and the second argument is a boolean (isRelative)
+ * specifying whether the page number is relative to the current pdf page or absolute
+ *
+ * Example 1: app.changeBackgroundPdfPageNr(1, true)
+ * changes the pdf page to the next one (relative mode)
+ *
+ * Example 2: app.changeBackgroundPdfPageNr(7, false)
+ * changes the page background to the 7th pdf page (absolute mode)
+ */
+static int applib_changeBackgroundPdfPageNr(lua_State* L) {
+    Plugin* plugin = Plugin::getPluginFromLua(L);
+
+    size_t nr = luaL_checkinteger(L, 1);
+    bool relative = true;
+    if (lua_isboolean(L, 2)) {
+        relative = lua_toboolean(L, 2);
+    }
+
+    Control* control = plugin->getControl();
+    Document* doc = control->getDocument();
+    PageRef const& page = control->getCurrentPage();
+
+    if (!page) {
+        luaL_error(L, "No page!");
+    }
+
+    size_t selected = nr - 1;
+    if (relative) {
+        bool isPdf = page->getBackgroundType().isPdfPage();
+        if (isPdf) {
+            selected = page->getPdfPageNr() + nr;
+        } else {
+            luaL_error(L, "Current page has no pdf background, cannot use relative mode!");
+        }
+    }
+    if (selected >= 0 && selected < static_cast<int>(doc->getPdfPageCount())) {
+        // no need to set a type, if we set the page number the type is also set
+        page->setBackgroundPdfPageNr(selected);
+
+        XojPdfPageSPtr p = doc->getPdfPage(selected);
+        page->setSize(p->getWidth(), p->getHeight());
+    } else {
+        luaL_error(L, "Pdf page number %d does not exist!", selected + 1);
+    }
+
+    return 1;
+}
+
+/*
+ * Returns a table encoding the document structure in a Lua table of the shape
+ * {
+ *   "pages" = {
+ *     {
+ *       "pageWidth" = number,
+ *       "pageHeight" = number,
+ *       "isAnnoated" = bool,
+ *       "pageTypeFormat" = string,
+ *       "pdfBackgroundPageNo" = integer (0, if there is no pdf background page),
+ *       "layers" = {
+ *         [0] = {
+ *           "isVisible" = bool
+ *         },
+ *         [1] = {
+ *           "isVisible" = bool,
+ *           "isAnnotated" = bool
+ *         },
+ *         ...
+ *       },
+ *       "currentLayer" = integer
+ *     },
+ *     ...
+ *   }
+ *   "currentPage" = integer,
+ *   "pdfBackgroundFilename" = string (empty if there is none)
+ * }
+ *
+ * Example: local docStructure = app.getDocumentStructure()
+ */
+static int applib_getDocumentStructure(lua_State* L) {
+    Plugin* plugin = Plugin::getPluginFromLua(L);
+    Control* control = plugin->getControl();
+    Document* doc = control->getDocument();
+    LayerController* lc = control->getLayerController();
+
+    lua_newtable(L);
+
+    lua_pushliteral(L, "pages");
+    lua_newtable(L);  // beginning of pages table
+
+    // add pages
+    for (size_t p = 1; p <= doc->getPageCount(); ++p) {
+        auto page = doc->getPage(p - 1);
+        lua_pushinteger(L, p);
+        lua_newtable(L);  // beginning of table for page p
+
+        lua_pushliteral(L, "pageWidth");
+        lua_pushnumber(L, page->getWidth());
+        lua_settable(L, -3);
+
+        lua_pushliteral(L, "pageHeight");
+        lua_pushnumber(L, page->getHeight());
+        lua_settable(L, -3);
+
+        lua_pushliteral(L, "isAnnotated");
+        lua_pushboolean(L, page->isAnnotated());
+        lua_settable(L, -3);
+
+        lua_pushliteral(L, "pageTypeFormat");
+        PageType pt = page->getBackgroundType();
+        std::string pageTypeFormat = PageTypeHandler::getStringForPageTypeFormat(pt.format);
+        lua_pushstring(L, pageTypeFormat.c_str());
+        lua_settable(L, -3);
+
+        lua_pushliteral(L, "pdfBackgroundPageNo");
+        lua_pushinteger(L, page->getPdfPageNr() + 1);
+        lua_settable(L, -3);
+
+        lua_pushstring(L, "layers");
+        lua_newtable(L);  // beginning of layers table
+
+        // add background layer
+        lua_pushinteger(L, 0);
+        lua_newtable(L);  // beginning of table for background layer
+
+        lua_pushliteral(L, "isVisible");
+        lua_pushboolean(L, page->isLayerVisible(0));
+        lua_settable(L, -3);
+
+        lua_settable(L, -3);  // end of table for background layer
+
+        // add (non-background) layers
+        int currLayer = 0;
+
+        for (auto l: *page->getLayers()) {
+            lua_pushinteger(L, ++currLayer);
+            lua_newtable(L);  // beginning of table for layer l
+
+            // lua_pushliteral(L, "name");
+            // lua_pushstring(L, layer->getName());
+            // lua_settable(L,-3);
+
+            lua_pushliteral(L, "isVisible");
+            lua_pushboolean(L, l->isVisible());
+            lua_settable(L, -3);
+
+            lua_pushliteral(L, "isAnnotated");
+            lua_pushboolean(L, l->isAnnotated());
+            lua_settable(L, -3);
+
+            lua_settable(L, -3);  // end of table for layer l
+        }
+        lua_settable(L, -3);  // end of layers table
+
+        lua_pushliteral(L, "currentLayer");
+        lua_pushinteger(L, page->getSelectedLayerId());
+        lua_settable(L, -3);
+
+        lua_settable(L, -3);  // end of table for page p
+    }
+    lua_settable(L, -3);  // end of pages table
+
+    lua_pushliteral(L, "currentPage");
+    lua_pushinteger(L, lc->getCurrentPageId() + 1);
+    lua_settable(L, -3);
+
+    lua_pushliteral(L, "pdfBackgroundFilename");
+    lua_pushstring(L, doc->getPdfFilepath().string().c_str());
+    lua_settable(L, -3);
+
+    return 1;
+}
+
+/**
+ * Scrolls to the page specified relatively or absolutely (by default)
+ * The page number is clamped to the range between the first and last page
+ *
+ * Example 1: app.scrollToPage(1, true)
+ * scrolls to the next page (relative mode)
+ *
+ * Example 2: app.scrollToPage(10)
+ * scrolls to page 10 (absolute mode)
+ **/
+static int applib_scrollToPage(lua_State* L) {
+    Plugin* plugin = Plugin::getPluginFromLua(L);
+    Control* control = plugin->getControl();
+
+    int val = luaL_checkinteger(L, 1);
+    bool relative = false;
+    if (lua_isboolean(L, 2)) {
+        relative = lua_toboolean(L, 2);
+    }
+    int page = (relative) ? control->getCurrentPageNo() + val : val - 1;
+
+    const int first = 0;
+    const int last = static_cast<int>(control->getDocument()->getPageCount()) - 1;
+    control->getScrollHandler()->scrollToPage(std::clamp(page, first, last));
+
+    return 1;
+}
+
+/**
+ * Scrolls to the position on the selected page specified relatively (by default) or absolutely
+ *
+ * Example 1: app.scrollToPos(20,10)
+ * scrolls 20pt right and 10pt down (relative mode)
+ *
+ * Example 2: app.scrollToPage(200, 50, false)
+ * scrolls to page position 200pt right and 50pt down from the left page corner  (absolute mode)
+ **/
+static int applib_scrollToPos(lua_State* L) {
+    Plugin* plugin = Plugin::getPluginFromLua(L);
+    Control* control = plugin->getControl();
+    Layout* layout = control->getWindow()->getLayout();
+
+    double dx = luaL_checknumber(L, 1);
+    double dy = luaL_checknumber(L, 2);
+    bool relative = true;
+    if (lua_isboolean(L, 3)) {
+        relative = lua_toboolean(L, 3);
+    }
+
+    if (relative) {
+        layout->scrollRelative(dx, dy);
+    } else {
+        layout->scrollAbs(dx, dy);
+    }
+
+    return 1;
+}
+
+/**
+ * Sets the current page as indicated (without scrolling)
+ * The page number passed is clamped to the range between first page and last page
+ *
+ * Example: app.setCurrentPage(1)
+ * makes the first page the new current page
+ **/
+static int applib_setCurrentPage(lua_State* L) {
+    Plugin* plugin = Plugin::getPluginFromLua(L);
+    Control* control = plugin->getControl();
+    size_t pageId = luaL_checkinteger(L, 1);
+    const size_t first = 1;
+    const size_t last = control->getDocument()->getPageCount();
+    control->firePageSelected(std::clamp(pageId, first, last) - 1);
+
+    return 1;
+}
+
+/**
+ * Sets the width and height of the current page in pt = 1/72 inch either relatively or absolutely (by default)
+ *
+ * Example 1: app.setPageSize(595.275591, 841.889764)
+ * makes the current page have standard (A4 paper) width and height (absolute mode)
+ *
+ * Example 2: app.setPageSize(0, 14.17*6, true)
+ * adds 14.17*6 pt = 3cm to the height of the page (relative mode)
+ **/
+static int applib_setPageSize(lua_State* L) {
+    Plugin* plugin = Plugin::getPluginFromLua(L);
+    Control* control = plugin->getControl();
+    Document* doc = control->getDocument();
+    PageRef const& page = control->getCurrentPage();
+
+    if (!page) {
+        luaL_error(L, "No page!");
+    }
+
+    double width = luaL_checknumber(L, 1);
+    double height = luaL_checknumber(L, 2);
+
+    bool relative = false;
+    if (lua_isboolean(L, 3)) {
+        relative = lua_toboolean(L, 3);
+    }
+
+    if (relative) {
+        width += page->getWidth();
+        height += page->getHeight();
+    }
+
+    if (width > 0 && height > 0) {
+        doc->lock();
+        Document::setPageSize(page, width, height);
+        doc->unlock();
+    }
+
+    size_t pageNo = doc->indexOf(page);
+    if (pageNo != npos && pageNo < doc->getPageCount()) {
+        control->firePageSizeChanged(pageNo);
+    }
+
+    return 1;
+}
+
+/**
+ * Sets the current layer of the current page as indicated and updates visibility if specified (by default it does not)
+ * Displays an error message, if the selected layer does not exist
+ *
+ * Example 1: app.setCurrentLayer(2, true)
+ * makes the second (non-background) layer the current layer and makes layers 1, 2 and the background layer visible, the
+ *others hidden
+ *
+ * Example 2: app.setCurrentLayer(2, false)
+ * makes the second (non-background) layer the current layer and does not change visibility
+ **/
+static int applib_setCurrentLayer(lua_State* L) {
+    Plugin* plugin = Plugin::getPluginFromLua(L);
+    Control* control = plugin->getControl();
+    PageRef const& page = control->getCurrentPage();
+
+    if (!page) {
+        luaL_error(L, "No page!");
+    }
+
+    size_t layerCount = page->getLayerCount();
+    size_t layerId = luaL_checkinteger(L, 1);
+
+    if (layerId < 0 || layerId > layerCount) {
+        luaL_error(L, "No layer with layer ID %d", layerId);
+    }
+
+    bool update = false;
+    if (lua_isboolean(L, 2)) {
+        update = lua_toboolean(L, 2);
+    }
+
+    control->getLayerController()->switchToLay(layerId, update);
+
+    return 1;
+}
+
+/*
+ * Sets the visibility of the current layer
+ *
+ * Example: app.setLayerVisibility(true)
+ * makes the current layer visible
+ */
+static int applib_setLayerVisibility(lua_State* L) {
+    Plugin* plugin = Plugin::getPluginFromLua(L);
+    Control* control = plugin->getControl();
+
+    bool enabled = true;
+    if (lua_isboolean(L, 1)) {
+        enabled = lua_toboolean(L, 1);
+    }
+
+    int layerId = control->getCurrentPage()->getSelectedLayerId();
+    control->getLayerController()->setLayerVisible(layerId, enabled);
+    return 1;
+}
+
+
+/*
+ * The full Lua Plugin API.
+ * See above for example usage of each function.
+ */
 static const luaL_Reg applib[] = {{"msgbox", applib_msgbox},
+                                  {"saveAs", applib_saveAs},
                                   {"registerUi", applib_registerUi},
                                   {"uiAction", applib_uiAction},
                                   {"uiActionSelected", applib_uiActionSelected},
-                                  {"changeCurrentPageBackground", applib_changeCurrentPageBackground},
-                                  {"saveAs", applib_saveAs},
+                                  {"sidebarAction", applib_sidebarAction},
+                                  {"layerAction", applib_layerAction},
                                   {"changeToolColor", applib_changeToolColor},
+                                  {"changeCurrentPageBackground", applib_changeCurrentPageBackground},
+                                  {"changeBackgroundPdfPageNr", applib_changeBackgroundPdfPageNr},
+                                  {"getDocumentStructure", applib_getDocumentStructure},
+                                  {"scrollToPage", applib_scrollToPage},
+                                  {"scrollToPos", applib_scrollToPos},
+                                  {"setCurrentPage", applib_setCurrentPage},
+                                  {"setPageSize", applib_setPageSize},
+                                  {"setCurrentLayer", applib_setCurrentLayer},
+                                  {"setLayerVisibility", applib_setLayerVisibility},
 
                                   // Placeholder
                                   //	{"MSG_BT_OK", nullptr},


### PR DESCRIPTION
This PR adds various new functions to the Lua Plugin API. Moreover a plugin is added for cloning all handwritten layers to the next page. 

The **new Plugin API functions** are:
- `app.sidebarAction` for actions accessible in the sidebar
- `app.layerAction` for actions accessible in the layer controller
- `app.changePdfBackgroundPageNr` to change the pdf background page number
- `app.getDocumentStructure` to get lots of useful info on the document, also used for applying operations on all/selected pages
- `app.scrollToPage`scrolls relatively or absolutely to a page
- `app.scrollToPos` scrolls relatively or absolutely to a new position on the same page
- `app.setCurrentPage` sets the given page as new current page
- `app.setPageSize` to set the size of the current page
- `app.setCurrentLayer` sets the given layer as the new current layer, and updates visibility if specified
- `app.setLayerVisibility` sets the visibility of the current layer

In order for the plugin to work correctly, the `XournalView::pageDeleted` function had to be fixed, so that the page layout is updated immediately. This will not be necessary after merging PR #2425 

A test plugin is now available which tests out the functionality of various API functions, mostly combined with each other. I am not sure if the test plugin should be merged or whether it is just for the reviewer to have an easier job.

- [x] Still some more testing is required
- [x] Some error messages will have to be included as well, if the user wants to execute impossible actions.

**Edit 1**: added `app.setLayerVisibility`
**Edit 2**: added `app.setPageSize`

**Edit 3**: The PR is now ready for review.