### PR TITLE
Fade all annotations without audio when clicking play object

### DIFF
--- a/src/model/AudioElement.h
+++ b/src/model/AudioElement.h
@@ -35,6 +35,7 @@ public:
 
     virtual bool intersects(double x, double y, double halfSize) = 0;
     virtual bool intersects(double x, double y, double halfSize, double* gap) = 0;
+    static const uint8_t opacityNoAudio = 50;
 
 protected:
     void serializeAudioElement(ObjectOutputStream& out);

--- a/src/view/DocumentView.cpp
+++ b/src/view/DocumentView.cpp
@@ -57,7 +57,7 @@ void DocumentView::drawStroke(cairo_t* cr, Stroke* s, int startPoint, double sca
     sv.paint(this->dontRenderEditingStroke);
 }
 
-void DocumentView::drawText(cairo_t* cr, Text* t) {
+void DocumentView::drawText(cairo_t* cr, Text* t) const{
     cairo_matrix_t defaultMatrix = {0};
     cairo_get_matrix(cr, &defaultMatrix);
     if (t->isInEditing()) {
@@ -65,13 +65,18 @@ void DocumentView::drawText(cairo_t* cr, Text* t) {
     }
 
     cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
-    applyColor(cr, t);
+    if(this->markAudioStroke && t->getAudioFilename().length() == 0){
+        applyColor(cr, t, AudioElement::opacityNoAudio);
+    }
+    else{
+        applyColor(cr, t);
+    }
 
     TextView::drawText(cr, t);
     cairo_set_matrix(cr, &defaultMatrix);
 }
 
-void DocumentView::drawImage(cairo_t* cr, Image* i) {
+void DocumentView::drawImage(cairo_t* cr, Image* i) const {
     cairo_matrix_t defaultMatrix = {0};
     cairo_get_matrix(cr, &defaultMatrix);
 
@@ -87,7 +92,11 @@ void DocumentView::drawImage(cairo_t* cr, Image* i) {
     cairo_scale(cr, xFactor, yFactor);
 
     cairo_set_source_surface(cr, img, i->getX() / xFactor, i->getY() / yFactor);
-    cairo_paint(cr);
+    if(this->markAudioStroke){
+        cairo_paint_with_alpha(cr, AudioElement::opacityNoAudio / 255.0);
+    } else{
+        cairo_paint(cr);
+    }
 
     cairo_set_matrix(cr, &defaultMatrix);
 }

--- a/src/view/DocumentView.h
+++ b/src/view/DocumentView.h
@@ -98,8 +98,8 @@ public:
     void finializeDrawing();
 
 private:
-    static void drawText(cairo_t* cr, Text* t);
-    static void drawImage(cairo_t* cr, Image* i);
+    void drawText(cairo_t* cr, Text* t) const;
+    void drawImage(cairo_t* cr, Image* i) const;
     static void drawTexImage(cairo_t* cr, TexImage* texImage);
 
     void drawElement(cairo_t* cr, Element* e) const;

--- a/src/view/StrokeView.cpp
+++ b/src/view/StrokeView.cpp
@@ -45,23 +45,27 @@ void StrokeView::changeCairoSource(bool markAudioStroke) {
     if (s->getFill() != -1 && s->getToolType() != STROKE_TOOL_HIGHLIGHTER) {
         cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
 
-        // Set the color and opacity
-        DocumentView::applyColor(cr, s, s->getFill());
+        if (markAudioStroke && s->getAudioFilename().length() == 0) {
+            DocumentView::applyColor(cr, s, AudioElement::opacityNoAudio);
+        } else {
+            // Set the color and opacity
+            DocumentView::applyColor(cr, s, (uint8_t) s->getFill());
+        }
 
         drawFillStroke();
     }
 
 
-    if (s->getToolType() == STROKE_TOOL_HIGHLIGHTER || (s->getAudioFilename().length() == 0 && markAudioStroke)) {
-        if (s->getToolType() == STROKE_TOOL_HIGHLIGHTER) {
+    if (markAudioStroke && s->getAudioFilename().length() == 0) {
+        cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
+        DocumentView::applyColor(cr, s, AudioElement::opacityNoAudio);
+    }
+    else if (s->getToolType() == STROKE_TOOL_HIGHLIGHTER) {
             cairo_set_operator(cr, CAIRO_OPERATOR_MULTIPLY);
-        } else {
-            cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
-        }
-
-        // Set the color
-        DocumentView::applyColor(cr, s, 120);
-    } else {
+            // Set the color
+            DocumentView::applyColor(cr, s, 120);
+    }
+    else {
         cairo_set_operator(cr, CAIRO_OPERATOR_SOURCE);
         // Set the color
         DocumentView::applyColor(cr, s);


### PR DESCRIPTION
If you record audio selectively, when you click on the `Play Object` tool, you have to essentially click on random objects until you find one with audio.

This commit fades (alpha=50/255) all of the annotations that don't have audio whenever `Play Object` tool is enabled, making it easier to find the objects with audio. Annotations revert to full opacity once another tool is chosen.

**Regular page:**

![image](https://user-images.githubusercontent.com/39338488/109107199-4f0e3000-76ff-11eb-92e6-ea0dcb3b3370.png)

**`Play object` is turned on**:

![image](https://user-images.githubusercontent.com/39338488/109107324-811f9200-76ff-11eb-8c33-c7b8f750144c.png)

Only the bright green text on the left, and the shapes on the right have related audio.

Notes that don't require any action:
* Images are not AudioElements, therefore they are currently always faded.
* Highlights are also always faded. This is because it doesn't seem like they ever store audio information.
* I think both of the above are by *current* design.

Notes that may require action:
* TexImages are currently always opaque. I couldn't find how to make the Tex translucent too since i'm not too familiar with how poppler works, would appreciate some pointers. While not necessary, would be great to get them translucent too when the tool is activated.