### PR TITLE
Use librsvg directly in thumbnailer to add icon to previews

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,9 @@ pkg_check_modules (PopplerGlib REQUIRED "poppler-glib >= 0.41.0")
 add_includes_ldflags ("${PopplerGlib_LDFLAGS}" "${PopplerGlib_INCLUDE_DIRS}")
 set(POPPLER_INCLUDE_DIR, "${PopplerGlib_INCLUDE_DIRS}")
 
+# librsvg
+pkg_check_modules (librsvg REQUIRED "librsvg-2.0 >= 2.40")
+
 # zlib
 find_package (ZLIB REQUIRED)
 add_includes_ldflags ("${ZLIB_LIBRARIES}" "${ZLIB_INCLUDE_DIRS}")

--- a/readme/LinuxBuild.md
+++ b/readme/LinuxBuild.md
@@ -30,32 +30,34 @@ poppler-glib texlive-bin texlive-pictures gettext libzip
 #### For Fedora/CentOS/RHEL:
 ```bash
 sudo dnf install gcc-c++ cmake gtk3-devel libxml2-devel cppunit-devel portaudio-devel libsndfile-devel \
-poppler-glib-devel texlive-scheme-basic texlive-dvipng 'tex(standalone.cls)' gettext libzip-devel
+poppler-glib-devel texlive-scheme-basic texlive-dvipng 'tex(standalone.cls)' gettext libzip-devel \
+librsvg2-devel
 ```
 
 #### For Ubuntu/Debian:
 ````bash
 sudo apt-get install cmake libgtk-3-dev libpoppler-glib-dev portaudio19-dev libsndfile-dev \
-libcppunit-dev dvipng texlive libxml2-dev liblua5.3-dev libzip-dev
+libcppunit-dev dvipng texlive libxml2-dev liblua5.3-dev libzip-dev librsvg2-dev gettext
 ````
 
 #### For Raspberry Pi OS (the same as Ubuntu/Debian with gettext added):
 ````bash
 sudo apt-get install cmake libgtk-3-dev libpoppler-glib-dev portaudio19-dev libsndfile-dev \
-libcppunit-dev dvipng texlive libxml2-dev liblua5.3-dev libzip-dev gettext
+libcppunit-dev dvipng texlive libxml2-dev liblua5.3-dev libzip-dev librsvg2-dev gettext
 ````
 
 #### For openSUSE:
 ```bash
 sudo zypper install cmake gtk3-devel cppunit-devel portaudio-devel libsndfile-devel \
-texlive-dvipng texlive libxml2-devel libpoppler-glib-devel libzip-devel
+texlive-dvipng texlive libxml2-devel libpoppler-glib-devel libzip-devel librsvg-devel
 ```
 
 #### For Solus:
 ```bash
 sudo eopkg it -c system.devel
 sudo eopkg it cmake libgtk-3-devel libxml2-devel poppler-devel libzip-devel \
-portaudio-devel libsndfile-devel alsa-lib-devel cppunit-devel lua-devel
+portaudio-devel libsndfile-devel alsa-lib-devel cppunit-devel lua-devel \
+librsvg-devel gettext
 ```
 
 ## Compiling

--- a/src/util/XojPreviewExtractor.h
+++ b/src/util/XojPreviewExtractor.h
@@ -14,7 +14,7 @@
 
 #include <string>
 
-#include <gdk/gdk.h>
+#include <glib.h>
 
 #include "filesystem.h"
 

--- a/src/xoj-preview-extractor/CMakeLists.txt
+++ b/src/xoj-preview-extractor/CMakeLists.txt
@@ -26,13 +26,16 @@ endif()
 add_dependencies(xournalpp-thumbnailer std::filesystem)
 
 target_link_libraries (xournalpp-thumbnailer
+  util
+  std::filesystem
+  ${thumbnailer_GTK_LDFLAGS}
   ${ZLIB_LIBRARIES}
+  ${librsvg_LDFLAGS}
   ${Glib_LDFLAGS}
   ${ZIP_LDFLAGS}
-  ${thumbnailer_GTK_LDFLAGS}
-  std::filesystem
-  util
-)
+  )
+
+target_include_directories (xournalpp-thumbnailer PRIVATE ${librsvg_INCLUDE_DIRS})
 
 set (THUMBNAILER_BIN "xournalpp-thumbnailer")
 


### PR DESCRIPTION
Fixes #1612.

Old behavior: crash during gtk initialization.

New behavior: emit warning message and render the thumbnail without the icon if the icon cannot be found.

The icon search code is not very comprehensive, but this is just a quick fix for the bug.