### PR TITLE
Fix highlighter initial rendering extremely thin

### DIFF
--- a/src/control/tools/StrokeHandler.cpp
+++ b/src/control/tools/StrokeHandler.cpp
@@ -141,6 +141,7 @@ void StrokeHandler::drawSegmentTo(const Point& point) {
             lastSegment.addPoint(prevPoint);
             lastSegment.addPoint(point);
             lastSegment.setWidth(stroke->getWidth());
+            lastSegment.setToolType(stroke->getToolType());
 
             cairo_set_operator(crMask, CAIRO_OPERATOR_OVER);
             cairo_set_source_rgba(crMask, 1, 1, 1, 1);

--- a/src/model/eraser/EraseableStroke.cpp
+++ b/src/model/eraser/EraseableStroke.cpp
@@ -33,9 +33,12 @@ void EraseableStroke::draw(cairo_t* cr) {
 
     double w = this->stroke->getWidth();
 
+    // Some tools ignore pressure sensitivity.
+    bool usePressure = this->stroke->getToolType() != STROKE_TOOL_HIGHLIGHTER;
+
     for (GList* l = tmpCopy->data; l != nullptr; l = l->next) {
         auto* part = static_cast<EraseableStrokePart*>(l->data);
-        if (part->getWidth() == Point::NO_PRESSURE) {
+        if (!usePressure || part->getWidth() == Point::NO_PRESSURE) {
             cairo_set_line_width(cr, w);
         } else {
             cairo_set_line_width(cr, part->getWidth());


### PR DESCRIPTION
## Summary
 * We weren't setting the tool type when drawing a segment of a stroke! As such, it defaulted to `STROKE_TOOL_PEN`, causing highlighter strokes to be treated like pen strokes (drawn based on pressure, etc.).

Should fix #2858