### PR TITLE
Layer preview stacked

### DIFF
--- a/src/control/jobs/PreviewJob.cpp
+++ b/src/control/jobs/PreviewJob.cpp
@@ -80,8 +80,10 @@ void PreviewJob::drawPage() {
         case RENDER_TYPE_PAGE_LAYER:
             if (layer != -1) {
                 break;  // out
-            }           // else fall through for layer == -1
+            }
+            [[fallthrough]];
 
+        case RENDER_TYPE_PAGE_LAYERSTACK:
         case RENDER_TYPE_PAGE_PREVIEW:
             if (page->getBackgroundType().isPdfPage()) {
                 drawBackgroundPdf(doc);
@@ -106,6 +108,17 @@ void PreviewJob::drawPage() {
                 view.drawBackground();
             } else {
                 Layer* drawLayer = (*page->getLayers())[layer];
+                view.drawLayer(cr2, drawLayer);
+            }
+            view.finializeDrawing();
+            break;
+
+        case RENDER_TYPE_PAGE_LAYERSTACK:
+            // render all layers up to layer
+            view.initDrawing(page, cr2, true);
+            view.drawBackground();
+            for (int i = 0; i <= layer; i++) {
+                Layer* drawLayer = (*page->getLayers())[i];
                 view.drawLayer(cr2, drawLayer);
             }
             view.finializeDrawing();

--- a/src/control/jobs/PreviewJob.h
+++ b/src/control/jobs/PreviewJob.h
@@ -45,7 +45,7 @@ private:
     void drawBorder();
     void finishPaint();
     void drawBackgroundPdf(Document* doc);
-    void drawPage(int layer);
+    void drawPage();
 
 private:
     /**

--- a/src/gui/sidebar/Sidebar.cpp
+++ b/src/gui/sidebar/Sidebar.cpp
@@ -25,7 +25,8 @@ Sidebar::Sidebar(GladeGui* gui, Control* control): toolbar(this, gui), control(c
 void Sidebar::initPages(GtkWidget* sidebarContents, GladeGui* gui) {
     addPage(new SidebarIndexPage(this->control, &this->toolbar));
     addPage(new SidebarPreviewPages(this->control, this->gui, &this->toolbar));
-    addPage(new SidebarPreviewLayers(this->control, this->gui, &this->toolbar));
+    addPage(new SidebarPreviewLayers(this->control, this->gui, &this->toolbar, false));
+    addPage(new SidebarPreviewLayers(this->control, this->gui, &this->toolbar, true));
 
     // Init toolbar with icons
 

--- a/src/gui/sidebar/previews/base/SidebarPreviewBaseEntry.h
+++ b/src/gui/sidebar/previews/base/SidebarPreviewBaseEntry.h
@@ -32,7 +32,12 @@ typedef enum {
     /**
      * Render only a layer
      */
-    RENDER_TYPE_PAGE_LAYER
+    RENDER_TYPE_PAGE_LAYER,
+
+    /**
+     * Render the stack up to a layer
+     */
+    RENDER_TYPE_PAGE_LAYERSTACK
 } PreviewRenderType;
 
 

--- a/src/gui/sidebar/previews/layer/SidebarPreviewLayerEntry.cpp
+++ b/src/gui/sidebar/previews/layer/SidebarPreviewLayerEntry.cpp
@@ -7,10 +7,11 @@
 
 
 SidebarPreviewLayerEntry::SidebarPreviewLayerEntry(SidebarPreviewBase* sidebar, const PageRef& page, int layer,
-                                                   const string& layerName, size_t index):
+                                                   const string& layerName, size_t index, bool stacked):
         SidebarPreviewBaseEntry(sidebar, page),
         index(index),
         layer(layer),
+        stacked(stacked),
         box(gtk_box_new(GTK_ORIENTATION_VERTICAL, 2)) {
     GtkWidget* toolbar = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 6);
 
@@ -56,7 +57,9 @@ void SidebarPreviewLayerEntry::mouseButtonPressCallback() {
     (dynamic_cast<SidebarPreviewLayers*>(sidebar))->layerSelected(index);
 }
 
