### PR TITLE
Fixes zoomFitValue update hindering scrolling

### DIFF
--- a/src/control/LatexController.cpp
+++ b/src/control/LatexController.cpp
@@ -102,7 +102,7 @@ void LatexController::findSelectedTexElement() {
         const double centerX = visibleBounds.x + 0.5 * visibleBounds.width;
         const double centerY = visibleBounds.y + 0.5 * visibleBounds.height;
 
-        if (layout->getViewAt(centerX, centerY) == this->view) {
+        if (layout->getPageViewAt(centerX, centerY) == this->view) {
             // Pick the center of the visible area (converting from screen to page coordinates)
             this->posx = (centerX - this->view->getX()) / zoom;
             this->posy = (centerY - this->view->getY()) / zoom;

--- a/src/control/tools/EditSelection.cpp
+++ b/src/control/tools/EditSelection.cpp
@@ -580,7 +580,7 @@ auto EditSelection::getPageViewUnderCursor() -> XojPageView* {
 
 
     Layout* layout = gtk_xournal_get_layout(this->view->getXournal()->getWidget());
-    XojPageView* v = layout->getViewAt(hx, hy);
+    XojPageView* v = layout->getPageViewAt(hx, hy);
 
     return v;
 }

--- a/src/control/zoom/ZoomControl.cpp
+++ b/src/control/zoom/ZoomControl.cpp
@@ -140,9 +140,7 @@ void ZoomControl::setZoom100Value(double zoom100Val) {
     fireZoomRangeValueChanged();
 }
 
-auto ZoomControl::updateZoomFitValue(size_t pageNo) -> bool { return updateZoomFitValue(getVisibleRect(), pageNo); }
-
-auto ZoomControl::updateZoomFitValue(const Rectangle<double>& widget_rect, size_t pageNo) -> bool {
+auto ZoomControl::updateZoomFitValue(size_t pageNo) -> bool {
     if (pageNo == 0) {
         pageNo = view->getCurrentPage();
     }
@@ -151,6 +149,7 @@ auto ZoomControl::updateZoomFitValue(const Rectangle<double>& widget_rect, size_
         return false;
     }
 
+    Rectangle widget_rect = getVisibleRect();
     double zoom_fit_width = widget_rect.width / (page->getWidth() + 20.0);
     if (zoom_fit_width < this->zoomMin || zoom_fit_width > this->zoomMax) {
         return false;
@@ -285,10 +284,9 @@ auto ZoomControl::onScrolledwindowMainScrollEvent(GtkWidget* widget, GdkEventScr
 auto ZoomControl::onWidgetSizeChangedEvent(GtkWidget* widget, GdkRectangle* allocation, ZoomControl* zoom) -> bool {
     g_assert_true(widget != zoom->view->getWidget());
 
-    Rectangle<double> r(allocation->x, allocation->y, allocation->width, allocation->height);
 
     zoom->updateZoomPresentationValue();
-    zoom->updateZoomFitValue(r);
+    zoom->updateZoomFitValue();
 
     auto layout = gtk_xournal_get_layout(zoom->view->getWidget());
     layout->layoutPages(allocation->width, allocation->height);

--- a/src/control/zoom/ZoomControl.h
+++ b/src/control/zoom/ZoomControl.h
@@ -121,7 +121,7 @@ public:
 
     void addZoomListener(ZoomListener* listener);
 
-    void initZoomHandler(GtkWidget* widget, XournalView* view, Control* control);
+    void initZoomHandler(GtkWidget* window, GtkWidget* widget, XournalView* v, Control* c);
 
     /**
      * Call this before any zoom is done, it saves the current page and position
@@ -168,12 +168,12 @@ protected:
     void pageSizeChanged(size_t page);
     void pageSelected(size_t page);
 
-    static bool onScrolledwindowMainScrollEvent(GtkWidget* widget, GdkEventScroll* event, ZoomControl* zoom);
-    static bool onWidgetSizeChangedEvent(GtkWidget* widget, GdkRectangle* allocation, ZoomControl* zoom);
-
 private:
     void zoomFit();
     void zoomPresentation();
+
+    friend bool onWindowSizeChangedEvent(GtkWidget* widget, GdkEvent* event, ZoomControl* zoom);
+    friend bool onScrolledwindowMainScrollEvent(GtkWidget* widget, GdkEventScroll* event, ZoomControl* zoom);
 
 private:
     XournalView* view = nullptr;

--- a/src/control/zoom/ZoomControl.h
+++ b/src/control/zoom/ZoomControl.h
@@ -111,7 +111,6 @@ public:
      * @param zoom zoom value depending zoom100Value
      */
     bool updateZoomFitValue(size_t pageNo = 0);
-    bool updateZoomFitValue(const Rectangle<double>& widget_rect, size_t pageNo = 0);
 
     /**
      * @return zoom value for zoom fit depending zoom100Value

--- a/src/gui/Layout.cpp
+++ b/src/gui/Layout.cpp
@@ -27,11 +27,9 @@ constexpr size_t const XOURNAL_PADDING_BETWEEN = 15;
 
 
 Layout::Layout(XournalView* view, ScrollHandling* scrollHandling): view(view), scrollHandling(scrollHandling) {
-    this->hadjHandler = g_signal_connect(scrollHandling->getHorizontal(), "value-changed",
-                                         G_CALLBACK(horizontalScrollChanged), this);
+    g_signal_connect(scrollHandling->getHorizontal(), "value-changed", G_CALLBACK(horizontalScrollChanged), this);
 
-    this->vadjHandler =
-            g_signal_connect(scrollHandling->getVertical(), "value-changed", G_CALLBACK(verticalScrollChanged), this);
+    g_signal_connect(scrollHandling->getVertical(), "value-changed", G_CALLBACK(verticalScrollChanged), this);
 
 
     lastScrollHorizontal = gtk_adjustment_get_value(scrollHandling->getHorizontal());
@@ -39,19 +37,15 @@ Layout::Layout(XournalView* view, ScrollHandling* scrollHandling): view(view), s
 }
 
 void Layout::horizontalScrollChanged(GtkAdjustment* adjustment, Layout* layout) {
-    g_signal_handler_block(layout->scrollHandling->getHorizontal(), layout->hadjHandler);
     Layout::checkScroll(adjustment, layout->lastScrollHorizontal);
     layout->updateVisibility();
     layout->scrollHandling->scrollChanged();
-    g_signal_handler_unblock(layout->scrollHandling->getHorizontal(), layout->hadjHandler);
 }
 
 void Layout::verticalScrollChanged(GtkAdjustment* adjustment, Layout* layout) {
-    g_signal_handler_block(layout->scrollHandling->getVertical(), layout->vadjHandler);
     Layout::checkScroll(adjustment, layout->lastScrollVertical);
     layout->updateVisibility();
     layout->scrollHandling->scrollChanged();
-    g_signal_handler_unblock(layout->scrollHandling->getVertical(), layout->vadjHandler);
 }
 
 Layout::~Layout() = default;

--- a/src/gui/Layout.h
+++ b/src/gui/Layout.h
@@ -129,9 +129,6 @@ private:
     double lastScrollHorizontal = -1;
     double lastScrollVertical = -1;
 
-    guint hadjHandler = -1;
-    guint vadjHandler = -1;
-
     /**
      * The last width and height of the widget
      */

--- a/src/gui/Layout.h
+++ b/src/gui/Layout.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -32,22 +33,34 @@ class ScrollHandling;
  * This class manages the layout of the XojPageView's contained
  * in the XournalWidget
  */
-class Layout {
+class Layout final {
 public:
     Layout(XournalView* view, ScrollHandling* scrollHandling);
-    virtual ~Layout();
+    struct PreCalculated {
+        std::mutex m{};
+
+        // The width and height of all our pages
+        size_t minWidth = 0;
+        size_t minHeight = 0;
+        std::vector<unsigned> widthCols;
+        std::vector<unsigned> heightRows;
+        bool valid = false;
+    };
 
 public:
+    // Todo(Fabian): move to ScrollHandling also it must not depend on Layout
     /**
      * Increases the adjustments by the given amounts
      */
     void scrollRelative(double x, double y);
 
+    // Todo(Fabian): move to ScrollHandling also it must not depend on Layout
     /**
      * Changes the adjustments by absolute amounts (for pinch-to-zoom)
      */
     void scrollAbs(double x, double y);
 
+    // Todo(Fabian): move to XournalView
     /**
      * Changes the adjustments in such a way as to make sure that
      * the given Rectangle is visible
@@ -67,6 +80,7 @@ public:
      */
     int getMinimalWidth() const;
 
+    // Todo(Fabian): move to XournalView this must not depend on Layout directly
     /**
      * Returns the Rectangle which is currently visible
      */
@@ -82,10 +96,11 @@ public:
      * Performs a layout of the XojPageView's managed in this Layout
      * Sets out pages in a grid.
      * Document pages are assigned to grid positions by the mapper object and may be ordered in a myriad of ways.
-     * only call this on size allocation
+     * ONLY call this on size allocation
      */
     void layoutPages(int width, int height);
 
+    // Todo(Fabian): move to View:
     /**
      * Updates the current XojPageView. The XojPageView is selected based on
      * the percentage of the visible area of the XojPageView relative
@@ -96,55 +111,46 @@ public:
     /**
      * Return the pageview containing co-ordinates.
      */
-    XojPageView* getViewAt(int x, int y);
+    XojPageView* getPageViewAt(int x, int y);
 
     /**
      * Return the page index found ( or std::nullopt if not found) at layout grid row,col
      *
      */
-    std::optional<size_t> getIndexAtGridMap(size_t row, size_t col);
+    std::optional<size_t> getPageIndexAtGridMap(size_t row, size_t col);
 
 protected:
+    // Todo(Fabian): move to ScrollHandling also it must not depend on Layout
     static void horizontalScrollChanged(GtkAdjustment* adjustment, Layout* layout);
     static void verticalScrollChanged(GtkAdjustment* adjustment, Layout* layout);
 
 private:
+    void recalculate_int() const;
+    // Todo(Fabian): move to ScrollHandling also it must not depend on Layout
     static void checkScroll(GtkAdjustment* adjustment, double& lastScroll);
 
     /**
      * Calls either the ScrollHandlingGtk or (when the Touch Workaround is enabled) the ScrollHandlingXournalpp
      * method to set the layout size by updating the horizontal and vertical GtkAdjustments
      */
+    // Todo(Fabian): remove this function the true size always depends on the expose event
     void setLayoutSize(int width, int height);
 
 private:
-    LayoutMapper mapper;
-
     XournalView* view = nullptr;
     ScrollHandling* scrollHandling = nullptr;
 
-    std::vector<unsigned> widthCols;
-    std::vector<unsigned> heightRows;
-
+    // Todo(Fabian): move to ScrollHandling also it must not depend on Layout
     double lastScrollHorizontal = -1;
     double lastScrollVertical = -1;
-
-    /**
-     * The last width and height of the widget
-     */
-    int lastWidgetWidth = 0;
-    int lastWidgetHeight = 0;
-
-    /**
-     * The width and height of all our pages
-     */
-    size_t minWidth = 0;
-    size_t minHeight = 0;
 
     /**
      * layoutPages invalidates the precalculation of recalculate
      * this bool prevents that layotPages can be called without a previously call to recalculate
      * Todo: we may want to remove the additional calculation in layoutPages, since we stored those values in
      */
-    bool valid = false;
+    mutable LayoutMapper mapper;
+    mutable PreCalculated pc{};
+    mutable std::vector<unsigned> colXStart;
+    mutable std::vector<unsigned> rowYStart;
 };

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -256,7 +256,7 @@ void MainWindow::initXournalWidget() {
         gtk_container_add(GTK_CONTAINER(box1),
                           gtk_scrollbar_new(GTK_ORIENTATION_HORIZONTAL, scrollHandling->getHorizontal()));
 
-        control->getZoomControl()->initZoomHandler(box2, xournal, control);
+        control->getZoomControl()->initZoomHandler(this->window, box2, xournal, control);
         gtk_widget_show_all(box1);
     } else {
         winXournal = gtk_scrolled_window_new(nullptr, nullptr);
@@ -273,10 +273,9 @@ void MainWindow::initXournalWidget() {
 
         this->xournal = new XournalView(vpXournal, control, scrollHandling);
 
-        control->getZoomControl()->initZoomHandler(winXournal, xournal, control);
+        control->getZoomControl()->initZoomHandler(this->window, winXournal, xournal, control);
         gtk_widget_show_all(winXournal);
     }
-    // Todo configure-event
 
     Layout* layout = gtk_xournal_get_layout(this->xournal->getWidget());
     scrollHandling->init(this->xournal->getWidget(), layout);

--- a/src/gui/XournalView.cpp
+++ b/src/gui/XournalView.cpp
@@ -411,7 +411,7 @@ void XournalView::pageRelativeXY(int offCol, int offRow) {
     int col = view->getMappedCol();
 
     Layout* layout = gtk_xournal_get_layout(this->widget);
-    auto optionalPageIndex = layout->getIndexAtGridMap(row + offRow, col + offCol);
+    auto optionalPageIndex = layout->getPageIndexAtGridMap(row + offRow, col + offCol);
     if (optionalPageIndex) {
         this->scrollTo(*optionalPageIndex, 0);
     }
@@ -656,7 +656,12 @@ void XournalView::repaintSelection(bool evenWithoutSelection) {
 void XournalView::layoutPages() {
     Layout* layout = gtk_xournal_get_layout(this->widget);
     layout->recalculate();
-    layout->layoutPages(layout->getMinimalWidth(), layout->getMinimalHeight());
+
+    // Todo (fabian): the following lines are conceptually wrong, the Layout::layoutPages function is meant to be called
+    //                by an expose event, but removing it, will break "add page".
+    auto rectangle = layout->getVisibleRect();
+    layout->layoutPages(std::max<int>(layout->getMinimalWidth(), std::lround(rectangle.width)),
+                        std::max<int>(layout->getMinimalHeight(), std::lround(rectangle.height)));
 }
 
 auto XournalView::getDisplayHeight() const -> int {

--- a/src/gui/inputdevices/AbstractInputHandler.cpp
+++ b/src/gui/inputdevices/AbstractInputHandler.cpp
@@ -52,7 +52,7 @@ auto AbstractInputHandler::getPageAtCurrentPosition(InputEvent const& event) -> 
     double x = eventX + xournal->x;
     double y = eventY + xournal->y;
 
-    return xournal->layout->getViewAt(x, y);
+    return xournal->layout->getPageViewAt(x, y);
 }
 
 /**

--- a/src/gui/inputdevices/old/InputSequence.cpp
+++ b/src/gui/inputdevices/old/InputSequence.cpp
@@ -103,7 +103,7 @@ auto InputSequence::getPageAtCurrentPosition() -> XojPageView* {
     double x = this->x + xournal->x;
     double y = this->y + xournal->y;
 
-    return xournal->layout->getViewAt(x, y);
+    return xournal->layout->getPageViewAt(x, y);
 }
 
 /**

--- a/src/gui/scroll/ScrollHandlingGtk.cpp
+++ b/src/gui/scroll/ScrollHandlingGtk.cpp
@@ -8,16 +8,21 @@ ScrollHandlingGtk::ScrollHandlingGtk(GtkScrollable* scrollable):
 
 ScrollHandlingGtk::~ScrollHandlingGtk() = default;
 
+#define TEMP_FIX true
+
 void ScrollHandlingGtk::setLayoutSize(int width, int height) {
     // after a page has been inserted the layout size must be updated immediately,
     // otherwise it comes down to a race deciding if scrolling happens normally or not
-    if (gtk_adjustment_get_upper(getHorizontal()) < width) {
+#if TEMP_FIX
+    // Todo(Fabian): remove that fix, since it is conceptually wrong behavior
+    //               the adjustment is/must be changed implicitly by the layout and the resulting expose event
+    if (gtk_adjustment_get_upper(getHorizontal()) != width) {
         gtk_adjustment_set_upper(getHorizontal(), width);
     }
-    if (gtk_adjustment_get_upper(getVertical()) < height) {
+    if (gtk_adjustment_get_upper(getVertical()) != height) {
         gtk_adjustment_set_upper(getVertical(), height);
     }
-    gtk_widget_queue_resize(xournal);
+#endif
 }
 
 auto ScrollHandlingGtk::getPreferredWidth() -> int { return layout->getMinimalWidth(); }

--- a/src/gui/widgets/XournalWidget.cpp
+++ b/src/gui/widgets/XournalWidget.cpp
@@ -163,12 +163,12 @@ static void gtk_xournal_init(GtkXournal* xournal) {
 
 static void gtk_xournal_get_preferred_width(GtkWidget* widget, gint* minimal_width, gint* natural_width) {
     GtkXournal* xournal = GTK_XOURNAL(widget);
-    *minimal_width = *natural_width = xournal->scrollHandling->getPreferredWidth();
+    *minimal_width = *natural_width = xournal->layout->getMinimalWidth();
 }
 
 static void gtk_xournal_get_preferred_height(GtkWidget* widget, gint* minimal_height, gint* natural_height) {
     GtkXournal* xournal = GTK_XOURNAL(widget);
-    *minimal_height = *natural_height = xournal->scrollHandling->getPreferredHeight();
+    *minimal_height = *natural_height = xournal->layout->getMinimalHeight();
 }
 
 /**


### PR DESCRIPTION
Fixes #2138 (and its duplicates #1699 and #2066)

The cause of the problem was that for the users that reported the problem the allocation width that was passed to `updateZoomFitValue` did not match with the width of the visible rectangle, which made the zoomFitValue alternate in rapid succession between two different values, which invoked `XournalView::scrollTo` method to keep the top part of the current page visible (if the whole page did not fit on the screen).

It must be checked carefully if we don't reintroduce a bug (#1139, #1132 ) that has been fixed in #1213. So far it seems, it doesn't reintroduce these bugs.