### PR TITLE
fix page rendering regression

### DIFF
--- a/src/gui/widgets/XournalWidget.cpp
+++ b/src/gui/widgets/XournalWidget.cpp
@@ -163,14 +163,12 @@ static void gtk_xournal_init(GtkXournal* xournal) {
 
 static void gtk_xournal_get_preferred_width(GtkWidget* widget, gint* minimal_width, gint* natural_width) {
     GtkXournal* xournal = GTK_XOURNAL(widget);
-    *minimal_width = 20;
-    *natural_width = xournal->layout->getMinimalWidth();
+    *minimal_width = *natural_width = xournal->layout->getMinimalWidth();
 }
 
 static void gtk_xournal_get_preferred_height(GtkWidget* widget, gint* minimal_height, gint* natural_height) {
     GtkXournal* xournal = GTK_XOURNAL(widget);
-    *minimal_height = 20;
-    *natural_height = xournal->layout->getMinimalHeight();
+    *minimal_height = *natural_height = xournal->layout->getMinimalHeight();
 }
 
 /**


### PR DESCRIPTION
This PR reverts the changes to `minimal_width` and `minimal_height` made in #2613, that lead to regression #2631. Fixes #2631.