### PR TITLE
Remove redundant space from TeX object

### DIFF
--- a/resources/default_template.tex
+++ b/resources/default_template.tex
@@ -25,7 +25,7 @@
 
 \begin{document}
   % Check if the formula is empty
-  \settoheight{\pheight}{\getstored[1]{preview}}
+  \settoheight{\pheight}{\getstored[1]{preview}}%
   \ifthenelse{\pheight=0}{\GenericError{}{xournalpp:blankformula}{}{}}
 
   % Render the user input


### PR DESCRIPTION
% is required at end of line for some TeX commands. Without it, redundant space is inserted.