### PR TITLE
Fix attributes of IM's preedit strings in TextEditor.

### DIFF
--- a/src/gui/TextEditor.h
+++ b/src/gui/TextEditor.h
@@ -96,6 +96,7 @@ private:
     PangoLayout* layout = nullptr;
     Text* text = nullptr;
 
+    PangoAttrList* preeditAttrList = nullptr;
     string preeditString;
     string lastText;
 


### PR DESCRIPTION
This PR deals with the attributes for preedit strings of IM.
1. Fix that attributes were not reflected.
2. Use attributes for the preedit strings set by IM.

**On the first point**
Seeing TextEditor.cpp, IM's preedit strings are to be displayed with underline.
But subsequent code for attributes of selections overrides it, and no underline appears.
Because TextSelection and PreEditingTexts are exclusive operation, there's no needs to compose their attributes.
So I moved the TextSelection code to PreEditing code's else clause.

**On the second point**
There are various IM programs, and they set attributes for preedit strings.  So Xournal++ should not set attributes for preedit string, but use IM's attributes. The PR uses only  IM's attributes, and does not intend to compose them with other attributes. When we need another kind of attributes, it'll be rewritten.