### PR TITLE
Fix Backup on Save Mechanism

### DIFF
--- a/src/control/jobs/SaveJob.cpp
+++ b/src/control/jobs/SaveJob.cpp
@@ -90,17 +90,19 @@ auto SaveJob::save() -> bool {
     fs::path const filepath = doc->getFilepath();
     doc->unlock();
 
+    auto const target = fs::path{filepath}.replace_extension(".xopp");
+
     if (doc->shouldCreateBackupOnSave()) {
         try {
-            Util::safeRenameFile(filepath, fs::path{filepath} += "~");
+            // Note: The backup must be created for the target as this is the filepath
+            // which will be written to. Do not use the `filepath` variable!
+            Util::safeRenameFile(target, fs::path{target} += "~");
         } catch (fs::filesystem_error const& fe) {
             g_warning("Could not create backup! Failed with %s", fe.what());
             return false;
         }
         doc->setCreateBackupOnSave(false);
     }
-
-    auto const target = fs::path{filepath}.replace_extension(".xopp");
 
     doc->lock();
     h.saveTo(target, this->control);


### PR DESCRIPTION
This PR fixes #2883

After the fix:
Backup will be created for the filepath that will be written to while saving.
Note backup here means aka. moving to `filename` + `~`.

Before the fix this was not always the case as non `.xopp` extensions where overwritten to `.xopp` upon saving, but only after the backup was already created for to original filepath.