### PR TITLE
Fix font size dpi scaling bug and search mark bug and add a plugin for migration of font sizes

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,6 +9,7 @@ Homepage: https://github.com/xournalpp/xournalpp/
 Package: xournalpp
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, libglib2.0-0 (>= 2.32), libgtk-3-0 (>= 3.18), libpoppler-glib8 (>= 0.41.0), libxml2 (>= 2.0.0), libportaudiocpp0 (>= 12), libsndfile1 (>= 1.0.25), liblua5.3-0, libzip4 (>= 1.0.1) | libzip5, zlib1g, libc6, librsvg2-2 (>= 2.40)
+Recommends: lua-lgi
 Suggests: texlive-base, texlive-latex-extra
 Description: Xournal++ - Open source hand note-taking program
  Xournal++ is a hand note taking software written in C++ with the target of 

--- a/plugins/MigrateFontSizes/dialog.glade
+++ b/plugins/MigrateFontSizes/dialog.glade
@@ -1,0 +1,341 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.2 -->
+<interface>
+  <requires lib="gtk+" version="3.20"/>
+  <object class="GtkAdjustment" id="adjOldDpi">
+    <property name="lower">13</property>
+    <property name="upper">400</property>
+    <property name="value">223</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjScaleFactor">
+    <property name="lower">0.17999999999999999</property>
+    <property name="upper">5.5499999999999998</property>
+    <property name="value">3.0899999999999999</property>
+    <property name="step_increment">0.01</property>
+    <property name="page_increment">1</property>
+  </object>
+  <object class="GtkDialog" id="dlgMigrateFontSizes">
+    <property name="can_focus">False</property>
+    <property name="resizable">False</property>
+    <property name="type_hint">dialog</property>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
+    <child internal-child="vbox">
+      <object class="GtkBox" id="vboxInternal">
+        <property name="can_focus">False</property>
+        <property name="margin_left">12</property>
+        <property name="margin_right">12</property>
+        <property name="margin_top">12</property>
+        <property name="margin_bottom">12</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox" id="btBox">
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton" id="btCancel">
+                <property name="label">gtk-cancel</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="btApply">
+                <property name="label">gtk-apply</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="vbox1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="margin_bottom">12</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">12</property>
+            <child>
+              <object class="GtkLabel" id="lblTitle">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Migrate font sizes</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkExpander" id="expHelp">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <child>
+                  <object class="GtkLabel" id="lblExplanation">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">In Xournal++ versions 1.0.x and earlier version of 1.1.0+dev font sizes were relative 
+to the display DPI setting from the preferences (slider in the zoom panel). Only
+with the standard setting of 72 DPI the fonts were saved with their true size. With a 
+20 pt Sans Regular font, two subsequent lines of text should be separated exactly 
+by the distance between two subsequent lines of the ruled paper background. 
+With 144 DPI (i.e. the doubled value) you however needed a font size of 10 pt
+(the half value) for that purpose. This was confusing. 
+
+We have changed that so that 20 pt Sans Regular will always fit to the ruled paper 
+background lines regardless of the display DPI setting.
+
+If you have created documents with a different display DPI setting than 72, you will 
+now see font sizes that are of different size then they looked like when you created 
+them. This plugin allows to correct that in the current document for once and 
+forever. For that purpose we need to scale all font sizes of the document with the 
+factor f = OldDPI / 72, where OldDPI is the display DPI value with which the 
+document was created.</property>
+                    <property name="wrap">True</property>
+                    <property name="width_chars">55</property>
+                  </object>
+                </child>
+                <child type="label">
+                  <object class="GtkLabel" id="lblHelp">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Show help</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                    </attributes>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_bottom">12</property>
+                <child>
+                  <object class="GtkLabel" id="lblCurrentDpiHeading">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Current Display DPI</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="lblCurrentDpi">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_left">24</property>
+                    <property name="label" translatable="yes">223</property>
+                    <property name="width_chars">5</property>
+                    <property name="max_width_chars">5</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkGrid" id="gridFactorSettings">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="row_spacing">12</property>
+                <property name="column_spacing">6</property>
+                <child>
+                  <object class="GtkLabel" id="lblScaleFactor">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">Scale Factor</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">4</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="lblDpiNormalization">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">DPI Normalization</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">2</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="lblOldDPI">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">Old DPI</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSpinButton" id="spbtOldDpi">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="max_length">6</property>
+                    <property name="width_chars">5</property>
+                    <property name="text" translatable="yes">223</property>
+                    <property name="adjustment">adjOldDpi</property>
+                    <property name="numeric">True</property>
+                    <property name="value">232</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="lblDivisionSign">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_left">24</property>
+                    <property name="label" translatable="yes">/</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="lblEqualSign">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_right">24</property>
+                    <property name="label" translatable="yes">=</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">3</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSpinButton" id="spbtScaleFactor">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="max_length">10</property>
+                    <property name="width_chars">8</property>
+                    <property name="progress_fraction">0.01</property>
+                    <property name="adjustment">adjScaleFactor</property>
+                    <property name="digits">4</property>
+                    <property name="numeric">True</property>
+                    <property name="value">3.0899999999999999</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">4</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="lblConstant">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">72</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">2</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">3</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="lblDialog">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">start</property>
+                <property name="margin_top">12</property>
+                <property name="label" translatable="yes">Click "Apply" to scale font sizes of all elements of the document by the scale factor.
+Save the document, when you are done.</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">4</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/plugins/MigrateFontSizes/main.lua
+++ b/plugins/MigrateFontSizes/main.lua
@@ -1,0 +1,87 @@
+-- Register all Toolbar actions and intialize all UI stuff
+function initUi()
+  app.registerUi({["menu"] = "Migrate font sizes with factor displayDPI / 72", ["callback"] = "migrate"});
+  app.registerUi({["menu"] = "Show font size migration dialog", ["callback"] = "showDialog"});
+
+  lgiInstallPaths = "/usr/share/lua/5.3/?.lua; /usr/local/share/lua/5.3/?.lua" -- change this if your lgi.lua file is located in a different directory
+  package.path = package.path .. ";../?.lua;" .. lgiInstallPaths 
+
+  sourcePath = debug.getinfo(1).source:match("@?(.*/)")
+end
+
+function migrate()
+  local displayDpi = app.getDisplayDpi()
+  local dpiNormalizationFactor = 72
+  local factor = displayDpi / dpiNormalizationFactor
+  -- print("Display DPI is " .. displayDpi .. " => scaling by factor " .. displayDpi .. "/72 = " .. factor)
+  local result = app.msgbox("Display DPI is " .. displayDpi .. ". By proceeding the font sizes of all text elements will be scaled by the factor " .. displayDpi .. "/72 = " .. factor, {[1]="Cancel", [2]="OK"})
+  if result == 2 then 
+    resize(factor)
+  end
+end
+
+local currDpi
+
+function showDialog()
+  local hasLgi, lgi = pcall(require, "lgi")
+  if not hasLgi then
+    app.msgbox("You need to have the Lua lgi-module installed in order to use the GUI for migrating font sizes. \n\n Also check the lgi module install paths in the file \n\n " .. sourcePath .. "main.lua \n\n Currently \n\n" .. lgiInstallPaths .. "\n\n is specified", {[1]="OK"})
+    return
+  end
+
+  --lgi module has been found
+  local Gtk = lgi.Gtk
+  local Gdk = lgi.Gdk
+  local assert = lgi.assert
+  local builder = Gtk.Builder()
+  assert(builder:add_from_file(sourcePath .. "dialog.glade"))
+  local ui = builder.objects
+  local dialog = ui.dlgMigrateFontSizes
+
+  if not currDpi then 
+    currDpi = app.getDisplayDpi()
+  end
+  ui.spbtOldDpi:set_value(currDpi)
+  ui.lblCurrentDpi:set_text(app.getDisplayDpi())
+
+-- Connect actions
+  function ui.btApply.on_clicked()
+    local factor = ui.spbtScaleFactor:get_value()
+    resize(factor)
+  end
+
+  function ui.btCancel.on_clicked()
+    dialog:destroy()
+  end
+
+  function ui.spbtScaleFactor.on_value_changed()
+    factor = ui.spbtScaleFactor:get_value()
+    currDpi = math.floor(factor*72+0.5)
+    ui.spbtOldDpi:set_value(currDpi)
+  end
+
+  function ui.spbtOldDpi.on_value_changed()
+    oldDpi = ui.spbtOldDpi:get_value()
+    ui.spbtScaleFactor:set_value(oldDpi/72)
+  end
+
+  dialog:show_all()
+end
+
+function resize(factor)
+  local docStructure = app.getDocumentStructure()
+  local numPages = #docStructure["pages"]
+  local page = docStructure["currentPage"]
+  local layer = docStructure["pages"][page]["currentLayer"]
+  
+  for i=1, numPages do
+    app.setCurrentPage(i)
+    local numLayers = #docStructure["pages"][page]["layers"]
+    for j=1, numLayers do
+      app.setCurrentLayer(j)
+      app.scaleTextElements(factor)
+    end
+  end
+  app.setCurrentPage(page)
+  app.setCurrentLayer(layer)
+end

