### PR TITLE
Escape linebreaks when saving LaTeX text

### DIFF
--- a/src/control/xml/TextAttribute.cpp
+++ b/src/control/xml/TextAttribute.cpp
@@ -15,6 +15,7 @@ void TextAttribute::writeOut(OutputStream* out) {
                                             replace_pair('\"', "&quot;"),
                                             replace_pair('<', "&lt;"),
                                             replace_pair('>', "&gt;"),
+                                            replace_pair('\n', "&#13;"),
                                     });
     out->write(v);
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/46334387/108773254-e82c2380-7512-11eb-806f-81480ef331de.png)
![image](https://user-images.githubusercontent.com/46334387/108773308-faa65d00-7512-11eb-9003-74f9e47aaaac.png)

On file load, linebreaks in XML attributes are ignored. Linebreaks were not escaped on file save. This PR escapes linebreaks on file save. 

This should be backwards compatible because we use a `GMarkupParseContext` to parse XML (on file load), which handles escape sequences for us.

Should fix #2526. 