### PR TITLE
Fix GTK touch workaround

### DIFF
--- a/src/gui/widgets/XournalWidget.cpp
+++ b/src/gui/widgets/XournalWidget.cpp
@@ -163,12 +163,12 @@ static void gtk_xournal_init(GtkXournal* xournal) {
 
 static void gtk_xournal_get_preferred_width(GtkWidget* widget, gint* minimal_width, gint* natural_width) {
     GtkXournal* xournal = GTK_XOURNAL(widget);
-    *minimal_width = *natural_width = xournal->layout->getMinimalWidth();
+    *minimal_width = *natural_width = xournal->scrollHandling->getPreferredWidth();
 }
 
 static void gtk_xournal_get_preferred_height(GtkWidget* widget, gint* minimal_height, gint* natural_height) {
     GtkXournal* xournal = GTK_XOURNAL(widget);
-    *minimal_height = *natural_height = xournal->layout->getMinimalHeight();
+    *minimal_height = *natural_height = xournal->scrollHandling->getPreferredHeight();
 }
 
 /**


### PR DESCRIPTION
See https://github.com/xournalpp/xournalpp/commit/67927ead3c36bcf6afa7723d7f80ca47650fffda#r46743703 -- `gtk_xournal_get_preferred_width/gtk_xournal_get_preferred_height` return the size of the layout, even when not in a scrolled widget. When we're handling scrolling ourselves (when the workaround is enabled), we should be returning a value much smaller than the layout size.

This should fix #2745.

**Edit:** The difference between this PR and #2613 is that `ScrollHandler` has a different implementation if we're using the touch workaround than if we're not. #2613 fixed this by setting the `minimal_width` and `minimal_height` to a constant regardless of whether the workaround was enabled. 