### PR TITLE
Fix confusing behavior of "Apply [page type] to current/all pages"

### DIFF
--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -81,7 +81,7 @@ Control::Control(GApplication* gtkApp, GladeSearchpath* gladeSearchPath): gtkApp
     TextView::setDpi(settings->getDisplayDpi());
 
     this->pageTypes = new PageTypeHandler(gladeSearchPath);
-    this->newPageType = new PageTypeMenu(this->pageTypes, settings, true, true);
+    this->newPageType = std::make_unique<PageTypeMenu>(this->pageTypes, settings, true, true);
 
     this->audioController = new AudioController(this->settings, this);
 
@@ -147,8 +147,6 @@ Control::~Control() {
     this->searchBar = nullptr;
     delete this->scrollHandler;
     this->scrollHandler = nullptr;
-    delete this->newPageType;
-    this->newPageType = nullptr;
     delete this->pageTypes;
     this->pageTypes = nullptr;
     delete this->metadata;
@@ -1303,14 +1301,12 @@ void Control::updateBackgroundSizeButton() {
 }
 
 void Control::paperTemplate() {
-    auto* dlg = new PageTemplateDialog(this->gladeSearchPath, settings, pageTypes);
+    auto dlg = std::make_unique<PageTemplateDialog>(this->gladeSearchPath, settings, pageTypes);
     dlg->show(GTK_WINDOW(this->win->getWindow()));
 
     if (dlg->isSaved()) {
         newPageType->loadDefaultPage();
     }
-
-    delete dlg;
 }
 
 void Control::paperFormat() {
@@ -2847,7 +2843,7 @@ auto Control::getAudioController() -> AudioController* { return this->audioContr
 
 auto Control::getPageTypes() -> PageTypeHandler* { return this->pageTypes; }
 
-auto Control::getNewPageType() -> PageTypeMenu* { return this->newPageType; }
+auto Control::getNewPageType() -> PageTypeMenu* { return this->newPageType.get(); }
 
 auto Control::getPageBackgroundChangeController() -> PageBackgroundChangeController* {
     return this->pageBackgroundChangeController;

--- a/src/control/Control.h
+++ b/src/control/Control.h
@@ -401,7 +401,7 @@ private:
     MetadataManager* metadata;
 
     PageTypeHandler* pageTypes;
-    PageTypeMenu* newPageType;
+    std::unique_ptr<PageTypeMenu> newPageType;
 
     PageBackgroundChangeController* pageBackgroundChangeController;
 

--- a/src/control/PageBackgroundChangeController.cpp
+++ b/src/control/PageBackgroundChangeController.cpp
@@ -43,6 +43,10 @@ void PageBackgroundChangeController::changeAllPagesBackground(const PageType& pt
     }
 
     control->getUndoRedoHandler()->addUndoAction(std::move(groupUndoAction));
+
+    ignoreEvent = true;
+    currentPageType.setSelected(pt);
+    ignoreEvent = false;
 }
 
 void PageBackgroundChangeController::changeCurrentPageBackground(PageTypeInfo* info) {
@@ -69,6 +73,10 @@ void PageBackgroundChangeController::changeCurrentPageBackground(PageType& pageT
     if (undoAction) {
         control->getUndoRedoHandler()->addUndoAction(std::move(undoAction));
     }
+
+    ignoreEvent = true;
+    currentPageType.setSelected(pageType);
+    ignoreEvent = false;
 }
 
 auto PageBackgroundChangeController::commitPageTypeChange(const size_t pageNum, const PageType& pageType)

--- a/src/control/PageBackgroundChangeController.cpp
+++ b/src/control/PageBackgroundChangeController.cpp
@@ -4,6 +4,7 @@
 
 #include "control/Control.h"
 #include "control/pagetype/PageTypeHandler.h"
+#include "control/pagetype/PageTypeMenu.h"
 #include "gui/dialog/backgroundSelect/ImagesDialog.h"
 #include "gui/dialog/backgroundSelect/PdfPagesDialog.h"
 #include "stockdlg/ImageOpenDlg.h"
@@ -20,7 +21,7 @@ PageBackgroundChangeController::PageBackgroundChangeController(Control* control)
 
     currentPageType.hideCopyPage();
 
-    currentPageType.addApplyBackgroundButton(this, true);
+    currentPageType.addApplyBackgroundButton(this, true, ApplyPageTypeSource::CURRENT);
 
     registerListener(control);
 }
@@ -291,8 +292,16 @@ void PageBackgroundChangeController::pageSelected(size_t page) {
     ignoreEvent = false;
 }
 
-void PageBackgroundChangeController::applyCurrentPageBackground(bool allPages) {
-    PageType pt = control->getNewPageType()->getSelected();
+void PageBackgroundChangeController::applySelectedPageBackground(bool allPages, ApplyPageTypeSource src) {
+    PageType pt;
+    switch (src) {
+        case ApplyPageTypeSource::SELECTED:
+            pt = control->getNewPageType()->getSelected();
+            break;
+        case ApplyPageTypeSource::CURRENT:
+            pt = control->getCurrentPage()->getBackgroundType();
+            break;
+    }
 
     if (allPages) {
         changeAllPagesBackground(pt);

--- a/src/control/PageBackgroundChangeController.h
+++ b/src/control/PageBackgroundChangeController.h
@@ -52,7 +52,7 @@ public:
 
     // PageTypeApplyListener
 public:
-    virtual void applyCurrentPageBackground(bool allPages);
+    virtual void applySelectedPageBackground(bool allPages, ApplyPageTypeSource src);
 
 private:
     /**

--- a/src/control/PageBackgroundChangeController.h
+++ b/src/control/PageBackgroundChangeController.h
@@ -24,6 +24,7 @@
 class PageTypeMenu;
 class Control;
 class XojPage;
+class UndoAction;
 
 class PageBackgroundChangeController:
         public PageTypeMenuChangeListener,
@@ -31,7 +32,7 @@ class PageBackgroundChangeController:
         public PageTypeApplyListener {
 public:
     PageBackgroundChangeController(Control* control);
-    virtual ~PageBackgroundChangeController();
+    virtual ~PageBackgroundChangeController() = default;
 
 public:
     virtual void changeCurrentPageBackground(PageType& pageType);
@@ -80,8 +81,13 @@ private:
      */
     bool applyImageBackground(PageRef page);
 
+    /**
+     * Perform the page type change.
+     */
+    auto commitPageTypeChange(size_t pageNum, const PageType& pageType) -> std::unique_ptr<UndoAction>;
+
 private:
     Control* control = nullptr;
-    PageTypeMenu* currentPageType = nullptr;
+    PageTypeMenu currentPageType;
     bool ignoreEvent = false;
 };

--- a/src/control/pagetype/PageTypeMenu.cpp
+++ b/src/control/pagetype/PageTypeMenu.cpp
@@ -198,18 +198,9 @@ void PageTypeMenu::addApplyBackgroundButton(PageTypeApplyListener* pageTypeApply
 }
 
 auto PageTypeMenu::createApplyMenuItem(const char* text) -> GtkWidget* {
-    GtkWidget* box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 6);
-    GtkWidget* icon = gtk_image_new_from_icon_name("gtk-apply", GTK_ICON_SIZE_MENU);
-    GtkWidget* label = gtk_label_new(text);
     GtkWidget* menuItem = gtk_menu_item_new();
-
-    gtk_container_add(GTK_CONTAINER(box), icon);
-    gtk_container_add(GTK_CONTAINER(box), label);
-
-    gtk_container_add(GTK_CONTAINER(menuItem), box);
-
+    gtk_menu_item_set_label(GTK_MENU_ITEM(menuItem), text);
     gtk_widget_show_all(menuItem);
-
     return menuItem;
 }
 

--- a/src/control/pagetype/PageTypeMenu.cpp
+++ b/src/control/pagetype/PageTypeMenu.cpp
@@ -23,17 +23,10 @@ PageTypeMenu::PageTypeMenu(PageTypeHandler* types, Settings* settings, bool show
         menuX(0),
         menuY(0),
         showPreview(showPreview),
-        pageTypeApplyListener(nullptr) {
+        pageTypeApplyListener(nullptr),
+        pageTypeSource(ApplyPageTypeSource::SELECTED) {
     initDefaultMenu();
     loadDefaultPage();
-}
-
-PageTypeMenu::~PageTypeMenu() {
-    /**
-     * The menu is used from the GUI
-     * Therefore the menu is not freed here, this will be done in the GUI
-     */
-    menu = nullptr;
 }
 
 void PageTypeMenu::loadDefaultPage() {
@@ -174,8 +167,10 @@ void PageTypeMenu::hideCopyPage() {
 /**
  * Apply background to current or to all pages button
  */
-void PageTypeMenu::addApplyBackgroundButton(PageTypeApplyListener* pageTypeApplyListener, bool onlyAllMenu) {
+void PageTypeMenu::addApplyBackgroundButton(PageTypeApplyListener* pageTypeApplyListener, bool onlyAllMenu,
+                                            ApplyPageTypeSource ptSource) {
     this->pageTypeApplyListener = pageTypeApplyListener;
+    this->pageTypeSource = ptSource;
 
     GtkWidget* separator = gtk_separator_menu_item_new();
     gtk_widget_show(separator);
@@ -188,7 +183,7 @@ void PageTypeMenu::addApplyBackgroundButton(PageTypeApplyListener* pageTypeApply
         gtk_menu_attach(GTK_MENU(menu), menuEntryApply, 0, PREVIEW_COLUMNS, menuY, menuY + 1);
         menuY++;
         g_signal_connect(menuEntryApply, "activate", G_CALLBACK(+[](GtkWidget* menu, PageTypeMenu* self) {
-                             self->pageTypeApplyListener->applyCurrentPageBackground(false);
+                             self->pageTypeApplyListener->applySelectedPageBackground(false, self->pageTypeSource);
                          }),
                          this);
     }
@@ -197,7 +192,7 @@ void PageTypeMenu::addApplyBackgroundButton(PageTypeApplyListener* pageTypeApply
     gtk_menu_attach(GTK_MENU(menu), menuEntryApplyAll, 0, PREVIEW_COLUMNS, menuY, menuY + 1);
     menuY++;
     g_signal_connect(menuEntryApplyAll, "activate", G_CALLBACK(+[](GtkWidget* menu, PageTypeMenu* self) {
-                         self->pageTypeApplyListener->applyCurrentPageBackground(true);
+                         self->pageTypeApplyListener->applySelectedPageBackground(true, self->pageTypeSource);
                      }),
                      this);
 }

--- a/src/control/pagetype/PageTypeMenu.h
+++ b/src/control/pagetype/PageTypeMenu.h
@@ -31,6 +31,13 @@ typedef struct {
     PageTypeInfo* info;
 } MenuCallbackInfo;
 
+enum class ApplyPageTypeSource {
+    /** Apply page type selected in dialog */
+    SELECTED,
+    /** Apply page type of current page */
+    CURRENT
+};
+
 class PageTypeMenuChangeListener {
 public:
     virtual void changeCurrentPageBackground(PageTypeInfo* info) = 0;
@@ -39,14 +46,13 @@ public:
 
 class PageTypeApplyListener {
 public:
-    virtual void applyCurrentPageBackground(bool allPages) = 0;
+    virtual void applySelectedPageBackground(bool allPages, ApplyPageTypeSource src) = 0;
     virtual ~PageTypeApplyListener();
 };
 
 class PageTypeMenu {
 public:
     PageTypeMenu(PageTypeHandler* types, Settings* settings, bool showPreview, bool showSpecial);
-    virtual ~PageTypeMenu();
 
 public:
     GtkWidget* getMenu();
@@ -59,7 +65,8 @@ public:
     /**
      * Apply background to current or to all pages button
      */
-    void addApplyBackgroundButton(PageTypeApplyListener* pageTypeApplyListener, bool onlyAllMenu);
+    void addApplyBackgroundButton(PageTypeApplyListener* pageTypeApplyListener, bool onlyAllMenu,
+                                  ApplyPageTypeSource ptSource);
 
 private:
     static GtkWidget* createApplyMenuItem(const char* text);
@@ -80,6 +87,8 @@ private:
     PageType selected;
 
     bool ignoreEvents;
+
+    ApplyPageTypeSource pageTypeSource;
 
     PageTypeMenuChangeListener* listener;
 

--- a/src/control/pagetype/PageTypeMenu.h
+++ b/src/control/pagetype/PageTypeMenu.h
@@ -64,9 +64,9 @@ public:
 private:
     static GtkWidget* createApplyMenuItem(const char* text);
     void initDefaultMenu();
-    void addMenuEntry(PageTypeInfo* t);
+    void addMenuEntry(MainBackgroundPainter* bgPainter, PageTypeInfo* t);
     void entrySelected(PageTypeInfo* t);
-    cairo_surface_t* createPreviewImage(const PageType& pt);
+    cairo_surface_t* createPreviewImage(MainBackgroundPainter* bgPainter, const PageType& pt);
 
 private:
     bool showSpecial;
@@ -83,10 +83,8 @@ private:
 
     PageTypeMenuChangeListener* listener;
 
-    int menuX;
-    int menuY;
-
-    MainBackgroundPainter* backgroundPainter;
+    guint menuX;
+    guint menuY;
 
     bool showPreview;
 

--- a/src/gui/dialog/PageTemplateDialog.h
+++ b/src/gui/dialog/PageTemplateDialog.h
@@ -24,6 +24,10 @@ class PopupMenuButton;
 class PageTemplateDialog: public GladeGui, public PageTypeMenuChangeListener {
 public:
     PageTemplateDialog(GladeSearchpath* gladeSearchPath, Settings* settings, PageTypeHandler* types);
+    PageTemplateDialog(PageTemplateDialog&) = delete;
+    PageTemplateDialog(PageTemplateDialog&&) = delete;
+    PageTemplateDialog& operator=(PageTemplateDialog&) = delete;
+    PageTemplateDialog&& operator=(PageTemplateDialog&&) = delete;
     virtual ~PageTemplateDialog();
 
 public:
@@ -49,9 +53,9 @@ private:
 
     PageTemplateSettings model;
 
-    PageTypeMenu* pageMenu;
+    std::unique_ptr<PageTypeMenu> pageMenu;
 
-    PopupMenuButton* popupMenuButton;
+    std::unique_ptr<PopupMenuButton> popupMenuButton;
 
     /**
      * The dialog was confirmed / saved

--- a/src/gui/toolbarMenubar/ToolMenuHandler.cpp
+++ b/src/gui/toolbarMenubar/ToolMenuHandler.cpp
@@ -34,7 +34,8 @@ ToolMenuHandler::ToolMenuHandler(Control* control, GladeGui* gui, GtkWindow* par
 
     // still owned by Control
     this->newPageType = control->getNewPageType();
-    this->newPageType->addApplyBackgroundButton(control->getPageBackgroundChangeController(), false);
+    this->newPageType->addApplyBackgroundButton(control->getPageBackgroundChangeController(), false,
+                                                ApplyPageTypeSource::SELECTED);
 
     // still owned by Control
     this->pageBackgroundChangeController = control->getPageBackgroundChangeController();


### PR DESCRIPTION
This PR fixes the confusing behavior of the `Apply to current/all pages` buttons. Fixes #951.

* Fixes a bug where the `Journal > Paper background` apply page type button would use the page type from the new page type dropdown. The fix is a bit hacky but it's simple and straightforward.
* Fixes a bug where the selected page type in `Journal > Paper background` would not update after using `Apply to all pages` from the new page type dropdown.
* Removes the confusing check mark next to the Apply to current / all pages button.

Merging in 48 hours if there are no objections.