### PR TITLE
Remove console window flash at startup on Windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -89,6 +89,14 @@ if (WIN32)
   unset (ICON_SIZES)
   unset (ICON_DEPS)
   add_custom_target (xournalpp_icon DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/win32/xournalpp.ico)
+
+  # Concatenate SOURCES lists
+  set (xournalpp_SOURCES ${xournalpp_SOURCES_RECURSE} ${xournalpp_SOURCES})
+  unset (xournalpp_SOURCES_RECURSE)
+
+  file (GLOB xournalpp_SOURCES_RECURSE
+    win32/*.cpp
+  )
 endif()
 
 # Concatenate SOURCES lists

--- a/src/Xournalpp.cpp
+++ b/src/Xournalpp.cpp
@@ -18,14 +18,13 @@
 #include "Stacktrace.h"
 
 #ifdef _WIN32
-#include <windows.h>
+#include "win32/console.h"
 #endif
 
 auto main(int argc, char* argv[]) -> int {
 #ifdef _WIN32
-    // Show and hide the console here. Otherwise, gspawn-win32-helper will create annoying console popups.
-    AllocConsole();
-    ShowWindow(GetConsoleWindow(), SW_HIDE);
+    // Attach to the console here. Otherwise, gspawn-win32-helper will create annoying console popups.
+    attachConsole();
 #endif
 
     // init crash handler

--- a/src/win32/console.cpp
+++ b/src/win32/console.cpp
@@ -1,0 +1,73 @@
+#include "console.h"
+
+#include <windows.h>
+
+void attachConsole() {
+    if (GetConsoleWindow() != NULL) {
+        // Console is already attached.
+        return;
+    }
+
+    // Make sure the console starts hidden.
+    STARTUPINFOW startupInfo = {0};
+    startupInfo.dwFlags = STARTF_USESHOWWINDOW;
+    startupInfo.wShowWindow = SW_HIDE;
+    startupInfo.cb = sizeof(startupInfo);
+
+    PROCESS_INFORMATION processInformation = {0};
+
+    bool consoleAttached = false;
+
+    if (CreateProcessW(L"C:\\Windows\\System32\\cmd.exe", NULL, NULL, NULL, FALSE, 0, NULL, NULL, &startupInfo,
+                       &processInformation)) {
+        HANDLE job = CreateJobObject(NULL, NULL);
+
+        if (job != NULL) {
+            // Terminate the console process automatically when Xournal++ exits.
+            JOBOBJECT_EXTENDED_LIMIT_INFORMATION jobInformation = {0};
+            jobInformation.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+
+            if (!SetInformationJobObject(job, JobObjectExtendedLimitInformation, &jobInformation,
+                                         sizeof(jobInformation)) ||
+                !AssignProcessToJobObject(job, processInformation.hProcess)) {
+                TerminateProcess(processInformation.hProcess, 0);
+                CloseHandle(processInformation.hProcess);
+                CloseHandle(processInformation.hThread);
+                CloseHandle(job);
+                processInformation.hProcess = processInformation.hThread = job = NULL;
+            } else {
+                // It takes a short time before the console becomes ready to be attached, unfortunately
+                // there is no API that would let us wait for it.
+                for (unsigned short i = 0; i < 20; i++) {
+                    if (AttachConsole(processInformation.dwProcessId)) {
+                        consoleAttached = true;
+                        break;
+                    }
+                    Sleep(50);
+                }
+            }
+        } else {
+            TerminateProcess(processInformation.hProcess, 0);
+            CloseHandle(processInformation.hProcess);
+            CloseHandle(processInformation.hThread);
+            processInformation.hProcess = processInformation.hThread = NULL;
+        }
+
+        if (processInformation.hProcess != NULL) {
+            if (!consoleAttached) {
+                TerminateProcess(processInformation.hProcess, 0);
+                CloseHandle(job);
+            }
+
+            CloseHandle(processInformation.hProcess);
+            CloseHandle(processInformation.hThread);
+        }
+    }
+
+    if (!consoleAttached) {
+        // Could not attach to the manually created console process, request one from the system instead.
+        // This will make the console window flash briefly before we hide it.
+        AllocConsole();
+        ShowWindow(GetConsoleWindow(), SW_HIDE);
+    }
+}

--- a/src/win32/console.h
+++ b/src/win32/console.h
@@ -1,0 +1,6 @@
+#pragma once
+
+/**
+ * Allocates a new (hidden) console and associates the standard input and output handles with it.
+ */
+void attachConsole();


### PR DESCRIPTION
I have noticed that the Windows build uses `AllocConsole` at Xournal++ startup to prevent `gspawn-win64-helper` from creating its own console popups, for example when rendering LaTeX. However, this makes the console window flash briefly on the screen, which is annoying especially in tablet mode. When you launch Xournal++ (using the start menu or by opening a file associated with it), a console window is opened and then hidden immediately.

In tablet mode, there is no classic desktop, instead a full-screen start menu is displayed when no window is in the foreground. This means that after hiding the console window, the screen drops back to the start menu. Then the actual Xournal++ GUI is opened in the background and you must switch to it by tapping its icon in the task bar.

Unfortunately there is no way to force `AllocConsole` to create an already-hidden console window, so if we want to solve this, we have to spawn our own console process manually and attach to it instead. `CreateProcess` allows us to start `cmd.exe` hidden, so it won’t flash on the screen. Then we can attach to it using `AttachConsole`. That’s what I’m doing in this PR.

I know this adds a lot of code, but when I noticed that #2606 will remove the launcher (which caused a similar issue, except it was the launcher that flashed on the screen), I thought it would be nice to get rid of this annoying behavior entirely.

Thanks for considering my PR!