### PR TITLE
Better dark mode: Fix & improve CSS styling

### DIFF
--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -1928,6 +1928,7 @@ void Control::showSettings() {
     this->zoom->setZoom100Value(settings->getDisplayDpi() / Util::DPI_NORMALIZATION_FACTOR);
 
     getWindow()->getXournal()->getHandRecognition()->reload();
+    getWindow()->updateColorscheme();
 
     TextView::setDpi(settings->getDisplayDpi());
 

--- a/src/control/jobs/PreviewJob.cpp
+++ b/src/control/jobs/PreviewJob.cpp
@@ -55,6 +55,7 @@ void PreviewJob::finishPaint() {
 void PreviewJob::drawBackgroundPdf(Document* doc) {
     int pgNo = this->sidebarPreview->page->getPdfPageNr();
     XojPdfPageSPtr popplerPage = doc->getPdfPage(pgNo);
+
     PdfView::drawPage(this->sidebarPreview->sidebar->getCache(), popplerPage, cr2, zoom,
                       this->sidebarPreview->page->getWidth(), this->sidebarPreview->page->getHeight());
 }
@@ -88,9 +89,17 @@ void PreviewJob::drawPage(int layer) {
     cairo_destroy(cr2);
 }
 
+void PreviewJob::clipToPage() {
+    // Only render within the preview page. Without this, the when preview jobs attempt
+    // to clear the display, we fill a region larger than the inside of the preview page!
+    cairo_rectangle(cr2, 0, 0, this->sidebarPreview->page->getWidth(), this->sidebarPreview->page->getHeight());
+    cairo_clip(cr2);
+}
+
 void PreviewJob::run() {
     initGraphics();
     drawBorder();
+    clipToPage();
 
     Document* doc = this->sidebarPreview->sidebar->getControl()->getDocument();
     doc->lock();

--- a/src/control/jobs/PreviewJob.h
+++ b/src/control/jobs/PreviewJob.h
@@ -41,6 +41,7 @@ public:
 
 private:
     void initGraphics();
+    void clipToPage();
     void drawBorder();
     void finishPaint();
     void drawBackgroundPdf(Document* doc);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -250,6 +250,17 @@ void MainWindow::toggleMenuBar(MainWindow* win) {
     }
 }
 
+void MainWindow::updateColorscheme() {
+    bool darkMode = control->getSettings()->isDarkTheme();
+    GtkStyleContext* context = gtk_widget_get_style_context(GTK_WIDGET(this->window));
+
+    if (darkMode) {
+        gtk_style_context_add_class(context, "darkMode");
+    } else {
+        gtk_style_context_remove_class(context, "darkMode");
+    }
+}
+
 void MainWindow::initXournalWidget() {
     GtkWidget* boxContents = get("boxContents");
 
@@ -273,6 +284,8 @@ void MainWindow::initXournalWidget() {
 
     Layout* layout = gtk_xournal_get_layout(this->xournal->getWidget());
     scrollHandling->init(this->xournal->getWidget(), layout);
+
+    updateColorscheme();
 }
 
 void MainWindow::setGtkTouchscreenScrollingForDeviceMapping() {

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -90,6 +90,7 @@ public:
     void setControlTmpDisabled(bool disabled);
 
     void updateToolbarMenu();
+    void updateColorscheme();
 
     GtkWidget** getToolbarWidgets(int& length);
     const char* getToolbarName(GtkToolbar* toolbar);

--- a/src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp
+++ b/src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp
@@ -31,6 +31,9 @@ ToolbarAdapter::ToolbarAdapter(GtkWidget* toolbar, string toolbarName, ToolMenuH
 
     showToolbar();
     prepareToolItems();
+
+    GtkStyleContext* ctx = gtk_widget_get_style_context(w);
+    gtk_style_context_add_class(ctx, "editing");
 }
 
 ToolbarAdapter::~ToolbarAdapter() {
@@ -40,6 +43,9 @@ ToolbarAdapter::~ToolbarAdapter() {
     g_signal_handlers_disconnect_by_func(this->w, (gpointer)toolbarDragDataReceivedCb, this);
 
     cleanupToolbars();
+
+    GtkStyleContext* ctx = gtk_widget_get_style_context(w);
+    gtk_style_context_remove_class(ctx, "editing");
 }
 
 void ToolbarAdapter::cleanupToolbars() {

--- a/src/gui/sidebar/previews/base/SidebarPreviewBase.cpp
+++ b/src/gui/sidebar/previews/base/SidebarPreviewBase.cpp
@@ -33,8 +33,6 @@ SidebarPreviewBase::SidebarPreviewBase(Control* control, GladeGui* gui, SidebarT
     g_signal_connect(this->scrollPreview, "size-allocate", G_CALLBACK(sizeChanged), this);
 
     gtk_widget_show_all(this->scrollPreview);
-
-    g_signal_connect(this->iconViewPreview, "draw", G_CALLBACK(Util::paintBackgroundWhite), nullptr);
 }
 
 SidebarPreviewBase::~SidebarPreviewBase() {

--- a/ui/xournalpp.css
+++ b/ui/xournalpp.css
@@ -1,50 +1,103 @@
-/*  
+/*
  * Backup before modifying
  *
- * 
+ *
  *  Try running Xournal++ like this:    GTK_DEBUG=interactive  xournalpp
- * 
+ *
  *  See: https://wiki.gnome.org/action/show/Projects/GTK/Inspector
  */
 
-
-
 /*Style the Floating Toolbox!*/
 
-#floatingToolbox>GtkBox 
-{
-	background-color: rgba(0,0,0,0.05);
-	border-radius:10%;
-}
-#floatingToolbox GtkBox GtkToolbar 
-{
-	background-color: rgba(255,255,255,0);
-}
-#floatingToolbox GtkButton 
-{
-	background-color: rgba(255,255,255,1);
-	border-radius: 50%;
+#floatingToolbox > box {
+	background-color: white;
+	border-radius: 12px;
+
+	box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.4);
+
+	/* Add a margin. If we don't have this, Gtk clips the shadow!  */
+	margin: 7px;
 }
 
+#floatingToolbox box toolbar {
+	background-color: rgba(255, 255, 255, 0);
+}
 
+#floatingToolbox button {
+	background-color: rgba(255, 255, 255, 0.8);
+	border-radius: 12px;
+}
+
+/*
+	Use :checked for a selected ToggleButton.
+	See https://stackoverflow.com/questions/39824345/use-css-to-style-gtktogglebutton-depending-on-the-state
+*/
+#floatingToolbox button:checked {
+	background-color: lightblue;
+	border-color: lightblue;
+	box-shadow: inset 0px 0px 3px lightblue;
+
+	transition: background-color 0.5s ease, border-color 0.5s ease, margin 0.3s ease;
+}
+
+#floatingToolbox toolbar {
+    /*
+      The Adaptia GTK theme adds box-shadows to toolbars.
+      Remove them to avoid horizontal lines that extend outside
+      the edge of the floating toolbox.
+     */
+
+    box-shadow: none;
+}
+
+window.darkMode #floatingToolbox button {
+	background: rgba(55, 53, 53, 0.5);
+}
+
+window.darkMode #floatingToolbox button:checked {
+	background: rgba(85, 85, 95, 0.1);
+	border-color: lightblue;
+	box-shadow: 0px 0px 3px lightblue;
+}
+
+window.darkMode #floatingToolbox > box {
+	background-color: black;
+
+	/*
+	  Lighter gray shadow for better contrast on dark
+	  backgrounds.
+	*/
+	box-shadow: 0px 0px 5px rgba(90, 90, 90, 0.7);
+}
+
+/* Add additional padding and a border to make editing toolbars easier. */
+toolbar.editing {
+	padding-top: 4px;
+	padding-bottom: 4px;
+
+	border: 4px dashed orange;
+	border-radius: 3px;
+
+	box-shadow: inset -2px -2px 8px orange;
+}
 
 /*Fix ugly Background drop down button
- * 
- * We need to select the button beside two labels or we will affect 
+ *
+ * We need to select the button beside two labels or we will affect
  * the pen tool when in FloatingToolbox (and can't see activation highlight).
- * 
- * Ideally we will give name properties to all of the widgets created in 
+ *
+ * Ideally we will give name properties to all of the widgets created in
  * code as well as specifying names in glade files.
- * 
+ *
  * Note: in glade files, property with name="name". i.e. <property name="name">floatingToolbox</property>
  */
 
 
