### PR TITLE
Fix LaTeX dialog threading for Windows

### DIFF
--- a/src/control/LatexController.h
+++ b/src/control/LatexController.h
@@ -106,7 +106,6 @@ private:
      */
     static void onPdfRenderComplete(GObject* procObj, GAsyncResult* res, LatexController* self);
 
-    void unsetUpdating();
     void updateStatus();
     bool isUpdating();
 


### PR DESCRIPTION
fixes https://github.com/xournalpp/xournalpp/issues/2775

I was debating if I should let the current (outdated) render finish or, if I should abort it to start the updated render. In the end, after some testing, letting the outdated render finish feels smoother for the user. That also means there is this simple fix.