### PR TITLE
fix snapping in horizontal/vertical direction

### DIFF
--- a/src/model/Snapping.cpp
+++ b/src/model/Snapping.cpp
@@ -8,12 +8,12 @@ namespace Snapping {
 [[nodiscard]] inline double distance(Point const& a, Point const& b) { return std::hypot(b.x - a.x, b.y - a.y); }
 double snapVertically(double y, double gridSize, double tolerance) {
     double ySnapped = roundToMultiple(y, gridSize);
-    return abs(ySnapped - y) < tolerance * gridSize ? ySnapped : y;
+    return abs(ySnapped - y) < tolerance * gridSize / 2.0 ? ySnapped : y;
 }
 
 double snapHorizontally(double x, double gridSize, double tolerance) {
     double xSnapped = roundToMultiple(x, gridSize);
-    return abs(xSnapped - x) < tolerance * gridSize ? xSnapped : x;
+    return abs(xSnapped - x) < tolerance * gridSize / 2.0 ? xSnapped : x;
 }
 
 Point snapToGrid(Point const& pos, double gridSize, double tolerance) {


### PR DESCRIPTION
This fixes a bug in the application of the grid snapping tolerance in horizontal and vertical direction. This is experienced when resizing a selection horizontally or verticalling.