### PR TITLE
Allow for panning during touchpad pinch gesture

### DIFF
--- a/src/control/zoom/ZoomControl.cpp
+++ b/src/control/zoom/ZoomControl.cpp
@@ -28,7 +28,7 @@ auto onScrolledwindowMainScrollEvent(GtkWidget* widget, GdkEventScroll* event, Z
 
 auto onTouchpadPinchEvent(GtkWidget* widget, GdkEventTouchpadPinch* event, ZoomControl* zoom) -> bool {
     if (event->type == GDK_TOUCHPAD_PINCH && event->n_fingers == 2) {
-        utl::Point<double> center;
+        utl::Point<double> center, visibleRectPos;
         switch (event->phase) {
             case GDK_TOUCHPAD_GESTURE_PHASE_BEGIN:
                 if (zoom->isZoomFitMode()) {
@@ -42,6 +42,9 @@ auto onTouchpadPinchEvent(GtkWidget* widget, GdkEventTouchpadPinch* event, ZoomC
                 break;
             case GDK_TOUCHPAD_GESTURE_PHASE_UPDATE:
                 zoom->zoomSequenceChange(event->scale, true);
+                visibleRectPos = {zoom->getVisibleRect().x, zoom->getVisibleRect().y};
+                // Use natural scrolling (the "-")
+                zoom->setScrollPositionAfterZoom(visibleRectPos - utl::Point{event->dx, event->dy});
                 break;
             case GDK_TOUCHPAD_GESTURE_PHASE_END:
                 zoom->endZoomSequence();


### PR DESCRIPTION
Just noticed that this doesn't respect natural scrolling which might feel weird. Not sure whether there is any method of checking whether the user has this enabled.
As in this case the touchpad really works like a touchscreen, I made it always use natural scrolling for now. I would find it nice, if this would depend on the libinput/whatever is being used setting but a quick search didn't yield anything helpful there.

If you want, I could add a setting for that.