### PR TITLE
Fix regression touchscreen disabling sometimes broken

### DIFF
--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -174,7 +174,7 @@ private:
     // of the setting -- usingTouchWorkaround should only change
     // on application restart!
     bool usingTouchWorkaround;
-    std::atomic_bool gtkTouchscreenScrollingEnabled;
+    std::atomic_bool gtkTouchscreenScrollingEnabled{true};
 
     // Toolbars
     ToolMenuHandler* toolbar;


### PR DESCRIPTION
An uninitialized variable was sometimes true, sometimes false, leading to inconsistent initial disabling of Gtk scrolling.

Should address #2626.
See https://github.com/xournalpp/xournalpp/issues/2626#issuecomment-756122243 for a full description. 