### PR TITLE
Fix #1679 -- Pen activates after exiting page when using floating toolbar

### DIFF
--- a/src/gui/inputdevices/PenInputHandler.cpp
+++ b/src/gui/inputdevices/PenInputHandler.cpp
@@ -182,6 +182,11 @@ double PenInputHandler::filterPressure(PositionInputData const& pos, XojPageView
 }
 
 auto PenInputHandler::actionMotion(InputEvent const& event) -> bool {
+    // If we're not handling input, do nothing!
+    if (!this->inputRunning) {
+        return false;
+    }
+
     /*
      * Workaround for misbehaving devices where Enter events are not published every time
      * This is required to disable outside scrolling again


### PR DESCRIPTION
This should fix #1679. Previously, calls to `PenInputHandler::actionMove` would result in drawing even when not `PenInputHandler::inputRunning`. This is a bit of a workaround. 
`PenInputHandler::actionMove` probably shouldn't be called if we're not drawing/the pen isn't down!

This should also fix #2762.