### PR TITLE
Make line style modifiable after drawing

### DIFF
--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -2748,12 +2748,8 @@ void Control::setLineStyle(const string& style) {
         sel = this->win->getXournal()->getSelection();
     }
 
-    // TODO(fabian): allow to change selection
     if (sel) {
-        //		UndoAction* undo = sel->setSize(size, toolHandler->getToolThickness(TOOL_PEN),
-        //										toolHandler->getToolThickness(TOOL_HIGHLIGHTER),
-        //										toolHandler->getToolThickness(TOOL_ERASER));
-        //		undoRedo->addUndoAction(undo);
+        undoRedo->addUndoAction(sel->setLineStyle(stl));
     }
 
     this->toolHandler->setLineStyle(stl);

--- a/src/control/tools/EditSelection.cpp
+++ b/src/control/tools/EditSelection.cpp
@@ -17,6 +17,7 @@
 #include "undo/ColorUndoAction.h"
 #include "undo/FontUndoAction.h"
 #include "undo/InsertUndoAction.h"
+#include "undo/LineStyleUndoAction.h"
 #include "undo/SizeUndoAction.h"
 #include "undo/UndoRedoHandler.h"
 
@@ -257,6 +258,12 @@ auto EditSelection::setSize(ToolSize size, const double* thicknessPen, const dou
 auto EditSelection::setFill(int alphaPen, int alphaHighligther) -> UndoAction* {
     return this->contents->setFill(alphaPen, alphaHighligther);
 }
+
+/**
+ * Set the line style of all elements, return an undo action
+ * (Or nullptr if nothing done)
+ */
+auto EditSelection::setLineStyle(LineStyle style) -> UndoActionPtr { return this->contents->setLineStyle(style); }
 
 /**
  * Set the color of all elements, return an undo action

--- a/src/control/tools/EditSelection.h
+++ b/src/control/tools/EditSelection.h
@@ -20,6 +20,7 @@
 #include "model/Font.h"
 #include "model/PageRef.h"
 #include "model/Snapping.h"
+#include "undo/UndoAction.h"
 #include "view/ElementContainer.h"
 
 #include "CursorSelectionType.h"
@@ -31,7 +32,6 @@ class Layer;
 class XojPageView;
 class Selection;
 class Element;
-class UndoAction;
 class EditSelectionContents;
 class DeleteUndoAction;
 
@@ -121,6 +121,12 @@ public:
      */
     UndoAction* setSize(ToolSize size, const double* thicknessPen, const double* thicknessHighlighter,
                         const double* thicknessEraser);
+
+    /**
+     * Set the line style of all strokes, return an undo action
+     * (Or nullptr if nothing done)
+     */
+    UndoActionPtr setLineStyle(LineStyle style);
 
     /**
      * Set the color of all elements, return an undo action

--- a/src/control/tools/EditSelectionContents.h
+++ b/src/control/tools/EditSelectionContents.h
@@ -19,6 +19,7 @@
 #include "model/Element.h"
 #include "model/Font.h"
 #include "model/PageRef.h"
+#include "undo/UndoAction.h"
 #include "view/ElementContainer.h"
 
 #include "CursorSelectionType.h"
@@ -29,7 +30,6 @@ class Layer;
 class XojPageView;
 class Selection;
 class Element;
-class UndoAction;
 class EditSelectionContents;
 class DeleteUndoAction;
 
@@ -40,6 +40,12 @@ public:
     virtual ~EditSelectionContents();
 
 public:
+    /**
+     * Sets the line style for all strokes, returs an undo action
+     * (or nullptr if nothing is done)
+     */
+    UndoActionPtr setLineStyle(LineStyle style);
+
     /**
      * Sets the tool size for pen or eraser, returs an undo action
      * (or nullptr if nothing is done)

--- a/src/undo/LineStyleUndoAction.cpp
+++ b/src/undo/LineStyleUndoAction.cpp
@@ -1,0 +1,71 @@
+#include "LineStyleUndoAction.h"
+
+#include "gui/Redrawable.h"
+#include "model/PageRef.h"
+#include "model/Stroke.h"
+
+#include "Rectangle.h"
+#include "i18n.h"
+
+LineStyleUndoAction::LineStyleUndoAction(const PageRef& page, Layer* layer): UndoAction("LineStyleUndoAction") {
+    this->page = page;
+    this->layer = layer;
+}
+
+void LineStyleUndoAction::addStroke(Stroke* s, LineStyle originalStyle, LineStyle newStyle) {
+    this->data.emplace_back(s, originalStyle, newStyle);
+}
+
+auto LineStyleUndoAction::undo(Control* control) -> bool {
+    if (this->data.empty()) {
+        return true;
+    }
+
+    LineStyleUndoActionEntry e = this->data.front();
+    double x1 = e.s->getX();
+    double x2 = e.s->getX() + e.s->getElementWidth();
+    double y1 = e.s->getY();
+    double y2 = e.s->getY() + e.s->getElementHeight();
+
+    for (LineStyleUndoActionEntry& e: this->data) {
+        e.s->setLineStyle(e.oldStyle);
+
+        x1 = std::min(x1, e.s->getX());
+        x2 = std::max(x2, e.s->getX() + e.s->getElementWidth());
+        y1 = std::min(y1, e.s->getY());
+        y2 = std::max(y2, e.s->getY() + e.s->getElementHeight());
+    }
+
+    Rectangle rect(x1, y1, x2 - x1, y2 - y1);
+    this->page->fireRectChanged(rect);
+
+    return true;
+}
+
+auto LineStyleUndoAction::redo(Control* control) -> bool {
+    if (this->data.empty()) {
+        return true;
+    }
+
+    LineStyleUndoActionEntry e = this->data.front();
+    double x1 = e.s->getX();
+    double x2 = e.s->getX() + e.s->getElementWidth();
+    double y1 = e.s->getY();
+    double y2 = e.s->getY() + e.s->getElementHeight();
+
+    for (LineStyleUndoActionEntry& e: this->data) {
+        e.s->setLineStyle(e.newStyle);
+
+        x1 = std::min(x1, e.s->getX());
+        x2 = std::max(x2, e.s->getX() + e.s->getElementWidth());
+        y1 = std::min(y1, e.s->getY());
+        y2 = std::max(y2, e.s->getY() + e.s->getElementHeight());
+    }
+
+    Rectangle rect(x1, y1, x2 - x1, y2 - y1);
+    this->page->fireRectChanged(rect);
+
+    return true;
+}
+
+auto LineStyleUndoAction::getText() -> string { return _("Change line style"); }

--- a/src/undo/LineStyleUndoAction.h
+++ b/src/undo/LineStyleUndoAction.h
@@ -1,0 +1,51 @@
+/*
+ * Xournal++
+ *
+ * Undo action for line style changes (Edit selection)
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+#include <vector>
+
+#include "model/LineStyle.h"
+
+#include "UndoAction.h"
+
+class Stroke;
+class Layer;
+class Redrawable;
+
+struct LineStyleUndoActionEntry {
+    LineStyleUndoActionEntry(Stroke* s, LineStyle oldStyle, LineStyle newStyle):
+            s(s), oldStyle(oldStyle), newStyle(newStyle) {}
+    Stroke* s;
+    LineStyle oldStyle;
+    LineStyle newStyle;
+};
+
+class LineStyleUndoAction: public UndoAction {
+public:
+    LineStyleUndoAction(const PageRef& page, Layer* layer);
+    LineStyleUndoAction(LineStyleUndoAction const&) = delete;
+    LineStyleUndoAction(LineStyleUndoAction&&) = delete;
+    LineStyleUndoAction& operator=(LineStyleUndoAction const&) = delete;
+    LineStyleUndoAction& operator=(LineStyleUndoAction&&) = delete;
+    ~LineStyleUndoAction() override = default;
+
+public:
+    bool undo(Control* control) override;
+    bool redo(Control* control) override;
+    string getText() override;
+
+    void addStroke(Stroke* s, LineStyle originalStyle, LineStyle newStyle);
+
+private:
+    std::vector<LineStyleUndoActionEntry> data;
+    Layer* layer;
+};

--- a/src/undo/UndoAction.h
+++ b/src/undo/UndoAction.h
@@ -42,3 +42,5 @@ protected:
     PageRef page;
     bool undone = false;
 };
+
+using UndoActionPtr = std::unique_ptr<UndoAction>;

--- a/src/undo/UndoRedoHandler.h
+++ b/src/undo/UndoRedoHandler.h
@@ -22,8 +22,6 @@
 
 class Control;
 
-using UndoActionPtr = std::unique_ptr<UndoAction>;
-
 class UndoRedoListener {
 public:
     virtual void undoRedoChanged() = 0;


### PR DESCRIPTION
I have often struggled with line styles, because they could not be modified after the strokes have been drawn. With this PR the line style of a whole selection is made modifiable similarly as for the color of a selection. See animation.
![LineStyleDemo](https://user-images.githubusercontent.com/40485433/104089223-64252180-526d-11eb-831f-0a21e81b95e6.gif)

