### PR TITLE
Fix Segfault due to missing nullptr

### DIFF
--- a/src/control/XournalMain.cpp
+++ b/src/control/XournalMain.cpp
@@ -550,7 +550,8 @@ auto XournalMain::run(int argc, char** argv) -> int {
                           GOptionEntry{G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_FILENAME_ARRAY, &app_data.optFilename,
                                        "<input>", nullptr},
                           GOptionEntry{"version", 0, 0, G_OPTION_ARG_NONE, &app_data.showVersion,
-                                       _("Get version of xournalpp"), nullptr}};
+                                       _("Get version of xournalpp"), nullptr},
+                          GOptionEntry{nullptr}};  // Must be terminated by a nullptr. See gtk doc
     g_application_add_main_option_entries(G_APPLICATION(app), options.data());
     auto rv = g_application_run(G_APPLICATION(app), argc, argv);
     g_object_unref(app);


### PR DESCRIPTION
I had a segfault message due to the lack of nullptr at the end of the option array. See
[Gtk's documentation](https://developer.gnome.org/gio/stable/GApplication.html#g-application-add-main-option-entries):

`void
g_application_add_main_option_entries (GApplication *application,
                                       const GOptionEntry *entries);`

>application: a GApplication
>
>entries: (array zero-terminated=1) (element-type GOptionEntry) a NULL-terminated list of GOptionEntrys

**Edit** Fixed link and added quote