### PR TITLE
Better Touchscreen Zooming

### DIFF
--- a/src/control/PdfCache.cpp
+++ b/src/control/PdfCache.cpp
@@ -1,13 +1,15 @@
 #include "PdfCache.h"
 
+#include <algorithm>
 #include <cstdio>
 #include <utility>
 
 class PdfCacheEntry {
 public:
-    PdfCacheEntry(XojPdfPageSPtr popplerPage, cairo_surface_t* img) {
+    PdfCacheEntry(XojPdfPageSPtr popplerPage, cairo_surface_t* img, double zoom) {
         this->popplerPage = std::move(popplerPage);
         this->rendered = img;
+        this->zoom = zoom;
     }
 
     ~PdfCacheEntry() {
@@ -15,6 +17,8 @@ public:
         cairo_surface_destroy(this->rendered);
         this->rendered = nullptr;
     }
+
+    double zoom;
     XojPdfPageSPtr popplerPage;
     cairo_surface_t* rendered;
 };
@@ -30,14 +34,9 @@ PdfCache::~PdfCache() {
     this->size = 0;
 }
 
-void PdfCache::setZoom(double zoom) {
-    if (this->zoom == zoom) {
-        return;
-    }
-    this->zoom = zoom;
+void PdfCache::setZoom(double zoom) { this->zoom = zoom; }
 
-    clearCache();
-}
+void PdfCache::setZoomingClearsCache(bool clears) { this->zoomClearsCache = clears; }
 
 void PdfCache::clearCache() {
     for (PdfCacheEntry* e: this->data) {
@@ -46,24 +45,26 @@ void PdfCache::clearCache() {
     this->data.clear();
 }
 
-auto PdfCache::lookup(const XojPdfPageSPtr& popplerPage) -> cairo_surface_t* {
+auto PdfCache::lookup(const XojPdfPageSPtr& popplerPage) -> PdfCacheEntry* {
     for (PdfCacheEntry* e: this->data) {
         if (e->popplerPage->getPageId() == popplerPage->getPageId()) {
-            return e->rendered;
+            return e;
         }
     }
 
     return nullptr;
 }
 
-void PdfCache::cache(XojPdfPageSPtr popplerPage, cairo_surface_t* img) {
-    auto* ne = new PdfCacheEntry(std::move(popplerPage), img);
-    this->data.push_front(ne);
-
-    while (this->data.size() > this->size) {
+PdfCacheEntry* PdfCache::cache(XojPdfPageSPtr popplerPage, cairo_surface_t* img, double zoom) {
+    while (this->data.size() >= this->size) {
         delete this->data.back();
         this->data.pop_back();
     }
+
+    auto* ne = new PdfCacheEntry(std::move(popplerPage), img, zoom);
+    this->data.push_front(ne);
+
+    return ne;
 }
 
 void PdfCache::render(cairo_t* cr, const XojPdfPageSPtr& popplerPage, double zoom) {
@@ -71,28 +72,36 @@ void PdfCache::render(cairo_t* cr, const XojPdfPageSPtr& popplerPage, double zoo
 
     this->setZoom(zoom);
 
-    cairo_surface_t* img = lookup(popplerPage);
-    if (img == nullptr) {
-        img = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, popplerPage->getWidth() * this->zoom,
-                                         popplerPage->getHeight() * this->zoom);
+    PdfCacheEntry* cacheResult = lookup(popplerPage);
+
+    if (cacheResult == nullptr || this->zoom < cacheResult->zoom / 2.0 && this->zoom > 1.0 ||
+        this->zoom > cacheResult->zoom * 2.0
+
+        || this->zoomClearsCache && this->zoom != cacheResult->zoom) {
+
+        double renderZoom = std::max(zoom, 1.0);
+
+        auto* img = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, popplerPage->getWidth() * renderZoom,
+                                               popplerPage->getHeight() * renderZoom);
         cairo_t* cr2 = cairo_create(img);
 
-        cairo_scale(cr2, this->zoom, this->zoom);
+        cairo_scale(cr2, renderZoom, renderZoom);
         popplerPage->render(cr2, false);
         cairo_destroy(cr2);
-        cache(popplerPage, img);
+
+        cacheResult = cache(popplerPage, img, renderZoom);
     }
 
     cairo_matrix_t mOriginal;
     cairo_matrix_t mScaled;
     cairo_get_matrix(cr, &mOriginal);
     cairo_get_matrix(cr, &mScaled);
-    mScaled.xx = 1;
-    mScaled.yy = 1;
+    mScaled.xx = this->zoom / cacheResult->zoom;
+    mScaled.yy = this->zoom / cacheResult->zoom;
     mScaled.xy = 0;
     mScaled.yx = 0;
     cairo_set_matrix(cr, &mScaled);
-    cairo_set_source_surface(cr, img, 0, 0);
+    cairo_set_source_surface(cr, cacheResult->rendered, 0, 0);
     cairo_paint(cr);
     cairo_set_matrix(cr, &mOriginal);
 

--- a/src/control/PdfCache.h
+++ b/src/control/PdfCache.h
@@ -38,7 +38,20 @@ public:
     void clearCache();
 
 public:
-    void setZoomingClearsCache(bool b);
+    /**
+     * @param b true iff any change in the view's zoom as compared to when a page
+     *  was cached forces a re-render.
+     */
+    void setAnyZoomChangeCausesRecache(bool b);
+
+    /**
+     * @brief Set the maximum tolerable zoom difference, as a percentage.
+     *
+     * @param threshold is the minimum percent-difference between the zoom value at
+     *  which the cached version of the page was rendered and the current zoom,
+     *  for which the page will be re-cached while zooming.
+     */
+    void setRefreshThreshold(double percentDifference);
 
 private:
     void setZoom(double zoom);
@@ -52,5 +65,6 @@ private:
     list<PdfCacheEntry*>::size_type size = 0;
 
     double zoom = -1;
+    double zoomRefreshThreshold;
     bool zoomClearsCache = true;
 };

--- a/src/control/PdfCache.h
+++ b/src/control/PdfCache.h
@@ -37,10 +37,13 @@ public:
     void render(cairo_t* cr, const XojPdfPageSPtr& popplerPage, double zoom);
     void clearCache();
 
+public:
+    void setZoomingClearsCache(bool b);
+
 private:
     void setZoom(double zoom);
-    cairo_surface_t* lookup(const XojPdfPageSPtr& popplerPage);
-    void cache(XojPdfPageSPtr popplerPage, cairo_surface_t* img);
+    PdfCacheEntry* lookup(const XojPdfPageSPtr& popplerPage);
+    PdfCacheEntry* cache(XojPdfPageSPtr popplerPage, cairo_surface_t* img, double zoom);
 
 private:
     GMutex renderMutex{};
@@ -49,4 +52,5 @@ private:
     list<PdfCacheEntry*>::size_type size = 0;
 
     double zoom = -1;
+    bool zoomClearsCache = true;
 };

--- a/src/control/ToolHandler.cpp
+++ b/src/control/ToolHandler.cpp
@@ -17,7 +17,6 @@ ToolListener::~ToolListener() = default;
 ToolHandler::ToolHandler(ToolListener* stateChangeListener, ActionHandler* actionHandler, Settings* settings) {
     this->settings = settings;
     initTools();
-    this->toolChangeListeners = std::vector<std::function<void(ToolType)> >();
     this->actionHandler = actionHandler;
 
     this->stateChangeListener = stateChangeListener;
@@ -169,15 +168,15 @@ void ToolHandler::selectTool(ToolType type) {
 }
 
 void ToolHandler::fireToolChanged() {
-    for (auto listener: this->toolChangeListeners) {
+    for (auto&& listener: this->toolChangeListeners) {
         listener(this->activeTool->type);
     }
 
     stateChangeListener->toolChanged();
 }
 
-void ToolHandler::addToolChangedListener(std::function<void(ToolType)> listener) {
-    toolChangeListeners.push_back(listener);
+void ToolHandler::addToolChangedListener(ToolChangedCallback listener) {
+    toolChangeListeners.emplace_back(std::move(listener));
 }
 
 auto ToolHandler::getTool(ToolType type) -> Tool& { return *(this->tools[type - TOOL_PEN]); }

--- a/src/control/ToolHandler.h
+++ b/src/control/ToolHandler.h
@@ -62,6 +62,7 @@ class ActionHandler;
 
 class ToolHandler {
 public:
+    using ToolChangedCallback = std::function<void(ToolType)>;
     ToolHandler(ToolListener* stateChangedListener, ActionHandler* actionHandler, Settings* settings);
     virtual ~ToolHandler();
 
@@ -226,7 +227,7 @@ public:
      * @param listener A callback, called when the user/client 
      *  changes tools.
      */
-    void addToolChangedListener(std::function<void(ToolType)> listener);
+    void addToolChangedListener(ToolChangedCallback listener);
 
     /**
      * @brief Get the Tool of a certain type
@@ -364,8 +365,7 @@ private:
     std::unique_ptr<Tool> mouseRightButtonTool;
     std::unique_ptr<Tool> touchDrawingButtonTool;
 
-    std::vector< std::function<void(ToolType)> > toolChangeListeners;
-
+    std::vector<ToolChangedCallback> toolChangeListeners;
 
     ToolListener* stateChangeListener = nullptr;
     ActionHandler* actionHandler = nullptr;

--- a/src/control/ToolHandler.h
+++ b/src/control/ToolHandler.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <array>
+#include <functional>
 #include <memory>
 #include <string>
 #include <vector>
@@ -61,7 +62,7 @@ class ActionHandler;
 
 class ToolHandler {
 public:
-    ToolHandler(ToolListener* listener, ActionHandler* actionHandler, Settings* settings);
+    ToolHandler(ToolListener* stateChangedListener, ActionHandler* actionHandler, Settings* settings);
     virtual ~ToolHandler();
 
     /**
@@ -216,8 +217,19 @@ public:
      */
     void fireToolChanged();
 
+    /** 
+     * @brief Listen for tool changes.
+     * 
+     * Different from the listener given to the constructor -- [listener]
+     * here only listens for when the current tool is changed to another.
+     * 
+     * @param listener A callback, called when the user/client 
+     *  changes tools.
+     */
+    void addToolChangedListener(std::function<void(ToolType)> listener);
+
     /**
-     * @brief Get the Tool of a certain typ
+     * @brief Get the Tool of a certain type
      *
      * @param type
      * @return Tool&
@@ -352,7 +364,10 @@ private:
     std::unique_ptr<Tool> mouseRightButtonTool;
     std::unique_ptr<Tool> touchDrawingButtonTool;
 
-    ToolListener* listener = nullptr;
+    std::vector< std::function<void(ToolType)> > toolChangeListeners;
+
+
+    ToolListener* stateChangeListener = nullptr;
     ActionHandler* actionHandler = nullptr;
     Settings* settings = nullptr;
 };

--- a/src/control/ToolHandler.h
+++ b/src/control/ToolHandler.h
@@ -218,13 +218,13 @@ public:
      */
     void fireToolChanged();
 
-    /** 
+    /**
      * @brief Listen for tool changes.
-     * 
+     *
      * Different from the listener given to the constructor -- [listener]
      * here only listens for when the current tool is changed to another.
-     * 
-     * @param listener A callback, called when the user/client 
+     *
+     * @param listener A callback, called when the user/client
      *  changes tools.
      */
     void addToolChangedListener(ToolChangedCallback listener);

--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -33,7 +33,9 @@ Settings::~Settings() {
 
 void Settings::loadDefault() {
     this->pressureSensitivity = true;
+    this->pressureGuessing = false;
     this->zoomGesturesEnabled = true;
+
     this->maximized = false;
     this->showPairedPages = false;
     this->presentationMode = false;
@@ -102,6 +104,7 @@ void Settings::loadDefault() {
     this->snapGridSize = DEFAULT_GRID_SIZE;
 
     this->touchWorkaround = false;
+    this->touchDrawing = false;
 
     this->defaultSaveName = _("%F-Note-%H-%M");
 
@@ -130,6 +133,7 @@ void Settings::loadDefault() {
     this->fullscreenHideElements = "mainMenubar";
     this->presentationHideElements = "mainMenubar,sidebarContents";
 
+    this->enableCacheClearOnZoom = true;
     this->pdfPageCacheSize = 10;
 
     this->selectionBorderColor = 0xff0000U;  // red
@@ -380,6 +384,8 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur) {
         this->fullscreenHideElements = reinterpret_cast<const char*>(value);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("presentationHideElements")) == 0) {
         this->presentationHideElements = reinterpret_cast<const char*>(value);
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("enableCacheClearOnZoom")) == 0) {
+        this->enableCacheClearOnZoom = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("pdfPageCacheSize")) == 0) {
         this->pdfPageCacheSize = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("selectionBorderColor")) == 0) {
@@ -412,6 +418,10 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur) {
         this->snapGridTolerance = tempg_ascii_strtod(reinterpret_cast<const char*>(value), nullptr);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("touchWorkaround")) == 0) {
         this->touchWorkaround = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("touchDrawing")) == 0) {
+        this->touchDrawing = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("pressureGuessing")) == 0) {
+        this->pressureGuessing = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("scrollbarHideType")) == 0) {
         if (xmlStrcmp(value, reinterpret_cast<const xmlChar*>("both")) == 0) {
             this->scrollbarHideType = SCROLLBAR_HIDE_BOTH;
@@ -808,10 +818,14 @@ void Settings::save() {
     WRITE_DOUBLE_PROP(snapGridSize);
 
     WRITE_BOOL_PROP(touchWorkaround);
+    WRITE_BOOL_PROP(touchDrawing);
+    WRITE_BOOL_PROP(pressureGuessing);
 
     WRITE_UINT_PROP(selectionBorderColor);
     WRITE_UINT_PROP(backgroundColor);
     WRITE_UINT_PROP(selectionMarkerColor);
+
+    WRITE_BOOL_PROP(enableCacheClearOnZoom);
 
     WRITE_INT_PROP(pdfPageCacheSize);
     WRITE_COMMENT("The count of rendered PDF pages which will be cached.");
@@ -1157,6 +1171,17 @@ void Settings::setSnapGridSize(double gridSize) {
     save();
 }
 
+auto Settings::getTouchDrawingEnabled() const -> bool { return this->touchDrawing; }
+
+void Settings::setTouchDrawingEnabled(bool b) {
+    if (this->touchDrawing == b) {
+        return;
+    }
+
+    this->touchDrawing = b;
+    save();
+}
+
 auto Settings::isTouchWorkaround() const -> bool { return this->touchWorkaround; }
 
 void Settings::setTouchWorkaround(bool b) {
@@ -1165,6 +1190,16 @@ void Settings::setTouchWorkaround(bool b) {
     }
 
     this->touchWorkaround = b;
+    save();
+}
+
+auto Settings::isPressureGuessingEnabled() const -> bool { return this->pressureGuessing; }
+void Settings::setPressureGuessingEnabled(bool b) {
+    if (this->pressureGuessing == b) {
+        return;
+    }
+
+    this->pressureGuessing = b;
     save();
 }
 
@@ -1517,6 +1552,16 @@ auto Settings::getPresentationHideElements() const -> string const& { return thi
 
 void Settings::setPresentationHideElements(string elements) {
     this->presentationHideElements = std::move(elements);
+    save();
+}
+
+auto Settings::getClearPDFCacheOnZoom() const -> bool { return this->enableCacheClearOnZoom; }
+void Settings::setClearPDFCacheOnZoom(bool b) {
+    if (this->enableCacheClearOnZoom == b) {
+        return;
+    }
+
+    this->enableCacheClearOnZoom = b;
     save();
 }
 

--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -133,7 +133,9 @@ void Settings::loadDefault() {
     this->fullscreenHideElements = "mainMenubar";
     this->presentationHideElements = "mainMenubar,sidebarContents";
 
-    this->enableCacheClearOnZoom = true;
+    this->touchZoomStartThreshold = 0.0;
+
+    this->pageRerenderThreshold = 5.0;
     this->pdfPageCacheSize = 10;
 
     this->selectionBorderColor = 0xff0000U;  // red
@@ -384,8 +386,10 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur) {
         this->fullscreenHideElements = reinterpret_cast<const char*>(value);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("presentationHideElements")) == 0) {
         this->presentationHideElements = reinterpret_cast<const char*>(value);
-    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("enableCacheClearOnZoom")) == 0) {
-        this->enableCacheClearOnZoom = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("touchZoomStartThreshold")) == 0) {
+        this->touchZoomStartThreshold = g_ascii_strtod(reinterpret_cast<const char*>(value), nullptr);
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("pageRerenderThreshold")) == 0) {
+        this->pageRerenderThreshold = g_ascii_strtod(reinterpret_cast<const char*>(value), nullptr);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("pdfPageCacheSize")) == 0) {
         this->pdfPageCacheSize = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("selectionBorderColor")) == 0) {
@@ -825,7 +829,8 @@ void Settings::save() {
     WRITE_UINT_PROP(backgroundColor);
     WRITE_UINT_PROP(selectionMarkerColor);
 
-    WRITE_BOOL_PROP(enableCacheClearOnZoom);
+    WRITE_DOUBLE_PROP(touchZoomStartThreshold);
+    WRITE_DOUBLE_PROP(pageRerenderThreshold);
 
     WRITE_INT_PROP(pdfPageCacheSize);
     WRITE_COMMENT("The count of rendered PDF pages which will be cached.");
@@ -1555,13 +1560,24 @@ void Settings::setPresentationHideElements(string elements) {
     save();
 }
 
-auto Settings::getClearPDFCacheOnZoom() const -> bool { return this->enableCacheClearOnZoom; }
-void Settings::setClearPDFCacheOnZoom(bool b) {
-    if (this->enableCacheClearOnZoom == b) {
+auto Settings::getTouchZoomStartThreshold() const -> double { return this->touchZoomStartThreshold; }
+void Settings::setTouchZoomStartThreshold(double threshold) {
+    if (this->touchZoomStartThreshold == threshold) {
         return;
     }
 
-    this->enableCacheClearOnZoom = b;
+    this->touchZoomStartThreshold = threshold;
+    save();
+}
+
+
+auto Settings::getPDFPageRerenderThreshold() const -> double { return this->pageRerenderThreshold; }
+void Settings::setPDFPageRerenderThreshold(double threshold) {
+    if (this->pageRerenderThreshold == threshold) {
+        return;
+    }
+
+    this->pageRerenderThreshold = threshold;
     save();
 }
 

--- a/src/control/settings/Settings.h
+++ b/src/control/settings/Settings.h
@@ -311,8 +311,12 @@ public:
     Color getBackgroundColor() const;
     void setBackgroundColor(Color color);
 
-    bool getClearPDFCacheOnZoom() const;
-    void setClearPDFCacheOnZoom(bool b);
+    // Re-render pages if document zoom differs from the last render zoom by the given threshold.
+    double getPDFPageRerenderThreshold() const;
+    void setPDFPageRerenderThreshold(double threshold);
+
+    double getTouchZoomStartThreshold() const;
+    void setTouchZoomStartThreshold(double threshold);
 
     int getPdfPageCacheSize() const;
     [[maybe_unused]] void setPdfPageCacheSize(int size);
@@ -760,11 +764,17 @@ private:
     int pdfPageCacheSize{};
 
     /**
-     *  Whether to clear the PDF cache on page zoom,
-     * or to use a previous rendering
-     * with nearly the current zoom, if available.
+     *  Percentage by which the page's zoom must change
+     * for PDF pages to re-render while zooming.
      */
-    bool enableCacheClearOnZoom{};
+    double pageRerenderThreshold{};
+
+    /**
+     * Don't start zooming with touch until the difference in distances between the
+     * current touch points and the original is greater than this percentage of the
+     * original distance.
+     */
+    double touchZoomStartThreshold{};
 
     /**
      * The color to draw borders on selected elements

--- a/src/control/settings/Settings.h
+++ b/src/control/settings/Settings.h
@@ -246,8 +246,14 @@ public:
     int getDrawDirModsRadius() const;
     void setDrawDirModsRadius(int pixels);
 
+    bool getTouchDrawingEnabled() const;
+    void setTouchDrawingEnabled(bool b);
+
     bool isTouchWorkaround() const;
     void setTouchWorkaround(bool b);
+
+    bool isPressureGuessingEnabled() const;
+    void setPressureGuessingEnabled(bool b);
 
     bool isSnapRotation() const;
     void setSnapRotation(bool b);
@@ -304,6 +310,9 @@ public:
 
     Color getBackgroundColor() const;
     void setBackgroundColor(Color color);
+
+    bool getClearPDFCacheOnZoom() const;
+    void setClearPDFCacheOnZoom(bool b);
 
     int getPdfPageCacheSize() const;
     [[maybe_unused]] void setPdfPageCacheSize(int size);
@@ -751,6 +760,13 @@ private:
     int pdfPageCacheSize{};
 
     /**
+     *  Whether to clear the PDF cache on page zoom,
+     * or to use a previous rendering
+     * with nearly the current zoom, if available.
+     */
+    bool enableCacheClearOnZoom{};
+
+    /**
      * The color to draw borders on selected elements
      * (Page, insert image selection etc.)
      */
@@ -799,6 +815,15 @@ private:
      * Do not use GTK Scrolling / Touch handling
      */
     bool touchWorkaround{};
+
+    // Touchscreens act like multi-touch-aware pens.
+    bool touchDrawing{};
+
+    /**
+     * Infer pressure from speed when device pressure
+     * is unavailable (e.g. drawing with a mouse).
+     */
+    bool pressureGuessing{};
 
     /**
      * The index of the audio device used for recording

--- a/src/control/tools/BaseStrokeHandler.cpp
+++ b/src/control/tools/BaseStrokeHandler.cpp
@@ -102,7 +102,13 @@ auto BaseStrokeHandler::onMotionNotifyEvent(const PositionInputData& pos) -> boo
     return true;
 }
 
-void BaseStrokeHandler::onMotionCancelEvent() { stroke = nullptr; }
+void BaseStrokeHandler::onMotionCancelEvent() {
+    if (stroke) {
+        delete stroke;
+
+        stroke = nullptr;
+    }
+}
 
 void BaseStrokeHandler::onButtonReleaseEvent(const PositionInputData& pos) {
     xournal->getCursor()->activateDrawDirCursor(false);  // in case released within  fixate_Dir_Mods_Dist

--- a/src/control/tools/BaseStrokeHandler.cpp
+++ b/src/control/tools/BaseStrokeHandler.cpp
@@ -103,11 +103,8 @@ auto BaseStrokeHandler::onMotionNotifyEvent(const PositionInputData& pos) -> boo
 }
 
 void BaseStrokeHandler::onMotionCancelEvent() {
-    if (stroke) {
-        delete stroke;
-
-        stroke = nullptr;
-    }
+    delete stroke;
+    stroke = nullptr;
 }
 
 void BaseStrokeHandler::onButtonReleaseEvent(const PositionInputData& pos) {

--- a/src/control/tools/BaseStrokeHandler.cpp
+++ b/src/control/tools/BaseStrokeHandler.cpp
@@ -23,6 +23,10 @@ BaseStrokeHandler::BaseStrokeHandler(XournalView* xournal, XojPageView* redrawab
 BaseStrokeHandler::~BaseStrokeHandler() = default;
 
 void BaseStrokeHandler::draw(cairo_t* cr) {
+    if (!stroke) {
+        return;
+    }
+
     double zoom = xournal->getZoom();
     int dpiScaleFactor = xournal->getDpiScaleFactor();
 
@@ -97,6 +101,8 @@ auto BaseStrokeHandler::onMotionNotifyEvent(const PositionInputData& pos) -> boo
 
     return true;
 }
+
+void BaseStrokeHandler::onMotionCancelEvent() { stroke = nullptr; }
 
 void BaseStrokeHandler::onButtonReleaseEvent(const PositionInputData& pos) {
     xournal->getCursor()->activateDrawDirCursor(false);  // in case released within  fixate_Dir_Mods_Dist

--- a/src/control/tools/BaseStrokeHandler.h
+++ b/src/control/tools/BaseStrokeHandler.h
@@ -30,6 +30,7 @@ public:
 
     void draw(cairo_t* cr);
 
+    void onMotionCancelEvent();
     bool onMotionNotifyEvent(const PositionInputData& pos);
     void onButtonReleaseEvent(const PositionInputData& pos);
     void onButtonPressEvent(const PositionInputData& pos);

--- a/src/control/tools/InputHandler.h
+++ b/src/control/tools/InputHandler.h
@@ -86,6 +86,13 @@ public:
     virtual void onButtonDoublePressEvent(const PositionInputData& pos) = 0;
 
     /**
+     * This method is called when an action taken by the pointer is canceled.
+     * It is used, for instance, to cancel a stroke drawn when a user starts
+     * to zoom on a touchscreen device.
+     */
+    virtual void onMotionCancelEvent() = 0;
+
+    /**
      * @return Current editing stroke
      */
     Stroke* getStroke();

--- a/src/control/tools/SplineHandler.cpp
+++ b/src/control/tools/SplineHandler.cpp
@@ -199,11 +199,8 @@ auto SplineHandler::onMotionNotifyEvent(const PositionInputData& pos) -> bool {
 }
 
 void SplineHandler::onMotionCancelEvent() {
-    if (stroke) {
-        delete stroke;
-
-        stroke = nullptr;
-    }
+    delete stroke;
+    stroke = nullptr;
 }
 
 void SplineHandler::onButtonReleaseEvent(const PositionInputData& pos) {

--- a/src/control/tools/SplineHandler.cpp
+++ b/src/control/tools/SplineHandler.cpp
@@ -198,6 +198,14 @@ auto SplineHandler::onMotionNotifyEvent(const PositionInputData& pos) -> bool {
     return true;
 }
 
+void SplineHandler::onMotionCancelEvent() {
+    if (stroke) {
+        delete stroke;
+
+        stroke = nullptr;
+    }
+}
+
 void SplineHandler::onButtonReleaseEvent(const PositionInputData& pos) {
     isButtonPressed = false;
 

--- a/src/control/tools/SplineHandler.h
+++ b/src/control/tools/SplineHandler.h
@@ -40,6 +40,7 @@ public:
 
     void draw(cairo_t* cr);
 
+    void onMotionCancelEvent();
     bool onMotionNotifyEvent(const PositionInputData& pos);
     void onButtonReleaseEvent(const PositionInputData& pos);
     void onButtonPressEvent(const PositionInputData& pos);

--- a/src/control/tools/StrokeHandler.cpp
+++ b/src/control/tools/StrokeHandler.cpp
@@ -115,11 +115,8 @@ auto StrokeHandler::onMotionNotifyEvent(const PositionInputData& pos) -> bool {
 }
 
 void StrokeHandler::onMotionCancelEvent() {
-    if (stroke) {
-        delete stroke;
-
-        stroke = nullptr;
-    }
+    delete stroke;
+    stroke = nullptr;
 }
 
 void StrokeHandler::onButtonReleaseEvent(const PositionInputData& pos) {

--- a/src/control/tools/StrokeHandler.cpp
+++ b/src/control/tools/StrokeHandler.cpp
@@ -114,6 +114,14 @@ auto StrokeHandler::onMotionNotifyEvent(const PositionInputData& pos) -> bool {
     return true;
 }
 
+void StrokeHandler::onMotionCancelEvent() {
+    if (stroke) {
+        delete stroke;
+
+        stroke = nullptr;
+    }
+}
+
 void StrokeHandler::onButtonReleaseEvent(const PositionInputData& pos) {
     if (!stroke) {
         return;

--- a/src/control/tools/StrokeHandler.h
+++ b/src/control/tools/StrokeHandler.h
@@ -34,6 +34,7 @@ public:
 
     void draw(cairo_t* cr);
 
+    void onMotionCancelEvent();
     bool onMotionNotifyEvent(const PositionInputData& pos);
     void onButtonReleaseEvent(const PositionInputData& pos);
     void onButtonPressEvent(const PositionInputData& pos);

--- a/src/control/zoom/ZoomControl.h
+++ b/src/control/zoom/ZoomControl.h
@@ -205,6 +205,10 @@ private:
     /// Cursorposition x for Ctrl + Scroll
     utl::Point<double> scrollCursorPosition;
 
+    /// Size {x, y} of the pixels before the current page that
+    /// do not scale.
+    utl::Point<double> unscaledPixels;
+
     /**
      * Zoomstep value for Ctrl - and Zoom In and Out Button
      * depends on dpi (REAL_PERCENTAGE_VALUE * zoom100Value)

--- a/src/gui/Layout.h
+++ b/src/gui/Layout.h
@@ -119,6 +119,29 @@ public:
      */
     std::optional<size_t> getPageIndexAtGridMap(size_t row, size_t col);
 
+    /**
+     * @brief Get the total padding above the page at the given index.
+     *
+     *  The size of this padding does not scale with pages as the user zooms in and out.
+     * As such, it is often necessary to get _just_ this padding.
+     *
+     * @param pageIndex is the index of the XojPageView as returned by [getIndexAtGridMap]
+     * @return the sum of the padding between pages above the page with the given index
+     *         and any padding the user added vertically above all pages (i.e. in settings).
+     */
+    int getPaddingAbovePage(size_t pageIndex) const;
+
+    /**
+     * @brief Get the static padding added to the left of the current page.
+     *
+     *  This does not include padding added to center the page on the screen.
+     *
+     * @param pageIndex is the index of the XojPageView, as given by [getIndexAtGridMap]
+     * @return the sum of the padding between pages left of the page at [pageIndex] and
+     *         any horizontal padding the user decided to add (from settings)
+     */
+    int getPaddingLeftOfPage(size_t pageIndex) const;
+
 protected:
     // Todo(Fabian): move to ScrollHandling also it must not depend on Layout
     static void horizontalScrollChanged(GtkAdjustment* adjustment, Layout* layout);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -298,19 +298,12 @@ void MainWindow::setGtkTouchscreenScrollingEnabled(bool enabled) {
 
     gtkTouchscreenScrollingEnabled.store(enabled);
 
-    // Run on the main thread:
-    // 0 = timeout (run as soon as possible)
-    gdk_threads_add_timeout(
-            0,
-            [](gpointer data) -> gboolean {
-                MainWindow* self = static_cast<MainWindow*>(data);
-
-                gtk_scrolled_window_set_kinetic_scrolling(GTK_SCROLLED_WINDOW(self->winXournal),
-                                                          self->gtkTouchscreenScrollingEnabled.load());
-
-                return FALSE;
+    Util::execInUiThread(
+            [=]() {
+                gtk_scrolled_window_set_kinetic_scrolling(GTK_SCROLLED_WINDOW(winXournal),
+                                                          gtkTouchscreenScrollingEnabled.load());
             },
-            this);
+            G_PRIORITY_HIGH);
 }
 
 bool MainWindow::getGtkTouchscreenScrollingEnabled() const {

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -288,7 +288,7 @@ void MainWindow::setGtkTouchscreenScrollingForDeviceMapping() {
             DeviceListHelper::getSourceMapping(GDK_SOURCE_TOUCHSCREEN, this->getControl()->getSettings());
 
     setGtkTouchscreenScrollingEnabled(touchscreenClass == INPUT_DEVICE_TOUCHSCREEN &&
-                                      control->getSettings()->getTouchDrawingEnabled());
+                                      !control->getSettings()->getTouchDrawingEnabled());
 }
 
 void MainWindow::setGtkTouchscreenScrollingEnabled(bool enabled) {
@@ -307,7 +307,7 @@ void MainWindow::setGtkTouchscreenScrollingEnabled(bool enabled) {
 }
 
 bool MainWindow::getGtkTouchscreenScrollingEnabled() const {
-    return gtkTouchscreenScrollingEnabled && !usingTouchWorkaround;
+    return gtkTouchscreenScrollingEnabled.load() && !usingTouchWorkaround;
 }
 
 /**

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -284,17 +284,11 @@ void MainWindow::initXournalWidget() {
 }
 
 void MainWindow::setGtkTouchscreenScrollingForDeviceMapping() {
-    for (InputDevice const& inputDevice: DeviceListHelper::getDeviceList(this->getControl()->getSettings())) {
-        InputDeviceClass deviceClass = InputEvents::translateDeviceType(inputDevice.getName(), inputDevice.getSource(),
-                                                                        this->getControl()->getSettings());
-        if (inputDevice.getSource() == GDK_SOURCE_TOUCHSCREEN && deviceClass != INPUT_DEVICE_TOUCHSCREEN) {
-            setGtkTouchscreenScrollingEnabled(false);
+    InputDeviceClass touchscreenClass =
+            DeviceListHelper::getSourceMapping(GDK_SOURCE_TOUCHSCREEN, this->getControl()->getSettings());
 
-            return;
-        }
-    }
-
-    setGtkTouchscreenScrollingEnabled(true);
+    setGtkTouchscreenScrollingEnabled(touchscreenClass == INPUT_DEVICE_TOUCHSCREEN &&
+                                      control->getSettings()->getTouchDrawingEnabled());
 }
 
 void MainWindow::setGtkTouchscreenScrollingEnabled(bool enabled) {

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -11,6 +11,8 @@
 
 #pragma once
 
+#include <atomic>
+
 #include "control/layer/LayerCtrlListener.h"
 #include "gui/FloatingToolbox.h"
 #include "model/Font.h"
@@ -27,6 +29,7 @@ class ToolbarData;
 class ToolbarModel;
 class XournalView;
 class MainWindowToolbarMenu;
+class atomic_bool;
 
 class MainWindow: public GladeGui, public LayerCtrlListener {
 public:
@@ -49,7 +52,7 @@ public:
     [[maybe_unused]] void reloadToolbars();
 
     /**
-     * This methods are only used internally and for toolbar configuration
+     * These methods are only used internally and for toolbar configuration
      */
     ToolbarData* clearToolbar();
     void loadToolbar(ToolbarData* d);
@@ -101,7 +104,9 @@ public:
      * Disable kinetic scrolling if there is a touchscreen device that was manually mapped to another enabled input
      * device class. This is required so the GtkScrolledWindow does not swallow all the events.
      */
-    void setTouchscreenScrollingForDeviceMapping();
+    void setGtkTouchscreenScrollingForDeviceMapping();
+    void setGtkTouchscreenScrollingEnabled(bool enabled);
+    bool getGtkTouchscreenScrollingEnabled() const;
 
     void rebindMenubarAccelerators();
 
@@ -164,6 +169,9 @@ private:
     XournalView* xournal = nullptr;
     GtkWidget* winXournal = nullptr;
     ScrollHandling* scrollHandling = nullptr;
+
+    bool usingTouchWorkaround;
+    std::atomic_bool gtkTouchscreenScrollingEnabled;
 
     // Toolbars
     ToolMenuHandler* toolbar;

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -29,7 +29,6 @@ class ToolbarData;
 class ToolbarModel;
 class XournalView;
 class MainWindowToolbarMenu;
-class atomic_bool;
 
 class MainWindow: public GladeGui, public LayerCtrlListener {
 public:

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -169,6 +169,10 @@ private:
     GtkWidget* winXournal = nullptr;
     ScrollHandling* scrollHandling = nullptr;
 
+    // Note: `usingTouchWorkaround` is cached here because
+    // Settings::isTouchWorkorkaround reflects the current state
+    // of the setting -- usingTouchWorkaround should only change
+    // on application restart!
     bool usingTouchWorkaround;
     std::atomic_bool gtkTouchscreenScrollingEnabled;
 

--- a/src/gui/PageView.cpp
+++ b/src/gui/PageView.cpp
@@ -480,6 +480,12 @@ auto XojPageView::onMotionNotifyEvent(const PositionInputData& pos) -> bool {
     return false;
 }
 
+void XojPageView::onMotionCancelEvent() {
+    if (this->inputHandler) {
+        this->inputHandler->onMotionCancelEvent();
+    }
+}
+
 auto XojPageView::onButtonReleaseEvent(const PositionInputData& pos) -> bool {
     Control* control = xournal->getControl();
 

--- a/src/gui/PageView.h
+++ b/src/gui/PageView.h
@@ -14,6 +14,7 @@
 #include "gui/inputdevices/PositionInputData.h"
 #include "model/PageListener.h"
 #include "model/PageRef.h"
+#include "model/Stroke.h"
 #include "model/TexImage.h"
 
 #include "Layout.h"
@@ -147,6 +148,7 @@ public:  // event handler
     bool onButtonDoublePressEvent(const PositionInputData& pos);
     bool onButtonTriplePressEvent(const PositionInputData& pos);
     bool onMotionNotifyEvent(const PositionInputData& pos);
+    void onMotionCancelEvent();
 
     /**
      * This method actually repaints the XojPageView, triggering

--- a/src/gui/XournalView.cpp
+++ b/src/gui/XournalView.cpp
@@ -27,6 +27,7 @@
 XournalView::XournalView(GtkWidget* parent, Control* control, ScrollHandling* scrollHandling):
         scrollHandling(scrollHandling), control(control) {
     this->cache = new PdfCache(control->getSettings()->getPdfPageCacheSize());
+
     registerListener(control);
 
     InputContext* inputContext = nullptr;
@@ -486,7 +487,9 @@ void XournalView::zoomChanged() {
 
     size_t currentPage = this->getCurrentPage();
     XojPageView* view = getViewFor(currentPage);
+
     ZoomControl* zoom = control->getZoomControl();
+    this->cache->setZoomingClearsCache(control->getSettings()->getClearPDFCacheOnZoom());
 
     if (!view) {
         return;

--- a/src/gui/XournalView.cpp
+++ b/src/gui/XournalView.cpp
@@ -489,7 +489,8 @@ void XournalView::zoomChanged() {
     XojPageView* view = getViewFor(currentPage);
 
     ZoomControl* zoom = control->getZoomControl();
-    this->cache->setZoomingClearsCache(control->getSettings()->getClearPDFCacheOnZoom());
+    this->cache->setAnyZoomChangeCausesRecache(false);  // We're zooming -- no need for repeated re-renders.
+    this->cache->setRefreshThreshold(control->getSettings()->getPDFPageRerenderThreshold());
 
     if (!view) {
         return;

--- a/src/gui/dialog/SettingsDialog.cpp
+++ b/src/gui/dialog/SettingsDialog.cpp
@@ -91,6 +91,12 @@ SettingsDialog::SettingsDialog(GladeSearchpath* gladeSearchPath, Settings* setti
             G_CALLBACK(+[](GtkComboBox* comboBox, SettingsDialog* self) { self->customHandRecognitionToggled(); }),
             this);
 
+    g_signal_connect(get("cbEnableZoomGestures"), "toggled",
+                     G_CALLBACK(+[](GtkComboBox* comboBox, SettingsDialog* self) {
+                         self->enableWithCheckbox("cbEnableZoomGestures", "gdStartZoomAtSetting");
+                     }),
+                     this);
+
     g_signal_connect(get("cbTouchWorkaround"), "toggled", G_CALLBACK(+[](GtkComboBox* comboBox, SettingsDialog* self) {
                          self->touchWorkaroundStatusChanged();
                      }),
@@ -279,7 +285,6 @@ void SettingsDialog::load() {
     loadCheckbox("cbHideVerticalScrollbar", settings->getScrollbarHideType() & SCROLLBAR_HIDE_VERTICAL);
     loadCheckbox("cbDisableScrollbarFadeout", settings->isScrollbarFadeoutDisabled());
     loadCheckbox("cbEnablePressureInference", settings->isPressureGuessingEnabled());
-    loadCheckbox("cbClearCacheOnZoom", settings->getClearPDFCacheOnZoom());
     loadCheckbox("cbTouchWorkaround", settings->isTouchWorkaround());
     loadCheckbox("cbTouchDrawing", settings->getTouchDrawingEnabled());
     const bool ignoreStylusEventsEnabled = settings->getIgnoredStylusEvents() != 0;  // 0 means disabled, >0 enabled
@@ -331,6 +336,12 @@ void SettingsDialog::load() {
 
     GtkWidget* spDrawDirModsRadius = get("spDrawDirModsRadius");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spDrawDirModsRadius), settings->getDrawDirModsRadius());
+
+    GtkWidget* spReRenderThreshold = get("spReRenderThreshold");
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(spReRenderThreshold), settings->getPDFPageRerenderThreshold());
+
+    GtkWidget* spTouchZoomStartThreshold = get("spTouchZoomStartThreshold");
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(spTouchZoomStartThreshold), settings->getTouchZoomStartThreshold());
 
     {
         int time = 0;
@@ -420,6 +431,7 @@ void SettingsDialog::load() {
     enableWithCheckbox("cbStrokeFilterEnabled", "spStrokeSuccessiveTime");
     enableWithCheckbox("cbStrokeFilterEnabled", "cbDoActionOnStrokeFiltered");
     enableWithCheckbox("cbStrokeFilterEnabled", "cbTrySelectOnStrokeFiltered");
+    enableWithCheckbox("cbEnableZoomGestures", "gdStartZoomAtSetting");
     enableWithCheckbox("cbDisableTouchOnPenNear", "boxInternalHandRecognition");
     customHandRecognitionToggled();
     customStylusIconTypeChanged();
@@ -562,7 +574,6 @@ void SettingsDialog::save() {
     settings->setRestoreLineWidthEnabled(getCheckbox("cbRestoreLineWidthEnabled"));
     settings->setDarkTheme(getCheckbox("cbDarkTheme"));
     settings->setPressureGuessingEnabled(getCheckbox("cbEnablePressureInference"));
-    settings->setClearPDFCacheOnZoom(getCheckbox("cbClearCacheOnZoom"));
     settings->setTouchWorkaround(getCheckbox("cbTouchWorkaround"));
     settings->setTouchDrawingEnabled(getCheckbox("cbTouchDrawing"));
     settings->setExperimentalInputSystemEnabled(getCheckbox("cbNewInputSystem"));
@@ -678,6 +689,14 @@ void SettingsDialog::save() {
     GtkWidget* spStrokeSuccessiveTime = get("spStrokeSuccessiveTime");
     int strokeSuccessiveTime = gtk_spin_button_get_value(GTK_SPIN_BUTTON(spStrokeSuccessiveTime));
     settings->setStrokeFilter(strokeIgnoreTime, strokeIgnoreLength, strokeSuccessiveTime);
+
+    GtkWidget* spTouchZoomStartThreshold = get("spTouchZoomStartThreshold");
+    double zoomStartThreshold = gtk_spin_button_get_value(GTK_SPIN_BUTTON(spTouchZoomStartThreshold));
+    settings->setTouchZoomStartThreshold(zoomStartThreshold);
+
+    GtkWidget* spReRenderThreshold = get("spReRenderThreshold");
+    double rerenderThreshold = gtk_spin_button_get_value(GTK_SPIN_BUTTON(spReRenderThreshold));
+    settings->setPDFPageRerenderThreshold(rerenderThreshold);
 
 
     settings->setDisplayDpi(dpi);

--- a/src/gui/dialog/SettingsDialog.h
+++ b/src/gui/dialog/SettingsDialog.h
@@ -35,9 +35,15 @@ public:
     void setDpi(int dpi);
 
     /**
-     * Autosave was toggled, enable / disable autosave config
+     * Set active regions
      */
     void enableWithCheckbox(const string& checkbox, const string& widget);
+    void disableWithCheckbox(const string& checkbox, const string& widget);
+
+    /**
+     * Listeners for changes to settings.
+     */
+    void touchWorkaroundStatusChanged();
     void customHandRecognitionToggled();
     void customStylusIconTypeChanged();
 

--- a/src/gui/dialog/SettingsDialog.h
+++ b/src/gui/dialog/SettingsDialog.h
@@ -40,7 +40,7 @@ public:
     void enableWithCheckbox(const string& checkbox, const string& widget);
     void disableWithCheckbox(const string& checkbox, const string& widget);
 
-    /**
+    /*
      * Listeners for changes to settings.
      */
     void touchWorkaroundStatusChanged();

--- a/src/gui/inputdevices/InputContext.cpp
+++ b/src/gui/inputdevices/InputContext.cpp
@@ -114,8 +114,10 @@ auto InputContext::handle(GdkEvent* sourceEvent) -> bool {
 
     // handle touchscreens
     if (event.deviceClass == INPUT_DEVICE_TOUCHSCREEN) {
+        bool touchDrawingEnabled = this->getSettings()->getTouchDrawingEnabled();
+
         // trigger touch drawing depending on the setting
-        if (this->touchWorkaroundEnabled) {
+        if (this->touchWorkaroundEnabled || touchDrawingEnabled) {
             return this->touchDrawingHandler->handle(event) || this->touchHandler->handle(event);
         }
 

--- a/src/gui/inputdevices/InputContext.cpp
+++ b/src/gui/inputdevices/InputContext.cpp
@@ -116,7 +116,7 @@ auto InputContext::handle(GdkEvent* sourceEvent) -> bool {
     if (event.deviceClass == INPUT_DEVICE_TOUCHSCREEN) {
         // trigger touch drawing depending on the setting
         if (this->touchWorkaroundEnabled) {
-            return this->touchDrawingHandler->handle(event);
+            return this->touchDrawingHandler->handle(event) || this->touchHandler->handle(event);
         }
 
         return this->touchHandler->handle(event);

--- a/src/gui/inputdevices/PenInputHandler.cpp
+++ b/src/gui/inputdevices/PenInputHandler.cpp
@@ -145,9 +145,9 @@ auto PenInputHandler::actionStart(InputEvent const& event) -> bool {
     return true;
 }
 
-double PenInputHandler::inferPressure(PositionInputData const& pos, XojPageView* page) {
+double PenInputHandler::inferPressureIfEnabled(PositionInputData const& pos, XojPageView* page) {
     // Infer pressure
-    if (pos.pressure == Point::NO_PRESSURE) {
+    if (pos.pressure == Point::NO_PRESSURE && this->inputContext->getSettings()->isPressureGuessingEnabled()) {
         PositionInputData lastPos = getInputDataRelativeToCurrentPage(page, this->lastEvent);
 
         double dt = std::min((pos.timestamp - lastPos.timestamp) / 10.0, 2.0);
@@ -268,7 +268,7 @@ auto PenInputHandler::actionMotion(InputEvent const& event) -> bool {
         pos.x = std::min(pos.x, static_cast<double>(sequenceStartPage->getDisplayWidth()));
         pos.y = std::min(pos.y, static_cast<double>(sequenceStartPage->getDisplayHeight()));
 
-        pos.pressure = this->inferPressure(pos, sequenceStartPage);
+        pos.pressure = this->inferPressureIfEnabled(pos, sequenceStartPage);
 
         result = sequenceStartPage->onMotionNotifyEvent(pos);
     }
@@ -276,7 +276,7 @@ auto PenInputHandler::actionMotion(InputEvent const& event) -> bool {
     if (currentPage && this->penInWidget) {
         // Relay the event to the page
         PositionInputData pos = getInputDataRelativeToCurrentPage(currentPage, event);
-        pos.pressure = this->inferPressure(pos, currentPage);
+        pos.pressure = this->inferPressureIfEnabled(pos, currentPage);
 
         result = currentPage->onMotionNotifyEvent(pos);
     }

--- a/src/gui/inputdevices/PenInputHandler.cpp
+++ b/src/gui/inputdevices/PenInputHandler.cpp
@@ -72,7 +72,7 @@ auto PenInputHandler::actionStart(InputEvent const& event) -> bool {
     // Change the tool depending on the key
     if (!changeTool(event))
         return false;
-    
+
     // Used for pressure inference
     this->lastPressure = 0.0;
 

--- a/src/gui/inputdevices/PenInputHandler.cpp
+++ b/src/gui/inputdevices/PenInputHandler.cpp
@@ -72,6 +72,9 @@ auto PenInputHandler::actionStart(InputEvent const& event) -> bool {
     // Change the tool depending on the key
     if (!changeTool(event))
         return false;
+    
+    // Used for pressure inference
+    this->lastPressure = 0.0;
 
     // Flag running input
     ToolHandler* toolHandler = this->inputContext->getToolHandler();
@@ -134,10 +137,31 @@ auto PenInputHandler::actionStart(InputEvent const& event) -> bool {
     // Forward event to page
     if (currentPage) {
         PositionInputData pos = this->getInputDataRelativeToCurrentPage(currentPage, event);
+        pos.pressure = this->inferPressureIfEnabled(pos, currentPage);
+
         return currentPage->onButtonPressEvent(pos);
     }
 
     return true;
+}
+
+double PenInputHandler::inferPressure(PositionInputData const& pos, XojPageView* page) {
+    // Infer pressure
+    if (pos.pressure == Point::NO_PRESSURE) {
+        PositionInputData lastPos = getInputDataRelativeToCurrentPage(page, this->lastEvent);
+
+        double dt = std::min((pos.timestamp - lastPos.timestamp) / 10.0, 2.0);
+        double inverseSpeed = (dt) / std::sqrt(std::pow(pos.x - lastPos.x, 2) + std::pow(pos.y - lastPos.y, 2) + 0.001);
+
+        double newPressure = 3.142 / 2.0 + std::atan(inverseSpeed * 3.14 - 1.3);
+
+        newPressure = std::min(newPressure, 2.0) / 5.0 + this->lastPressure * 4.0 / 5.0;
+        this->lastPressure = newPressure;
+
+        return (newPressure * 1.1 + 0.8) / 2.0;
+    }
+
+    return pos.pressure;
 }
 
 auto PenInputHandler::actionMotion(InputEvent const& event) -> bool {
@@ -147,6 +171,7 @@ auto PenInputHandler::actionMotion(InputEvent const& event) -> bool {
      */
     gdouble eventX = event.relativeX;
     gdouble eventY = event.relativeY;
+
     GtkAdjustment* adjHorizontal = this->inputContext->getScrollHandling()->getHorizontal();
     GtkAdjustment* adjVertical = this->inputContext->getScrollHandling()->getVertical();
     double h = gtk_adjustment_get_value(adjHorizontal);
@@ -227,8 +252,7 @@ auto PenInputHandler::actionMotion(InputEvent const& event) -> bool {
         }
     }
 
-    // Update the last position of the input device
-    this->updateLastEvent(event);
+    bool result = false;
 
     // Update the cursor
     xournal->view->getCursor()->setInsidePage(currentPage != nullptr);
@@ -244,16 +268,23 @@ auto PenInputHandler::actionMotion(InputEvent const& event) -> bool {
         pos.x = std::min(pos.x, static_cast<double>(sequenceStartPage->getDisplayWidth()));
         pos.y = std::min(pos.y, static_cast<double>(sequenceStartPage->getDisplayHeight()));
 
-        return sequenceStartPage->onMotionNotifyEvent(pos);
+        pos.pressure = this->inferPressure(pos, sequenceStartPage);
+
+        result = sequenceStartPage->onMotionNotifyEvent(pos);
     }
 
     if (currentPage && this->penInWidget) {
         // Relay the event to the page
         PositionInputData pos = getInputDataRelativeToCurrentPage(currentPage, event);
-        return currentPage->onMotionNotifyEvent(pos);
+        pos.pressure = this->inferPressure(pos, currentPage);
+
+        result = currentPage->onMotionNotifyEvent(pos);
     }
 
-    return false;
+    // Update the last position of the input device
+    this->updateLastEvent(event);
+
+    return result;
 }
 
 auto PenInputHandler::actionEnd(InputEvent const& event) -> bool {
@@ -271,6 +302,8 @@ auto PenInputHandler::actionEnd(InputEvent const& event) -> bool {
     // Selections and single-page elements will always work on one page so we need to handle them differently
     if (this->sequenceStartPage && toolHandler->isSinglePageTool()) {
         PositionInputData pos = getInputDataRelativeToCurrentPage(this->sequenceStartPage, event);
+        pos.pressure = this->inferPressureIfEnabled(pos, this->sequenceStartPage);
+
         this->sequenceStartPage->onButtonReleaseEvent(pos);
     } else {
         // Relay the event to the page
@@ -289,6 +322,8 @@ auto PenInputHandler::actionEnd(InputEvent const& event) -> bool {
 
         if (currentPage) {
             PositionInputData pos = getInputDataRelativeToCurrentPage(currentPage, event);
+            pos.pressure = this->inferPressureIfEnabled(pos, currentPage);
+
             currentPage->onButtonReleaseEvent(pos);
         }
     }

--- a/src/gui/inputdevices/PenInputHandler.h
+++ b/src/gui/inputdevices/PenInputHandler.h
@@ -36,6 +36,11 @@ protected:
     InputEvent lastEvent{};
 
     /**
+     * Last pressure inferred.
+     */
+    double lastPressure{0.0};
+
+    /**
      * Reference to the last event actually hitting a page
      */
     InputEvent lastHitEvent{};
@@ -118,4 +123,11 @@ protected:
      * @param event
      */
     void updateLastEvent(InputEvent const& event);
+
+    /**
+     * Estimate pressure based on pen speed using the previous event.
+     * @param pos The position of the current event
+     * @param page The page the event is relative to.
+     */
+    double inferPressure(PositionInputData const& pos, XojPageView* page);
 };

--- a/src/gui/inputdevices/PenInputHandler.h
+++ b/src/gui/inputdevices/PenInputHandler.h
@@ -129,5 +129,5 @@ protected:
      * @param pos The position of the current event
      * @param page The page the event is relative to.
      */
-    double inferPressure(PositionInputData const& pos, XojPageView* page);
+    double inferPressureIfEnabled(PositionInputData const& pos, XojPageView* page);
 };

--- a/src/gui/inputdevices/TouchDrawingInputHandler.cpp
+++ b/src/gui/inputdevices/TouchDrawingInputHandler.cpp
@@ -56,12 +56,10 @@ auto TouchDrawingInputHandler::handleImpl(InputEvent const& event) -> bool {
             // momentum-based scrolling!
             mainWindow->setGtkTouchscreenScrollingEnabled(true);
 
-            if (this->startedSingleInput) {
-                XojPageView* currentPage = this->getPageAtCurrentPosition(event);
+            XojPageView* currentPage = this->getPageAtCurrentPosition(event);
 
-                if (currentPage) {
-                    currentPage->onMotionCancelEvent();
-                }
+            if (currentPage) {
+                currentPage->onMotionCancelEvent();
             }
         }
 
@@ -87,20 +85,11 @@ auto TouchDrawingInputHandler::handleImpl(InputEvent const& event) -> bool {
         this->primarySequence = event.sequence;
         this->deviceClassPressed = true;
 
-        // Defer starting the single-touch action --
-        // this lets us avoid calling onMotionCancel event
-        // if this becomes a multi-touch event.
-        this->startedSingleInput = false;
+        this->actionStart(event);
 
         updateKineticScrollingEnabled();
 
         return false;
-    }
-
-    // If we defered the single-touch action,
-    if (this->deviceClassPressed && !this->startedSingleInput) {
-        this->actionStart(event);
-        this->startedSingleInput = true;
     }
 
     // Trigger motion action when finger is pressed and moved,

--- a/src/gui/inputdevices/TouchDrawingInputHandler.cpp
+++ b/src/gui/inputdevices/TouchDrawingInputHandler.cpp
@@ -7,6 +7,7 @@
 #include "gui/XournalppCursor.h"
 #include "gui/inputdevices/InputUtils.h"
 #include "gui/widgets/XournalWidget.h"
+#include "model/Stroke.h"
 
 #include "InputContext.h"
 
@@ -18,8 +19,32 @@ auto TouchDrawingInputHandler::handleImpl(InputEvent const& event) -> bool {
     // Only handle events when there is no active gesture
     GtkXournal* xournal = inputContext->getXournal();
 
-    // Disallow multitouch
-    if (this->currentSequence && this->currentSequence != event.sequence) {
+    // Trigger end of action if mouse button is released
+    bool mustEnd = event.type == BUTTON_RELEASE_EVENT;
+
+    // If we loose our Grab on the device end the current action
+    mustEnd = mustEnd || event.type == GRAB_BROKEN_EVENT && this->deviceClassPressed;
+
+    // Multitouch
+    if (this->primarySequence && this->primarySequence != event.sequence || this->secondarySequence) {
+        if (!this->secondarySequence) {
+            this->secondarySequence = event.sequence;
+
+            if (this->startedSingleInput) {
+                XojPageView* currentPage = this->getPageAtCurrentPosition(event);
+                currentPage->onMotionCancelEvent();
+            }
+        }
+
+        if (mustEnd) {
+            if (event.sequence == this->primarySequence) {
+                this->primarySequence = nullptr;
+            } else if (event.sequence == this->secondarySequence) {
+                this->secondarySequence = this->primarySequence;
+                this->primarySequence = nullptr;
+            }
+        }
+
         return false;
     }
 
@@ -27,21 +52,31 @@ auto TouchDrawingInputHandler::handleImpl(InputEvent const& event) -> bool {
      * Trigger start action
      */
     // Trigger start of action when pen/mouse is pressed
-    if (event.type == BUTTON_PRESS_EVENT && this->currentSequence == nullptr) {
-        this->currentSequence = event.sequence;
+    if (event.type == BUTTON_PRESS_EVENT && this->primarySequence == nullptr) {
+        this->primarySequence = event.sequence;
         this->deviceClassPressed = true;
-        this->actionStart(event);
-        return true;
+        this->startedSingleInput = false;
+
+        return false;
     }
 
     /*
      * Trigger motion actions
      */
+    if (this->deviceClassPressed && !this->startedSingleInput) {
+        this->actionStart(event);
+        this->startedSingleInput = true;
+    }
+
     // Trigger motion action when finger is pressed and moved
     if (this->deviceClassPressed && event.type == MOTION_EVENT) {
+        this->inputContext->getView()->getCursor()->setRotationAngle(event.relativeX);
+
         this->actionMotion(event);
         XournalppCursor* cursor = xournal->view->getCursor();
         cursor->updateCursor();
+
+        return true;
     }
 
     // Notify if finger enters/leaves widget
@@ -52,20 +87,12 @@ auto TouchDrawingInputHandler::handleImpl(InputEvent const& event) -> bool {
         this->actionLeaveWindow(event);
     }
 
-    // Trigger end of action if mouse button is released
-    if (event.type == BUTTON_RELEASE_EVENT) {
-        this->currentSequence = nullptr;
+    if (mustEnd) {
+        this->primarySequence = nullptr;
         this->actionEnd(event);
-        this->deviceClassPressed = false;
-        return true;
-    }
 
-    // If we loose our Grab on the device end the current action
-    if (event.type == GRAB_BROKEN_EVENT && this->deviceClassPressed) {
-        this->currentSequence = nullptr;
-        this->actionEnd(event);
         this->deviceClassPressed = false;
-        return true;
+        return false;  // Any alternates should also end.
     }
 
     return false;

--- a/src/gui/inputdevices/TouchDrawingInputHandler.cpp
+++ b/src/gui/inputdevices/TouchDrawingInputHandler.cpp
@@ -32,7 +32,10 @@ auto TouchDrawingInputHandler::handleImpl(InputEvent const& event) -> bool {
 
             if (this->startedSingleInput) {
                 XojPageView* currentPage = this->getPageAtCurrentPosition(event);
-                currentPage->onMotionCancelEvent();
+
+                if (currentPage) {
+                    currentPage->onMotionCancelEvent();
+                }
             }
         }
 
@@ -82,9 +85,14 @@ auto TouchDrawingInputHandler::handleImpl(InputEvent const& event) -> bool {
     // Notify if finger enters/leaves widget
     if (event.type == ENTER_EVENT) {
         this->actionEnterWindow(event);
+
+        return true;
     }
+
     if (event.type == LEAVE_EVENT) {
         this->actionLeaveWindow(event);
+
+        return true;
     }
 
     if (mustEnd) {

--- a/src/gui/inputdevices/TouchDrawingInputHandler.cpp
+++ b/src/gui/inputdevices/TouchDrawingInputHandler.cpp
@@ -64,14 +64,15 @@ auto TouchDrawingInputHandler::handleImpl(InputEvent const& event) -> bool {
         }
 
         if (mustEnd) {
+            // Ending two-finger panning/zooming? We should now only have a primary sequence.
             if (event.sequence == this->primarySequence) {
-                this->primarySequence = nullptr;
+                this->primarySequence = this->secondarySequence;
+                this->secondarySequence = nullptr;
 
                 // Only scrolling now if using the hand tool.
                 mainWindow->setGtkTouchscreenScrollingEnabled(toolHandler->getToolType() == TOOL_HAND);
             } else if (event.sequence == this->secondarySequence) {
-                this->secondarySequence = this->primarySequence;
-                this->primarySequence = nullptr;
+                this->secondarySequence = nullptr;
             }
         }
 

--- a/src/gui/inputdevices/TouchDrawingInputHandler.h
+++ b/src/gui/inputdevices/TouchDrawingInputHandler.h
@@ -14,6 +14,8 @@
 #include <string>
 #include <vector>
 
+#include "control/Actions.h"
+
 #include "PenInputHandler.h"
 #include "XournalType.h"
 

--- a/src/gui/inputdevices/TouchDrawingInputHandler.h
+++ b/src/gui/inputdevices/TouchDrawingInputHandler.h
@@ -25,7 +25,6 @@ class TouchDrawingInputHandler: public PenInputHandler {
 private:
     GdkEventSequence* primarySequence = nullptr;
     GdkEventSequence* secondarySequence = nullptr;
-    bool startedSingleInput = false;
 
 public:
     explicit TouchDrawingInputHandler(InputContext* inputContext);

--- a/src/gui/inputdevices/TouchDrawingInputHandler.h
+++ b/src/gui/inputdevices/TouchDrawingInputHandler.h
@@ -42,4 +42,7 @@ protected:
      * @return false if tool was not changed successfully
      */
     bool changeTool(InputEvent const& event) override;
+
+private:
+    void updateKineticScrollingEnabled();
 };

--- a/src/gui/inputdevices/TouchDrawingInputHandler.h
+++ b/src/gui/inputdevices/TouchDrawingInputHandler.h
@@ -21,7 +21,9 @@ class InputContext;
 
 class TouchDrawingInputHandler: public PenInputHandler {
 private:
-    GdkEventSequence* currentSequence = nullptr;
+    GdkEventSequence* primarySequence = nullptr;
+    GdkEventSequence* secondarySequence = nullptr;
+    bool startedSingleInput = false;
 
 public:
     explicit TouchDrawingInputHandler(InputContext* inputContext);

--- a/src/gui/inputdevices/TouchInputHandler.cpp
+++ b/src/gui/inputdevices/TouchInputHandler.cpp
@@ -25,15 +25,20 @@ auto TouchInputHandler::handleImpl(InputEvent const& event) -> bool {
             // Set sequence data
             sequenceStart(event);
         }
-        // Start zooming as soon as we have two sequences
+        // Start zooming as soon as we have two sequences.
         else if (this->primarySequence && this->primarySequence != event.sequence &&
-                 this->secondarySequence == nullptr && zoomGesturesEnabled) {
+                 this->secondarySequence == nullptr) {
             this->secondarySequence = event.sequence;
 
             // Set sequence data
             sequenceStart(event);
 
-            zoomStart();
+            // Even if zoom gestures are disabled,
+            // this is still the start of a sequence. Just
+            // don't start zooming.
+            if (zoomGesturesEnabled) {
+                zoomStart();
+            }
         }
     }
 
@@ -42,6 +47,8 @@ auto TouchInputHandler::handleImpl(InputEvent const& event) -> bool {
             zoomMotion(event);
         } else if (event.sequence == this->primarySequence) {
             scrollMotion(event);
+        } else if (this->primarySequence && this->secondarySequence) {
+            sequenceStart(event);
         }
     }
 

--- a/src/gui/inputdevices/TouchInputHandler.cpp
+++ b/src/gui/inputdevices/TouchInputHandler.cpp
@@ -51,8 +51,13 @@ auto TouchInputHandler::handleImpl(InputEvent const& event) -> bool {
         }
 
         if (event.sequence == this->primarySequence) {
+            // If secondarySequence is nullptr, this sets primarySequence
+            // to nullptr.
             this->primarySequence = this->secondarySequence;
             this->secondarySequence = nullptr;
+
+            this->priLastAbs = this->secLastAbs;
+            this->priLastRel = this->secLastRel;
         } else {
             this->secondarySequence = nullptr;
         }

--- a/src/gui/inputdevices/TouchInputHandler.cpp
+++ b/src/gui/inputdevices/TouchInputHandler.cpp
@@ -40,7 +40,7 @@ auto TouchInputHandler::handleImpl(InputEvent const& event) -> bool {
     if (event.type == MOTION_EVENT && this->primarySequence) {
         if (this->primarySequence && this->secondarySequence && zoomGesturesEnabled) {
             zoomMotion(event);
-        } else {
+        } else if (event.sequence == this->primarySequence) {
             scrollMotion(event);
         }
     }
@@ -53,11 +53,12 @@ auto TouchInputHandler::handleImpl(InputEvent const& event) -> bool {
 
         if (event.sequence == this->primarySequence) {
             // If secondarySequence is nullptr, this sets primarySequence
-            // to nullptr.
+            // to nullptr. If it isn't, then it is now the primary sequence!
             this->primarySequence = this->secondarySequence;
             this->secondarySequence = nullptr;
 
             this->priLastAbs = this->secLastAbs;
+            this->priLastRel = this->secLastRel;
         } else {
             this->secondarySequence = nullptr;
         }

--- a/src/gui/inputdevices/TouchInputHandler.h
+++ b/src/gui/inputdevices/TouchInputHandler.h
@@ -1,7 +1,7 @@
 /*
  * Xournal++
  *
- * [Header description]
+ * Handle touchscreen zooming and panning.
  *
  * @author Xournal++ Team
  * https://github.com/xournalpp/xournalpp
@@ -34,6 +34,8 @@ private:
 
     utl::Point<double> priLastRel{-1.0, -1.0};
     utl::Point<double> secLastRel{-1.0, -1.0};
+
+    bool canBlockZoom{false};
 
 private:
     void sequenceStart(InputEvent const& event);

--- a/src/gui/sidebar/previews/base/SidebarPreviewBase.cpp
+++ b/src/gui/sidebar/previews/base/SidebarPreviewBase.cpp
@@ -128,6 +128,6 @@ auto SidebarPreviewBase::scrollToPreview(SidebarPreviewBase* sidebar) -> bool {
     return false;
 }
 
-void SidebarPreviewBase::pageDeleted(int page) {}
+void SidebarPreviewBase::pageDeleted(size_t page) {}
 
-void SidebarPreviewBase::pageInserted(int page) {}
+void SidebarPreviewBase::pageInserted(size_t page) {}

--- a/src/gui/sidebar/previews/base/SidebarPreviewBase.h
+++ b/src/gui/sidebar/previews/base/SidebarPreviewBase.h
@@ -68,8 +68,8 @@ public:
 public:
     // DocumentListener interface (only the part handled by SidebarPreviewBase)
     virtual void documentChanged(DocumentChangeType type);
-    virtual void pageInserted(int page);
-    virtual void pageDeleted(int page);
+    virtual void pageInserted(size_t page);
+    virtual void pageDeleted(size_t page);
 
 protected:
     /**

--- a/src/util/DeviceListHelper.cpp
+++ b/src/util/DeviceListHelper.cpp
@@ -74,6 +74,21 @@ auto DeviceListHelper::getDeviceList(Settings* settings, bool ignoreTouchDevices
     return deviceList;
 }
 
+InputDeviceClass DeviceListHelper::getSourceMapping(GdkInputSource source, Settings* settings) {
+    auto deviceList = DeviceListHelper::getDeviceList(settings);
+
+    for (InputDevice const& inputDevice: deviceList) {
+        InputDeviceClass deviceClass =
+                InputEvents::translateDeviceType(inputDevice.getName(), inputDevice.getSource(), settings);
+
+        if (inputDevice.getSource() == source) {
+            return deviceClass;
+        }
+    }
+
+    return InputDeviceClass::INPUT_DEVICE_IGNORE;
+}
+
 InputDevice::InputDevice(GdkDevice* device): name(gdk_device_get_name(device)), source(gdk_device_get_source(device)) {}
 
 InputDevice::InputDevice(string name, GdkInputSource source): name(std::move(name)), source(source) {}

--- a/src/util/DeviceListHelper.h
+++ b/src/util/DeviceListHelper.h
@@ -18,6 +18,7 @@
 #include <gtk/gtk.h>
 
 #include "control/settings/Settings.h"
+#include "gui/inputdevices/InputEvents.h"
 
 using std::string;
 using std::vector;
@@ -42,5 +43,7 @@ private:
 };
 
 namespace DeviceListHelper {
+
 vector<InputDevice> getDeviceList(Settings* settings, bool ignoreTouchDevices = false);
+InputDeviceClass getSourceMapping(GdkInputSource src, Settings* settings);
 }

--- a/src/util/Point.h
+++ b/src/util/Point.h
@@ -22,7 +22,7 @@ struct Point {
     Point() = default;
     Point(T x, T y): x(x), y(y) {}
 
-    [[maybe_unused]] double distance(Point p) { return std::hypot(p.x - this->x, p.y - this->y); }
+    [[maybe_unused]] double distance(Point p) const { return std::hypot(p.x - this->x, p.y - this->y); }
 
     [[maybe_unused]] Point operator-(Point p) const { return {this->x - p.x, this->y - p.y}; }
     [[maybe_unused]] Point& operator-=(Point p) { return *this = *this - p; }

--- a/src/util/Util.cpp
+++ b/src/util/Util.cpp
@@ -34,9 +34,10 @@ static auto execInUiThreadCallback(CallbackUiData* cb) -> bool {
  *
  * Make sure the container class is not deleted before the UI stuff is finished!
  */
-void Util::execInUiThread(std::function<void()>&& callback) {
-    gdk_threads_add_idle(reinterpret_cast<GSourceFunc>(execInUiThreadCallback),
-                         new CallbackUiData(std::move(callback)));
+void Util::execInUiThread(std::function<void()>&& callback, gint priority) {
+    // Note: nullptr = GDestroyNotify notify.
+    gdk_threads_add_idle_full(priority, reinterpret_cast<GSourceFunc>(execInUiThreadCallback),
+                              new CallbackUiData(std::move(callback)), nullptr);
 }
 
 void Util::cairo_set_source_rgbi(cairo_t* cr, Color color) {

--- a/src/util/Util.h
+++ b/src/util/Util.h
@@ -37,7 +37,7 @@ void systemWithMessage(const char* command);
  *
  * Make sure the container class is not deleted before the UI stuff is finished!
  */
-void execInUiThread(std::function<void()>&& callback);
+void execInUiThread(std::function<void()>&& callback, gint priority = G_PRIORITY_DEFAULT_IDLE);
 
 gboolean paintBackgroundWhite(GtkWidget* widget, cairo_t* cr, void* unused);
 

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -1,168 +1,165 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.36.0 -->
+<!-- Generated with glade 3.38.2 -->
 <interface>
-  <requires lib="gtk+" version="3.18" />
+  <requires lib="gtk+" version="3.18"/>
   <object class="GtkAdjustment" id="adjustmentAudioGain">
     <property name="upper">10</property>
     <property name="value">1</property>
-    <property name="step_increment">0.1</property>
+    <property name="step-increment">0.10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentCursorHighlightBorderWidth">
     <property name="upper">30</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentCursorHighlightRadius">
     <property name="upper">30</property>
     <property name="value">30</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">5</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">5</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentDrawDirModRadius">
     <property name="lower">2</property>
     <property name="upper">1000</property>
     <property name="value">50</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentHorizontalSpace">
     <property name="upper">1000</property>
     <property name="value">150</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentIgnoreStylusEvents">
     <property name="lower">1</property>
     <property name="upper">1000</property>
     <property name="value">1</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentPairsOffset">
     <property name="upper">100</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">1</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">1</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentSeekTime">
     <property name="lower">1</property>
     <property name="upper">90</property>
     <property name="value">5</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentSnapGridSize">
     <property name="lower">0.01</property>
     <property name="upper">20</property>
     <property name="value">1</property>
-    <property name="step_increment">0.01</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">0.01</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentSnapGridTolerance">
-    <property name="lower">0.1</property>
+    <property name="lower">0.10</property>
     <property name="upper">1</property>
     <property name="value">0.5</property>
-    <property name="step_increment">0.05</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">0.05</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentSnapRotationTolerance">
-    <property name="lower">0.1</property>
+    <property name="lower">0.10</property>
     <property name="upper">1</property>
-    <property name="value">0.3</property>
-    <property name="step_increment">0.05</property>
-    <property name="page_increment">10</property>
+    <property name="value">0.29999999999999999</property>
+    <property name="step-increment">0.05</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentStrokeIgnoreLength">
     <property name="lower">0.01000000000000001</property>
     <property name="upper">100</property>
     <property name="value">1</property>
-    <property name="step_increment">0.1</property>
-    <property name="page_increment">2</property>
+    <property name="step-increment">0.10</property>
+    <property name="page-increment">2</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentStrokeIgnoreTime">
     <property name="upper">1000</property>
     <property name="value">150</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentStrokeSuccessiveTime">
     <property name="upper">1000</property>
     <property name="value">500</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentTimeout">
     <property name="lower">1</property>
     <property name="upper">100</property>
     <property name="value">1</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentTouchTImeout">
     <property name="lower">0.5</property>
     <property name="upper">10</property>
     <property name="value">1</property>
-    <property name="step_increment">0.1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">0.10</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentVerticalSpace">
     <property name="upper">1000</property>
     <property name="value">150</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentZoom">
     <property name="lower">50</property>
     <property name="upper">400</property>
     <property name="value">72</property>
-    <property name="step_increment">1</property>
+    <property name="step-increment">1</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentZoomStep">
-    <property name="lower">0.1</property>
+    <property name="lower">0.10</property>
     <property name="upper">50</property>
     <property name="value">10</property>
-    <property name="step_increment">0.5</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">0.5</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentZoomStepScroll">
-    <property name="lower">0.1</property>
+    <property name="lower">0.10</property>
     <property name="upper">50</property>
     <property name="value">2</property>
-    <property name="step_increment">0.5</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">0.5</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkDialog" id="settingsDialog">
     <property name="name">settingsDialog</property>
-    <property name="can_focus">False</property>
-    <property name="border_width">5</property>
+    <property name="can-focus">False</property>
+    <property name="border-width">5</property>
     <property name="title" translatable="yes">Xournal++ Preferences</property>
-    <property name="window_position">center</property>
+    <property name="window-position">center</property>
     <property name="icon">pixmaps/com.github.xournalpp.xournalpp.svg</property>
-    <property name="type_hint">normal</property>
+    <property name="type-hint">normal</property>
     <property name="gravity">center</property>
-    <signal name="close" handler="gtk_widget_hide" swapped="no" />
-    <child type="titlebar">
-      <placeholder />
-    </child>
+    <signal name="close" handler="gtk_widget_hide" swapped="no"/>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox3">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
         <property name="spacing">2</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="btSettingsButton">
             <property name="name">btSettingsButton</property>
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
+            <property name="can-focus">False</property>
+            <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="btSettingsCancel">
                 <property name="label">gtk-cancel</property>
                 <property name="name">btSettingsCancel</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="use-stock">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -175,9 +172,9 @@
                 <property name="label">gtk-ok</property>
                 <property name="name">btSettingsOk</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="use-stock">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -189,7 +186,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="pack_type">end</property>
+            <property name="pack-type">end</property>
             <property name="position">0</property>
           </packing>
         </child>
@@ -197,60 +194,59 @@
           <object class="GtkNotebook" id="notebook1">
             <property name="name">notebook1</property>
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="tab_pos">left</property>
-            <property name="show_border">False</property>
-	    <property name="scrollable">True</property>
+            <property name="can-focus">True</property>
+            <property name="tab-pos">left</property>
+            <property name="show-border">False</property>
+            <property name="scrollable">True</property>
             <child>
               <object class="GtkBox" id="saveLoadTabBox">
                 <property name="name">saveLoadTabBox</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_left">5</property>
+                <property name="can-focus">False</property>
+                <property name="margin-left">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid01">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="min_content_height">450</property>
-		    <property name="min_content_width">500</property>
+                    <property name="can-focus">True</property>
+                    <property name="min-content-width">500</property>
+                    <property name="min-content-height">450</property>
                     <child>
                       <object class="GtkViewport" id="sid02">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkBox" id="sid03">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="sid04">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.009999999776482582</property>
-                                <property name="margin">12</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid05">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid06">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="label28">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;If the document already was saved you can find it in the same folder with the extension .autosave.xoj
 If the file was not yet saved you can find it in your home directory, in ~/.xournalpp/autosave&lt;/i&gt;</property>
-                                            <property name="use_markup">True</property>
+                                            <property name="use-markup">True</property>
                                             <property name="wrap">True</property>
-                                            <property name="max_width_chars">85</property>
+                                            <property name="max-width-chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -262,16 +258,16 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                         <child>
                                           <object class="GtkBox" id="sid07">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <child>
                                               <object class="GtkCheckButton" id="cbAutosave">
                                                 <property name="label" translatable="yes">Enable Autosaving</property>
                                                 <property name="name">cbAutosave</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="receives_default">False</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">False</property>
                                                 <property name="xalign">0</property>
-                                                <property name="draw_indicator">True</property>
+                                                <property name="draw-indicator">True</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
@@ -283,12 +279,12 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                               <object class="GtkBox" id="boxAutosave">
                                                 <property name="name">boxAutosave</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <child>
                                                   <object class="GtkLabel" id="lbAutosaveTimeout1">
                                                     <property name="name">lbAutosaveTimeout1</property>
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="label" translatable="yes">every</property>
                                                   </object>
                                                   <packing>
@@ -301,7 +297,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                                   <object class="GtkSpinButton" id="spAutosaveTimeout">
                                                     <property name="name">spAutosaveTimeout</property>
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">True</property>
+                                                    <property name="can-focus">True</property>
                                                     <property name="adjustment">adjustmentTimeout</property>
                                                   </object>
                                                   <packing>
@@ -315,7 +311,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                                   <object class="GtkLabel" id="lbAutosaveTimeout2">
                                                     <property name="name">lbAutosaveTimeout2</property>
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="label" translatable="yes">minutes</property>
                                                   </object>
                                                   <packing>
@@ -345,7 +341,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                 <child type="label">
                                   <object class="GtkLabel" id="sid08">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Autosaving</property>
                                   </object>
                                 </child>
@@ -359,28 +355,27 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                             <child>
                               <object class="GtkFrame" id="sid09">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.009999999776482582</property>
-                                <property name="margin">12</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid10">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="vbox3">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="label30">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;This name will be proposed if you save a new document.&lt;/i&gt;</property>
-                                            <property name="use_markup">True</property>
+                                            <property name="use-markup">True</property>
                                             <property name="wrap">True</property>
-                                            <property name="max_width_chars">85</property>
+                                            <property name="max-width-chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -393,7 +388,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                           <object class="GtkEntry" id="txtDefaultSaveName">
                                             <property name="name">txtDefaultSaveName</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
+                                            <property name="can-focus">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -404,13 +399,13 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                         <child>
                                           <object class="GtkBox" id="box14">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <child>
                                               <object class="GtkLabel" id="label31">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">Default name: </property>
-                                                <property name="use_markup">True</property>
+                                                <property name="use-markup">True</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
@@ -422,7 +417,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                               <object class="GtkLabel" id="lbDefaultSavename">
                                                 <property name="name">lbDefaultSavename</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">%F-Note-%H-%M</property>
                                               </object>
                                               <packing>
@@ -442,12 +437,12 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                           <object class="GtkExpander" id="expander1">
                                             <property name="name">expander1</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
+                                            <property name="can-focus">True</property>
                                             <child>
                                               <object class="GtkLabel" id="label33">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="margin_left">20</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="margin-left">20</property>
                                                 <property name="label" translatable="yes">%a		Abbreviated weekday name (e.g. Thu)
 %A		Full weekday name (e.g. Thursday)
 %b		Abbreviated month name (e.g. Aug)
@@ -477,11 +472,11 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             <child type="label">
                                               <object class="GtkBox" id="box15">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <child>
                                                   <object class="GtkImage" id="image1">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="stock">gtk-info</property>
                                                   </object>
                                                   <packing>
@@ -493,8 +488,8 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                                 <child>
                                                   <object class="GtkLabel" id="label32">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
-                                                    <property name="margin_left">3</property>
+                                                    <property name="can-focus">False</property>
+                                                    <property name="margin-left">3</property>
                                                     <property name="label" translatable="yes">Available Placeholders</property>
                                                   </object>
                                                   <packing>
@@ -520,7 +515,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                 <child type="label">
                                   <object class="GtkLabel" id="sid11">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Default Save Name</property>
                                   </object>
                                 </child>
@@ -534,29 +529,28 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                             <child>
                               <object class="GtkFrame" id="sid12">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.009999999776482582</property>
-                                <property name="margin">12</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid13">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid14">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="sid15">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;If you open a PDF and there is a Xournal file with the same name it will open the xoj file.&lt;/i&gt;</property>
-                                            <property name="use_markup">True</property>
+                                            <property name="use-markup">True</property>
                                             <property name="wrap">True</property>
-                                            <property name="max_width_chars">85</property>
+                                            <property name="max-width-chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -570,10 +564,10 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             <property name="label" translatable="yes">Enable Autoloading of Journals</property>
                                             <property name="name">cbAutoloadXoj</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -588,7 +582,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                 <child type="label">
                                   <object class="GtkLabel" id="sid16">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Autoloading Journals</property>
                                   </object>
                                 </child>
@@ -616,363 +610,387 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
               <object class="GtkLabel" id="saveLoadTabLabel">
                 <property name="name">saveLoadTabLabel</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Load / Save</property>
               </object>
               <packing>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="inputTabBox">
                 <property name="name">inputTabBox</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_left">5</property>
+                <property name="can-focus">False</property>
+                <property name="margin-left">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="swInputTab">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="min_content_height">450</property>
-		    <property name="min_content_width">500</property>
+                    <property name="can-focus">True</property>
+                    <property name="min-content-width">500</property>
+                    <property name="min-content-height">450</property>
                     <child>
-		      <object class="GtkViewport" id="wpInputTab">
+                      <object class="GtkViewport" id="wpInputTab">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkBox" id="bxInputTab">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
-			      <object class="GtkFrame" id="sid79">
-				<property name="visible">True</property>
-				<property name="can_focus">False</property>
-				<property name="label_xalign">0.009999999776482582</property>
-				<property name="margin">12</property>
-				<child>
-				  <object class="GtkAlignment" id="sid80">
-				    <property name="visible">True</property>
-				    <property name="can_focus">False</property>
-				    <property name="bottom_padding">8</property>
-				    <property name="left_padding">12</property>
-				    <property name="right_padding">12</property>
-				    <child>
-				      <object class="GtkBox" id="sid81">
-					<property name="visible">True</property>
-					<property name="can_focus">False</property>
-					<property name="orientation">vertical</property>
-					<child>
-					  <object class="GtkLabel" id="sid82">
-					    <property name="visible">True</property>
-					    <property name="can_focus">False</property>
-					    <property name="label" translatable="yes">This is an experimental feature! Use it with care.</property>
-					    <property name="xalign">0</property>
-					  </object>
-					  <packing>
-					    <property name="expand">False</property>
-					    <property name="fill">True</property>
-					    <property name="position">0</property>
-					  </packing>
-					</child>
-					<child>
-					  <object class="GtkGrid" id="grid7">
-					    <property name="visible">True</property>
-					    <property name="can_focus">False</property>
-					    <child>
-					      <object class="GtkCheckButton" id="cbNewInputSystem">
-						<property name="label" translatable="yes">Enable new input system (Requires restart)</property>
-						<property name="name">cbNewInputSystem</property>
-						<property name="visible">True</property>
-						<property name="can_focus">True</property>
-						<property name="receives_default">False</property>
-						<property name="tooltip_markup" translatable="yes">Drag LEFT from start point acts like shift key is being held.
+                              <object class="GtkFrame" id="sid79">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
+                                <child>
+                                  <object class="GtkAlignment" id="sid80">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
+                                    <child>
+                                      <object class="GtkBox" id="sid81">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                          <object class="GtkLabel" id="sid82">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">This is an experimental feature! Use it with care.</property>
+                                            <property name="xalign">0</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <!-- n-columns=3 n-rows=3 -->
+                                          <object class="GtkGrid" id="grid7">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <child>
+                                              <object class="GtkCheckButton" id="cbNewInputSystem">
+                                                <property name="label" translatable="yes">Enable new input system (Requires restart)</property>
+                                                <property name="name">cbNewInputSystem</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">False</property>
+                                                <property name="tooltip-markup" translatable="yes">Drag LEFT from start point acts like shift key is being held.
 	    Drag UP acts as if Control key is being held.
 
 	    Determination Radius: Radius at which modifiers will lock in until finished drawing.
 
 	    &lt;i&gt;Useful for operating without keyboard.&lt;/i&gt;</property>
-						<property name="xalign">0</property>
-						<property name="draw_indicator">True</property>
-					      </object>
-					      <packing>
-						<property name="left_attach">0</property>
-						<property name="top_attach">0</property>
-					      </packing>
-					    </child>
-					  </object>
-					  <packing>
-					    <property name="expand">False</property>
-					    <property name="fill">True</property>
-					    <property name="position">1</property>
-					  </packing>
-					</child>
-				      </object>
-				    </child>
-				  </object>
-				</child>
-				<child type="label">
-				  <object class="GtkLabel" id="sid83">
-				    <property name="visible">True</property>
-				    <property name="can_focus">False</property>
-				    <property name="label" translatable="yes">Experimental Input System</property>
-				  </object>
-				</child>
-			      </object>
-			      <packing>
-				<property name="expand">False</property>
-				<property name="fill">True</property>
-				<property name="position">0</property>
-			      </packing>
-			    </child>
-			    <child>
-			      <object class="GtkFrame" id="sid84">
-				<property name="visible">True</property>
-				<property name="can_focus">False</property>
-				<property name="label_xalign">0.009999999776482582</property>
-				<property name="margin">12</property>
-				<child>
-				  <object class="GtkAlignment" id="sid85">
-				    <property name="visible">True</property>
-				    <property name="can_focus">False</property>
-				    <property name="bottom_padding">8</property>
-				    <property name="left_padding">12</property>
-				    <property name="right_padding">12</property>
-				    <child>
-				      <object class="GtkBox">
-					<property name="visible">True</property>
-					<property name="can_focus">False</property>
-					<property name="orientation">vertical</property>
-					<child>
-					  <object class="GtkLabel">
-					    <property name="visible">True</property>
-					    <property name="can_focus">False</property>
-					    <property name="label" translatable="yes">&lt;i&gt;Assign device classes to each input device of your system. Only change these values if your devices are not correctly matched. (e.g. your pen shows up as touchscreen)&lt;/i&gt;</property>
-					    <property name="use_markup">True</property>
-					    <property name="wrap">True</property>
-					    <property name="max_width_chars">85</property>
-					    <property name="xalign">0</property>
-					  </object>
-					  <packing>
-					    <property name="expand">False</property>
-					    <property name="fill">True</property>
-					    <property name="position">0</property>
-					  </packing>
-					</child>
-					<child>
-					  <object class="GtkBox" id="hboxInputDeviceClasses">
-					    <property name="name">hboxInputDeviceClasses</property>
-					    <property name="visible">True</property>
-					    <property name="can_focus">False</property>
-					    <property name="orientation">vertical</property>
-					    <child>
-					      <placeholder />
-					    </child>
-					  </object>
-					  <packing>
-					    <property name="expand">False</property>
-					    <property name="fill">True</property>
-					    <property name="position">1</property>
-					  </packing>
-					</child>
-				      </object>
-				    </child>
-				  </object>
-				</child>
-				<child type="label">
-				  <object class="GtkLabel" id="sid87">
-				    <property name="visible">True</property>
-				    <property name="can_focus">False</property>
-				    <property name="label" translatable="yes">Input Devices</property>
-				  </object>
-				</child>
-			      </object>
-			      <packing>
-				<property name="expand">False</property>
-				<property name="fill">True</property>
-				<property name="position">1</property>
-			      </packing>
-			    </child>
-			    <child>
-			      <object class="GtkFrame" id="sid88">
-				<property name="visible">True</property>
-				<property name="can_focus">False</property>
-				<property name="label_xalign">0.009999999776482582</property>
-				<property name="margin">12</property>
-				<child>
-				  <object class="GtkAlignment" id="sid89">
-				    <property name="visible">True</property>
-				    <property name="can_focus">False</property>
-				    <property name="bottom_padding">8</property>
-				    <property name="left_padding">12</property>
-				    <property name="right_padding">12</property>
-				    <child>
-				      <object class="GtkBox" id="sid90">
-					<property name="visible">True</property>
-					<property name="can_focus">False</property>
-					<property name="orientation">vertical</property>
-					<child>
-					  <object class="GtkLabel" id="sid91">
-					    <property name="visible">True</property>
-					    <property name="can_focus">False</property>
-					    <property name="label" translatable="yes">These settings take only effect if the experimental input system is activated</property>
-					    <property name="xalign">0</property>
-					  </object>
-					  <packing>
-					    <property name="expand">False</property>
-					    <property name="fill">True</property>
-					    <property name="position">0</property>
-					  </packing>
-					</child>
-					<child>
-					  <object class="GtkCheckButton" id="cbInputSystemDrawOutsideWindow">
-					    <property name="name">cbInputSystemDrawOutsideWindow</property>
-					    <property name="visible">True</property>
-					    <property name="can_focus">True</property>
-					    <property name="receives_default">False</property>
-					    <property name="xalign">0.5</property>
-					    <property name="draw_indicator">True</property>
-					    <child>
-					      <object class="GtkLabel" id="sid92">
-						<property name="visible">True</property>
-						<property name="can_focus">False</property>
-						<property name="label" translatable="yes">Enable drawing outside of window &lt;i&gt;(Drawing will not stop at the border of the window)&lt;/i&gt;</property>
-						<property name="use_markup">True</property>
-						<property name="wrap">True</property>
-						<property name="xalign">0</property>
-					      </object>
-					    </child>
-					  </object>
-					  <packing>
-					    <property name="expand">False</property>
-					    <property name="fill">True</property>
-					    <property name="position">1</property>
-					  </packing>
-					</child>
-					<child>
-					  <object class="GtkCheckButton" id="cbInputSystemTPCButton">
-					    <property name="name">cbInputSystemTPCButton</property>
-					    <property name="visible">True</property>
-					    <property name="can_focus">True</property>
-					    <property name="receives_default">False</property>
-					    <property name="tooltip_markup" translatable="yes">Drag LEFT from start point acts like shift key is being held.
+                                                <property name="xalign">0</property>
+                                                <property name="draw-indicator">True</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label">
+                                  <object class="GtkLabel" id="sid83">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">Experimental Input System</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkFrame" id="sid84">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
+                                <child>
+                                  <object class="GtkAlignment" id="sid85">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
+                                    <child>
+                                      <object class="GtkBox">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                          <object class="GtkLabel">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">&lt;i&gt;Assign device classes to each input device of your system. Only change these values if your devices are not correctly matched. (e.g. your pen shows up as touchscreen)&lt;/i&gt;</property>
+                                            <property name="use-markup">True</property>
+                                            <property name="wrap">True</property>
+                                            <property name="max-width-chars">85</property>
+                                            <property name="xalign">0</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkBox" id="hboxInputDeviceClasses">
+                                            <property name="name">hboxInputDeviceClasses</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="orientation">vertical</property>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label">
+                                  <object class="GtkLabel" id="sid87">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">Input Devices</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkFrame" id="sid88">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
+                                <child>
+                                  <object class="GtkAlignment" id="sid89">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
+                                    <child>
+                                      <object class="GtkBox" id="sid90">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                          <object class="GtkLabel" id="sid91">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">These settings take only effect if the experimental input system is activated</property>
+                                            <property name="xalign">0</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="cbInputSystemDrawOutsideWindow">
+                                            <property name="name">cbInputSystemDrawOutsideWindow</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="xalign">0.5</property>
+                                            <property name="draw-indicator">True</property>
+                                            <child>
+                                              <object class="GtkLabel" id="sid92">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">Enable drawing outside of window &lt;i&gt;(Drawing will not stop at the border of the window)&lt;/i&gt;</property>
+                                                <property name="use-markup">True</property>
+                                                <property name="wrap">True</property>
+                                                <property name="xalign">0</property>
+                                              </object>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="cbInputSystemTPCButton">
+                                            <property name="name">cbInputSystemTPCButton</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-markup" translatable="yes">Drag LEFT from start point acts like shift key is being held.
 	    Drag UP acts as if Control key is being held.
 
 	    Determination Radius: Radius at which modifiers will lock in until finished drawing.
 
 	    &lt;i&gt;Useful for operating without keyboard.&lt;/i&gt;</property>
-					    <property name="xalign">0</property>
-					    <property name="draw_indicator">True</property>
-					    <child>
-					      <object class="GtkLabel" id="sid93">
-						<property name="visible">True</property>
-						<property name="can_focus">False</property>
-						<property name="label" translatable="yes">Merge button events with stylus tip events
+                                            <property name="xalign">0</property>
+                                            <property name="draw-indicator">True</property>
+                                            <child>
+                                              <object class="GtkLabel" id="sid93">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">Merge button events with stylus tip events
 	    &lt;i&gt;(Check this if&lt;/i&gt; "&lt;tt&gt;xsetwacom get *deviceId* TabletPCButton&lt;/tt&gt;" &lt;i&gt;returns&lt;/i&gt; "&lt;tt&gt;on&lt;/tt&gt;"&lt;i&gt;)&lt;/i&gt;</property>
-						<property name="use_markup">True</property>
-						<property name="wrap">True</property>
-						<property name="xalign">0</property>
-					      </object>
-					    </child>
-					  </object>
-					  <packing>
-					    <property name="expand">False</property>
-					    <property name="fill">True</property>
-					    <property name="position">2</property>
-					  </packing>
-					</child>
-				      </object>
-				    </child>
-				  </object>
-				</child>
-				<child type="label">
-				  <object class="GtkLabel" id="sid94">
-				    <property name="visible">True</property>
-				    <property name="can_focus">False</property>
-				    <property name="label" translatable="yes">Options</property>
-				  </object>
-				</child>
-			      </object>
-			      <packing>
-				<property name="expand">False</property>
-				<property name="fill">True</property>
-				<property name="position">2</property>
-			      </packing>
-			    </child>
-			  </object>
-			</child>
-		      </object>
-		    </child>
-		  </object>
-		  <packing>
+                                                <property name="use-markup">True</property>
+                                                <property name="wrap">True</property>
+                                                <property name="xalign">0</property>
+                                              </object>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">2</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label">
+                                  <object class="GtkLabel" id="sid94">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">Options</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">2</property>
+                              </packing>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
                     <property name="expand">True</property>
                     <property name="fill">True</property>
                     <property name="position">0</property>
-		  </packing>
-		</child>
-	      </object>
-	    </child>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="position">1</property>
+              </packing>
+            </child>
             <child type="tab">
               <object class="GtkLabel" id="inputTabLabel">
                 <property name="name">inputTabLabel</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Input System</property>
               </object>
               <packing>
                 <property name="position">1</property>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="mouseTabBox">
                 <property name="name">mouseTabBox</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_left">5</property>
+                <property name="can-focus">False</property>
+                <property name="margin-left">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid17">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="can-focus">True</property>
                     <child>
                       <object class="GtkViewport" id="sid18">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkBox" id="sid19">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="sid20">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.009999999776482582</property>
-                                <property name="margin">12</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid21">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">12</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">12</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid22">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="label23">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;Define which tools will be selected if you press a mouse button. After you release the button the previously selected tool will be selected.&lt;/i&gt;</property>
-                                            <property name="use_markup">True</property>
+                                            <property name="use-markup">True</property>
                                             <property name="wrap">True</property>
-                                            <property name="max_width_chars">85</property>
+                                            <property name="max-width-chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -984,22 +1002,22 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                         <child>
                                           <object class="GtkFrame" id="sid23">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label_xalign">0.009999999776482582</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label-xalign">0.009999999776482582</property>
                                             <child>
                                               <object class="GtkAlignment" id="sid24">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="bottom_padding">8</property>
-                                                <property name="left_padding">12</property>
-                                                <property name="right_padding">12</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="bottom-padding">8</property>
+                                                <property name="left-padding">12</property>
+                                                <property name="right-padding">12</property>
                                                 <child>
                                                   <object class="GtkBox" id="hboxMidleMouse">
                                                     <property name="name">hboxMidleMouse</property>
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <child>
-                                                      <placeholder />
+                                                      <placeholder/>
                                                     </child>
                                                   </object>
                                                 </child>
@@ -1008,7 +1026,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             <child type="label">
                                               <object class="GtkLabel" id="sid25">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">Middle Mouse Button</property>
                                               </object>
                                             </child>
@@ -1022,22 +1040,22 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                         <child>
                                           <object class="GtkFrame" id="sid26">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label_xalign">0.009999999776482582</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label-xalign">0.009999999776482582</property>
                                             <child>
                                               <object class="GtkAlignment" id="sid27">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="bottom_padding">8</property>
-                                                <property name="left_padding">12</property>
-                                                <property name="right_padding">12</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="bottom-padding">8</property>
+                                                <property name="left-padding">12</property>
+                                                <property name="right-padding">12</property>
                                                 <child>
                                                   <object class="GtkBox" id="hboxRightMouse">
                                                     <property name="name">hboxRightMouse</property>
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <child>
-                                                      <placeholder />
+                                                      <placeholder/>
                                                     </child>
                                                   </object>
                                                 </child>
@@ -1046,7 +1064,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             <child type="label">
                                               <object class="GtkLabel" id="sid28">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">Right Mouse Button</property>
                                               </object>
                                             </child>
@@ -1064,7 +1082,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                 <child type="label">
                                   <object class="GtkLabel" id="sid29">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Mouse Buttons</property>
                                   </object>
                                 </child>
@@ -1095,63 +1113,62 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
               <object class="GtkLabel" id="mouseTabLabel">
                 <property name="name">mouseTabLabel</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Mouse</property>
               </object>
               <packing>
                 <property name="position">2</property>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="stylusTabBox">
                 <property name="name">stylusTabBox</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_left">5</property>
+                <property name="can-focus">False</property>
+                <property name="margin-left">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid30">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="min_content_height">450</property>
-		    <property name="min_content_width">500</property>
+                    <property name="can-focus">True</property>
+                    <property name="min-content-width">500</property>
+                    <property name="min-content-height">450</property>
                     <child>
                       <object class="GtkViewport" id="sid31">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkBox" id="sid32">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="sid33">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.009999999776482582</property>
-                                <property name="margin">12</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid34">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid35">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="sid36">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;Pressure Sensitivity allows you to draw lines with different widths, depending on how much pressure you apply to the pen. If your tablet does not support this feature this setting has no effect.&lt;/i&gt;</property>
-                                            <property name="use_markup">True</property>
+                                            <property name="use-markup">True</property>
                                             <property name="wrap">True</property>
-                                            <property name="max_width_chars">85</property>
+                                            <property name="max-width-chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -1165,10 +1182,10 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             <property name="label" translatable="yes">Enable Pressure Sensitivity</property>
                                             <property name="name">cbSettingPresureSensitivity</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -1183,7 +1200,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                 <child type="label">
                                   <object class="GtkLabel" id="sid37">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Pressure Sensitivity</property>
                                   </object>
                                 </child>
@@ -1197,29 +1214,28 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                             <child>
                               <object class="GtkFrame" id="sid183">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.009999999776482582</property>
-                                <property name="margin">12</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid184">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid185">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="sid186">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;With some setup, pen strokes have artifacts at their beginning. This can be avoided by ignoring the first few events/stroke-points when the pen touches the screen.&lt;/i&gt;</property>
-                                            <property name="use_markup">True</property>
+                                            <property name="use-markup">True</property>
                                             <property name="wrap">True</property>
-                                            <property name="max_width_chars">85</property>
+                                            <property name="max-width-chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -1231,16 +1247,16 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                         <child>
                                           <object class="GtkBox" id="sid187">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <child>
                                               <object class="GtkCheckButton" id="cbIgnoreFirstStylusEvents">
                                                 <property name="label" translatable="yes">Ignore the first</property>
                                                 <property name="name">cbSettingIgnoreFirstStylusEvents</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="receives_default">False</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">False</property>
                                                 <property name="xalign">0</property>
-                                                <property name="draw_indicator">True</property>
+                                                <property name="draw-indicator">True</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
@@ -1252,7 +1268,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                               <object class="GtkSpinButton" id="spNumIgnoredStylusEvents">
                                                 <property name="name">spNrOfIgnoredFirstStylusEvents</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
+                                                <property name="can-focus">True</property>
                                                 <property name="text" translatable="yes">1</property>
                                                 <property name="adjustment">adjustmentIgnoreStylusEvents</property>
                                                 <property name="value">1</property>
@@ -1268,7 +1284,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                               <object class="GtkLabel" id="lbIgnoreFirstStylusEvents">
                                                 <property name="name">lbIgnoreFirstStylusEvents</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">events</property>
                                               </object>
                                               <packing>
@@ -1291,7 +1307,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                 <child type="label">
                                   <object class="GtkLabel" id="sid188">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Artifact workaround</property>
                                   </object>
                                 </child>
@@ -1305,29 +1321,28 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                             <child>
                               <object class="GtkFrame" id="sid38">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.009999999776482582</property>
-                                <property name="margin">12</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid39">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">12</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">12</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid40">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="sid41">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;Specify the tools that will be selected if a button of the stylus is pressed or the eraser is used. After releasing the button, the previous tool will be selected.&lt;/i&gt;</property>
-                                            <property name="use_markup">True</property>
+                                            <property name="use-markup">True</property>
                                             <property name="wrap">True</property>
-                                            <property name="max_width_chars">85</property>
+                                            <property name="max-width-chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -1339,22 +1354,22 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                         <child>
                                           <object class="GtkFrame" id="sid42">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label_xalign">0.009999999776482582</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label-xalign">0.009999999776482582</property>
                                             <child>
                                               <object class="GtkAlignment" id="sid43">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="bottom_padding">8</property>
-                                                <property name="left_padding">12</property>
-                                                <property name="right_padding">12</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="bottom-padding">8</property>
+                                                <property name="left-padding">12</property>
+                                                <property name="right-padding">12</property>
                                                 <child>
                                                   <object class="GtkBox" id="hboxPenButton1">
                                                     <property name="name">hboxPenButton1</property>
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <child>
-                                                      <placeholder />
+                                                      <placeholder/>
                                                     </child>
                                                   </object>
                                                 </child>
@@ -1363,7 +1378,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             <child type="label">
                                               <object class="GtkLabel" id="sid44">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">Button 1</property>
                                               </object>
                                             </child>
@@ -1377,22 +1392,22 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                         <child>
                                           <object class="GtkFrame" id="sid45">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label_xalign">0.009999999776482582</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label-xalign">0.009999999776482582</property>
                                             <child>
                                               <object class="GtkAlignment" id="sid46">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="bottom_padding">8</property>
-                                                <property name="left_padding">12</property>
-                                                <property name="right_padding">12</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="bottom-padding">8</property>
+                                                <property name="left-padding">12</property>
+                                                <property name="right-padding">12</property>
                                                 <child>
                                                   <object class="GtkBox" id="hboxPenButton2">
                                                     <property name="name">hboxPenButton2</property>
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <child>
-                                                      <placeholder />
+                                                      <placeholder/>
                                                     </child>
                                                   </object>
                                                 </child>
@@ -1401,7 +1416,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             <child type="label">
                                               <object class="GtkLabel" id="sid47">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">Button 2</property>
                                               </object>
                                             </child>
@@ -1415,22 +1430,22 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                         <child>
                                           <object class="GtkFrame" id="sid48">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label_xalign">0.009999999776482582</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label-xalign">0.009999999776482582</property>
                                             <child>
                                               <object class="GtkAlignment" id="sid49">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="bottom_padding">8</property>
-                                                <property name="left_padding">12</property>
-                                                <property name="right_padding">12</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="bottom-padding">8</property>
+                                                <property name="left-padding">12</property>
+                                                <property name="right-padding">12</property>
                                                 <child>
                                                   <object class="GtkBox" id="hboxEraser">
                                                     <property name="name">hboxEraser</property>
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <child>
-                                                      <placeholder />
+                                                      <placeholder/>
                                                     </child>
                                                   </object>
                                                 </child>
@@ -1439,7 +1454,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             <child type="label">
                                               <object class="GtkLabel" id="sid50">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">Eraser</property>
                                               </object>
                                             </child>
@@ -1457,7 +1472,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                 <child type="label">
                                   <object class="GtkLabel" id="sid51">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Stylus Buttons</property>
                                   </object>
                                 </child>
@@ -1488,63 +1503,62 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
               <object class="GtkLabel" id="stylusTabLabel">
                 <property name="name">stylusTabLabel</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Stylus</property>
               </object>
               <packing>
                 <property name="position">3</property>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="touchTabBox">
                 <property name="name">touchTabBox</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_left">5</property>
+                <property name="can-focus">False</property>
+                <property name="margin-left">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid52">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="min_content_height">450</property>
-		    <property name="min_content_width">500</property>
+                    <property name="can-focus">True</property>
+                    <property name="min-content-width">500</property>
+                    <property name="min-content-height">450</property>
                     <child>
                       <object class="GtkViewport" id="sid53">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkBox" id="sid54">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="sid55">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.009999999776482582</property>
-                                <property name="margin">12</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid56">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid57">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="sid58">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;You can configure devices, not identified by GTK as touchscreen, to behave as if they were one.&lt;/i&gt;</property>
-                                            <property name="use_markup">True</property>
+                                            <property name="use-markup">True</property>
                                             <property name="wrap">True</property>
-                                            <property name="max_width_chars">85</property>
+                                            <property name="max-width-chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -1557,9 +1571,9 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                           <object class="GtkBox" id="hboxTouch">
                                             <property name="name">hboxTouch</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <child>
-                                              <placeholder />
+                                              <placeholder/>
                                             </child>
                                           </object>
                                           <packing>
@@ -1575,7 +1589,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                 <child type="label">
                                   <object class="GtkLabel" id="sid59">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Touchscreen</property>
                                   </object>
                                 </child>
@@ -1589,29 +1603,28 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                             <child>
                               <object class="GtkFrame" id="sid60">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.009999999776482582</property>
-                                <property name="margin">12</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid61">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid62">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="sid63">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;If your hardware does not support hand recognition, Xournal++ can disable your touchscreen when your pen is near the screen.&lt;/i&gt;</property>
-                                            <property name="use_markup">True</property>
+                                            <property name="use-markup">True</property>
                                             <property name="wrap">True</property>
-                                            <property name="max_width_chars">85</property>
+                                            <property name="max-width-chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -1625,10 +1638,10 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             <property name="label" translatable="yes">Enable internal Hand Recognition</property>
                                             <property name="name">cbDisableTouchOnPenNear</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -1640,42 +1653,43 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                           <object class="GtkBox" id="boxInternalHandRecognition">
                                             <property name="name">boxInternalHandRecognition</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="orientation">vertical</property>
                                             <child>
+                                              <!-- n-columns=3 n-rows=3 -->
                                               <object class="GtkGrid" id="sid64">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="row_spacing">5</property>
-                                                <property name="column_spacing">5</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="row-spacing">5</property>
+                                                <property name="column-spacing">5</property>
                                                 <child>
                                                   <object class="GtkLabel" id="label50">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="label" translatable="yes">Disabling Method</property>
                                                   </object>
                                                   <packing>
-                                                    <property name="left_attach">0</property>
-                                                    <property name="top_attach">0</property>
+                                                    <property name="left-attach">0</property>
+                                                    <property name="top-attach">0</property>
                                                   </packing>
                                                 </child>
                                                 <child>
                                                   <object class="GtkLabel" id="label55">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="label" translatable="yes">Timeout</property>
                                                     <property name="xalign">0</property>
                                                   </object>
                                                   <packing>
-                                                    <property name="left_attach">0</property>
-                                                    <property name="top_attach">1</property>
+                                                    <property name="left-attach">0</property>
+                                                    <property name="top-attach">1</property>
                                                   </packing>
                                                 </child>
                                                 <child>
                                                   <object class="GtkComboBoxText" id="cbTouchDisableMethod">
                                                     <property name="name">cbTouchDisableMethod</property>
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="active">0</property>
                                                     <items>
                                                       <item translatable="yes">Autodetect</item>
@@ -1684,40 +1698,49 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                                     </items>
                                                   </object>
                                                   <packing>
-                                                    <property name="left_attach">1</property>
-                                                    <property name="top_attach">0</property>
+                                                    <property name="left-attach">1</property>
+                                                    <property name="top-attach">0</property>
                                                   </packing>
                                                 </child>
                                                 <child>
                                                   <object class="GtkSpinButton" id="spTouchDisableTimeout">
                                                     <property name="name">spTouchDisableTimeout</property>
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">True</property>
+                                                    <property name="can-focus">True</property>
                                                     <property name="adjustment">adjustmentTouchTImeout</property>
-                                                    <property name="climb_rate">0.5</property>
+                                                    <property name="climb-rate">0.5</property>
                                                     <property name="digits">1</property>
                                                     <property name="value">1</property>
                                                   </object>
                                                   <packing>
-                                                    <property name="left_attach">1</property>
-                                                    <property name="top_attach">1</property>
+                                                    <property name="left-attach">1</property>
+                                                    <property name="top-attach">1</property>
                                                   </packing>
                                                 </child>
                                                 <child>
                                                   <object class="GtkLabel" id="label56">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="label" translatable="yes">s &lt;i&gt;(after which the touchscreen will be reactivated again)&lt;/i&gt;</property>
-                                                    <property name="use_markup">True</property>
+                                                    <property name="use-markup">True</property>
                                                     <property name="xalign">0</property>
                                                   </object>
                                                   <packing>
-                                                    <property name="left_attach">2</property>
-                                                    <property name="top_attach">1</property>
+                                                    <property name="left-attach">2</property>
+                                                    <property name="top-attach">1</property>
                                                   </packing>
                                                 </child>
                                                 <child>
-                                                  <placeholder />
+                                                  <placeholder/>
+                                                </child>
+                                                <child>
+                                                  <placeholder/>
+                                                </child>
+                                                <child>
+                                                  <placeholder/>
+                                                </child>
+                                                <child>
+                                                  <placeholder/>
                                                 </child>
                                               </object>
                                               <packing>
@@ -1730,28 +1753,28 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                               <object class="GtkFrame" id="boxCustomTouchDisableSettings">
                                                 <property name="name">boxCustomTouchDisableSettings</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="label_xalign">0.009999999776482582</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label-xalign">0.009999999776482582</property>
                                                 <child>
                                                   <object class="GtkAlignment" id="sid65">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
-                                                    <property name="bottom_padding">8</property>
-                                                    <property name="left_padding">12</property>
-                                                    <property name="right_padding">12</property>
+                                                    <property name="can-focus">False</property>
+                                                    <property name="bottom-padding">8</property>
+                                                    <property name="left-padding">12</property>
+                                                    <property name="right-padding">12</property>
                                                     <child>
                                                       <object class="GtkBox" id="sid66">
                                                         <property name="visible">True</property>
-                                                        <property name="can_focus">False</property>
+                                                        <property name="can-focus">False</property>
                                                         <property name="orientation">vertical</property>
                                                         <child>
                                                           <object class="GtkLabel" id="label54">
                                                             <property name="visible">True</property>
-                                                            <property name="can_focus">False</property>
+                                                            <property name="can-focus">False</property>
                                                             <property name="label" translatable="yes">&lt;i&gt;Specify commands that are called once Hand Recognition triggers. The commands will be executed in the UI Thread, make sure they are not blocking!&lt;/i&gt;</property>
-                                                            <property name="use_markup">True</property>
+                                                            <property name="use-markup">True</property>
                                                             <property name="wrap">True</property>
-                                                            <property name="max_width_chars">85</property>
+                                                            <property name="max-width-chars">85</property>
                                                             <property name="xalign">0</property>
                                                           </object>
                                                           <packing>
@@ -1761,83 +1784,93 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                                           </packing>
                                                         </child>
                                                         <child>
+                                                          <!-- n-columns=3 n-rows=3 -->
                                                           <object class="GtkGrid" id="grid3">
                                                             <property name="visible">True</property>
-                                                            <property name="can_focus">False</property>
-                                                            <property name="row_spacing">5</property>
-                                                            <property name="column_spacing">5</property>
+                                                            <property name="can-focus">False</property>
+                                                            <property name="row-spacing">5</property>
+                                                            <property name="column-spacing">5</property>
                                                             <child>
-                                                              <object class="GtkLabel" id="label52">
-                                                                <property name="visible">True</property>
-                                                                <property name="can_focus">False</property>
-                                                                <property name="label" translatable="yes">Enable</property>
-                                                                <property name="xalign">0</property>
-                                                              </object>
-                                                              <packing>
-                                                                <property name="left_attach">0</property>
-                                                                <property name="top_attach">0</property>
-                                                              </packing>
+                                                            <object class="GtkLabel" id="label52">
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">False</property>
+                                                            <property name="label" translatable="yes">Enable</property>
+                                                            <property name="xalign">0</property>
+                                                            </object>
+                                                            <packing>
+                                                            <property name="left-attach">0</property>
+                                                            <property name="top-attach">0</property>
+                                                            </packing>
                                                             </child>
                                                             <child>
-                                                              <object class="GtkLabel" id="label53">
-                                                                <property name="visible">True</property>
-                                                                <property name="can_focus">False</property>
-                                                                <property name="label" translatable="yes">Disable</property>
-                                                              </object>
-                                                              <packing>
-                                                                <property name="left_attach">0</property>
-                                                                <property name="top_attach">1</property>
-                                                              </packing>
+                                                            <object class="GtkLabel" id="label53">
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">False</property>
+                                                            <property name="label" translatable="yes">Disable</property>
+                                                            </object>
+                                                            <packing>
+                                                            <property name="left-attach">0</property>
+                                                            <property name="top-attach">1</property>
+                                                            </packing>
                                                             </child>
                                                             <child>
-                                                              <object class="GtkEntry" id="txtEnableTouchCommand">
-                                                                <property name="name">txtEnableTouchCommand</property>
-                                                                <property name="visible">True</property>
-                                                                <property name="can_focus">True</property>
-                                                                <property name="hexpand">True</property>
-                                                              </object>
-                                                              <packing>
-                                                                <property name="left_attach">1</property>
-                                                                <property name="top_attach">0</property>
-                                                              </packing>
+                                                            <object class="GtkEntry" id="txtEnableTouchCommand">
+                                                            <property name="name">txtEnableTouchCommand</property>
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">True</property>
+                                                            <property name="hexpand">True</property>
+                                                            </object>
+                                                            <packing>
+                                                            <property name="left-attach">1</property>
+                                                            <property name="top-attach">0</property>
+                                                            </packing>
                                                             </child>
                                                             <child>
-                                                              <object class="GtkEntry" id="txtDisableTouchCommand">
-                                                                <property name="name">txtDisableTouchCommand</property>
-                                                                <property name="visible">True</property>
-                                                                <property name="can_focus">True</property>
-                                                                <property name="hexpand">True</property>
-                                                              </object>
-                                                              <packing>
-                                                                <property name="left_attach">1</property>
-                                                                <property name="top_attach">1</property>
-                                                              </packing>
+                                                            <object class="GtkEntry" id="txtDisableTouchCommand">
+                                                            <property name="name">txtDisableTouchCommand</property>
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">True</property>
+                                                            <property name="hexpand">True</property>
+                                                            </object>
+                                                            <packing>
+                                                            <property name="left-attach">1</property>
+                                                            <property name="top-attach">1</property>
+                                                            </packing>
                                                             </child>
                                                             <child>
-                                                              <object class="GtkButton" id="btTestEnable">
-                                                                <property name="label" translatable="yes">Test</property>
-                                                                <property name="name">btTestEnable</property>
-                                                                <property name="visible">True</property>
-                                                                <property name="can_focus">True</property>
-                                                                <property name="receives_default">True</property>
-                                                              </object>
-                                                              <packing>
-                                                                <property name="left_attach">2</property>
-                                                                <property name="top_attach">0</property>
-                                                              </packing>
+                                                            <object class="GtkButton" id="btTestEnable">
+                                                            <property name="label" translatable="yes">Test</property>
+                                                            <property name="name">btTestEnable</property>
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">True</property>
+                                                            <property name="receives-default">True</property>
+                                                            </object>
+                                                            <packing>
+                                                            <property name="left-attach">2</property>
+                                                            <property name="top-attach">0</property>
+                                                            </packing>
                                                             </child>
                                                             <child>
-                                                              <object class="GtkButton" id="btTestDisable">
-                                                                <property name="label" translatable="yes">Test</property>
-                                                                <property name="name">btTestDisable</property>
-                                                                <property name="visible">True</property>
-                                                                <property name="can_focus">True</property>
-                                                                <property name="receives_default">True</property>
-                                                              </object>
-                                                              <packing>
-                                                                <property name="left_attach">2</property>
-                                                                <property name="top_attach">1</property>
-                                                              </packing>
+                                                            <object class="GtkButton" id="btTestDisable">
+                                                            <property name="label" translatable="yes">Test</property>
+                                                            <property name="name">btTestDisable</property>
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">True</property>
+                                                            <property name="receives-default">True</property>
+                                                            </object>
+                                                            <packing>
+                                                            <property name="left-attach">2</property>
+                                                            <property name="top-attach">1</property>
+                                                            </packing>
+                                                            </child>
+                                                            <child>
+                                                            <placeholder/>
+                                                            </child>
+                                                            <child>
+                                                            <placeholder/>
+                                                            </child>
+                                                            <child>
+                                                            <placeholder/>
                                                             </child>
                                                           </object>
                                                           <packing>
@@ -1853,7 +1886,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                                 <child type="label">
                                                   <object class="GtkLabel" id="sid67">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="label" translatable="yes">Custom Commands (for Method "Custom")</property>
                                                   </object>
                                                 </child>
@@ -1878,7 +1911,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                 <child type="label">
                                   <object class="GtkLabel" id="sid68">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Hand Recognition</property>
                                   </object>
                                 </child>
@@ -1892,27 +1925,26 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                             <child>
                               <object class="GtkFrame" id="sid69">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.009999999776482582</property>
-                                <property name="margin">12</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid70">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid71">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="sid72">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;Use pinch gestures to zoom journal pages.&lt;/i&gt;</property>
-                                            <property name="use_markup">True</property>
+                                            <property name="use-markup">True</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -1926,10 +1958,10 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             <property name="label" translatable="yes">Enable zoom gestures (requires restart)</property>
                                             <property name="name">cbEnableZoomGestures</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -1944,7 +1976,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                 <child type="label">
                                   <object class="GtkLabel" id="sid73">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Zoom Gestures</property>
                                   </object>
                                 </child>
@@ -1958,30 +1990,29 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                             <child>
                               <object class="GtkFrame" id="sid74">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.009999999776482582</property>
-                                <property name="margin">12</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid75">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid76">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="sid77">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;For some specific hardware the scroll / touch behaviour of the system is not as expected. For these cases Xournal++ has a workaround.
 This also enables touch drawing.&lt;/i&gt;</property>
-                                            <property name="use_markup">True</property>
+                                            <property name="use-markup">True</property>
                                             <property name="wrap">True</property>
-                                            <property name="max_width_chars">85</property>
+                                            <property name="max-width-chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -1995,10 +2026,10 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                             <property name="label" translatable="yes">Enable GTK Touch / Scrolling workaround  (requires restart)</property>
                                             <property name="name">cbTouchWorkaround</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -2013,7 +2044,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid78">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Workaround</property>
                                   </object>
                                 </child>
@@ -2044,69 +2075,68 @@ This also enables touch drawing.&lt;/i&gt;</property>
               <object class="GtkLabel" id="touchTabLabel">
                 <property name="name">touchTabLabel</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Touchscreen</property>
               </object>
               <packing>
                 <property name="position">4</property>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="viewTabBox">
                 <property name="name">viewTabBox</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_left">5</property>
+                <property name="can-focus">False</property>
+                <property name="margin-left">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid95">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="min_content_height">450</property>
-		    <property name="min_content_width">500</property>
+                    <property name="can-focus">True</property>
+                    <property name="min-content-width">500</property>
+                    <property name="min-content-height">450</property>
                     <child>
                       <object class="GtkViewport" id="sid96">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkBox" id="sid97">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="sid98">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.009999999776482582</property>
-                                <property name="margin">12</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid99">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">12</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">12</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid100">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkBox" id="vbox6">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="halign">start</property>
                                             <child>
                                               <object class="GtkCheckButton" id="cbHideMenubarStartup">
                                                 <property name="label" translatable="yes">Show Menubar on Startup</property>
                                                 <property name="name">cbHideMenubarStartup</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="receives_default">False</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">False</property>
                                                 <property name="xalign">0</property>
-                                                <property name="draw_indicator">True</property>
+                                                <property name="draw-indicator">True</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
@@ -2117,10 +2147,10 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                             <child>
                                               <object class="GtkLabel" id="sid101">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="margin_left">5</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="margin-left">5</property>
                                                 <property name="label" translatable="yes">&lt;i&gt;Toggle visibility of menubar with F10&lt;/i&gt;</property>
-                                                <property name="use_markup">True</property>
+                                                <property name="use-markup">True</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
@@ -2139,94 +2169,95 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                           <object class="GtkFrame" id="colorsFrame">
                                             <property name="name">colorsFrame</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label_xalign">0.009999999776482582</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label-xalign">0.009999999776482582</property>
                                             <child>
                                               <object class="GtkAlignment" id="sid102">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="bottom_padding">8</property>
-                                                <property name="left_padding">12</property>
-                                                <property name="right_padding">12</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="bottom-padding">8</property>
+                                                <property name="left-padding">12</property>
+                                                <property name="right-padding">12</property>
                                                 <child>
+                                                  <!-- n-columns=3 n-rows=4 -->
                                                   <object class="GtkGrid" id="grid2">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <child>
                                                       <object class="GtkLabel" id="label10">
                                                         <property name="visible">True</property>
-                                                        <property name="can_focus">False</property>
+                                                        <property name="can-focus">False</property>
                                                         <property name="hexpand">True</property>
                                                         <property name="label" translatable="yes">Border color for current page and other selections</property>
                                                         <property name="justify">right</property>
                                                         <property name="xalign">0</property>
                                                       </object>
                                                       <packing>
-                                                        <property name="left_attach">0</property>
-                                                        <property name="top_attach">0</property>
+                                                        <property name="left-attach">0</property>
+                                                        <property name="top-attach">0</property>
                                                       </packing>
                                                     </child>
                                                     <child>
                                                       <object class="GtkColorButton" id="colorBorder">
                                                         <property name="name">colorBorder</property>
                                                         <property name="visible">True</property>
-                                                        <property name="can_focus">True</property>
-                                                        <property name="receives_default">True</property>
+                                                        <property name="can-focus">True</property>
+                                                        <property name="receives-default">True</property>
                                                         <property name="title" translatable="yes">Border color</property>
                                                       </object>
                                                       <packing>
-                                                        <property name="left_attach">1</property>
-                                                        <property name="top_attach">0</property>
+                                                        <property name="left-attach">1</property>
+                                                        <property name="top-attach">0</property>
                                                       </packing>
                                                     </child>
                                                     <child>
                                                       <object class="GtkLabel" id="label13">
                                                         <property name="visible">True</property>
-                                                        <property name="can_focus">False</property>
+                                                        <property name="can-focus">False</property>
                                                         <property name="label" translatable="yes">Background color between pages</property>
                                                         <property name="xalign">0</property>
                                                       </object>
                                                       <packing>
-                                                        <property name="left_attach">0</property>
-                                                        <property name="top_attach">1</property>
+                                                        <property name="left-attach">0</property>
+                                                        <property name="top-attach">1</property>
                                                       </packing>
                                                     </child>
                                                     <child>
                                                       <object class="GtkColorButton" id="colorBackground">
                                                         <property name="name">colorBackground</property>
                                                         <property name="visible">True</property>
-                                                        <property name="can_focus">True</property>
-                                                        <property name="receives_default">True</property>
-                                                        <property name="margin_top">5</property>
+                                                        <property name="can-focus">True</property>
+                                                        <property name="receives-default">True</property>
+                                                        <property name="margin-top">5</property>
                                                       </object>
                                                       <packing>
-                                                        <property name="left_attach">1</property>
-                                                        <property name="top_attach">1</property>
+                                                        <property name="left-attach">1</property>
+                                                        <property name="top-attach">1</property>
                                                       </packing>
                                                     </child>
                                                     <child>
                                                       <object class="GtkLabel" id="label57">
                                                         <property name="visible">True</property>
-                                                        <property name="can_focus">False</property>
+                                                        <property name="can-focus">False</property>
                                                         <property name="label" translatable="yes">Selection Color (Text, Stroke Selection etc.)</property>
                                                         <property name="xalign">0</property>
                                                       </object>
                                                       <packing>
-                                                        <property name="left_attach">0</property>
-                                                        <property name="top_attach">2</property>
+                                                        <property name="left-attach">0</property>
+                                                        <property name="top-attach">2</property>
                                                       </packing>
                                                     </child>
                                                     <child>
                                                       <object class="GtkColorButton" id="colorSelection">
                                                         <property name="name">colorSelection</property>
                                                         <property name="visible">True</property>
-                                                        <property name="can_focus">True</property>
-                                                        <property name="receives_default">True</property>
-                                                        <property name="margin_top">5</property>
+                                                        <property name="can-focus">True</property>
+                                                        <property name="receives-default">True</property>
+                                                        <property name="margin-top">5</property>
                                                       </object>
                                                       <packing>
-                                                        <property name="left_attach">1</property>
-                                                        <property name="top_attach">2</property>
+                                                        <property name="left-attach">1</property>
+                                                        <property name="top-attach">2</property>
                                                       </packing>
                                                     </child>
                                                     <child>
@@ -2234,16 +2265,28 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                                         <property name="label" translatable="yes">Dark Theme (requires restart)</property>
                                                         <property name="name">cbDarkTheme</property>
                                                         <property name="visible">True</property>
-                                                        <property name="can_focus">True</property>
-                                                        <property name="receives_default">False</property>
+                                                        <property name="can-focus">True</property>
+                                                        <property name="receives-default">False</property>
                                                         <property name="xalign">0</property>
-                                                        <property name="draw_indicator">True</property>
+                                                        <property name="draw-indicator">True</property>
                                                       </object>
                                                       <packing>
-                                                        <property name="left_attach">0</property>
-                                                        <property name="top_attach">3</property>
+                                                        <property name="left-attach">0</property>
+                                                        <property name="top-attach">3</property>
                                                         <property name="width">2</property>
                                                       </packing>
+                                                    </child>
+                                                    <child>
+                                                      <placeholder/>
+                                                    </child>
+                                                    <child>
+                                                      <placeholder/>
+                                                    </child>
+                                                    <child>
+                                                      <placeholder/>
+                                                    </child>
+                                                    <child>
+                                                      <placeholder/>
                                                     </child>
                                                   </object>
                                                 </child>
@@ -2252,7 +2295,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                             <child type="label">
                                               <object class="GtkLabel" id="sid103">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">Colors</property>
                                               </object>
                                             </child>
@@ -2270,9 +2313,9 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid104">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Global</property>
-                                    <property name="use_markup">True</property>
+                                    <property name="use-markup">True</property>
                                   </object>
                                 </child>
                               </object>
@@ -2285,30 +2328,29 @@ This also enables touch drawing.&lt;/i&gt;</property>
                             <child>
                               <object class="GtkFrame" id="sid105">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.009999999776482582</property>
-                                <property name="margin">12</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid106">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="vbox15">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkBox">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="spacing">5</property>
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">Cursor icon for pen</property>
                                                 <property name="xalign">0</property>
                                               </object>
@@ -2322,7 +2364,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                               <object class="GtkComboBoxText" id="cbStylusCursorType">
                                                 <property name="name">cbStylusCursorType</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="active">0</property>
                                                 <items>
                                                   <item id="none" translatable="yes" context="stylus cursor uses no icon">No icon</item>
@@ -2344,210 +2386,220 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                           </packing>
                                         </child>
                                         <child>
+                                          <!-- n-columns=3 n-rows=3 -->
                                           <object class="GtkGrid" id="highlightCursorGrid">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="column_homogeneous">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="column-homogeneous">True</property>
                                             <child>
                                               <object class="GtkCheckButton" id="cbHighlightPosition">
                                                 <property name="label" translatable="yes">Highlight cursor position</property>
                                                 <property name="name">cbHighlightPosition</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="receives_default">False</property>
-                                                <property name="tooltip_text" translatable="yes">Draw a transparent circle around the cursor</property>
-                                                <property name="draw_indicator">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">False</property>
+                                                <property name="tooltip-text" translatable="yes">Draw a transparent circle around the cursor</property>
+                                                <property name="draw-indicator">True</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">0</property>
-                                                <property name="top_attach">0</property>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkBox">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <child>
                                                   <object class="GtkColorButton" id="cursorHighlightColor">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">True</property>
-                                                    <property name="receives_default">True</property>
-                                                    <property name="use_alpha">True</property>
+                                                    <property name="can-focus">True</property>
+                                                    <property name="receives-default">True</property>
+                                                    <property name="use-alpha">True</property>
                                                     <property name="title" translatable="yes">Choose the color to use for "Highlight cursor position"</property>
-                                                    <property name="show_editor">True</property>
+                                                    <property name="show-editor">True</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
                                                     <property name="fill">True</property>
-                                                    <property name="pack_type">end</property>
+                                                    <property name="pack-type">end</property>
                                                     <property name="position">0</property>
                                                   </packing>
                                                 </child>
                                                 <child>
                                                   <object class="GtkLabel">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="label" translatable="yes">Circle Color</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
                                                     <property name="fill">True</property>
                                                     <property name="padding">10</property>
-                                                    <property name="pack_type">end</property>
+                                                    <property name="pack-type">end</property>
                                                     <property name="position">1</property>
                                                   </packing>
                                                 </child>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">1</property>
-                                                <property name="top_attach">1</property>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">1</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkBox">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <child>
                                                   <object class="GtkLabel">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="label" translatable="yes">pixels</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
                                                     <property name="fill">True</property>
-                                                    <property name="pack_type">end</property>
+                                                    <property name="pack-type">end</property>
                                                     <property name="position">0</property>
                                                   </packing>
                                                 </child>
                                                 <child>
                                                   <object class="GtkSpinButton" id="cursorHighlightRadius">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">True</property>
-                                                    <property name="input_purpose">number</property>
+                                                    <property name="can-focus">True</property>
+                                                    <property name="input-purpose">number</property>
                                                     <property name="adjustment">adjustmentCursorHighlightRadius</property>
                                                     <property name="numeric">True</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
                                                     <property name="fill">True</property>
-                                                    <property name="pack_type">end</property>
+                                                    <property name="pack-type">end</property>
                                                     <property name="position">1</property>
                                                   </packing>
                                                 </child>
                                                 <child>
                                                   <object class="GtkLabel">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="label" translatable="yes">Radius</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
                                                     <property name="fill">True</property>
-                                                    <property name="pack_type">end</property>
+                                                    <property name="pack-type">end</property>
                                                     <property name="position">3</property>
                                                   </packing>
                                                 </child>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">0</property>
-                                                <property name="top_attach">1</property>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">1</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkBox">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <child>
                                                   <object class="GtkLabel">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="label" translatable="yes">pixels</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
                                                     <property name="fill">True</property>
-                                                    <property name="pack_type">end</property>
+                                                    <property name="pack-type">end</property>
                                                     <property name="position">0</property>
                                                   </packing>
                                                 </child>
                                                 <child>
                                                   <object class="GtkSpinButton" id="cursorHighlightBorderWidth">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">True</property>
+                                                    <property name="can-focus">True</property>
                                                     <property name="text" translatable="yes">30</property>
-                                                    <property name="input_purpose">number</property>
+                                                    <property name="input-purpose">number</property>
                                                     <property name="adjustment">adjustmentCursorHighlightBorderWidth</property>
                                                     <property name="numeric">True</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
                                                     <property name="fill">True</property>
-                                                    <property name="pack_type">end</property>
+                                                    <property name="pack-type">end</property>
                                                     <property name="position">1</property>
                                                   </packing>
                                                 </child>
                                                 <child>
                                                   <object class="GtkLabel">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="label" translatable="yes">Border Width</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
                                                     <property name="fill">True</property>
-                                                    <property name="pack_type">end</property>
+                                                    <property name="pack-type">end</property>
                                                     <property name="position">3</property>
                                                   </packing>
                                                 </child>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">0</property>
-                                                <property name="top_attach">2</property>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">2</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkBox">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <child>
                                                   <object class="GtkColorButton" id="cursorHighlightBorderColor">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">True</property>
-                                                    <property name="receives_default">True</property>
-                                                    <property name="use_alpha">True</property>
+                                                    <property name="can-focus">True</property>
+                                                    <property name="receives-default">True</property>
+                                                    <property name="use-alpha">True</property>
                                                     <property name="title" translatable="yes">Choose the color to use for "Highlight cursor position"</property>
-                                                    <property name="show_editor">True</property>
+                                                    <property name="show-editor">True</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
                                                     <property name="fill">True</property>
-                                                    <property name="pack_type">end</property>
+                                                    <property name="pack-type">end</property>
                                                     <property name="position">0</property>
                                                   </packing>
                                                 </child>
                                                 <child>
                                                   <object class="GtkLabel">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="label" translatable="yes">Border Color</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
                                                     <property name="fill">True</property>
                                                     <property name="padding">10</property>
-                                                    <property name="pack_type">end</property>
+                                                    <property name="pack-type">end</property>
                                                     <property name="position">1</property>
                                                   </packing>
                                                 </child>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">1</property>
-                                                <property name="top_attach">2</property>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">2</property>
                                               </packing>
                                             </child>
                                             <child>
-                                              <placeholder />
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
                                             </child>
                                           </object>
                                           <packing>
@@ -2563,7 +2615,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid107">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Cursor</property>
                                   </object>
                                 </child>
@@ -2577,30 +2629,29 @@ This also enables touch drawing.&lt;/i&gt;</property>
                             <child>
                               <object class="GtkFrame" id="sid108">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.009999999776482582</property>
-                                <property name="margin">12</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid109">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="box19">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkCheckButton" id="cbShowSidebarRight">
                                             <property name="label" translatable="yes">Show sidebar on the right side</property>
                                             <property name="name">cbShowSidebarRight</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -2613,10 +2664,10 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                             <property name="label" translatable="yes">Show vertical scrollbar on the left side</property>
                                             <property name="name">cbShowScrollbarLeft</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -2631,7 +2682,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid110">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Left / Right-Handed</property>
                                   </object>
                                 </child>
@@ -2645,29 +2696,28 @@ This also enables touch drawing.&lt;/i&gt;</property>
                             <child>
                               <object class="GtkFrame" id="sid111">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.009999999776482582</property>
-                                <property name="margin">12</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid112">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="box42">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkCheckButton" id="cbHideHorizontalScrollbar">
                                             <property name="label" translatable="yes">Hide the horizontal scrollbar</property>
                                             <property name="name">cbHideHorizontalScrollbar</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -2680,9 +2730,9 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                             <property name="label" translatable="yes">Hide the vertical scrollbar</property>
                                             <property name="name">cbHideVerticalScrollbar</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -2694,9 +2744,9 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                           <object class="GtkCheckButton" id="cbDisableScrollbarFadeout">
                                             <property name="label" translatable="yes">Disable scrollbar fade out</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -2711,7 +2761,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid113">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Scrollbars</property>
                                   </object>
                                 </child>
@@ -2725,30 +2775,29 @@ This also enables touch drawing.&lt;/i&gt;</property>
                             <child>
                               <object class="GtkFrame" id="sid114">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.009999999776482582</property>
-                                <property name="margin">12</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid115">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="vbox9">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkCheckButton" id="cbHideFullscreenMenubar">
                                             <property name="label" translatable="yes">Hide Menubar</property>
                                             <property name="name">cbHideFullscreenMenubar</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -2761,10 +2810,10 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                             <property name="label" translatable="yes">Hide Sidebar</property>
                                             <property name="name">cbHideFullscreenSidebar</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -2779,7 +2828,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid116">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Fullscreen</property>
                                   </object>
                                 </child>
@@ -2793,30 +2842,29 @@ This also enables touch drawing.&lt;/i&gt;</property>
                             <child>
                               <object class="GtkFrame" id="sid117">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.009999999776482582</property>
-                                <property name="margin">12</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid118">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="vbox1">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkCheckButton" id="cbHidePresentationMenubar">
                                             <property name="label" translatable="yes">Hide Menubar</property>
                                             <property name="name">cbHidePresentationMenubar</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -2829,10 +2877,10 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                             <property name="label" translatable="yes">Hide Sidebar</property>
                                             <property name="name">cbHidePresentationSidebar</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -2842,11 +2890,11 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                         </child>
                                         <child>
                                           <object class="GtkBox" id="box8">
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <child>
                                               <object class="GtkLabel" id="label16">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">Select toolbar:</property>
                                               </object>
                                               <packing>
@@ -2859,7 +2907,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                               <object class="GtkComboBoxText" id="comboboxtext1">
                                                 <property name="name">comboboxtext1</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
@@ -2881,7 +2929,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid119">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Presentation Mode</property>
                                   </object>
                                 </child>
@@ -2912,133 +2960,142 @@ This also enables touch drawing.&lt;/i&gt;</property>
               <object class="GtkLabel" id="viewTabLabel">
                 <property name="name">viewTabLabel</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">View</property>
               </object>
               <packing>
                 <property name="position">5</property>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="zoomTabBox">
                 <property name="name">zoomTabBox</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_left">5</property>
+                <property name="can-focus">False</property>
+                <property name="margin-left">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid120">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="min_content_height">450</property>
-		    <property name="min_content_width">500</property>
+                    <property name="can-focus">True</property>
+                    <property name="min-content-width">500</property>
+                    <property name="min-content-height">450</property>
                     <child>
                       <object class="GtkViewport" id="sid121">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkBox" id="sid122">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="sid123">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.009999999776482582</property>
-                                <property name="margin">12</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid124">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
+                                      <!-- n-columns=3 n-rows=3 -->
                                       <object class="GtkGrid" id="sid125">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="column_spacing">5</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="column-spacing">5</property>
                                         <child>
                                           <object class="GtkLabel" id="settingZoomCtrlScrollSpeedLabel">
                                             <property name="name">settingZoomCtrlScrollSpeedLabel</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">Speed for Ctrl + Scroll</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">0</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="spZoomStepScroll">
                                             <property name="name">spZoomStepScroll</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
+                                            <property name="can-focus">True</property>
                                             <property name="adjustment">adjustmentZoomStepScroll</property>
                                             <property name="digits">1</property>
                                             <property name="numeric">True</property>
                                             <property name="value">2</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="settingZoomStepSpeedLabel">
                                             <property name="name">settingZoomStepSpeedLabel</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">Speed for a Zoomstep</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">0</property>
-                                            <property name="top_attach">1</property>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">1</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="spZoomStep">
                                             <property name="name">spZoomStep</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="margin_top">5</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="margin-top">5</property>
                                             <property name="adjustment">adjustmentZoomStep</property>
                                             <property name="digits">1</property>
                                             <property name="numeric">True</property>
                                             <property name="value">10</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">1</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">1</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="sid126">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">%</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">2</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">2</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="sid127">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">%</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">2</property>
-                                            <property name="top_attach">1</property>
+                                            <property name="left-attach">2</property>
+                                            <property name="top-attach">1</property>
                                           </packing>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
                                         </child>
                                       </object>
                                     </child>
@@ -3047,7 +3104,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid128">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Zoom Speed</property>
                                   </object>
                                 </child>
@@ -3061,28 +3118,27 @@ This also enables touch drawing.&lt;/i&gt;</property>
                             <child>
                               <object class="GtkFrame" id="sid129">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.009999999776482582</property>
-                                <property name="margin">12</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid130">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid131">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="sid132">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;To make sure on 100% zoom the size of elements is natural. (requires restart)&lt;/i&gt;</property>
-                                            <property name="use_markup">True</property>
-                                            <property name="max_width_chars">85</property>
+                                            <property name="use-markup">True</property>
+                                            <property name="max-width-chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -3094,16 +3150,16 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                         <child>
                                           <object class="GtkBox" id="box5">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="orientation">vertical</property>
                                             <child>
                                               <object class="GtkLabel" id="label21">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="margin_top">5</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="margin-top">5</property>
                                                 <property name="label" translatable="yes">&lt;i&gt;Put a ruler on your screen and move the slider until both rulers match.&lt;/i&gt;</property>
-                                                <property name="use_markup">True</property>
-                                                <property name="max_width_chars">85</property>
+                                                <property name="use-markup">True</property>
+                                                <property name="max-width-chars">85</property>
                                                 <property name="xalign">0</property>
                                               </object>
                                               <packing>
@@ -3116,11 +3172,11 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                               <object class="GtkScale" id="zoomCallibSlider">
                                                 <property name="name">zoomCallibSlider</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="margin_top">10</property>
-                                                <property name="margin_bottom">20</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="margin-top">10</property>
+                                                <property name="margin-bottom">20</property>
                                                 <property name="adjustment">adjustmentZoom</property>
-                                                <property name="round_digits">0</property>
+                                                <property name="round-digits">0</property>
                                                 <property name="digits">0</property>
                                               </object>
                                               <packing>
@@ -3133,10 +3189,10 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                               <object class="GtkBox" id="zoomVBox">
                                                 <property name="name">zoomVBox</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="orientation">vertical</property>
                                                 <child>
-                                                  <placeholder />
+                                                  <placeholder/>
                                                 </child>
                                               </object>
                                               <packing>
@@ -3148,7 +3204,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                             <child>
                                               <object class="GtkLabel" id="label22">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">The unit of the ruler is cm</property>
                                               </object>
                                               <packing>
@@ -3171,7 +3227,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid133">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Display DPI Calibration</property>
                                   </object>
                                 </child>
@@ -3202,63 +3258,62 @@ This also enables touch drawing.&lt;/i&gt;</property>
               <object class="GtkLabel" id="zoomTabLabel">
                 <property name="name">zoomTabLabel</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Zoom</property>
               </object>
               <packing>
                 <property name="position">6</property>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="drawingAreaTabBox">
                 <property name="name">drawingAreaTabBox</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_left">5</property>
+                <property name="can-focus">False</property>
+                <property name="margin-left">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid134">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="min_content_height">450</property>
-		    <property name="min_content_width">500</property>
+                    <property name="can-focus">True</property>
+                    <property name="min-content-width">500</property>
+                    <property name="min-content-height">450</property>
                     <child>
                       <object class="GtkViewport" id="sid135">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkBox" id="sid136">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="sid137">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.009999999776482582</property>
-                                <property name="margin">12</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid138">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="box41">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="label37">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;If you add additional space beside the pages you can choose the area of the screen you would like to work on.&lt;/i&gt;</property>
-                                            <property name="use_markup">True</property>
+                                            <property name="use-markup">True</property>
                                             <property name="wrap">True</property>
-                                            <property name="max_width_chars">85</property>
+                                            <property name="max-width-chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -3268,101 +3323,111 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                           </packing>
                                         </child>
                                         <child>
+                                          <!-- n-columns=3 n-rows=3 -->
                                           <object class="GtkGrid" id="sid139">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="row_spacing">5</property>
-                                            <property name="column_spacing">5</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="row-spacing">5</property>
+                                            <property name="column-spacing">5</property>
                                             <child>
                                               <object class="GtkCheckButton" id="cbAddVerticalSpace">
                                                 <property name="name">cbAddVerticalSpace</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="receives_default">False</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">False</property>
                                                 <property name="xalign">0</property>
-                                                <property name="draw_indicator">True</property>
+                                                <property name="draw-indicator">True</property>
                                                 <child>
                                                   <object class="GtkLabel" id="label38">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="label" translatable="yes">Add additional vertical space of</property>
-                                                    <property name="use_markup">True</property>
+                                                    <property name="use-markup">True</property>
                                                   </object>
                                                 </child>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">0</property>
-                                                <property name="top_attach">0</property>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkCheckButton" id="cbAddHorizontalSpace">
                                                 <property name="name">cbAddHorizontalSpace</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="receives_default">False</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">False</property>
                                                 <property name="xalign">0</property>
-                                                <property name="draw_indicator">True</property>
+                                                <property name="draw-indicator">True</property>
                                                 <child>
                                                   <object class="GtkLabel" id="label39">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="label" translatable="yes">Add additional horizontal space of</property>
-                                                    <property name="use_markup">True</property>
+                                                    <property name="use-markup">True</property>
                                                     <property name="ellipsize">end</property>
                                                   </object>
                                                 </child>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">0</property>
-                                                <property name="top_attach">1</property>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">1</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkSpinButton" id="spAddVerticalSpace">
                                                 <property name="name">spAddVerticalSpace</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
+                                                <property name="can-focus">True</property>
                                                 <property name="adjustment">adjustmentVerticalSpace</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">1</property>
-                                                <property name="top_attach">0</property>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkSpinButton" id="spAddHorizontalSpace">
                                                 <property name="name">spAddHorizontalSpace</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
+                                                <property name="can-focus">True</property>
                                                 <property name="adjustment">adjustmentHorizontalSpace</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">1</property>
-                                                <property name="top_attach">1</property>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">1</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkLabel" id="sid140">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">pixels</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">2</property>
-                                                <property name="top_attach">0</property>
+                                                <property name="left-attach">2</property>
+                                                <property name="top-attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkLabel" id="sid141">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">pixels</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">2</property>
-                                                <property name="top_attach">1</property>
+                                                <property name="left-attach">2</property>
+                                                <property name="top-attach">1</property>
                                               </packing>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
                                             </child>
                                           </object>
                                           <packing>
@@ -3378,7 +3443,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid142">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Scrolling outside the page</property>
                                   </object>
                                 </child>
@@ -3392,50 +3457,71 @@ This also enables touch drawing.&lt;/i&gt;</property>
                             <child>
                               <object class="GtkFrame" id="sid143">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.009999999776482582</property>
-                                <property name="margin">12</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid144">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
+                                      <!-- n-columns=3 n-rows=3 -->
                                       <object class="GtkGrid" id="grid4">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="column_spacing">5</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="column-spacing">5</property>
                                         <child>
                                           <object class="GtkLabel" id="label58a">
                                             <property name="name">label58a</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="tooltip_markup" translatable="yes">Offset first page this many pages when &lt;b&gt;Pair Pages&lt;/b&gt; enabled</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="tooltip-markup" translatable="yes">Offset first page this many pages when &lt;b&gt;Pair Pages&lt;/b&gt; enabled</property>
                                             <property name="label" translatable="yes">First Page Offset </property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">0</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="spPairsOffset">
                                             <property name="name">spPairsOffset</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="tooltip_text" translatable="yes">Usually 0 or 1</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="tooltip-text" translatable="yes">Usually 0 or 1</property>
                                             <property name="valign">start</property>
-                                            <property name="max_width_chars">0</property>
+                                            <property name="max-width-chars">0</property>
                                             <property name="adjustment">adjustmentPairsOffset</property>
                                             <property name="numeric">True</property>
-                                            <property name="update_policy">if-valid</property>
+                                            <property name="update-policy">if-valid</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
                                         </child>
                                       </object>
                                     </child>
@@ -3444,7 +3530,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid145">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Paired Pages</property>
                                   </object>
                                 </child>
@@ -3458,111 +3544,120 @@ This also enables touch drawing.&lt;/i&gt;</property>
                             <child>
                               <object class="GtkFrame" id="sid146">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.009999999776482582</property>
-                                <property name="margin">12</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid147">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="box51">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <property name="spacing">6</property>
                                         <child>
+                                          <!-- n-columns=3 n-rows=3 -->
                                           <object class="GtkGrid" id="sid148">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="row_spacing">5</property>
-                                            <property name="column_spacing">5</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="row-spacing">5</property>
+                                            <property name="column-spacing">5</property>
                                             <child>
                                               <object class="GtkLabel" id="lbSnapRotationTolerance">
                                                 <property name="name">lbSnapRotationTolerance</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">Rotation snapping tolerance</property>
                                                 <property name="xalign">0</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">0</property>
-                                                <property name="top_attach">0</property>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkLabel" id="lbSnapGridTolerance">
                                                 <property name="name">lbSnapGridTolerance</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">Grid snapping tolerance</property>
                                                 <property name="xalign">0</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">0</property>
-                                                <property name="top_attach">1</property>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">1</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkSpinButton" id="spSnapRotationTolerance">
                                                 <property name="name">spSnapRotationTolerance</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
+                                                <property name="can-focus">True</property>
                                                 <property name="adjustment">adjustmentSnapRotationTolerance</property>
-                                                <property name="climb_rate">0.050000000000000003</property>
+                                                <property name="climb-rate">0.05</property>
                                                 <property name="digits">2</property>
-                                                <property name="value">0.20000000000000001</property>
+                                                <property name="value">0.20</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">1</property>
-                                                <property name="top_attach">0</property>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkSpinButton" id="spSnapGridTolerance">
                                                 <property name="name">spSnapGridTolerance</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
+                                                <property name="can-focus">True</property>
                                                 <property name="adjustment">adjustmentSnapGridTolerance</property>
-                                                <property name="climb_rate">0.050000000000000003</property>
+                                                <property name="climb-rate">0.05</property>
                                                 <property name="digits">2</property>
                                                 <property name="value">0.25</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">1</property>
-                                                <property name="top_attach">1</property>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">1</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkLabel" id="lbSnapGridSize">
                                                 <property name="name">lbSnapGridSize</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">Grid size</property>
                                                 <property name="xalign">0</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">0</property>
-                                                <property name="top_attach">2</property>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">2</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkSpinButton" id="spSnapGridSize">
                                                 <property name="name">spSnapGridSize</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
+                                                <property name="can-focus">True</property>
                                                 <property name="adjustment">adjustmentSnapGridSize</property>
-                                                <property name="climb_rate">0.01</property>
+                                                <property name="climb-rate">0.01</property>
                                                 <property name="digits">2</property>
                                                 <property name="value">1</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">1</property>
-                                                <property name="top_attach">2</property>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">2</property>
                                               </packing>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
                                             </child>
                                           </object>
                                           <packing>
@@ -3575,11 +3670,11 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                           <object class="GtkCheckButton" id="cbSnapRecognizedShapesEnabled">
                                             <property name="label" translatable="yes">Use snapping for recognized shapes</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="tooltip_text" translatable="yes">If activated, shapes that have been recognized by the shape recognizer will be snapped to the grid automatically. This may lead to unexpected results if you have the shape recognizer turned on while writing.</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-text" translatable="yes">If activated, shapes that have been recognized by the shape recognizer will be snapped to the grid automatically. This may lead to unexpected results if you have the shape recognizer turned on while writing.</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -3594,7 +3689,7 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid149">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Snapping</property>
                                   </object>
                                 </child>
@@ -3608,69 +3703,87 @@ This also enables touch drawing.&lt;/i&gt;</property>
                             <child>
                               <object class="GtkFrame" id="sid150">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.009999999776482582</property>
-                                <property name="margin">12</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid151">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
+                                      <!-- n-columns=3 n-rows=3 -->
                                       <object class="GtkGrid" id="grid6">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="column_spacing">5</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="column-spacing">5</property>
                                         <child>
                                           <object class="GtkCheckButton" id="cbDrawDirModsEnabled">
                                             <property name="label" translatable="yes">Enable  with determination radius of </property>
                                             <property name="name">cbDrawDirModsEnabled</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="tooltip_markup" translatable="yes">Drag LEFT from start point acts like shift key is being held.
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-markup" translatable="yes">Drag LEFT from start point acts like shift key is being held.
 Drag UP acts as if Control key is being held.
 
 Determination Radius: Radius at which modifiers will lock in until finished drawing.
 
 &lt;i&gt;Useful for operating without keyboard.&lt;/i&gt;</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">0</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="spDrawDirModsRadius">
                                             <property name="name">spDrawDirModsRadius</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
+                                            <property name="can-focus">True</property>
                                             <property name="valign">start</property>
-                                            <property name="max_width_chars">0</property>
+                                            <property name="max-width-chars">0</property>
                                             <property name="adjustment">adjustmentDrawDirModRadius</property>
                                             <property name="numeric">True</property>
-                                            <property name="update_policy">if-valid</property>
+                                            <property name="update-policy">if-valid</property>
                                             <property name="value">50</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="sid152">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">pixels</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">2</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">2</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
                                         </child>
                                       </object>
                                     </child>
@@ -3679,7 +3792,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                 <child type="label">
                                   <object class="GtkLabel" id="sid153">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Drawing Tools - Set Modifiers by Draw Direction (Experimental)</property>
                                   </object>
                                 </child>
@@ -3693,34 +3806,58 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                             <child>
                               <object class="GtkFrame" id="sid 155">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
-                                <property name="margin">12</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="left_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="left-padding">12</property>
                                     <child>
+                                      <!-- n-columns=3 n-rows=3 -->
                                       <object class="GtkGrid">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <child>
                                           <object class="GtkCheckButton" id="cbRestoreLineWidthEnabled">
                                             <property name="label" translatable="yes">Preserve line width</property>
                                             <property name="name">cbRestoreLineWidthEnabled</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="tooltip_markup" translatable="yes">After resizing a selection, the line width of all strokes will be the same as before the resizing operation. </property>
-                                            <property name="margin_bottom">2</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-markup" translatable="yes">After resizing a selection, the line width of all strokes will be the same as before the resizing operation. </property>
+                                            <property name="margin-bottom">2</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">0</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
                                         </child>
                                       </object>
                                     </child>
@@ -3729,7 +3866,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                 <child type="label">
                                   <object class="GtkLabel">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Resizing</property>
                                   </object>
                                 </child>
@@ -3743,129 +3880,129 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                             <child>
                               <object class="GtkFrame" id="sid154">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.009999999776482582</property>
-                                <property name="margin">12</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid155">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
+                                      <!-- n-columns=4 n-rows=3 -->
                                       <object class="GtkGrid" id="grid1">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="column_spacing">5</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="column-spacing">5</property>
                                         <child>
                                           <object class="GtkCheckButton" id="cbStrokeFilterEnabled">
                                             <property name="label" translatable="yes">Enable Tap action</property>
                                             <property name="name">cbStrokeFilterEnabled</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="tooltip_markup" translatable="yes">Do not draw for inputs of short time and length unless it comes in short succession. Instead, show floating toolbox.</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-markup" translatable="yes">Do not draw for inputs of short time and length unless it comes in short succession. Instead, show floating toolbox.</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">0</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="sid156">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">Ignore Time (ms)</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="spStrokeIgnoreTime">
                                             <property name="name">spStrokeIgnoreTime</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="tooltip_markup" translatable="yes">How short (time)  AND...
+                                            <property name="can-focus">True</property>
+                                            <property name="tooltip-markup" translatable="yes">How short (time)  AND...
 
 &lt;i&gt;Recommended: 150ms&lt;/i&gt;</property>
                                             <property name="valign">start</property>
-                                            <property name="max_width_chars">0</property>
+                                            <property name="max-width-chars">0</property>
                                             <property name="adjustment">adjustmentStrokeIgnoreTime</property>
                                             <property name="numeric">True</property>
-                                            <property name="update_policy">if-valid</property>
+                                            <property name="update-policy">if-valid</property>
                                             <property name="value">150</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">1</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">1</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="spStrokeIgnoreLength">
                                             <property name="name">spStrokeIgnoreLength</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="tooltip_markup" translatable="yes">How short (screen mm)  of the stroke  AND...
+                                            <property name="can-focus">True</property>
+                                            <property name="tooltip-markup" translatable="yes">How short (screen mm)  of the stroke  AND...
 
 &lt;i&gt;Recommended: 1 mm&lt;/i&gt;</property>
                                             <property name="valign">start</property>
-                                            <property name="max_width_chars">0</property>
+                                            <property name="max-width-chars">0</property>
                                             <property name="adjustment">adjustmentStrokeIgnoreLength</property>
                                             <property name="digits">2</property>
                                             <property name="numeric">True</property>
-                                            <property name="update_policy">if-valid</property>
+                                            <property name="update-policy">if-valid</property>
                                             <property name="value">1</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">2</property>
-                                            <property name="top_attach">1</property>
+                                            <property name="left-attach">2</property>
+                                            <property name="top-attach">1</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="sid157">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">Max Length (mm)</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">2</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">2</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="sid158">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">Successive (ms)</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">3</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">3</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="spStrokeSuccessiveTime">
                                             <property name="name">spStrokeSuccessiveTime</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="tooltip_markup" translatable="yes">... AND How much time must have passed since last stroke.
+                                            <property name="can-focus">True</property>
+                                            <property name="tooltip-markup" translatable="yes">... AND How much time must have passed since last stroke.
 
 &lt;i&gt;Recommended: 500ms&lt;/i&gt;</property>
                                             <property name="valign">start</property>
-                                            <property name="max_width_chars">0</property>
+                                            <property name="max-width-chars">0</property>
                                             <property name="adjustment">adjustmentStrokeSuccessiveTime</property>
                                             <property name="numeric">True</property>
-                                            <property name="update_policy">if-valid</property>
+                                            <property name="update-policy">if-valid</property>
                                             <property name="value">500</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">3</property>
-                                            <property name="top_attach">1</property>
+                                            <property name="left-attach">3</property>
+                                            <property name="top-attach">1</property>
                                           </packing>
                                         </child>
                                         <child>
@@ -3873,31 +4010,31 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                             <property name="label" translatable="yes">Try to select object first.</property>
                                             <property name="name">cbTrySelectOnStrokeFiltered</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="tooltip_markup" translatable="yes">Try to select object first; if nothing selected then show floating toolbox if enabled.</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-markup" translatable="yes">Try to select object first; if nothing selected then show floating toolbox if enabled.</property>
                                             <property name="xalign">0</property>
                                             <property name="yalign">0.4399999976158142</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">2</property>
-					    <property name="width">3</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">2</property>
+                                            <property name="width">3</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="label1">
                                             <property name="visible">True</property>
-					    <property name="halign">GTK_ALIGN_END</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="tooltip_text" translatable="yes">All three conditions must be met before stroke is ignored.
+                                            <property name="can-focus">False</property>
+                                            <property name="tooltip-text" translatable="yes">All three conditions must be met before stroke is ignored.
 It must be short in time and length and we can't have ignored another stroke recently.</property>
+                                            <property name="halign">end</property>
                                             <property name="label" translatable="yes">Settings:</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">0</property>
-                                            <property name="top_attach">1</property>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">1</property>
                                           </packing>
                                         </child>
                                         <child>
@@ -3905,16 +4042,16 @@ It must be short in time and length and we can't have ignored another stroke rec
                                             <property name="label" translatable="yes">Show Floating Toolbox</property>
                                             <property name="name">cbDoActionOnStrokeFiltered</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="tooltip_markup" translatable="yes">Try to select object first; if nothing selected then show floating toolbox if enabled.</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-markup" translatable="yes">Try to select object first; if nothing selected then show floating toolbox if enabled.</property>
                                             <property name="xalign">0</property>
-                                            <property name="yalign">0.4300000071525574</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="yalign">0.43000000715255737</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">0</property>
-                                            <property name="top_attach">2</property>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">2</property>
                                           </packing>
                                         </child>
                                       </object>
@@ -3924,7 +4061,7 @@ It must be short in time and length and we can't have ignored another stroke rec
                                 <child type="label">
                                   <object class="GtkLabel" id="sid159">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Action on Tool Tap</property>
                                   </object>
                                 </child>
@@ -3955,62 +4092,61 @@ It must be short in time and length and we can't have ignored another stroke rec
               <object class="GtkLabel" id="drawingAreaTabLabel">
                 <property name="name">drawingAreaTabLabel</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Drawing Area</property>
               </object>
               <packing>
                 <property name="position">7</property>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="defaultTabBox">
                 <property name="name">defaultTabBox</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_left">5</property>
+                <property name="can-focus">False</property>
+                <property name="margin-left">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid160">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="min_content_height">450</property>
-		    <property name="min_content_width">500</property>
+                    <property name="can-focus">True</property>
+                    <property name="min-content-width">500</property>
+                    <property name="min-content-height">450</property>
                     <child>
                       <object class="GtkViewport" id="sid161">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkBox" id="sid162">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="sid163">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.009999999776482582</property>
-                                <property name="margin">12</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid164">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid165">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="label9">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;Select the tool and Settings if you press the Default Button.&lt;/i&gt;</property>
-                                            <property name="use_markup">True</property>
-                                            <property name="max_width_chars">85</property>
+                                            <property name="use-markup">True</property>
+                                            <property name="max-width-chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -4024,9 +4160,9 @@ It must be short in time and length and we can't have ignored another stroke rec
                                           <object class="GtkBox" id="hboxDefaultTool">
                                             <property name="name">hboxDefaultTool</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <child>
-                                              <placeholder />
+                                              <placeholder/>
                                             </child>
                                           </object>
                                           <packing>
@@ -4036,7 +4172,7 @@ It must be short in time and length and we can't have ignored another stroke rec
                                           </packing>
                                         </child>
                                         <child>
-                                          <placeholder />
+                                          <placeholder/>
                                         </child>
                                       </object>
                                     </child>
@@ -4045,11 +4181,11 @@ It must be short in time and length and we can't have ignored another stroke rec
                                 <child type="label">
                                   <object class="GtkBox" id="box1">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <child>
                                       <object class="GtkImage" id="image2">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="pixbuf">pixmaps/default.svg</property>
                                       </object>
                                       <packing>
@@ -4061,9 +4197,9 @@ It must be short in time and length and we can't have ignored another stroke rec
                                     <child>
                                       <object class="GtkLabel" id="label8">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="label" translatable="yes">&lt;b&gt;Default&lt;/b&gt;</property>
-                                        <property name="use_markup">True</property>
+                                        <property name="use-markup">True</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -4101,62 +4237,61 @@ It must be short in time and length and we can't have ignored another stroke rec
               <object class="GtkLabel" id="defaultTabLabel">
                 <property name="name">defaultTabLabel</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Defaults</property>
               </object>
               <packing>
                 <property name="position">8</property>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="audioRecordingTabBox">
                 <property name="name">audioRecordingTabBox</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_left">5</property>
+                <property name="can-focus">False</property>
+                <property name="margin-left">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid166">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="min_content_height">450</property>
-		    <property name="min_content_width">500</property>
+                    <property name="can-focus">True</property>
+                    <property name="min-content-width">500</property>
+                    <property name="min-content-height">450</property>
                     <child>
                       <object class="GtkViewport" id="sid167">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkBox" id="sid168">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="sid169">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.009999999776482582</property>
-                                <property name="margin">12</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid170">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid171">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="label45">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;Audio recordings are currently stored in a separate folder and referenced from the journal.&lt;/i&gt;</property>
-                                            <property name="use_markup">True</property>
-                                            <property name="max_width_chars">85</property>
+                                            <property name="use-markup">True</property>
+                                            <property name="max-width-chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -4166,36 +4301,58 @@ It must be short in time and length and we can't have ignored another stroke rec
                                           </packing>
                                         </child>
                                         <child>
+                                          <!-- n-columns=3 n-rows=3 -->
                                           <object class="GtkGrid" id="grid5">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="row_spacing">10</property>
-                                            <property name="column_spacing">10</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="row-spacing">10</property>
+                                            <property name="column-spacing">10</property>
                                             <child>
                                               <object class="GtkLabel" id="label46">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">Storage Folder</property>
                                                 <property name="xalign">0</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">0</property>
-                                                <property name="top_attach">0</property>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkFileChooserButton" id="fcAudioPath">
                                                 <property name="name">fcAudioPath</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="hexpand">True</property>
                                                 <property name="action">select-folder</property>
                                                 <property name="title" translatable="yes">Select Folder</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">1</property>
-                                                <property name="top_attach">0</property>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">0</property>
                                               </packing>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
                                             </child>
                                           </object>
                                           <packing>
@@ -4211,7 +4368,7 @@ It must be short in time and length and we can't have ignored another stroke rec
                                 <child type="label">
                                   <object class="GtkLabel" id="sid172">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Storage Folder</property>
                                   </object>
                                 </child>
@@ -4225,30 +4382,29 @@ It must be short in time and length and we can't have ignored another stroke rec
                             <child>
                               <object class="GtkFrame" id="sid173">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.009999999776482582</property>
-                                <property name="margin">12</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid174">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid175">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="sid176">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;Specify the audio devices used for recording and playback of audio attachments.
 If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as input / output device.&lt;/i&gt;</property>
-                                            <property name="use_markup">True</property>
+                                            <property name="use-markup">True</property>
                                             <property name="wrap">True</property>
-                                            <property name="max_width_chars">85</property>
+                                            <property name="max-width-chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -4258,56 +4414,72 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                           </packing>
                                         </child>
                                         <child>
+                                          <!-- n-columns=3 n-rows=3 -->
                                           <object class="GtkGrid" id="grid8">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="row_spacing">10</property>
-                                            <property name="column_spacing">10</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="row-spacing">10</property>
+                                            <property name="column-spacing">10</property>
                                             <child>
                                               <object class="GtkLabel" id="label36">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">Input Device</property>
                                                 <property name="xalign">0</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">0</property>
-                                                <property name="top_attach">0</property>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkComboBoxText" id="cbAudioInputDevice">
                                                 <property name="name">cbAudioInputDevice</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">1</property>
-                                                <property name="top_attach">0</property>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkLabel" id="label58">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">Output Device</property>
                                                 <property name="xalign">0</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">0</property>
-                                                <property name="top_attach">1</property>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">1</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkComboBoxText" id="cbAudioOutputDevice">
                                                 <property name="name">cbAudioOutputDevice</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">1</property>
-                                                <property name="top_attach">1</property>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">1</property>
                                               </packing>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
                                             </child>
                                           </object>
                                           <packing>
@@ -4323,7 +4495,7 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                 <child type="label">
                                   <object class="GtkLabel" id="sid177">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Audio Devices</property>
                                   </object>
                                 </child>
@@ -4337,51 +4509,51 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                             <child>
                               <object class="GtkFrame" id="sid178">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.009999999776482582</property>
-                                <property name="margin">12</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid179">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
+                                      <!-- n-columns=3 n-rows=3 -->
                                       <object class="GtkGrid" id="sid180">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="row_spacing">10</property>
-                                        <property name="column_spacing">10</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="row-spacing">10</property>
+                                        <property name="column-spacing">10</property>
                                         <child>
                                           <object class="GtkLabel" id="label59">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">Sample Rate</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">0</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="label61">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">Gain</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">0</property>
-                                            <property name="top_attach">1</property>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">1</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkComboBoxText" id="cbAudioSampleRate">
                                             <property name="name">cbAudioSampleRate</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="active">0</property>
                                             <items>
                                               <item id="16000">16000 Hz</item>
@@ -4391,25 +4563,40 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                             </items>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="spAudioGain">
                                             <property name="name">spAudioGain</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
+                                            <property name="can-focus">True</property>
                                             <property name="adjustment">adjustmentAudioGain</property>
-                                            <property name="climb_rate">0.1</property>
+                                            <property name="climb-rate">0.10</property>
                                             <property name="digits">2</property>
                                             <property name="numeric">True</property>
                                             <property name="value">1</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">1</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">1</property>
                                           </packing>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
                                         </child>
                                       </object>
                                     </child>
@@ -4418,7 +4605,7 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                 <child type="label">
                                   <object class="GtkLabel" id="sid181">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Recording Quality</property>
                                   </object>
                                 </child>
@@ -4432,50 +4619,71 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                             <child>
                               <object class="GtkFrame" id="sid1">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.009999999776482582</property>
-                                <property name="margin">12</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid2">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
+                                      <!-- n-columns=3 n-rows=3 -->
                                       <object class="GtkGrid" id="sid3">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="row_spacing">10</property>
-                                        <property name="column_spacing">10</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="row-spacing">10</property>
+                                        <property name="column-spacing">10</property>
                                         <child>
                                           <object class="GtkLabel" id="label3">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">Default Seek Time (in seconds)</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">0</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="spDefaultSeekTime">
                                             <property name="name">spAudioGain</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
+                                            <property name="can-focus">True</property>
                                             <property name="text" translatable="yes">1,00</property>
                                             <property name="adjustment">adjustmentSeekTime</property>
-                                            <property name="climb_rate">0.1</property>
+                                            <property name="climb-rate">0.10</property>
                                             <property name="digits">2</property>
                                             <property name="numeric">True</property>
                                             <property name="value">1</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
                                         </child>
                                       </object>
                                     </child>
@@ -4484,7 +4692,7 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                 <child type="label">
                                   <object class="GtkLabel" id="sid4">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Playback Settings</property>
                                   </object>
                                 </child>
@@ -4498,10 +4706,10 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                             <child>
                               <object class="GtkLabel" id="sid182">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="label" translatable="yes">&lt;i&gt;Changes take only effect on new recordings and playbacks.&lt;/i&gt;</property>
-                                <property name="use_markup">True</property>
-                                <property name="max_width_chars">85</property>
+                                <property name="use-markup">True</property>
+                                <property name="max-width-chars">85</property>
                                 <property name="xalign">0</property>
                               </object>
                               <packing>
@@ -4530,22 +4738,22 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
               <object class="GtkLabel" id="audioRecordingTabLabel">
                 <property name="name">audioRecordingTabLabel</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Audio Recording</property>
               </object>
               <packing>
                 <property name="position">9</property>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="latexTabBox">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-		<property name="margin-left">5</property>
+                <property name="can-focus">False</property>
+                <property name="margin-left">5</property>
                 <property name="orientation">vertical</property>
                 <child>
-                  <placeholder />
+                  <placeholder/>
                 </child>
               </object>
               <packing>
@@ -4555,61 +4763,61 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
             <child type="tab">
               <object class="GtkLabel" id="latexTabLabel">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">LaTeX</property>
               </object>
               <packing>
                 <property name="position">11</property>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="languageTabBox">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_left">5</property>
+                <property name="can-focus">False</property>
+                <property name="margin-left">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid189">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="can-focus">True</property>
                     <child>
                       <object class="GtkViewport" id="sid190">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkBox" id="sid191">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="sid192">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.009999999776482582</property>
-                                <property name="margin_left">4</property>
-                                <property name="margin_top">3</property>
-                                <property name="margin_bottom">3</property>
-                                <property name="border_width">2</property>
+                                <property name="can-focus">False</property>
+                                <property name="margin-left">4</property>
+                                <property name="margin-top">3</property>
+                                <property name="margin-bottom">3</property>
+                                <property name="border-width">2</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid193">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">12</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">12</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid194">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="label195">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;Select language (requires restart)&lt;/i&gt;</property>
-                                            <property name="use_markup">True</property>
+                                            <property name="use-markup">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -4620,19 +4828,19 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                         <child>
                                           <object class="GtkFrame" id="sid195">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label_xalign">0.009999999776482582</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label-xalign">0.009999999776482582</property>
                                             <child>
                                               <object class="GtkAlignment" id="sid196">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="bottom_padding">8</property>
-                                                <property name="left_padding">12</property>
-                                                <property name="right_padding">12</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="bottom-padding">8</property>
+                                                <property name="left-padding">12</property>
+                                                <property name="right-padding">12</property>
                                                 <child>
                                                   <object class="GtkBox" id="hboxLanguageSelect">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="orientation">vertical</property>
                                                     <child>
                                                       <placeholder/>
@@ -4644,7 +4852,7 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                             <child type="label">
                                               <object class="GtkLabel" id="label196">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">Language</property>
                                               </object>
                                             </child>
@@ -4662,7 +4870,7 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                 <child type="label">
                                   <object class="GtkLabel" id="label193">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Language Settings</property>
                                   </object>
                                 </child>
@@ -4692,12 +4900,12 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
             <child type="tab">
               <object class="GtkLabel" id="languageTabLabel">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Language</property>
               </object>
               <packing>
                 <property name="position">11</property>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
           </object>
@@ -4713,8 +4921,5 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
       <action-widget response="0">btSettingsCancel</action-widget>
       <action-widget response="1">btSettingsOk</action-widget>
     </action-widgets>
-    <child type="titlebar">
-      <placeholder/>
-    </child>
   </object>
 </interface>

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -43,6 +43,12 @@
     <property name="step-increment">1</property>
     <property name="page-increment">1</property>
   </object>
+  <object class="GtkAdjustment" id="adjustmentReRenderThreshold">
+    <property name="upper">900</property>
+    <property name="value">10</property>
+    <property name="step-increment">5</property>
+    <property name="page-increment">100</property>
+  </object>
   <object class="GtkAdjustment" id="adjustmentSeekTime">
     <property name="lower">1</property>
     <property name="upper">90</property>
@@ -115,6 +121,11 @@
     <property name="upper">400</property>
     <property name="value">72</property>
     <property name="step-increment">1</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustmentZoomStartThreshold">
+    <property name="upper">100</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentZoomStep">
     <property name="lower">0.10</property>
@@ -1995,6 +2006,58 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             <property name="expand">False</property>
                                             <property name="fill">True</property>
                                             <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <!-- n-columns=3 n-rows=1 -->
+                                          <object class="GtkGrid" id="gdStartZoomAtSetting">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="tooltip-text" translatable="yes">When drawing with touch, two-finger gestures intended to pan the view can instead cause it to zoom, causing performance issues. 
+This setting can make it easier to draw with touch. </property>
+                                            <child>
+                                              <object class="GtkLabel" id="label2">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">Start zooming after a distance </property>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSpinButton" id="spTouchZoomStartThreshold">
+                                                <property name="name">spTouchDisableTimeout</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="text" translatable="yes">1.0</property>
+                                                <property name="adjustment">adjustmentZoomStartThreshold</property>
+                                                <property name="climb-rate">0.5</property>
+                                                <property name="digits">1</property>
+                                                <property name="value">1</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel" id="label4">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">% greater than the initial distance between the two touches.</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">2</property>
+                                                <property name="top-attach">0</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">2</property>
                                           </packing>
                                         </child>
                                       </object>
@@ -4170,27 +4233,27 @@ It must be short in time and length and we can't have ignored another stroke rec
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkFrame" id="boxPdfCaching">
+                              <object class="GtkFrame" id="framePDFCacheOptions">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
                                 <child>
-                                  <object class="GtkAlignment" id="alignPdfCachingContent">
+                                  <object class="GtkAlignment" id="alignPDFCacheOptions">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
                                     <property name="bottom-padding">8</property>
                                     <property name="left-padding">12</property>
                                     <property name="right-padding">12</property>
                                     <child>
-                                      <object class="GtkBox" id="boxPdfCachingContent">
+                                      <object class="GtkBox" id="boxReRenderSetting">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
-                                          <object class="GtkLabel" id="lblPdfCaching">
+                                          <object class="GtkLabel" id="lblReRenderMoreOftenWhileZooming">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">&lt;i&gt;Re-render PDF backgrounds more often for better render quality. 
+                                            <property name="label" translatable="yes">&lt;i&gt;Re-render PDF backgrounds more often while zooming for better render quality. 
 &lt;b&gt;Note:&lt;/b&gt; This should not affect print quality.&lt;/i&gt;</property>
                                             <property name="use-markup">True</property>
                                             <property name="wrap">True</property>
@@ -4205,14 +4268,57 @@ It must be short in time and length and we can't have ignored another stroke rec
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkCheckButton" id="cbClearCacheOnZoom">
-                                            <property name="label" translatable="yes">Clear cache whenever zoom changes</property>
-                                            <property name="name">cbClearCacheOnZoom</property>
+                                          <!-- n-columns=3 n-rows=1 -->
+                                          <object class="GtkGrid" id="gdRecacheOptions">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="row-spacing">5</property>
+                                            <property name="column-spacing">5</property>
+                                            <child>
+                                              <object class="GtkLabel" id="lbReRenderThreshold">
+                                                <property name="name">lbSnapRotationTolerance</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="tooltip-text" translatable="yes">When zoomed in on a high-resolution PDF, each re-render can take a long time. Setting this to a large value causes these re-renders to happen less often.
+
+Set this to 0% to always re-render on zoom.</property>
+                                                <property name="label" translatable="yes">Re-render when the page's zoom changes by more than </property>
+                                                <property name="xalign">0</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSpinButton" id="spReRenderThreshold">
+                                                <property name="name">spSnapRotationTolerance</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="text" translatable="yes">0.00</property>
+                                                <property name="input-purpose">number</property>
+                                                <property name="adjustment">adjustmentReRenderThreshold</property>
+                                                <property name="climb-rate">2</property>
+                                                <property name="numeric">True</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel" id="lbReRenderThresholdEnding">
+                                                <property name="name">lbSnapRotationTolerance</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">%.</property>
+                                                <property name="xalign">0</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">2</property>
+                                                <property name="top-attach">0</property>
+                                              </packing>
+                                            </child>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -899,6 +899,34 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             <property name="position">2</property>
                                           </packing>
                                         </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="cbEnablePressureInference">
+                                            <property name="name">cbEnablePressureInference</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-markup" translatable="yes">Slower strokes are assigned a greater pressure than faster strokes, if pressure information is absent.
+
+&lt;i&gt;This feature may be useful for devices that lack pressure sensitivity. For example, a mouse or touchscreen.&lt;/i&gt;</property>
+                                            <property name="xalign">0</property>
+                                            <property name="draw-indicator">True</property>
+                                            <child>
+                                              <object class="GtkLabel" id="sid201">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">Enable Pressure Inference &lt;i&gt;(Guess pressure from drawing speed when device-supplied pressure is not available)&lt;/i&gt;</property>
+                                                <property name="use-markup">True</property>
+                                                <property name="wrap">True</property>
+                                                <property name="xalign">0</property>
+                                              </object>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">3</property>
+                                          </packing>
+                                        </child>
                                       </object>
                                     </child>
                                   </object>
@@ -2053,6 +2081,75 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
                                 <property name="position">3</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkFrame" id="frameTouchDrawing">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
+                                <child>
+                                  <object class="GtkAlignment" id="touchDrawingFrameAlignment">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
+                                    <child>
+                                      <object class="GtkBox" id="boxTouchDrawing">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                          <object class="GtkLabel" id="lblTouchDrawingDescription">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">&lt;i&gt;Use the touchscreen like a multi-touch-aware pen (requires new input system).&lt;/i&gt;</property>
+                                            <property name="use-markup">True</property>
+                                            <property name="wrap">True</property>
+                                            <property name="width-chars">85</property>
+                                            <property name="max-width-chars">85</property>
+                                            <property name="xalign">0</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="cbTouchDrawing">
+                                            <property name="label" translatable="yes">Enable touch drawing</property>
+                                            <property name="name">cbTouchDrawing</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-text" translatable="yes">Use two fingers to pan/zoom and one finger to use the selected tool.</property>
+                                            <property name="xalign">0</property>
+                                            <property name="draw-indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label">
+                                  <object class="GtkLabel" id="headerTouchDrawingFrame">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">Touch Drawing</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">4</property>
                               </packing>
                             </child>
                           </object>
@@ -3538,7 +3635,184 @@ This also enables touch drawing.&lt;/i&gt;</property>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkFrame" id="sid150">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
+                                <child>
+                                  <object class="GtkAlignment" id="sid151">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
+                                    <child>
+                                      <!-- n-columns=3 n-rows=3 -->
+                                      <object class="GtkGrid" id="grid6">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="column-spacing">5</property>
+                                        <child>
+                                          <object class="GtkCheckButton" id="cbDrawDirModsEnabled">
+                                            <property name="label" translatable="yes">Enable  with determination radius of </property>
+                                            <property name="name">cbDrawDirModsEnabled</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-markup" translatable="yes">Drag LEFT from start point acts like shift key is being held.
+Drag UP acts as if Control key is being held.
+
+Determination Radius: Radius at which modifiers will lock in until finished drawing.
+
+&lt;i&gt;Useful for operating without keyboard.&lt;/i&gt;</property>
+                                            <property name="xalign">0</property>
+                                            <property name="draw-indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSpinButton" id="spDrawDirModsRadius">
+                                            <property name="name">spDrawDirModsRadius</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="valign">start</property>
+                                            <property name="max-width-chars">0</property>
+                                            <property name="adjustment">adjustmentDrawDirModRadius</property>
+                                            <property name="numeric">True</property>
+                                            <property name="update-policy">if-valid</property>
+                                            <property name="value">50</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="sid152">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">pixels</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">2</property>
+                                            <property name="top-attach">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label">
+                                  <object class="GtkLabel" id="sid153">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">Drawing Tools - Set Modifiers by Draw Direction (Experimental)</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
                                 <property name="position">2</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkFrame" id="sid 155">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
+                                <child>
+                                  <object class="GtkAlignment">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="left-padding">12</property>
+                                    <child>
+                                      <!-- n-columns=3 n-rows=3 -->
+                                      <object class="GtkGrid">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <child>
+                                          <object class="GtkCheckButton" id="cbRestoreLineWidthEnabled">
+                                            <property name="label" translatable="yes">Preserve line width</property>
+                                            <property name="name">cbRestoreLineWidthEnabled</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-markup" translatable="yes">After resizing a selection, the line width of all strokes will be the same as before the resizing operation. </property>
+                                            <property name="margin-bottom">2</property>
+                                            <property name="xalign">0</property>
+                                            <property name="draw-indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label">
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">Resizing</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">3</property>
                               </packing>
                             </child>
                             <child>
@@ -3691,183 +3965,6 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Snapping</property>
-                                  </object>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">3</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkFrame" id="sid150">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
-                                <child>
-                                  <object class="GtkAlignment" id="sid151">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
-                                    <child>
-                                      <!-- n-columns=3 n-rows=3 -->
-                                      <object class="GtkGrid" id="grid6">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="column-spacing">5</property>
-                                        <child>
-                                          <object class="GtkCheckButton" id="cbDrawDirModsEnabled">
-                                            <property name="label" translatable="yes">Enable  with determination radius of </property>
-                                            <property name="name">cbDrawDirModsEnabled</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="tooltip-markup" translatable="yes">Drag LEFT from start point acts like shift key is being held.
-Drag UP acts as if Control key is being held.
-
-Determination Radius: Radius at which modifiers will lock in until finished drawing.
-
-&lt;i&gt;Useful for operating without keyboard.&lt;/i&gt;</property>
-                                            <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSpinButton" id="spDrawDirModsRadius">
-                                            <property name="name">spDrawDirModsRadius</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="valign">start</property>
-                                            <property name="max-width-chars">0</property>
-                                            <property name="adjustment">adjustmentDrawDirModRadius</property>
-                                            <property name="numeric">True</property>
-                                            <property name="update-policy">if-valid</property>
-                                            <property name="value">50</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">1</property>
-                                            <property name="top-attach">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkLabel" id="sid152">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">pixels</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">2</property>
-                                            <property name="top-attach">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child type="label">
-                                  <object class="GtkLabel" id="sid153">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="label" translatable="yes">Drawing Tools - Set Modifiers by Draw Direction (Experimental)</property>
-                                  </object>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">3</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkFrame" id="sid 155">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
-                                <child>
-                                  <object class="GtkAlignment">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="left-padding">12</property>
-                                    <child>
-                                      <!-- n-columns=3 n-rows=3 -->
-                                      <object class="GtkGrid">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <child>
-                                          <object class="GtkCheckButton" id="cbRestoreLineWidthEnabled">
-                                            <property name="label" translatable="yes">Preserve line width</property>
-                                            <property name="name">cbRestoreLineWidthEnabled</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="tooltip-markup" translatable="yes">After resizing a selection, the line width of all strokes will be the same as before the resizing operation. </property>
-                                            <property name="margin-bottom">2</property>
-                                            <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child type="label">
-                                  <object class="GtkLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="label" translatable="yes">Resizing</property>
                                   </object>
                                 </child>
                               </object>
@@ -4063,6 +4160,75 @@ It must be short in time and length and we can't have ignored another stroke rec
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Action on Tool Tap</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">5</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkFrame" id="boxPdfCaching">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
+                                <child>
+                                  <object class="GtkAlignment" id="alignPdfCachingContent">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
+                                    <child>
+                                      <object class="GtkBox" id="boxPdfCachingContent">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                          <object class="GtkLabel" id="lblPdfCaching">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">&lt;i&gt;Re-render PDF backgrounds more often for better render quality. 
+&lt;b&gt;Note:&lt;/b&gt; This should not affect print quality.&lt;/i&gt;</property>
+                                            <property name="use-markup">True</property>
+                                            <property name="wrap">True</property>
+                                            <property name="width-chars">85</property>
+                                            <property name="max-width-chars">85</property>
+                                            <property name="xalign">0</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="cbClearCacheOnZoom">
+                                            <property name="label" translatable="yes">Clear cache whenever zoom changes</property>
+                                            <property name="name">cbClearCacheOnZoom</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="xalign">0</property>
+                                            <property name="draw-indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label">
+                                  <object class="GtkLabel" id="headerPdfCaching">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">PDF Cache</property>
                                   </object>
                                 </child>
                               </object>

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -2187,7 +2187,6 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                             <property name="visible">True</property>
                                             <property name="can-focus">True</property>
                                             <property name="receives-default">False</property>
-                                            <property name="tooltip-text" translatable="yes">Use two fingers to pan/zoom and one finger to use the selected tool.</property>
                                             <property name="xalign">0</property>
                                             <property name="draw-indicator">True</property>
                                           </object>


### PR DESCRIPTION
## Addresses these issues:
 * Previously, when touch drawing was enabled, the touchscreen could not be used to pan and zoom. 
 * Additionally, zoom with touch caused the page to scroll up and down by large amounts (zoom centered at top-left of document).
      * **Edit:** This only happened when touch drawing/the touchscreen workaround was enabled.
 * Zooming can be very slow when editing large PDFs.
      * **Only partially fixes this issue** 

## Adds these features:
  * Two-finger touch panning/scrolling when touch drawing is enabled.
  * An option to clear the PDF page cache less frequently.
  * Pressure inference (faster strokes -> lower pressure).
      * An option to toggle this in settings.

## Screenshot
![image](https://user-images.githubusercontent.com/46334387/100393728-84678c80-2fef-11eb-871a-57846467f412.png)


## Questions I Have:
 * What is the reason for the workaround that enables touch drawing? Is it reasonable to allow panning and zooming when the user uses multi-touch with this workaround enabled?