### PR TITLE
add StartupWMClass to desktop file

### DIFF
--- a/desktop/com.github.xournalpp.xournalpp.desktop
+++ b/desktop/com.github.xournalpp.xournalpp.desktop
@@ -20,6 +20,7 @@ Name[ru]=Xournal++
 Comment[ru]=Делайте рукописные заметки
 
 Exec=xournalpp %f
+StartupWMClass=xournalpp
 Terminal=false
 StartupNotify=true
 MimeType=application/x-xoj;application/x-xojpp;application/x-xopp;application/x-xopt;application/pdf;


### PR DESCRIPTION
Fixes #1791

Under Ubuntu (20.10) the StartupWMClass is also needed to avoid duplication of the icon in the dock and to add a running Xournal++ to the favorites.