--- a/plugins/MigrateFontSizes/plugin.ini
+++ b/plugins/MigrateFontSizes/plugin.ini
@@ -1,0 +1,15 @@
+[about]
+## Author / Copyright notice
+author=Roland Lötscher
+
+description=Migrate font sizes to Display DPI independent font size handling since Feb 2021
+
+## If the plugin is packed with Xournal++, use
+## <xournalpp> then it gets the same version number
+version=<xournalpp>
+
+[default]
+enabled=true
+
+[plugin]
+mainfile=main.lua

--- a/readme/LinuxBuild.md
+++ b/readme/LinuxBuild.md
@@ -24,26 +24,26 @@ The minimum required CMake version is 3.10, but we recommend to use >=3.15.
 #### For Arch
 ```bash
 sudo pacman -S cmake gtk3 base-devel libxml2 cppunit portaudio libsndfile \
-poppler-glib texlive-bin texlive-pictures gettext libzip
+poppler-glib texlive-bin texlive-pictures gettext libzip lua53 lua53-lgi
 ```
 
 #### For Fedora/CentOS/RHEL:
 ```bash
 sudo dnf install gcc-c++ cmake gtk3-devel libxml2-devel cppunit-devel portaudio-devel libsndfile-devel \
 poppler-glib-devel texlive-scheme-basic texlive-dvipng 'tex(standalone.cls)' gettext libzip-devel \
-librsvg2-devel
+librsvg2-devel lua-devel lua-lgi
 ```
 
 #### For Ubuntu/Debian and Raspberry Pi OS:
 ````bash
 sudo apt-get install cmake libgtk-3-dev libpoppler-glib-dev portaudio19-dev libsndfile-dev \
