### PR TITLE
Remove unnecessary copy of stroke data in Stroke::freeUnusedPointItems()

### DIFF
--- a/src/model/Stroke.cpp
+++ b/src/model/Stroke.cpp
@@ -158,7 +158,13 @@ auto Stroke::getPoint(int index) const -> Point {
 
 auto Stroke::getPoints() const -> const Point* { return this->points.data(); }
 
-void Stroke::freeUnusedPointItems() { this->points = {begin(this->points), end(this->points)}; }
+void Stroke::freeUnusedPointItems() {
+    size_t capacity = this->points.capacity();
+    // Reduce the vector's memory footprint if it has to much unused memory
+    if (capacity > 1024 && 4 * this->points.size() < 3 * capacity) {
+        this->points = {this->points.begin(), this->points.end()};
+    }
+}
 
 void Stroke::setToolType(StrokeTool type) { this->toolType = type; }
 

--- a/src/model/Stroke.h
+++ b/src/model/Stroke.h
@@ -65,7 +65,7 @@ public:
     void setFirstPoint(double x, double y);
     void setLastPoint(const Point& p);
     int getPointCount() const;
-    void freeUnusedPointItems();
+    [[deprecated("Memory should be std::reserve'd beforehand instead")]] void freeUnusedPointItems();
     std::vector<Point> const& getPointVector() const;
     Point getPoint(int index) const;
     const Point* getPoints() const;


### PR DESCRIPTION
`Stroke::freeUnusedPointItems` copies the strokes points to a new location. Using `std::vector::shrink_to_fit()` instead is (way) cheaper with the same memory footprint shrinking.

The line `this->points = {begin(this->points), end(this->points)};` was introduced with commit
> commit 742499a20b99bc1d6d103c7a16376c4a2ef053a8
> Author: Fabian Keßler <fabian_kessler@gmx.de>
> Date:   Fri Oct 11 09:41:38 2019 +0200
>
>     Fixed undefined behaviour
>     by replacing dynamic allocated and resized c-array with a std::vector

@Febbe: was there a specific reason for using `this->points = {begin(this->points), end(this->points)};` and not `std::vector::shrink_to_fit()`?