### PR TITLE
Fix regression large sidebar buttons in Adapta theme

### DIFF
--- a/ui/main.glade
+++ b/ui/main.glade
@@ -2128,7 +2128,7 @@
                                     <property name="can-focus">False</property>
                                   </object>
                                   <packing>
-                                    <property name="expand">False</property>
+                                    <property name="expand">True</property>
                                     <property name="fill">True</property>
                                     <property name="position">0</property>
                                   </packing>
@@ -2158,6 +2158,10 @@
                                     <property name="position">1</property>
                                   </packing>
                                 </child>
+                                <style>
+                                  <class name="linked"/>
+                                  <class name="inline-toolbar"/>
+                                </style>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -2265,6 +2269,10 @@
                                     <property name="position">4</property>
                                   </packing>
                                 </child>
+                                <style>
+                                  <class name="linked"/>
+                                  <class name="raised"/>
+                                </style>
                               </object>
                               <packing>
                                 <property name="expand">False</property>


### PR DESCRIPTION
Some themes (e.g. Adapta) draw large buttons when their container is missing the `linked` style class.

**Before**
![Shadow in the wrong place and large buttons at the bottom of the sidebar](https://user-images.githubusercontent.com/46334387/108245257-e9b9ae00-7104-11eb-98fb-61271fbbb4fb.png)

**After**
![Buttons are smaller (as before) and the shadow no longer looks out-of-place](https://user-images.githubusercontent.com/46334387/108245156-ce4ea300-7104-11eb-8d96-d76a72482e29.png)


This should address https://github.com/xournalpp/xournalpp/pull/2727#issuecomment-776191629.

Note that while this decreases the size of the sidebar in some themes, adding the `linked` class slightly increases the size of the sidebar in others.
For example, with the Breeze GTK theme,

**After**
![more padding between buttons](https://user-images.githubusercontent.com/46334387/107430409-f709e380-6ad9-11eb-9044-ac2825d4d967.png)

**Before**
![less space between buttons](https://user-images.githubusercontent.com/46334387/107430464-0a1cb380-6ada-11eb-81e2-7bdc282e6b92.png)
