### PR TITLE
Automatically request dark/light GTK theme based on "use dark theme" settings option

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -44,11 +44,13 @@ MainWindow::MainWindow(GladeSearchpath* gladeSearchPath, Control* control):
     g_object_ref(mainContentWidget);
     g_object_ref(sidebarWidget);
 
+    GtkSettings* appSettings = gtk_settings_get_default();
+    g_object_set(appSettings, "gtk-application-prefer-dark-theme", control->getSettings()->isDarkTheme(), NULL);
+
     loadMainCSS(gladeSearchPath, "xournalpp.css");
 
     GtkOverlay* overlay = GTK_OVERLAY(get("mainOverlay"));
     this->floatingToolbox = new FloatingToolbox(this, overlay);
-
 
     for (int i = 0; i < TOOLBAR_DEFINITIONS_LEN; i++) {
         GtkWidget* w = get(TOOLBAR_DEFINITIONS[i].guiName);


### PR DESCRIPTION
This should fix #2764 and #3278.

<strike>**Note that, at present, this PR selects the theme that matches the icon theme, even if the user has not checked/unchecked 'dark mode' in settings.** I think this is reasonable behavior -- otherwise, we end up with difficult-to-see icons, but could be seen as a breaking change. </strike> (The dark mode toggle no longer just changes the icon theme and Xournal++ now uses its own icons in place of the system's).

**Potential issues**
 * The default GTK theme must also have a dark variant installed.

**Edit:** Xournal++ now uses its own icons by default, making earlier issues mentioned here no longer relevant.