### PR TITLE
Support for input stabilizing

### DIFF
--- a/src/control/settings/Settings.h
+++ b/src/control/settings/Settings.h
@@ -19,6 +19,7 @@
 #include <portaudio.h>
 
 #include "control/Tool.h"
+#include "control/tools/StrokeStabilizerEnum.h"
 #include "model/Font.h"
 
 #include "LatexSettings.h"
@@ -478,6 +479,29 @@ public:
      */
     std::string getPreferredLocale() const;
 
+    /**
+     * Stabilizer related getters and setters
+     */
+    bool getStabilizerCuspDetection() const;
+    bool getStabilizerFinalizeStroke() const;
+    size_t getStabilizerBuffersize() const;
+    double getStabilizerDeadzoneRadius() const;
+    double getStabilizerDrag() const;
+    double getStabilizerMass() const;
+    double getStabilizerSigma() const;
+    StrokeStabilizer::AveragingMethod getStabilizerAveragingMethod() const;
+    StrokeStabilizer::Preprocessor getStabilizerPreprocessor() const;
+
+    void setStabilizerCuspDetection(bool cuspDetection);
+    void setStabilizerFinalizeStroke(bool finalizeStroke);
+    void setStabilizerBuffersize(size_t buffersize);
+    void setStabilizerDeadzoneRadius(double deadzoneRadius);
+    void setStabilizerDrag(double drag);
+    void setStabilizerMass(double mass);
+    void setStabilizerSigma(double sigma);
+    void setStabilizerAveragingMethod(StrokeStabilizer::AveragingMethod averagingMethod);
+    void setStabilizerPreprocessor(StrokeStabilizer::Preprocessor preprocessor);
+
 public:
     // Custom settings
     SElement& getCustomElement(const string& name);
@@ -931,6 +955,7 @@ private:
      * e.g. "en_US"
      */
     std::string preferredLocale;
+
     /**
      * The number of pages to pre-load before the current page.
      */
@@ -945,4 +970,18 @@ private:
      * Whether to evict from the page buffer cache when scrolling.
      */
     bool eagerPageCleanup{};
+
+    /**
+     * Stabilizer related settings
+     */
+    bool stabilizerCuspDetection{};
+    bool stabilizerFinalizeStroke{};
+
+    size_t stabilizerBuffersize{};
+    double stabilizerDeadzoneRadius{};
+    double stabilizerDrag{};
+    double stabilizerMass{};
+    double stabilizerSigma{};
+    StrokeStabilizer::AveragingMethod stabilizerAveragingMethod{};
+    StrokeStabilizer::Preprocessor stabilizerPreprocessor{};
 };

--- a/src/control/tools/InputHandler.cpp
+++ b/src/control/tools/InputHandler.cpp
@@ -14,8 +14,6 @@
 #include "util/Rectangle.h"
 #include "view/DocumentView.h"
 
-#define PIXEL_MOTION_THRESHOLD 0.3
-
 InputHandler::InputHandler(XournalView* xournal, XojPageView* redrawable, const PageRef& page):
         xournal(xournal), redrawable(redrawable), page(page), stroke(nullptr) {}
 

--- a/src/control/tools/InputHandler.h
+++ b/src/control/tools/InputHandler.h
@@ -113,6 +113,8 @@ protected:
 
     void createStroke(Point p);
 
+    static constexpr double PIXEL_MOTION_THRESHOLD = 0.3;
+
 protected:
     XournalView* xournal;
     XojPageView* redrawable;

