### PR TITLE
export layers in different PDF pages

### DIFF
--- a/src/control/jobs/BaseExportJob.cpp
+++ b/src/control/jobs/BaseExportJob.cpp
@@ -68,7 +68,7 @@ auto BaseExportJob::showFilechooser() -> bool {
             gtk_widget_destroy(dialog);
             return false;
         }
-        auto file =  Util::fromGFilename(gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog)));
+        auto file = Util::fromGFilename(gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog)));
         Util::clearExtensions(file);
         // Since we add the extension after the OK button, we have to check manually on existing files
         if (testAndSetFilepath(std::move(file)) && control->askToReplace(this->filepath)) {
@@ -85,7 +85,7 @@ auto BaseExportJob::showFilechooser() -> bool {
 
 auto BaseExportJob::testAndSetFilepath(fs::path file) -> bool {
     try {
-        if(fs::is_directory(file.parent_path())){
+        if (fs::is_directory(file.parent_path())) {
             this->filepath = std::move(file);
             return true;
         }

--- a/src/control/jobs/CustomExportJob.cpp
+++ b/src/control/jobs/CustomExportJob.cpp
@@ -75,7 +75,7 @@ auto CustomExportJob::showFilechooser() -> bool {
     doc->lock();
     auto* dlg = new ExportDialog(control->getGladeSearchPath());
     if (filepath.extension() == ".pdf") {
-        dlg->removeQualitySetting();
+        dlg->showPresentationMode();
         format = EXPORT_GRAPHICS_PDF;
     } else if (filepath.extension() == ".svg") {
         dlg->removeQualitySetting();
@@ -94,6 +94,7 @@ auto CustomExportJob::showFilechooser() -> bool {
     }
 
     exportRange = dlg->getRange();
+    presentationMode = dlg->presentationMode();
 
     if (format == EXPORT_GRAPHICS_PNG) {
         pngQualityParameter = dlg->getPngQualityParameter();
@@ -142,7 +143,7 @@ void CustomExportJob::run() {
 
         pdfe->setNoBackgroundExport(filters[this->chosenFilterName]->withoutBackground);
 
-        if (!pdfe->createPdf(this->filepath, exportRange)) {
+        if (!pdfe->createPdf(this->filepath, exportRange, presentationMode)) {
             this->errorMsg = pdfe->getLastError();
         }
 

--- a/src/control/jobs/CustomExportJob.h
+++ b/src/control/jobs/CustomExportJob.h
@@ -67,6 +67,11 @@ private:
      */
     bool exportTypeXoj = false;
 
+    /**
+     * Export Layers as pages
+     */
+    bool presentationMode = false;
+
     string lastError;
 
     string chosenFilterName;

--- a/src/control/jobs/PdfExportJob.cpp
+++ b/src/control/jobs/PdfExportJob.cpp
@@ -32,7 +32,7 @@ void PdfExportJob::run() {
     XojPdfExport* pdfe = XojPdfExportFactory::createExport(doc, control);
     doc->unlock();
 
-    if (!pdfe->createPdf(this->filepath)) {
+    if (!pdfe->createPdf(this->filepath, false)) {
         if (control->getWindow()) {
             callAfterRun();
         } else {

--- a/src/gui/dialog/ExportDialog.cpp
+++ b/src/gui/dialog/ExportDialog.cpp
@@ -8,6 +8,7 @@
 ExportDialog::ExportDialog(GladeSearchpath* gladeSearchPath):
         GladeGui(gladeSearchPath, "exportSettings.glade", "exportDialog") {
 
+    gtk_widget_hide(get("cbPresentationMode"));
     g_signal_connect(get("rdRangePages"), "toggled", G_CALLBACK(+[](GtkToggleButton* togglebutton, ExportDialog* self) {
                          gtk_widget_set_sensitive(self->get("txtPages"), gtk_toggle_button_get_active(togglebutton));
                      }),
@@ -44,6 +45,11 @@ void ExportDialog::removeQualitySetting() {
     gtk_widget_hide(get("cbQuality"));
 }
 
+void ExportDialog::showPresentationMode() {
+    gtk_widget_show(get("cbPresentationMode"));
+    removeQualitySetting();
+}
+
 void ExportDialog::selectQualityCriterion(GtkComboBox* comboBox, ExportDialog* self) {
     int activeCriterion = gtk_combo_box_get_active(comboBox);
     switch (activeCriterion) {
@@ -69,6 +75,10 @@ auto ExportDialog::getPngQualityParameter() -> RasterImageQualityParameter {
 }
 
 auto ExportDialog::isConfirmed() const -> bool { return this->confirmed; }
+
+auto ExportDialog::presentationMode() -> bool {
+    return gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(get("cbPresentationMode")));
+}
 
 auto ExportDialog::getRange() -> PageRangeVector {
     GtkWidget* rdRangeCurrent = get("rdRangeCurrent");

--- a/src/gui/dialog/ExportDialog.h
+++ b/src/gui/dialog/ExportDialog.h
@@ -27,6 +27,7 @@ public:
     void initPages(int current, int count);
     bool isConfirmed() const;
     PageRangeVector getRange();
+    bool presentationMode();
 
     /**
      * @brief Reads the quality parameter from the dialog
@@ -39,6 +40,12 @@ public:
      * @brief Hides the quality settings
      */
     void removeQualitySetting();
+
+    /**
+     * @brief Show "presentation mode" checkbox and hide quality settings
+     * (both cannot be shown at the same time)
+     */
+    void showPresentationMode();
 
     /**
      * @brief Handler for changes in combobox cbQuality

--- a/src/pdf/base/XojCairoPdfExport.h
+++ b/src/pdf/base/XojCairoPdfExport.h
@@ -23,8 +23,8 @@ public:
     virtual ~XojCairoPdfExport();
 
 public:
-    virtual bool createPdf(fs::path const& file);
-    virtual bool createPdf(fs::path const& file, PageRangeVector& range);
+    virtual bool createPdf(fs::path const& file, bool presentationMode);
+    virtual bool createPdf(fs::path const& file, PageRangeVector& range, bool presentationMode);
     virtual string getLastError();
 
     /**
@@ -47,6 +47,10 @@ private:
 #endif
     void endPdf();
     void exportPage(size_t page);
+    /**
+     * Export as a PDF document where each additional layer creates a
+     * new page */
+    void exportPageLayers(size_t page);
 
 private:
     Document* doc = nullptr;

--- a/src/pdf/base/XojPdfExport.h
+++ b/src/pdf/base/XojPdfExport.h
@@ -24,8 +24,8 @@ public:
     virtual ~XojPdfExport();
 
 public:
-    virtual bool createPdf(fs::path const& file) = 0;
-    virtual bool createPdf(fs::path const& file, PageRangeVector& range) = 0;
+    virtual bool createPdf(fs::path const& file, bool presentationMode) = 0;
+    virtual bool createPdf(fs::path const& file, PageRangeVector& range, bool presentationMode) = 0;
     virtual string getLastError() = 0;
 
     /**

--- a/ui/exportSettings.glade
+++ b/ui/exportSettings.glade
@@ -328,6 +328,24 @@ Set export parameters</property>
                     <property name="top-attach">0</property>
                   </packing>
                 </child>
+
+		<child>
+                  <object class="GtkCheckButton" id="cbPresentationMode">
+                    <property name="label" translatable="yes">Export as a presentation</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="tooltip_text" translatable="yes">If enabled, the layers of each page will be added one by one. The resulting PDF file can be used for a presentation.</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+		    <!-- Same place as "Image quality"; only one of them is shown -->
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">0</property>
+                    <property name="width">3</property>
+                  </packing>
+                </child>
+
                 <child>
                   <placeholder/>
                 </child>


### PR DESCRIPTION
Enhancement proposal: see Issue https://github.com/xournalpp/xournalpp/issues/2373

In order to save all layers as separate pages, two options:
1. use "Save as..." in the File menu, select "PDF File" or "PDF File with plain background", and in the "Document export setting" dialog, check the box "Export all layers as separate pages"
2. use the command-line, as in 
    `xournalpp -p output.pdf --export-layers file.xopp`