### PR TITLE
Fix Rectangle::unite not properly calculating the union

### DIFF
--- a/src/util/Rectangle.h
+++ b/src/util/Rectangle.h
@@ -53,10 +53,12 @@ public:
     void unite(const Rectangle& other) {
         // assert(other.width > 0 && other.height > 0 && "Rectangle not normalized"); (does not need to be valid for
         // snappedBounds)
+        this->width = std::max(this->x + this->width, other.x + other.width);
+        this->height = std::max(this->y + this->height, other.y + other.height);
         this->x = std::min(this->x, other.x);
         this->y = std::min(this->y, other.y);
-        this->width = std::max(this->x + this->width, other.x + other.width) - this->x;
-        this->height = std::max(this->y + this->height, other.y + other.height) - this->y;
+        this->width -= this->x;
+        this->height -= this->y;
     }
 
     /**


### PR DESCRIPTION
Intersection of rectangles was not computed properly. This fixes it.

Example: `{1, 0, 1, 0}.unite({0, 0, 1, 0})` resulted in `{0, 0, 1, 0}` instead of `{0, 0, 2, 0}`.