--- a/src/control/tools/StrokeStabilizer.cpp
+++ b/src/control/tools/StrokeStabilizer.cpp
@@ -1,0 +1,394 @@
+#include "StrokeStabilizer.h"
+
+#include <numeric>
+
+#include "control/settings/Settings.h"
+#include "model/SplineSegment.h"
+
+/**
+ * StrokeStabilizer::get
+ */
+auto StrokeStabilizer::get(Settings* settings) -> std::unique_ptr<StrokeStabilizer::Base> {
+
+    AveragingMethod averagingMethod = settings->getStabilizerAveragingMethod();
+    Preprocessor preprocessor = settings->getStabilizerPreprocessor();
+
+    if (averagingMethod == AveragingMethod::ARITHMETIC) {
+        if (preprocessor == Preprocessor::DEADZONE) {
+            return std::make_unique<StrokeStabilizer::ArithmeticDeadzone>(
+                    settings->getStabilizerFinalizeStroke(), settings->getStabilizerBuffersize(),
+                    settings->getStabilizerDeadzoneRadius(), settings->getStabilizerCuspDetection());
+        }
+
+        if (preprocessor == Preprocessor::INERTIA) {
+            return std::make_unique<StrokeStabilizer::ArithmeticInertia>(
+                    settings->getStabilizerFinalizeStroke(), settings->getStabilizerBuffersize(),
+                    settings->getStabilizerDrag(), settings->getStabilizerMass());
+        }
+
+        return std::make_unique<StrokeStabilizer::Arithmetic>(settings->getStabilizerFinalizeStroke(),
+                                                              settings->getStabilizerBuffersize());
+    }
+
+    if (averagingMethod == AveragingMethod::VELOCITY_GAUSSIAN) {
+        if (preprocessor == Preprocessor::DEADZONE) {
+            return std::make_unique<StrokeStabilizer::VelocityGaussianDeadzone>(
+                    settings->getStabilizerFinalizeStroke(), settings->getStabilizerSigma(),
+                    settings->getStabilizerDeadzoneRadius(), settings->getStabilizerCuspDetection());
+        }
+
+        if (preprocessor == Preprocessor::INERTIA) {
+            return std::make_unique<StrokeStabilizer::VelocityGaussianInertia>(
+                    settings->getStabilizerFinalizeStroke(), settings->getStabilizerSigma(),
+                    settings->getStabilizerDrag(), settings->getStabilizerMass());
+        }
+
+        return std::make_unique<StrokeStabilizer::VelocityGaussian>(settings->getStabilizerFinalizeStroke(),
+                                                                    settings->getStabilizerSigma());
+    }
+
+    if (preprocessor == Preprocessor::DEADZONE) {
+        return std::make_unique<StrokeStabilizer::Deadzone>(settings->getStabilizerFinalizeStroke(),
+                                                            settings->getStabilizerDeadzoneRadius(),
+                                                            settings->getStabilizerCuspDetection());
+    }
+
+    if (preprocessor == Preprocessor::INERTIA) {
+        return std::make_unique<StrokeStabilizer::Inertia>(
+                settings->getStabilizerFinalizeStroke(), settings->getStabilizerDrag(), settings->getStabilizerMass());
+    }
+
+    /**
+     * Defaults to no stabilization
+     */
+    return std::make_unique<StrokeStabilizer::Base>();
+}
+
+/**
+ * StrokeStabilizer::Active
+ */
+void StrokeStabilizer::Active::finalizeStroke() {
+    if (finalize) {
+        rebalanceStrokePressures();
+        Event ev = getLastEvent();
+        quadraticSplineTo(ev);
+    }
+}
+
+void StrokeStabilizer::Active::quadraticSplineTo(const Event& ev) {
+    /**
+     * Using the last two points of the stroke, draw a spline quadratic segment to the coordinates of ev.
+     */
+    Stroke* stroke = strokeHandler->getStroke();
+    int pointCount = stroke->getPointCount();
+    if (pointCount <= 0) {
+        return;
+    }
+
+    if (pointCount == 1) {
+        /**
+         * Draw a line segment
+         */
+        drawEvent(ev);
+        return;
+    }
+
+    /**
+     * Draw a quadratic spline segment, with first tangent vector parallel to AB
+     */
+    Point B = stroke->getPoint(pointCount - 1);
+    Point A = stroke->getPoint(pointCount - 2);
+    Point C(ev.x / zoom, ev.y / zoom);
+
+    MathVect vAB = {B.x - A.x, B.y - A.y};
+    MathVect vBC = {C.x - B.x, C.y - B.y};
+    const double squaredNormBC = vBC.dx * vBC.dx + vBC.dy * vBC.dy;
+    const double normBC = std::sqrt(squaredNormBC);
+    const double normAB = vAB.norm();
+
+    /**
+     * The first argument of std::min would give a symmetric quadratic spline segment.
+     * The std::min and its second argument ensure the spline segment stays reasonably close to its nodes
+     */
+    double distance = std::min(std::abs(squaredNormBC * normAB / (2 * MathVect::scalarProduct(vAB, vBC))), normBC);
+
+    // Quadratic control point
+    Point Q = B.lineTo(A, -distance);
+
+    /**
+     * The quadratic control point is converted into two cubic control points
+     */
+    // Equivalent to fp = B.lineTo(Q, 2/3*distance), but avoids recomputing the norms
+    Point fp((Q.x - B.x) * 2 / 3 + B.x, (Q.y - B.y) * 2 / 3 + B.y);
+    // Equivalent to sp = C.lineTo(Q, 2/3*distance), but avoids recomputing the norms
+    Point sp((Q.x - C.x) * 2 / 3 + C.x, (Q.y - C.y) * 2 / 3 + C.y);
+
+    /**
+     * Set the pressure values. We assume the tool is pressure sensitive:
+     *      stroke->getToolType() == STROKE_TOOL_PEN
+     */
+    bool usePressure = ev.pressure != Point::NO_PRESSURE;
+    if (usePressure) {
+        C.z = ev.pressure * stroke->getWidth();
+        double coeff = normBC / 2 + distance;  // Very rough estimation of the spline's length
+        B.z = (coeff * A.z + normAB * C.z) / (normAB + coeff);
+        stroke->setLastPressure(B.z);
+    }
+
+    SplineSegment spline(B, fp, sp, C);
+    /**
+     * TODO Add support for spline segments in Stroke and replace this point sequence by a single spline segment
+     */
+    std::list<Point> pointsToPaint = spline.toPointSequence(usePressure);
+
+    pointsToPaint.pop_front();  // Point B has already been painted
+
+    for (auto&& point: pointsToPaint) {
+        strokeHandler->drawSegmentTo(point);
+    }
+    C.z = ev.pressure;  // Normal state after having added a segment. Useful?
+    strokeHandler->drawSegmentTo(C);
+}
+
+
+/**
+ * StrokeStabilizer::Deadzone
+ */
+void StrokeStabilizer::Deadzone::recordFirstEvent(const PositionInputData& pos) {
+    lastEvent = Event(pos);
+    lastPaintedEvent = lastEvent;
+}
+
+void StrokeStabilizer::Deadzone::processEvent(const PositionInputData& pos) {
+
+    /**
+     * Record the event for the stroke finisher
+     */
+    lastEvent = Event(pos);
+
+    MathVect movement = {lastEvent.x - lastPaintedEvent.x, lastEvent.y - lastPaintedEvent.y};
+    double ratio = deadzoneRadius / movement.norm();
+
+    if (ratio >= 1) {
+        /**
+         * The event occurred inside the deadzone. Invalidate it.
+         * Flush the contingent buffer for sharper change of directions
+         */
+        resetBuffer(lastPaintedEvent, pos.timestamp);
+        return;
+    }
+
+    if (cuspDetection && (MathVect::scalarProduct(movement, lastLiveDirection) < 0)) {
+        /**
+         * lastLiveDirection != 0 and the angle between movement and lastLiveDirection is greater than 90°
+         * We have a clear change of direction. This is a cusp. Draw the entire cusp
+         */
+
+        /**
+         * Paint a segment from the stroke's last point to the tip of the cusp.
+         */
+        //         drawEvent(lastLiveEvent);
+        quadraticSplineTo(lastLiveEvent);
+
+        /**
+         * Paint the way back from the tip of the cusp
+         * To do so, we create an artificial point between lastEvent and lastLiveEvent
+         */
+        MathVect diff = {lastEvent.x - lastLiveEvent.x, lastEvent.y - lastLiveEvent.y};
+        double diffNorm = diff.norm();
+        double coeff = deadzoneRadius / diffNorm;
+
+        lastLiveDirection.dx = coeff * diff.dx;
+        lastLiveDirection.dy = coeff * diff.dy;
+
+        lastPaintedEvent.x = lastEvent.x - lastLiveDirection.dx;
+        lastPaintedEvent.y = lastEvent.y - lastLiveDirection.dy;
+        lastPaintedEvent.pressure = coeff * lastLiveEvent.pressure + (1 - coeff) * lastEvent.pressure;
+
+        drawEvent(lastPaintedEvent);
+
+        lastLiveEvent = lastEvent;
+
+        resetBuffer(lastPaintedEvent, pos.timestamp);
+        return;
+    }
+
+    /**
+     * Normal behaviour. Adjust the event's coordinates according to the deadzoneRadius
+     */
+    lastLiveEvent = lastEvent;
+    lastLiveDirection = movement;
+
+    Event ev(lastEvent.x - ratio * movement.dx, lastEvent.y - ratio * movement.dy, lastEvent.pressure);
+
+    averageAndPaint(ev, pos.timestamp);
+}
+
+void StrokeStabilizer::Deadzone::rebalanceStrokePressures() {
+    Stroke* stroke = strokeHandler->getStroke();
+    int pointCount = stroke->getPointCount();
+    if (pointCount >= 3) {
+        /**
+         * Smoothen a little bit the pressure variations
+         */
+        stroke->setSecondToLastPressure((stroke->getPoint(pointCount - 2).z + stroke->getPoint(pointCount - 3).z) / 2);
+    }
+}
+
+
+/**
+ * StrokeStabilizer::Inertia
+ */
+void StrokeStabilizer::Inertia::recordFirstEvent(const PositionInputData& pos) {
+    lastEvent = Event(pos);
+    lastPaintedEvent = lastEvent;
+}
+
+void StrokeStabilizer::Inertia::processEvent(const PositionInputData& pos) {
+
+    /**
+     * Record the event for the stroke finisher
+     */
+    lastEvent = Event(pos);
+
+    /**
+     * Compute the acceleration due to the spring action
+     */
+    MathVect springAcceleration = {(lastEvent.x - lastPaintedEvent.x) / mass,
+                                   (lastEvent.y - lastPaintedEvent.y) / mass};
+
+    speed.dx = speed.dx * oneMinusDrag + springAcceleration.dx;
+    speed.dy = speed.dy * oneMinusDrag + springAcceleration.dy;
+
+    Event ev(lastPaintedEvent.x + speed.dx, lastPaintedEvent.y + speed.dy, lastEvent.pressure);
+
+    averageAndPaint(ev, pos.timestamp);
+}
+
+void StrokeStabilizer::Inertia::rebalanceStrokePressures() {
+    Stroke* stroke = strokeHandler->getStroke();
+    int pointCount = stroke->getPointCount();
+    if (pointCount >= 3) {
+        /**
+         * Smoothen a little bit the pressure variations
+         */
+        stroke->setSecondToLastPressure((stroke->getPoint(pointCount - 2).z + stroke->getPoint(pointCount - 3).z) / 2);
+    }
+}
+
+
+/**
+ * StrokeStabilizer::Arithmetic
+ */
+void StrokeStabilizer::Arithmetic::recordFirstEvent(const PositionInputData& pos) {
+    eventBuffer.assign(Event(pos));  // Fill the buffer with copies of Event(pos)
+}
+
+void StrokeStabilizer::Arithmetic::averageAndPaint(const Event& ev, guint32 timestamp) {
+    /**
+     * Push the event and overwrite the oldest event in the buffer
+     */
+    eventBuffer.push_front(ev);
+
+    /**
+     * Average the coordinates using an arithmetic mean
+     */
+    Event sum = std::accumulate(begin(eventBuffer), end(eventBuffer), Event(0, 0, 0), [](auto&& lhs, auto&& rhs) {
+        return Event(lhs.x + rhs.x, lhs.y + rhs.y, lhs.pressure + rhs.pressure);
+    });
+
+    /**
+     * Rescale the averaged coordinates and draw
+     */
+    double d = static_cast<double>(eventBuffer.size());
+    sum.pressure /= d;
+    sum.x /= d;
+    sum.y /= d;
+    setLastPaintedEvent(sum);
+    drawEvent(sum);
+}
+
+auto StrokeStabilizer::Arithmetic::getLastEvent() -> Event { return eventBuffer.front(); }
+
+void StrokeStabilizer::Arithmetic::resetBuffer(Event& ev, guint32 timestamp) {
+    if (eventBuffer.back() != ev) {
+        eventBuffer.assign(ev);  // Replace the entire content of the buffer with copies of ev
+    }
+}
+
+/**
+ * StrokeStabilizer::VelocityGaussian
+ */
+void StrokeStabilizer::VelocityGaussian::recordFirstEvent(const PositionInputData& pos) {
+    eventBuffer.emplace_front(pos);
+    lastEventTimestamp = pos.timestamp;
+}
+
+void StrokeStabilizer::VelocityGaussian::averageAndPaint(const Event& ev, guint32 timestamp) {
+
+    /**
+     * Compute the velocity (if possible) and push the event to eventBuffer
+     */
+    if (eventBuffer.empty()) {
+        eventBuffer.emplace_front(ev);
+    } else {
+        /**
+         * Issue: timestamps are in ms. They are not precise enough. Different events can have the same timestamp.
+         */
+        VelocityEvent& last = eventBuffer.front();
+        guint32 timelaps = timestamp - lastEventTimestamp;
+        if (timelaps == 0) {
+            timelaps = 1;
+        }
+        eventBuffer.emplace_front(ev, std::hypot(ev.x - last.x, ev.y - last.y) / static_cast<double>(timelaps));
+    }
+    lastEventTimestamp = timestamp;
+
+    /**
+     * Average the coordinates using the gimp-like weights
+     */
+    Event weightedSum = {0, 0, 0};
+    double weight;
+    double sumOfWeights = 0;
+    double sumOfVelocities = 0;
+
+    auto it = eventBuffer.cbegin();
+    for (; it != eventBuffer.cend(); ++it) {
+        /**
+         * The first weight is always 1
+         */
+        weight = exp(-sumOfVelocities * sumOfVelocities / twoSigmaSquared);
+        if (weight < 0.01) {
+            break;
+        }
+        sumOfVelocities += (*it).velocity;
+        weightedSum.x += weight * (*it).x;
+        weightedSum.y += weight * (*it).y;
+        weightedSum.pressure += weight * (*it).pressure;
+        sumOfWeights += weight;
+    }
+    eventBuffer.erase(it, eventBuffer.cend());
+
+    weightedSum.x /= sumOfWeights;
+    weightedSum.y /= sumOfWeights;
+    weightedSum.pressure /= sumOfWeights;
+
+    setLastPaintedEvent(weightedSum);
+    drawEvent(weightedSum);
+}
+
+auto StrokeStabilizer::VelocityGaussian::getLastEvent() -> Event {
+    if (eventBuffer.empty()) {
+        g_warning("StrokeStabilizer::VelocityGaussian buffer empty. This should never be!");
+        return Event(0, 0, 0);
+    }
+    return eventBuffer.front();
+}
+
+void StrokeStabilizer::VelocityGaussian::resetBuffer(Event& ev, guint32 timestamp) {
+    if (eventBuffer.size() != 1 || lastEventTimestamp != timestamp || eventBuffer.front() != ev) {
+        eventBuffer.clear();
+        lastEventTimestamp = timestamp;
+        eventBuffer.emplace_front(ev);
+    }
+}

