### PR TITLE
Allow exports without ruling (but with other backgrounds)

### DIFF
--- a/src/control/jobs/BaseExportJob.h
+++ b/src/control/jobs/BaseExportJob.h
@@ -21,7 +21,8 @@
 
 /**
  *  @brief List of types for the export of background components.
- *  Keep the order so that one can check for intermediate types using comparsion.
+ *  The order must agree with the corresponding listBackgroundType in ui/exportSettings.glade.
+ *  It is constructed so that one can check for intermediate types using comparison.
  */
 enum ExportBackgroundType { EXPORT_BACKGROUND_NONE, EXPORT_BACKGROUND_UNRULED, EXPORT_BACKGROUND_ALL };
 
@@ -62,8 +63,7 @@ protected:
     class ExportType {
     public:
         string extension;
-        ExportBackgroundType exportBackground;
 
-        ExportType(string ext, ExportBackgroundType exportBg): extension(ext), exportBackground(exportBg) {}
+        ExportType(string ext): extension(ext) {}
     };
 };

--- a/src/control/jobs/BaseExportJob.h
+++ b/src/control/jobs/BaseExportJob.h
@@ -23,7 +23,7 @@
  *  @brief List of types for the export of background components.
  *  Keep the order so that one can check for intermediate types using comparsion.
  */
-enum ExportBackgroundType { EXPORT_BACKGROUND_NONE, EXPORT_BACKGROUND_ALL };
+enum ExportBackgroundType { EXPORT_BACKGROUND_NONE, EXPORT_BACKGROUND_UNRULED, EXPORT_BACKGROUND_ALL };
 
 class Control;
 

--- a/src/control/jobs/BaseExportJob.h
+++ b/src/control/jobs/BaseExportJob.h
@@ -19,6 +19,12 @@
 #include "XournalType.h"
 #include "filesystem.h"
 
+/**
+ *  @brief List of types for the export of background components.
+ *  Keep the order so that one can check for intermediate types using comparsion.
+ */
+enum ExportBackgroundType { EXPORT_BACKGROUND_NONE, EXPORT_BACKGROUND_ALL };
+
 class Control;
 
 class BaseExportJob: public BlockingJob {
@@ -56,8 +62,8 @@ protected:
     class ExportType {
     public:
         string extension;
-        bool withoutBackground;
+        ExportBackgroundType exportBackground;
 
-        ExportType(string ext, bool hideBg): extension(ext), withoutBackground(hideBg) {}
+        ExportType(string ext, ExportBackgroundType exportBg): extension(ext), exportBackground(exportBg) {}
     };
 };

--- a/src/control/jobs/CustomExportJob.cpp
+++ b/src/control/jobs/CustomExportJob.cpp
@@ -19,10 +19,13 @@
 CustomExportJob::CustomExportJob(Control* control): BaseExportJob(control, _("Custom Export")) {
     // Supported filters
     filters[_("PDF files")] = new ExportType(".pdf", EXPORT_BACKGROUND_ALL);
+    filters[_("PDF without ruling")] = new ExportType(".pdf", EXPORT_BACKGROUND_UNRULED);
     filters[_("PDF with plain background")] = new ExportType(".pdf", EXPORT_BACKGROUND_NONE);
     filters[_("PNG graphics")] = new ExportType(".png", EXPORT_BACKGROUND_ALL);
+    filters[_("PNG without ruling")] = new ExportType(".png", EXPORT_BACKGROUND_UNRULED);
     filters[_("PNG with transparent background")] = new ExportType(".png", EXPORT_BACKGROUND_NONE);
     filters[_("SVG graphics")] = new ExportType(".svg", EXPORT_BACKGROUND_ALL);
+    filters[_("SVG without ruling")] = new ExportType(".svg", EXPORT_BACKGROUND_UNRULED);
     filters[_("SVG with transparent background")] = new ExportType(".svg", EXPORT_BACKGROUND_NONE);
     filters[_("Xournal (Compatibility)")] = new ExportType(".xoj", EXPORT_BACKGROUND_ALL);
 }

