### PR TITLE
Layer preview fixes

### DIFF
--- a/src/gui/sidebar/Sidebar.cpp
+++ b/src/gui/sidebar/Sidebar.cpp
@@ -15,14 +15,14 @@ Sidebar::Sidebar(GladeGui* gui, Control* control): toolbar(this, gui), control(c
     this->tbSelectPage = GTK_TOOLBAR(gui->get("tbSelectSidebarPage"));
     this->buttonCloseSidebar = gui->get("buttonCloseSidebar");
 
-    this->sidebar = gui->get("sidebarContents");
+    this->sidebarContents = gui->get("sidebarContents");
 
-    this->initPages(sidebar, gui);
+    this->initPages(sidebarContents, gui);
 
     registerListener(control);
 }
 
-void Sidebar::initPages(GtkWidget* sidebar, GladeGui* gui) {
+void Sidebar::initPages(GtkWidget* sidebarContents, GladeGui* gui) {
     addPage(new SidebarIndexPage(this->control, &this->toolbar));
     addPage(new SidebarPreviewPages(this->control, this->gui, &this->toolbar));
     addPage(new SidebarPreviewLayers(this->control, this->gui, &this->toolbar));
@@ -43,7 +43,7 @@ void Sidebar::initPages(GtkWidget* sidebar, GladeGui* gui) {
         gtk_toolbar_insert(tbSelectPage, it, -1);
 
         // Add widget to sidebar
-        gtk_box_pack_start(GTK_BOX(sidebar), p->getWidget(), true, true, 0);
+        gtk_box_pack_start(GTK_BOX(sidebarContents), p->getWidget(), true, true, 0);
 
         i++;
     }
@@ -73,7 +73,7 @@ Sidebar::~Sidebar() {
     }
     this->pages.clear();
 
-    this->sidebar = nullptr;
+    this->sidebarContents = nullptr;
     this->currentPage = nullptr;
 }
 
@@ -146,7 +146,7 @@ void Sidebar::setTmpDisabled(bool disabled) {
 
 void Sidebar::saveSize() {
     GtkAllocation alloc;
-    gtk_widget_get_allocation(this->sidebar, &alloc);
+    gtk_widget_get_allocation(this->sidebarContents, &alloc);
 
     this->control->getSettings()->setSidebarWidth(alloc.width);
 }

--- a/src/gui/sidebar/Sidebar.h
+++ b/src/gui/sidebar/Sidebar.h
@@ -30,7 +30,7 @@ public:
     virtual ~Sidebar();
 
 private:
-    void initPages(GtkWidget* sidebar, GladeGui* gui);
+    void initPages(GtkWidget* sidebarContents, GladeGui* gui);
     void addPage(AbstractSidebarPage* page);
 
     // SidebarToolbarActionListener
@@ -114,9 +114,9 @@ private:
     AbstractSidebarPage* currentPage = nullptr;
 
     /**
-     * The sidebar widget
+     * The sidebarContents widget
      */
-    GtkWidget* sidebar = nullptr;
+    GtkWidget* sidebarContents = nullptr;
 
     /**
      * Sidebar toolbar

--- a/src/gui/sidebar/previews/base/SidebarToolbar.cpp
+++ b/src/gui/sidebar/previews/base/SidebarToolbar.cpp
@@ -46,6 +46,13 @@ void SidebarToolbar::setButtonEnabled(SidebarActions enabledActions) {
     gtk_widget_set_sensitive(GTK_WIDGET(this->btDelete), enabledActions & SIDEBAR_ACTION_DELETE);
 }
 
+void SidebarToolbar::setButtonTooltips(const string& tipUp, const string& tipDown, const string& tipCopy,
+                                       const string& tipDelete) {
+    gtk_widget_set_tooltip_text(GTK_WIDGET(this->btUp), tipUp.c_str());
+    gtk_widget_set_tooltip_text(GTK_WIDGET(this->btDown), tipDown.c_str());
+    gtk_widget_set_tooltip_text(GTK_WIDGET(this->btCopy), tipCopy.c_str());
+    gtk_widget_set_tooltip_text(GTK_WIDGET(this->btDelete), tipDelete.c_str());
+}
 
 SidebarToolbarActionListener::~SidebarToolbarActionListener() = default;
 

--- a/src/gui/sidebar/previews/base/SidebarToolbar.h
+++ b/src/gui/sidebar/previews/base/SidebarToolbar.h
@@ -50,6 +50,7 @@ public:
      * Sets the button enabled / disabled
      */
     void setButtonEnabled(SidebarActions enabledActions);
+    void setButtonTooltips(const string& tipUp, const string& tipDown, const string& tipCopy, const string& tipDelete);
 
     void setHidden(bool hidden);
 

--- a/src/gui/sidebar/previews/layer/SidebarPreviewLayers.cpp
+++ b/src/gui/sidebar/previews/layer/SidebarPreviewLayers.cpp
@@ -50,6 +50,9 @@ void SidebarPreviewLayers::actionPerformed(SidebarActions action) {
 void SidebarPreviewLayers::enableSidebar() {
     SidebarPreviewBase::enableSidebar();
 
+    this->toolbar->setButtonTooltips(_("Swap the current layer with the one above"),
+                                     _("Swap the current layer with the one below"),
+                                     _("Insert a copy of the current layer below"), _("Delete this layer"));
     rebuildLayerMenu();
 }
 

--- a/src/gui/sidebar/previews/page/SidebarPreviewPages.cpp
+++ b/src/gui/sidebar/previews/page/SidebarPreviewPages.cpp
@@ -257,6 +257,10 @@ void SidebarPreviewPages::pageSelected(size_t page) {
     }
     this->selectedEntry = page;
 
+    if (!this->enabled) {
+        return;
+    }
+
     if (this->selectedEntry != npos && this->selectedEntry < this->previews.size()) {
         SidebarPreviewBaseEntry* p = this->previews[this->selectedEntry];
         p->setSelected(true);

--- a/src/gui/sidebar/previews/page/SidebarPreviewPages.cpp
+++ b/src/gui/sidebar/previews/page/SidebarPreviewPages.cpp
@@ -62,6 +62,9 @@ SidebarPreviewPages::~SidebarPreviewPages() {
 void SidebarPreviewPages::enableSidebar() {
     SidebarPreviewBase::enableSidebar();
 
+    this->toolbar->setButtonTooltips(_("Swap the current page with the one above"),
+                                     _("Swap the current page with the one below"),
+                                     _("Insert a copy of the current page below"), _("Delete this page"));
     pageSelected(this->selectedEntry);
 }
 

--- a/src/gui/sidebar/previews/page/SidebarPreviewPages.cpp
+++ b/src/gui/sidebar/previews/page/SidebarPreviewPages.cpp
@@ -59,6 +59,12 @@ SidebarPreviewPages::~SidebarPreviewPages() {
     }
 }
 
+void SidebarPreviewPages::enableSidebar() {
+    SidebarPreviewBase::enableSidebar();
+
+    pageSelected(this->selectedEntry);
+}
+
 auto SidebarPreviewPages::getName() -> string { return _("Page Preview"); }
 
 auto SidebarPreviewPages::getIconName() -> string { return "sidebar-page-preview"; }

--- a/src/gui/sidebar/previews/page/SidebarPreviewPages.h
+++ b/src/gui/sidebar/previews/page/SidebarPreviewPages.h
@@ -31,6 +31,8 @@ public:
      */
     void actionPerformed(SidebarActions action);
 
+    void enableSidebar();
+
     /**
      * @overwrite
      */

--- a/ui/main.glade
+++ b/ui/main.glade
@@ -2136,7 +2136,6 @@
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>
                                 <property name="receives-default">True</property>
-                                <property name="tooltip-text" translatable="yes">Swap the current page with the one above</property>
                                 <property name="margin-left">2</property>
                                 <child>
                                   <object class="GtkImage" id="image1">
@@ -2158,7 +2157,6 @@
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>
                                 <property name="receives-default">True</property>
-                                <property name="tooltip-text" translatable="yes">Swap the current page with the one below</property>
                                 <child>
                                   <object class="GtkImage" id="image5">
                                     <property name="visible">True</property>
@@ -2179,7 +2177,6 @@
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>
                                 <property name="receives-default">True</property>
-                                <property name="tooltip-text" translatable="yes">Insert a copy of the current page below</property>
                                 <child>
                                   <object class="GtkImage" id="image6">
                                     <property name="visible">True</property>
@@ -2200,7 +2197,6 @@
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>
                                 <property name="receives-default">True</property>
-                                <property name="tooltip-text" translatable="yes">Delete this page</property>
                                 <child>
                                   <object class="GtkImage" id="image7">
                                     <property name="visible">True</property>


### PR DESCRIPTION
This PR solves a few issues with the sidebar, some of which are only noticable if you have a document with bookmarks:

- sidebar is not initialised properly (toolbar shows up even if it should not)
- toolbar is not reenabled properly (if it was disabled and you switch to page preview)
- toolbar tooltips refer to pages even when they act on layers

As a sidebar fix, PR #2674 could go on top of this, but because of the concerns mentioned there I'll save it for later (when I implement another sidebar mode with stacked previews).