--- a/src/control/tools/StrokeStabilizer.h
+++ b/src/control/tools/StrokeStabilizer.h
@@ -1,0 +1,595 @@
+/*
+ * Xournal++
+ *
+ * Handles input of strokes
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+#pragma once
+
+#include <array>
+#include <cmath>
+#include <deque>
+#include <functional>
+
+#include "control/tools/StrokeHandler.h"
+
+#include "CircularBuffer.h"
+#include "StrokeStabilizerEnum.h"
+
+namespace StrokeStabilizer {
+
+/**
+ * Auxiliary structures
+ */
+
+/**
+ * @brief A (rudimentary) structure for 2D mathematical vectors
+ */
+struct MathVect {
+    double dx{};
+    double dy{};
+    static inline double scalarProduct(MathVect u, MathVect v) { return u.dx * v.dx + u.dy * v.dy; }
+    inline double norm() { return std::hypot(dx, dy); }
+};
+
+/**
+ * @brief A structure containing the event's information relevant for the stabilizers
+ */
+struct Event {
+    Event() = default;
+    Event(double x, double y, double pressure): x(x), y(y), pressure(pressure) {}
+    Event(const PositionInputData& pos): x(pos.x), y(pos.y), pressure(pos.pressure) {}
+    bool operator!=(const Event& ev) { return (x != ev.x) || (y != ev.y) || (pressure != ev.pressure); }
+    double x{};
+    double y{};
+    double pressure{};
+};
+
+/**
+ * @brief Base stabilizer class. Also used as default (no stabilization).
+ */
+class Base {
+public:
+    Base() = default;
+    virtual ~Base() = default;
+
+    /**
+     * @brief Initialize the stabilizer
+     * @param sH Pointer to the StrokeHandler instance handling the stroke
+     * @param zoomValue The current zoom
+     * @param pos The position of the button down event starting the stroke
+     */
+    void initialize(StrokeHandler* sH, double zoomValue, const PositionInputData& pos) {
+        strokeHandler = sH;
+        zoom = zoomValue;
+        recordFirstEvent(pos);
+    }
+
+    /**
+     * @brief Compute stabilized coordinates for the event and paints the obtained point
+     * @param pos The MotionNotify event information
+     */
+    virtual void processEvent(const PositionInputData& pos) {
+        strokeHandler->paintTo(Point(pos.x / zoom, pos.y / zoom, pos.pressure));
+    }
+
+    /**
+     * @brief Fill the possible gap between the last painted point and the last event received by the stabilizer.
+     *
+     * Does nothing in the base class
+     */
+    virtual void finalizeStroke() {}
+
+    [[maybe_unused]] virtual auto getInfo() -> string { return "No stabilizer"; }
+
+protected:
+    /**
+     * @brief Upon initialization, record the first event for the stabilizer's benefits.
+     * @param pos The first event
+     *
+     * Does nothing in the base class
+     */
+    virtual inline void recordFirstEvent(const PositionInputData& pos){};
+
+    /**
+     * @brief Pointer to the StrokeHandler instance handling the stroke
+     */
+    StrokeHandler* strokeHandler;
+
+    /**
+     * @brief The zoom value to be applied on all painted points
+     */
+    double zoom;
+};
+
+/**
+ * @brief Abstract base class for active stabilizers
+ */
+class Active: public Base {
+public:
+    Active(bool finalize): finalize(finalize) {}
+    virtual ~Active() = default;
+
+    /**
+     * @brief Fill the possible gap between the last painted point and the last event received by the stabilizer.
+     * It does so by creating a quadraticSplineTo the last event's coordinates
+     */
+    virtual void finalizeStroke() override;
+
+    /**
+     * @brief Compute stabilized coordinates for the event and paints the obtained point
+     * @param pos The MotionNotify event information
+     */
+    virtual void processEvent(const PositionInputData& pos) override {
+        Event ev(pos);
+        averageAndPaint(ev, pos.timestamp);
+    }
+
+protected:
+    /**
+     * @brief Add a segment to the stroke ending at the parameters coordinates
+     * @param ev The event whose coordinates determine the stroke's new endpoint
+     */
+    inline void drawEvent(const Event& ev) { strokeHandler->paintTo(Point(ev.x / zoom, ev.y / zoom, ev.pressure)); }
+
+    /**
+     * @brief Record the event corresponding to last painted point
+     * @param ev The event corresponding to last painted point
+     *
+     * Does nothing in the base class.
+     */
+    virtual inline void setLastPaintedEvent(const Event& ev) {}
+
+    /**
+     * @brief For stabilizers with a buffer, clear the buffer and reinitialize it with the provided data
+     * @param ev New event to push to the buffer
+     * @param timestamp The timestamp of that event
+     *
+     * Does nothing in the base class
+     */
+    virtual inline void resetBuffer(Event& ev, guint32 timestamp) {}
+
+    /**
+     * @brief On stabilizers with a buffer, use it to average the input's position and paint the resulting point
+     * @param ev An event to add to the mix
+     * @param timestamp The event's timestamp
+     *
+     * In the base class, simply paint the point corresponding to the given event
+     */
+    virtual inline void averageAndPaint(const Event& ev, guint32 timestamp) {
+        setLastPaintedEvent(ev);
+        drawEvent(ev);
+    }
+
+    /**
+     * @brief Add a quadratic spline segment from the end of the stroke to the point corresponding to the parameters, so
+     * that the stroke is smooth at its former endpoint
+     * @param ev Event whose coordinates determine the stroke's new endpoint
+     */
+    void quadraticSplineTo(const Event& ev);
+
+private:
+    /**
+     * @brief Get the last event received by the stabilizer
+     * @return The last event
+     */
+    virtual inline Event getLastEvent() = 0;
+
+    /**
+     * @brief Tweak the stroke's pressure values upon finalizing the stroke
+     *
+     * Does nothing in the base class
+     */
+    virtual inline void rebalanceStrokePressures() {}
+
+    /**
+     * @brief Wether or not to finalize the stroke
+     */
+    bool finalize = true;
+};
+
+
+/*****************************
+ *       PREPROCESSORS       *
+ *****************************/
+
+/**
+ * @brief Class for deadzone stabilizer/preprocessor
+ */
+class Deadzone: virtual public Active {
+public:
+    Deadzone(bool finalize, double dzRadius, bool cuspDetection):
+            Active(finalize), deadzoneRadius(dzRadius), cuspDetection(cuspDetection) {}
+    virtual ~Deadzone() = default;
+
+    /**
+     * @brief Compute stabilized coordinates for the event and paints the obtained point
+     * @param pos The MotionNotify event information
+     */
+    virtual void processEvent(const PositionInputData& pos) override;
+
+    [[maybe_unused]] virtual auto getInfo() -> string override {
+        return "Deadzone stabilizer with deadzoneRadius = " + std::to_string(deadzoneRadius) +
+               ", cusp detection = " + (cuspDetection ? "on" : "off");
+    }
+
+protected:
+    /**
+     * @brief Upon initialization, record the first event for the stabilizer's benefits.
+     * @param pos The first event
+     */
+    virtual void recordFirstEvent(const PositionInputData& pos) override;
+
+    /**
+     * @brief Record the event corresponding to last painted point
+     * @param ev The event corresponding to last painted point
+     */
+    virtual inline void setLastPaintedEvent(const Event& ev) override { lastPaintedEvent = ev; }
+
+    /**
+     * @brief Get the last event received by the stabilizer
+     * @return The last event
+     */
+    virtual inline Event getLastEvent() override { return lastEvent; }
+
+private:
+    /**
+     * @brief The deadzone radius
+     */
+    const double deadzoneRadius;
+
+    /**
+     * @brief Flag to turn on/off the cusp detection
+     */
+    const bool cuspDetection;
+
+    /**
+     * @brief The direction of the last event outside the deadzone
+     */
+    MathVect lastLiveDirection = {0, 0};
+
+    /**
+     * @brief The last event outside the deadzone
+     */
+    Event lastLiveEvent;
+
+    /**
+     * @brief The last (stabilized) painted point, center of the deadzone
+     */
+    Event lastPaintedEvent;
+
+    /**
+     * @brief The last event (anywhere), used by finishStroke
+     */
+    Event lastEvent;
+
+    /**
+     * @brief Tweak the stroke's pressure values upon finalizing the stroke
+     */
+    virtual void rebalanceStrokePressures() override;
+};
+
+/**
+ * @brief Class for inertial preprocessor
+ *
+ * Principle: Assign a mass to the pencil tip and simulate a spring between the tip and the pointer device.
+ * Friction between the tip and the paper is added by using a drag coefficient.
+ *
+ * A too small drag can lead to unwanted oscillations
+ */
+class Inertia: virtual public Active {
+public:
+    Inertia(bool finalize, double drag, double mass):
+            Active(finalize), mass(mass), oneMinusDrag(1 - drag), speed{0.0, 0.0} {}
+    virtual ~Inertia() = default;
+
+    /**
+     * @brief Compute stabilized coordinates for the event and paints the obtained point
+     * @param pos The MotionNotify event information
+     */
+    virtual void processEvent(const PositionInputData& pos) override;
+
+    [[maybe_unused]] virtual auto getInfo() -> string override {
+        return "Inertia stabilizer with mass = " + std::to_string(mass) +
+               ", drag = " + std::to_string(1 - oneMinusDrag);
+    }
+
+protected:
+    /**
+     * @brief Upon initialization, record the first event for the stabilizer's benefits.
+     * @param pos The first event
+     */
+    virtual void recordFirstEvent(const PositionInputData& pos) override;
+
+    /**
+     * @brief Record the event corresponding to last painted point
+     * @param ev The event corresponding to last painted point
+     */
+    virtual inline void setLastPaintedEvent(const Event& ev) override { lastPaintedEvent = ev; }
+
+    /**
+     * @brief Get the last event received by the stabilizer
+     * @return The last event
+     */
+    virtual inline Event getLastEvent() override { return lastEvent; }
+
+private:
+    /**
+     * @brief mass of the pen
+     */
+    const double mass;
+
+    /**
+     * @brief Friction coefficient
+     */
+    const double oneMinusDrag;
+
+    /**
+     * @brief Speed during the last step
+     */
+    MathVect speed;
+
+    /**
+     * @brief The last (stabilized) painted point, center of the deadzone
+     */
+    Event lastPaintedEvent;
+
+    /**
+     * @brief The last event (anywhere), used by finishStroke
+     */
+    Event lastEvent;
+
+    /**
+     * @brief Tweak the stroke's pressure values upon finalizing the stroke
+     */
+    virtual void rebalanceStrokePressures() override;
+};
+
+
+/*****************************
+ *         AVERAGERS         *
+ *****************************/
+
+/**
+ * @brief Class for the Velocity-based Gaussian averaging stabilizer (a.k.a. Gimp-like)
+ */
+class VelocityGaussian: virtual public Active {
+public:
+    VelocityGaussian(bool finalize, double sigma): Active(finalize), twoSigmaSquared(2 * sigma * sigma) {}
+    virtual ~VelocityGaussian() = default;
+
+    [[maybe_unused]] virtual auto getInfo() -> string override {
+        return "Velocity-based gaussian weight stabilizer with "
+               "2σ² = " +
+               std::to_string(twoSigmaSquared);
+    }
+
+protected:
+    /**
+     * @brief Upon initialization, record the first event for the stabilizer's benefits.
+     * @param pos The first event
+     */
+    virtual void recordFirstEvent(const PositionInputData& pos) override;
+
+    /**
+     * @brief Use the buffer to average the input's position and paint the resulting point
+     * @param ev An event to add to the mix
+     * @param timestamp The event's timestamp
+     */
+    void averageAndPaint(const Event& ev, guint32 timestamp) override;
+
+    /**
+     * @brief For stabilizers with a buffer, clear the buffer and reinitialize it with the provided data
+     * @param ev New event to push to the buffer
+     * @param timestamp The timestamp of that event
+     */
+    virtual void resetBuffer(Event& ev, guint32 timestamp) override;
+
+    /**
+     * @brief Structure containing the event's information relevant to the VelocityGaussian stabilizer
+     */
+    struct VelocityEvent: public Event {
+        VelocityEvent() = default;
+        VelocityEvent(double x, double y, double pressure, double velocity):
+                Event(x, y, pressure), velocity(velocity) {}
+        VelocityEvent(const PositionInputData& pos, double velocity = 0): Event(pos), velocity(velocity) {}
+        VelocityEvent(const Event& ev, double velocity = 0): Event(ev), velocity(velocity) {}
+        double velocity{};
+    };
+
+    /**
+     * @brief A queue containing the relevant information on the last events
+     * The beginning of the queue contains the most recent event
+     * The end of the queue contains the most ancient event stored
+     */
+    std::deque<VelocityEvent> eventBuffer;
+
+private:
+    /**
+     * @brief Get the last event received by the stabilizer
+     * @return The last event
+     */
+    virtual Event getLastEvent() override;
+
+    /**
+     * @brief The Gaussian parameter
+     */
+    const double twoSigmaSquared;
+
+    /**
+     * @brief Timestamp of the last event received. Used to compute the velocity of the next event
+     */
+    guint32 lastEventTimestamp;
+};
+
+class Arithmetic: virtual public Active {
+public:
+    Arithmetic(bool finalize, size_t buffersize): Active(finalize), bufferLength(buffersize), eventBuffer(buffersize) {}
+    virtual ~Arithmetic() = default;
+
+    [[maybe_unused]] virtual auto getInfo() -> string override {
+        return "Arithmetic stabilizer with bufferLength " + std::to_string(bufferLength);
+    }
+
+protected:
+    /**
+     * @brief Upon initialization, record the first event for the stabilizer's benefits.
+     * @param pos The first event
+     */
+    virtual void recordFirstEvent(const PositionInputData& pos) override;
+
+    /**
+     * @brief Use the buffer to average the input's position and paint the resulting point
+     * @param ev An event to add to the mix
+     * @param timestamp The event's timestamp
+     */
+    void averageAndPaint(const Event& ev, guint32 timestamp) override;
+
+    /**
+     * @brief For stabilizers with a buffer, clear the buffer and reinitialize it with the provided data
+     * @param ev New event to push to the buffer
+     * @param timestamp The timestamp of that event
+     */
+    virtual void resetBuffer(Event& ev, guint32 timestamp) override;
+
+    /**
+     * @brief The maximal length of the buffer
+     */
+    const size_t bufferLength;
+
+    /**
+     * @brief A circular buffer containing the relevant information on the last events
+     * The front of the buffer contains the most recent event
+     * The back of the buffer contains the most ancient event stored
+     */
+    CircularBuffer<Event> eventBuffer;
+
+private:
+    /**
+     * @brief Get the last event received by the stabilizer
+     * @return The last event received
+     */
+    virtual Event getLastEvent() override;
+};
+
+
+/*****************************
+ *          HYBRIDS          *
+ *****************************/
+
+class ArithmeticDeadzone: public Arithmetic, public Deadzone {
+public:
+    ArithmeticDeadzone(bool finalize, size_t buffersize, double dzRadius, bool cuspDetection):
+            Active(finalize), Arithmetic(finalize, buffersize), Deadzone(finalize, dzRadius, cuspDetection) {}
+    virtual ~ArithmeticDeadzone() = default;
+
+    [[maybe_unused]] virtual auto getInfo() -> string override {
+        return "Hybrid stabilizer:\n   * " + Arithmetic::getInfo() + "\n   * " + Deadzone::getInfo();
+    }
+
+private:
+    /**
+     * @brief Upon initialization, record the first event for the stabilizer's benefits.
+     * @param pos The first event
+     */
+    virtual inline void recordFirstEvent(const PositionInputData& pos) override {
+        Arithmetic::recordFirstEvent(pos);
+        Deadzone::recordFirstEvent(pos);
+    }
+    /**
+     * @brief Get the last event received by the stabilizer
+     * @return The last event received
+     */
+    inline Event getLastEvent() override { return Deadzone::getLastEvent(); }
+};
+
+class ArithmeticInertia: public Arithmetic, public Inertia {
+public:
+    ArithmeticInertia(bool finalize, size_t buffersize, double drag, double mass):
+            Active(finalize), Arithmetic(finalize, buffersize), Inertia(finalize, drag, mass) {}
+    virtual ~ArithmeticInertia() = default;
+
+    [[maybe_unused]] virtual auto getInfo() -> string override {
+        return "Hybrid stabilizer:\n   * " + Arithmetic::getInfo() + "\n   * " + Inertia::getInfo();
+    }
+
+private:
+    /**
+     * @brief Upon initialization, record the first event for the stabilizer's benefits.
+     * @param pos The first event
+     */
+    virtual inline void recordFirstEvent(const PositionInputData& pos) override {
+        Arithmetic::recordFirstEvent(pos);
+        Inertia::recordFirstEvent(pos);
+    }
+    /**
+     * @brief Get the last event received by the stabilizer
+     * @return The last event received
+     */
+    inline Event getLastEvent() override { return Inertia::getLastEvent(); }
+};
+
+class VelocityGaussianDeadzone: public VelocityGaussian, public Deadzone {
+public:
+    VelocityGaussianDeadzone(bool finalize, double sigma, double dzRadius, bool cuspDetection):
+            Active(finalize), VelocityGaussian(finalize, sigma), Deadzone(finalize, dzRadius, cuspDetection) {}
+    virtual ~VelocityGaussianDeadzone() = default;
+
+    [[maybe_unused]] virtual auto getInfo() -> string override {
+        return "Hybrid stabilizer:\n   * " + VelocityGaussian::getInfo() + "\n   * " + Deadzone::getInfo();
+    }
+
+private:
+    /**
+     * @brief Upon initialization, record the first event for the stabilizer's benefits.
+     * @param pos The first event
+     */
+    virtual inline void recordFirstEvent(const PositionInputData& pos) override {
+        VelocityGaussian::recordFirstEvent(pos);
+        Deadzone::recordFirstEvent(pos);
+    }
+    /**
+     * @brief Get the last event received by the stabilizer
+     * @return The last event received
+     */
+    inline Event getLastEvent() override { return Deadzone::getLastEvent(); }
+};
+
+class VelocityGaussianInertia: public VelocityGaussian, public Inertia {
+public:
+    VelocityGaussianInertia(bool finalize, double sigma, double drag, double mass):
+            Active(finalize), VelocityGaussian(finalize, sigma), Inertia(finalize, drag, mass) {}
+    virtual ~VelocityGaussianInertia() = default;
+
+    [[maybe_unused]] virtual auto getInfo() -> string override {
+        return "Hybrid stabilizer:\n   * " + VelocityGaussian::getInfo() + "\n   * " + Inertia::getInfo();
+    }
+
+private:
+    /**
+     * @brief Upon initialization, record the first event for the stabilizer's benefits.
+     * @param pos The first event
+     */
+    virtual inline void recordFirstEvent(const PositionInputData& pos) override {
+        VelocityGaussian::recordFirstEvent(pos);
+        Inertia::recordFirstEvent(pos);
+    }
+    /**
+     * @brief Get the last event received by the stabilizer
+     * @return The last event received
+     */
+    inline Event getLastEvent() override { return Inertia::getLastEvent(); }
+};
+
+/**
+ * @brief Stabilizer factory: create a stabilizer of the right kind
+ * @param settings The Settings instance to read to determine what kind of stabilizer to create
+ * @return A unique point to the create stabilizer instance.
+ */
+std::unique_ptr<Base> get(Settings* settings);
+
+}  // namespace StrokeStabilizer

