### PR TITLE
Update xournalpp-ubuntu-ppa.recipe

### DIFF
--- a/xournalpp-ubuntu-ppa.recipe
+++ b/xournalpp-ubuntu-ppa.recipe
@@ -1,3 +1,3 @@
-# git-build-recipe format 0.4 deb-version {debupstream}-0~{revtime}
+# git-build-recipe format 0.4 deb-version {debupstream}+dev~{revtime}
 lp:xournalpp master
 


### PR DESCRIPTION
The current version from PPA (launchpad) should be called 1.1.0+dev (once the tag 1.1.0 is pushed), not 1.1.0-0 (currently 1.0.6-0).