-auto SidebarPreviewLayerEntry::getRenderType() -> PreviewRenderType { return RENDER_TYPE_PAGE_LAYER; }
+auto SidebarPreviewLayerEntry::getRenderType() -> PreviewRenderType {
+    return stacked ? RENDER_TYPE_PAGE_LAYERSTACK : RENDER_TYPE_PAGE_LAYER;
+}
 
 auto SidebarPreviewLayerEntry::getHeight() -> int { return getWidgetHeight() + toolbarHeight; }
 

--- a/src/gui/sidebar/previews/layer/SidebarPreviewLayerEntry.h
+++ b/src/gui/sidebar/previews/layer/SidebarPreviewLayerEntry.h
@@ -19,7 +19,7 @@ class SidebarPreviewBase;
 class SidebarPreviewLayerEntry: public SidebarPreviewBaseEntry {
 public:
     SidebarPreviewLayerEntry(SidebarPreviewBase* sidebar, const PageRef& page, int layer, const string& layerName,
-                             size_t index);
+                             size_t index, bool stacked);
     virtual ~SidebarPreviewLayerEntry();
 
 public:
@@ -77,6 +77,11 @@ private:
      * Ignore events
      */
     bool inUpdate = false;
+
+    /**
+     * render as stacked
+     */
+    bool stacked = false;
 
     friend class PreviewJob;
 };

--- a/src/gui/sidebar/previews/layer/SidebarPreviewLayers.cpp
+++ b/src/gui/sidebar/previews/layer/SidebarPreviewLayers.cpp
@@ -7,8 +7,8 @@
 #include "SidebarPreviewLayerEntry.h"
 #include "i18n.h"
 