--- a/src/control/tools/StrokeStabilizerEnum.h
+++ b/src/control/tools/StrokeStabilizerEnum.h
@@ -1,0 +1,27 @@
+/*
+ * Xournal++
+ *
+ * Enum available stabilizer
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+namespace StrokeStabilizer {
+
+enum class AveragingMethod { NONE, ARITHMETIC, VELOCITY_GAUSSIAN };
+
+constexpr bool isValid(AveragingMethod am) {
+    return am == AveragingMethod::NONE || am == AveragingMethod::ARITHMETIC || am == AveragingMethod::VELOCITY_GAUSSIAN;
+}
+
+enum class Preprocessor { NONE, DEADZONE, INERTIA };
+
+constexpr bool isValid(Preprocessor pp) {
+    return pp == Preprocessor::NONE || pp == Preprocessor::DEADZONE || pp == Preprocessor::INERTIA;
+}
+}  // namespace StrokeStabilizer

--- a/src/gui/dialog/SettingsDialog.h
+++ b/src/gui/dialog/SettingsDialog.h
@@ -67,6 +67,9 @@ private:
 
     void initLanguageSettings();
 
+    void showStabilizerAvMethodOptions(StrokeStabilizer::AveragingMethod method);
+    void showStabilizerPreprocessorOptions(StrokeStabilizer::Preprocessor preprocessor);
+
 private:
     Settings* settings = nullptr;
     Control* control = nullptr;

--- a/src/model/SplineSegment.h
+++ b/src/model/SplineSegment.h
@@ -58,16 +58,18 @@ public:
 
     /**
      * @brief Convert the spline segment to a list of points.
+     * @param usePressure If true, interpolate the pressure along the spline. Default: false
      * @return A point list which represents the spline segment without the end point.
      */
