### PR TITLE
update msys2 to get cairo 1.17.4-2

### DIFF
--- a/azure-pipelines/steps/build_windows.yml
+++ b/azure-pipelines/steps/build_windows.yml
@@ -8,6 +8,7 @@ steps:
   # Copy of msys2-blob as a temporary fix for Windows CI
   - script: |
       set PATH=C:\msys64\usr\bin;C:\msys64\mingw64\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem
+      pacman --noconfirm -Sy
       pacman --noconfirm -S mingw-w64-x86_64-imagemagick mingw-w64-x86_64-ninja mingw-w64-x86_64-cppunit mingw-w64-x86_64-poppler mingw-w64-x86_64-gtk3 mingw-w64-x86_64-libsndfile mingw-w64-x86_64-libzip mingw-w64-x86_64-lua
     env:
       MSYS2_ARCH: x86_64


### PR DESCRIPTION
Fixes #2601 by updating MSYS2 to include mingw-w64-x86_64-cairo-1.17.4-2 instead of mingw-w64-x86_64-cairo-1.17.4-1.

I just checked running the msys2-blob to check if the Cairo version gets really bumped to 1.17.4-2 (it does). 

**Edit:** The continuos integration pipeline shows the same result. The downside is, that it take about 15 minutes longer to build on Windows.

**Edit2:** I now replaced `pacman -Syuu` (twice) by `pacman -Sy` (once) to only update the package index without a full system upgrade.