### PR TITLE
Fix zoom jumping and zoom steps (Partial Zoom Refactor)

### DIFF
--- a/src/control/zoom/ZoomControl.cpp
+++ b/src/control/zoom/ZoomControl.cpp
@@ -18,7 +18,11 @@ auto onScrolledwindowMainScrollEvent(GtkWidget* widget, GdkEventScroll* event, Z
                 (event->direction == GDK_SCROLL_UP || (event->direction == GDK_SCROLL_SMOOTH && event->delta_y < 0)) ?
                         ZOOM_IN :
                         ZOOM_OUT;
-        zoom->zoomScroll(direction, {event->x, event->y});
+        // use screen pixel coordinates for the zoom center
+        // as relative coordinates depend on the changing zoom level
+        int rx, ry;
+        gdk_window_get_root_coords(gtk_widget_get_window(widget), 0, 0, &rx, &ry);
+        zoom->zoomScroll(direction, {event->x_root - rx, event->y_root - ry});
         return true;
     }
 
@@ -29,15 +33,16 @@ auto onScrolledwindowMainScrollEvent(GtkWidget* widget, GdkEventScroll* event, Z
 auto onTouchpadPinchEvent(GtkWidget* widget, GdkEventTouchpadPinch* event, ZoomControl* zoom) -> bool {
     if (event->type == GDK_TOUCHPAD_PINCH && event->n_fingers == 2) {
         utl::Point<double> center;
+        int rx, ry;
         switch (event->phase) {
             case GDK_TOUCHPAD_GESTURE_PHASE_BEGIN:
                 if (zoom->isZoomFitMode()) {
                     zoom->setZoomFitMode(false);
                 }
-                center = {event->x, event->y};
-                // Need to adjust the center because the event coordinates are relative
-                // to the widget, not to the zoomed (and translated) view
-                center += {zoom->getVisibleRect().x, zoom->getVisibleRect().y};
+                // use screen pixel coordinates for the zoom center
+                // as relative coordinates depend on the changing zoom level
+                gdk_window_get_root_coords(gtk_widget_get_window(widget), 0, 0, &rx, &ry);
+                center = {event->x_root - rx, event->y_root - ry};
                 zoom->startZoomSequence(center);
                 break;
             case GDK_TOUCHPAD_GESTURE_PHASE_UPDATE:
@@ -84,15 +89,18 @@ void ZoomControl::zoomOneStep(ZoomDirection direction, utl::Point<double> zoomCe
     }
     this->setZoomFitMode(false);
 
+    double multiplier = 1.0 + this->zoomStep;
+    double newZoomStep = (direction == ZOOM_IN) ? multiplier : 1.0 / multiplier;
+    double newZoom = this->zoom * newZoomStep;
+
     startZoomSequence(zoomCenter);
-    double newZoom = (direction == ZOOM_IN) ? this->zoom + this->zoomStep : this->zoom - this->zoomStep;
     this->zoomSequenceChange(newZoom, false);
     endZoomSequence();
 }
 
 void ZoomControl::zoomOneStep(ZoomDirection direction) {
     Rectangle rect = getVisibleRect();
-    zoomOneStep(direction, {rect.x + rect.width / 2.0, rect.y + rect.height / 2.0});
+    zoomOneStep(direction, {rect.width / 2.0, rect.height / 2.0});
 }
 
 
@@ -105,34 +113,63 @@ void ZoomControl::zoomScroll(ZoomDirection zoomIn, utl::Point<double> zoomCenter
         this->setZoomFitMode(false);
     }
 
-    if (this->zoomSequenceStart == -1 || scrollCursorPosition != zoomCenter) {
-        scrollCursorPosition = zoomCenter;
-        startZoomSequence(zoomCenter);
-    }
+    double multiplier = 1.0 + this->zoomStepScroll;
+    double newZoomStep = zoomIn ? multiplier : 1.0 / multiplier;
+    double newZoom = this->zoom * newZoomStep;
 
-    double newZoom = this->zoom + (zoomIn ? this->zoomStepScroll : -this->zoomStepScroll);
+    startZoomSequence(zoomCenter);
     this->zoomSequenceChange(newZoom, false);
+    endZoomSequence();
 }
 
 void ZoomControl::startZoomSequence() {
     Rectangle rect = getVisibleRect();
-    startZoomSequence({rect.x + rect.width / 2.0, rect.y + rect.height / 2.0});
+    startZoomSequence({rect.width / 2.0, rect.height / 2.0});
 }
 
 void ZoomControl::startZoomSequence(utl::Point<double> zoomCenter) {
+    // * set zoom center and zoom startlevel
+    this->zoomWidgetPos = zoomCenter;  // window space coordinates of the zoomCenter!
+    this->zoomSequenceStart = this->zoom;
+
+    // * set unscaledPixels padding value
+    size_t currentPageIdx = this->view->getCurrentPage();
+
+    // To get the layout, we need to call view->getWidget(), which isn't const.
+    // As such, we get the view and determine `unscaledPixels` here, rather than
+    // in `getScrollPositionAfterZoom`.
+    GtkWidget* widget = view->getWidget();
+    Layout* layout = gtk_xournal_get_layout(widget);
+
+    // Not everything changes size as we zoom in/out. The padding, for example,
+    // remains constant! (changed when page changes, but the error stays small enough)
+    this->unscaledPixels = {static_cast<double>(layout->getPaddingLeftOfPage(currentPageIdx)),
+                            static_cast<double>(layout->getPaddingAbovePage(currentPageIdx))};
+
+    // * set initial scrollPosition value
     auto const& rect = getVisibleRect();
     auto const& view_pos = utl::Point{rect.x, rect.y};
 
-    this->zoomWidgetPos = zoomCenter - view_pos;
-    this->zoomSequenceStart = this->zoom;
-
-    setScrollPositionAfterZoom(view_pos);
+    // Use this->zoomWidgetPos to zoom into a location other than the top-left (e.g. where
+    // the user pinched).
+    this->scrollPosition = (view_pos + this->zoomWidgetPos - this->unscaledPixels) / this->zoom;
 }
 
 void ZoomControl::zoomSequenceChange(double zoom, bool relative) {
-    if (relative && this->zoomSequenceStart != -1) {
-        zoom *= zoomSequenceStart;
+    if (relative) {
+        zoom *= this->zoomSequenceStart != -1 ? zoomSequenceStart : this->zoom;
     }
+
+    setZoom(zoom);
+}
+
+void ZoomControl::zoomSequenceChange(double zoom, bool relative, utl::Point<double> scrollVector) {
+    if (relative) {
+        zoom *= this->zoomSequenceStart != -1 ? zoomSequenceStart : this->zoom;
+    }
+
+    // scroll update
+    this->zoomWidgetPos += scrollVector;
 
     setZoom(zoom);
 }
@@ -155,38 +192,17 @@ auto ZoomControl::getVisibleRect() -> Rectangle<double> {
     return layout->getVisibleRect();
 }
 
-void ZoomControl::setScrollPositionAfterZoom(utl::Point<double> scrollPos) {
-    size_t currentPageIdx = this->view->getCurrentPage();
-
-    // To get the layout, we need to call view->getWidget(), which isn't const.
-    // As such, we get the view and determine `unscaledPixels` here, rather than
-    // in `getScrollPositionAfterZoom`.
-    GtkWidget* widget = view->getWidget();
-    Layout* layout = gtk_xournal_get_layout(widget);
-
-    // TODO(personalizedrefrigerator) While this zooms in nearly where intended, it
-    //                                "jitters" while zooming if very far into the document.
-
-    // Not everything changes size as we zoom in/out. The padding, for example,
-    // remains constant!
-    this->unscaledPixels = {static_cast<double>(layout->getPaddingLeftOfPage(currentPageIdx)),
-                            static_cast<double>(layout->getPaddingAbovePage(currentPageIdx))};
-
-    // Use this->zoomWidgetPos to zoom into a location other than the top-left (e.g. where
-    // the user pinched).
-    this->scrollPosition = (scrollPos - this->unscaledPixels + this->zoomWidgetPos) / this->zoom;
-}
-
 auto ZoomControl::getScrollPositionAfterZoom() const -> utl::Point<double> {
     //  If we aren't in a zoomSequence, `unscaledPixels`, `scrollPosition`, and `zoomWidgetPos
     // can't be used to determine the scroll position! Return now.
+    // NOTE: this case should never happend currently.
+    //       getScrollPositionAfterZoom is called from XournalView after setZoom() fired the ZoomListeners
     if (this->zoomSequenceStart == -1) {
         return {-1, -1};
     }
 
-    return (this->scrollPosition * this->zoom) - this->zoomWidgetPos + this->unscaledPixels;
+    return this->scrollPosition * this->zoom - this->zoomWidgetPos + this->unscaledPixels;
 }
-
 
 void ZoomControl::addZoomListener(ZoomListener* l) { this->listener.emplace_back(l); }
 
@@ -201,14 +217,6 @@ void ZoomControl::initZoomHandler(GtkWidget* window, GtkWidget* widget, XournalV
 }
 
 void ZoomControl::fireZoomChanged() {
-    if (this->zoom < this->zoomMin) {
-        this->zoom = this->zoomMin;
-    }
-
-    if (this->zoom > this->zoomMax) {
-        this->zoom = this->zoomMax;
-    }
-
     for (ZoomListener* z: this->listener) {
         z->zoomChanged();
     }
@@ -225,14 +233,12 @@ auto ZoomControl::getZoom() const -> double { return this->zoom; }
 auto ZoomControl::getZoomReal() const -> double { return this->zoom / this->zoom100Value; }
 
 void ZoomControl::setZoom(double zoomI) {
-    this->zoom = zoomI;
+    this->zoom = std::clamp(zoomI, this->zoomMin, this->zoomMax);
     fireZoomChanged();
 }
 
 void ZoomControl::setZoom100Value(double zoom100Val) {
     auto setWithRelZoom = [zoomOld = this->zoom100Value, zoom100Val](double& val) { val = val / zoomOld * zoom100Val; };
-    setWithRelZoom(this->zoomStep);
-    setWithRelZoom(this->zoomStepScroll);
     setWithRelZoom(this->zoomMax);
     setWithRelZoom(this->zoomMin);
     this->zoom100Value = zoom100Val;
@@ -341,9 +347,9 @@ void ZoomControl::setZoomPresentationMode(bool isZoomPresentationMode) {
 
 auto ZoomControl::isZoomPresentationMode() const -> bool { return this->zoomPresentationMode; }
 
-void ZoomControl::setZoomStep(double zoomStep) { this->zoomStep = zoomStep * this->zoom100Value; }
+void ZoomControl::setZoomStep(double zoomStep) { this->zoomStep = zoomStep; }
 
-void ZoomControl::setZoomStepScroll(double zoomStep) { this->zoomStepScroll = zoomStep * this->zoom100Value; }
+void ZoomControl::setZoomStepScroll(double zoomStep) { this->zoomStepScroll = zoomStep; }
 
 void ZoomControl::pageSizeChanged(size_t page) {
     updateZoomPresentationValue(page);

--- a/src/control/zoom/ZoomControl.h
+++ b/src/control/zoom/ZoomControl.h
@@ -126,7 +126,7 @@ public:
     /**
      * Call this before any zoom is done, it saves the current page and position
      *
-     * @param zoomCenter position of zoom focus
+     * @param zoomCenter position of zoom focus in window coordinate space
      */
 
     void startZoomSequence(utl::Point<double> zoomCenter);
@@ -144,6 +144,15 @@ public:
      * @param relative If the zoom is relative to the start value (for Gesture)
      */
     void zoomSequenceChange(double zoom, bool relative);
+    /**
+     * Change the zoom and zoomCenter within a Zoom sequence (startZoomSequence() / endZoomSequence())
+     * Used while touch pinch event
+     *
+     * @param zoom Current zoom value
+     * @param relative If the zoom is relative to the start value (for Gesture)
+     * @param scrollVector relative zoom center movement in pixels since last call
+     */
+    void zoomSequenceChange(double zoom, bool relative, utl::Point<double> scrollVector);
 
     /// Clear all stored data from startZoomSequence()
     void endZoomSequence();
@@ -200,14 +209,11 @@ private:
     /// Base zoom on start, for relative zoom (Gesture)
     double zoomSequenceStart = -1;
 
-    /// Zoom center pos on view, will not be zoomed!
+    /// Zoom center position in window coordinate space, will not be zoomed!
     utl::Point<double> zoomWidgetPos;
 
     /// Scroll position (top left corner of view) to scale
     utl::Point<double> scrollPosition;
-
-    /// Cursorposition x for Ctrl + Scroll
-    utl::Point<double> scrollCursorPosition;
 
     /// Size {x, y} of the pixels before the current page that
     /// do not scale.

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -334,6 +334,8 @@ void MainWindow::initHideMenu() {
 
 auto MainWindow::getLayout() -> Layout* { return gtk_xournal_get_layout(GTK_WIDGET(this->xournal->getWidget())); }
 
+auto MainWindow::getWinXournal() -> GtkWidget* { return this->winXournal; }
+
 auto cancellable_cancel(GCancellable* cancel) -> bool {
     g_cancellable_cancel(cancel);
 

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -98,6 +98,8 @@ public:
 
     bool isGestureActive();
 
+    GtkWidget* getWinXournal();
+
 
     /**
      * Disable kinetic scrolling if there is a touchscreen device that was manually mapped to another enabled input

--- a/src/gui/inputdevices/TouchDrawingInputHandler.cpp
+++ b/src/gui/inputdevices/TouchDrawingInputHandler.cpp
@@ -47,6 +47,12 @@ auto TouchDrawingInputHandler::handleImpl(InputEvent const& event) -> bool {
         return false;
     }
 
+    // Don't handle more then 2 inputs
+    /*if (this->primarySequence && this->primarySequence != event.sequence && this->secondarySequence &&
+        this->secondarySequence != event.sequence) {
+        return false;
+    }*/
+
     // Multitouch
     if (this->primarySequence && this->primarySequence != event.sequence || this->secondarySequence) {
         if (!this->secondarySequence) {

--- a/src/gui/inputdevices/TouchInputHandler.cpp
+++ b/src/gui/inputdevices/TouchInputHandler.cpp
@@ -32,21 +32,26 @@ auto TouchInputHandler::handleImpl(InputEvent const& event) -> bool {
                  this->secondarySequence == nullptr) {
             this->secondarySequence = event.sequence;
 
+            // Even if zoom gestures are disabled,
+            // this is still the start of a sequence.
+
             // Set sequence data
             sequenceStart(event);
 
-            // Even if zoom gestures are disabled,
-            // this is still the start of a sequence. Just
-            // don't start zooming.
-            if (zoomGesturesEnabled) {
-                zoomStart();
-            }
+            startZoomReady = true;
         }
     }
 
     if (event.type == MOTION_EVENT && this->primarySequence) {
         if (this->primarySequence && this->secondarySequence && zoomGesturesEnabled) {
-            zoomMotion(event);
+            if (startZoomReady) {
+                if (this->primarySequence == event.sequence) {
+                    sequenceStart(event);
+                    zoomStart();
+                }
+            } else {
+                zoomMotion(event);
+            }
         } else if (event.sequence == this->primarySequence) {
             scrollMotion(event);
         } else if (this->primarySequence && this->secondarySequence) {
@@ -107,16 +112,6 @@ void TouchInputHandler::scrollMotion(InputEvent const& event) {
 }
 
 void TouchInputHandler::zoomStart() {
-    // Take horizontal and vertical padding of view into account when calculating the center of the gesture
-    int vPadding = inputContext->getSettings()->getAddVerticalSpace() ?
-                           inputContext->getSettings()->getAddVerticalSpaceAmount() :
-                           0;
-    int hPadding = inputContext->getSettings()->getAddHorizontalSpace() ?
-                           inputContext->getSettings()->getAddHorizontalSpaceAmount() :
-                           0;
-
-    auto center = (this->priLastRel + this->secLastRel) / 2.0 - utl::Point<double>{double(hPadding), double(vPadding)};
-
     this->startZoomDistance = this->priLastAbs.distance(this->secLastAbs);
 
     if (this->startZoomDistance == 0.0) {
@@ -137,16 +132,25 @@ void TouchInputHandler::zoomStart() {
         zoomControl->setZoomFitMode(false);
     }
 
+    auto center = (this->priLastAbs + this->secLastAbs) / 2.0;
+
     auto* mainWindow = inputContext->getView()->getControl()->getWindow();
+    // use screen pixel coordinates for the zoom center
+    // as relative coordinates depend on the changing zoom level
+    int rx, ry;
+    gdk_window_get_root_coords(gtk_widget_get_window(mainWindow->getWinXournal()), 0, 0, &rx, &ry);
+    center.x -= rx;
+    center.y -= ry;
 
     // When not using touch drawing, we're using a different scrolling method.
     // This requires different centering.
-    if (!mainWindow->getGtkTouchscreenScrollingEnabled()) {
-        Rectangle zoomSequenceRectangle = zoomControl->getVisibleRect();
-        center += utl::Point<double>{zoomSequenceRectangle.x, zoomSequenceRectangle.y};
-    }
+    /*if (!mainWindow->getGtkTouchscreenScrollingEnabled()) {
+        center = (this->priLastRel + this->secLastRel) / 2.0;  // TODO check!
+    }*/
 
     zoomControl->startZoomSequence(center);
+
+    startZoomReady = false;
 }
 
 void TouchInputHandler::zoomMotion(InputEvent const& event) {
@@ -172,13 +176,8 @@ void TouchInputHandler::zoomMotion(InputEvent const& event) {
     }
 
     ZoomControl* zoomControl = this->inputContext->getView()->getControl()->getZoomControl();
-    zoomControl->zoomSequenceChange(zoom, true);
-
     auto center = (this->priLastAbs + this->secLastAbs) / 2;
-    auto lastScrollPosition = zoomControl->getScrollPositionAfterZoom();
-    auto offset = lastScrollPosition - (center - lastZoomScrollCenter);
-
-    zoomControl->setScrollPositionAfterZoom(offset);
+    zoomControl->zoomSequenceChange(zoom, true, center - lastZoomScrollCenter);
     lastZoomScrollCenter = center;
 }
 

--- a/src/gui/inputdevices/TouchInputHandler.h
+++ b/src/gui/inputdevices/TouchInputHandler.h
@@ -35,6 +35,8 @@ private:
     utl::Point<double> priLastRel{-1.0, -1.0};
     utl::Point<double> secLastRel{-1.0, -1.0};
 
+    bool startZoomReady = false;
+
     bool canBlockZoom{false};
 
 private:


### PR DESCRIPTION
This is a splitup part of https://github.com/xournalpp/xournalpp/pull/2743 .
see https://github.com/xournalpp/xournalpp/pull/2743 for older comments.

This patch fixes the issues with zoom jumping to previous/different pages. It also changes zoom steps to be relative for a much better zooming experience.

Internally this is a change from local to global coordinates, because the local coordinates had weird position spikes in them. This is honestly mostly due to my missing understanding of where the local coordinates come from. I am sure that part of this patch can be done differently.

I have also simplified some of the logic to avoid addition/subtraction of large floating point values and simpler access of the zoom calls.