-    std::list<Point> toPointSequence() const;
+    std::list<Point> toPointSequence(bool usePressure = false) const;
 
     /**
      * @brief Subdivide the spline into two parts with respect to parameter t.
      * @param t the parameter between 0 and 1, which corresponds to the point where the spline is split
+     * @param usePressure If true, infer pressure values for the resulting SplineSegments' endpoints. Default: false.
      * @return A pair of two spline segments corresponding to the two parts of the spline
      */
-    std::pair<SplineSegment, SplineSegment> subdivide(float t) const;
+    std::pair<SplineSegment, SplineSegment> subdivide(float t, bool usePressure = false) const;
 
     /**
      * @brief Interpolate a line segment with respect to parameter t
@@ -80,9 +82,10 @@ public:
 
     /**
      * @brief checks if the spline segment is flat enough so that it can be drawn as a straight line
+     * @param usePressure If true, return false if the endpoints' pressure values are to far appart. Default: false.
      * @return true, if the spline segment is flat enough; false otherwise
      */
-    bool isFlatEnough() const;
+    bool isFlatEnough(bool usePressure = false) const;
 
 
 public:

--- a/src/model/Stroke.cpp
+++ b/src/model/Stroke.cpp
@@ -247,6 +247,13 @@ void Stroke::setLastPressure(double pressure) {
     }
 }
 
