### PR TITLE
[1.0.x] Fixup overwrite file in pdf export

### DIFF
--- a/src/util/XojMsgBox.cpp
+++ b/src/util/XojMsgBox.cpp
@@ -78,8 +78,8 @@ int XojMsgBox::replaceFileQuestion(GtkWindow* win, string msg)
 	{
 		gtk_window_set_transient_for(GTK_WINDOW(dialog), win);
 	}
-	gtk_dialog_add_button(GTK_DIALOG(dialog), _("Select another name"), 1);
-	gtk_dialog_add_button(GTK_DIALOG(dialog), _("Replace"), 2);
+	gtk_dialog_add_button(GTK_DIALOG(dialog), _("Select another name"), GTK_RESPONSE_CANCEL);
+	gtk_dialog_add_button(GTK_DIALOG(dialog), _("Replace"), GTK_RESPONSE_OK);
 	int res = gtk_dialog_run(GTK_DIALOG(dialog));
 	gtk_widget_destroy(dialog);
 	return res;


### PR DESCRIPTION
Fixes #2355 introduced in backport of #1989