### PR TITLE
Make circle go up to cursor when drawing from center

### DIFF
--- a/src/control/tools/CircleHandler.cpp
+++ b/src/control/tools/CircleHandler.cpp
@@ -45,7 +45,8 @@ void CircleHandler::drawShape(Point& c, const PositionInputData& pos) {
         {
             int signW = width > 0 ? 1 : -1;
             int signH = height > 0 ? 1 : -1;
-            width = std::max(width * signW, height * signH) * signW;
+            width = (this->modControl) ? sqrt(pow(width, 2) + pow(height, 2)) :
+                                         std::max(width * signW, height * signH) * signW;
             height = (width * signW) * signH;
         }
 


### PR DESCRIPTION
When drawing a circle from the center, it makes sense to put the edge of the circle wherever the cursor is, but the current implementation is to take the maximum of the width and height, which corresponds to the cursor only at the principal axes, and makes a smaller circle everywhere else.

Apologies if there's an issue or PR about this already, there were a lot about circles to look through!