### PR TITLE
Take toolsize and erasertype from corresponding toolbar tool when triggered by Button

### DIFF
--- a/src/control/ToolHandler.cpp
+++ b/src/control/ToolHandler.cpp
@@ -114,8 +114,8 @@ ToolHandler::~ToolHandler() {
 }
 
 void ToolHandler::setEraserType(EraserType eraserType) {
-    Tool* tool = this->toolbarSelectedTool;
-    tool->setEraserType(eraserType);
+    Tool& tool = this->getTool(TOOL_ERASER);
+    tool.setEraserType(eraserType);
     eraserTypeChanged();
 }
 
@@ -146,9 +146,12 @@ void ToolHandler::eraserTypeChanged() {
     }
 }
 
-auto ToolHandler::getEraserType(SelectedTool selectedTool) -> EraserType {
-    Tool* tool = getSelectedTool(selectedTool);
-    return tool->getEraserType();
+auto ToolHandler::getEraserType() -> EraserType {
+    // if active tool is eraser get its type
+    if (this->activeTool->type == TOOL_ERASER)
+        return this->activeTool->getEraserType();
+    else  // otherwise get EraserType of Toolbar Eraser
+        return this->getTool(TOOL_ERASER).getEraserType();
 }
 
 void ToolHandler::selectTool(ToolType type) {

--- a/src/control/ToolHandler.h
+++ b/src/control/ToolHandler.h
@@ -225,9 +225,10 @@ public:
     Tool& getTool(ToolType type);
 
     /**
-     * @brief Set the Eraser Type of the toolbar selected tool
-     * @note It is safer to always set the toolbar tool as the active tool could be pointing to a button tool which
-     * could lead to hard to debug behaviour
+     * @brief Set the Eraser Type of the Eraser in the toolbar
+     * @note Here the Eraser Tool in the toolbar is changed regardless of the the tool currently selected.
+     * This is necessary to allow users to change the Eraser type for their Button Tools while having another tool
+     * active. This is relevant in case of Eraser Type being set to "Don't Change" for the button.
      *
      * @param eraserType
      */
@@ -242,12 +243,14 @@ public:
     void setButtonEraserType(EraserType eraserType, Button button);
 
     /**
-     * @brief Get the Eraser Type of one of the selected Tools
+     * @brief Get the Eraser Type
+     * If the currently active Tool is an eraser it's type is returned (relevant for Buttontools).
+     * If the currently active Tool is not a eraser the erasertype of the eraser in the toolbar is obtained.
      *
      * @param selectedTool
      * @return EraserType
      */
-    EraserType getEraserType(SelectedTool selectedTool = SelectedTool::active);
+    EraserType getEraserType();
 
     /**
      * @brief Update the toolbar based on the Eraser type of the active tool

--- a/src/control/settings/ButtonConfig.cpp
+++ b/src/control/settings/ButtonConfig.cpp
@@ -28,18 +28,18 @@ void ButtonConfig::initButton(ToolHandler* toolHandler, Button button) {
     toolHandler->resetButtonTool(this->action, button);
 
     if (this->action == TOOL_PEN || this->action == TOOL_HIGHLIGHTER || this->action == TOOL_ERASER) {
-
-        if (this->drawingType != DRAWING_TYPE_DONT_CHANGE) {
-            toolHandler->setButtonDrawingType(this->drawingType, button);
-        }
-
         if (this->size != TOOL_SIZE_NONE) {
             toolHandler->setButtonSize(this->size, button);
         }
-        toolHandler->setButtonColor(this->color, button);
-    }
-    if (this->action == TOOL_ERASER && this->eraserMode != ERASER_TYPE_NONE) {
-        toolHandler->setButtonEraserType(this->eraserMode, button);
+        if (this->action == TOOL_PEN || this->action == TOOL_HIGHLIGHTER) {
+            toolHandler->setButtonColor(this->color, button);
+            if (this->drawingType != DRAWING_TYPE_DONT_CHANGE)
+                toolHandler->setButtonDrawingType(this->drawingType, button);
+        }
+        if (this->action == TOOL_ERASER) {
+            if (this->eraserMode != ERASER_TYPE_NONE)
+                toolHandler->setButtonEraserType(this->eraserMode, button);
+        }
     }
 }
 
@@ -50,18 +50,18 @@ void ButtonConfig::applyConfigToToolbarTool(ToolHandler* toolHandler) {
     toolHandler->selectTool(this->action);
 
     if (this->action == TOOL_PEN || this->action == TOOL_HIGHLIGHTER || this->action == TOOL_ERASER) {
-
-        if (this->drawingType != DRAWING_TYPE_DONT_CHANGE) {
-            toolHandler->setDrawingType(this->drawingType);
-        }
-
         if (this->size != TOOL_SIZE_NONE) {
             toolHandler->setSize(this->size);
         }
-        toolHandler->setColor(this->color, false);
-    }
-    if (this->action == TOOL_ERASER && this->eraserMode != ERASER_TYPE_NONE) {
-        toolHandler->setEraserType(this->eraserMode);
+        if (this->action == TOOL_PEN || this->action == TOOL_HIGHLIGHTER) {
+            toolHandler->setColor(this->color, false);
+            if (this->drawingType != DRAWING_TYPE_DONT_CHANGE)
+                toolHandler->setDrawingType(this->drawingType);
+        }
+        if (this->action == TOOL_ERASER) {
+            if (this->eraserMode != ERASER_TYPE_NONE)
+                toolHandler->setEraserType(this->eraserMode);
+        }
     }
 }
 
@@ -70,17 +70,20 @@ bool ButtonConfig::applyNoChangeSettings(ToolHandler* toolHandler, Button button
         return false;
     }
     if (this->action == TOOL_PEN || this->action == TOOL_HIGHLIGHTER || this->action == TOOL_ERASER) {
-
-        if (this->drawingType == DRAWING_TYPE_DONT_CHANGE) {
-            toolHandler->setButtonDrawingType(toolHandler->getDrawingType(SelectedTool::toolbar), button);
-        }
+        Tool& correspondingTool = toolHandler->getTool(this->action);
 
         if (this->size == TOOL_SIZE_NONE) {
-            toolHandler->setButtonSize(toolHandler->getSize(SelectedTool::toolbar), button);
+            toolHandler->setButtonSize(correspondingTool.getSize(), button);
+        }
+        if (this->action == TOOL_PEN || this->action == TOOL_HIGHLIGHTER) {
+            if (this->drawingType == DRAWING_TYPE_DONT_CHANGE)
+                toolHandler->setButtonDrawingType(correspondingTool.getDrawingType(), button);
+        }
+        if (this->action == TOOL_ERASER) {
+            if (this->eraserMode == ERASER_TYPE_NONE)
+                toolHandler->setButtonEraserType(correspondingTool.getEraserType(), button);
         }
     }
-    if (this->action == TOOL_ERASER && this->eraserMode == ERASER_TYPE_NONE) {
-        toolHandler->setButtonEraserType(toolHandler->getEraserType(SelectedTool::toolbar), button);
-    }
+
     return true;
 }

--- a/src/control/settings/ButtonConfig.h
+++ b/src/control/settings/ButtonConfig.h
@@ -28,14 +28,15 @@ public:
 
 public:
     /**
-     * @brief Apply Changes to the button tool in case "No Change" was selected for one of it's properties
+     * @brief Apply Changes to the button tool in case "Don't Change" was selected for one of it's properties
      * This is usually used after switching to a button tool from the toolbar tool
+     * Note: In case of the setting "Don't Change" for Size/DrawingType/EraserType the
+     * Size/DrawingType/EraserType of the corresponding tool in the toolbar is used.
      *
      * @param toolHandler
      * @param button button to be applied
      * @return true if some action was selected
      * @return false if no action was selected
-     * [idotobi: this should be refactored as this might not be optimal for current usage]
      */
     bool applyNoChangeSettings(ToolHandler* toolHandler, Button button);
 


### PR DESCRIPTION
Fix the behaviour of "Don't Change" settings for the Buttons to use the corresponding Tool from the toolbar as reference.

This fixes #2521 .