### PR TITLE
Mini fixups to the CMake script and the CI

### DIFF
--- a/azure-pipelines/clang-format-applied.yml
+++ b/azure-pipelines/clang-format-applied.yml
@@ -10,8 +10,6 @@ pr:
       - po/xournalpp.pot
       - po/*.po
 
-
-
 stages:
 - stage: 'Build_Test_Stage'
   jobs:
@@ -22,9 +20,9 @@ stages:
     steps:
     - bash: |
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-        sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main"
+        sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-10 main"
         sudo apt-get update
-        sudo apt-get install -y clang-format-9
+        sudo apt-get install -y clang-format-10
       displayName: 'Install clang-format'
     - bash: |
         # Checkout the master branch as we require it to get the list of modified files

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -85,8 +85,8 @@ stages:
         steps:
           - template: steps/build_windows.yml
             parameters:
-              build_type: 'RelWithDebInfo'
-              cmake_flags: ''
+              build_type: 'MinSizeRel'
+              cmake_flags: '-DCMAKE_CXX_FLAGS=-g'
           - script: |
               set PATH=%PATH%;C:\msys64\usr\bin;C:\msys64\mingw64\bin"
               C:\msys64\usr\bin\bash -lc "./build-setup.sh"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,8 +17,6 @@ add_subdirectory (xoj-preview-extractor)
 add_definitions (-g -Wreturn-type -Wuninitialized -Wunused-value -Wunused-variable)
 
 if (WIN32)
-  # optimize for size (the Windows .exe is really big)
-  set (xournalpp_LDFLAGS ${xournalpp_LDFLAGS} "-Os -s")
 elseif (APPLE OR LINUX)
   # Nothing to do for APPLE and linux
 else ()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,10 +16,7 @@ add_subdirectory (xoj-preview-extractor)
 # Used for both util and xournalpp targets
 add_definitions (-g -Wreturn-type -Wuninitialized -Wunused-value -Wunused-variable)
 
-if (WIN32)
-elseif (APPLE OR LINUX)
-  # Nothing to do for APPLE and linux
-else ()
+if (NOT WIN32 AND (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU"))
   set(xournalpp_LDFLAGS ${xournalpp_LDFLAGS} -rdynamic)
 endif ()
 


### PR DESCRIPTION
 - fixed a bug, that prevented the creation of debug symbols on Windows
 - fixed a bug, that no stacktrace is shown anymore
 - fixed a small clang-format issue