### PR TITLE
fix crash when closing the latex dialog early

### DIFF
--- a/src/control/LatexController.cpp
+++ b/src/control/LatexController.cpp
@@ -149,7 +149,8 @@ void LatexController::triggerImageUpdate(const string& texString) {
         XojMsgBox::showErrorToUser(this->control->getGtkWindow(), err->message);
     } else if (auto** proc = std::get_if<GSubprocess*>(&result)) {
         updating_cancellable = g_cancellable_new();
-        g_subprocess_wait_check_async(*proc, updating_cancellable, reinterpret_cast<GAsyncReadyCallback>(onPdfRenderComplete), this);
+        g_subprocess_wait_check_async(*proc, updating_cancellable,
+                                      reinterpret_cast<GAsyncReadyCallback>(onPdfRenderComplete), this);
     }
 
     updateStatus();
@@ -182,8 +183,7 @@ void LatexController::onPdfRenderComplete(GObject* procObj, GAsyncResult* res, L
             // the render was canceled
             g_error_free(err);
             return;
-        }
-        else if (!g_error_matches(err, G_SPAWN_EXIT_ERROR, 1)) {
+        } else if (!g_error_matches(err, G_SPAWN_EXIT_ERROR, 1)) {
             // The error was not caused by invalid LaTeX.
             string message =
                     FS(_F("Latex generation encountered an error: {1} (exit code: {2})") % err->message % err->code);

--- a/src/control/LatexController.cpp
+++ b/src/control/LatexController.cpp
@@ -166,7 +166,9 @@ void LatexController::handleTexChanged(GtkTextBuffer* buffer, LatexController* s
 }
 
 void LatexController::onPdfRenderComplete(GObject* procObj, GAsyncResult* res, LatexController* self) {
-    g_assert(self->isUpdating);
+    if (!self->isUpdating) {
+        return;
+    }
     GError* err = nullptr;
     GSubprocess* proc = G_SUBPROCESS(procObj);
     g_subprocess_wait_check_finish(proc, res, &err);

--- a/src/control/LatexController.cpp
+++ b/src/control/LatexController.cpp
@@ -169,15 +169,10 @@ void LatexController::handleTexChanged(GtkTextBuffer* buffer, LatexController* s
 }
 
 void LatexController::onPdfRenderComplete(GObject* procObj, GAsyncResult* res, LatexController* self) {
-    if (!self->isUpdating()) {
-        return;
-    }
     GError* err = nullptr;
     GSubprocess* proc = G_SUBPROCESS(procObj);
     g_subprocess_wait_check_finish(proc, res, &err);
 
-    const string currentTex = self->dlg.getBufferContents();
-    bool shouldUpdate = self->lastPreviewedTex != currentTex;
     if (err != nullptr) {
         if (g_error_matches(err, G_IO_ERROR, G_IO_ERROR_CANCELLED)) {
             // the render was canceled
@@ -194,7 +189,11 @@ void LatexController::onPdfRenderComplete(GObject* procObj, GAsyncResult* res, L
         fs::path pdfPath = self->texTmpDir / "tex.pdf";
         fs::remove(pdfPath);
         g_error_free(err);
-    } else {
+    }
+
+    const string currentTex = self->dlg.getBufferContents();
+    bool shouldUpdate = self->lastPreviewedTex != currentTex;
+    if (err == nullptr) {
         self->isValidTex = true;
         self->temporaryRender = self->loadRendered(currentTex);
         if (self->temporaryRender != nullptr) {

--- a/src/control/LatexController.cpp
+++ b/src/control/LatexController.cpp
@@ -209,9 +209,7 @@ void LatexController::onPdfRenderComplete(GObject* procObj, GAsyncResult* res, L
     }
 }
 
-bool LatexController::isUpdating() {
-    return updating_cancellable && !g_cancellable_is_cancelled(updating_cancellable);
-}
+bool LatexController::isUpdating() { return updating_cancellable && !g_cancellable_is_cancelled(updating_cancellable); }
 
 void LatexController::updateStatus() {
     GtkWidget* okButton = this->dlg.get("texokbutton");

--- a/src/control/LatexController.cpp
+++ b/src/control/LatexController.cpp
@@ -210,20 +210,18 @@ void LatexController::onPdfRenderComplete(GObject* procObj, GAsyncResult* res, L
 }
 
 bool LatexController::isUpdating() {
-    return !updating_cancellable || !g_cancellable_is_cancelled(updating_cancellable);
+    return updating_cancellable && !g_cancellable_is_cancelled(updating_cancellable);
 }
 
 void LatexController::updateStatus() {
     GtkWidget* okButton = this->dlg.get("texokbutton");
     bool buttonEnabled = true;
-    bool updating = this->isUpdating();
     // Disable LatexDialog OK button while updating. This is a workaround
     // for the fact that 1) the LatexController only lives while the dialog
     // is open; 2) the preview is generated asynchronously; and 3) the `run`
     // method that inserts the TexImage object is called synchronously after
     // the dialog is closed with the OK button.
-    buttonEnabled = !updating;
-
+    buttonEnabled = !this->isUpdating();
 
     // Invalid LaTeX will generate an invalid PDF, so disable the OK button if
     // needed.

--- a/src/control/LatexController.h
+++ b/src/control/LatexController.h
@@ -106,7 +106,9 @@ private:
      */
     static void onPdfRenderComplete(GObject* procObj, GAsyncResult* res, LatexController* self);
 
-    void setUpdating(bool newValue);
+    void unsetUpdating();
+    void updateStatus();
+    bool isUpdating();
 
     /**
      * Load the preview PDF from disk and create a TexImage object.
@@ -151,7 +153,7 @@ private:
     /**
      * Whether a preview is currently being generated.
      */
-    bool isUpdating = false;
+    GCancellable* updating_cancellable = nullptr;
 
     /**
      * Whether the current TeX string is valid.


### PR DESCRIPTION
fixes https://github.com/xournalpp/xournalpp/issues/2332 by aborting the render instead of calling an assert to crash the program deliberately.