### PR TITLE
Fix segmentation fault for missing ColorToolItem

### DIFF
--- a/src/gui/toolbarMenubar/ColorToolItem.cpp
+++ b/src/gui/toolbarMenubar/ColorToolItem.cpp
@@ -115,10 +115,6 @@ void ColorToolItem::enable(bool enabled) {
             // and mainTool has Colour capability
             icon->setState(COLOR_ICON_STATE_PEN);
             AbstractToolItem::enable(true);
-        } else {
-            // disallow changes in color
-            icon->setState(COLOR_ICON_STATE_DISABLED);
-            AbstractToolItem::enable(false);
         }
         return;
     }


### PR DESCRIPTION
This change removes code that was erroneously implemented but leads to a
nullptr being referenced in case no ColorToolItem is present in the
toolbar and a buttontool is activated that has no color capability.

This fixes #2533.

The code removed cannot be called in any case where it would not lead to a segmentation fault so removing it should not affect any functionality. It's actually kind of stupid :sweat_smile: 