### PR TITLE
[1.0.x] hotfix for debian package

### DIFF
--- a/debian/package_description
+++ b/debian/package_description
@@ -1,11 +1,11 @@
-Xournal++ is a hand note taking software written in C++ with the target of 
-flexibility, functionality and speed. Stroke recognizer and other parts are 
-based on Xournal Code, which you can find at sourceforge. 
-It supports Linux (e.g. Ubuntu, Debian, Arch, SUSE), macOS and Windows 10. 
-Supports pen input from devices such as Wacom Tablets.
-
-Xournal++ features:
-
+Xournal++ is a hand note taking software written in C++ with the target of
+ flexibility, functionality and speed. Stroke recognizer and other parts are
+ based on Xournal Code, which you can find at sourceforge.
+ It supports Linux (e.g. Ubuntu, Debian, Arch, SUSE), macOS and Windows 10.
+ Supports pen input from devices such as Wacom Tablets.
+ 
+ Xournal++ features:
+ 
  - Support for Pen pressure, e.g. Wacom Tablet
  - Support for annotating PDFs
  - Fill shape functionality
@@ -24,5 +24,5 @@ Xournal++ features:
  - Rotation snapping every 45 degrees
  - Rect snapping to grid
  - Audio recording and playback alongside with handwritten notes
- - Multi Language Support, English, German, Italian ...
+ - Multi Language Support, English, German, Italian, ...
  - Plugins using Lua Scripting


### PR DESCRIPTION
This fixes the Debian package for version 1.0.20

The problem were the spaces at the end of lines (there shouldn't be any) and missing spaces at the beginning of lines starting from the 2nd line (including otherwise empty lines).