### PR TITLE
Layer preview: show PDF background in background layer only

### DIFF
--- a/src/control/jobs/PreviewJob.cpp
+++ b/src/control/jobs/PreviewJob.cpp
@@ -62,6 +62,11 @@ void PreviewJob::drawBackgroundPdf(Document* doc) {
 void PreviewJob::drawPage(int layer) {
     DocumentView view;
     PageRef page = this->sidebarPreview->page;
+    Document* doc = this->sidebarPreview->sidebar->getControl()->getDocument();
+
+    if (page->getBackgroundType().isPdfPage() && (layer == -100 || layer == -1)) {
+        drawBackgroundPdf(doc);
+    }
 
     if (layer == -100) {
         // render all layer
@@ -95,10 +100,6 @@ void PreviewJob::run() {
 
     if (RENDER_TYPE_PAGE_LAYER == type) {
         layer = (dynamic_cast<SidebarPreviewLayerEntry*>(this->sidebarPreview))->getLayer();
-    }
-
-    if (this->sidebarPreview->page->getBackgroundType().isPdfPage()) {
-        drawBackgroundPdf(doc);
     }
 
     drawPage(layer);


### PR DESCRIPTION
A PDF background lives in the background layer just like any other
background. In the sidebar layer preview, however, PDF backgrounds are
drawn for every layer; all other backgrounds (ruling, image) are drawn
for the background layer only.

Move the corresponding codeblock to drawPage() where all the logic is
about what to draw in the preview, and make it draw PDF backgrounds on
the background layer (and combined page view) only.

**Note**: If we can rely on -100 and -1 being the only negative layer values then `layer == -100 || layer == -1` can be simplified to `layer < 0`, of course.