### PR TITLE
Notify the IM of its cursor position in Xournal++

### DIFF
--- a/src/gui/TextEditor.cpp
+++ b/src/gui/TextEditor.cpp
@@ -1056,7 +1056,7 @@ void TextEditor::paint(cairo_t* cr, GdkRectangle* repaintRect, double zoom) {
     cairo_rectangle(cr, x0 - 5 / zoom, y0 - 5 / zoom, width + 10 / zoom, height + 10 / zoom);
     cairo_stroke(cr);
 
-    // Notify window and cursor position to IM.
+    // Notify the IM of the app's window and cursor position.
     gtk_im_context_set_client_window(this->imContext, gtk_widget_get_window(this->widget));
     GdkRectangle cursorRect;
     cursorRect.x = static_cast<int>(zoom * x0 + x1 + zoom * cX);

--- a/src/gui/TextEditor.h
+++ b/src/gui/TextEditor.h
@@ -97,6 +97,7 @@ private:
     Text* text = nullptr;
 
     PangoAttrList* preeditAttrList = nullptr;
+    int preeditCursor;
     string preeditString;
     string lastText;
 


### PR DESCRIPTION
When InputMethod makes external window separate from the Xournal++'s one,
IM needs cursor position of Xournal++ to determine where to open the window.
Current Xournal++ doesn't notify the IM of the cursor position, so the IM window
is displayed at unexpected place.

For example, if I use uim-skk (IM) on dual monitor environment, the candidate
window is displayed on a monitor different from the monitor on which Xournal++
is displayed. This is very stressful.

This PR makes Xournal++ to notify the IM of the app's window and cursor position. 
To be precise, the cursor position is not the one Xournal++ has a mark (just after preedit string),
but the one somewhere in the preedit text which is indicated by IM. The following
movie shows how the candidate window of ibus-anthy is displayed.

https://user-images.githubusercontent.com/6355486/108800014-520d0180-75d5-11eb-9382-cbd8121b4d1f.mp4

