### PR TITLE
[Proof of concept] Enhanced PDF tools

### DIFF
--- a/src/pdf/base/XojPdfPage.h
+++ b/src/pdf/base/XojPdfPage.h
@@ -37,6 +37,8 @@ public:
     XojPdfPage();
     virtual ~XojPdfPage();
 
+    using Link = std::pair<XojPdfRectangle, GUri*>;
+
 public:
     virtual double getWidth() = 0;
     virtual double getHeight() = 0;
@@ -44,6 +46,8 @@ public:
     virtual void render(cairo_t* cr, bool forPrinting = false) = 0;
 
     virtual vector<XojPdfRectangle> findText(string& text) = 0;
+
+    virtual auto getLinks() -> std::vector<Link> = 0;
 
     virtual int getPageId() = 0;
 

--- a/src/pdf/popplerapi/PopplerGlibPage.h
+++ b/src/pdf/popplerapi/PopplerGlibPage.h
@@ -31,6 +31,8 @@ public:
 
     virtual vector<XojPdfRectangle> findText(string& text);
 
+    auto getLinks() -> std::vector<Link> override;
+
     virtual int getPageId();
 
 private:


### PR DESCRIPTION
This PR adds additional features for PDF interaction and notetaking. In particular, this extends the `Select Rectangle` tool to interact with objects in the background PDF (if it exists) when clicking with Alt held down (keybindings subject to change).

Currently, this PR is a proof-of-concept. Ideas, feedback, and additional help are welcome. We don't want to feature-creep this too much--the idea is to get something merged into `master` within a reasonable timeframe.

TODO:
* [ ] Interaction with links in document (#1027)
  * [x] URL support
  * [ ] Local document references (awaiting integration with Technius/xournalpp#1)
  * [ ] Button to convert into text element
  * [ ] Button to copy URL to clipboard
* [x] ~Text selection~ #1745) superceded by #3326
* [ ] Image selection
  * [ ] Popup
  * [ ] Button to copy to clipboard
  * [ ] Button to convert into image element

Demo:
![Peek 2021-01-12 15-15](https://user-images.githubusercontent.com/1066652/104386849-c9d21180-54ea-11eb-867b-632e76c935ad.gif)
