### PR TITLE
Fix multiple memory bugs in toolbar customization

### DIFF
--- a/src/gui/ToolitemDragDrop.cpp
+++ b/src/gui/ToolitemDragDrop.cpp
@@ -55,7 +55,7 @@ auto ToolitemDragDrop::getIcon(ToolItemDragDropData* data) -> GtkWidget* {
         return data->item->getNewToolIcon();
     }
     if (data->type == TOOL_ITEM_SEPARATOR) {
-        return ToolbarSeparatorImage::newSepeartorImage();
+        return ToolbarSeparatorImage::newImage();
     }
 
     g_warning("ToolitemDragDrop::getIcon unhandled type: %i\n", data->type);

--- a/src/gui/ToolitemDragDrop.h
+++ b/src/gui/ToolitemDragDrop.h
@@ -45,6 +45,9 @@ public:
 
     static ToolItemDragDropData* metadataGetMetadata(GtkWidget* w);
 
+    /**
+     * Returns: (transfer floating)
+     */
     static GtkWidget* getIcon(ToolItemDragDropData* data);
 
 public:

--- a/src/gui/XojColor.cpp
+++ b/src/gui/XojColor.cpp
@@ -2,10 +2,8 @@
 
 #include <utility>
 
-XojColor::XojColor(Color color, string name): color(color), name(std::move(name)) {}
-
-XojColor::~XojColor() = default;
+XojColor::XojColor(Color color, std::string name): color(color), name(std::move(name)) {}
 
 auto XojColor::getColor() const -> Color { return this->color; }
 
-auto XojColor::getName() -> string { return this->name; }
+auto XojColor::getName() const -> string { return this->name; }

--- a/src/gui/XojColor.h
+++ b/src/gui/XojColor.h
@@ -18,17 +18,16 @@
 
 #include "XournalType.h"
 
