### PR TITLE
Fix regression default tool at startup

### DIFF
--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -2493,9 +2493,6 @@ void Control::initButtonTool() {
         cfg = settings->getButtonConfig(b);
         cfg->initButton(this->toolHandler, b);
     }
-
-    cfg = settings->getButtonConfig(Button::BUTTON_DEFAULT);
-    cfg->applyConfigToToolbarTool(this->toolHandler);
 }
 
 auto Control::askToReplace(fs::path const& filepath) const -> bool {


### PR DESCRIPTION
This commit changes the behaviour back to always using the last tool
selected at startup, rather then the default button Tool.

This fixes #2535.