### PR TITLE
Input system/regression: Fix cursor not changing

### DIFF
--- a/src/gui/inputdevices/AbstractInputHandler.h
+++ b/src/gui/inputdevices/AbstractInputHandler.h
@@ -35,6 +35,11 @@ private:
 
 protected:
     InputContext* inputContext;
+
+    /**
+     *  Whether we're in a press-move-up event sequence.
+     * E.g. the user has clicked and is currently moving the mouse.
+     */
     bool inputRunning = false;
 
 protected:

--- a/src/gui/inputdevices/MouseInputHandler.cpp
+++ b/src/gui/inputdevices/MouseInputHandler.cpp
@@ -93,6 +93,7 @@ void MouseInputHandler::setPressedState(InputEvent const& event) {
                 break;
         }
     }
+
     if (event.type == BUTTON_RELEASE_EVENT)  // mouse button released or pen not touching surface anymore
     {
         this->deviceClassPressed = false;


### PR DESCRIPTION
Previously, all input-move events would be ignored if we weren't in a press-move-release event sequence (i.e. the mouse was hovering & not pressed).


Should fix #2833.