### PR TITLE
fix debian release pipeline

### DIFF
--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -69,7 +69,7 @@ stages:
         steps:
           - bash: |
               sudo apt-get update
-              sudo apt-get install -y gcc-8 g++-8 cmake ninja-build libcppunit-dev libgtk-3-dev libpoppler-glib-dev libxml2-dev portaudio19-dev libsndfile-dev liblua5.3-dev \
+              sudo apt-get install -y build-essential gcc-8 g++-8 cmake ninja-build libcppunit-dev libgtk-3-dev libpoppler-glib-dev libxml2-dev portaudio19-dev libsndfile-dev liblua5.3-dev \
                                       libzip-dev gettext lsb-release
             displayName: 'Install dependencies'
           - template: steps/build_linux.yml


### PR DESCRIPTION
Attempt to fix the failure of building the 1.0.20 debian release package

```term
CMake Error at CMakeLists.txt:3 (project):
No CMAKE_CXX_COMPILER could be found.

Tell CMake where to find the compiler by setting either the environment
variable "CXX" or the CMake cache entry CMAKE_CXX_COMPILER to the full path
to the compiler, or to the compiler name if it is in the PATH.```