### PR TITLE
Fix Zoom Jitter

### DIFF
--- a/src/gui/Layout.cpp
+++ b/src/gui/Layout.cpp
@@ -158,8 +158,8 @@ void Layout::recalculate_int() const {
     pc.minWidth = as_unsigned(2 * hPadding + as_signed_strict((pc.widthCols.size() - 1) * XOURNAL_PADDING_BETWEEN));
     pc.minHeight = as_unsigned(2 * vPadding + as_signed_strict((pc.heightRows.size() - 1) * XOURNAL_PADDING_BETWEEN));
 
-    pc.minWidth = floor_cast<size_t>(std::accumulate(begin(pc.widthCols), end(pc.widthCols), pc.minWidth));
-    pc.minHeight = floor_cast<size_t>(std::accumulate(begin(pc.heightRows), end(pc.heightRows), pc.minHeight));
+    pc.minWidth = floor_cast<size_t>(std::accumulate(begin(pc.widthCols), end(pc.widthCols), double(pc.minWidth)));
+    pc.minHeight = floor_cast<size_t>(std::accumulate(begin(pc.heightRows), end(pc.heightRows), double(pc.minHeight)));
     pc.valid = true;
 }
 

--- a/src/gui/Layout.h
+++ b/src/gui/Layout.h
@@ -42,8 +42,8 @@ public:
         // The width and height of all our pages
         size_t minWidth = 0;
         size_t minHeight = 0;
-        std::vector<unsigned> widthCols;
-        std::vector<unsigned> heightRows;
+        std::vector<double> widthCols;
+        std::vector<double> heightRows;
         bool valid = false;
     };
 

--- a/src/gui/PageView.cpp
+++ b/src/gui/PageView.cpp
@@ -867,6 +867,12 @@ auto XojPageView::getDisplayHeight() const -> int {
     return std::lround(this->page->getHeight() * this->xournal->getZoom());
 }
 
+auto XojPageView::getDisplayWidthDouble() const -> double { return this->page->getWidth() * this->xournal->getZoom(); }
+
+auto XojPageView::getDisplayHeightDouble() const -> double {
+    return this->page->getHeight() * this->xournal->getZoom();
+}
+
 auto XojPageView::getSelectedTex() -> TexImage* {
     EditSelection* theSelection = this->xournal->getSelection();
     if (!theSelection) {

--- a/src/gui/PageView.h
+++ b/src/gui/PageView.h
@@ -119,11 +119,13 @@ public:
      * on the display taking into account the current zoom
      */
     int getDisplayWidth() const;
+    double getDisplayWidthDouble() const;
     /**
      * Returns the height of this XojPageView as displayed
      * on the display taking into account the current zoom
      */
     int getDisplayHeight() const;
+    double getDisplayHeightDouble() const;
 
     /**
      * Returns the x coordinate of this XojPageView with

--- a/src/gui/XournalView.cpp
+++ b/src/gui/XournalView.cpp
@@ -486,7 +486,6 @@ void XournalView::zoomChanged() {
     } else {
         auto pos = zoom->getScrollPositionAfterZoom();
         if (pos.x != -1 && pos.y != -1) {
-            // Todo: This could be one source of all evil:
             Layout* layout = gtk_xournal_get_layout(this->widget);
             layout->scrollAbs(pos.x, pos.y);
         }


### PR DESCRIPTION
fixes https://github.com/xournalpp/xournalpp/issues/2703

The fix was to make layout calculate the page height/width with double precision, because otherwise on page N a random error of ~N/2 would have been accumulated.

~~I also refactored some of the space conversion code to be less error prone to double-precision-errors. Also with the old code I noticed, that when zooming with the mouse on the last page, it would randomly jump to prior pages. That is fixed with the refactor. I did test a lot of things, but I am sure I left something untested, so testing is highly encouraged!~~

~~If requested I can split this PR into the refactor/jump fix and the jitter fix as they are mostly separate in code.~~

**Edit:** This PR got split.