-SidebarPreviewLayers::SidebarPreviewLayers(Control* control, GladeGui* gui, SidebarToolbar* toolbar):
-        SidebarPreviewBase(control, gui, toolbar), lc(control->getLayerController()) {
+SidebarPreviewLayers::SidebarPreviewLayers(Control* control, GladeGui* gui, SidebarToolbar* toolbar, bool stacked):
+        SidebarPreviewBase(control, gui, toolbar), lc(control->getLayerController()), stacked(stacked) {
     LayerCtrlListener::registerListener(lc);
 
     this->toolbar->setButtonEnabled(SIDEBAR_ACTION_NONE);
@@ -56,9 +56,9 @@ void SidebarPreviewLayers::enableSidebar() {
     rebuildLayerMenu();
 }
 
-auto SidebarPreviewLayers::getName() -> string { return _("Layer Preview"); }
+auto SidebarPreviewLayers::getName() -> string { return stacked ? _("Layerstack Preview") : _("Layer Preview"); }
 
-auto SidebarPreviewLayers::getIconName() -> string { return "layer"; }
+auto SidebarPreviewLayers::getIconName() -> string { return stacked ? "sidebar-layerstack" : "layer"; }
 
 void SidebarPreviewLayers::pageSizeChanged(size_t page) {
     if (page != this->lc->getCurrentPageId() || !enabled) {
@@ -101,7 +101,7 @@ void SidebarPreviewLayers::updatePreviews() {
     size_t index = 0;
     for (int i = layerCount; i >= 0; i--) {
         std::string name = lc->getLayerNameById(i);
-        SidebarPreviewBaseEntry* p = new SidebarPreviewLayerEntry(this, page, i - 1, name, index++);
+        SidebarPreviewBaseEntry* p = new SidebarPreviewLayerEntry(this, page, i - 1, name, index++, this->stacked);
         this->previews.push_back(p);
         gtk_layout_put(GTK_LAYOUT(this->iconViewPreview), p->getWidget(), 0, 0);
     }

--- a/src/gui/sidebar/previews/layer/SidebarPreviewLayers.h
+++ b/src/gui/sidebar/previews/layer/SidebarPreviewLayers.h
@@ -21,7 +21,7 @@
 
 class SidebarPreviewLayers: public SidebarPreviewBase, public LayerCtrlListener {
 public:
-    SidebarPreviewLayers(Control* control, GladeGui* gui, SidebarToolbar* toolbar);
+    SidebarPreviewLayers(Control* control, GladeGui* gui, SidebarToolbar* toolbar, bool stacked);
     virtual ~SidebarPreviewLayers();
 
 public:
@@ -75,4 +75,9 @@ private:
      * Layer Controller
      */
     LayerController* lc;
+
+    /**
+     * render as stacked
+     */
+    bool stacked;
 };

--- a/ui/icons/hicolor/scalable/actions/sidebar-layerstack.svg
+++ b/ui/icons/hicolor/scalable/actions/sidebar-layerstack.svg
@@ -1,0 +1,345 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="sidebar-layerstack-preview.svg"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient6057">
+      <stop
+         style="stop-color:#222222;stop-opacity:0.88973391;"
+         offset="0"
+         id="stop6059" />
+      <stop
+         id="stop6065"
+         offset="1"
+         style="stop-color:#989898;stop-opacity:0.44313726;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6041">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop6043" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop6045" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6035"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#ff0000;stop-opacity:1;"
+         offset="0"
+         id="stop6037" />
+    </linearGradient>
+    <marker
+       inkscape:stockid="Arrow1Lstart"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow1Lstart"
+       style="overflow:visible">
+      <path
+         id="path3787"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1.0pt"
+         transform="scale(0.8) translate(12.5,0)" />
+    </marker>
+    <linearGradient
+       id="linearGradient2999">
+      <stop
+         id="stop3775"
+         offset="0"
+         style="stop-color:#4c4c4c;stop-opacity:0.41176471;" />
+      <stop
+         style="stop-color:#999999;stop-opacity:0;"
+         offset="1"
+         id="stop3003" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6057-4"
+       id="linearGradient6063"
+       x1="9.4017859"
+       y1="0.4598214"
+       x2="15.6875"
+       y2="21.084822"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83739436,0,0,0.92539931,0.02701454,1029.9763)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6057-4"
+       id="linearGradient6063-2"
+       x1="9.4017859"
+       y1="0.4598214"
+       x2="15.6875"
+       y2="21.084822"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83739436,0,0,0.92539931,0.27955268,1030.3551)" />
+    <linearGradient
+       id="linearGradient6057-4">
+      <stop
+         style="stop-color:#222222;stop-opacity:1;"
+         offset="0"
+         id="stop6059-3" />
+      <stop
+         id="stop6065-7"
+         offset="1"
+         style="stop-color:#989898;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="21.084822"
+       x2="15.6875"
+       y1="0.4598214"
+       x1="9.4017859"
+       gradientTransform="matrix(0.83739436,0,0,0.92539931,2.8079284,1032.6099)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6101"
+       xlink:href="#linearGradient6057-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6057-4"
+       id="linearGradient6148"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83739436,0,0,0.92539931,-0.74791045,1041.6003)"
+       x1="9.4017859"
+       y1="0.4598214"
+       x2="18.929443"
+       y2="10.23719" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6057-4-4"
+       id="linearGradient6148-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83739436,0,0,0.92539931,-1.1695472,1038.6099)"
+       x1="9.4017859"
+       y1="0.4598214"
+       x2="18.929443"
+       y2="10.23719" />
+    <linearGradient
+       id="linearGradient6057-4-4">
+      <stop
+         style="stop-color:#222222;stop-opacity:1;"
+         offset="0"
+         id="stop6059-3-1" />
+      <stop
+         id="stop6065-7-1"
+         offset="1"
+         style="stop-color:#989898;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="10.23719"
+       x2="18.929443"
+       y1="0.4598214"
+       x1="9.4017859"
+       gradientTransform="matrix(0.83739436,0,0,0.92539931,-0.77947715,1036.1053)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6165"
+       xlink:href="#linearGradient6057-4-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6057-4-41"
+       id="linearGradient6148-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83739436,0,0,0.92539931,-1.1695472,1038.6099)"
+       x1="9.4017859"
+       y1="0.4598214"
+       x2="18.929443"
+       y2="10.23719" />
+    <linearGradient
+       id="linearGradient6057-4-41">
+      <stop
+         style="stop-color:#222222;stop-opacity:1;"
+         offset="0"
+         id="stop6059-3-7" />
+      <stop
+         id="stop6065-7-4"
+         offset="1"
+         style="stop-color:#989898;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="10.23719"
+       x2="18.929443"
+       y1="0.4598214"
+       x1="9.4017859"
+       gradientTransform="matrix(0.83739436,0,0,0.92539931,-1.2011139,1033.6831)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6165-5"
+       xlink:href="#linearGradient6057-4-41"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="10.23719"
+       x2="18.929443"
+       y1="0.4598214"
+       x1="9.4017859"
+       gradientTransform="matrix(0.83739436,0,0,0.92539931,-1.2011139,1033.1149)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6165-2"
+       xlink:href="#linearGradient6057-4-4-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient6057-4-4-9">
+      <stop
+         style="stop-color:#222222;stop-opacity:1;"
+         offset="0"
+         id="stop6059-3-1-7" />
+      <stop
+         id="stop6065-7-1-6"
+         offset="1"
+         style="stop-color:#989898;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="10.23719"
+       x2="18.929443"
+       y1="0.4598214"
+       x1="9.4017859"
+       gradientTransform="matrix(0.83739436,0,0,0.92539931,-4.1053025,1032.5467)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6250"
+       xlink:href="#linearGradient6057-4-4-9"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="10.23719"
+       x2="18.929443"
+       y1="0.4598214"
+       x1="9.4017859"
+       gradientTransform="matrix(0.83739436,0,0,0.92539931,-0.79525875,1030.6141)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient6165-57"
+       xlink:href="#linearGradient6057-4-4-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient6057-4-4-7">
+      <stop
+         style="stop-color:#222222;stop-opacity:1;"
+         offset="0"
+         id="stop6059-3-1-4" />
+      <stop
+         id="stop6065-7-1-9"
+         offset="1"
+         style="stop-color:#989898;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6057-4-9"
+       id="linearGradient6148-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83739436,0,0,0.92539931,-1.1695472,1042.4206)"
+       x1="9.4017859"
+       y1="0.4598214"
+       x2="18.929443"
+       y2="10.23719" />
+    <linearGradient
+       id="linearGradient6057-4-9">
+      <stop
+         style="stop-color:#222222;stop-opacity:1;"
+         offset="0"
+         id="stop6059-3-8" />
+      <stop
+         id="stop6065-7-9"
+         offset="1"
+         style="stop-color:#989898;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6057-4-4-7"
+       id="linearGradient890"
+       x1="11.848196"
+       y1="1042.8193"
+       x2="12.848196"
+       y2="1042.8193"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.86828886,-0.16873382,136.38463)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6057-4-4-7"
+       id="linearGradient900"
+       x1="8.8144598"
+       y1="1035.7736"
+       x2="15.143537"
+       y2="1035.7736"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="15.839192"
+     inkscape:cx="11.573871"
+     inkscape:cy="5.6881091"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1916"
+     inkscape:window-height="1054"
+     inkscape:window-x="1920"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:document-rotation="0" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Ebene 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1030.3622)">
+    <path
+       style="fill:#ffffff;fill-opacity:1;stroke:url(#linearGradient6148);stroke-width:1.7606;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
+       d="M 1.3081923,1042.9967 H 14.056011 l 6.755396,7.6699 -13.6948373,10e-5 z"
+       id="rect3777-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;stroke:url(#linearGradient6165);stroke-width:1.7606;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
+       d="M 1.2766256,1037.5017 H 14.024444 l 6.755396,7.6699 -13.694837,1e-4 z"
+       id="rect3777-6-9"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;stroke:url(#linearGradient6165-57);stroke-width:1.761;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 1.260845,1032.0105 H 14.00862 l 6.755396,7.6699 -13.6948105,10e-5 z"
+       id="rect3777-6-9-4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:none;stroke:url(#linearGradient890);stroke-width:1.64124;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 12.179462,1048.6656 v -13.6252"
+       id="path882" />
+    <path
+       style="fill:none;stroke:url(#linearGradient900);stroke-width:1.76133333;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 9.4371793,1037.421 2.672,-2.672 2.672,2.672"
+       id="path892" />
+  </g>
+</svg>


### PR DESCRIPTION
Here is the follow-up to PR #2674.

Things to note in addition to the commit messages:

- The existing layer preview shows layers irrespective of the "active" check-box (which is useful); I kept this behaviour.
- The new sidebar icon uses some screen real estate that - until a few days ago - was unused anyways. I still think both the sidebar "page" (tab) icon and the close box belong there.
- The technical implementation makes it easy to use a checkbox instead of a new sidebar tab.