### PR TITLE
Rewrite and improve page load caching algorithm

### DIFF
--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -139,6 +139,9 @@ void Settings::loadDefault() {
 
     this->pageRerenderThreshold = 5.0;
     this->pdfPageCacheSize = 10;
+    this->preloadPagesBefore = 3U;
+    this->preloadPagesAfter = 5U;
+    this->eagerPageCleanup = true;
 
     this->selectionBorderColor = 0xff0000U;  // red
     this->selectionMarkerColor = 0x729fcfU;  // light blue
@@ -398,6 +401,12 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur) {
         this->pageRerenderThreshold = g_ascii_strtod(reinterpret_cast<const char*>(value), nullptr);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("pdfPageCacheSize")) == 0) {
         this->pdfPageCacheSize = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("preloadPagesBefore")) == 0) {
+        this->preloadPagesBefore = g_ascii_strtoull(reinterpret_cast<const char*>(value), nullptr, 10);
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("preloadPagesAfter")) == 0) {
+        this->preloadPagesAfter = g_ascii_strtoull(reinterpret_cast<const char*>(value), nullptr, 10);
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("eagerPageCleanup")) == 0) {
+        this->eagerPageCleanup = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("selectionBorderColor")) == 0) {
         this->selectionBorderColor = Color(g_ascii_strtoull(reinterpret_cast<const char*>(value), nullptr, 10));
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("selectionMarkerColor")) == 0) {
@@ -843,6 +852,9 @@ void Settings::save() {
 
     WRITE_INT_PROP(pdfPageCacheSize);
     WRITE_COMMENT("The count of rendered PDF pages which will be cached.");
+    WRITE_UINT_PROP(preloadPagesBefore);
+    WRITE_UINT_PROP(preloadPagesAfter);
+    WRITE_BOOL_PROP(eagerPageCleanup);
 
     WRITE_COMMENT("Config for new pages");
     WRITE_STRING_PROP(pageTemplate);
@@ -1621,6 +1633,36 @@ void Settings::setPdfPageCacheSize(int size) {
         return;
     }
     this->pdfPageCacheSize = size;
+    save();
+}
+
+auto Settings::getPreloadPagesBefore() const -> unsigned int { return this->preloadPagesBefore; }
+
+void Settings::setPreloadPagesBefore(unsigned int n) {
+    if (this->preloadPagesBefore == n) {
+        return;
+    }
+    this->preloadPagesBefore = n;
+    save();
+}
+
+auto Settings::getPreloadPagesAfter() const -> unsigned int { return this->preloadPagesAfter; }
+
+void Settings::setPreloadPagesAfter(unsigned int n) {
+    if (this->preloadPagesAfter == n) {
+        return;
+    }
+    this->preloadPagesAfter = n;
+    save();
+}
+
+auto Settings::isEagerPageCleanup() const -> bool { return this->eagerPageCleanup; }
+
+void Settings::setEagerPageCleanup(bool b) {
+    if (this->eagerPageCleanup == b) {
+        return;
+    }
+    this->eagerPageCleanup = b;
     save();
 }
 

--- a/src/control/settings/Settings.h
+++ b/src/control/settings/Settings.h
@@ -330,6 +330,15 @@ public:
     int getPdfPageCacheSize() const;
     [[maybe_unused]] void setPdfPageCacheSize(int size);
 
+    unsigned int getPreloadPagesBefore() const;
+    void setPreloadPagesBefore(unsigned int n);
+
+    unsigned int getPreloadPagesAfter() const;
+    void setPreloadPagesAfter(unsigned int n);
+
+    bool isEagerPageCleanup() const;
+    void setEagerPageCleanup(bool b);
+
     string const& getPageTemplate() const;
     void setPageTemplate(const string& pageTemplate);
 
@@ -937,4 +946,18 @@ private:
      * e.g. "en_US"
      */
     std::string preferredLocale;
+    /**
+     * The number of pages to pre-load before the current page.
+     */
+    unsigned int preloadPagesBefore{};
+
+    /**
+     * The number of pages to pre-load after the current page.
+     */
+    unsigned int preloadPagesAfter{};
+
+    /**
+     * Whether to evict from the page buffer cache when scrolling.
+     */
+    bool eagerPageCleanup{};
 };

--- a/src/gui/XournalView.h
+++ b/src/gui/XournalView.h
@@ -140,11 +140,13 @@ public:
 private:
     void fireZoomChanged();
 
-    void addLoadPageToQue(PageRef page, int priority);
+    std::pair<size_t, size_t> preloadPageBounds(size_t page, size_t maxPage);
 
     Rectangle<double>* getVisibleRect(size_t page);
 
     static gboolean clearMemoryTimer(XournalView* widget);
