### PR TITLE
Update font-button when editing text, make it work locale-independent

### DIFF
--- a/src/gui/PageView.cpp
+++ b/src/gui/PageView.cpp
@@ -183,6 +183,7 @@ void XojPageView::endText() {
 
     delete this->textEditor;
     this->textEditor = nullptr;
+    this->xournal->getControl()->getWindow()->setFontButtonFont(settings->getFont());
     this->rerenderPage();
 }
 
@@ -244,6 +245,7 @@ void XojPageView::startText(double x, double y) {
             text->setY(oldtext->getY());
             text->setColor(oldtext->getColor());
             text->setFont(oldtext->getFont());
+            this->xournal->getControl()->getWindow()->setFontButtonFont(oldtext->getFont());
             text->setText(oldtext->getText());
             text->setTimestamp(oldtext->getTimestamp());
             text->setAudioFilename(oldtext->getAudioFilename());

--- a/src/gui/toolbarMenubar/FontButton.cpp
+++ b/src/gui/toolbarMenubar/FontButton.cpp
@@ -1,5 +1,7 @@
 #include "FontButton.h"
 
+#include <locale>
+#include <sstream>
 #include <utility>
 
 #include <config.h>
@@ -29,7 +31,11 @@ void FontButton::activated(GdkEvent* event, GtkMenuItem* menuitem, GtkToolButton
 
 void FontButton::setFontFontButton(GtkWidget* fontButton, XojFont& font) {
     GtkFontButton* button = GTK_FONT_BUTTON(fontButton);
-    string name = font.getName() + " " + std::to_string(font.getSize());
+    // Fixing locale to make format of font-size string independent of localization setting
+    std::stringstream fontSizeStream;
+    fontSizeStream.imbue(std::locale("C"));
+    fontSizeStream << font.getSize();
+    string name = font.getName() + " " + fontSizeStream.str();
     gtk_font_button_set_font_name(button, name.c_str());
 }
 


### PR DESCRIPTION
Updates the font button in the toolbar when entering and leaving edit mode of a text filed. That makes is easier to change the font relative to how it was before. When leaving the edit mode of a text field the font is reset to the font last chosen in the dialog.

Also, the creation of the string to set the font shown by the toolbar button is made independent of locale settings. Before, e.g. German locale caused the string to be formatted with a decimal comma instead of a decimal point, which wasn't recognized by the button. Therefore closes #1051 and #1061