### PR TITLE
Changed shortcuts for page deletion and layer navigation

### DIFF
--- a/ui/main.glade
+++ b/ui/main.glade
@@ -1041,7 +1041,7 @@
                             <property name="label" translatable="yes">_Previous Layer</property>
                             <property name="use-underline">True</property>
                             <signal name="activate" handler="ACTION_GOTO_PREVIOUS_LAYER" swapped="no"/>
-                            <accelerator key="Left" signal="activate" modifiers="GDK_SHIFT_MASK | GDK_CONTROL_MASK"/>
+                            <accelerator key="Page_Down" signal="activate" modifiers="GDK_SHIFT_MASK"/>
                           </object>
                         </child>
                         <child>
@@ -1052,7 +1052,7 @@
                             <property name="label" translatable="yes">_Next Layer</property>
                             <property name="use-underline">True</property>
                             <signal name="activate" handler="ACTION_GOTO_NEXT_LAYER" swapped="no"/>
-                            <accelerator key="Right" signal="activate" modifiers="GDK_SHIFT_MASK | GDK_CONTROL_MASK"/>
+                            <accelerator key="Page_Up" signal="activate" modifiers="GDK_SHIFT_MASK"/>
                           </object>
                         </child>
                         <child>
@@ -1167,7 +1167,7 @@
                             <property name="label" translatable="yes">_Delete Page</property>
                             <property name="use-underline">True</property>
                             <signal name="activate" handler="ACTION_DELETE_PAGE" swapped="no"/>
-                            <accelerator key="Delete" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                            <accelerator key="Delete" signal="activate" modifiers="GDK_SHIFT_MASK | GDK_CONTROL_MASK"/>
                           </object>
                         </child>
                         <child>


### PR DESCRIPTION
This is a proposition to change the` Ctrl+Del` shortcut for page deletion to `Ctrl+Shift+Del` to not interfere with text editing shortcuts according to #2679 .
The same was done for `Ctrl+Shift+Left` --> `Shift+PageDown`,  ` Ctrl+Shift+Right` --> `Shift+PageUp`  (see #2755). 
I don't mean to change the shortcut rationale randomly, please comment and I will change the PR as requested.