--- a/src/control/jobs/CustomExportJob.cpp
+++ b/src/control/jobs/CustomExportJob.cpp
@@ -18,16 +18,10 @@
 
 CustomExportJob::CustomExportJob(Control* control): BaseExportJob(control, _("Custom Export")) {
     // Supported filters
-    filters[_("PDF files")] = new ExportType(".pdf", EXPORT_BACKGROUND_ALL);
-    filters[_("PDF without ruling")] = new ExportType(".pdf", EXPORT_BACKGROUND_UNRULED);
-    filters[_("PDF with plain background")] = new ExportType(".pdf", EXPORT_BACKGROUND_NONE);
-    filters[_("PNG graphics")] = new ExportType(".png", EXPORT_BACKGROUND_ALL);
-    filters[_("PNG without ruling")] = new ExportType(".png", EXPORT_BACKGROUND_UNRULED);
-    filters[_("PNG with transparent background")] = new ExportType(".png", EXPORT_BACKGROUND_NONE);
-    filters[_("SVG graphics")] = new ExportType(".svg", EXPORT_BACKGROUND_ALL);
-    filters[_("SVG without ruling")] = new ExportType(".svg", EXPORT_BACKGROUND_UNRULED);
-    filters[_("SVG with transparent background")] = new ExportType(".svg", EXPORT_BACKGROUND_NONE);
-    filters[_("Xournal (Compatibility)")] = new ExportType(".xoj", EXPORT_BACKGROUND_ALL);
+    filters[_("PDF files")] = new ExportType(".pdf");
+    filters[_("PNG graphics")] = new ExportType(".png");
+    filters[_("SVG graphics")] = new ExportType(".svg");
+    filters[_("Xournal (Compatibility)")] = new ExportType(".xoj");
 }
 
 CustomExportJob::~CustomExportJob() {
@@ -98,6 +92,7 @@ auto CustomExportJob::showFilechooser() -> bool {
 
     exportRange = dlg->getRange();
     progressiveMode = dlg->progressiveMode();
+    exportBackground = dlg->getBackgroundType();
 
     if (format == EXPORT_GRAPHICS_PNG) {
         pngQualityParameter = dlg->getPngQualityParameter();
@@ -112,7 +107,6 @@ auto CustomExportJob::showFilechooser() -> bool {
  * Create one Graphics file per page
  */
 void CustomExportJob::exportGraphics() {
-    ExportBackgroundType exportBackground = filters.at(this->chosenFilterName)->exportBackground;
     ImageExport imgExport(control->getDocument(), filepath, format, exportBackground, exportRange);
     if (format == EXPORT_GRAPHICS_PNG) {
         imgExport.setQualityParameter(pngQualityParameter);
@@ -144,7 +138,7 @@ void CustomExportJob::run() {
 
         XojPdfExport* pdfe = XojPdfExportFactory::createExport(doc, control);
 
-        pdfe->setExportBackground(filters[this->chosenFilterName]->exportBackground);
+        pdfe->setExportBackground(exportBackground);
 
         if (!pdfe->createPdf(this->filepath, exportRange, progressiveMode)) {
             this->errorMsg = pdfe->getLastError();

--- a/src/control/jobs/CustomExportJob.cpp
+++ b/src/control/jobs/CustomExportJob.cpp
@@ -18,13 +18,13 @@
 
 CustomExportJob::CustomExportJob(Control* control): BaseExportJob(control, _("Custom Export")) {
     // Supported filters
-    filters[_("PDF files")] = new ExportType(".pdf", false);
-    filters[_("PDF with plain background")] = new ExportType(".pdf", true);
-    filters[_("PNG graphics")] = new ExportType(".png", false);
-    filters[_("PNG with transparent background")] = new ExportType(".png", true);
-    filters[_("SVG graphics")] = new ExportType(".svg", false);
-    filters[_("SVG with transparent background")] = new ExportType(".svg", true);
-    filters[_("Xournal (Compatibility)")] = new ExportType(".xoj", false);
+    filters[_("PDF files")] = new ExportType(".pdf", EXPORT_BACKGROUND_ALL);
+    filters[_("PDF with plain background")] = new ExportType(".pdf", EXPORT_BACKGROUND_NONE);
+    filters[_("PNG graphics")] = new ExportType(".png", EXPORT_BACKGROUND_ALL);
+    filters[_("PNG with transparent background")] = new ExportType(".png", EXPORT_BACKGROUND_NONE);
+    filters[_("SVG graphics")] = new ExportType(".svg", EXPORT_BACKGROUND_ALL);
+    filters[_("SVG with transparent background")] = new ExportType(".svg", EXPORT_BACKGROUND_NONE);
+    filters[_("Xournal (Compatibility)")] = new ExportType(".xoj", EXPORT_BACKGROUND_ALL);
 }
 
 CustomExportJob::~CustomExportJob() {
@@ -109,8 +109,8 @@ auto CustomExportJob::showFilechooser() -> bool {
  * Create one Graphics file per page
  */
 void CustomExportJob::exportGraphics() {
-    bool hideBackground = filters.at(this->chosenFilterName)->withoutBackground;
-    ImageExport imgExport(control->getDocument(), filepath, format, hideBackground, exportRange);
+    ExportBackgroundType exportBackground = filters.at(this->chosenFilterName)->exportBackground;
+    ImageExport imgExport(control->getDocument(), filepath, format, exportBackground, exportRange);
     if (format == EXPORT_GRAPHICS_PNG) {
         imgExport.setQualityParameter(pngQualityParameter);
     }
@@ -141,7 +141,7 @@ void CustomExportJob::run() {
 
         XojPdfExport* pdfe = XojPdfExportFactory::createExport(doc, control);
 
-        pdfe->setNoBackgroundExport(filters[this->chosenFilterName]->withoutBackground);
+        pdfe->setExportBackground(filters[this->chosenFilterName]->exportBackground);
 
         if (!pdfe->createPdf(this->filepath, exportRange, progressiveMode)) {
             this->errorMsg = pdfe->getLastError();

--- a/src/control/jobs/CustomExportJob.h
+++ b/src/control/jobs/CustomExportJob.h
@@ -68,6 +68,11 @@ private:
     bool exportTypeXoj = false;
 
     /**
+     * Background export type
+     */
+    ExportBackgroundType exportBackground = EXPORT_BACKGROUND_ALL;
+
+    /**
      * Export all Layers progressively
      */
     bool progressiveMode = false;

--- a/src/control/jobs/ImageExport.cpp
+++ b/src/control/jobs/ImageExport.cpp
@@ -144,14 +144,15 @@ void ImageExport::exportImagePage(int pageId, int id, double zoomRatio, ExportGr
         return;
     }
 
-    if (page->getBackgroundType().isPdfPage() && (exportBackground == EXPORT_BACKGROUND_ALL)) {
+    if (page->getBackgroundType().isPdfPage() && (exportBackground >= EXPORT_BACKGROUND_UNRULED)) {
         int pgNo = page->getPdfPageNr();
         XojPdfPageSPtr popplerPage = doc->getPdfPage(pgNo);
 
         PdfView::drawPage(nullptr, popplerPage, cr, zoomRatio, page->getWidth(), page->getHeight());
     }
 
-    view.drawPage(page, this->cr, true, exportBackground == EXPORT_BACKGROUND_NONE);
+    view.drawPage(page, this->cr, true, exportBackground == EXPORT_BACKGROUND_NONE,
+                  exportBackground == EXPORT_BACKGROUND_NONE, exportBackground <= EXPORT_BACKGROUND_UNRULED);
 
     if (!freeSurface(id)) {
         // could not create this file...

--- a/src/control/jobs/ImageExport.cpp
+++ b/src/control/jobs/ImageExport.cpp
@@ -144,7 +144,7 @@ void ImageExport::exportImagePage(int pageId, int id, double zoomRatio, ExportGr
         return;
     }
 
-    if (page->getBackgroundType().isPdfPage()) {
+    if (page->getBackgroundType().isPdfPage() && !hideBackground) {
         int pgNo = page->getPdfPageNr();
         XojPdfPageSPtr popplerPage = doc->getPdfPage(pgNo);
 

--- a/src/control/jobs/ImageExport.cpp
+++ b/src/control/jobs/ImageExport.cpp
@@ -13,9 +13,9 @@
 #include "i18n.h"
 
 
-ImageExport::ImageExport(Document* doc, fs::path file, ExportGraphicsFormat format, bool hideBackground,
-                         PageRangeVector& exportRange):
-        doc(doc), file(std::move(file)), format(format), hideBackground(hideBackground), exportRange(exportRange) {}
+ImageExport::ImageExport(Document* doc, fs::path file, ExportGraphicsFormat format,
+                         ExportBackgroundType exportBackground, PageRangeVector& exportRange):
+        doc(doc), file(std::move(file)), format(format), exportBackground(exportBackground), exportRange(exportRange) {}
 
 ImageExport::~ImageExport() = default;
 
@@ -144,14 +144,14 @@ void ImageExport::exportImagePage(int pageId, int id, double zoomRatio, ExportGr
         return;
     }
 
-    if (page->getBackgroundType().isPdfPage() && !hideBackground) {
+    if (page->getBackgroundType().isPdfPage() && (exportBackground == EXPORT_BACKGROUND_ALL)) {
         int pgNo = page->getPdfPageNr();
         XojPdfPageSPtr popplerPage = doc->getPdfPage(pgNo);
 
         PdfView::drawPage(nullptr, popplerPage, cr, zoomRatio, page->getWidth(), page->getHeight());
     }
 
-    view.drawPage(page, this->cr, true, hideBackground);
+    view.drawPage(page, this->cr, true, exportBackground == EXPORT_BACKGROUND_NONE);
 
     if (!freeSurface(id)) {
         // could not create this file...

--- a/src/control/jobs/ImageExport.h
+++ b/src/control/jobs/ImageExport.h
@@ -18,6 +18,7 @@
 
 #include "view/DocumentView.h"
 
+#include "BaseExportJob.h"
 #include "PageRange.h"
 #include "XournalType.h"
 #include "filesystem.h"
@@ -26,7 +27,6 @@ class Document;
 class ProgressListener;
 
 enum ExportGraphicsFormat { EXPORT_GRAPHICS_UNDEFINED, EXPORT_GRAPHICS_PDF, EXPORT_GRAPHICS_PNG, EXPORT_GRAPHICS_SVG };
-
 
 /**
  * @brief List of available criterion for determining a PNG export quality.
@@ -68,7 +68,7 @@ private:
  */
 class ImageExport {
 public:
-    ImageExport(Document* doc, fs::path file, ExportGraphicsFormat format, bool hideBackground,
+    ImageExport(Document* doc, fs::path file, ExportGraphicsFormat format, ExportBackgroundType exportBackground,
                 PageRangeVector& exportRange);
     virtual ~ImageExport();
 
@@ -155,7 +155,7 @@ public:
     /**
      * Do not export the Background
      */
-    bool hideBackground = false;
+    ExportBackgroundType exportBackground = EXPORT_BACKGROUND_ALL;
 
     /**
      * The range to export

--- a/src/gui/dialog/ExportDialog.cpp
+++ b/src/gui/dialog/ExportDialog.cpp
@@ -80,6 +80,10 @@ auto ExportDialog::progressiveMode() -> bool {
     return gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(get("cbProgressiveMode")));
 }
 
+auto ExportDialog::getBackgroundType() -> ExportBackgroundType {
+    return (ExportBackgroundType)gtk_combo_box_get_active(GTK_COMBO_BOX(get("cbBackgroundType")));
+}
+
 auto ExportDialog::getRange() -> PageRangeVector {
     GtkWidget* rdRangeCurrent = get("rdRangeCurrent");
     GtkWidget* rdRangePages = get("rdRangePages");

--- a/src/gui/dialog/ExportDialog.h
+++ b/src/gui/dialog/ExportDialog.h
@@ -28,6 +28,7 @@ public:
     bool isConfirmed() const;
     PageRangeVector getRange();
     bool progressiveMode();
+    ExportBackgroundType getBackgroundType();
 
     /**
      * @brief Reads the quality parameter from the dialog

--- a/src/pdf/base/XojCairoPdfExport.cpp
+++ b/src/pdf/base/XojCairoPdfExport.cpp
@@ -106,14 +106,15 @@ void XojCairoPdfExport::exportPage(size_t page) {
     DocumentView view;
 
     cairo_save(this->cr);
-    if (p->getBackgroundType().isPdfPage() && (exportBackground == EXPORT_BACKGROUND_ALL)) {
+    if (p->getBackgroundType().isPdfPage() && (exportBackground >= EXPORT_BACKGROUND_UNRULED)) {
         int pgNo = p->getPdfPageNr();
         XojPdfPageSPtr popplerPage = doc->getPdfPage(pgNo);
 
         popplerPage->render(cr, true);
     }
 
-    view.drawPage(p, this->cr, true /* dont render eraseable */, exportBackground == EXPORT_BACKGROUND_NONE);
+    view.drawPage(p, this->cr, true /* dont render eraseable */, exportBackground == EXPORT_BACKGROUND_NONE,
+                  exportBackground == EXPORT_BACKGROUND_NONE, exportBackground <= EXPORT_BACKGROUND_UNRULED);
 
     // next page
     cairo_show_page(this->cr);

--- a/src/pdf/base/XojCairoPdfExport.cpp
+++ b/src/pdf/base/XojCairoPdfExport.cpp
@@ -24,8 +24,8 @@ XojCairoPdfExport::~XojCairoPdfExport() {
 /**
  * Export without background
  */
-void XojCairoPdfExport::setNoBackgroundExport(bool noBackgroundExport) {
-    this->noBackgroundExport = noBackgroundExport;
+void XojCairoPdfExport::setExportBackground(ExportBackgroundType exportBackground) {
+    this->exportBackground = exportBackground;
 }
 
 auto XojCairoPdfExport::startPdf(const fs::path& file) -> bool {
@@ -106,14 +106,14 @@ void XojCairoPdfExport::exportPage(size_t page) {
     DocumentView view;
 
     cairo_save(this->cr);
-    if (p->getBackgroundType().isPdfPage() && !noBackgroundExport) {
+    if (p->getBackgroundType().isPdfPage() && (exportBackground == EXPORT_BACKGROUND_ALL)) {
         int pgNo = p->getPdfPageNr();
         XojPdfPageSPtr popplerPage = doc->getPdfPage(pgNo);
 
         popplerPage->render(cr, true);
     }
 
-    view.drawPage(p, this->cr, true /* dont render eraseable */, noBackgroundExport);
+    view.drawPage(p, this->cr, true /* dont render eraseable */, exportBackground == EXPORT_BACKGROUND_NONE);
 
     // next page
     cairo_show_page(this->cr);

--- a/src/pdf/base/XojCairoPdfExport.h
+++ b/src/pdf/base/XojCairoPdfExport.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "control/jobs/BaseExportJob.h"
 #include "control/jobs/ProgressListener.h"
 #include "model/Document.h"
 
@@ -30,7 +31,7 @@ public:
     /**
      * Export without background
      */
-    virtual void setNoBackgroundExport(bool noBackgroundExport);
+    virtual void setExportBackground(ExportBackgroundType exportBackground);
 
 private:
     bool startPdf(const fs::path& file);
@@ -59,7 +60,7 @@ private:
     cairo_surface_t* surface = nullptr;
     cairo_t* cr = nullptr;
 
-    bool noBackgroundExport = false;
+    ExportBackgroundType exportBackground = EXPORT_BACKGROUND_ALL;
 
     string lastError;
 };

--- a/src/pdf/base/XojPdfExport.cpp
+++ b/src/pdf/base/XojPdfExport.cpp
@@ -7,6 +7,6 @@ XojPdfExport::~XojPdfExport() = default;
 /**
  * Export without background
  */
-void XojPdfExport::setNoBackgroundExport(bool noBackgroundExport) {
+void XojPdfExport::setExportBackground(ExportBackgroundType exportBackground) {
     // Does nothing in the base class
 }

--- a/src/pdf/base/XojPdfExport.h
+++ b/src/pdf/base/XojPdfExport.h
@@ -14,6 +14,8 @@
 #include <string>
 #include <vector>
 
+#include "control/jobs/BaseExportJob.h"
+
 #include "PageRange.h"
 #include "XournalType.h"
 #include "filesystem.h"
@@ -31,7 +33,7 @@ public:
     /**
      * Export without background
      */
-    virtual void setNoBackgroundExport(bool noBackgroundExport);
+    virtual void setExportBackground(ExportBackgroundType exportBackground);
 
 private:
 };

--- a/src/view/DocumentView.cpp
+++ b/src/view/DocumentView.cpp
@@ -267,13 +267,13 @@ void DocumentView::finializeDrawing() {
 /**
  * Draw the background
  */
-void DocumentView::drawBackground() {
+void DocumentView::drawBackground(bool hidePdfBackground, bool hideImageBackground, bool hideRulingBackground) {
     PageType pt = page->getBackgroundType();
     if (pt.isPdfPage()) {
         // Handled in PdfView
-    } else if (pt.isImagePage()) {
+    } else if (pt.isImagePage() && !hideImageBackground) {
         paintBackgroundImage();
-    } else {
+    } else if (!hideRulingBackground) {
         backgroundPainter->paint(pt, cr, page);
     }
 }
@@ -305,13 +305,14 @@ void DocumentView::drawTransparentBackgroundPattern() {
  * @param dontRenderEditingStroke false to draw currently drawing stroke
  * @param hideBackground true to hide the background
  */
-void DocumentView::drawPage(PageRef page, cairo_t* cr, bool dontRenderEditingStroke, bool hideBackground) {
+void DocumentView::drawPage(PageRef page, cairo_t* cr, bool dontRenderEditingStroke, bool hidePdfBackground,
+                            bool hideImageBackground, bool hideRulingBackground) {
     initDrawing(page, cr, dontRenderEditingStroke);
 
     bool backgroundVisible = page->isLayerVisible(0);
 
-    if (!hideBackground && backgroundVisible) {
-        drawBackground();
+    if (backgroundVisible) {
+        drawBackground(hidePdfBackground, hideImageBackground, hideRulingBackground);
     }
 
     if (!backgroundVisible) {

--- a/src/view/DocumentView.h
+++ b/src/view/DocumentView.h
@@ -40,9 +40,12 @@ public:
      * @param page The page to draw
      * @param cr Draw to thgis context
      * @param dontRenderEditingStroke false to draw currently drawing stroke
-     * @param hideBackground true to hide the background
+     * @param hidePdfBackground true to hide the PDF background
+     * @param hideImageBackground true to hide the PDF background
+     * @param hideRulingBacground true to hide the ruling background
      */
-    void drawPage(PageRef page, cairo_t* cr, bool dontRenderEditingStroke, bool hideBackground = false);
+    void drawPage(PageRef page, cairo_t* cr, bool dontRenderEditingStroke, bool hidePdfBackground = false,
+                  bool hideImageBackground = false, bool hideRulingBackground = false);
 
 
     void drawStroke(cairo_t* cr, Stroke* s, int startPoint = 0, double scaleFactor = 1, bool changeSource = true,
@@ -74,7 +77,8 @@ public:
     /**
      * Draw the background
      */
-    void drawBackground();
+    void drawBackground(bool hidePdfBackground = false, bool hideImageBackground = false,
+                        bool hideRulingBackground = false);
 
     /**
      * Draw background if there is no background shown, like in GIMP etc.

--- a/ui/exportSettings.glade
+++ b/ui/exportSettings.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.1 -->
+<!-- Generated with glade 3.38.2 -->
 <interface>
   <requires lib="gtk+" version="3.16"/>
   <object class="GtkAdjustment" id="adjustmentDpi">
@@ -30,6 +30,23 @@
       </row>
       <row>
         <col id="0" translatable="yes">Height</col>
+      </row>
+    </data>
+  </object>
+  <object class="GtkListStore" id="listBackgroundType">
+    <columns>
+      <!-- column-name Text -->
+      <column type="gchararray"/>
+    </columns>
+    <data>
+      <row>
+        <col id="0" translatable="yes">None</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">No ruling</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">All</col>
       </row>
     </data>
   </object>
@@ -114,7 +131,7 @@ Set export parameters</property>
               </packing>
             </child>
             <child>
-              <!-- n-columns=3 n-rows=5 -->
+              <!-- n-columns=3 n-rows=6 -->
               <object class="GtkGrid" id="grid1">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
@@ -149,7 +166,7 @@ Set export parameters</property>
                   </object>
                   <packing>
                     <property name="left-attach">0</property>
-                    <property name="top-attach">1</property>
+                    <property name="top-attach">2</property>
                   </packing>
                 </child>
                 <child>
@@ -165,7 +182,7 @@ Set export parameters</property>
                   </object>
                   <packing>
                     <property name="left-attach">1</property>
-                    <property name="top-attach">1</property>
+                    <property name="top-attach">2</property>
                   </packing>
                 </child>
                 <child>
@@ -181,7 +198,7 @@ Set export parameters</property>
                   </object>
                   <packing>
                     <property name="left-attach">1</property>
-                    <property name="top-attach">2</property>
+                    <property name="top-attach">3</property>
                   </packing>
                 </child>
                 <child>
@@ -197,7 +214,7 @@ Set export parameters</property>
                   </object>
                   <packing>
                     <property name="left-attach">1</property>
-                    <property name="top-attach">3</property>
+                    <property name="top-attach">4</property>
                   </packing>
                 </child>
                 <child>
@@ -213,7 +230,7 @@ Set export parameters</property>
                   </object>
                   <packing>
                     <property name="left-attach">2</property>
-                    <property name="top-attach">3</property>
+                    <property name="top-attach">4</property>
                   </packing>
                 </child>
                 <child>
@@ -226,7 +243,7 @@ Set export parameters</property>
                   </object>
                   <packing>
                     <property name="left-attach">2</property>
-                    <property name="top-attach">4</property>
+                    <property name="top-attach">5</property>
                   </packing>
                 </child>
                 <child>
@@ -242,7 +259,7 @@ Set export parameters</property>
                   </object>
                   <packing>
                     <property name="left-attach">2</property>
-                    <property name="top-attach">1</property>
+                    <property name="top-attach">2</property>
                   </packing>
                 </child>
                 <child>
@@ -258,7 +275,7 @@ Set export parameters</property>
                   </object>
                   <packing>
                     <property name="left-attach">2</property>
-                    <property name="top-attach">2</property>
+                    <property name="top-attach">3</property>
                   </packing>
                 </child>
                 <child>
@@ -328,24 +345,62 @@ Set export parameters</property>
                     <property name="top-attach">0</property>
                   </packing>
                 </child>
-
-		<child>
+                <child>
+                  <object class="GtkLabel" id="label2">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="tooltip-text" translatable="yes" comments="Keep the order the same as in listBackgroundType and use the translation of these types in parentheses.">Export the document without any background (None) or with PDF and image backgrounds only (No ruling) or with all background types (All).</property>
+                    <property name="label" translatable="yes">Background</property>
+                    <property name="ellipsize">middle</property>
+                    <property name="xalign">0</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">1</property>
+                  </packing>
+                </child>
+                <child>
                   <object class="GtkCheckButton" id="cbProgressiveMode">
                     <property name="label" translatable="yes">Export layers progressively</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">If enabled, the layers of each page will be added one by one. The resulting PDF file can be used for a presentation.</property>
-                    <property name="draw_indicator">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">False</property>
+                    <property name="tooltip-text" translatable="yes">If enabled, the layers of each page will be added one by one. The resulting PDF file can be used for a presentation.</property>
+                    <property name="draw-indicator">True</property>
                   </object>
                   <packing>
-		    <!-- Same place as "Image quality"; only one of them is shown -->
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">0</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">0</property>
                     <property name="width">3</property>
                   </packing>
                 </child>
-
+                <child>
+                  <object class="GtkComboBox" id="cbBackgroundType">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="model">listBackgroundType</property>
+                    <property name="active">2</property>
+                    <property name="id-column">0</property>
+                    <property name="active-id">0</property>
+                    <child>
+                      <object class="GtkCellRendererText" id="cbBackgroundTypeCell"/>
+                      <attributes>
+                        <attribute name="markup">0</attribute>
+                        <attribute name="text">0</attribute>
+                      </attributes>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
                 <child>
                   <placeholder/>
                 </child>


### PR DESCRIPTION
The aim of this series is to allow exports without ruling but with the other backgrounds, since the former are often auxiliary only, but the latter are essential. If you have documents with mixed background types or batch process documents with different background types then the new `--export-no-ruling` option should come in handy.

The 1st commit is an independent but technically related bugfix (do not export PDF background to PNG when asked not to).

The 2nd commit marks an existing bug as TODO (PDF backgrounds are never exported to SVG). I don't know if you prefer to carry TODOs in code. A proper fix would be to render the PDF to an image cairo surface and attach the image to the SVG surface, which is over my cairo head, unfortunately.

The remaining commits address the actual purpose: refactor and introduce the new export mode.