### PR TITLE
Make TEXTDOMAINDIR work under Windows

### DIFF
--- a/src/util/PathUtil.cpp
+++ b/src/util/PathUtil.cpp
@@ -159,7 +159,7 @@ auto Util::getGettextFilepath(const char* localeDir) -> fs::path {
     std::string directories;
     if (gettextEnv) {
         directories = std::string(gettextEnv);
-        size_t firstDot = directories.find(':');
+        size_t firstDot = directories.find(G_SEARCHPATH_SEPARATOR);
         if (firstDot != std::string::npos) {
             directories = directories.substr(0, firstDot);
         }


### PR DESCRIPTION
The searchpath separator under Windows is not `:` like on Linux/Unix, but `;`
To distinguish OS's we can use the `G_SEACHPATH_SEPARATOR` variable, see [this link](https://developer.gnome.org/glib/stable/glib-Standard-Macros.html#G-SEARCHPATH-SEPARATOR:CAPS).