+
+    void cleanupBufferCache();
 
     static void staticLayoutPages(GtkWidget* widget, GtkAllocation* allocation, void* data);
 

--- a/src/gui/dialog/SettingsDialog.cpp
+++ b/src/gui/dialog/SettingsDialog.cpp
@@ -487,6 +487,12 @@ void SettingsDialog::load() {
     loadCheckbox("cbHidePresentationSidebar", hidePresentationSidebar);
     loadCheckbox("cbHideMenubarStartup", settings->isMenubarVisible());
 
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(get("preloadPagesBefore")),
+                              static_cast<double>(settings->getPreloadPagesBefore()));
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(get("preloadPagesAfter")),
+                              static_cast<double>(settings->getPreloadPagesAfter()));
+    loadCheckbox("cbEagerPageCleanup", settings->isEagerPageCleanup());
+
     enableWithCheckbox("cbAutosave", "boxAutosave");
     enableWithCheckbox("cbIgnoreFirstStylusEvents", "spNumIgnoredStylusEvents");
     enableWithCheckbox("cbAddVerticalSpace", "spAddVerticalSpace");
@@ -705,6 +711,16 @@ void SettingsDialog::save() {
                                                            hidePresentationMenubar, hidePresentationSidebar));
 
     settings->setMenubarVisible(getCheckbox("cbHideMenubarStartup"));
+
+    constexpr auto spinAsUint = [&](GtkSpinButton* btn) {
+        int v = gtk_spin_button_get_value_as_int(btn);
+        return v < 0 ? 0U : static_cast<unsigned int>(v);
+    };
+    unsigned int preloadPagesBefore = spinAsUint(GTK_SPIN_BUTTON(get("preloadPagesBefore")));
+    unsigned int preloadPagesAfter = spinAsUint(GTK_SPIN_BUTTON(get("preloadPagesAfter")));
+    settings->setPreloadPagesAfter(preloadPagesAfter);
+    settings->setPreloadPagesBefore(preloadPagesBefore);
+    settings->setEagerPageCleanup(getCheckbox("cbEagerPageCleanup"));
 
     settings->setDefaultSaveName(gtk_entry_get_text(GTK_ENTRY(get("txtDefaultSaveName"))));
     // Todo(fabian): use Util::fromGFilename!

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -48,6 +48,16 @@
     <property name="step-increment">1</property>
     <property name="page-increment">1</property>
   </object>
+  <object class="GtkAdjustment" id="adjustmentPreloadPagesAfter">
+    <property name="upper">99</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustmentPreloadPagesBefore">
+    <property name="upper">99</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
   <object class="GtkAdjustment" id="adjustmentPressureMultiplier">
     <property name="lower">0.5</property>
     <property name="upper">4</property>
@@ -3225,6 +3235,106 @@ This also enables touch drawing.&lt;/i&gt;</property>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
                                 <property name="position">5</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkFrame">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
+                                <child>
+                                  <object class="GtkAlignment">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="left-padding">12</property>
+                                    <child>
+                                      <!-- n-columns=2 n-rows=3 -->
+                                      <object class="GtkGrid">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="column-spacing">10</property>
+                                        <child>
+                                          <object class="GtkLabel">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="halign">start</property>
+                                            <property name="label" translatable="yes">Pre-load pages before</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="halign">start</property>
+                                            <property name="label" translatable="yes">Pre-load pages after</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSpinButton" id="preloadPagesBefore">
+                                            <property name="name">preloadPagesBefore</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="input-purpose">number</property>
+                                            <property name="adjustment">adjustmentPreloadPagesBefore</property>
+                                            <property name="numeric">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSpinButton" id="preloadPagesAfter">
+                                            <property name="name">preloadPagesAfter</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="input-purpose">number</property>
+                                            <property name="adjustment">adjustmentPreloadPagesAfter</property>
+                                            <property name="numeric">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="cbEagerPageCleanup">
+                                            <property name="label" translatable="yes">Clear cached paged while scrolling</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="draw-indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">2</property>
+                                            <property name="width">2</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label">
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">Performance</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">6</property>
                               </packing>
                             </child>
                           </object>


### PR DESCRIPTION
This PR updates the page cache algorithm and adds a page preloading feature. Fixes #2412.

TODO:
* [x] Configuration option for `n` pages to preload before current page
* [x] Configuration option for `n` pages to preload after current page
* [ ] Configuration option for `n` additional pages to keep in LRU cache
* [x] Address performance concerns when rapidly scrolling through pages (pages are loaded eagerly, so they consume a lot of memory).
