### PR TITLE
Daily snapshot release for Fedora

### DIFF
--- a/rpm/fedora/xournalpp.spec
+++ b/rpm/fedora/xournalpp.spec
@@ -1,11 +1,17 @@
+# This spec file is intended for a daily git snapshot
+
+# Force out of source build
+%undefine __cmake_in_source_build
+
+#This spec file is intended for daily development snapshot release
 %global	build_repo https://github.com/xournalpp/xournalpp/
 %global	build_branch master
-%global	version_string 1.0.17
+%global	version_string 1.1.0
 %define	build_commit %(git ls-remote %{build_repo} | grep "refs/heads/%{build_branch}" | cut -c1-41)
 %define	build_shortcommit %(c=%{build_commit}; echo ${c:0:7})
 %global	build_timestamp %(date +"%Y%m%d")
 %global	rel_build %{build_timestamp}git%{build_shortcommit}%{?dist}
-%global         _with_cppunit 1
+%bcond_without  cppunit
 
 
 Name:           xournalpp
@@ -17,23 +23,25 @@ License:        GPLv2+
 URL:            https://github.com/%{name}/%{name}
 Source:         %{url}/archive/%{build_branch}.tar.gz
 
-BuildRequires:  cmake3 >= 3.10
+BuildRequires:  cmake >= 3.10
 BuildRequires:  desktop-file-utils
 BuildRequires:  gcc-c++
 BuildRequires:  gettext
 BuildRequires:  git
 BuildRequires:  libappstream-glib
-%{?_with_cppunit:
+%if %{with cppunit}
 BuildRequires:  pkgconfig(cppunit) >= 1.12-0
-}
-BuildRequires:  pkgconfig(glib-2.0)
-BuildRequires:  pkgconfig(gtk+-3.0)
-BuildRequires:  pkgconfig(libxml-2.0)
-BuildRequires:  pkgconfig(libzip)
-BuildRequires:  pkgconfig(lua)
-BuildRequires:  pkgconfig(poppler-glib)
+%endif
+BuildRequires:  pkgconfig(glib-2.0) >= 2.32.0
+BuildRequires:  pkgconfig(gtk+-3.0) >= 3.18.9
+BuildRequires:  pkgconfig(librsvg-2.0)
+BuildRequires:  pkgconfig(libxml-2.0) >= 2.0.0
+BuildRequires:  pkgconfig(libzip) >= 1.0.1
+BuildRequires:  pkgconfig(lua) >= 5.3
+BuildRequires:  pkgconfig(poppler-glib) >= 0.41.0
 BuildRequires:  pkgconfig(portaudiocpp) >= 12
-BuildRequires:  pkgconfig(sndfile)
+BuildRequires:  pkgconfig(sndfile) >= 1.0.25
+BuildRequires:	pkgconfig(zlib)
 Recommends:     texlive-scheme-basic
 Recommends:     texlive-dvipng
 Recommends:     texlive-standalone
@@ -68,13 +76,14 @@ mv po/tlh_AA.po po/tlh.po
 sed -i 's|tlh-AA|tlh|g' po/tlh.po
 
 %build
-%cmake3 \
-        %{_with_cppunit: -DENABLE_CPPUNIT=ON} \
-        .
-%make_build translations
+%cmake \
+        %if %{with cppunit}
+         -DENABLE_CPPUNIT=ON
+        %endif
+%cmake_build
 
 %install
-%make_install
+%cmake_install
 
 #Remove depreciated key from desktop file
 desktop-file-install \
@@ -103,6 +112,7 @@ appstream-util validate-relax --nonet %{buildroot}%{_metainfodir}/com.github.%{n
 %exclude %{_datadir}/mimelnk/application/*
 %{_datadir}/thumbnailers/com.github.%{name}.%{name}.thumbnailer
 %dir %{_datadir}/%{name}
+%{_datadir}/%{name}/resources/default_template.tex
 %{_metainfodir}/com.github.%{name}.%{name}.appdata.xml
 
 %files plugins
@@ -112,47 +122,9 @@ appstream-util validate-relax --nonet %{buildroot}%{_metainfodir}/com.github.%{n
 %{_datadir}/%{name}/ui
 
 %changelog
+* Sat Feb 20 2021 Luya Tshimbalanga <luya@fedoraproject.org>
+- Add librsvg2 dependencies
+- Add notice about daily git snapshot
+
 * Mon Dec 16 2019 Luya Tshimbalanga <luya@fedoraproject.org>
 - Implement some version autodetection to reduce maintenance work.
-
-* Mon Dec 16 2019 Luya Tshimbalanga <luya@fedoraproject.org> - 1.0.16-7
-- Remove architecture requirement for plugins and ui
-
-* Mon Dec 16 2019 Luya Tshimbalanga <luya@fedoraproject.org> - 1.0.16-6
-- Fix typos
-
-* Mon Dec 16 2019 Luya Tshimbalanga <luya@fedoraproject.org> - 1.0.16-5
-- Fix architecture requirement for ui
-
-* Wed Dec 11 2019 Luya Tshimbalanga <luya@fedoraproject.org> - 1.0.16-4
-- Review fixes
-
-* Wed Dec 11 2019 Luya Tshimbalanga <luya@fedoraproject.org> - 1.0.16-3
-- Add hicolor-icon-theme to requirement
-- Use desktop file validation
-- Split xournal data share into subpackages
-- Review fixes
-
-* Sun Nov 17 2019 Luya Tshimbalanga <luya@fedoraproject.org> 1.0.16-2
-- Remove scripts from ui icons directory
-- Relocate tlh locale directory
-
-* Sun Nov 17 2019 Luya Tshimbalanga <luya@fedoraproject.org> 1.0.16-1
-- Release 1.0.16
-- Enable cppunit
-
-* Sun Nov 10 2019 Luya Tshimbalanga <luya@fedoraproject.org> 1.0.15-2
-- Update spec file based on review
-- Include appstream data
-
-* Sun Nov 10 2019 Luya Tshimbalanga <luya@fedoraproject.org> 1.0.15-1
-- Release 1.0.15
-
-* Tue Aug 13 2019 dfas <d.dfas@moens.cc> - 1.0.13-2.git7349762
-- Release 1.0.13-current
-
-* Tue Jun 25 2019 dfas <d.dfas@moens.cc> - 1.0.13-1.gita7f0275
-- Release 1.0.13-current
-
-* Fri May 3 2019 Francisco Gonzalez <gzmorell@gmail.com> - 1.0.10-1
-- First attempt at packaging xournalpp.


### PR DESCRIPTION
This spec file is set for daily snapshot with very minimal maintenance. The comment is added to describe the purpose. The benefit is bringing more Fedora testers to find possible bugs and test improvement. The only change is `version_string` set for development release i.e. 1.1.0.