-class XojColor {
+struct XojColor {
 public:
-    XojColor(Color color, string name);
-    virtual ~XojColor();
+    XojColor(Color color, std::string name);
 
 public:
     Color getColor() const;
-    string getName();
+    string getName() const;
 
 private:
     Color color;
     // the localized name of the color
-    string name;
+    std::string name;
 };

--- a/src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp
+++ b/src/gui/dialog/toolbarCustomize/CustomizeableColorList.cpp
@@ -20,15 +20,8 @@ CustomizeableColorList::CustomizeableColorList() {
     this->addPredefinedColor(0xffffffU, _("White"));
 }
 
-CustomizeableColorList::~CustomizeableColorList() {
-    for (XojColor* c: this->colors) {
-        delete c;
-    }
-    this->colors.clear();
-}
-
-auto CustomizeableColorList::getPredefinedColors() -> vector<XojColor*>* { return &this->colors; }
+auto CustomizeableColorList::getPredefinedColors() const -> const vector<XojColor>& { return this->colors; }
 
 void CustomizeableColorList::addPredefinedColor(Color color, string name) {
-    this->colors.push_back(new XojColor(color, std::move(name)));
+    this->colors.push_back(XojColor(color, std::move(name)));
 }

--- a/src/gui/dialog/toolbarCustomize/CustomizeableColorList.h
+++ b/src/gui/dialog/toolbarCustomize/CustomizeableColorList.h
@@ -21,14 +21,13 @@
 class CustomizeableColorList {
 public:
     CustomizeableColorList();
-    virtual ~CustomizeableColorList();
 
 public:
-    vector<XojColor*>* getPredefinedColors();
+    const vector<XojColor>& getPredefinedColors() const;
 
 private:
     void addPredefinedColor(Color color, string name);
 
 private:
-    vector<XojColor*> colors;
+    vector<XojColor> colors;
 };

--- a/src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp
+++ b/src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp
@@ -144,8 +144,13 @@ void ToolbarAdapter::toolitemDragBegin(GtkWidget* widget, GdkDragContext* contex
     ToolItemDragCurrentData::setData(data);
 
     GtkWidget* icon = ToolitemDragDrop::getIcon(data);
+    g_object_ref_sink(icon);
 
-    gtk_drag_set_icon_pixbuf(context, ToolbarDragDropHelper::getImagePixbuf(GTK_IMAGE(icon)), -2, -2);
+    GdkPixbuf* pixbuf = ToolbarDragDropHelper::getImagePixbuf(GTK_IMAGE(icon));
+    g_assert_nonnull(pixbuf);
+
+    gtk_drag_set_icon_pixbuf(context, pixbuf, -2, -2);
+    g_object_unref(pixbuf);
 
     g_object_unref(icon);
 

--- a/src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp
+++ b/src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp
@@ -138,20 +138,12 @@ void ToolbarAdapter::showToolbar() {
  */
 void ToolbarAdapter::toolitemDragBegin(GtkWidget* widget, GdkDragContext* context, void* unused) {
     ToolItemDragDropData* data = ToolitemDragDrop::metadataGetMetadata(widget);
-
     g_return_if_fail(data != nullptr);
-
     ToolItemDragCurrentData::setData(data);
 
-    GtkWidget* icon = ToolitemDragDrop::getIcon(data);
+    auto* icon = ToolitemDragDrop::getIcon(data);
     g_object_ref_sink(icon);
-
-    GdkPixbuf* pixbuf = ToolbarDragDropHelper::getImagePixbuf(GTK_IMAGE(icon));
-    g_assert_nonnull(pixbuf);
-
-    gtk_drag_set_icon_pixbuf(context, pixbuf, -2, -2);
-    g_object_unref(pixbuf);
-
+    ToolbarDragDropHelper::gdk_context_set_icon_from_image(context, icon);
     g_object_unref(icon);
 
     gtk_widget_hide(widget);

--- a/src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp
+++ b/src/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp
@@ -95,10 +95,18 @@ void ToolbarAdapter::prepareToolItem(GtkToolItem* it) {
 
     gtk_tool_item_set_use_drag_window(it, true);
 
-    GdkScreen* screen = gtk_widget_get_screen(GTK_WIDGET(it));
-    GdkCursor* cursor = gdk_cursor_new_for_display(gdk_screen_get_display(screen), GDK_HAND2);
-    gdk_window_set_cursor(gtk_widget_get_window(GTK_WIDGET(it)), cursor);
-    g_object_unref(cursor);
+    // Set cursor of drag drop to hand. Note: the tool item must be realized for
+    // this to work!
+    {
+        gtk_widget_realize(GTK_WIDGET(it));
+        GdkScreen* screen = gtk_widget_get_screen(GTK_WIDGET(it));
+        GdkCursor* cursor = gdk_cursor_new_for_display(gdk_screen_get_display(screen), GDK_HAND2);
+        g_assert_nonnull(cursor);
+        GdkWindow* window = gtk_widget_get_window(GTK_WIDGET(it));
+        g_assert_nonnull(window);
+        gdk_window_set_cursor(window, cursor);
+        g_object_unref(cursor);
+    }
 
     gtk_drag_source_set(GTK_WIDGET(it), GDK_BUTTON1_MASK, &ToolbarDragDropHelper::dropTargetEntry, 1, GDK_ACTION_MOVE);
     ToolbarDragDropHelper::dragSourceAddToolbar(GTK_WIDGET(it));
@@ -272,10 +280,9 @@ void ToolbarAdapter::toolbarDragDataReceivedCb(GtkToolbar* toolbar, GdkDragConte
         bool horizontal = gtk_orientable_get_orientation(GTK_ORIENTABLE(toolbar)) == GTK_ORIENTATION_HORIZONTAL;
         GtkToolItem* it = d->item->createItem(horizontal);
 
-        adapter->prepareToolItem(it);
-
         gtk_widget_show_all(GTK_WIDGET(it));
         gtk_toolbar_insert(toolbar, it, pos);
+        adapter->prepareToolItem(it);
 
         ToolbarData* tb = adapter->window->getSelectedToolbar();
         const char* name = adapter->window->getToolbarName(toolbar);
@@ -291,10 +298,9 @@ void ToolbarAdapter::toolbarDragDataReceivedCb(GtkToolbar* toolbar, GdkDragConte
         bool horizontal = gtk_orientable_get_orientation(GTK_ORIENTABLE(toolbar)) == GTK_ORIENTATION_HORIZONTAL;
         GtkToolItem* it = item->createItem(horizontal);
 
-        adapter->prepareToolItem(it);
-
         gtk_widget_show_all(GTK_WIDGET(it));
         gtk_toolbar_insert(toolbar, it, pos);
+        adapter->prepareToolItem(it);
 
         ToolbarData* tb = adapter->window->getSelectedToolbar();
         const char* name = adapter->window->getToolbarName(toolbar);
@@ -309,7 +315,6 @@ void ToolbarAdapter::toolbarDragDataReceivedCb(GtkToolbar* toolbar, GdkDragConte
         GtkToolItem* it = gtk_separator_tool_item_new();
         gtk_widget_show_all(GTK_WIDGET(it));
         gtk_toolbar_insert(toolbar, it, pos);
-
         adapter->prepareToolItem(it);
 
         ToolbarData* tb = adapter->window->getSelectedToolbar();

--- a/src/gui/dialog/toolbarCustomize/ToolbarCustomizeDialog.cpp
+++ b/src/gui/dialog/toolbarCustomize/ToolbarCustomizeDialog.cpp
@@ -17,11 +17,9 @@
 #include "Util.h"
 #include "i18n.h"
 
-using ToolItemDragData = struct _ToolItemDragData;
-
-struct _ToolItemDragData {
+struct ToolItemDragData {
     ToolbarCustomizeDialog* dlg;
-    GdkPixbuf* icon;
+    GtkWidget* icon;  ///< Currently must be an GtkImage
     AbstractToolItem* item;
     GtkWidget* ebox;
 };
@@ -119,7 +117,7 @@ void ToolbarCustomizeDialog::toolitemDragDataGetSeparator(GtkWidget* widget, Gdk
 void ToolbarCustomizeDialog::toolitemDragBegin(GtkWidget* widget, GdkDragContext* context, ToolItemDragData* data) {
     ToolItemDragCurrentData::setData(TOOL_ITEM_ITEM, -1, data->item);
     if (data->icon) {
-        gtk_drag_set_icon_pixbuf(context, data->icon, -2, -2);
+        ToolbarDragDropHelper::gdk_context_set_icon_from_image(context, data->icon);
     }
     gtk_widget_hide(data->ebox);
 }
@@ -274,7 +272,7 @@ void ToolbarCustomizeDialog::rebuildIconview() {
 
         ToolItemDragData* data = g_new(ToolItemDragData, 1);
         data->dlg = this;
-        data->icon = ToolbarDragDropHelper::getImagePixbuf(GTK_IMAGE(icon));
+        data->icon = GTK_WIDGET(g_object_ref(icon));
         data->item = item;
         // store reference to ebox
         data->ebox = ebox;

--- a/src/gui/dialog/toolbarCustomize/ToolbarCustomizeDialog.cpp
+++ b/src/gui/dialog/toolbarCustomize/ToolbarCustomizeDialog.cpp
@@ -91,9 +91,9 @@ ToolbarCustomizeDialog::~ToolbarCustomizeDialog() {
 void ToolbarCustomizeDialog::toolitemDragBeginSeparator(GtkWidget* widget, GdkDragContext* context, void* unused) {
     ToolItemDragCurrentData::setData(TOOL_ITEM_SEPARATOR, -1, nullptr);
 
-    GtkWidget* icon = ToolbarSeparatorImage::newSepeartorImage();
-    gtk_drag_set_icon_pixbuf(context, ToolbarDragDropHelper::getImagePixbuf(GTK_IMAGE(icon)), -2, -2);
-    g_object_unref(icon);
+    GdkPixbuf* pixbuf = ToolbarSeparatorImage::newPixbuf();
+    gtk_drag_set_icon_pixbuf(context, pixbuf, -2, -2);
+    g_object_unref(pixbuf);
 }
 
 void ToolbarCustomizeDialog::toolitemDragEndSeparator(GtkWidget* widget, GdkDragContext* context, void* unused) {
@@ -250,7 +250,7 @@ void ToolbarCustomizeDialog::rebuildIconview() {
         }
 
         string name = item->getToolDisplayName();
-        GtkWidget* icon = item->getNewToolIcon();
+        GtkWidget* icon = item->getNewToolIcon(); /* floating */
         g_return_if_fail(icon != nullptr);
 
         GtkWidget* box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 3);

--- a/src/gui/dialog/toolbarCustomize/ToolbarCustomizeDialog.cpp
+++ b/src/gui/dialog/toolbarCustomize/ToolbarCustomizeDialog.cpp
@@ -80,7 +80,10 @@ ToolbarCustomizeDialog::~ToolbarCustomizeDialog() {
     // We can only delete this list at the end, it would be better to delete this list
     // after a refresh and after drag_end is called...
     for (ToolItemDragData* data: this->itemDatalist) {
-        g_object_unref(data->icon);
+        if (data->icon != nullptr) {
+            g_object_unref(data->icon);
+        }
+        g_object_unref(data->ebox);
         g_free(data);
     }
 }
@@ -115,8 +118,9 @@ void ToolbarCustomizeDialog::toolitemDragDataGetSeparator(GtkWidget* widget, Gdk
  */
 void ToolbarCustomizeDialog::toolitemDragBegin(GtkWidget* widget, GdkDragContext* context, ToolItemDragData* data) {
     ToolItemDragCurrentData::setData(TOOL_ITEM_ITEM, -1, data->item);
-
-    gtk_drag_set_icon_pixbuf(context, data->icon, -2, -2);
+    if (data->icon) {
+        gtk_drag_set_icon_pixbuf(context, data->icon, -2, -2);
+    }
     gtk_widget_hide(data->ebox);
 }
 
@@ -272,7 +276,9 @@ void ToolbarCustomizeDialog::rebuildIconview() {
         data->dlg = this;
         data->icon = ToolbarDragDropHelper::getImagePixbuf(GTK_IMAGE(icon));
         data->item = item;
+        // store reference to ebox
         data->ebox = ebox;
+        g_object_ref(ebox);
 
         this->itemDatalist.push_front(data);
 

--- a/src/gui/dialog/toolbarCustomize/ToolbarCustomizeDialog.cpp
+++ b/src/gui/dialog/toolbarCustomize/ToolbarCustomizeDialog.cpp
@@ -154,7 +154,7 @@ void ToolbarCustomizeDialog::toolitemColorDragBegin(GtkWidget* widget, GdkDragCo
     Color color = GPOINTER_TO_UINT(data);
     ToolItemDragCurrentData::setDataColor(-1, color);
 
-    GdkPixbuf* image = ColorSelectImage::newColorIconPixbuf(color, 32, true);
+    GdkPixbuf* image = ColorSelectImage::newColorIconPixbuf(color, 16, true);
 
     gtk_drag_set_icon_pixbuf(context, image, -2, -2);
 

--- a/src/gui/dialog/toolbarCustomize/ToolbarCustomizeDialog.cpp
+++ b/src/gui/dialog/toolbarCustomize/ToolbarCustomizeDialog.cpp
@@ -31,7 +31,6 @@ ToolbarCustomizeDialog::ToolbarCustomizeDialog(GladeSearchpath* gladeSearchPath,
         GladeGui(gladeSearchPath, "toolbarCustomizeDialog.glade", "DialogCustomizeToolbar") {
     this->win = win;
     this->handler = handler;
-    this->colorList = new CustomizeableColorList();
 
     rebuildIconview();
     rebuildColorIcons();
@@ -84,9 +83,6 @@ ToolbarCustomizeDialog::~ToolbarCustomizeDialog() {
         g_object_unref(data->icon);
         g_free(data);
     }
-
-    delete this->colorList;
-    this->colorList = nullptr;
 }
 
 void ToolbarCustomizeDialog::toolitemDragBeginSeparator(GtkWidget* widget, GdkDragContext* context, void* unused) {
@@ -285,8 +281,8 @@ void ToolbarCustomizeDialog::rebuildIconview() {
 
         g_signal_connect(ebox, "drag-data-get", G_CALLBACK(toolitemDragDataGet), data);
 
-        int x = i % 3;
-        int y = i / 3;
+        const int x = i % 3;
+        const int y = i / 3;
         gtk_grid_attach(table, ebox, x, y, 1, 1);
 
         i++;
@@ -317,17 +313,17 @@ void ToolbarCustomizeDialog::rebuildColorIcons() {
     ToolMenuHandler* tmh = this->win->getToolMenuHandler();
 
     int i = 0;
-    for (XojColor* color: *this->colorList->getPredefinedColors()) {
-        if (tmh->isColorInUse(color->getColor())) {
+    for (const XojColor& color: this->colorList.getPredefinedColors()) {
+        if (tmh->isColorInUse(color.getColor())) {
             continue;
         }
 
-        GtkWidget* icon = ColorSelectImage::newColorIcon(color->getColor(), 16, true);
+        GtkWidget* icon = ColorSelectImage::newColorIcon(color.getColor(), 16, true);
 
         GtkWidget* box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 3);
         gtk_widget_show(box);
 
-        GtkWidget* label = gtk_label_new(color->getName().c_str());
+        GtkWidget* label = gtk_label_new(color.getName().c_str());
         gtk_widget_show(label);
         gtk_box_pack_end(GTK_BOX(box), label, false, false, 0);
 
@@ -343,10 +339,10 @@ void ToolbarCustomizeDialog::rebuildColorIcons() {
         gtk_drag_source_set(ebox, GDK_BUTTON1_MASK, &ToolbarDragDropHelper::dropTargetEntry, 1, GDK_ACTION_MOVE);
         ToolbarDragDropHelper::dragSourceAddToolbar(ebox);
 
-        g_signal_connect(ebox, "drag-begin", G_CALLBACK(toolitemColorDragBegin), GUINT_TO_POINTER(color->getColor()));
+        g_signal_connect(ebox, "drag-begin", G_CALLBACK(toolitemColorDragBegin), GUINT_TO_POINTER(color.getColor()));
         g_signal_connect(ebox, "drag-end", G_CALLBACK(toolitemColorDragEnd), this);
         g_signal_connect(ebox, "drag-data-get", G_CALLBACK(toolitemColorDragDataGet),
-                         GUINT_TO_POINTER(color->getColor()));
+                         GUINT_TO_POINTER(color.getColor()));
 
         int x = i % 5;
         int y = i / 5;

--- a/src/gui/dialog/toolbarCustomize/ToolbarCustomizeDialog.h
+++ b/src/gui/dialog/toolbarCustomize/ToolbarCustomizeDialog.h
@@ -68,7 +68,7 @@ private:
     static void windowResponseCb(GtkDialog* dialog, int response, ToolbarCustomizeDialog* dlg);
 
 private:
-    CustomizeableColorList* colorList;
+    CustomizeableColorList colorList;
 
     std::list<ToolItemDragData*> itemDatalist;
 

--- a/src/gui/dialog/toolbarCustomize/ToolbarCustomizeDialog.h
+++ b/src/gui/dialog/toolbarCustomize/ToolbarCustomizeDialog.h
@@ -24,8 +24,7 @@ class AbstractToolItem;
 class MainWindow;
 class ToolbarDragDropHandler;
 
-typedef struct _ToolItemDragData ToolItemDragData;
-struct _ToolItemDragData;
+struct ToolItemDragData;
 
 class ToolbarCustomizeDialog: public GladeGui {
 public:

--- a/src/gui/dialog/toolbarCustomize/ToolbarDragDropHelper.cpp
+++ b/src/gui/dialog/toolbarCustomize/ToolbarDragDropHelper.cpp
@@ -1,16 +1,14 @@
 #include "ToolbarDragDropHelper.h"
 
-GdkAtom ToolbarDragDropHelper::atomToolItem = gdk_atom_intern_static_string("application/xournal-ToolbarItem");
-GtkTargetEntry ToolbarDragDropHelper::dropTargetEntry = {const_cast<char*>("move-buffer"), GTK_TARGET_SAME_APP, 1};
+namespace ToolbarDragDropHelper {
 
-ToolbarDragDropHelper::ToolbarDragDropHelper() = default;
-
-ToolbarDragDropHelper::~ToolbarDragDropHelper() = default;
+const GdkAtom atomToolItem = gdk_atom_intern_static_string("application/xournal-ToolbarItem");
+const GtkTargetEntry dropTargetEntry = {const_cast<char*>("move-buffer"), GTK_TARGET_SAME_APP, 1};
 
 /**
  * Get a GDK Pixbuf from GTK widget image
  */
-auto ToolbarDragDropHelper::getImagePixbuf(GtkImage* image) -> GdkPixbuf* {
+auto getImagePixbuf(GtkImage* image) -> GdkPixbuf* {
     switch (gtk_image_get_storage_type(image)) {
         case GTK_IMAGE_PIXBUF:
             return static_cast<GdkPixbuf*>(g_object_ref(gtk_image_get_pixbuf(image)));
@@ -28,7 +26,7 @@ auto ToolbarDragDropHelper::getImagePixbuf(GtkImage* image) -> GdkPixbuf* {
     }
 }
 
-void ToolbarDragDropHelper::dragDestAddToolbar(GtkWidget* target) {
+void dragDestAddToolbar(GtkWidget* target) {
     GtkTargetList* targetList = gtk_drag_dest_get_target_list(target);
     if (targetList) {
         gtk_target_list_ref(targetList);
@@ -45,7 +43,7 @@ void ToolbarDragDropHelper::dragDestAddToolbar(GtkWidget* target) {
     gtk_target_list_unref(targetList);
 }
 
-void ToolbarDragDropHelper::dragSourceAddToolbar(GtkWidget* widget) {
+void dragSourceAddToolbar(GtkWidget* widget) {
     GtkTargetList* targetList = gtk_drag_source_get_target_list(widget);
     if (targetList) {
         // List contains already this type
@@ -61,3 +59,4 @@ void ToolbarDragDropHelper::dragSourceAddToolbar(GtkWidget* widget) {
     gtk_drag_source_set_target_list(widget, targetList);
     gtk_target_list_unref(targetList);
 }
+}  // namespace ToolbarDragDropHelper

--- a/src/gui/dialog/toolbarCustomize/ToolbarDragDropHelper.h
+++ b/src/gui/dialog/toolbarCustomize/ToolbarDragDropHelper.h
@@ -17,7 +17,7 @@ namespace ToolbarDragDropHelper {
 void dragDestAddToolbar(GtkWidget* target);
 void dragSourceAddToolbar(GtkWidget* widget);
 
-GdkPixbuf* getImagePixbuf(GtkImage* image);
+auto gdk_context_set_icon_from_image(GdkDragContext* ctx, GtkWidget* image) -> bool;
 
 extern const GdkAtom atomToolItem;
 extern const GtkTargetEntry dropTargetEntry;

--- a/src/gui/dialog/toolbarCustomize/ToolbarDragDropHelper.h
+++ b/src/gui/dialog/toolbarCustomize/ToolbarDragDropHelper.h
@@ -13,18 +13,12 @@
 
 #include <gtk/gtk.h>
 
-class ToolbarDragDropHelper {
-private:
-    ToolbarDragDropHelper();
-    virtual ~ToolbarDragDropHelper();
+namespace ToolbarDragDropHelper {
+void dragDestAddToolbar(GtkWidget* target);
+void dragSourceAddToolbar(GtkWidget* widget);
 
-public:
-    static void dragDestAddToolbar(GtkWidget* target);
-    static void dragSourceAddToolbar(GtkWidget* widget);
+GdkPixbuf* getImagePixbuf(GtkImage* image);
 
-    static GdkPixbuf* getImagePixbuf(GtkImage* image);
-
-public:
-    static GdkAtom atomToolItem;
-    static GtkTargetEntry dropTargetEntry;
-};
+extern const GdkAtom atomToolItem;
+extern const GtkTargetEntry dropTargetEntry;
+};  // namespace ToolbarDragDropHelper

--- a/src/gui/toolbarMenubar/AbstractToolItem.h
+++ b/src/gui/toolbarMenubar/AbstractToolItem.h
@@ -30,6 +30,10 @@ public:
     static void toolButtonCallback(GtkToolButton* toolbutton, AbstractToolItem* item);
 
     virtual string getToolDisplayName() = 0;
+
+    /**
+     * Returns: (transfer floating)
+     */
     virtual GtkWidget* getNewToolIcon() = 0;
 
     /**

--- a/src/gui/toolbarMenubar/icon/ToolbarSeparatorImage.cpp
+++ b/src/gui/toolbarMenubar/icon/ToolbarSeparatorImage.cpp
@@ -1,17 +1,25 @@
 #include "ToolbarSeparatorImage.h"
 
-auto ToolbarSeparatorImage::newSepeartorImage() -> GtkWidget* {
-    cairo_surface_t* crImage = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, 30, 30);
+auto ToolbarSeparatorImage::newPixbuf() -> GdkPixbuf* {
+    constexpr auto width = 30;
+    constexpr auto height = 30;
+    cairo_surface_t* crImage = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
     cairo_t* cr = cairo_create(crImage);
 
     cairo_set_source_rgb(cr, 255, 0, 0);
     cairo_set_line_width(cr, 5);
-    cairo_move_to(cr, 15, 0);
-    cairo_line_to(cr, 15, 30);
+    cairo_move_to(cr, width / 2, 0);
+    cairo_line_to(cr, width / 2, height);
     cairo_stroke(cr);
     cairo_destroy(cr);
-
-    GtkWidget* w = gtk_image_new_from_surface(crImage);
+    GdkPixbuf* pixbuf = gdk_pixbuf_get_from_surface(crImage, 0, 0, width, height);
     cairo_surface_destroy(crImage);
+    return pixbuf;
+}
+
+auto ToolbarSeparatorImage::newImage() -> GtkWidget* {
+    GdkPixbuf* pixbuf = ToolbarSeparatorImage::newPixbuf();
+    GtkWidget* w = gtk_image_new_from_pixbuf(pixbuf);
+    g_object_unref(pixbuf);
     return w;
 }

--- a/src/gui/toolbarMenubar/icon/ToolbarSeparatorImage.h
+++ b/src/gui/toolbarMenubar/icon/ToolbarSeparatorImage.h
@@ -16,11 +16,14 @@
 /**
  * Menuitem handler
  */
-class ToolbarSeparatorImage {
-private:
-    ToolbarSeparatorImage();
-    virtual ~ToolbarSeparatorImage();
+namespace ToolbarSeparatorImage {
+/**
+ * Returns: (transfer full)
+ */
+GdkPixbuf* newPixbuf();
 
-public:
-    static GtkWidget* newSepeartorImage();
-};
+/**
+ * Returns: (transfer floating)
+ */
+GtkWidget* newImage();
+}  // namespace ToolbarSeparatorImage

--- a/src/gui/toolbarMenubar/model/ToolbarEntry.cpp
+++ b/src/gui/toolbarMenubar/model/ToolbarEntry.cpp
@@ -1,18 +1,28 @@
 #include "ToolbarEntry.h"
 
+#include <algorithm>
 #include <utility>
 
 ToolbarEntry::ToolbarEntry() = default;
 
 ToolbarEntry::ToolbarEntry(const ToolbarEntry& e) { *this = e; }
+ToolbarEntry::ToolbarEntry(ToolbarEntry&& e) { *this = std::move(e); }
 
-void ToolbarEntry::operator=(const ToolbarEntry& e) {
+ToolbarEntry& ToolbarEntry::operator=(const ToolbarEntry& e) {
     this->name = e.name;
-    clearList();
-
+    std::vector<ToolbarItem*> entries;
     for (ToolbarItem* item: e.entries) {
         entries.push_back(new ToolbarItem(*item));
     }
+    clearList();
+    this->entries = std::move(entries);
+    return *this;
+}
+
+ToolbarEntry& ToolbarEntry::operator=(ToolbarEntry&& e) {
+    this->name = std::move(e.name);
+    std::swap(this->entries, e.entries);
+    return *this;
 }
 
 ToolbarEntry::~ToolbarEntry() { clearList(); }
@@ -36,11 +46,10 @@ auto ToolbarEntry::addItem(string item) -> int {
 }
 
 auto ToolbarEntry::removeItemById(int id) -> bool {
-    for (unsigned int i = 0; i < this->entries.size(); i++) {
-        if (this->entries[i]->getId() == id) {
-            delete this->entries[i];
-            entries[i] = nullptr;
-            entries.erase(entries.begin() + i);
+    for (auto it = this->entries.begin(); it != this->entries.end(); it++) {
+        if ((*it)->getId() == id) {
+            delete *it;
+            this->entries.erase(it);
             return true;
         }
     }

--- a/src/gui/toolbarMenubar/model/ToolbarEntry.h
+++ b/src/gui/toolbarMenubar/model/ToolbarEntry.h
@@ -19,9 +19,11 @@ class ToolbarEntry {
 public:
     ToolbarEntry();
     ToolbarEntry(const ToolbarEntry& e);
+    ToolbarEntry(ToolbarEntry&& e);
     ~ToolbarEntry();
 
-    void operator=(const ToolbarEntry& e);
+    ToolbarEntry& operator=(const ToolbarEntry& e);
+    ToolbarEntry& operator=(ToolbarEntry&& e);
 
 public:
     void clearList();

--- a/src/gui/toolbarMenubar/model/ToolbarItem.cpp
+++ b/src/gui/toolbarMenubar/model/ToolbarItem.cpp
@@ -13,19 +13,12 @@ ToolbarItem::ToolbarItem(string name) {
     }
 }
 
-ToolbarItem::ToolbarItem(const ToolbarItem& item) {
-    this->id = item.id;
-    this->name = item.name;
-}
-
 ToolbarItem::ToolbarItem() {
     this->name = "";
     this->id = -100;
 }
 
-ToolbarItem::~ToolbarItem() = default;
-
-auto ToolbarItem::getName() -> string { return this->name; }
+auto ToolbarItem::getName() const -> const std::string& { return this->name; }
 
 auto ToolbarItem::operator==(ToolbarItem& other) -> bool { return this->name == other.name; }
 

--- a/src/gui/toolbarMenubar/model/ToolbarItem.h
+++ b/src/gui/toolbarMenubar/model/ToolbarItem.h
@@ -19,15 +19,10 @@
 class ToolbarItem {
 public:
     ToolbarItem(string name);
-    ToolbarItem(const ToolbarItem& item);
     ToolbarItem();
-    virtual ~ToolbarItem();
-
-private:
-    void operator=(const ToolbarItem& other);
 
 public:
-    string getName();
+    const std::string& getName() const;
 
     bool operator==(ToolbarItem& other);
 


### PR DESCRIPTION
This PR fixes multiple memory allocation bugs in the toolbar customizer.
* Fix double free when closing toolbar customization dialog.
* Fix separator icon not being rendered correctly when dragging to the toolbar.
* Fix errors involving the tool icons being left as floating references
* Refactor some of the toolbar customization code

There is a still a lingering issue where dragging & dropping a toolbar item may occasionally not trigger a redraw of the customization dialog.