### PR TITLE
Fix page preview only updating one page

### DIFF
--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -1622,12 +1622,9 @@ void Control::undoRedoChanged() {
 }
 
 void Control::undoRedoPageChanged(PageRef page) {
-    if (!this->changedPages.empty() &&
-        std::find(begin(this->changedPages), end(this->changedPages), page) == end(this->changedPages)) {
-        return;
+    if (std::find(begin(this->changedPages), end(this->changedPages), page) == end(this->changedPages)) {
+        this->changedPages.emplace_back(std::move(page));
     }
-
-    this->changedPages.emplace_back(std::move(page));
 }
 
 void Control::selectTool(ToolType type) {


### PR DESCRIPTION
When writing on 2 (or more) different pages between two refreshing of the page preview (5 seconds between two successive refreshing), only the first modified page gets its preview updated. 
This PR fixes that.