### PR TITLE
Fix page layout update in a unified way

### DIFF
--- a/src/control/XournalMain.cpp
+++ b/src/control/XournalMain.cpp
@@ -404,9 +404,8 @@ auto XournalMain::run(int argc, char* argv[]) -> int {
     checkForErrorlog();
     checkForEmergencySave(control);
 
-    // There is a timing issue with the layout
-    // This fixes it, see #405
-    Util::execInUiThread([=]() { control->getWindow()->getXournal()->layoutPages(); });
+    // There was a timing issue with the layout, see #405
+    control->getWindow()->getXournal()->layoutPages();
 
     if (migrateResult.status != MigrateStatus::NotNeeded) {
         Util::execInUiThread([=]() { XojMsgBox::showErrorToUser(control->getGtkWindow(), migrateResult.message); });

--- a/src/gui/XournalView.cpp
+++ b/src/gui/XournalView.cpp
@@ -487,7 +487,7 @@ void XournalView::ensureRectIsVisible(int x, int y, int width, int height) {
 }
 
 void XournalView::zoomChanged() {
-    Layout* layout = gtk_xournal_get_layout(this->widget);
+
     size_t currentPage = this->getCurrentPage();
     XojPageView* view = getViewFor(currentPage);
     ZoomControl* zoom = control->getZoomControl();
@@ -496,6 +496,7 @@ void XournalView::zoomChanged() {
         return;
     }
 
+    layoutPages();
 
     if (zoom->isZoomPresentationMode() || zoom->isZoomFitMode()) {
         scrollTo(currentPage);
@@ -503,11 +504,10 @@ void XournalView::zoomChanged() {
         auto pos = zoom->getScrollPositionAfterZoom();
         if (pos.x != -1 && pos.y != -1) {
             // Todo: This could be one source of all evil:
+            Layout* layout = gtk_xournal_get_layout(this->widget);
             layout->scrollAbs(pos.x, pos.y);
         }
     }
-    // move this somewhere else maybe
-    layout->recalculate();
 
     Document* doc = control->getDocument();
     doc->lock();
@@ -566,13 +566,9 @@ void XournalView::pageInserted(size_t page) {
 
     viewPages.insert(begin(viewPages) + page, pageView);
 
-    Layout* layout = gtk_xournal_get_layout(this->widget);
-
-    // recalculate the layout width and height amd layout the pages with the updated layout size
-    layout->recalculate();
-    layout->layoutPages(layout->getMinimalWidth(), layout->getMinimalHeight());
-
+    layoutPages();
     // check which pages are visible and select the most visible page
+    Layout* layout = gtk_xournal_get_layout(this->widget);
     layout->updateVisibility();
 }
 
@@ -656,12 +652,10 @@ void XournalView::repaintSelection(bool evenWithoutSelection) {
     gtk_widget_queue_draw(this->widget);
 }
 
-/**
- * Recalculates the layout height and width for the XournalView widget
- */
 void XournalView::layoutPages() {
     Layout* layout = gtk_xournal_get_layout(this->widget);
     layout->recalculate();
+    layout->layoutPages(layout->getMinimalWidth(), layout->getMinimalHeight());
 }
 
 auto XournalView::getDisplayHeight() const -> int {

--- a/src/gui/XournalView.h
+++ b/src/gui/XournalView.h
@@ -44,6 +44,7 @@ public:
 
     void requestPage(XojPageView* page);
 
+    // Recalculate the layout width and height amd layout the pages with the updated layout size
     void layoutPages();
 
     void scrollTo(size_t pageNo, double y = 0);


### PR DESCRIPTION
Fixes #1777. 
Partially fixes #2411.

Also fixes page update after page deletion (which is relevant for navigating through pages in plugins) and after other changes of page layout than switching from paired view to non-paired view.

I also simplified the code in `XournalMain::run`, since the timing issue is solved with the new page layout method anyway.

Note that zooming in and out may still change the active page (although not drastically any more). This is due to the fact, that the `Layout::updateVisibility() method computes the most visible page and makes that page the active page and that `scrollToPage` makes the top of the page visible. 