### PR TITLE
add EditSelection mirror functionality for strokes and images

### DIFF
--- a/src/control/tools/EditSelection.h
+++ b/src/control/tools/EditSelection.h
@@ -314,6 +314,11 @@ private:  // DATA
     bool aspectRatio{};
 
     /**
+     * If mirrors are allowed e.g. for strokes
+     */
+    bool mirror{};
+
+    /**
      * Size of the editing handles
      */
 

--- a/src/control/tools/EditSelectionContents.cpp
+++ b/src/control/tools/EditSelectionContents.cpp
@@ -484,12 +484,14 @@ void EditSelectionContents::paint(cairo_t* cr, double x, double y, double rotati
     }
 
     if (this->crBuffer == nullptr) {
-        this->crBuffer = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width * zoom, height * zoom);
+        this->crBuffer = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, static_cast<int>(std::abs(width) * zoom),
+                                                    static_cast<int>(std::abs(height) * zoom));
         cairo_t* cr2 = cairo_create(this->crBuffer);
 
         int dx = static_cast<int>(this->relativeX * zoom);
         int dy = static_cast<int>(this->relativeY * zoom);
 
+        cairo_translate(cr2, fx < 0 ? -width * zoom : 0, fy < 0 ? -height * zoom : 0);
         cairo_scale(cr2, fx, fy);
         cairo_translate(cr2, -dx, -dy);
         cairo_scale(cr2, zoom, zoom);
@@ -504,8 +506,8 @@ void EditSelectionContents::paint(cairo_t* cr, double x, double y, double rotati
     int wImg = cairo_image_surface_get_width(this->crBuffer);
     int hImg = cairo_image_surface_get_height(this->crBuffer);
 
-    int wTarget = static_cast<int>(width * zoom);
-    int hTarget = static_cast<int>(height * zoom);
+    int wTarget = static_cast<int>(std::abs(width) * zoom);
+    int hTarget = static_cast<int>(std::abs(height) * zoom);
 
     double sx = static_cast<double>(wTarget) / wImg;
     double sy = static_cast<double>(hTarget) / hImg;
@@ -517,8 +519,8 @@ void EditSelectionContents::paint(cairo_t* cr, double x, double y, double rotati
         cairo_scale(cr, sx, sy);
     }
 
-    double dx = static_cast<int>(x * zoom / sx);
-    double dy = static_cast<int>(y * zoom / sy);
+    double dx = static_cast<int>(std::min(x, x + width) * zoom / sx);
+    double dy = static_cast<int>(std::min(y, y + height) * zoom / sy);
 
     cairo_set_source_surface(cr, this->crBuffer, dx, dy);
     cairo_paint(cr);

--- a/src/gui/XournalppCursor.cpp
+++ b/src/gui/XournalppCursor.cpp
@@ -138,6 +138,7 @@ void XournalppCursor::setMouseSelectionType(CursorSelectionType selectionType) {
 }
 
 void XournalppCursor::setRotationAngle(double angle) { this->angle = angle; }
+void XournalppCursor::setMirror(bool mirror) { this->mirror = mirror; }
 
 /*This handles setting the busy cursor for the main window and calls
  * updateCursor to set the busy cursor for the XournalWidget region.
@@ -314,7 +315,10 @@ void XournalppCursor::updateCursor() {
 }
 
 auto XournalppCursor::getResizeCursor(double deltaAngle) -> GdkCursor* {
-    gulong flavour = static_cast<gulong>(RESIZE_CURSOR_HASH_PRECISION * (angle + deltaAngle));
+    if (this->mirror) {
+        deltaAngle = -deltaAngle;
+    }
+    gulong flavour = static_cast<gulong>(RESIZE_CURSOR_HASH_PRECISION * fmod(angle + deltaAngle, 180.0));
     if (CRSR_RESIZE == this->currentCursor && flavour == this->currentCursorFlavour) {
         return nullptr;
     }

--- a/src/gui/XournalppCursor.h
+++ b/src/gui/XournalppCursor.h
@@ -39,6 +39,7 @@ public:
     void activateDrawDirCursor(bool enable, bool shift = false, bool ctrl = false);
     void setInputDeviceClass(InputDeviceClass inputDevice);
     void setRotationAngle(double angle);
+    void setMirror(bool mirror);
 
 private:
     void setCursor(int id);
@@ -73,6 +74,7 @@ private:
     gulong currentCursorFlavour{};  // for different flavours of a cursor (i.e. drawdir, pen and highlighter custom
                                     // cursors)
 
-    // for resizing rotated selections
+    // for resizing rotated/mirrored selections
     double angle = 0;
+    bool mirror = false;
 };

--- a/src/model/Element.cpp
+++ b/src/model/Element.cpp
@@ -117,6 +117,7 @@ auto Element::isInSelection(ShapeContainer* container) -> bool {
 }
 
 auto Element::rescaleOnlyAspectRatio() -> bool { return false; }
+auto Element::rescaleWithMirror() -> bool { return false; }
 
 void Element::serializeElement(ObjectOutputStream& out) const {
     out.writeObject("Element");

--- a/src/model/Element.h
+++ b/src/model/Element.h
@@ -66,6 +66,7 @@ public:
     virtual bool isInSelection(ShapeContainer* container);
 
     virtual bool rescaleOnlyAspectRatio();
+    virtual bool rescaleWithMirror();
 
     /**
      * Take 1:1 copy of this element

--- a/src/model/Stroke.cpp
+++ b/src/model/Stroke.cpp
@@ -102,6 +102,8 @@ void Stroke::setWidth(double width) { this->width = width; }
 
 auto Stroke::getWidth() const -> double { return this->width; }
 
+auto Stroke::rescaleWithMirror() -> bool { return true; }
+
 auto Stroke::isInSelection(ShapeContainer* container) -> bool {
     for (auto&& p: this->points) {
         double px = p.x;
@@ -190,7 +192,7 @@ void Stroke::rotate(double x0, double y0, double th) {
 }
 
 void Stroke::scale(double x0, double y0, double fx, double fy, double rotation, bool restoreLineWidth) {
-    double fz = (restoreLineWidth) ? 1 : sqrt(fx * fy);
+    double fz = (restoreLineWidth) ? 1 : sqrt(std::abs(fx * fy));
     cairo_matrix_t scaleMatrix;
     cairo_matrix_init_identity(&scaleMatrix);
     cairo_matrix_translate(&scaleMatrix, x0, y0);

--- a/src/model/Stroke.h
+++ b/src/model/Stroke.h
@@ -106,6 +106,8 @@ public:
     void serialize(ObjectOutputStream& out) override;
     void readSerialized(ObjectInputStream& in) override;
 
+    bool rescaleWithMirror() override;
+
 protected:
     void calcSize() const override;
 


### PR DESCRIPTION
fixes https://github.com/xournalpp/xournalpp/issues/2718
fixes https://github.com/xournalpp/xournalpp/issues/1440

Simplifies the edit selection logic. Then adds in the mirror functionality, but
just like `aspectRatio` is fixed for some objects, also `mirror` is fixed for some objects.

The handling of the corners is now linear for all cases. Before this PR it was non linear for the corners, resulting in weird behavior when the mouse is not exactly on the grabbed corner.

Also adjusted cursors to match the mirrored scale directions in the corners.