### PR TITLE
avoid SVG 1.2 compositing operators

### DIFF
--- a/src/view/PdfView.cpp
+++ b/src/view/PdfView.cpp
@@ -11,17 +11,16 @@ PdfView::~PdfView() = default;
 void PdfView::drawPage(PdfCache* cache, const XojPdfPageSPtr& popplerPage, cairo_t* cr, double zoom, double width,
                        double height, bool forPrinting) {
     if (popplerPage) {
+        if (!forPrinting) {
+            cairo_set_source_rgb(cr, 1., 1., 1.);
+            cairo_paint(cr);
+        }
+
         if (cache && !forPrinting) {
             cache->render(cr, popplerPage, zoom);
         } else {
             popplerPage->render(cr, forPrinting);
         }
-
-        if (!forPrinting) {
-            cairo_set_operator(cr, CAIRO_OPERATOR_DEST_OVER);
-            cairo_set_source_rgb(cr, 1., 1., 1.);
-        }
-        cairo_paint(cr);
     } else {
         cairo_select_font_face(cr, "Sans", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_BOLD);
         cairo_set_font_size(cr, 26);


### PR DESCRIPTION
Note: I have not checked the effect of this on printing yet. It helps with the issue mentioned in #2575, though.

xournalpp paints a white background behind the PDF even for export (but
nor for printing). It does so by painting it after the PDF is rendered,
specifying CAIRO_OPERATOR_DEST_OVER as the compositing operator to get
it below the PDF rendering. When rendering to a SVG 1.2 surface cairo
turns this into a comp-op:dst-over style.

So what's the problem? SVG 1.2 never got accepted as a standard, and
thus it is supported only partially. The resulting SVG does not even
work in inkscape.

Instead, render the white background first and avoid the compositing
operator. This dies not change the resulting image for png outputs but
helps to produce simpler svg.