### PR TITLE
fix deb package with non-satisfiable dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: https://github.com/xournalpp/xournalpp/
 
 Package: xournalpp
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, libglib2.0-0 (>= 2.32), libgtk-3-0 (>= 3.18), libpoppler-glib8 (>= 0.41.0), libxml2 (>= 2.0.0), libportaudiocpp0 (>= 12), libsndfile1 (>= 1.0.25), liblua5.3-0, libzip4 (>= 1.0.1) | libzip5, zlib1g, libc6, librsvg-2.0 (>= 2.40)
+Depends: ${shlibs:Depends}, ${misc:Depends}, libglib2.0-0 (>= 2.32), libgtk-3-0 (>= 3.18), libpoppler-glib8 (>= 0.41.0), libxml2 (>= 2.0.0), libportaudiocpp0 (>= 12), libsndfile1 (>= 1.0.25), liblua5.3-0, libzip4 (>= 1.0.1) | libzip5, zlib1g, libc6, librsvg2-2 (>= 2.40)
 Suggests: texlive-base, texlive-latex-extra
 Description: Xournal++ - Open source hand note-taking program
  Xournal++ is a hand note taking software written in C++ with the target of 


### PR DESCRIPTION
I am not sure it fixes the problem, but I don't see a way to try it out without merging the commit, letting it build on Launchpad and trying out the package.

Since `librsvg` is only used for the thumbnailer an option would be to add this dependency only to the `Recommends` field.