### PR TITLE
Fix element cloning

### DIFF
--- a/src/control/UndoRedoController.cpp
+++ b/src/control/UndoRedoController.cpp
@@ -53,9 +53,10 @@ void UndoRedoController::after() {
 
         visibleElements.push_back(e);
     }
-
-    auto* selection = new EditSelection(control->getUndoRedoHandler(), visibleElements, view, page);
-    control->getWindow()->getXournal()->setSelection(selection);
+    if (!visibleElements.empty()) {
+        auto* selection = new EditSelection(control->getUndoRedoHandler(), visibleElements, view, page);
+        control->getWindow()->getXournal()->setSelection(selection);
+    }
 }
 
 void UndoRedoController::undo(Control* control) {

--- a/src/control/tools/EditSelection.cpp
+++ b/src/control/tools/EditSelection.cpp
@@ -642,13 +642,13 @@ void EditSelection::copySelection() {
     // apply transformations and add to layer
     finalizeSelection();
 
+    // restore insert order
+    contents->replaceInsertOrder(clonedInsertOrder);
+
     // add undo action
     PageRef page = this->view->getPage();
     Layer* layer = page->getSelectedLayer();
     undo->addUndoAction(std::unique_ptr<UndoAction>(new InsertsUndoAction(page, layer, *getElements())));
-
-    // restore insert order
-    contents->replaceInsertOrder(clonedInsertOrder);
 }
 
 /**

--- a/src/control/tools/EditSelectionContents.cpp
+++ b/src/control/tools/EditSelectionContents.cpp
@@ -393,6 +393,8 @@ void EditSelectionContents::updateContent(Rectangle<double> bounds, Rectangle<do
                                           XojPageView* targetView, UndoRedoHandler* undo, CursorSelectionType type) {
     double mx = snappedBounds.x - this->lastSnappedBounds.x;
     double my = snappedBounds.y - this->lastSnappedBounds.y;
+    bool move = mx != 0 || my != 0;
+
     this->rotation = rotation;
 
     double fx = snappedBounds.width / this->lastSnappedBounds.width;
@@ -404,13 +406,14 @@ void EditSelectionContents::updateContent(Rectangle<double> bounds, Rectangle<do
         fy = f;
     }
 
+    bool rotate = (std::abs(this->rotation - this->lastRotation) > __DBL_EPSILON__);
     bool scale = (snappedBounds.width != this->lastSnappedBounds.width ||
                   snappedBounds.height != this->lastSnappedBounds.height);
 
-    if (type == CURSOR_SELECTION_MOVE) {
+    if (type == CURSOR_SELECTION_MOVE && move) {
         undo->addUndoAction(std::make_unique<MoveUndoAction>(this->sourceLayer, this->sourcePage, &this->selected, mx,
                                                              my, layer, targetPage));
-    } else if (type == CURSOR_SELECTION_ROTATE) {
+    } else if (type == CURSOR_SELECTION_ROTATE && rotate) {
         undo->addUndoAction(std::make_unique<RotateUndoAction>(
                 this->sourcePage, &this->selected, snappedBounds.x + snappedBounds.width / 2,
                 snappedBounds.y + snappedBounds.height / 2, rotation - this->lastRotation));

--- a/src/model/Image.cpp
+++ b/src/model/Image.cpp
@@ -27,7 +27,9 @@ auto Image::clone() -> Element* {
     img->data = this->data;
 
     img->image = cairo_surface_reference(this->image);
-    img->calcSize();
+    img->snappedBounds = this->snappedBounds;
+    img->sizeCalculated = this->sizeCalculated;
+    img->read = this->read;
 
     return img;
 }

--- a/src/model/Stroke.cpp
+++ b/src/model/Stroke.cpp
@@ -29,6 +29,13 @@ auto Stroke::cloneStroke() const -> Stroke* {
     auto* s = new Stroke();
     s->applyStyleFrom(this);
     s->points = this->points;
+    s->x = this->x;
+    s->y = this->y;
+    s->width = this->width;  // stroke width, not bounding box width
+    s->Element::width = this->Element::width;
+    s->Element::height = this->Element::height;
+    s->snappedBounds = this->snappedBounds;
+    s->sizeCalculated = this->sizeCalculated;
     return s;
 }
 

--- a/src/model/TexImage.cpp
+++ b/src/model/TexImage.cpp
@@ -32,6 +32,9 @@ auto TexImage::clone() -> Element* {
     img->width = this->width;
     img->height = this->height;
     img->text = this->text;
+    img->snappedBounds = this->snappedBounds;
+    img->sizeCalculated = this->sizeCalculated;
+    img->pdf = this->pdf;
     return img;
 }
 

--- a/src/model/Text.cpp
+++ b/src/model/Text.cpp
@@ -22,8 +22,12 @@ auto Text::clone() -> Element* {
     text->setColor(this->getColor());
     text->x = this->x;
     text->y = this->y;
+    text->width = this->width;
+    text->height = this->height;
     text->cloneAudioData(this);
-    this->updateSnapping();
+    text->snappedBounds = this->snappedBounds;
+    text->sizeCalculated = this->sizeCalculated;
+    text->inEditing = this->inEditing;
 
     return text;
 }


### PR DESCRIPTION
- Fixes #2720 
- Removes creating unnecessary undo actions
- Makes cloning of elements complete. This may have been the cause for elements with width and height 0 in #2464. So it might partially fix #2464. 