-GtkToolItem>GtkBox>GtkLabel+GtkLabel+GtkButton 
+toolitem > box > label+label+button 
 {
 	border-width:0;
 	box-shadow:none;
-	background-image:none
+	background-image:none;
 }
 
 
@@ -54,7 +107,7 @@ GtkToolItem>GtkBox>GtkLabel+GtkLabel+GtkButton
 */
 
 /*
-GtkToolbar GtkButton
+toolbar button
 {
 	padding: 2
 }
@@ -62,11 +115,11 @@ GtkToolbar GtkButton
 
 
 
-/* Or for individual toolbars: tbLeft1 tbLeft2 tbTop1 tbTop2 tbBottom1 tbFloat4 etc: 
+/* Or for individual toolbars: tbLeft1 tbLeft2 tbTop1 tbTop2 tbBottom1 tbFloat4 etc:
  */
- 
+
 /*
-#tbLeft2 GtkButton
+#tbLeft2 button
 {
 	padding: 2
 }
@@ -76,7 +129,20 @@ GtkToolbar GtkButton
 /*
 Labels for subsections of the Settings dialog
 */
-notebook frame>label{
+notebook frame>label {
     color: #666;
     font-weight: bold;
 }
+
+
+/*
+  Sidebar (page select, layer select, etc)
+ */
+#sidebarContents {
+	background-color: white;
+}
+
+window.darkMode #sidebarContents {
+	background-color: #222;
+}
+


