### PR TITLE
[1.0.x] Fix all debian packaging errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,6 +313,7 @@ set (CPACK_OUTPUT_FILE_PREFIX packages)
 set (CPACK_PACKAGE_NAME "${PROJECT_PACKAGE}")
 set (CPACK_PACKAGE_DESCRIPTION_SUMMARY "Xournal++ - Open source hand note-taking program")
 file(READ "${PROJECT_SOURCE_DIR}/debian/package_description" CPACK_DEBIAN_PACKAGE_DESCRIPTION)
+string(REGEX REPLACE "\n$" "" CPACK_DEBIAN_PACKAGE_DESCRIPTION "${CPACK_DEBIAN_PACKAGE_DESCRIPTION}")  #Automatically generated trailing newline must be removed
 set (CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/LICENSE")
 set (CPACK_PACKAGE_INSTALL_DIRECTORY "Xournal++")
 set (CPACK_PACKAGE_FILE_NAME "xournalpp-${PROJECT_VERSION}-${DISTRO_NAME}-${DISTRO_CODENAME}-${PACKAGE_ARCH}")
@@ -332,12 +333,16 @@ endif()
 
 if(CPACK_GENERATOR STREQUAL "DEB")
 	message("Preparing documentation for DEB package")
-	add_custom_target(package_docummentation ALL)
+	add_custom_target(package_documentation ALL)
 
 	#Compress changelog and save it as share/doc/xournalpp/changelog.Debian.gz
-	add_custom_command(TARGET package_docummentation PRE_BUILD
+	add_custom_command(TARGET package_documentation PRE_BUILD
 	COMMAND gzip -c -9 -n "${PROJECT_SOURCE_DIR}/debian/changelog" > "changelog.Debian.gz" VERBATIM)
 	install(FILES "${CMAKE_CURRENT_BINARY_DIR}/changelog.Debian.gz" DESTINATION "share/doc/xournalpp/")
+
+	message("Install copyright for DEB package")
+	#Copy copyright to share/doc/xournalpp/copyright
+	install(FILES "${PROJECT_SOURCE_DIR}/debian/copyright" DESTINATION "share/doc/xournalpp/")
 endif()
 
 if (NOT DEFINED CPACK_GENERATOR)

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -75,7 +75,7 @@ stages:
           - template: steps/build_linux.yml
             parameters:
               build_type: 'RelWithDebInfo'
-              cmake_flags: '-DCMAKE_DEBUG_INCLUDES_LDFLAGS=ON -DENABLE_CPPUNIT=ON -DDEBUG_COMPILE=ON -DCMAKE_INSTALL_PREFIX=$PWD/staging -DCPACK_GENERATOR="TGZ;DEB"'
+              cmake_flags: '-DCMAKE_DEBUG_INCLUDES_LDFLAGS=ON -DENABLE_CPPUNIT=ON -DDEBUG_COMPILE=ON -DCMAKE_INSTALL_PREFIX=$PWD/staging -DCPACK_GENERATOR="TGZ;DEB" -DCMAKE_CXX_FLAGS="-s"'
               cmake_commands: '--target package'
           - task: PublishPipelineArtifact@1
             inputs:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,13 +1,13 @@
 xournalpp (1.0.20-hotfix) unstable; urgency=medium
 
-  * Fixed an issue with packaging information for Debian packages preventing installation
+  * Fixed an issue with packaging info for deb packages preventing installation
 
- -- Ulrich Huber <ulrich@huberulrich.de> Wed, 23 Dec 2020 19:23:00 +0100
+ -- Ulrich Huber <ulrich@huberulrich.de>  Wed, 23 Dec 2020 23:19:30 +0100
 
 xournalpp (1.0.20-0) unstable; urgency=medium
 
   * Fixed a regression with pdf files that could not be overwritten
-  * Fixed page layout update after inserting or deleting a page, changeing the page layout or zooming
+  * Fixed page layout update after inserting, deleting, changing page layout or zooming
   * Fixed incorrect rendering of pages after changing the page format
   * Fixed blocked scrolling after saving a file
   * Fixed presentation mode after startup
@@ -56,4 +56,3 @@ xournalpp (1.0.2-0) unstable; urgency=low
   * Initial release Debian Packaging
 
  -- Andreas Butti <andreasbutti@gmail.com>  Mon, 03 Dec 2018 20:00:00 +0100
-

--- a/debian/control
+++ b/debian/control
@@ -11,10 +11,10 @@ Architecture: any
 Depends: libglib2.0-0 (>= 2.32), libgtk-3-0 (>= 3.18), libpoppler-glib8 (>= 0.41.0), libxml2 (>= 2.0.0), libportaudiocpp0 (>= 12), libsndfile1 (>= 1.0.25), liblua5.3-0, libzip4 (>= 1.0.1) | libzip5, zlib1g, libc6
 Suggests: texlive-base, texlive-latex-extra
 Description: Xournal++ - Open source hand note-taking program
- Xournal++ is a hand note taking software written in C++ with the target of 
- flexibility, functionality and speed. Stroke recognizer and other parts are 
- based on Xournal Code, which you can find at sourceforge. 
- It supports Linux (e.g. Ubuntu, Debian, Arch, SUSE), macOS and Windows 10. 
+ Xournal++ is a hand note taking software written in C++ with the target of
+ flexibility, functionality and speed. Stroke recognizer and other parts are
+ based on Xournal Code, which you can find at sourceforge.
+ It supports Linux (e.g. Ubuntu, Debian, Arch, SUSE), macOS and Windows 10.
  Supports pen input from devices such as Wacom Tablets.
  .
  Xournal++ features:
@@ -37,5 +37,5 @@ Description: Xournal++ - Open source hand note-taking program
   - Rotation snapping every 45 degrees
   - Rect snapping to grid
   - Audio recording and playback alongside with handwritten notes
-  - Multi Language Support, English, German, Italian ...
+  - Multi Language Support, English, German, Italian, ...
   - Plugins using Lua Scripting

--- a/debian/package_description
+++ b/debian/package_description
@@ -1,28 +1,29 @@
-Xournal++ is a hand note taking software written in C++ with the target of
+Xournal++ - Open source hand note-taking program
+ Xournal++ is a hand note taking software written in C++ with the target of
  flexibility, functionality and speed. Stroke recognizer and other parts are
  based on Xournal Code, which you can find at sourceforge.
  It supports Linux (e.g. Ubuntu, Debian, Arch, SUSE), macOS and Windows 10.
  Supports pen input from devices such as Wacom Tablets.
- 
+ .
  Xournal++ features:
- 
- - Support for Pen pressure, e.g. Wacom Tablet
- - Support for annotating PDFs
- - Fill shape functionality
- - PDF Export (with and without paper style)
- - PNG Export (with and without transparent background)
- - Allows maping different tools/colors etc. to stylus/mouse buttons
- - Sidebar with Page Previews with page sorting, PDF Bookmarks and Layers
- - Enhanced support for image insertion
- - Eraser with multiple configurations
- - LaTeX support (requires a working LaTeX install)
- - Bug reporting, autosave, and auto backup tools
- - Customizeable toolbar, with multiple configurations
- - Page Template definitions
- - Shape drawing (line, arrow, circle, rect)
- - Shape resizing and rotation
- - Rotation snapping every 45 degrees
- - Rect snapping to grid
- - Audio recording and playback alongside with handwritten notes
- - Multi Language Support, English, German, Italian, ...
- - Plugins using Lua Scripting
+ .
+  - Support for Pen pressure, e.g. Wacom Tablet
+  - Support for annotating PDFs
+  - Fill shape functionality
+  - PDF Export (with and without paper style)
+  - PNG Export (with and without transparent background)
+  - Allows maping different tools/colors etc. to stylus/mouse buttons
+  - Sidebar with Page Previews with page sorting, PDF Bookmarks and Layers
+  - Enhanced support for image insertion
+  - Eraser with multiple configurations
+  - LaTeX support (requires a working LaTeX install)
+  - Bug reporting, autosave, and auto backup tools
+  - Customizeable toolbar, with multiple configurations
+  - Page Template definitions
+  - Shape drawing (line, arrow, circle, rect)
+  - Shape resizing and rotation
+  - Rotation snapping every 45 degrees
+  - Rect snapping to grid
+  - Audio recording and playback alongside with handwritten notes
+  - Multi Language Support, English, German, Italian, ...
+  - Plugins using Lua Scripting


### PR DESCRIPTION
The manual page says:
>        Description: short-description (recommended)
>         long-description
>               The format for the package description is a short brief
>               summary on the first line (after the Description field).
>               The following lines should be used as a longer, more
>               detailed description. Each line of the long description
>               must be preceded by a space, and blank lines in the long
>               description must contain a single ‘.’ following the
>               preceding space.