### PR TITLE
added shortcut for default tool

### DIFF
--- a/ui/main.glade
+++ b/ui/main.glade
@@ -1377,6 +1377,7 @@
                             <property name="label" translatable="yes">_Default Tools</property>
                             <property name="use-underline">True</property>
                             <signal name="activate" handler="ACTION_TOOL_DEFAULT" swapped="no"/>
+                            <accelerator key="d" signal="activate" modifiers="GDK_SHIFT_MASK | GDK_CONTROL_MASK"/>
                           </object>
                         </child>
                         <child>


### PR DESCRIPTION
Fixes #2754.
Added shortcut "Ctrl+Shift+D" for the default tool, which makes it accessible by keyboard.

I know that it's also possible to write a plugin for it, but imo this makes the UI more consistent since the majority of other tools(pen, eraser, etc) also have shortcuts, and if the default tool is considered important/popular it should have a built-in shortcut as well.

The only other main tools left that don't have shortcuts are: "Play Object" and "Record/Stop".