### PR DESCRIPTION
## Summary
Fixes broken selectors in `xournalpp.css` and changes applied styles when in dark mode.

## Fixes these issues
 * When in dark mode (i.e. using a dark Gtk theme), the page preview background would still be white
     -  This led to low text contrast (layer titles). For example, below, the word "Background" is difficult to read.
![Demonstration of low text contrast](https://user-images.githubusercontent.com/46334387/108425077-d84cd080-71ee-11eb-8779-a279f456dbd9.png)
     -  The preview pane's background is now styled with CSS, rather than filled with Cairo.
 * `xournal.css` was using selectors including `GtkButton` and `GtkWindow` that seem to no longer match parts of the page. For example, `GtkButton { color: red; }` wasn't changing the color of text in buttons. 
      -  These have been replaced with `button`, `window`, etc. selectors. 
      - This changes the selectors such that they match those used in [the GTK+ CSS Overview](https://developer.gnome.org/gtk3/stable/chap-css-overview.html).
      - As a result, rules intended to style the floating toolbox now do so:
![Floating toolbox in light mode](https://user-images.githubusercontent.com/46334387/106346728-eb165a00-626d-11eb-8dd8-0dbef214c24c.png)
      -  Some changes were made to these rules when the user requests dark mode:
![Floating toolbox in dark mode](https://user-images.githubusercontent.com/46334387/106347312-5c580c00-6272-11eb-9bdb-90869e027a72.png)
 * When editing a toolbar layout, it was difficult to locate drag/drop targets. This is fixed by adding an orange border around editable toolbars when in drag & drop edit mode.
![Orange, dashed borders surround toolbars when in edit mode](https://user-images.githubusercontent.com/46334387/106378522-6a815780-635a-11eb-94b9-6b12a523e36a.png)
