### PR TITLE
Add command line export options

### DIFF
--- a/src/control/jobs/CustomExportJob.cpp
+++ b/src/control/jobs/CustomExportJob.cpp
@@ -75,13 +75,12 @@ auto CustomExportJob::showFilechooser() -> bool {
     doc->lock();
     auto* dlg = new ExportDialog(control->getGladeSearchPath());
     if (filepath.extension() == ".pdf") {
-        dlg->removeDpiSelection();
+        dlg->removeQualitySetting();
         format = EXPORT_GRAPHICS_PDF;
     } else if (filepath.extension() == ".svg") {
-        dlg->removeDpiSelection();
+        dlg->removeQualitySetting();
         format = EXPORT_GRAPHICS_SVG;
     } else if (filepath.extension() == ".png") {
-        dlg->removeDpiSelection();
         format = EXPORT_GRAPHICS_PNG;
     }
 
@@ -95,7 +94,10 @@ auto CustomExportJob::showFilechooser() -> bool {
     }
 
     exportRange = dlg->getRange();
-    pngDpi = dlg->getPngDpi();
+
+    if (format == EXPORT_GRAPHICS_PNG) {
+        pngQualityParameter = dlg->getPngQualityParameter();
+    }
 
     delete dlg;
     doc->unlock();
@@ -108,7 +110,9 @@ auto CustomExportJob::showFilechooser() -> bool {
 void CustomExportJob::exportGraphics() {
     bool hideBackground = filters.at(this->chosenFilterName)->withoutBackground;
     ImageExport imgExport(control->getDocument(), filepath, format, hideBackground, exportRange);
-    imgExport.setPngDpi(pngDpi);
+    if (format == EXPORT_GRAPHICS_PNG) {
+        imgExport.setQualityParameter(pngQualityParameter);
+    }
     imgExport.exportGraphics(control);
     errorMsg = imgExport.getLastErrorMsg();
 }

--- a/src/control/jobs/CustomExportJob.h
+++ b/src/control/jobs/CustomExportJob.h
@@ -53,9 +53,9 @@ private:
     PageRangeVector exportRange;
 
     /**
-     * PNG dpi
+     * @brief Quality parameter for PNG exports
      */
-    int pngDpi = 300;
+    RasterImageQualityParameter pngQualityParameter = RasterImageQualityParameter();
 
     /**
      * Export graphics format

--- a/src/control/jobs/ImageExport.h
+++ b/src/control/jobs/ImageExport.h
@@ -27,6 +27,45 @@ class ProgressListener;
 
 enum ExportGraphicsFormat { EXPORT_GRAPHICS_UNDEFINED, EXPORT_GRAPHICS_PDF, EXPORT_GRAPHICS_PNG, EXPORT_GRAPHICS_SVG };
 
+
+/**
+ * @brief List of available criterion for determining a PNG export quality.
+ * The order must agree with the corresponding listAvailableCriterion in ui/exportSettings.glade
+ */
+enum ExportQualityCriterion { EXPORT_QUALITY_DPI, EXPORT_QUALITY_WIDTH, EXPORT_QUALITY_HEIGHT };
+
+/**
+ * @brief A class storing the available quality parameters for PNG export
+ */
+class RasterImageQualityParameter {
+public:
+    RasterImageQualityParameter(ExportQualityCriterion criterion, int value);
+    RasterImageQualityParameter();
+    ~RasterImageQualityParameter();
+
+    /**
+     * @brief Get the quality criterion of this parameter
+     * @return The quality criterion
+     */
+    ExportQualityCriterion getQualityCriterion();
+
+    /**
+     * @brief Get the target value of this parameter
+     * @return The target value
+     */
+    int getValue();
+
+private:
+    /**
+     * @brief Default quality is: DPI=300
+     */
+    ExportQualityCriterion qualityCriterion = EXPORT_QUALITY_DPI;
+    int value = 300;
+};
+
+/**
+ * @brief A class handling export as images
+ */
 class ImageExport {
 public:
     ImageExport(Document* doc, fs::path file, ExportGraphicsFormat format, bool hideBackground,
@@ -35,25 +74,43 @@ public:
 
 public:
     /**
-     * PNG dpi
-     */
-    void setPngDpi(int dpi);
-
-    /**
+     * @brief Get the last error message
      * @return The last error message to show to the user
      */
     string getLastErrorMsg() const;
 
     /**
-     * Create one Graphics file per page
+     * @brief Create one Graphics file per page
+     * @param stateListener A listener to track the progress
      */
     void exportGraphics(ProgressListener* stateListener);
 
+    /**
+     * @brief Set a quality level for PNG exports
+     * @param qParam A quality parameter for the export
+     */
+    void setQualityParameter(RasterImageQualityParameter qParam);
+
+    /**
+     * @brief Set a quality level for PNG exports
+     * @param criterion A quality criterion for the export
+     * @param value The target value of this criterion
+     */
+    void setQualityParameter(ExportQualityCriterion criterion, int value);
+
 private:
     /**
-     * Create surface
+     * @brief Create Cairo surface for a given page
+     * @param width the width of the page being exported
+     * @param height the height of the page being exported
+     * @param id the id of the page being exported
+     * @param zoomRatio the zoom ratio for PNG exports with fixed DPI
+     *
+     * @return the zoom ratio of the current page if the export type is PNG, 0.0 otherwise
+     *          The return value may differ from that of the parameter zoomRatio
+     *          if the export has fixed page width or height (in pixels)
      */
-    void createSurface(double width, double height, int id);
+    double createSurface(double width, double height, int id, double zoomRatio);
 
     /**
      * Free / store the surface
@@ -61,14 +118,23 @@ private:
     bool freeSurface(int id);
 
     /**
-     * Get a filename with a number, e.g. .../export-1.png, if the no is -1, return .../export.png
+     * @brief Get a filename with a (page) number appended
+     * @param no The appended number. If no==-1, does not append anything.
+     * e.g. .../export-2.png, if the no is -1, return .../export.png
+     *
+     * @return The filename
      */
     fs::path getFilenameWithNumber(int no) const;
 
     /**
-     * Export a single Image page
+     * @brief Export a single PNG/SVG page
+     * @param pageId The index of the page being exported
+     * @param id The number of the page being exported
+     * @param zoomRatio The zoom ratio for PNG exports with fixed DPI
+     * @param format The format of the exported image
+     * @param view A DocumentView for drawing the page
      */
-    void exportImagePage(int pageId, int id, double zoom, ExportGraphicsFormat format, DocumentView& view);
+    void exportImagePage(int pageId, int id, double zoomRatio, ExportGraphicsFormat format, DocumentView& view);
 
 public:
     /**
@@ -97,9 +163,9 @@ public:
     PageRangeVector& exportRange;
 
     /**
-     * PNG dpi
+     * @brief The export quality parameters, used if format==EXPORT_GRAPHICS_PNG
      */
-    int pngDpi = 300;
+    RasterImageQualityParameter qualityParameter = RasterImageQualityParameter();
 
     /**
      * Export surface

--- a/src/gui/dialog/ExportDialog.cpp
+++ b/src/gui/dialog/ExportDialog.cpp
@@ -7,12 +7,14 @@
 
 ExportDialog::ExportDialog(GladeSearchpath* gladeSearchPath):
         GladeGui(gladeSearchPath, "exportSettings.glade", "exportDialog") {
-    gtk_spin_button_set_value(GTK_SPIN_BUTTON(get("spDpi")), 300);
 
     g_signal_connect(get("rdRangePages"), "toggled", G_CALLBACK(+[](GtkToggleButton* togglebutton, ExportDialog* self) {
                          gtk_widget_set_sensitive(self->get("txtPages"), gtk_toggle_button_get_active(togglebutton));
                      }),
                      this);
+
+    g_signal_connect(get("cbQuality"), "changed", G_CALLBACK(ExportDialog::selectQualityCriterion), this);
+
 
     GSList* radios = gtk_radio_button_get_group(GTK_RADIO_BUTTON(get("rdRangeAll")));
     for (GSList* head = radios; head != nullptr; head = head->next) {
@@ -36,13 +38,35 @@ void ExportDialog::initPages(int current, int count) {
     this->pageCount = count;
 }
 
-void ExportDialog::removeDpiSelection() {
-    gtk_widget_hide(get("lbResolution"));
-    gtk_widget_hide(get("spDpi"));
-    gtk_widget_hide(get("lbDpi"));
+void ExportDialog::removeQualitySetting() {
+    gtk_widget_hide(get("lbQuality"));
+    gtk_widget_hide(get("boxQuality"));
+    gtk_widget_hide(get("cbQuality"));
 }
 
-auto ExportDialog::getPngDpi() -> int { return gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spDpi"))); }
+void ExportDialog::selectQualityCriterion(GtkComboBox* comboBox, ExportDialog* self) {
+    int activeCriterion = gtk_combo_box_get_active(comboBox);
+    switch (activeCriterion) {
+        case EXPORT_QUALITY_DPI:
+            gtk_label_set_text(GTK_LABEL(self->get("lbQualityUnit")), "dpi");
+            gtk_spin_button_set_adjustment(GTK_SPIN_BUTTON(self->get("sbQualityValue")),
+                                           GTK_ADJUSTMENT(gtk_builder_get_object(self->getBuilder(), "adjustmentDpi")));
+            break;
+        case EXPORT_QUALITY_WIDTH:
+        case EXPORT_QUALITY_HEIGHT:
+            gtk_label_set_text(GTK_LABEL(self->get("lbQualityUnit")), "px");
+            gtk_spin_button_set_adjustment(
+                    GTK_SPIN_BUTTON(self->get("sbQualityValue")),
+                    GTK_ADJUSTMENT(gtk_builder_get_object(self->getBuilder(), "adjustmentHeightWidth")));
+            break;
+    }
+}
+
+auto ExportDialog::getPngQualityParameter() -> RasterImageQualityParameter {
+    return RasterImageQualityParameter(
+            (ExportQualityCriterion)gtk_combo_box_get_active(GTK_COMBO_BOX(get("cbQuality"))),
+            gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("sbQualityValue"))));
+}
 
 auto ExportDialog::isConfirmed() const -> bool { return this->confirmed; }
 
@@ -51,7 +75,7 @@ auto ExportDialog::getRange() -> PageRangeVector {
     GtkWidget* rdRangePages = get("rdRangePages");
 
     if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(rdRangePages))) {
-        return PageRange::parse(gtk_entry_get_text(GTK_ENTRY(get("txtPages"))));
+        return PageRange::parse(gtk_entry_get_text(GTK_ENTRY(get("txtPages"))), this->pageCount);
     }
     if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(rdRangeCurrent))) {
         PageRangeVector range;

--- a/src/gui/dialog/ExportDialog.h
+++ b/src/gui/dialog/ExportDialog.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "control/jobs/ImageExport.h"
 #include "control/settings/Settings.h"
 #include "gui/GladeGui.h"
 
@@ -23,11 +24,26 @@ public:
 
 public:
     virtual void show(GtkWindow* parent);
-    void removeDpiSelection();
     void initPages(int current, int count);
-    int getPngDpi();
     bool isConfirmed() const;
     PageRangeVector getRange();
+
+    /**
+     * @brief Reads the quality parameter from the dialog
+     *
+     * @return The selected quality parameter
+     */
+    RasterImageQualityParameter getPngQualityParameter();
+
+    /**
+     * @brief Hides the quality settings
+     */
+    void removeQualitySetting();
+
+    /**
+     * @brief Handler for changes in combobox cbQuality
+     */
+    static void selectQualityCriterion(GtkComboBox* comboBox, ExportDialog* self);
 
 private:
     int currentPage = 0;

--- a/src/util/PageRange.cpp
+++ b/src/util/PageRange.cpp
@@ -16,7 +16,7 @@ auto PageRangeEntry::getFirst() const -> int { return this->first; }
 
 auto PageRange::isSeparator(char c) -> bool { return (c == ',' || c == ';' || c == ':'); }
 
-auto PageRange::parse(const char* str) -> PageRangeVector {
+auto PageRange::parse(const char* str, int pageCount) -> PageRangeVector {
     PageRangeVector data;
 
     if (*str == 0) {
@@ -53,7 +53,7 @@ auto PageRange::parse(const char* str) -> PageRangeVector {
             end = static_cast<int>(strtol(p, &next, 10));
             if (next == p)  // a half-open range like 2-
             {
-                end = 0;
+                end = pageCount;
             } else if (end < start) {
                 end = start;
             }

--- a/src/util/PageRange.h
+++ b/src/util/PageRange.h
@@ -39,5 +39,5 @@ private:
 
 public:
     static bool isSeparator(char c);
-    static PageRangeVector parse(const char* str);
+    static PageRangeVector parse(const char* str, int pageCount);
 };

--- a/ui/exportSettings.glade
+++ b/ui/exportSettings.glade
@@ -1,55 +1,66 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.2 -->
+<!-- Generated with glade 3.38.1 -->
 <interface>
   <requires lib="gtk+" version="3.16"/>
-  <object class="GtkAdjustment" id="adjustment1">
-    <property name="upper">10000</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
-  </object>
-  <object class="GtkAdjustment" id="adjustment2">
-    <property name="upper">10000</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
-  </object>
   <object class="GtkAdjustment" id="adjustmentDpi">
     <property name="lower">72</property>
     <property name="upper">1200</property>
     <property name="value">300</property>
-    <property name="step_increment">10</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">10</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustmentHeightWidth">
+    <property name="lower">100</property>
+    <property name="upper">10000</property>
+    <property name="value">1000</property>
+    <property name="step-increment">100</property>
+    <property name="page-increment">1000</property>
+  </object>
+  <object class="GtkListStore" id="listAvailableCriterion">
+    <columns>
+      <!-- column-name Text -->
+      <column type="gchararray"/>
+    </columns>
+    <data>
+      <row>
+        <col id="0" translatable="yes">Resolution</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Width</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Height</col>
+      </row>
+    </data>
   </object>
   <object class="GtkDialog" id="exportDialog">
     <property name="name">exportDialog</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="title" translatable="yes">Export</property>
-    <property name="window_position">center</property>
+    <property name="window-position">center</property>
     <property name="icon">pixmaps/com.github.xournalpp.xournalpp.svg</property>
-    <property name="type_hint">dialog</property>
-    <child type="titlebar">
-      <placeholder/>
-    </child>
+    <property name="type-hint">dialog</property>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox2">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
         <property name="spacing">4</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="dialog-action_area2">
             <property name="name">dialog-action_area2</property>
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
+            <property name="can-focus">False</property>
+            <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="btCancel">
                 <property name="label">gtk-cancel</property>
                 <property name="name">btCancel</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="can_default">True</property>
-                <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="can-focus">True</property>
+                <property name="can-default">True</property>
+                <property name="receives-default">False</property>
+                <property name="use-stock">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -62,9 +73,9 @@
                 <property name="label">gtk-ok</property>
                 <property name="name">btOk</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="use-stock">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -76,23 +87,23 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">False</property>
-            <property name="pack_type">end</property>
+            <property name="pack-type">end</property>
             <property name="position">0</property>
           </packing>
         </child>
         <child>
           <object class="GtkBox" id="vbox1">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="orientation">vertical</property>
             <property name="spacing">10</property>
             <child>
               <object class="GtkLabel" id="label1">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">&lt;b&gt;Document export settings&lt;/b&gt;
-Select pages to export</property>
-                <property name="use_markup">True</property>
+Set export parameters</property>
+                <property name="use-markup">True</property>
                 <property name="xalign">0</property>
               </object>
               <packing>
@@ -102,31 +113,32 @@ Select pages to export</property>
               </packing>
             </child>
             <child>
+              <!-- n-columns=3 n-rows=5 -->
               <object class="GtkGrid" id="grid1">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="row_spacing">10</property>
-                <property name="column_spacing">10</property>
+                <property name="can-focus">False</property>
+                <property name="row-spacing">10</property>
+                <property name="column-spacing">10</property>
                 <child>
-                  <object class="GtkLabel" id="lbResolution">
+                  <object class="GtkLabel" id="lbQuality">
                     <property name="name">lbResolution</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Resolution</property>
+                    <property name="can-focus">False</property>
+                    <property name="label" translatable="yes">Image quality</property>
                     <property name="xalign">0</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">0</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">0</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="label4">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Range</property>
                     <property name="ellipsize">middle</property>
                     <property name="xalign">0</property>
@@ -135,8 +147,8 @@ Select pages to export</property>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">1</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">1</property>
                   </packing>
                 </child>
                 <child>
@@ -144,15 +156,15 @@ Select pages to export</property>
                     <property name="label" translatable="yes">All pages</property>
                     <property name="name">rdRangeAll</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">False</property>
                     <property name="halign">start</property>
                     <property name="active">True</property>
-                    <property name="draw_indicator">True</property>
+                    <property name="draw-indicator">True</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">1</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">1</property>
                   </packing>
                 </child>
                 <child>
@@ -160,15 +172,15 @@ Select pages to export</property>
                     <property name="label" translatable="yes">Current page</property>
                     <property name="name">rdRangeCurrent</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">False</property>
                     <property name="halign">start</property>
-                    <property name="draw_indicator">True</property>
+                    <property name="draw-indicator">True</property>
                     <property name="group">rdRangeAll</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">2</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">2</property>
                   </packing>
                 </child>
                 <child>
@@ -176,15 +188,15 @@ Select pages to export</property>
                     <property name="label" translatable="yes">Pages:</property>
                     <property name="name">rdRangePages</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">False</property>
                     <property name="halign">start</property>
-                    <property name="draw_indicator">True</property>
+                    <property name="draw-indicator">True</property>
                     <property name="group">rdRangeAll</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">3</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">3</property>
                   </packing>
                 </child>
                 <child>
@@ -192,49 +204,35 @@ Select pages to export</property>
                     <property name="name">txtPages</property>
                     <property name="visible">True</property>
                     <property name="sensitive">False</property>
-                    <property name="can_focus">True</property>
+                    <property name="can-focus">True</property>
                     <property name="hexpand">True</property>
-                    <property name="invisible_char">●</property>
-                    <property name="primary_icon_activatable">False</property>
-                    <property name="secondary_icon_activatable">False</property>
+                    <property name="invisible-char">●</property>
+                    <property name="primary-icon-activatable">False</property>
+                    <property name="secondary-icon-activatable">False</property>
                   </object>
                   <packing>
-                    <property name="left_attach">2</property>
-                    <property name="top_attach">3</property>
+                    <property name="left-attach">2</property>
+                    <property name="top-attach">3</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="label5">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">&lt;i&gt;Example:&lt;/i&gt; 1-3 or 1,3,5-7 etc.</property>
-                    <property name="use_markup">True</property>
+                    <property name="use-markup">True</property>
                     <property name="xalign">0</property>
                   </object>
                   <packing>
-                    <property name="left_attach">2</property>
-                    <property name="top_attach">4</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="lbDpi">
-                    <property name="name">lbDpi</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">dpi</property>
-                    <property name="ellipsize">middle</property>
-                    <property name="xalign">0</property>
-                  </object>
-                  <packing>
-                    <property name="left_attach">2</property>
-                    <property name="top_attach">0</property>
+                    <property name="left-attach">2</property>
+                    <property name="top-attach">4</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="lbAllPagesInfo">
                     <property name="name">lbAllPagesInfo</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label">PLACEHOLDER</property>
                     <property name="xalign">0</property>
                     <attributes>
@@ -242,15 +240,15 @@ Select pages to export</property>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">2</property>
-                    <property name="top_attach">1</property>
+                    <property name="left-attach">2</property>
+                    <property name="top-attach">1</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="lbCurrentPage">
                     <property name="name">lbCurrentPage</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label">PLACEHOLDER</property>
                     <property name="xalign">0</property>
                     <attributes>
@@ -258,25 +256,75 @@ Select pages to export</property>
                     </attributes>
                   </object>
                   <packing>
-                    <property name="left_attach">2</property>
-                    <property name="top_attach">2</property>
+                    <property name="left-attach">2</property>
+                    <property name="top-attach">2</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkSpinButton" id="spDpi">
-                    <property name="name">spDpi</property>
+                  <object class="GtkBox" id="boxQuality">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="invisible_char">●</property>
-                    <property name="text">300</property>
-                    <property name="primary_icon_activatable">False</property>
-                    <property name="secondary_icon_activatable">False</property>
-                    <property name="adjustment">adjustmentDpi</property>
-                    <property name="value">300</property>
+                    <property name="can-focus">False</property>
+                    <property name="spacing">5</property>
+                    <child>
+                      <object class="GtkSpinButton" id="sbQualityValue">
+                        <property name="name">spDpi</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="hexpand">True</property>
+                        <property name="invisible-char">●</property>
+                        <property name="text">300</property>
+                        <property name="primary-icon-activatable">False</property>
+                        <property name="secondary-icon-activatable">False</property>
+                        <property name="adjustment">adjustmentDpi</property>
+                        <property name="value">300</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="lbQualityUnit">
+                        <property name="name">lbDpi</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">dpi</property>
+                        <property name="ellipsize">middle</property>
+                        <property name="width-chars">4</property>
+                        <property name="xalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">0</property>
+                    <property name="left-attach">2</property>
+                    <property name="top-attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkComboBox" id="cbQuality">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="model">listAvailableCriterion</property>
+                    <property name="active">0</property>
+                    <property name="id-column">0</property>
+                    <property name="active-id">0</property>
+                    <child>
+                      <object class="GtkCellRendererText" id="cbQualityCell"/>
+                      <attributes>
+                        <attribute name="markup">0</attribute>
+                        <attribute name="text">0</attribute>
+                      </attributes>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">0</property>
                   </packing>
                 </child>
                 <child>
@@ -311,8 +359,5 @@ Select pages to export</property>
       <action-widget response="-6">btCancel</action-widget>
       <action-widget response="-5">btOk</action-widget>
     </action-widgets>
-  </object>
-  <object class="GtkEntryBuffer" id="entrybuffer1">
-    <property name="text">0</property>
   </object>
 </interface>


### PR DESCRIPTION
Hey,
Here is a first commit implementing a --export-range=... option for the command line. It works as is but I have a question.

As this new option (obiously) uses the same backend as the ExportDialog, I also fixed a bug (not listed) making the ExportDialog fail to understand a page range of the form "n-" (from page n until the end). Now, there are two ways of handling such a page range:
1) Set the end of the range to -1 and implement this possibility in the export job
2) Set the end of the range to the number of the last page **when we parse the string**

I chose option 2 (it was simpler to implement, and I don't yet see a possible benefit of option 1). However, andreasb123, who implemented PageRange::parse (in [this commit](https://github.com/xournalpp/xournalpp/commit/2d412eec34f5cb2f21bcb29db9d1d107dcc276c3#diff-56f37a5274511463372c1a4502e7cd937a822676995d9fc560766855ee3ef0f8)) seemed to have had option 1 in mind (although the ExportJob's don't support it yet).

Does anyone have an opinion?

**Edit**
I now implemented the following command line arguments:
--export-range   (a string used as a page range vector for exports. e.g. "-2,4-6,8,10-" will only export pages 1,2,4,5,6,8 and all pages after no 10)
--export-png-dpi   (an integer used as dpi for png exports)
--export-png-width   (an integer used as the width in pixels of png exports)
--export-png-height   (an integer used as the height in pixels of png exports)

if --export-png-dpi is set, then --export-png-width and --export-png-height are ignored.
if --export-png-width is set, then --export-png-height is ignored.
In particular, the exported png files always have the original page's aspect ratio.

**Further possible improvements:**
Add the dpi, width and height parameters to the GUI's ExportDialog