-libcppunit-dev dvipng texlive libxml2-dev liblua5.3-dev libzip-dev librsvg2-dev gettext
+libcppunit-dev dvipng texlive libxml2-dev liblua5.3-dev libzip-dev librsvg2-dev gettext lua-lgi
 ````
 
 #### For openSUSE:
 ```bash
 sudo zypper install cmake gtk3-devel cppunit-devel portaudio-devel libsndfile-devel \
-texlive-dvipng texlive libxml2-devel libpoppler-glib-devel libzip-devel librsvg-devel
+texlive-dvipng texlive libxml2-devel libpoppler-glib-devel libzip-devel librsvg-devel lua-lgi
 ```
 
 #### For Solus:

--- a/src/plugin/luapi_application.h
+++ b/src/plugin/luapi_application.h
@@ -17,7 +17,9 @@
 #include "control/Tool.h"
 #include "control/layer/LayerController.h"
 #include "control/pagetype/PageTypeHandler.h"
+#include "gui/XournalView.h"
 #include "gui/widgets/XournalWidget.h"
+#include "model/Text.h"
 
 #include "StringUtils.h"
 #include "XojMsgBox.h"
@@ -784,6 +786,51 @@ static int applib_setBackgroundName(lua_State* L) {
 }
 
 
+/**
+ * Scales all text elements of the current layer by the given scale factor.
+ * This means the font sizes get scaled, wheras the position of the left upper corner
+ * of the bounding box remains unchanged
+ *
+ * Example: app.scaleTextElements(2.3)
+ * scales all text elements on the current layer with factor 2.3
+ **/
+static int applib_scaleTextElements(lua_State* L) {
+    Plugin* plugin = Plugin::getPluginFromLua(L);
+    Control* control = plugin->getControl();
+
+    double f = luaL_checknumber(L, 1);
+
+    control->clearSelectionEndText();
+
+    std::vector<Element*> elements = *control->getCurrentPage()->getSelectedLayer()->getElements();
+
+    for (Element* e: elements) {
+        if (e->getType() == ELEMENT_TEXT) {
+            Text* t = static_cast<Text*>(e);
+            t->scale(t->getX(), t->getY(), f, f, 0.0, false);
+        }
+    }
+
+    elements.clear();
+
+    return 1;
+}
+
+
+/**
+ * Gets the display DPI.
+ * Example: app.getDisplayDpi()
+ **/
+static int applib_getDisplayDpi(lua_State* L) {
+    Plugin* plugin = Plugin::getPluginFromLua(L);
+    Control* control = plugin->getControl();
+    int dpi = control->getSettings()->getDisplayDpi();
+    lua_pushinteger(L, dpi);
+
+    return 1;
+}
+
+
 /*
  * The full Lua Plugin API.
  * See above for example usage of each function.
@@ -807,6 +854,8 @@ static const luaL_Reg applib[] = {{"msgbox", applib_msgbox},
                                   {"setLayerVisibility", applib_setLayerVisibility},
                                   {"setCurrentLayerName", applib_setCurrentLayerName},
                                   {"setBackgroundName", applib_setBackgroundName},
+                                  {"scaleTextElements", applib_scaleTextElements},
+                                  {"getDisplayDpi", applib_getDisplayDpi},
                                   // Placeholder
                                   //	{"MSG_BT_OK", nullptr},
 

--- a/src/view/TextView.cpp
+++ b/src/view/TextView.cpp
@@ -32,8 +32,7 @@ auto TextView::initPango(cairo_t* cr, const Text* t) -> PangoLayout* {
 
 void TextView::updatePangoFont(PangoLayout* layout, const Text* t) {
     PangoFontDescription* desc = pango_font_description_from_string(t->getFontName().c_str());
-    // pango_font_description_set_absolute_size(desc, t->getFontSize() * PANGO_SCALE);
-    pango_font_description_set_size(desc, t->getFontSize() * PANGO_SCALE);
+    pango_font_description_set_absolute_size(desc, t->getFontSize() * PANGO_SCALE);
 
     pango_layout_set_font_description(layout, desc);
     pango_font_description_free(desc);
@@ -80,7 +79,7 @@ auto TextView::findText(const Text* t, string& search) -> vector<XojPdfRectangle
             mark.x1 = (static_cast<double>(rect.x)) / PANGO_SCALE + t->getX();
             mark.y1 = (static_cast<double>(rect.y)) / PANGO_SCALE + t->getY();
 
-            pango_layout_index_to_pos(layout, pos + srch.length(), &rect);
+            pango_layout_index_to_pos(layout, pos + srch.length() - 1, &rect);
             mark.x2 = (static_cast<double>(rect.x) + rect.width) / PANGO_SCALE + t->getX();
             mark.y2 = (static_cast<double>(rect.y) + rect.height) / PANGO_SCALE + t->getY();
 


### PR DESCRIPTION
This PR replaces PR #2182. 
It does not take care of line spacing in pdf export (for which we would need Pango's `pango_layout_set_line_spacing` to work correctly). 

Currently the plugin will derive the scaling factor from the display dpi setting (in the zoom panel of the preferences). This will usually be the correct choice, but it is not if the user has changed his display dpi setting since he created the document. So I think a display dpi that can be set from the GUI should be included. This could be done either by adding a GUI element in the Lua plugin API or by creating the GUI element in the plugin using the `lgi` module. In the latter case it may make sense to add the `lgi` module to the project. It is always needed when creating a non-trivial GUI.