### PR TITLE
Dropped support for macOS 10.13 High Sierra

### DIFF
--- a/azure-pipelines/continuous-integration.yml
+++ b/azure-pipelines/continuous-integration.yml
@@ -60,7 +60,7 @@ stages:
           - template: steps/build_mac.yml
             parameters:
               build_type: 'Debug'
-              cmake_flags: '-DCMAKE_DEBUG_INCLUDES_LDFLAGS=ON -DENABLE_CPPUNIT=ON -DDEBUG_COMPILE=ON -DCMAKE_OSX_DEPLOYMENT_TARGET=10.13'
+              cmake_flags: '-DCMAKE_DEBUG_INCLUDES_LDFLAGS=ON -DENABLE_CPPUNIT=ON -DDEBUG_COMPILE=ON'
           - bash: |
               export PATH="$HOME/.local/bin:/Users/git-bin/gtk/inst/bin:$PATH"
               install_name_tool -add_rpath /Users/git-bin/gtk/inst/lib/. test/test-loadHandler

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -110,7 +110,6 @@ stages:
           - template: steps/build_mac.yml
             parameters:
               build_type: 'RelWithDebInfo'
-              cmake_flags: '-DCMAKE_OSX_DEPLOYMENT_TARGET=10.13'
           - bash: |
               export PATH="$HOME/.local/bin:/Users/git-bin/gtk/inst/bin:$PATH"
               ./build-app.sh /Users/git-bin/gtk


### PR DESCRIPTION
 - macOS 10.13 High Sierra is EOL
 - it prevented progress, regarding many c++17 features
 - c++20 is released and c++23 knocks on the door