### PR TITLE
Settings not saving: Fix stabilizer averaging method and preprocessor settings

### DIFF
--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -922,8 +922,8 @@ void Settings::save() {
     /**
      * Stabilizer related settings
      */
-    WRITE_INT_PROP(static_cast<int>(stabilizerAveragingMethod));
-    WRITE_INT_PROP(static_cast<int>(stabilizerPreprocessor));
+    saveProperty("stabilizerAveragingMethod", static_cast<int>(stabilizerAveragingMethod), root);
+    saveProperty("stabilizerPreprocessor", static_cast<int>(stabilizerPreprocessor), root);
     WRITE_UINT_PROP(stabilizerBuffersize);
     WRITE_DOUBLE_PROP(stabilizerSigma);
     WRITE_DOUBLE_PROP(stabilizerDeadzoneRadius);


### PR DESCRIPTION
Should fix #2854

Due to the definition of `WRITE_INT_PROP`, the property name for `stabilizerAveragingMethod` and `stabilizerPreprocessor` included a `static_cast&lt;...`