+void Stroke::setSecondToLastPressure(double pressure) {
+    auto const pointCount = this->getPointCount();
+    if (pointCount >= 2) {
+        this->points[pointCount - 2].z = pressure;
+    }
+}
+
 void Stroke::setPressure(const vector<double>& pressure) {
     // The last pressure is not used - as there is no line drawn from this point
     if (this->points.size() - 1 != pressure.size()) {

--- a/src/model/Stroke.h
+++ b/src/model/Stroke.h
@@ -84,6 +84,7 @@ public:
 
     void setPressure(const vector<double>& pressure);
     void setLastPressure(double pressure);
+    void setSecondToLastPressure(double pressure);
     void clearPressure();
     void scalePressure(double factor);
 

--- a/src/util/CircularBuffer.h
+++ b/src/util/CircularBuffer.h
@@ -1,0 +1,46 @@
+/*
+ * Xournal++
+ *
+ * A rudimentary circular buffer
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+template <class T>
+class CircularBuffer: private std::vector<T> {
+public:
+    CircularBuffer(size_t length): std::vector<T>(length > 1 ? length : 1), length(length > 1 ? length : 1) {}
+    ~CircularBuffer() = default;
+    T front() { return (*this)[head]; }
+    T back() {
+        if (head == 0) {
+            return (*this)[length - 1];
+        }
+        return (*this)[head - 1];
+    }
+    void push_front(const T& ev) {
+        head++;
+        head %= length;
+        (*this)[head] = ev;
+    }
+    void assign(const T& ev) {
+        for (T& e: *this) {
+            e = ev;
+        }
+    }
+    size_t size() { return length; }
+
+    /**
+     * Beware: begin and end are not related to the position of the head
+     */
+    using std::vector<T>::cbegin;
+    using std::vector<T>::begin;
+    using std::vector<T>::cend;
+    using std::vector<T>::end;
+
+private:
+    const size_t length;
+    size_t head = length - 1;
+};

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -99,6 +99,40 @@
     <property name="step-increment">0.05</property>
     <property name="page-increment">10</property>
   </object>
+  <object class="GtkAdjustment" id="adjustmentStabilizerDeadzoneRadius">
+    <property name="lower">0.10</property>
+    <property name="upper">50</property>
+    <property name="value">1.3</property>
+    <property name="step-increment">0.10</property>
+    <property name="page-increment">1</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustmentStabilizerDrag">
+    <property name="upper">1</property>
+    <property name="value">0.40</property>
+    <property name="step-increment">0.05</property>
+    <property name="page-increment">0.20</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustmentStabilizerMass">
+    <property name="lower">1</property>
+    <property name="upper">30</property>
+    <property name="value">5</property>
+    <property name="step-increment">0.10</property>
+    <property name="page-increment">1</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustmentStabilizerSigma">
+    <property name="lower">0.05</property>
+    <property name="upper">5</property>
+    <property name="value">0.5</property>
+    <property name="step-increment">0.05</property>
+    <property name="page-increment">1</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustmentStabilizingBuffersize">
+    <property name="lower">2</property>
+    <property name="upper">100</property>
+    <property name="value">20</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
   <object class="GtkAdjustment" id="adjustmentStrokeIgnoreLength">
     <property name="lower">0.01000000000000001</property>
     <property name="upper">100</property>
@@ -162,6 +196,40 @@
     <property name="value">2</property>
     <property name="step-increment">0.5</property>
     <property name="page-increment">10</property>
+  </object>
+  <object class="GtkListStore" id="listStabilizerAveragingMethods">
+    <columns>
+      <!-- column-name Name -->
+      <column type="gchararray"/>
+    </columns>
+    <data>
+      <row>
+        <col id="0" translatable="yes">None</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Arithmetic mean</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Velocity based Gaussian weights</col>
+      </row>
+    </data>
+  </object>
+  <object class="GtkListStore" id="listStabilizerPreprocessors">
+    <columns>
+      <!-- column-name Name -->
+      <column type="gchararray"/>
+    </columns>
+    <data>
+      <row>
+        <col id="0" translatable="yes">None</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Deadzone</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Inertia</col>
+      </row>
+    </data>
   </object>
   <object class="GtkDialog" id="settingsDialog">
     <property name="name">settingsDialog</property>
@@ -791,7 +859,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             <property name="tooltip-markup" translatable="yes">Drag LEFT from start point acts like shift key is being held.
 	    Drag UP acts as if Control key is being held.
 
-	    Determination Radius: Radius at which modifiers will lock in until finished drawing.
+            Determination Radius: Radius at which modifiers will lock in until finished drawing.
 
 	    &lt;i&gt;Useful for operating without keyboard.&lt;/i&gt;</property>
                                             <property name="xalign">0</property>
@@ -858,6 +926,320 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
                                 <property name="position">2</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkFrame" id="frameStabilizerSettings">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
+                                <child>
+                                  <object class="GtkAlignment" id="alignmentStabilizer">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">12</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
+                                    <child>
+                                      <!-- n-columns=4 n-rows=4 -->
+                                      <object class="GtkGrid" id="gridStabilizer">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="column-spacing">10</property>
+                                        <child>
+                                          <object class="GtkLabel" id="lbStabilizerAveragingMethod">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="halign">start</property>
+                                            <property name="margin-start">16</property>
+                                            <property name="label" translatable="yes">Averaging method</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkComboBox" id="cbStabilizerAveragingMethods">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="hexpand">True</property>
+                                            <property name="model">listStabilizerAveragingMethods</property>
+                                            <property name="active">0</property>
+                                            <property name="id-column">0</property>
+                                            <property name="active-id">0</property>
+                                            <child>
+                                              <object class="GtkCellRendererText"/>
+                                              <attributes>
+                                                <attribute name="markup">0</attribute>
+                                                <attribute name="text">0</attribute>
+                                              </attributes>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="lbStabilizerDescription">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">&lt;i&gt;Pick an input stabilization algorithm and its parameters&lt;/i&gt;</property>
+                                            <property name="use-markup">True</property>
+                                            <property name="wrap">True</property>
+                                            <property name="width-chars">85</property>
+                                            <property name="max-width-chars">85</property>
+                                            <property name="xalign">0</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">0</property>
+                                            <property name="width">4</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="lbStabilizerBuffersize">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">Buffersize</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">2</property>
+                                            <property name="top-attach">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSpinButton" id="sbStabilizerBuffersize">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="hexpand">True</property>
+                                            <property name="text" translatable="yes">20</property>
+                                            <property name="input-purpose">number</property>
+                                            <property name="adjustment">adjustmentStabilizingBuffersize</property>
+                                            <property name="climb-rate">1</property>
+                                            <property name="snap-to-ticks">True</property>
+                                            <property name="numeric">True</property>
+                                            <property name="value">20</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">3</property>
+                                            <property name="top-attach">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="lbStabilizerDeadzoneRadius">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">Deadzone radius</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">2</property>
+                                            <property name="top-attach">2</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSpinButton" id="sbStabilizerDeadzoneRadius">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="hexpand">True</property>
+                                            <property name="text" translatable="yes">1,30</property>
+                                            <property name="input-purpose">number</property>
+                                            <property name="adjustment">adjustmentStabilizerDeadzoneRadius</property>
+                                            <property name="climb-rate">2</property>
+                                            <property name="digits">2</property>
+                                            <property name="snap-to-ticks">True</property>
+                                            <property name="numeric">True</property>
+                                            <property name="value">1.3</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">3</property>
+                                            <property name="top-attach">2</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="lbStabilizerDrag">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="tooltip-text" translatable="yes">Drag: If the value is to small, unwanted oscillations may appear. If the value is to high, there will be no stabilization.</property>
+                                            <property name="label" translatable="yes">Drag</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">2</property>
+                                            <property name="top-attach">2</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSpinButton" id="sbStabilizerDrag">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="tooltip-text" translatable="yes">Drag: If the value is to small, unwanted oscillations may appear. If the value is too small, there will be no stabilization.</property>
+                                            <property name="hexpand">True</property>
+                                            <property name="text" translatable="yes">0,4</property>
+                                            <property name="input-purpose">number</property>
+                                            <property name="adjustment">adjustmentStabilizerDrag</property>
+                                            <property name="climb-rate">2</property>
+                                            <property name="digits">2</property>
+                                            <property name="snap-to-ticks">True</property>
+                                            <property name="numeric">True</property>
+                                            <property name="value">0.40</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">3</property>
+                                            <property name="top-attach">2</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="lbStabilizerMass">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="tooltip-text" translatable="yes">Mass: the higher the mass, the more inertia and the more stabilization</property>
+                                            <property name="label" translatable="yes">Mass</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">2</property>
+                                            <property name="top-attach">3</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSpinButton" id="sbStabilizerMass">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="tooltip-text" translatable="yes">Mass: the higher the mass, the more inertia and the more stabilization</property>
+                                            <property name="hexpand">True</property>
+                                            <property name="text" translatable="yes">5</property>
+                                            <property name="input-purpose">number</property>
+                                            <property name="adjustment">adjustmentStabilizerMass</property>
+                                            <property name="climb-rate">2</property>
+                                            <property name="digits">2</property>
+                                            <property name="snap-to-ticks">True</property>
+                                            <property name="numeric">True</property>
+                                            <property name="value">5</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">3</property>
+                                            <property name="top-attach">3</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSpinButton" id="sbStabilizerSigma">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="tooltip-text" translatable="yes">Gaussian parameter: the higher, the more stabilization and the more lag between your cursor and the painting tip.</property>
+                                            <property name="hexpand">True</property>
+                                            <property name="text" translatable="yes">0,50</property>
+                                            <property name="input-purpose">number</property>
+                                            <property name="adjustment">adjustmentStabilizerSigma</property>
+                                            <property name="climb-rate">0.99999999977648257</property>
+                                            <property name="digits">2</property>
+                                            <property name="snap-to-ticks">True</property>
+                                            <property name="numeric">True</property>
+                                            <property name="value">0.5</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">3</property>
+                                            <property name="top-attach">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="lbStabilizerSigma">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="tooltip-text" translatable="yes">Gaussian parameter: the higher, the more stabilization and the more lag between your cursor and the painting tip.</property>
+                                            <property name="label" translatable="yes">σ</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">2</property>
+                                            <property name="top-attach">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="lbStabilizerPreprocessor">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="halign">start</property>
+                                            <property name="margin-start">15</property>
+                                            <property name="label" translatable="yes">Preprocessor</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">2</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkComboBox" id="cbStabilizerPreprocessors">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="hexpand">True</property>
+                                            <property name="model">listStabilizerPreprocessors</property>
+                                            <property name="active">0</property>
+                                            <property name="id-column">0</property>
+                                            <property name="active-id">0</property>
+                                            <child>
+                                              <object class="GtkCellRendererText"/>
+                                              <attributes>
+                                                <attribute name="markup">0</attribute>
+                                                <attribute name="text">0</attribute>
+                                              </attributes>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">2</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="cbStabilizerEnableCuspDetection">
+                                            <property name="label" translatable="yes">Cusp detection</property>
+                                            <property name="name">cbStabilizerEnableCuspDetection</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="halign">start</property>
+                                            <property name="active">True</property>
+                                            <property name="draw-indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">2</property>
+                                            <property name="top-attach">3</property>
+                                            <property name="width">2</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="cbStabilizerEnableFinalizeStroke">
+                                            <property name="label" translatable="yes">Finalize the stroke</property>
+                                            <property name="name">cbStabilizerEnableFinalizeStroke</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-text" translatable="yes">Input stabilization can create a gap at the end of your stroke. If enabled, this gap is filled.</property>
+                                            <property name="active">True</property>
+                                            <property name="draw-indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">3</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label">
+                                  <object class="GtkLabel" id="lbStabilizerSettings">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">Input stabilization</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">3</property>
                               </packing>
                             </child>
                           </object>


### PR DESCRIPTION
This follows up on #2320.
I implemented basic support for smoothing algorithms, as well as a a version of Gimp's smoothing algorithm (see #2320 for more details on this algorigthm). You can see the results in the following gifs (no smoothing vs Gimp's smoothing).
![rolandlo](https://user-images.githubusercontent.com/17818041/101608063-93920580-3a05-11eb-94ae-28435cabca96.gif)
![TentativeConvert](https://user-images.githubusercontent.com/17818041/101608071-955bc900-3a05-11eb-9231-9538c4f50a79.gif)

This is pretty rudimentary and there is no GUI control for now. To try out the smoother, you need to use --smoothing=GIMP in your command line. There are two parameters you can tweak: 

- A (double) coefficient sigma (through --smoothing-sigma=0.2 for instance). In the first gif, it was set to 1, in the second gif, it was set to 2.
- The size of the buffer used by the algorithm (through --smoothing-buffer-size=20). In the examples above, I let to 20.

[You can also try out --smoothing=ARITHMETIC which is fun but not very useful]

**Edit:** the parameters are now set in the GUI settings dialog (Stylus tab). The CLI arguments are no longer valid. **End of Edit**

There are a couple of issues to work through:


- [x] The rate events arrive depends on the input device (for Wacom tablets, I've seen it vary from 1 event per 3ms to 1 event per 10ms). Since the buffer has a predetermined size, this rate influences the smoothing parameters. It should not. For instance, one could dynamically change the buffer's length (based on what criteria?)

- (No fix, but not important) Gimp's algorithm uses velocities as a parameter. Here, the velocity is computed using the event's timestamps. However the timestamps are not quite precise enough and different events can have the same timestamp. This results in a division by 0 when computing the velocity. See the console log.
- (No fix, but not important) Because StrokeHandler receives the events in coordinate relative to the page's dpi (right?), the parameter sigma has to be changed if using a different dpi (I think...). I think I made it zoom-independent, but I might have messed that up too.

And more generic TODOs:
- [x] Add parameter selection to the GUI and get rid of the ugly CLI parameter workaround
- [x] Add a version of Krita's deadzone stabilizer (see #2320 for details).
- [x] Implement those smoothing algorithms either as lamdas, function objects, std::functions, Concepts / Interfaces. Do not determine it on every loop cycle.
- [x] Use range based for loops.
- [x] Add a stroke finisher (see [this post](https://github.com/xournalpp/xournalpp/issues/2320#issuecomment-742081126) and the next)
- [x] Remove Glade's default sid1234 names to avoid conflicts with other PR

Known bugs:
 - [Fixed] For small values of sigma, gimp's algorithm makes stroke segments disappear. This is because the weights become 0 and a division by 0 messes the whole thing up. 
 - [Fixed] Single taps/clicks don't draw anything with deadzone stabilizer on