### PR TITLE
Fix panning speed when selection is on the edge of the screen

### DIFF
--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -54,6 +54,9 @@ void Settings::loadDefault() {
 
     this->numPairsOffset = 1;
 
+    this->edgePanSpeed = 20.0;
+    this->edgePanMaxMult = 5.0;
+
     this->zoomStep = 10.0;
     this->zoomStepScroll = 2.0;
 
@@ -334,6 +337,10 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur) {
         this->lastOpenPath = fs::u8path(reinterpret_cast<const char*>(value));
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("lastImagePath")) == 0) {
         this->lastImagePath = fs::u8path(reinterpret_cast<const char*>(value));
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("edgePanSpeed")) == 0) {
+        this->edgePanSpeed = tempg_ascii_strtod(reinterpret_cast<const char*>(value), nullptr);
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("edgePanMaxMult")) == 0) {
+        this->edgePanMaxMult = tempg_ascii_strtod(reinterpret_cast<const char*>(value), nullptr);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("zoomStep")) == 0) {
         this->zoomStep = tempg_ascii_strtod(reinterpret_cast<const char*>(value), nullptr);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("zoomStepScroll")) == 0) {
@@ -803,6 +810,8 @@ void Settings::save() {
     SAVE_STRING_PROP(lastOpenPath);
     SAVE_STRING_PROP(lastImagePath);
 
+    SAVE_DOUBLE_PROP(edgePanSpeed);
+    SAVE_DOUBLE_PROP(edgePanMaxMult);
     SAVE_DOUBLE_PROP(zoomStep);
     SAVE_DOUBLE_PROP(zoomStepScroll);
     SAVE_INT_PROP(displayDpi);
@@ -1550,6 +1559,26 @@ void Settings::setZoomStepScroll(double zoomStepScroll) {
 }
 
 auto Settings::getZoomStepScroll() const -> double { return this->zoomStepScroll; }
+
+void Settings::setEdgePanSpeed(double speed) {
+    if (this->edgePanSpeed == speed) {
+        return;
+    }
+    this->edgePanSpeed = speed;
+    save();
+}
+
+auto Settings::getEdgePanSpeed() const -> double { return this->edgePanSpeed; }
+
+void Settings::setEdgePanMaxMult(double maxMult) {
+    if (this->edgePanMaxMult == maxMult) {
+        return;
+    }
+    this->edgePanMaxMult = maxMult;
+    save();
+}
+
+auto Settings::getEdgePanMaxMult() const -> double { return this->edgePanMaxMult; }
 
 void Settings::setDisplayDpi(int dpi) {
     if (this->displayDpi == dpi) {

--- a/src/control/settings/Settings.h
+++ b/src/control/settings/Settings.h
@@ -142,6 +142,12 @@ public:
     void setSelectedToolbar(const std::string& name);
     std::string const& getSelectedToolbar() const;
 
+    void setEdgePanSpeed(double speed);
+    double getEdgePanSpeed() const;
+
+    void setEdgePanMaxMult(double mult);
+    double getEdgePanMaxMult() const;
+
     /**
      * Set the Zoomstep for one step in percent
      */
@@ -657,6 +663,18 @@ private:
      * The last used font
      */
     XojFont font;
+
+    /**
+     * Base speed (as a percentage of visible canvas) of edge pan per
+     * second
+     */
+    double edgePanSpeed{};
+
+    /**
+     * Maximum multiplier of edge pan speed due to proportion of selection out
+     * of view
+     */
+    double edgePanMaxMult{};
 
     /**
      * Zoomstep for one step

--- a/src/control/tools/EditSelection.cpp
+++ b/src/control/tools/EditSelection.cpp
@@ -740,6 +740,7 @@ bool EditSelection::handleEdgePan(EditSelection* self) {
 
 
     Layout* layout = gtk_xournal_get_layout(self->view->getXournal()->getWidget());
+    const Settings* const settings = self->getView()->getXournal()->getControl()->getSettings();
     const double zoom = self->view->getXournal()->getZoom();
 
     // Helper function to compute scroll amount for a single dimension, based on visible region and selection bbox
@@ -754,7 +755,7 @@ bool EditSelection::handleEdgePan(EditSelection* self) {
         double mult = 0.0;
 
         // Calculate bonus scroll amount due to proportion of selection out of view.
-        const double maxMult = 5.0;
+        const double maxMult = settings->getEdgePanMaxMult();
         int panDir = 0;
         if (aboveMax) {
             panDir = 1;
@@ -765,7 +766,7 @@ bool EditSelection::handleEdgePan(EditSelection* self) {
         }
 
         // Base amount to translate selection (in document coordinates) per timer tick
-        const double panSpeed = 20.0;
+        const double panSpeed = settings->getEdgePanSpeed();
         const double translateAmt = visLen * panSpeed / (100.0 * PAN_TIMER_RATE);
 
         // Amount to scroll the visible area by (in layout coordinates), accounting for multiplier

--- a/src/control/tools/EditSelection.cpp
+++ b/src/control/tools/EditSelection.cpp
@@ -30,9 +30,11 @@
 
 using std::vector;
 
-constexpr size_t MINPIXSIZE = 5;  // smallest can scale down to, in pixels.
+/// Smallest can scale down to, in pixels.
+constexpr size_t MINPIXSIZE = 5;
 
-constexpr int DELETE_PADDING = 20;  // ui button padding
+/// Padding for ui buttons
+constexpr int DELETE_PADDING = 20;
 constexpr int ROTATE_PADDING = 8;
 
 EditSelection::EditSelection(UndoRedoHandler* undo, const PageRef& page, XojPageView* view):
@@ -697,10 +699,7 @@ void EditSelection::moveSelection(double dx, double dy) {
     this->view->getXournal()->repaintSelection();
 }
 
-/**
- * If the selection is outside the visible area correct the coordinates
- */
-void EditSelection::ensureWithinVisibleArea() {
+auto EditSelection::getBoundingBoxInView() const -> Rectangle<double> {
     int viewx = this->view->getX();
     int viewy = this->view->getY();
     double zoom = this->view->getXournal()->getZoom();
@@ -714,11 +713,15 @@ void EditSelection::ensureWithinVisibleArea() {
     double minx = cx - w / 2.0;
     double miny = cy - h / 2.0;
 
+    return {viewx + minx * zoom, viewy + miny * zoom, w * zoom, h * zoom};
+}
+
+void EditSelection::ensureWithinVisibleArea() {
+    const Rectangle<double> viewRect = this->getBoundingBoxInView();
     // need to modify this to take into account the position
     // of the object, plus typecast because XojPageView takes ints
-    this->view->getXournal()->ensureRectIsVisible(static_cast<int>(viewx + minx * zoom),
-                                                  static_cast<int>(viewy + miny * zoom), static_cast<int>(w * zoom),
-                                                  static_cast<int>(h * zoom));
+    this->view->getXournal()->ensureRectIsVisible(static_cast<int>(viewRect.x), static_cast<int>(viewRect.y),
+                                                  static_cast<int>(viewRect.width), static_cast<int>(viewRect.height));
 }
 
 /**

--- a/src/control/tools/EditSelection.cpp
+++ b/src/control/tools/EditSelection.cpp
@@ -9,6 +9,7 @@
 #include "gui/PageView.h"
 #include "gui/XournalView.h"
 #include "gui/XournalppCursor.h"
+#include "gui/widgets/XournalWidget.h"
 #include "model/Document.h"
 #include "model/Element.h"
 #include "model/Layer.h"
@@ -36,6 +37,9 @@ constexpr size_t MINPIXSIZE = 5;
 /// Padding for ui buttons
 constexpr int DELETE_PADDING = 20;
 constexpr int ROTATE_PADDING = 8;
+
+/// Number of times to trigger edge pan timer per second
+constexpr unsigned int PAN_TIMER_RATE = 30;
 
 EditSelection::EditSelection(UndoRedoHandler* undo, const PageRef& page, XojPageView* view):
         snappingHandler(view->getXournal()->getControl()->getSettings()),
@@ -162,6 +166,11 @@ EditSelection::~EditSelection() {
 
     this->view = nullptr;
     this->undo = nullptr;
+
+    if (this->edgePanHandler) {
+        g_source_destroy(this->edgePanHandler);
+        g_source_unref(this->edgePanHandler);
+    }
 }
 
 /**
@@ -408,7 +417,13 @@ void EditSelection::mouseUp() {
                                   this->view, this->undo, this->mouseDownType);
 
     this->mouseDownType = CURSOR_SELECTION_NONE;
+
+    const bool wasEdgePanning = this->isEdgePanning();
+    this->setEdgePan(false);
     updateMatrix();
+    if (wasEdgePanning) {
+        this->ensureWithinVisibleArea();
+    }
 }
 
 /**
@@ -469,7 +484,12 @@ void EditSelection::mouseMove(double mouseX, double mouseY, bool alt) {
         p = snappingHandler.snapToGrid(p, alt);
 
         // move
-        moveSelection(p.x - cx, p.y - cy);
+        if (!this->edgePanInhibitNext) {
+            moveSelection(p.x - cx, p.y - cy);
+            this->setEdgePan(true);
+        } else {
+            this->edgePanInhibitNext = false;
+        }
     } else if (this->mouseDownType == CURSOR_SELECTION_ROTATE && supportRotation) {  // catch rotation here
         double rdx = mouseX / zoom - this->snappedBounds.x - this->snappedBounds.width / 2;
         double rdy = mouseY / zoom - this->snappedBounds.y - this->snappedBounds.height / 2;
@@ -692,11 +712,101 @@ void EditSelection::moveSelection(double dx, double dy) {
     this->snappedBounds.x += dx;
     this->snappedBounds.y += dy;
 
-    ensureWithinVisibleArea();
-
     updateMatrix();
 
     this->view->getXournal()->repaintSelection();
+}
+
+void EditSelection::setEdgePan(bool pan) {
+    if (pan && !this->edgePanHandler) {
+        this->edgePanHandler = g_timeout_source_new(1000 / PAN_TIMER_RATE);
+        g_source_set_callback(this->edgePanHandler, reinterpret_cast<GSourceFunc>(EditSelection::handleEdgePan), this,
+                              nullptr);
+        g_source_attach(this->edgePanHandler, nullptr);
+    } else if (!pan && this->edgePanHandler) {
+        g_source_unref(this->edgePanHandler);
+        this->edgePanHandler = nullptr;
+        this->edgePanInhibitNext = false;
+    }
+}
+
+bool EditSelection::isEdgePanning() const { return this->edgePanHandler; }
+
+bool EditSelection::handleEdgePan(EditSelection* self) {
+    if (self->view->getXournal()->getControl()->getZoomControl()->isZoomPresentationMode()) {
+        self->setEdgePan(false);
+        return false;
+    }
+
+
+    Layout* layout = gtk_xournal_get_layout(self->view->getXournal()->getWidget());
+    const double zoom = self->view->getXournal()->getZoom();
+
+    // Helper function to compute scroll amount for a single dimension, based on visible region and selection bbox
+    const auto computeScrollAmt = [&](double visMin, double visLen, double bboxMin, double bboxLen,
+                                      double layoutSize) -> double {
+        const bool belowMin = bboxMin < visMin;
+        const bool aboveMax = bboxMin + bboxLen > visMin + visLen;
+        const double visMax = visMin + visLen;
+        const double bboxMax = bboxMin + bboxLen;
+
+        // Scroll amount multiplier
+        double mult = 0.0;
+
+        // Calculate bonus scroll amount due to proportion of selection out of view.
+        const double maxMult = 5.0;
+        int panDir = 0;
+        if (aboveMax) {
+            panDir = 1;
+            mult = maxMult * std::min(bboxLen, bboxMax - visMax) / bboxLen;
+        } else if (belowMin) {
+            panDir = -1;
+            mult = maxMult * std::min(bboxLen, visMin - bboxMin) / bboxLen;
+        }
+
+        // Base amount to translate selection (in document coordinates) per timer tick
+        const double panSpeed = 20.0;
+        const double translateAmt = visLen * panSpeed / (100.0 * PAN_TIMER_RATE);
+
+        // Amount to scroll the visible area by (in layout coordinates), accounting for multiplier
+        double layoutScroll = zoom * panDir * (translateAmt * mult);
+
+        // If scrolling past layout boundaries, clamp scroll amount to boundary
+        if (visMin + layoutScroll < 0) {
+            layoutScroll = -visMin;
+        } else if (visMax + layoutScroll > layoutSize) {
+            layoutScroll = std::max(0.0, layoutSize - visMax);
+        }
+
+        return layoutScroll;
+    };
+
+    // Compute scroll (for layout) and translation (for selection) for x and y
+    const int layoutWidth = layout->getMinimalWidth();
+    const int layoutHeight = layout->getMinimalHeight();
+    const auto visRect = layout->getVisibleRect();
+    const auto bbox = self->getBoundingBoxInView();
+    const auto layoutScrollX = computeScrollAmt(visRect.x, visRect.width, bbox.x, bbox.width, layoutWidth);
+    const auto layoutScrollY = computeScrollAmt(visRect.y, visRect.height, bbox.y, bbox.height, layoutHeight);
+    const auto translateX = layoutScrollX / zoom;
+    const auto translateY = layoutScrollY / zoom;
+
+    // Perform the scrolling
+    bool edgePanned = false;
+    if (self->isMoving() && (layoutScrollX != 0.0 || layoutScrollY != 0.0)) {
+        layout->scrollRelative(layoutScrollX, layoutScrollY);
+        self->moveSelection(translateX, translateY);
+        edgePanned = true;
+
+        // To prevent the selection from jumping and to reduce jitter, block the selection movement triggered by user
+        // input
+        self->edgePanInhibitNext = true;
+    } else {
+        // No panning, so disable the timer.
+        self->setEdgePan(false);
+    }
+
+    return edgePanned;
 }
 
 auto EditSelection::getBoundingBoxInView() const -> Rectangle<double> {

--- a/src/control/tools/EditSelection.cpp
+++ b/src/control/tools/EditSelection.cpp
@@ -248,7 +248,7 @@ auto EditSelection::getSourceLayer() -> Layer* { return this->sourceLayer; }
  */
 auto EditSelection::getXOnViewAbsolute() -> int {
     double zoom = view->getXournal()->getZoom();
-    return this->view->getX() + this->getXOnView() * zoom;
+    return this->view->getX() + static_cast<int>(this->getXOnView() * zoom);
 }
 
 /**
@@ -256,7 +256,7 @@ auto EditSelection::getXOnViewAbsolute() -> int {
  */
 auto EditSelection::getYOnViewAbsolute() -> int {
     double zoom = view->getXournal()->getZoom();
-    return this->view->getY() + this->getYOnView() * zoom;
+    return this->view->getY() + static_cast<int>(this->getYOnView() * zoom);
 }
 
 /**
@@ -561,7 +561,7 @@ void EditSelection::mouseMove(double mouseX, double mouseY, bool alt) {
 
     if (v && v != this->view) {
         XournalView* xournal = this->view->getXournal();
-        auto pageNr = xournal->getControl()->getDocument()->indexOf(v->getPage());
+        const auto pageNr = xournal->getControl()->getDocument()->indexOf(v->getPage());
 
         xournal->pageSelected(pageNr);
 
@@ -609,7 +609,7 @@ auto EditSelection::getPageViewUnderCursor() -> XojPageView* {
 
 
     Layout* layout = gtk_xournal_get_layout(this->view->getXournal()->getWidget());
-    XojPageView* v = layout->getPageViewAt(hx, hy);
+    XojPageView* v = layout->getPageViewAt(static_cast<int>(hx), static_cast<int>(hy));
 
     return v;
 }
@@ -941,7 +941,7 @@ void EditSelection::serialize(ObjectOutputStream& out) {
     this->contents->serialize(out);
     out.endObject();
 
-    out.writeInt(this->getElements()->size());
+    out.writeInt(static_cast<int>(this->getElements()->size()));
     for (Element* e: *this->getElements()) { e->serialize(out); }
 }
 

--- a/src/control/tools/EditSelection.h
+++ b/src/control/tools/EditSelection.h
@@ -206,6 +206,12 @@ public:
     void paint(cairo_t* cr, double zoom);
 
     /**
+     * Gets the selection's bounding box in view coordinates. This takes document zoom
+     * and selection rotation into account.
+     */
+    auto getBoundingBoxInView() const -> Rectangle<double>;
+
+    /**
      * If the selection is outside the visible area correct the coordinates
      */
     void ensureWithinVisibleArea();
@@ -222,7 +228,7 @@ public:
     void mouseMove(double x, double y, bool alt);
 
     /**
-     * If the selection should moved (or rescaled)
+     * If the user is currently moving the selection.
      */
     bool isMoving();
 

--- a/src/control/tools/EditSelection.h
+++ b/src/control/tools/EditSelection.h
@@ -314,7 +314,7 @@ private:  // DATA
     /**
      * Mouse coordinates for moving / resizing
      */
-    CursorSelectionType mouseDownType;
+    CursorSelectionType mouseDownType = CURSOR_SELECTION_NONE;
     double relMousePosX{};
     double relMousePosY{};
     double relMousePosRotX{};

--- a/src/control/tools/EditSelection.h
+++ b/src/control/tools/EditSelection.h
@@ -287,6 +287,18 @@ private:
      */
     void scaleShift(double fx, double fy, bool changeLeft, bool changeTop);
 
+    /**
+     * Set edge panning signal.
+     */
+    void setEdgePan(bool edgePan);
+
+    /**
+     * Whether the edge pan signal is set.
+     */
+    bool isEdgePanning() const;
+
+    static bool handleEdgePan(EditSelection* self);
+
 private:  // DATA
     /**
      * Support rotation
@@ -373,4 +385,17 @@ private:  // HANDLER
      * The handler for snapping points
      */
     SnapToGridInputHandler snappingHandler;
+
+    /**
+     * Edge pan timer
+     */
+    GSource* edgePanHandler = nullptr;
+
+    /**
+     * Inhibit the next move event after edge panning finishes. This prevents
+     * the selection from teleporting if the page has changed during panning.
+     * Additionally, this reduces the amount of "jitter" resulting from moving
+     * the selection in mouseDown while edge panning.
+     */
+    bool edgePanInhibitNext = false;
 };

--- a/src/gui/dialog/SettingsDialog.cpp
+++ b/src/gui/dialog/SettingsDialog.cpp
@@ -416,6 +416,9 @@ void SettingsDialog::load() {
     GtkWidget* spSnapGridSize = get("spSnapGridSize");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spSnapGridSize), settings->getSnapGridSize() / DEFAULT_GRID_SIZE);
 
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(get("edgePanSpeed")), settings->getEdgePanSpeed());
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(get("edgePanMaxMult")), settings->getEdgePanMaxMult());
+
     GtkWidget* spZoomStep = get("spZoomStep");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spZoomStep), settings->getZoomStep());
 
@@ -785,6 +788,9 @@ void SettingsDialog::save() {
     GtkWidget* spPairsOffset = get("spPairsOffset");
     int numPairsOffset = gtk_spin_button_get_value(GTK_SPIN_BUTTON(spPairsOffset));
     settings->setPairsOffset(numPairsOffset);
+
+    settings->setEdgePanSpeed(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("edgePanSpeed"))));
+    settings->setEdgePanMaxMult(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("edgePanMaxMult"))));
 
     GtkWidget* spZoomStep = get("spZoomStep");
     double zoomStep = gtk_spin_button_get_value(GTK_SPIN_BUTTON(spZoomStep));

--- a/src/gui/inputdevices/KeyboardInputHandler.cpp
+++ b/src/gui/inputdevices/KeyboardInputHandler.cpp
@@ -40,6 +40,7 @@ auto KeyboardInputHandler::handleImpl(InputEvent const& event) -> bool {
             }
             if (xdir != 0 || ydir != 0) {
                 selection->moveSelection(d * xdir, d * ydir);
+                selection->ensureWithinVisibleArea();
                 return true;
             }
         }

--- a/src/gui/inputdevices/KeyboardInputHandler.cpp
+++ b/src/gui/inputdevices/KeyboardInputHandler.cpp
@@ -21,29 +21,25 @@ auto KeyboardInputHandler::handleImpl(InputEvent const& event) -> bool {
         EditSelection* selection = xournal->selection;
         if (selection) {
             int d = 3;
-
-            if ((keyEvent->state & GDK_MOD1_MASK) || (keyEvent->state & GDK_SHIFT_MASK)) {
-                if (keyEvent->state & GDK_MOD1_MASK) {
-                    d = 1;
-                } else {
-                    d = 20;
-                }
+            if (keyEvent->state & GDK_MOD1_MASK) {
+                d = 1;
+            } else if (keyEvent->state & GDK_SHIFT_MASK) {
+                d = 20;
             }
 
+            int xdir = 0;
+            int ydir = 0;
             if (keyEvent->keyval == GDK_KEY_Left) {
-                selection->moveSelection(-d, 0);
-                return true;
+                xdir = -1;
+            } else if (keyEvent->keyval == GDK_KEY_Up) {
+                ydir = -1;
+            } else if (keyEvent->keyval == GDK_KEY_Right) {
+                xdir = 1;
+            } else if (keyEvent->keyval == GDK_KEY_Down) {
+                ydir = 1;
             }
-            if (keyEvent->keyval == GDK_KEY_Up) {
-                selection->moveSelection(0, -d);
-                return true;
-            }
-            if (keyEvent->keyval == GDK_KEY_Right) {
-                selection->moveSelection(d, 0);
-                return true;
-            }
-            if (keyEvent->keyval == GDK_KEY_Down) {
-                selection->moveSelection(0, d);
+            if (xdir != 0 || ydir != 0) {
+                selection->moveSelection(d * xdir, d * ydir);
                 return true;
             }
         }

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -25,6 +25,16 @@
     <property name="step-increment">1</property>
     <property name="page-increment">10</property>
   </object>
+  <object class="GtkAdjustment" id="adjustmentEdgePanMaxMult">
+    <property name="upper">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustmentEdgePanSpeed">
+    <property name="upper">100</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
   <object class="GtkAdjustment" id="adjustmentHorizontalSpace">
     <property name="upper">1000</property>
     <property name="value">150</property>
@@ -3324,6 +3334,93 @@ This setting can make it easier to draw with touch. </property>
                               </packing>
                             </child>
                             <child>
+                              <object class="GtkFrame">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0</property>
+                                <property name="shadow-type">none</property>
+                                <child>
+                                  <object class="GtkAlignment">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
+                                    <child>
+                                      <!-- n-columns=2 n-rows=2 -->
+                                      <object class="GtkGrid">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <child>
+                                          <object class="GtkSpinButton" id="edgePanSpeed">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="input-purpose">number</property>
+                                            <property name="adjustment">adjustmentEdgePanSpeed</property>
+                                            <property name="numeric">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSpinButton" id="edgePanMaxMult">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="input-purpose">number</property>
+                                            <property name="adjustment">adjustmentEdgePanMaxMult</property>
+                                            <property name="numeric">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="tooltip-text" translatable="yes">When an element is selected and moved past the visible portion of the canvas, pan the screen by an amount equal to this percentage of the visible part of the canvas. </property>
+                                            <property name="halign">start</property>
+                                            <property name="label" translatable="yes">Base speed</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="tooltip-text" translatable="yes">Multiply the panning speed by up to this amount, based on how much of the selected element is out of view.</property>
+                                            <property name="halign">start</property>
+                                            <property name="label" translatable="yes">Max multiplier</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">1</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label">
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">Selection Edge Panning</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">4</property>
+                              </packing>
+                            </child>
+                            <child>
                               <object class="GtkFrame" id="sid114">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
@@ -3387,7 +3484,7 @@ This setting can make it easier to draw with touch. </property>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">4</property>
+                                <property name="position">5</property>
                               </packing>
                             </child>
                             <child>
@@ -3488,7 +3585,7 @@ This setting can make it easier to draw with touch. </property>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">5</property>
+                                <property name="position">6</property>
                               </packing>
                             </child>
                             <child>
@@ -3597,7 +3694,7 @@ This setting can make it easier to draw with touch. </property>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">6</property>
+                                <property name="position">7</property>
                               </packing>
                             </child>
                           </object>

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -1,206 +1,206 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.2 -->
+<!-- Generated with glade 3.38.2 -->
 <interface>
   <requires lib="gtk+" version="3.18"/>
   <object class="GtkAdjustment" id="adjustmentAudioGain">
     <property name="upper">10</property>
     <property name="value">1</property>
-    <property name="step_increment">0.10000000000000001</property>
+    <property name="step-increment">0.10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentCursorHighlightBorderWidth">
     <property name="upper">30</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentCursorHighlightRadius">
     <property name="upper">30</property>
     <property name="value">30</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">5</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">5</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentDrawDirModRadius">
     <property name="lower">2</property>
     <property name="upper">1000</property>
     <property name="value">50</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentHorizontalSpace">
     <property name="upper">1000</property>
     <property name="value">150</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentIgnoreStylusEvents">
     <property name="lower">1</property>
     <property name="upper">1000</property>
     <property name="value">1</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentMinimumPressure">
     <property name="upper">1</property>
-    <property name="step_increment">0.01</property>
-    <property name="page_increment">0.5</property>
+    <property name="step-increment">0.01</property>
+    <property name="page-increment">0.5</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentPairsOffset">
     <property name="upper">100</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">1</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">1</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentPreloadPagesAfter">
     <property name="upper">99</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentPreloadPagesBefore">
     <property name="upper">99</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentPressureMultiplier">
     <property name="lower">0.5</property>
     <property name="upper">4</property>
     <property name="value">1</property>
-    <property name="step_increment">0.050000000000000003</property>
-    <property name="page_increment">0.5</property>
+    <property name="step-increment">0.05</property>
+    <property name="page-increment">0.5</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentReRenderThreshold">
     <property name="upper">900</property>
     <property name="value">10</property>
-    <property name="step_increment">5</property>
-    <property name="page_increment">100</property>
+    <property name="step-increment">5</property>
+    <property name="page-increment">100</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentSeekTime">
     <property name="lower">1</property>
     <property name="upper">90</property>
     <property name="value">5</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentSnapGridSize">
     <property name="lower">0.01</property>
     <property name="upper">20</property>
     <property name="value">1</property>
-    <property name="step_increment">0.01</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">0.01</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentSnapGridTolerance">
-    <property name="lower">0.10000000000000001</property>
+    <property name="lower">0.10</property>
     <property name="upper">1</property>
     <property name="value">0.5</property>
-    <property name="step_increment">0.050000000000000003</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">0.05</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentSnapRotationTolerance">
-    <property name="lower">0.10000000000000001</property>
+    <property name="lower">0.10</property>
     <property name="upper">1</property>
     <property name="value">0.29999999999999999</property>
-    <property name="step_increment">0.050000000000000003</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">0.05</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentStabilizerDeadzoneRadius">
-    <property name="lower">0.10000000000000001</property>
+    <property name="lower">0.10</property>
     <property name="upper">50</property>
     <property name="value">1.3</property>
-    <property name="step_increment">0.10000000000000001</property>
-    <property name="page_increment">1</property>
+    <property name="step-increment">0.10</property>
+    <property name="page-increment">1</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentStabilizerDrag">
     <property name="upper">1</property>
-    <property name="value">0.40000000000000002</property>
-    <property name="step_increment">0.050000000000000003</property>
-    <property name="page_increment">0.20000000000000001</property>
+    <property name="value">0.40</property>
+    <property name="step-increment">0.05</property>
+    <property name="page-increment">0.20</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentStabilizerMass">
     <property name="lower">1</property>
     <property name="upper">30</property>
     <property name="value">5</property>
-    <property name="step_increment">0.10000000000000001</property>
-    <property name="page_increment">1</property>
+    <property name="step-increment">0.10</property>
+    <property name="page-increment">1</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentStabilizerSigma">
-    <property name="lower">0.050000000000000003</property>
+    <property name="lower">0.05</property>
     <property name="upper">5</property>
     <property name="value">0.5</property>
-    <property name="step_increment">0.050000000000000003</property>
-    <property name="page_increment">1</property>
+    <property name="step-increment">0.05</property>
+    <property name="page-increment">1</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentStabilizingBuffersize">
     <property name="lower">2</property>
     <property name="upper">100</property>
     <property name="value">20</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentStrokeIgnoreLength">
-    <property name="lower">0.010000000000000011</property>
+    <property name="lower">0.01000000000000001</property>
     <property name="upper">100</property>
     <property name="value">1</property>
-    <property name="step_increment">0.10000000000000001</property>
-    <property name="page_increment">2</property>
+    <property name="step-increment">0.10</property>
+    <property name="page-increment">2</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentStrokeIgnoreTime">
     <property name="upper">1000</property>
     <property name="value">150</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentStrokeSuccessiveTime">
     <property name="upper">1000</property>
     <property name="value">500</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentTimeout">
     <property name="lower">1</property>
     <property name="upper">100</property>
     <property name="value">1</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentTouchTImeout">
     <property name="lower">0.5</property>
     <property name="upper">10</property>
     <property name="value">1</property>
-    <property name="step_increment">0.10000000000000001</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">0.10</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentVerticalSpace">
     <property name="upper">1000</property>
     <property name="value">150</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentZoom">
     <property name="lower">50</property>
     <property name="upper">400</property>
     <property name="value">72</property>
-    <property name="step_increment">1</property>
+    <property name="step-increment">1</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentZoomStartThreshold">
     <property name="upper">100</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentZoomStep">
-    <property name="lower">0.10000000000000001</property>
+    <property name="lower">0.10</property>
     <property name="upper">50</property>
     <property name="value">10</property>
-    <property name="step_increment">0.5</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">0.5</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentZoomStepScroll">
-    <property name="lower">0.10000000000000001</property>
+    <property name="lower">0.10</property>
     <property name="upper">50</property>
     <property name="value">2</property>
-    <property name="step_increment">0.5</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">0.5</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkListStore" id="listStabilizerAveragingMethods">
     <columns>
       <!-- column-name Name -->
-      <column type="gchararray" />
+      <column type="gchararray"/>
     </columns>
     <data>
       <row>
@@ -217,7 +217,7 @@
   <object class="GtkListStore" id="listStabilizerPreprocessors">
     <columns>
       <!-- column-name Name -->
-      <column type="gchararray" />
+      <column type="gchararray"/>
     </columns>
     <data>
       <row>
@@ -233,34 +233,34 @@
   </object>
   <object class="GtkDialog" id="settingsDialog">
     <property name="name">settingsDialog</property>
-    <property name="can_focus">False</property>
-    <property name="border_width">5</property>
+    <property name="can-focus">False</property>
+    <property name="border-width">5</property>
     <property name="title" translatable="yes">Xournal++ Preferences</property>
-    <property name="window_position">center</property>
+    <property name="window-position">center</property>
     <property name="icon">pixmaps/com.github.xournalpp.xournalpp.svg</property>
-    <property name="type_hint">normal</property>
+    <property name="type-hint">normal</property>
     <property name="gravity">center</property>
     <signal name="close" handler="gtk_widget_hide" swapped="no"/>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox3">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
         <property name="spacing">2</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="btSettingsButton">
             <property name="name">btSettingsButton</property>
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
+            <property name="can-focus">False</property>
+            <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="btSettingsCancel">
                 <property name="label">gtk-cancel</property>
                 <property name="name">btSettingsCancel</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="use-stock">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -273,9 +273,9 @@
                 <property name="label">gtk-ok</property>
                 <property name="name">btSettingsOk</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="use-stock">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -287,7 +287,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="pack_type">end</property>
+            <property name="pack-type">end</property>
             <property name="position">0</property>
           </packing>
         </child>
@@ -295,59 +295,59 @@
           <object class="GtkNotebook" id="notebook1">
             <property name="name">notebook1</property>
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="tab_pos">left</property>
-            <property name="show_border">False</property>
+            <property name="can-focus">True</property>
+            <property name="tab-pos">left</property>
+            <property name="show-border">False</property>
             <property name="scrollable">True</property>
             <child>
               <object class="GtkBox" id="saveLoadTabBox">
                 <property name="name">saveLoadTabBox</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_left">5</property>
+                <property name="can-focus">False</property>
+                <property name="margin-left">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid01">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="min_content_width">500</property>
-                    <property name="min_content_height">450</property>
+                    <property name="can-focus">True</property>
+                    <property name="min-content-width">500</property>
+                    <property name="min-content-height">450</property>
                     <child>
                       <object class="GtkViewport" id="sid02">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkBox" id="sid03">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="sid04">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid05">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid06">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="label28">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;If the document already was saved you can find it in the same folder with the extension .autosave.xoj
 If the file was not yet saved you can find it in your home directory, in ~/.xournalpp/autosave&lt;/i&gt;</property>
-                                            <property name="use_markup">True</property>
+                                            <property name="use-markup">True</property>
                                             <property name="wrap">True</property>
-                                            <property name="max_width_chars">85</property>
+                                            <property name="max-width-chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -359,16 +359,16 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                         <child>
                                           <object class="GtkBox" id="sid07">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <child>
                                               <object class="GtkCheckButton" id="cbAutosave">
                                                 <property name="label" translatable="yes">Enable Autosaving</property>
                                                 <property name="name">cbAutosave</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="receives_default">False</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">False</property>
                                                 <property name="xalign">0</property>
-                                                <property name="draw_indicator">True</property>
+                                                <property name="draw-indicator">True</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
@@ -380,12 +380,12 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                               <object class="GtkBox" id="boxAutosave">
                                                 <property name="name">boxAutosave</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <child>
                                                   <object class="GtkLabel" id="lbAutosaveTimeout1">
                                                     <property name="name">lbAutosaveTimeout1</property>
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="label" translatable="yes">every</property>
                                                   </object>
                                                   <packing>
@@ -398,7 +398,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                                   <object class="GtkSpinButton" id="spAutosaveTimeout">
                                                     <property name="name">spAutosaveTimeout</property>
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">True</property>
+                                                    <property name="can-focus">True</property>
                                                     <property name="adjustment">adjustmentTimeout</property>
                                                   </object>
                                                   <packing>
@@ -412,7 +412,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                                   <object class="GtkLabel" id="lbAutosaveTimeout2">
                                                     <property name="name">lbAutosaveTimeout2</property>
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="label" translatable="yes">minutes</property>
                                                   </object>
                                                   <packing>
@@ -442,7 +442,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                 <child type="label">
                                   <object class="GtkLabel" id="sid08">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Autosaving</property>
                                   </object>
                                 </child>
@@ -456,27 +456,27 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                             <child>
                               <object class="GtkFrame" id="sid09">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid10">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="vbox3">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="label30">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;This name will be proposed if you save a new document.&lt;/i&gt;</property>
-                                            <property name="use_markup">True</property>
+                                            <property name="use-markup">True</property>
                                             <property name="wrap">True</property>
-                                            <property name="max_width_chars">85</property>
+                                            <property name="max-width-chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -489,7 +489,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                           <object class="GtkEntry" id="txtDefaultSaveName">
                                             <property name="name">txtDefaultSaveName</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
+                                            <property name="can-focus">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -500,13 +500,13 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                         <child>
                                           <object class="GtkBox" id="box14">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <child>
                                               <object class="GtkLabel" id="label31">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">Default name: </property>
-                                                <property name="use_markup">True</property>
+                                                <property name="use-markup">True</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
@@ -518,7 +518,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                               <object class="GtkLabel" id="lbDefaultSavename">
                                                 <property name="name">lbDefaultSavename</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">%F-Note-%H-%M</property>
                                               </object>
                                               <packing>
@@ -538,12 +538,12 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                           <object class="GtkExpander" id="expander1">
                                             <property name="name">expander1</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
+                                            <property name="can-focus">True</property>
                                             <child>
                                               <object class="GtkLabel" id="label33">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="margin_left">20</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="margin-left">20</property>
                                                 <property name="label" translatable="yes">%a		Abbreviated weekday name (e.g. Thu)
 %A		Full weekday name (e.g. Thursday)
 %b		Abbreviated month name (e.g. Aug)
@@ -573,11 +573,11 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             <child type="label">
                                               <object class="GtkBox" id="box15">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <child>
                                                   <object class="GtkImage" id="image1">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="stock">gtk-info</property>
                                                   </object>
                                                   <packing>
@@ -589,8 +589,8 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                                 <child>
                                                   <object class="GtkLabel" id="label32">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
-                                                    <property name="margin_left">3</property>
+                                                    <property name="can-focus">False</property>
+                                                    <property name="margin-left">3</property>
                                                     <property name="label" translatable="yes">Available Placeholders</property>
                                                   </object>
                                                   <packing>
@@ -616,7 +616,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                 <child type="label">
                                   <object class="GtkLabel" id="sid11">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Default Save Name</property>
                                   </object>
                                 </child>
@@ -630,19 +630,19 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                             <child>
                               <object class="GtkFrame" id="sid12">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid13">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid14">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkCheckButton" id="cbAutoloadXoj">
@@ -670,7 +670,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             <property name="receives-default">False</property>
                                             <property name="tooltip-text" translatable="yes">If enabled Xournal++ will open the most recent document automatically that you can continue editing your last saved document.</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -713,61 +713,61 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
               <object class="GtkLabel" id="saveLoadTabLabel">
                 <property name="name">saveLoadTabLabel</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Load / Save</property>
               </object>
               <packing>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="inputTabBox">
                 <property name="name">inputTabBox</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_left">5</property>
+                <property name="can-focus">False</property>
+                <property name="margin-left">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="swInputTab">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="min_content_width">500</property>
-                    <property name="min_content_height">450</property>
+                    <property name="can-focus">True</property>
+                    <property name="min-content-width">500</property>
+                    <property name="min-content-height">450</property>
                     <child>
                       <object class="GtkViewport" id="wpInputTab">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkBox" id="bxInputTab">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="sid84">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid85">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;Assign device classes to each input device of your system. Only change these values if your devices are not correctly matched. (e.g. your pen shows up as touchscreen)&lt;/i&gt;</property>
-                                            <property name="use_markup">True</property>
+                                            <property name="use-markup">True</property>
                                             <property name="wrap">True</property>
-                                            <property name="max_width_chars">85</property>
+                                            <property name="max-width-chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -780,7 +780,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                           <object class="GtkBox" id="hboxInputDeviceClasses">
                                             <property name="name">hboxInputDeviceClasses</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="orientation">vertical</property>
                                             <child>
                                               <placeholder/>
@@ -799,7 +799,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                 <child type="label">
                                   <object class="GtkLabel" id="sid87">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Input Devices</property>
                                   </object>
                                 </child>
@@ -813,34 +813,34 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                             <child>
                               <object class="GtkFrame" id="sid88">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid89">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid90">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkCheckButton" id="cbInputSystemDrawOutsideWindow">
                                             <property name="name">cbInputSystemDrawOutsideWindow</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
                                             <property name="xalign">0.5</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                             <child>
                                               <object class="GtkLabel" id="sid92">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">Enable drawing outside of window &lt;i&gt;(Drawing will not stop at the border of the window)&lt;/i&gt;</property>
-                                                <property name="use_markup">True</property>
+                                                <property name="use-markup">True</property>
                                                 <property name="wrap">True</property>
                                                 <property name="xalign">0</property>
                                               </object>
@@ -856,23 +856,23 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                           <object class="GtkCheckButton" id="cbInputSystemTPCButton">
                                             <property name="name">cbInputSystemTPCButton</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="tooltip_markup" translatable="yes">Drag LEFT from start point acts like shift key is being held.
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-markup" translatable="yes">Drag LEFT from start point acts like shift key is being held.
 	    Drag UP acts as if Control key is being held.
 
             Determination Radius: Radius at which modifiers will lock in until finished drawing.
 
 	    &lt;i&gt;Useful for operating without keyboard.&lt;/i&gt;</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                             <child>
                                               <object class="GtkLabel" id="sid93">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">Merge button events with stylus tip events
 	    &lt;i&gt;(Check this if&lt;/i&gt; "&lt;tt&gt;xsetwacom get *deviceId* TabletPCButton&lt;/tt&gt;" &lt;i&gt;returns&lt;/i&gt; "&lt;tt&gt;on&lt;/tt&gt;"&lt;i&gt;)&lt;/i&gt;</property>
-                                                <property name="use_markup">True</property>
+                                                <property name="use-markup">True</property>
                                                 <property name="wrap">True</property>
                                                 <property name="xalign">0</property>
                                               </object>
@@ -888,19 +888,19 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                           <object class="GtkCheckButton" id="cbEnablePressureInference">
                                             <property name="name">cbEnablePressureInference</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="tooltip_markup" translatable="yes">Slower strokes are assigned a greater pressure than faster strokes, if pressure information is absent.
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-markup" translatable="yes">Slower strokes are assigned a greater pressure than faster strokes, if pressure information is absent.
 
 &lt;i&gt;This feature may be useful for devices that lack pressure sensitivity. For example, a mouse or touchscreen.&lt;/i&gt;</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                             <child>
                                               <object class="GtkLabel" id="sid201">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">Enable Pressure Inference &lt;i&gt;(Guess pressure from drawing speed when device-supplied pressure is not available)&lt;/i&gt;</property>
-                                                <property name="use_markup">True</property>
+                                                <property name="use-markup">True</property>
                                                 <property name="wrap">True</property>
                                                 <property name="xalign">0</property>
                                               </object>
@@ -919,7 +919,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                 <child type="label">
                                   <object class="GtkLabel" id="sid94">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Options</property>
                                   </object>
                                 </child>
@@ -933,44 +933,45 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                             <child>
                               <object class="GtkFrame" id="frameStabilizerSettings">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="alignmentStabilizer">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">12</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">12</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
+                                      <!-- n-columns=4 n-rows=4 -->
                                       <object class="GtkGrid" id="gridStabilizer">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="column_spacing">10</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="column-spacing">10</property>
                                         <child>
                                           <object class="GtkLabel" id="lbStabilizerAveragingMethod">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="halign">start</property>
-                                            <property name="margin_start">16</property>
+                                            <property name="margin-start">16</property>
                                             <property name="label" translatable="yes">Averaging method</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">0</property>
-                                            <property name="top_attach">1</property>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">1</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkComboBox" id="cbStabilizerAveragingMethods">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="hexpand">True</property>
                                             <property name="model">listStabilizerAveragingMethods</property>
                                             <property name="active">0</property>
-                                            <property name="id_column">0</property>
-                                            <property name="active_id">0</property>
+                                            <property name="id-column">0</property>
+                                            <property name="active-id">0</property>
                                             <child>
-                                              <object class="GtkCellRendererText" />
+                                              <object class="GtkCellRendererText"/>
                                               <attributes>
                                                 <attribute name="markup">0</attribute>
                                                 <attribute name="text">0</attribute>
@@ -978,206 +979,206 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             </child>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">1</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">1</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="lbStabilizerDescription">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;Pick an input stabilization algorithm and its parameters&lt;/i&gt;</property>
-                                            <property name="use_markup">True</property>
+                                            <property name="use-markup">True</property>
                                             <property name="wrap">True</property>
-                                            <property name="width_chars">85</property>
-                                            <property name="max_width_chars">85</property>
+                                            <property name="width-chars">85</property>
+                                            <property name="max-width-chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">0</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">0</property>
                                             <property name="width">4</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="lbStabilizerBuffersize">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">Buffersize</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">2</property>
-                                            <property name="top_attach">1</property>
+                                            <property name="left-attach">2</property>
+                                            <property name="top-attach">1</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="sbStabilizerBuffersize">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
+                                            <property name="can-focus">True</property>
                                             <property name="hexpand">True</property>
                                             <property name="text" translatable="yes">20</property>
-                                            <property name="input_purpose">number</property>
+                                            <property name="input-purpose">number</property>
                                             <property name="adjustment">adjustmentStabilizingBuffersize</property>
-                                            <property name="climb_rate">1</property>
-                                            <property name="snap_to_ticks">True</property>
+                                            <property name="climb-rate">1</property>
+                                            <property name="snap-to-ticks">True</property>
                                             <property name="numeric">True</property>
                                             <property name="value">20</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">3</property>
-                                            <property name="top_attach">1</property>
+                                            <property name="left-attach">3</property>
+                                            <property name="top-attach">1</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="lbStabilizerDeadzoneRadius">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">Deadzone radius</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">2</property>
-                                            <property name="top_attach">2</property>
+                                            <property name="left-attach">2</property>
+                                            <property name="top-attach">2</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="sbStabilizerDeadzoneRadius">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
+                                            <property name="can-focus">True</property>
                                             <property name="hexpand">True</property>
                                             <property name="text" translatable="yes">1,30</property>
-                                            <property name="input_purpose">number</property>
+                                            <property name="input-purpose">number</property>
                                             <property name="adjustment">adjustmentStabilizerDeadzoneRadius</property>
-                                            <property name="climb_rate">2</property>
+                                            <property name="climb-rate">2</property>
                                             <property name="digits">2</property>
-                                            <property name="snap_to_ticks">True</property>
+                                            <property name="snap-to-ticks">True</property>
                                             <property name="numeric">True</property>
                                             <property name="value">1.3</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">3</property>
-                                            <property name="top_attach">2</property>
+                                            <property name="left-attach">3</property>
+                                            <property name="top-attach">2</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="lbStabilizerDrag">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="tooltip_text" translatable="yes">Drag: If the value is too small, unwanted oscillations may appear. If the value is too high, there will be no stabilization.</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="tooltip-text" translatable="yes">Drag: If the value is too small, unwanted oscillations may appear. If the value is too high, there will be no stabilization.</property>
                                             <property name="label" translatable="yes">Drag</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">2</property>
-                                            <property name="top_attach">2</property>
+                                            <property name="left-attach">2</property>
+                                            <property name="top-attach">2</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="sbStabilizerDrag">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="tooltip_text" translatable="yes">Drag: If the value is too small, unwanted oscillations may appear. If the value is too high, there will be no stabilization.</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="tooltip-text" translatable="yes">Drag: If the value is too small, unwanted oscillations may appear. If the value is too high, there will be no stabilization.</property>
                                             <property name="hexpand">True</property>
                                             <property name="text" translatable="yes">0,4</property>
-                                            <property name="input_purpose">number</property>
+                                            <property name="input-purpose">number</property>
                                             <property name="adjustment">adjustmentStabilizerDrag</property>
-                                            <property name="climb_rate">2</property>
+                                            <property name="climb-rate">2</property>
                                             <property name="digits">2</property>
-                                            <property name="snap_to_ticks">True</property>
+                                            <property name="snap-to-ticks">True</property>
                                             <property name="numeric">True</property>
-                                            <property name="value">0.40000000000000002</property>
+                                            <property name="value">0.40</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">3</property>
-                                            <property name="top_attach">2</property>
+                                            <property name="left-attach">3</property>
+                                            <property name="top-attach">2</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="lbStabilizerMass">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="tooltip_text" translatable="yes">Mass: the higher the mass, the more inertia and the more stabilization</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="tooltip-text" translatable="yes">Mass: the higher the mass, the more inertia and the more stabilization</property>
                                             <property name="label" translatable="yes">Mass</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">2</property>
-                                            <property name="top_attach">3</property>
+                                            <property name="left-attach">2</property>
+                                            <property name="top-attach">3</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="sbStabilizerMass">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="tooltip_text" translatable="yes">Mass: the higher the mass, the more inertia and the more stabilization</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="tooltip-text" translatable="yes">Mass: the higher the mass, the more inertia and the more stabilization</property>
                                             <property name="hexpand">True</property>
                                             <property name="text" translatable="yes">5</property>
-                                            <property name="input_purpose">number</property>
+                                            <property name="input-purpose">number</property>
                                             <property name="adjustment">adjustmentStabilizerMass</property>
-                                            <property name="climb_rate">2</property>
+                                            <property name="climb-rate">2</property>
                                             <property name="digits">2</property>
-                                            <property name="snap_to_ticks">True</property>
+                                            <property name="snap-to-ticks">True</property>
                                             <property name="numeric">True</property>
                                             <property name="value">5</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">3</property>
-                                            <property name="top_attach">3</property>
+                                            <property name="left-attach">3</property>
+                                            <property name="top-attach">3</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="sbStabilizerSigma">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="tooltip_text" translatable="yes">Gaussian parameter: the higher, the more stabilization and the more lag between your cursor and the painting tip.</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="tooltip-text" translatable="yes">Gaussian parameter: the higher, the more stabilization and the more lag between your cursor and the painting tip.</property>
                                             <property name="hexpand">True</property>
                                             <property name="text" translatable="yes">0,50</property>
-                                            <property name="input_purpose">number</property>
+                                            <property name="input-purpose">number</property>
                                             <property name="adjustment">adjustmentStabilizerSigma</property>
-                                            <property name="climb_rate">0.99999999977648257</property>
+                                            <property name="climb-rate">0.99999999977648257</property>
                                             <property name="digits">2</property>
-                                            <property name="snap_to_ticks">True</property>
+                                            <property name="snap-to-ticks">True</property>
                                             <property name="numeric">True</property>
                                             <property name="value">0.5</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">3</property>
-                                            <property name="top_attach">1</property>
+                                            <property name="left-attach">3</property>
+                                            <property name="top-attach">1</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="lbStabilizerSigma">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="tooltip_text" translatable="yes">Gaussian parameter: the higher, the more stabilization and the more lag between your cursor and the painting tip.</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="tooltip-text" translatable="yes">Gaussian parameter: the higher, the more stabilization and the more lag between your cursor and the painting tip.</property>
                                             <property name="label" translatable="yes">σ</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">2</property>
-                                            <property name="top_attach">1</property>
+                                            <property name="left-attach">2</property>
+                                            <property name="top-attach">1</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="lbStabilizerPreprocessor">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="halign">start</property>
-                                            <property name="margin_start">15</property>
+                                            <property name="margin-start">15</property>
                                             <property name="label" translatable="yes">Preprocessor</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">0</property>
-                                            <property name="top_attach">2</property>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">2</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkComboBox" id="cbStabilizerPreprocessors">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="hexpand">True</property>
                                             <property name="model">listStabilizerPreprocessors</property>
                                             <property name="active">0</property>
-                                            <property name="id_column">0</property>
-                                            <property name="active_id">0</property>
+                                            <property name="id-column">0</property>
+                                            <property name="active-id">0</property>
                                             <child>
-                                              <object class="GtkCellRendererText" />
+                                              <object class="GtkCellRendererText"/>
                                               <attributes>
                                                 <attribute name="markup">0</attribute>
                                                 <attribute name="text">0</attribute>
@@ -1185,8 +1186,8 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             </child>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">2</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">2</property>
                                           </packing>
                                         </child>
                                         <child>
@@ -1194,15 +1195,15 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             <property name="label" translatable="yes">Cusp detection</property>
                                             <property name="name">cbStabilizerEnableCuspDetection</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
                                             <property name="halign">start</property>
                                             <property name="active">True</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">2</property>
-                                            <property name="top_attach">3</property>
+                                            <property name="left-attach">2</property>
+                                            <property name="top-attach">3</property>
                                             <property name="width">2</property>
                                           </packing>
                                         </child>
@@ -1211,19 +1212,19 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             <property name="label" translatable="yes">Finalize the stroke</property>
                                             <property name="name">cbStabilizerEnableFinalizeStroke</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="tooltip_text" translatable="yes">Input stabilization can create a gap at the end of your stroke. If enabled, this gap is filled.</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-text" translatable="yes">Input stabilization can create a gap at the end of your stroke. If enabled, this gap is filled.</property>
                                             <property name="active">True</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">0</property>
-                                            <property name="top_attach">3</property>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">3</property>
                                           </packing>
                                         </child>
                                         <child>
-                                          <placeholder />
+                                          <placeholder/>
                                         </child>
                                       </object>
                                     </child>
@@ -1232,7 +1233,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                 <child type="label">
                                   <object class="GtkLabel" id="lbStabilizerSettings">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Input stabilization</property>
                                   </object>
                                 </child>
@@ -1263,60 +1264,60 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
               <object class="GtkLabel" id="inputTabLabel">
                 <property name="name">inputTabLabel</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Input System</property>
               </object>
               <packing>
                 <property name="position">1</property>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="mouseTabBox">
                 <property name="name">mouseTabBox</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_left">5</property>
+                <property name="can-focus">False</property>
+                <property name="margin-left">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid17">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="can-focus">True</property>
                     <child>
                       <object class="GtkViewport" id="sid18">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkBox" id="sid19">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="sid20">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid21">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">12</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">12</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid22">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="label23">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;Define which tools will be selected if you press a mouse button. After you release the button the previously selected tool will be selected.&lt;/i&gt;</property>
-                                            <property name="use_markup">True</property>
+                                            <property name="use-markup">True</property>
                                             <property name="wrap">True</property>
-                                            <property name="max_width_chars">85</property>
+                                            <property name="max-width-chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -1328,20 +1329,20 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                         <child>
                                           <object class="GtkFrame" id="sid23">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label_xalign">0.0099999997764825821</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label-xalign">0.009999999776482582</property>
                                             <child>
                                               <object class="GtkAlignment" id="sid24">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="bottom_padding">8</property>
-                                                <property name="left_padding">12</property>
-                                                <property name="right_padding">12</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="bottom-padding">8</property>
+                                                <property name="left-padding">12</property>
+                                                <property name="right-padding">12</property>
                                                 <child>
                                                   <object class="GtkBox" id="hboxMidleMouse">
                                                     <property name="name">hboxMidleMouse</property>
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <child>
                                                       <placeholder/>
                                                     </child>
@@ -1352,7 +1353,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             <child type="label">
                                               <object class="GtkLabel" id="sid25">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">Middle Mouse Button</property>
                                               </object>
                                             </child>
@@ -1366,20 +1367,20 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                         <child>
                                           <object class="GtkFrame" id="sid26">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label_xalign">0.0099999997764825821</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label-xalign">0.009999999776482582</property>
                                             <child>
                                               <object class="GtkAlignment" id="sid27">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="bottom_padding">8</property>
-                                                <property name="left_padding">12</property>
-                                                <property name="right_padding">12</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="bottom-padding">8</property>
+                                                <property name="left-padding">12</property>
+                                                <property name="right-padding">12</property>
                                                 <child>
                                                   <object class="GtkBox" id="hboxRightMouse">
                                                     <property name="name">hboxRightMouse</property>
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <child>
                                                       <placeholder/>
                                                     </child>
@@ -1390,7 +1391,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             <child type="label">
                                               <object class="GtkLabel" id="sid28">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">Right Mouse Button</property>
                                               </object>
                                             </child>
@@ -1408,7 +1409,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                 <child type="label">
                                   <object class="GtkLabel" id="sid29">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Mouse Buttons</property>
                                   </object>
                                 </child>
@@ -1439,62 +1440,62 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
               <object class="GtkLabel" id="mouseTabLabel">
                 <property name="name">mouseTabLabel</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Mouse</property>
               </object>
               <packing>
                 <property name="position">2</property>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="stylusTabBox">
                 <property name="name">stylusTabBox</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_left">5</property>
+                <property name="can-focus">False</property>
+                <property name="margin-left">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid30">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="min_content_width">500</property>
-                    <property name="min_content_height">450</property>
+                    <property name="can-focus">True</property>
+                    <property name="min-content-width">500</property>
+                    <property name="min-content-height">450</property>
                     <child>
                       <object class="GtkViewport" id="sid31">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkBox" id="sid32">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="sid33">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid34">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid35">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="sid36">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;Pressure Sensitivity allows you to draw lines with different widths, depending on how much pressure you apply to the pen. If your tablet does not support this feature this setting has no effect.&lt;/i&gt;</property>
-                                            <property name="use_markup">True</property>
+                                            <property name="use-markup">True</property>
                                             <property name="wrap">True</property>
-                                            <property name="max_width_chars">85</property>
+                                            <property name="max-width-chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -1508,10 +1509,10 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             <property name="label" translatable="yes">Enable Pressure Sensitivity</property>
                                             <property name="name">cbSettingPresureSensitivity</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -1522,28 +1523,28 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                         <child>
                                           <object class="GtkFrame" id="framePressureSensitivityScale">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label_xalign">0.0099999997764825821</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label-xalign">0.009999999776482582</property>
                                             <child>
                                               <object class="GtkAlignment" id="alignSensitivityScale">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="bottom_padding">8</property>
-                                                <property name="left_padding">12</property>
-                                                <property name="right_padding">12</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="bottom-padding">8</property>
+                                                <property name="left-padding">12</property>
+                                                <property name="right-padding">12</property>
                                                 <child>
                                                   <object class="GtkBox" id="boxSensitivityScaleOptions">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="orientation">vertical</property>
                                                     <child>
                                                       <object class="GtkLabel" id="lbSensitivityScaleDescription">
                                                         <property name="visible">True</property>
-                                                        <property name="can_focus">False</property>
+                                                        <property name="can-focus">False</property>
                                                         <property name="label" translatable="yes">&lt;i&gt;Some devices report unexpectedly small or large pressures. This can be fixed by setting a minimum pressure or scaling the pressure reported by the device.&lt;/i&gt;</property>
-                                                        <property name="use_markup">True</property>
+                                                        <property name="use-markup">True</property>
                                                         <property name="wrap">True</property>
-                                                        <property name="max_width_chars">85</property>
+                                                        <property name="max-width-chars">85</property>
                                                         <property name="xalign">0</property>
                                                       </object>
                                                       <packing>
@@ -1553,62 +1554,72 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                                       </packing>
                                                     </child>
                                                     <child>
+                                                      <!-- n-columns=3 n-rows=3 -->
                                                       <object class="GtkGrid" id="gridPressureSensitivityOptions">
                                                         <property name="visible">True</property>
-                                                        <property name="can_focus">False</property>
-                                                        <property name="column_spacing">5</property>
-                                                        <property name="column_homogeneous">True</property>
+                                                        <property name="can-focus">False</property>
+                                                        <property name="column-spacing">5</property>
+                                                        <property name="column-homogeneous">True</property>
                                                         <child>
                                                           <object class="GtkLabel">
                                                             <property name="visible">True</property>
-                                                            <property name="can_focus">False</property>
+                                                            <property name="can-focus">False</property>
                                                             <property name="label" translatable="yes">Minimum Pressure:</property>
                                                           </object>
                                                           <packing>
-                                                            <property name="left_attach">0</property>
-                                                            <property name="top_attach">0</property>
+                                                            <property name="left-attach">0</property>
+                                                            <property name="top-attach">0</property>
                                                           </packing>
                                                         </child>
                                                         <child>
                                                           <object class="GtkLabel">
                                                             <property name="visible">True</property>
-                                                            <property name="can_focus">False</property>
+                                                            <property name="can-focus">False</property>
                                                             <property name="label" translatable="yes">Pressure Multiplier: </property>
                                                           </object>
                                                           <packing>
-                                                            <property name="left_attach">0</property>
-                                                            <property name="top_attach">1</property>
+                                                            <property name="left-attach">0</property>
+                                                            <property name="top-attach">1</property>
                                                           </packing>
                                                         </child>
                                                         <child>
                                                           <object class="GtkScale" id="scaleMinimumPressure">
                                                             <property name="visible">True</property>
-                                                            <property name="can_focus">True</property>
+                                                            <property name="can-focus">True</property>
                                                             <property name="adjustment">adjustmentMinimumPressure</property>
-                                                            <property name="round_digits">1</property>
+                                                            <property name="round-digits">1</property>
                                                             <property name="digits">2</property>
-                                                            <property name="value_pos">right</property>
+                                                            <property name="value-pos">right</property>
                                                           </object>
                                                           <packing>
-                                                            <property name="left_attach">1</property>
-                                                            <property name="top_attach">0</property>
+                                                            <property name="left-attach">1</property>
+                                                            <property name="top-attach">0</property>
                                                             <property name="width">2</property>
                                                           </packing>
                                                         </child>
                                                         <child>
                                                           <object class="GtkScale" id="scalePressureMultiplier">
                                                             <property name="visible">True</property>
-                                                            <property name="can_focus">True</property>
+                                                            <property name="can-focus">True</property>
                                                             <property name="adjustment">adjustmentPressureMultiplier</property>
-                                                            <property name="round_digits">1</property>
+                                                            <property name="round-digits">1</property>
                                                             <property name="digits">2</property>
-                                                            <property name="value_pos">right</property>
+                                                            <property name="value-pos">right</property>
                                                           </object>
                                                           <packing>
-                                                            <property name="left_attach">1</property>
-                                                            <property name="top_attach">1</property>
+                                                            <property name="left-attach">1</property>
+                                                            <property name="top-attach">1</property>
                                                             <property name="width">2</property>
                                                           </packing>
+                                                        </child>
+                                                        <child>
+                                                          <placeholder/>
+                                                        </child>
+                                                        <child>
+                                                          <placeholder/>
+                                                        </child>
+                                                        <child>
+                                                          <placeholder/>
                                                         </child>
                                                       </object>
                                                       <packing>
@@ -1624,7 +1635,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             <child type="label">
                                               <object class="GtkLabel" id="lbSensitivityScaleHeader">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">Sensitivity Scale</property>
                                               </object>
                                             </child>
@@ -1642,7 +1653,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                 <child type="label">
                                   <object class="GtkLabel" id="sid37">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Pressure Sensitivity</property>
                                   </object>
                                 </child>
@@ -1656,28 +1667,28 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                             <child>
                               <object class="GtkFrame" id="sid183">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid184">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid185">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="sid186">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;With some setup, pen strokes have artifacts at their beginning. This can be avoided by ignoring the first few events/stroke-points when the pen touches the screen.&lt;/i&gt;</property>
-                                            <property name="use_markup">True</property>
+                                            <property name="use-markup">True</property>
                                             <property name="wrap">True</property>
-                                            <property name="max_width_chars">85</property>
+                                            <property name="max-width-chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -1689,16 +1700,16 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                         <child>
                                           <object class="GtkBox" id="sid187">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <child>
                                               <object class="GtkCheckButton" id="cbIgnoreFirstStylusEvents">
                                                 <property name="label" translatable="yes">Ignore the first</property>
                                                 <property name="name">cbSettingIgnoreFirstStylusEvents</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="receives_default">False</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">False</property>
                                                 <property name="xalign">0</property>
-                                                <property name="draw_indicator">True</property>
+                                                <property name="draw-indicator">True</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
@@ -1710,7 +1721,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                               <object class="GtkSpinButton" id="spNumIgnoredStylusEvents">
                                                 <property name="name">spNrOfIgnoredFirstStylusEvents</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
+                                                <property name="can-focus">True</property>
                                                 <property name="text" translatable="yes">1</property>
                                                 <property name="adjustment">adjustmentIgnoreStylusEvents</property>
                                                 <property name="value">1</property>
@@ -1726,7 +1737,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                               <object class="GtkLabel" id="lbIgnoreFirstStylusEvents">
                                                 <property name="name">lbIgnoreFirstStylusEvents</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">events</property>
                                               </object>
                                               <packing>
@@ -1749,7 +1760,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                 <child type="label">
                                   <object class="GtkLabel" id="sid188">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Artifact workaround</property>
                                   </object>
                                 </child>
@@ -1763,28 +1774,28 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                             <child>
                               <object class="GtkFrame" id="sid38">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid39">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">12</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">12</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid40">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="sid41">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;Specify the tools that will be selected if a button of the stylus is pressed or the eraser is used. After releasing the button, the previous tool will be selected.&lt;/i&gt;</property>
-                                            <property name="use_markup">True</property>
+                                            <property name="use-markup">True</property>
                                             <property name="wrap">True</property>
-                                            <property name="max_width_chars">85</property>
+                                            <property name="max-width-chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -1796,20 +1807,20 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                         <child>
                                           <object class="GtkFrame" id="sid42">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label_xalign">0.0099999997764825821</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label-xalign">0.009999999776482582</property>
                                             <child>
                                               <object class="GtkAlignment" id="sid43">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="bottom_padding">8</property>
-                                                <property name="left_padding">12</property>
-                                                <property name="right_padding">12</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="bottom-padding">8</property>
+                                                <property name="left-padding">12</property>
+                                                <property name="right-padding">12</property>
                                                 <child>
                                                   <object class="GtkBox" id="hboxPenButton1">
                                                     <property name="name">hboxPenButton1</property>
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <child>
                                                       <placeholder/>
                                                     </child>
@@ -1820,7 +1831,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             <child type="label">
                                               <object class="GtkLabel" id="sid44">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">Button 1</property>
                                               </object>
                                             </child>
@@ -1834,20 +1845,20 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                         <child>
                                           <object class="GtkFrame" id="sid45">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label_xalign">0.0099999997764825821</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label-xalign">0.009999999776482582</property>
                                             <child>
                                               <object class="GtkAlignment" id="sid46">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="bottom_padding">8</property>
-                                                <property name="left_padding">12</property>
-                                                <property name="right_padding">12</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="bottom-padding">8</property>
+                                                <property name="left-padding">12</property>
+                                                <property name="right-padding">12</property>
                                                 <child>
                                                   <object class="GtkBox" id="hboxPenButton2">
                                                     <property name="name">hboxPenButton2</property>
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <child>
                                                       <placeholder/>
                                                     </child>
@@ -1858,7 +1869,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             <child type="label">
                                               <object class="GtkLabel" id="sid47">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">Button 2</property>
                                               </object>
                                             </child>
@@ -1872,20 +1883,20 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                         <child>
                                           <object class="GtkFrame" id="sid48">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label_xalign">0.0099999997764825821</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label-xalign">0.009999999776482582</property>
                                             <child>
                                               <object class="GtkAlignment" id="sid49">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="bottom_padding">8</property>
-                                                <property name="left_padding">12</property>
-                                                <property name="right_padding">12</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="bottom-padding">8</property>
+                                                <property name="left-padding">12</property>
+                                                <property name="right-padding">12</property>
                                                 <child>
                                                   <object class="GtkBox" id="hboxEraser">
                                                     <property name="name">hboxEraser</property>
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <child>
                                                       <placeholder/>
                                                     </child>
@@ -1896,7 +1907,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             <child type="label">
                                               <object class="GtkLabel" id="sid50">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">Eraser</property>
                                               </object>
                                             </child>
@@ -1914,7 +1925,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                 <child type="label">
                                   <object class="GtkLabel" id="sid51">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Stylus Buttons</property>
                                   </object>
                                 </child>
@@ -1945,62 +1956,62 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
               <object class="GtkLabel" id="stylusTabLabel">
                 <property name="name">stylusTabLabel</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Stylus</property>
               </object>
               <packing>
                 <property name="position">3</property>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="touchTabBox">
                 <property name="name">touchTabBox</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_left">5</property>
+                <property name="can-focus">False</property>
+                <property name="margin-left">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid52">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="min_content_width">500</property>
-                    <property name="min_content_height">450</property>
+                    <property name="can-focus">True</property>
+                    <property name="min-content-width">500</property>
+                    <property name="min-content-height">450</property>
                     <child>
                       <object class="GtkViewport" id="sid53">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkBox" id="sid54">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="sid55">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid56">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid57">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="sid58">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;You can configure devices, not identified by GTK as touchscreen, to behave as if they were one.&lt;/i&gt;</property>
-                                            <property name="use_markup">True</property>
+                                            <property name="use-markup">True</property>
                                             <property name="wrap">True</property>
-                                            <property name="max_width_chars">85</property>
+                                            <property name="max-width-chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -2013,7 +2024,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                           <object class="GtkBox" id="hboxTouch">
                                             <property name="name">hboxTouch</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <child>
                                               <placeholder/>
                                             </child>
@@ -2031,7 +2042,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                 <child type="label">
                                   <object class="GtkLabel" id="sid59">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Touchscreen</property>
                                   </object>
                                 </child>
@@ -2045,28 +2056,28 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                             <child>
                               <object class="GtkFrame" id="sid60">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid61">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid62">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="sid63">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;If your hardware does not support hand recognition, Xournal++ can disable your touchscreen when your pen is near the screen.&lt;/i&gt;</property>
-                                            <property name="use_markup">True</property>
+                                            <property name="use-markup">True</property>
                                             <property name="wrap">True</property>
-                                            <property name="max_width_chars">85</property>
+                                            <property name="max-width-chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -2080,10 +2091,10 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             <property name="label" translatable="yes">Enable internal Hand Recognition</property>
                                             <property name="name">cbDisableTouchOnPenNear</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -2095,42 +2106,43 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                           <object class="GtkBox" id="boxInternalHandRecognition">
                                             <property name="name">boxInternalHandRecognition</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="orientation">vertical</property>
                                             <child>
+                                              <!-- n-columns=3 n-rows=3 -->
                                               <object class="GtkGrid" id="sid64">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="row_spacing">5</property>
-                                                <property name="column_spacing">5</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="row-spacing">5</property>
+                                                <property name="column-spacing">5</property>
                                                 <child>
                                                   <object class="GtkLabel" id="label50">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="label" translatable="yes">Disabling Method</property>
                                                   </object>
                                                   <packing>
-                                                    <property name="left_attach">0</property>
-                                                    <property name="top_attach">0</property>
+                                                    <property name="left-attach">0</property>
+                                                    <property name="top-attach">0</property>
                                                   </packing>
                                                 </child>
                                                 <child>
                                                   <object class="GtkLabel" id="label55">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="label" translatable="yes">Timeout</property>
                                                     <property name="xalign">0</property>
                                                   </object>
                                                   <packing>
-                                                    <property name="left_attach">0</property>
-                                                    <property name="top_attach">1</property>
+                                                    <property name="left-attach">0</property>
+                                                    <property name="top-attach">1</property>
                                                   </packing>
                                                 </child>
                                                 <child>
                                                   <object class="GtkComboBoxText" id="cbTouchDisableMethod">
                                                     <property name="name">cbTouchDisableMethod</property>
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="active">0</property>
                                                     <items>
                                                       <item translatable="yes">Autodetect</item>
@@ -2139,37 +2151,46 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                                     </items>
                                                   </object>
                                                   <packing>
-                                                    <property name="left_attach">1</property>
-                                                    <property name="top_attach">0</property>
+                                                    <property name="left-attach">1</property>
+                                                    <property name="top-attach">0</property>
                                                   </packing>
                                                 </child>
                                                 <child>
                                                   <object class="GtkSpinButton" id="spTouchDisableTimeout">
                                                     <property name="name">spTouchDisableTimeout</property>
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">True</property>
+                                                    <property name="can-focus">True</property>
                                                     <property name="adjustment">adjustmentTouchTImeout</property>
-                                                    <property name="climb_rate">0.5</property>
+                                                    <property name="climb-rate">0.5</property>
                                                     <property name="digits">1</property>
                                                     <property name="value">1</property>
                                                   </object>
                                                   <packing>
-                                                    <property name="left_attach">1</property>
-                                                    <property name="top_attach">1</property>
+                                                    <property name="left-attach">1</property>
+                                                    <property name="top-attach">1</property>
                                                   </packing>
                                                 </child>
                                                 <child>
                                                   <object class="GtkLabel" id="label56">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="label" translatable="yes">s &lt;i&gt;(after which the touchscreen will be reactivated again)&lt;/i&gt;</property>
-                                                    <property name="use_markup">True</property>
+                                                    <property name="use-markup">True</property>
                                                     <property name="xalign">0</property>
                                                   </object>
                                                   <packing>
-                                                    <property name="left_attach">2</property>
-                                                    <property name="top_attach">1</property>
+                                                    <property name="left-attach">2</property>
+                                                    <property name="top-attach">1</property>
                                                   </packing>
+                                                </child>
+                                                <child>
+                                                  <placeholder/>
+                                                </child>
+                                                <child>
+                                                  <placeholder/>
+                                                </child>
+                                                <child>
+                                                  <placeholder/>
                                                 </child>
                                                 <child>
                                                   <placeholder/>
@@ -2185,28 +2206,28 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                               <object class="GtkFrame" id="boxCustomTouchDisableSettings">
                                                 <property name="name">boxCustomTouchDisableSettings</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="label_xalign">0.0099999997764825821</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label-xalign">0.009999999776482582</property>
                                                 <child>
                                                   <object class="GtkAlignment" id="sid65">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
-                                                    <property name="bottom_padding">8</property>
-                                                    <property name="left_padding">12</property>
-                                                    <property name="right_padding">12</property>
+                                                    <property name="can-focus">False</property>
+                                                    <property name="bottom-padding">8</property>
+                                                    <property name="left-padding">12</property>
+                                                    <property name="right-padding">12</property>
                                                     <child>
                                                       <object class="GtkBox" id="sid66">
                                                         <property name="visible">True</property>
-                                                        <property name="can_focus">False</property>
+                                                        <property name="can-focus">False</property>
                                                         <property name="orientation">vertical</property>
                                                         <child>
                                                           <object class="GtkLabel" id="label54">
                                                             <property name="visible">True</property>
-                                                            <property name="can_focus">False</property>
+                                                            <property name="can-focus">False</property>
                                                             <property name="label" translatable="yes">&lt;i&gt;Specify commands that are called once Hand Recognition triggers. The commands will be executed in the UI Thread, make sure they are not blocking!&lt;/i&gt;</property>
-                                                            <property name="use_markup">True</property>
+                                                            <property name="use-markup">True</property>
                                                             <property name="wrap">True</property>
-                                                            <property name="max_width_chars">85</property>
+                                                            <property name="max-width-chars">85</property>
                                                             <property name="xalign">0</property>
                                                           </object>
                                                           <packing>
@@ -2216,83 +2237,93 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                                           </packing>
                                                         </child>
                                                         <child>
+                                                          <!-- n-columns=3 n-rows=3 -->
                                                           <object class="GtkGrid" id="grid3">
                                                             <property name="visible">True</property>
-                                                            <property name="can_focus">False</property>
-                                                            <property name="row_spacing">5</property>
-                                                            <property name="column_spacing">5</property>
+                                                            <property name="can-focus">False</property>
+                                                            <property name="row-spacing">5</property>
+                                                            <property name="column-spacing">5</property>
                                                             <child>
-                                                              <object class="GtkLabel" id="label52">
-                                                                <property name="visible">True</property>
-                                                                <property name="can_focus">False</property>
-                                                                <property name="label" translatable="yes">Enable</property>
-                                                                <property name="xalign">0</property>
-                                                              </object>
-                                                              <packing>
-                                                                <property name="left_attach">0</property>
-                                                                <property name="top_attach">0</property>
-                                                              </packing>
+                                                            <object class="GtkLabel" id="label52">
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">False</property>
+                                                            <property name="label" translatable="yes">Enable</property>
+                                                            <property name="xalign">0</property>
+                                                            </object>
+                                                            <packing>
+                                                            <property name="left-attach">0</property>
+                                                            <property name="top-attach">0</property>
+                                                            </packing>
                                                             </child>
                                                             <child>
-                                                              <object class="GtkLabel" id="label53">
-                                                                <property name="visible">True</property>
-                                                                <property name="can_focus">False</property>
-                                                                <property name="label" translatable="yes">Disable</property>
-                                                              </object>
-                                                              <packing>
-                                                                <property name="left_attach">0</property>
-                                                                <property name="top_attach">1</property>
-                                                              </packing>
+                                                            <object class="GtkLabel" id="label53">
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">False</property>
+                                                            <property name="label" translatable="yes">Disable</property>
+                                                            </object>
+                                                            <packing>
+                                                            <property name="left-attach">0</property>
+                                                            <property name="top-attach">1</property>
+                                                            </packing>
                                                             </child>
                                                             <child>
-                                                              <object class="GtkEntry" id="txtEnableTouchCommand">
-                                                                <property name="name">txtEnableTouchCommand</property>
-                                                                <property name="visible">True</property>
-                                                                <property name="can_focus">True</property>
-                                                                <property name="hexpand">True</property>
-                                                              </object>
-                                                              <packing>
-                                                                <property name="left_attach">1</property>
-                                                                <property name="top_attach">0</property>
-                                                              </packing>
+                                                            <object class="GtkEntry" id="txtEnableTouchCommand">
+                                                            <property name="name">txtEnableTouchCommand</property>
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">True</property>
+                                                            <property name="hexpand">True</property>
+                                                            </object>
+                                                            <packing>
+                                                            <property name="left-attach">1</property>
+                                                            <property name="top-attach">0</property>
+                                                            </packing>
                                                             </child>
                                                             <child>
-                                                              <object class="GtkEntry" id="txtDisableTouchCommand">
-                                                                <property name="name">txtDisableTouchCommand</property>
-                                                                <property name="visible">True</property>
-                                                                <property name="can_focus">True</property>
-                                                                <property name="hexpand">True</property>
-                                                              </object>
-                                                              <packing>
-                                                                <property name="left_attach">1</property>
-                                                                <property name="top_attach">1</property>
-                                                              </packing>
+                                                            <object class="GtkEntry" id="txtDisableTouchCommand">
+                                                            <property name="name">txtDisableTouchCommand</property>
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">True</property>
+                                                            <property name="hexpand">True</property>
+                                                            </object>
+                                                            <packing>
+                                                            <property name="left-attach">1</property>
+                                                            <property name="top-attach">1</property>
+                                                            </packing>
                                                             </child>
                                                             <child>
-                                                              <object class="GtkButton" id="btTestEnable">
-                                                                <property name="label" translatable="yes">Test</property>
-                                                                <property name="name">btTestEnable</property>
-                                                                <property name="visible">True</property>
-                                                                <property name="can_focus">True</property>
-                                                                <property name="receives_default">True</property>
-                                                              </object>
-                                                              <packing>
-                                                                <property name="left_attach">2</property>
-                                                                <property name="top_attach">0</property>
-                                                              </packing>
+                                                            <object class="GtkButton" id="btTestEnable">
+                                                            <property name="label" translatable="yes">Test</property>
+                                                            <property name="name">btTestEnable</property>
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">True</property>
+                                                            <property name="receives-default">True</property>
+                                                            </object>
+                                                            <packing>
+                                                            <property name="left-attach">2</property>
+                                                            <property name="top-attach">0</property>
+                                                            </packing>
                                                             </child>
                                                             <child>
-                                                              <object class="GtkButton" id="btTestDisable">
-                                                                <property name="label" translatable="yes">Test</property>
-                                                                <property name="name">btTestDisable</property>
-                                                                <property name="visible">True</property>
-                                                                <property name="can_focus">True</property>
-                                                                <property name="receives_default">True</property>
-                                                              </object>
-                                                              <packing>
-                                                                <property name="left_attach">2</property>
-                                                                <property name="top_attach">1</property>
-                                                              </packing>
+                                                            <object class="GtkButton" id="btTestDisable">
+                                                            <property name="label" translatable="yes">Test</property>
+                                                            <property name="name">btTestDisable</property>
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">True</property>
+                                                            <property name="receives-default">True</property>
+                                                            </object>
+                                                            <packing>
+                                                            <property name="left-attach">2</property>
+                                                            <property name="top-attach">1</property>
+                                                            </packing>
+                                                            </child>
+                                                            <child>
+                                                            <placeholder/>
+                                                            </child>
+                                                            <child>
+                                                            <placeholder/>
+                                                            </child>
+                                                            <child>
+                                                            <placeholder/>
                                                             </child>
                                                           </object>
                                                           <packing>
@@ -2308,7 +2339,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                                 <child type="label">
                                                   <object class="GtkLabel" id="sid67">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="label" translatable="yes">Custom Commands (for Method "Custom")</property>
                                                   </object>
                                                 </child>
@@ -2333,7 +2364,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                 <child type="label">
                                   <object class="GtkLabel" id="sid68">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Hand Recognition</property>
                                   </object>
                                 </child>
@@ -2347,26 +2378,26 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                             <child>
                               <object class="GtkFrame" id="sid69">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid70">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid71">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="sid72">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;Use pinch gestures to zoom journal pages.&lt;/i&gt;</property>
-                                            <property name="use_markup">True</property>
+                                            <property name="use-markup">True</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -2380,10 +2411,10 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             <property name="label" translatable="yes">Enable zoom gestures (requires restart)</property>
                                             <property name="name">cbEnableZoomGestures</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -2392,48 +2423,67 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                           </packing>
                                         </child>
                                         <child>
+                                          <!-- n-columns=3 n-rows=3 -->
                                           <object class="GtkGrid" id="gdStartZoomAtSetting">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="tooltip_text" translatable="yes">When drawing with touch, two-finger gestures intended to pan the view can instead cause it to zoom, causing performance issues. 
+                                            <property name="can-focus">False</property>
+                                            <property name="tooltip-text" translatable="yes">When drawing with touch, two-finger gestures intended to pan the view can instead cause it to zoom, causing performance issues. 
 This setting can make it easier to draw with touch. </property>
                                             <child>
                                               <object class="GtkLabel" id="label2">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">Start zooming after a distance </property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">0</property>
-                                                <property name="top_attach">0</property>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkSpinButton" id="spTouchZoomStartThreshold">
                                                 <property name="name">spTouchDisableTimeout</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
+                                                <property name="can-focus">True</property>
                                                 <property name="text" translatable="yes">1.0</property>
                                                 <property name="adjustment">adjustmentZoomStartThreshold</property>
-                                                <property name="climb_rate">0.5</property>
+                                                <property name="climb-rate">0.5</property>
                                                 <property name="digits">1</property>
                                                 <property name="value">1</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">1</property>
-                                                <property name="top_attach">0</property>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkLabel" id="label4">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">% greater than the initial distance between the two touches.</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">2</property>
-                                                <property name="top_attach">0</property>
+                                                <property name="left-attach">2</property>
+                                                <property name="top-attach">0</property>
                                               </packing>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
                                             </child>
                                           </object>
                                           <packing>
@@ -2449,7 +2499,7 @@ This setting can make it easier to draw with touch. </property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid73">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Zoom Gestures</property>
                                   </object>
                                 </child>
@@ -2463,28 +2513,28 @@ This setting can make it easier to draw with touch. </property>
                             <child>
                               <object class="GtkFrame" id="frameTouchDrawing">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="touchDrawingFrameAlignment">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="boxTouchDrawing">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="lblTouchDrawingDescription">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;Use the touchscreen like a multi-touch-aware pen.&lt;/i&gt;</property>
-                                            <property name="use_markup">True</property>
+                                            <property name="use-markup">True</property>
                                             <property name="wrap">True</property>
-                                            <property name="max_width_chars">85</property>
+                                            <property name="max-width-chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -2498,11 +2548,11 @@ This setting can make it easier to draw with touch. </property>
                                             <property name="label" translatable="yes">Enable touch drawing</property>
                                             <property name="name">cbTouchDrawing</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="tooltip_text" translatable="yes">Use two fingers to pan/zoom and one finger to use the selected tool.</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-text" translatable="yes">Use two fingers to pan/zoom and one finger to use the selected tool.</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -2517,7 +2567,7 @@ This setting can make it easier to draw with touch. </property>
                                 <child type="label">
                                   <object class="GtkLabel" id="headerTouchDrawingFrame">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Touch Drawing</property>
                                   </object>
                                 </child>
@@ -2548,68 +2598,68 @@ This setting can make it easier to draw with touch. </property>
               <object class="GtkLabel" id="touchTabLabel">
                 <property name="name">touchTabLabel</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Touchscreen</property>
               </object>
               <packing>
                 <property name="position">4</property>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="viewTabBox">
                 <property name="name">viewTabBox</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_left">5</property>
+                <property name="can-focus">False</property>
+                <property name="margin-left">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid95">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="min_content_width">500</property>
-                    <property name="min_content_height">450</property>
+                    <property name="can-focus">True</property>
+                    <property name="min-content-width">500</property>
+                    <property name="min-content-height">450</property>
                     <child>
                       <object class="GtkViewport" id="sid96">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkBox" id="sid97">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="sid98">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid99">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">12</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">12</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid100">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkBox" id="vbox6">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="halign">start</property>
                                             <child>
                                               <object class="GtkCheckButton" id="cbHideMenubarStartup">
                                                 <property name="label" translatable="yes">Show Menubar on Startup</property>
                                                 <property name="name">cbHideMenubarStartup</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="receives_default">False</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">False</property>
                                                 <property name="xalign">0</property>
-                                                <property name="draw_indicator">True</property>
+                                                <property name="draw-indicator">True</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
@@ -2620,10 +2670,10 @@ This setting can make it easier to draw with touch. </property>
                                             <child>
                                               <object class="GtkLabel" id="sid101">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="margin_left">5</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="margin-left">5</property>
                                                 <property name="label" translatable="yes">&lt;i&gt;Toggle visibility of menubar with F10&lt;/i&gt;</property>
-                                                <property name="use_markup">True</property>
+                                                <property name="use-markup">True</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
@@ -2642,94 +2692,95 @@ This setting can make it easier to draw with touch. </property>
                                           <object class="GtkFrame" id="colorsFrame">
                                             <property name="name">colorsFrame</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label_xalign">0.0099999997764825821</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label-xalign">0.009999999776482582</property>
                                             <child>
                                               <object class="GtkAlignment" id="sid102">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="bottom_padding">8</property>
-                                                <property name="left_padding">12</property>
-                                                <property name="right_padding">12</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="bottom-padding">8</property>
+                                                <property name="left-padding">12</property>
+                                                <property name="right-padding">12</property>
                                                 <child>
+                                                  <!-- n-columns=3 n-rows=6 -->
                                                   <object class="GtkGrid" id="grid2">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <child>
                                                       <object class="GtkLabel" id="label10">
                                                         <property name="visible">True</property>
-                                                        <property name="can_focus">False</property>
+                                                        <property name="can-focus">False</property>
                                                         <property name="hexpand">True</property>
                                                         <property name="label" translatable="yes">Border color for current page and other selections</property>
                                                         <property name="justify">right</property>
                                                         <property name="xalign">0</property>
                                                       </object>
                                                       <packing>
-                                                        <property name="left_attach">0</property>
-                                                        <property name="top_attach">0</property>
+                                                        <property name="left-attach">0</property>
+                                                        <property name="top-attach">0</property>
                                                       </packing>
                                                     </child>
                                                     <child>
                                                       <object class="GtkColorButton" id="colorBorder">
                                                         <property name="name">colorBorder</property>
                                                         <property name="visible">True</property>
-                                                        <property name="can_focus">True</property>
-                                                        <property name="receives_default">True</property>
+                                                        <property name="can-focus">True</property>
+                                                        <property name="receives-default">True</property>
                                                         <property name="title" translatable="yes">Border color</property>
                                                       </object>
                                                       <packing>
-                                                        <property name="left_attach">1</property>
-                                                        <property name="top_attach">0</property>
+                                                        <property name="left-attach">1</property>
+                                                        <property name="top-attach">0</property>
                                                       </packing>
                                                     </child>
                                                     <child>
                                                       <object class="GtkLabel" id="label13">
                                                         <property name="visible">True</property>
-                                                        <property name="can_focus">False</property>
+                                                        <property name="can-focus">False</property>
                                                         <property name="label" translatable="yes">Background color between pages</property>
                                                         <property name="xalign">0</property>
                                                       </object>
                                                       <packing>
-                                                        <property name="left_attach">0</property>
-                                                        <property name="top_attach">1</property>
+                                                        <property name="left-attach">0</property>
+                                                        <property name="top-attach">1</property>
                                                       </packing>
                                                     </child>
                                                     <child>
                                                       <object class="GtkColorButton" id="colorBackground">
                                                         <property name="name">colorBackground</property>
                                                         <property name="visible">True</property>
-                                                        <property name="can_focus">True</property>
-                                                        <property name="receives_default">True</property>
-                                                        <property name="margin_top">5</property>
+                                                        <property name="can-focus">True</property>
+                                                        <property name="receives-default">True</property>
+                                                        <property name="margin-top">5</property>
                                                       </object>
                                                       <packing>
-                                                        <property name="left_attach">1</property>
-                                                        <property name="top_attach">1</property>
+                                                        <property name="left-attach">1</property>
+                                                        <property name="top-attach">1</property>
                                                       </packing>
                                                     </child>
                                                     <child>
                                                       <object class="GtkLabel" id="label57">
                                                         <property name="visible">True</property>
-                                                        <property name="can_focus">False</property>
+                                                        <property name="can-focus">False</property>
                                                         <property name="label" translatable="yes">Selection Color (Text, Stroke Selection etc.)</property>
                                                         <property name="xalign">0</property>
                                                       </object>
                                                       <packing>
-                                                        <property name="left_attach">0</property>
-                                                        <property name="top_attach">2</property>
+                                                        <property name="left-attach">0</property>
+                                                        <property name="top-attach">2</property>
                                                       </packing>
                                                     </child>
                                                     <child>
                                                       <object class="GtkColorButton" id="colorSelection">
                                                         <property name="name">colorSelection</property>
                                                         <property name="visible">True</property>
-                                                        <property name="can_focus">True</property>
-                                                        <property name="receives_default">True</property>
-                                                        <property name="margin_top">5</property>
+                                                        <property name="can-focus">True</property>
+                                                        <property name="receives-default">True</property>
+                                                        <property name="margin-top">5</property>
                                                       </object>
                                                       <packing>
-                                                        <property name="left_attach">1</property>
-                                                        <property name="top_attach">2</property>
+                                                        <property name="left-attach">1</property>
+                                                        <property name="top-attach">2</property>
                                                       </packing>
                                                     </child>
                                                     <child>
@@ -2737,14 +2788,14 @@ This setting can make it easier to draw with touch. </property>
                                                         <property name="label" translatable="yes">Dark Theme (requires restart)</property>
                                                         <property name="name">cbDarkTheme</property>
                                                         <property name="visible">True</property>
-                                                        <property name="can_focus">True</property>
-                                                        <property name="receives_default">False</property>
+                                                        <property name="can-focus">True</property>
+                                                        <property name="receives-default">False</property>
                                                         <property name="xalign">0</property>
-                                                        <property name="draw_indicator">True</property>
+                                                        <property name="draw-indicator">True</property>
                                                       </object>
                                                       <packing>
-                                                        <property name="left_attach">0</property>
-                                                        <property name="top_attach">3</property>
+                                                        <property name="left-attach">0</property>
+                                                        <property name="top-attach">3</property>
                                                         <property name="width">2</property>
                                                       </packing>
                                                     </child>
@@ -2753,16 +2804,40 @@ This setting can make it easier to draw with touch. </property>
                                                         <property name="label" translatable="yes">Use  available Stock Icons (requires restart)</property>
                                                         <property name="name">cbStockIcons</property>
                                                         <property name="visible">True</property>
-                                                        <property name="can_focus">True</property>
-                                                        <property name="receives_default">False</property>
+                                                        <property name="can-focus">True</property>
+                                                        <property name="receives-default">False</property>
                                                         <property name="xalign">0</property>
-                                                        <property name="draw_indicator">True</property>
+                                                        <property name="draw-indicator">True</property>
                                                       </object>
                                                       <packing>
-                                                        <property name="left_attach">0</property>
-                                                        <property name="top_attach">5</property>
+                                                        <property name="left-attach">0</property>
+                                                        <property name="top-attach">5</property>
                                                         <property name="width">2</property>
                                                       </packing>
+                                                    </child>
+                                                    <child>
+                                                      <placeholder/>
+                                                    </child>
+                                                    <child>
+                                                      <placeholder/>
+                                                    </child>
+                                                    <child>
+                                                      <placeholder/>
+                                                    </child>
+                                                    <child>
+                                                      <placeholder/>
+                                                    </child>
+                                                    <child>
+                                                      <placeholder/>
+                                                    </child>
+                                                    <child>
+                                                      <placeholder/>
+                                                    </child>
+                                                    <child>
+                                                      <placeholder/>
+                                                    </child>
+                                                    <child>
+                                                      <placeholder/>
                                                     </child>
                                                   </object>
                                                 </child>
@@ -2771,7 +2846,7 @@ This setting can make it easier to draw with touch. </property>
                                             <child type="label">
                                               <object class="GtkLabel" id="sid103">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">Colors</property>
                                               </object>
                                             </child>
@@ -2789,9 +2864,9 @@ This setting can make it easier to draw with touch. </property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid104">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Global</property>
-                                    <property name="use_markup">True</property>
+                                    <property name="use-markup">True</property>
                                   </object>
                                 </child>
                               </object>
@@ -2804,29 +2879,29 @@ This setting can make it easier to draw with touch. </property>
                             <child>
                               <object class="GtkFrame" id="sid105">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid106">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="vbox15">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkBox">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="spacing">5</property>
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">Cursor icon for pen</property>
                                                 <property name="xalign">0</property>
                                               </object>
@@ -2840,7 +2915,7 @@ This setting can make it easier to draw with touch. </property>
                                               <object class="GtkComboBoxText" id="cbStylusCursorType">
                                                 <property name="name">cbStylusCursorType</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="active">0</property>
                                                 <items>
                                                   <item id="none" translatable="yes" context="stylus cursor uses no icon">No icon</item>
@@ -2862,207 +2937,217 @@ This setting can make it easier to draw with touch. </property>
                                           </packing>
                                         </child>
                                         <child>
+                                          <!-- n-columns=3 n-rows=3 -->
                                           <object class="GtkGrid" id="highlightCursorGrid">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="column_homogeneous">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="column-homogeneous">True</property>
                                             <child>
                                               <object class="GtkCheckButton" id="cbHighlightPosition">
                                                 <property name="label" translatable="yes">Highlight cursor position</property>
                                                 <property name="name">cbHighlightPosition</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="receives_default">False</property>
-                                                <property name="tooltip_text" translatable="yes">Draw a transparent circle around the cursor</property>
-                                                <property name="draw_indicator">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">False</property>
+                                                <property name="tooltip-text" translatable="yes">Draw a transparent circle around the cursor</property>
+                                                <property name="draw-indicator">True</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">0</property>
-                                                <property name="top_attach">0</property>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkBox">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <child>
                                                   <object class="GtkColorButton" id="cursorHighlightColor">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">True</property>
-                                                    <property name="receives_default">True</property>
-                                                    <property name="use_alpha">True</property>
+                                                    <property name="can-focus">True</property>
+                                                    <property name="receives-default">True</property>
+                                                    <property name="use-alpha">True</property>
                                                     <property name="title" translatable="yes">Choose the color to use for "Highlight cursor position"</property>
-                                                    <property name="show_editor">True</property>
+                                                    <property name="show-editor">True</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
                                                     <property name="fill">True</property>
-                                                    <property name="pack_type">end</property>
+                                                    <property name="pack-type">end</property>
                                                     <property name="position">0</property>
                                                   </packing>
                                                 </child>
                                                 <child>
                                                   <object class="GtkLabel">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="label" translatable="yes">Circle Color</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
                                                     <property name="fill">True</property>
                                                     <property name="padding">10</property>
-                                                    <property name="pack_type">end</property>
+                                                    <property name="pack-type">end</property>
                                                     <property name="position">1</property>
                                                   </packing>
                                                 </child>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">1</property>
-                                                <property name="top_attach">1</property>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">1</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkBox">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <child>
                                                   <object class="GtkLabel">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="label" translatable="yes">pixels</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
                                                     <property name="fill">True</property>
-                                                    <property name="pack_type">end</property>
+                                                    <property name="pack-type">end</property>
                                                     <property name="position">0</property>
                                                   </packing>
                                                 </child>
                                                 <child>
                                                   <object class="GtkSpinButton" id="cursorHighlightRadius">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">True</property>
-                                                    <property name="input_purpose">number</property>
+                                                    <property name="can-focus">True</property>
+                                                    <property name="input-purpose">number</property>
                                                     <property name="adjustment">adjustmentCursorHighlightRadius</property>
                                                     <property name="numeric">True</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
                                                     <property name="fill">True</property>
-                                                    <property name="pack_type">end</property>
+                                                    <property name="pack-type">end</property>
                                                     <property name="position">1</property>
                                                   </packing>
                                                 </child>
                                                 <child>
                                                   <object class="GtkLabel">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="label" translatable="yes">Radius</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
                                                     <property name="fill">True</property>
-                                                    <property name="pack_type">end</property>
+                                                    <property name="pack-type">end</property>
                                                     <property name="position">3</property>
                                                   </packing>
                                                 </child>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">0</property>
-                                                <property name="top_attach">1</property>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">1</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkBox">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <child>
                                                   <object class="GtkLabel">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="label" translatable="yes">pixels</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
                                                     <property name="fill">True</property>
-                                                    <property name="pack_type">end</property>
+                                                    <property name="pack-type">end</property>
                                                     <property name="position">0</property>
                                                   </packing>
                                                 </child>
                                                 <child>
                                                   <object class="GtkSpinButton" id="cursorHighlightBorderWidth">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">True</property>
+                                                    <property name="can-focus">True</property>
                                                     <property name="text" translatable="yes">30</property>
-                                                    <property name="input_purpose">number</property>
+                                                    <property name="input-purpose">number</property>
                                                     <property name="adjustment">adjustmentCursorHighlightBorderWidth</property>
                                                     <property name="numeric">True</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
                                                     <property name="fill">True</property>
-                                                    <property name="pack_type">end</property>
+                                                    <property name="pack-type">end</property>
                                                     <property name="position">1</property>
                                                   </packing>
                                                 </child>
                                                 <child>
                                                   <object class="GtkLabel">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="label" translatable="yes">Border Width</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
                                                     <property name="fill">True</property>
-                                                    <property name="pack_type">end</property>
+                                                    <property name="pack-type">end</property>
                                                     <property name="position">3</property>
                                                   </packing>
                                                 </child>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">0</property>
-                                                <property name="top_attach">2</property>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">2</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkBox">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <child>
                                                   <object class="GtkColorButton" id="cursorHighlightBorderColor">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">True</property>
-                                                    <property name="receives_default">True</property>
-                                                    <property name="use_alpha">True</property>
+                                                    <property name="can-focus">True</property>
+                                                    <property name="receives-default">True</property>
+                                                    <property name="use-alpha">True</property>
                                                     <property name="title" translatable="yes">Choose the color to use for "Highlight cursor position"</property>
-                                                    <property name="show_editor">True</property>
+                                                    <property name="show-editor">True</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
                                                     <property name="fill">True</property>
-                                                    <property name="pack_type">end</property>
+                                                    <property name="pack-type">end</property>
                                                     <property name="position">0</property>
                                                   </packing>
                                                 </child>
                                                 <child>
                                                   <object class="GtkLabel">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="label" translatable="yes">Border Color</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
                                                     <property name="fill">True</property>
                                                     <property name="padding">10</property>
-                                                    <property name="pack_type">end</property>
+                                                    <property name="pack-type">end</property>
                                                     <property name="position">1</property>
                                                   </packing>
                                                 </child>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">1</property>
-                                                <property name="top_attach">2</property>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">2</property>
                                               </packing>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
                                             </child>
                                             <child>
                                               <placeholder/>
@@ -3081,7 +3166,7 @@ This setting can make it easier to draw with touch. </property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid107">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Cursor</property>
                                   </object>
                                 </child>
@@ -3095,29 +3180,29 @@ This setting can make it easier to draw with touch. </property>
                             <child>
                               <object class="GtkFrame" id="sid108">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid109">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="box19">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkCheckButton" id="cbShowSidebarRight">
                                             <property name="label" translatable="yes">Show sidebar on the right side</property>
                                             <property name="name">cbShowSidebarRight</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -3130,10 +3215,10 @@ This setting can make it easier to draw with touch. </property>
                                             <property name="label" translatable="yes">Show vertical scrollbar on the left side</property>
                                             <property name="name">cbShowScrollbarLeft</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -3148,7 +3233,7 @@ This setting can make it easier to draw with touch. </property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid110">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Left / Right-Handed</property>
                                   </object>
                                 </child>
@@ -3162,28 +3247,28 @@ This setting can make it easier to draw with touch. </property>
                             <child>
                               <object class="GtkFrame" id="sid111">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid112">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="box42">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkCheckButton" id="cbHideHorizontalScrollbar">
                                             <property name="label" translatable="yes">Hide the horizontal scrollbar</property>
                                             <property name="name">cbHideHorizontalScrollbar</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -3196,9 +3281,9 @@ This setting can make it easier to draw with touch. </property>
                                             <property name="label" translatable="yes">Hide the vertical scrollbar</property>
                                             <property name="name">cbHideVerticalScrollbar</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -3210,9 +3295,9 @@ This setting can make it easier to draw with touch. </property>
                                           <object class="GtkCheckButton" id="cbDisableScrollbarFadeout">
                                             <property name="label" translatable="yes">Disable scrollbar fade out</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -3227,7 +3312,7 @@ This setting can make it easier to draw with touch. </property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid113">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Scrollbars</property>
                                   </object>
                                 </child>
@@ -3241,29 +3326,29 @@ This setting can make it easier to draw with touch. </property>
                             <child>
                               <object class="GtkFrame" id="sid114">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid115">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="vbox9">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkCheckButton" id="cbHideFullscreenMenubar">
                                             <property name="label" translatable="yes">Hide Menubar</property>
                                             <property name="name">cbHideFullscreenMenubar</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -3276,10 +3361,10 @@ This setting can make it easier to draw with touch. </property>
                                             <property name="label" translatable="yes">Hide Sidebar</property>
                                             <property name="name">cbHideFullscreenSidebar</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -3294,7 +3379,7 @@ This setting can make it easier to draw with touch. </property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid116">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Fullscreen</property>
                                   </object>
                                 </child>
@@ -3308,29 +3393,29 @@ This setting can make it easier to draw with touch. </property>
                             <child>
                               <object class="GtkFrame" id="sid117">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid118">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="vbox1">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkCheckButton" id="cbHidePresentationMenubar">
                                             <property name="label" translatable="yes">Hide Menubar</property>
                                             <property name="name">cbHidePresentationMenubar</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -3343,10 +3428,10 @@ This setting can make it easier to draw with touch. </property>
                                             <property name="label" translatable="yes">Hide Sidebar</property>
                                             <property name="name">cbHidePresentationSidebar</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -3356,11 +3441,11 @@ This setting can make it easier to draw with touch. </property>
                                         </child>
                                         <child>
                                           <object class="GtkBox" id="box8">
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <child>
                                               <object class="GtkLabel" id="label16">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">Select toolbar:</property>
                                               </object>
                                               <packing>
@@ -3373,7 +3458,7 @@ This setting can make it easier to draw with touch. </property>
                                               <object class="GtkComboBoxText" id="comboboxtext1">
                                                 <property name="name">comboboxtext1</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
@@ -3395,7 +3480,7 @@ This setting can make it easier to draw with touch. </property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid119">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Presentation Mode</property>
                                   </object>
                                 </child>
@@ -3409,83 +3494,93 @@ This setting can make it easier to draw with touch. </property>
                             <child>
                               <object class="GtkFrame">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="left_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="left-padding">12</property>
                                     <child>
+                                      <!-- n-columns=3 n-rows=3 -->
                                       <object class="GtkGrid">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="column_spacing">10</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="column-spacing">10</property>
                                         <child>
                                           <object class="GtkLabel">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="halign">start</property>
                                             <property name="label" translatable="yes">Pre-load pages before</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">0</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="halign">start</property>
                                             <property name="label" translatable="yes">Pre-load pages after</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">0</property>
-                                            <property name="top_attach">1</property>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">1</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="preloadPagesBefore">
                                             <property name="name">preloadPagesBefore</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="input_purpose">number</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="input-purpose">number</property>
                                             <property name="adjustment">adjustmentPreloadPagesBefore</property>
                                             <property name="numeric">True</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="preloadPagesAfter">
                                             <property name="name">preloadPagesAfter</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="input_purpose">number</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="input-purpose">number</property>
                                             <property name="adjustment">adjustmentPreloadPagesAfter</property>
                                             <property name="numeric">True</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">1</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">1</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkCheckButton" id="cbEagerPageCleanup">
                                             <property name="label" translatable="yes">Clear cached paged while scrolling</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">0</property>
-                                            <property name="top_attach">2</property>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">2</property>
                                             <property name="width">2</property>
                                           </packing>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
                                         </child>
                                       </object>
                                     </child>
@@ -3494,7 +3589,7 @@ This setting can make it easier to draw with touch. </property>
                                 <child type="label">
                                   <object class="GtkLabel">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Performance</property>
                                   </object>
                                 </child>
@@ -3525,132 +3620,142 @@ This setting can make it easier to draw with touch. </property>
               <object class="GtkLabel" id="viewTabLabel">
                 <property name="name">viewTabLabel</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">View</property>
               </object>
               <packing>
                 <property name="position">5</property>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="zoomTabBox">
                 <property name="name">zoomTabBox</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_left">5</property>
+                <property name="can-focus">False</property>
+                <property name="margin-left">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid120">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="min_content_width">500</property>
-                    <property name="min_content_height">450</property>
+                    <property name="can-focus">True</property>
+                    <property name="min-content-width">500</property>
+                    <property name="min-content-height">450</property>
                     <child>
                       <object class="GtkViewport" id="sid121">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkBox" id="sid122">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="sid123">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid124">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
+                                      <!-- n-columns=3 n-rows=3 -->
                                       <object class="GtkGrid" id="sid125">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="column_spacing">5</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="column-spacing">5</property>
                                         <child>
                                           <object class="GtkLabel" id="settingZoomCtrlScrollSpeedLabel">
                                             <property name="name">settingZoomCtrlScrollSpeedLabel</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">Speed for Ctrl + Scroll</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">0</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="spZoomStepScroll">
                                             <property name="name">spZoomStepScroll</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
+                                            <property name="can-focus">True</property>
                                             <property name="adjustment">adjustmentZoomStepScroll</property>
                                             <property name="digits">1</property>
                                             <property name="numeric">True</property>
                                             <property name="value">2</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="settingZoomStepSpeedLabel">
                                             <property name="name">settingZoomStepSpeedLabel</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">Speed for a Zoomstep</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">0</property>
-                                            <property name="top_attach">1</property>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">1</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="spZoomStep">
                                             <property name="name">spZoomStep</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="margin_top">5</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="margin-top">5</property>
                                             <property name="adjustment">adjustmentZoomStep</property>
                                             <property name="digits">1</property>
                                             <property name="numeric">True</property>
                                             <property name="value">10</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">1</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">1</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="sid126">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">%</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">2</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">2</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="sid127">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">%</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">2</property>
-                                            <property name="top_attach">1</property>
+                                            <property name="left-attach">2</property>
+                                            <property name="top-attach">1</property>
                                           </packing>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
                                         </child>
                                       </object>
                                     </child>
@@ -3659,7 +3764,7 @@ This setting can make it easier to draw with touch. </property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid128">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Zoom Speed</property>
                                   </object>
                                 </child>
@@ -3673,27 +3778,27 @@ This setting can make it easier to draw with touch. </property>
                             <child>
                               <object class="GtkFrame" id="sid129">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid130">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid131">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="sid132">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;To make sure on 100% zoom the size of elements is natural. (requires restart)&lt;/i&gt;</property>
-                                            <property name="use_markup">True</property>
-                                            <property name="max_width_chars">85</property>
+                                            <property name="use-markup">True</property>
+                                            <property name="max-width-chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -3705,16 +3810,16 @@ This setting can make it easier to draw with touch. </property>
                                         <child>
                                           <object class="GtkBox" id="box5">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="orientation">vertical</property>
                                             <child>
                                               <object class="GtkLabel" id="label21">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="margin_top">5</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="margin-top">5</property>
                                                 <property name="label" translatable="yes">&lt;i&gt;Put a ruler on your screen and move the slider until both rulers match.&lt;/i&gt;</property>
-                                                <property name="use_markup">True</property>
-                                                <property name="max_width_chars">85</property>
+                                                <property name="use-markup">True</property>
+                                                <property name="max-width-chars">85</property>
                                                 <property name="xalign">0</property>
                                               </object>
                                               <packing>
@@ -3727,11 +3832,11 @@ This setting can make it easier to draw with touch. </property>
                                               <object class="GtkScale" id="zoomCallibSlider">
                                                 <property name="name">zoomCallibSlider</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="margin_top">10</property>
-                                                <property name="margin_bottom">20</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="margin-top">10</property>
+                                                <property name="margin-bottom">20</property>
                                                 <property name="adjustment">adjustmentZoom</property>
-                                                <property name="round_digits">0</property>
+                                                <property name="round-digits">0</property>
                                                 <property name="digits">0</property>
                                               </object>
                                               <packing>
@@ -3744,7 +3849,7 @@ This setting can make it easier to draw with touch. </property>
                                               <object class="GtkBox" id="zoomVBox">
                                                 <property name="name">zoomVBox</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="orientation">vertical</property>
                                                 <child>
                                                   <placeholder/>
@@ -3759,7 +3864,7 @@ This setting can make it easier to draw with touch. </property>
                                             <child>
                                               <object class="GtkLabel" id="label22">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">The unit of the ruler is cm</property>
                                               </object>
                                               <packing>
@@ -3782,7 +3887,7 @@ This setting can make it easier to draw with touch. </property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid133">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Display DPI Calibration</property>
                                   </object>
                                 </child>
@@ -3813,62 +3918,62 @@ This setting can make it easier to draw with touch. </property>
               <object class="GtkLabel" id="zoomTabLabel">
                 <property name="name">zoomTabLabel</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Zoom</property>
               </object>
               <packing>
                 <property name="position">6</property>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="drawingAreaTabBox">
                 <property name="name">drawingAreaTabBox</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_left">5</property>
+                <property name="can-focus">False</property>
+                <property name="margin-left">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid134">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="min_content_width">500</property>
-                    <property name="min_content_height">450</property>
+                    <property name="can-focus">True</property>
+                    <property name="min-content-width">500</property>
+                    <property name="min-content-height">450</property>
                     <child>
                       <object class="GtkViewport" id="sid135">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkBox" id="sid136">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="sid137">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid138">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="box41">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="label37">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;If you add additional space beside the pages you can choose the area of the screen you would like to work on.&lt;/i&gt;</property>
-                                            <property name="use_markup">True</property>
+                                            <property name="use-markup">True</property>
                                             <property name="wrap">True</property>
-                                            <property name="max_width_chars">85</property>
+                                            <property name="max-width-chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -3878,101 +3983,111 @@ This setting can make it easier to draw with touch. </property>
                                           </packing>
                                         </child>
                                         <child>
+                                          <!-- n-columns=3 n-rows=3 -->
                                           <object class="GtkGrid" id="sid139">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="row_spacing">5</property>
-                                            <property name="column_spacing">5</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="row-spacing">5</property>
+                                            <property name="column-spacing">5</property>
                                             <child>
                                               <object class="GtkCheckButton" id="cbAddVerticalSpace">
                                                 <property name="name">cbAddVerticalSpace</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="receives_default">False</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">False</property>
                                                 <property name="xalign">0</property>
-                                                <property name="draw_indicator">True</property>
+                                                <property name="draw-indicator">True</property>
                                                 <child>
                                                   <object class="GtkLabel" id="label38">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="label" translatable="yes">Add additional vertical space of</property>
-                                                    <property name="use_markup">True</property>
+                                                    <property name="use-markup">True</property>
                                                   </object>
                                                 </child>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">0</property>
-                                                <property name="top_attach">0</property>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkCheckButton" id="cbAddHorizontalSpace">
                                                 <property name="name">cbAddHorizontalSpace</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="receives_default">False</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">False</property>
                                                 <property name="xalign">0</property>
-                                                <property name="draw_indicator">True</property>
+                                                <property name="draw-indicator">True</property>
                                                 <child>
                                                   <object class="GtkLabel" id="label39">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="label" translatable="yes">Add additional horizontal space of</property>
-                                                    <property name="use_markup">True</property>
+                                                    <property name="use-markup">True</property>
                                                     <property name="ellipsize">end</property>
                                                   </object>
                                                 </child>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">0</property>
-                                                <property name="top_attach">1</property>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">1</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkSpinButton" id="spAddVerticalSpace">
                                                 <property name="name">spAddVerticalSpace</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
+                                                <property name="can-focus">True</property>
                                                 <property name="adjustment">adjustmentVerticalSpace</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">1</property>
-                                                <property name="top_attach">0</property>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkSpinButton" id="spAddHorizontalSpace">
                                                 <property name="name">spAddHorizontalSpace</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
+                                                <property name="can-focus">True</property>
                                                 <property name="adjustment">adjustmentHorizontalSpace</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">1</property>
-                                                <property name="top_attach">1</property>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">1</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkLabel" id="sid140">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">pixels</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">2</property>
-                                                <property name="top_attach">0</property>
+                                                <property name="left-attach">2</property>
+                                                <property name="top-attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkLabel" id="sid141">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">pixels</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">2</property>
-                                                <property name="top_attach">1</property>
+                                                <property name="left-attach">2</property>
+                                                <property name="top-attach">1</property>
                                               </packing>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
                                             </child>
                                           </object>
                                           <packing>
@@ -3988,7 +4103,7 @@ This setting can make it easier to draw with touch. </property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid142">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Scrolling outside the page</property>
                                   </object>
                                 </child>
@@ -4002,49 +4117,71 @@ This setting can make it easier to draw with touch. </property>
                             <child>
                               <object class="GtkFrame" id="sid143">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid144">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
+                                      <!-- n-columns=3 n-rows=3 -->
                                       <object class="GtkGrid" id="grid4">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="column_spacing">5</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="column-spacing">5</property>
                                         <child>
                                           <object class="GtkLabel" id="label58a">
                                             <property name="name">label58a</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="tooltip_markup" translatable="yes">Offset first page this many pages when &lt;b&gt;Pair Pages&lt;/b&gt; enabled</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="tooltip-markup" translatable="yes">Offset first page this many pages when &lt;b&gt;Pair Pages&lt;/b&gt; enabled</property>
                                             <property name="label" translatable="yes">First Page Offset </property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">0</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="spPairsOffset">
                                             <property name="name">spPairsOffset</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="tooltip_text" translatable="yes">Usually 0 or 1</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="tooltip-text" translatable="yes">Usually 0 or 1</property>
                                             <property name="valign">start</property>
-                                            <property name="max_width_chars">0</property>
+                                            <property name="max-width-chars">0</property>
                                             <property name="adjustment">adjustmentPairsOffset</property>
                                             <property name="numeric">True</property>
-                                            <property name="update_policy">if-valid</property>
+                                            <property name="update-policy">if-valid</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
                                         </child>
                                       </object>
                                     </child>
@@ -4053,7 +4190,7 @@ This setting can make it easier to draw with touch. </property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid145">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Paired Pages</property>
                                   </object>
                                 </child>
@@ -4067,68 +4204,87 @@ This setting can make it easier to draw with touch. </property>
                             <child>
                               <object class="GtkFrame" id="sid150">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid151">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
+                                      <!-- n-columns=3 n-rows=3 -->
                                       <object class="GtkGrid" id="grid6">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="column_spacing">5</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="column-spacing">5</property>
                                         <child>
                                           <object class="GtkCheckButton" id="cbDrawDirModsEnabled">
                                             <property name="label" translatable="yes">Enable  with determination radius of </property>
                                             <property name="name">cbDrawDirModsEnabled</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="tooltip_markup" translatable="yes">Drag LEFT from start point acts like shift key is being held.
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-markup" translatable="yes">Drag LEFT from start point acts like shift key is being held.
 Drag UP acts as if Control key is being held.
 
 Determination Radius: Radius at which modifiers will lock in until finished drawing.
 
 &lt;i&gt;Useful for operating without keyboard.&lt;/i&gt;</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">0</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="spDrawDirModsRadius">
                                             <property name="name">spDrawDirModsRadius</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
+                                            <property name="can-focus">True</property>
                                             <property name="valign">start</property>
-                                            <property name="max_width_chars">0</property>
+                                            <property name="max-width-chars">0</property>
                                             <property name="adjustment">adjustmentDrawDirModRadius</property>
                                             <property name="numeric">True</property>
-                                            <property name="update_policy">if-valid</property>
+                                            <property name="update-policy">if-valid</property>
                                             <property name="value">50</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="sid152">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">pixels</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">2</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">2</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
                                         </child>
                                       </object>
                                     </child>
@@ -4137,7 +4293,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                 <child type="label">
                                   <object class="GtkLabel" id="sid153">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Drawing Tools - Set Modifiers by Draw Direction (Experimental)</property>
                                   </object>
                                 </child>
@@ -4151,33 +4307,58 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                             <child>
                               <object class="GtkFrame" id="sid 155">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="left_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="left-padding">12</property>
                                     <child>
+                                      <!-- n-columns=3 n-rows=3 -->
                                       <object class="GtkGrid">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <child>
                                           <object class="GtkCheckButton" id="cbRestoreLineWidthEnabled">
                                             <property name="label" translatable="yes">Preserve line width</property>
                                             <property name="name">cbRestoreLineWidthEnabled</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="tooltip_markup" translatable="yes">After resizing a selection, the line width of all strokes will be the same as before the resizing operation. </property>
-                                            <property name="margin_bottom">2</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-markup" translatable="yes">After resizing a selection, the line width of all strokes will be the same as before the resizing operation. </property>
+                                            <property name="margin-bottom">2</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">0</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
                                         </child>
                                       </object>
                                     </child>
@@ -4186,7 +4367,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                 <child type="label">
                                   <object class="GtkLabel">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Resizing</property>
                                   </object>
                                 </child>
@@ -4200,110 +4381,120 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                             <child>
                               <object class="GtkFrame" id="sid146">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid147">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="box51">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <property name="spacing">6</property>
                                         <child>
+                                          <!-- n-columns=3 n-rows=3 -->
                                           <object class="GtkGrid" id="sid148">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="row_spacing">5</property>
-                                            <property name="column_spacing">5</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="row-spacing">5</property>
+                                            <property name="column-spacing">5</property>
                                             <child>
                                               <object class="GtkLabel" id="lbSnapRotationTolerance">
                                                 <property name="name">lbSnapRotationTolerance</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">Rotation snapping tolerance</property>
                                                 <property name="xalign">0</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">0</property>
-                                                <property name="top_attach">0</property>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkLabel" id="lbSnapGridTolerance">
                                                 <property name="name">lbSnapGridTolerance</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">Grid snapping tolerance</property>
                                                 <property name="xalign">0</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">0</property>
-                                                <property name="top_attach">1</property>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">1</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkSpinButton" id="spSnapRotationTolerance">
                                                 <property name="name">spSnapRotationTolerance</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
+                                                <property name="can-focus">True</property>
                                                 <property name="adjustment">adjustmentSnapRotationTolerance</property>
-                                                <property name="climb_rate">0.050000000000000003</property>
+                                                <property name="climb-rate">0.05</property>
                                                 <property name="digits">2</property>
-                                                <property name="value">0.20000000000000001</property>
+                                                <property name="value">0.20</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">1</property>
-                                                <property name="top_attach">0</property>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkSpinButton" id="spSnapGridTolerance">
                                                 <property name="name">spSnapGridTolerance</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
+                                                <property name="can-focus">True</property>
                                                 <property name="adjustment">adjustmentSnapGridTolerance</property>
-                                                <property name="climb_rate">0.050000000000000003</property>
+                                                <property name="climb-rate">0.05</property>
                                                 <property name="digits">2</property>
                                                 <property name="value">0.25</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">1</property>
-                                                <property name="top_attach">1</property>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">1</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkLabel" id="lbSnapGridSize">
                                                 <property name="name">lbSnapGridSize</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">Grid size</property>
                                                 <property name="xalign">0</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">0</property>
-                                                <property name="top_attach">2</property>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">2</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkSpinButton" id="spSnapGridSize">
                                                 <property name="name">spSnapGridSize</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
+                                                <property name="can-focus">True</property>
                                                 <property name="adjustment">adjustmentSnapGridSize</property>
-                                                <property name="climb_rate">0.01</property>
+                                                <property name="climb-rate">0.01</property>
                                                 <property name="digits">2</property>
                                                 <property name="value">1</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">1</property>
-                                                <property name="top_attach">2</property>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">2</property>
                                               </packing>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
                                             </child>
                                           </object>
                                           <packing>
@@ -4316,11 +4507,11 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                           <object class="GtkCheckButton" id="cbSnapRecognizedShapesEnabled">
                                             <property name="label" translatable="yes">Use snapping for recognized shapes</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="tooltip_text" translatable="yes">If activated, shapes that have been recognized by the shape recognizer will be snapped to the grid automatically. This may lead to unexpected results if you have the shape recognizer turned on while writing.</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-text" translatable="yes">If activated, shapes that have been recognized by the shape recognizer will be snapped to the grid automatically. This may lead to unexpected results if you have the shape recognizer turned on while writing.</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -4335,7 +4526,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                 <child type="label">
                                   <object class="GtkLabel" id="sid149">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Snapping</property>
                                   </object>
                                 </child>
@@ -4349,128 +4540,129 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                             <child>
                               <object class="GtkFrame" id="sid154">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid155">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
+                                      <!-- n-columns=4 n-rows=3 -->
                                       <object class="GtkGrid" id="grid1">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="column_spacing">5</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="column-spacing">5</property>
                                         <child>
                                           <object class="GtkCheckButton" id="cbStrokeFilterEnabled">
                                             <property name="label" translatable="yes">Enable Tap action</property>
                                             <property name="name">cbStrokeFilterEnabled</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="tooltip_markup" translatable="yes">Do not draw for inputs of short time and length unless it comes in short succession. Instead, show floating toolbox.</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-markup" translatable="yes">Do not draw for inputs of short time and length unless it comes in short succession. Instead, show floating toolbox.</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">0</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="sid156">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">Ignore Time (ms)</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="spStrokeIgnoreTime">
                                             <property name="name">spStrokeIgnoreTime</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="tooltip_markup" translatable="yes">How short (time)  AND...
+                                            <property name="can-focus">True</property>
+                                            <property name="tooltip-markup" translatable="yes">How short (time)  AND...
 
 &lt;i&gt;Recommended: 150ms&lt;/i&gt;</property>
                                             <property name="valign">start</property>
-                                            <property name="max_width_chars">0</property>
+                                            <property name="max-width-chars">0</property>
                                             <property name="adjustment">adjustmentStrokeIgnoreTime</property>
                                             <property name="numeric">True</property>
-                                            <property name="update_policy">if-valid</property>
+                                            <property name="update-policy">if-valid</property>
                                             <property name="value">150</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">1</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">1</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="spStrokeIgnoreLength">
                                             <property name="name">spStrokeIgnoreLength</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="tooltip_markup" translatable="yes">How short (screen mm)  of the stroke  AND...
+                                            <property name="can-focus">True</property>
+                                            <property name="tooltip-markup" translatable="yes">How short (screen mm)  of the stroke  AND...
 
 &lt;i&gt;Recommended: 1 mm&lt;/i&gt;</property>
                                             <property name="valign">start</property>
-                                            <property name="max_width_chars">0</property>
+                                            <property name="max-width-chars">0</property>
                                             <property name="adjustment">adjustmentStrokeIgnoreLength</property>
                                             <property name="digits">2</property>
                                             <property name="numeric">True</property>
-                                            <property name="update_policy">if-valid</property>
+                                            <property name="update-policy">if-valid</property>
                                             <property name="value">1</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">2</property>
-                                            <property name="top_attach">1</property>
+                                            <property name="left-attach">2</property>
+                                            <property name="top-attach">1</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="sid157">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">Max Length (mm)</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">2</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">2</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="sid158">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">Successive (ms)</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">3</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">3</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="spStrokeSuccessiveTime">
                                             <property name="name">spStrokeSuccessiveTime</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="tooltip_markup" translatable="yes">... AND How much time must have passed since last stroke.
+                                            <property name="can-focus">True</property>
+                                            <property name="tooltip-markup" translatable="yes">... AND How much time must have passed since last stroke.
 
 &lt;i&gt;Recommended: 500ms&lt;/i&gt;</property>
                                             <property name="valign">start</property>
-                                            <property name="max_width_chars">0</property>
+                                            <property name="max-width-chars">0</property>
                                             <property name="adjustment">adjustmentStrokeSuccessiveTime</property>
                                             <property name="numeric">True</property>
-                                            <property name="update_policy">if-valid</property>
+                                            <property name="update-policy">if-valid</property>
                                             <property name="value">500</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">3</property>
-                                            <property name="top_attach">1</property>
+                                            <property name="left-attach">3</property>
+                                            <property name="top-attach">1</property>
                                           </packing>
                                         </child>
                                         <child>
@@ -4478,31 +4670,31 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                             <property name="label" translatable="yes">Try to select object first.</property>
                                             <property name="name">cbTrySelectOnStrokeFiltered</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="tooltip_markup" translatable="yes">Try to select object first; if nothing selected then show floating toolbox if enabled.</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-markup" translatable="yes">Try to select object first; if nothing selected then show floating toolbox if enabled.</property>
                                             <property name="xalign">0</property>
-                                            <property name="yalign">0.43999999761581421</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="yalign">0.4399999976158142</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">2</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">2</property>
                                             <property name="width">3</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="label1">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="tooltip_text" translatable="yes">All three conditions must be met before stroke is ignored.
+                                            <property name="can-focus">False</property>
+                                            <property name="tooltip-text" translatable="yes">All three conditions must be met before stroke is ignored.
 It must be short in time and length and we can't have ignored another stroke recently.</property>
                                             <property name="halign">end</property>
                                             <property name="label" translatable="yes">Settings:</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">0</property>
-                                            <property name="top_attach">1</property>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">1</property>
                                           </packing>
                                         </child>
                                         <child>
@@ -4510,16 +4702,16 @@ It must be short in time and length and we can't have ignored another stroke rec
                                             <property name="label" translatable="yes">Show Floating Toolbox</property>
                                             <property name="name">cbDoActionOnStrokeFiltered</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="tooltip_markup" translatable="yes">Try to select object first; if nothing selected then show floating toolbox if enabled.</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-markup" translatable="yes">Try to select object first; if nothing selected then show floating toolbox if enabled.</property>
                                             <property name="xalign">0</property>
                                             <property name="yalign">0.43000000715255737</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">0</property>
-                                            <property name="top_attach">2</property>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">2</property>
                                           </packing>
                                         </child>
                                       </object>
@@ -4529,7 +4721,7 @@ It must be short in time and length and we can't have ignored another stroke rec
                                 <child type="label">
                                   <object class="GtkLabel" id="sid159">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Action on Tool Tap</property>
                                   </object>
                                 </child>
@@ -4543,29 +4735,29 @@ It must be short in time and length and we can't have ignored another stroke rec
                             <child>
                               <object class="GtkFrame" id="framePDFCacheOptions">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="alignPDFCacheOptions">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="boxReRenderSetting">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="lblReRenderMoreOftenWhileZooming">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;Re-render PDF backgrounds more often while zooming for better render quality. 
 &lt;b&gt;Note:&lt;/b&gt; This should not affect print quality.&lt;/i&gt;</property>
-                                            <property name="use_markup">True</property>
+                                            <property name="use-markup">True</property>
                                             <property name="wrap">True</property>
-                                            <property name="max_width_chars">85</property>
+                                            <property name="max-width-chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -4575,55 +4767,74 @@ It must be short in time and length and we can't have ignored another stroke rec
                                           </packing>
                                         </child>
                                         <child>
+                                          <!-- n-columns=3 n-rows=3 -->
                                           <object class="GtkGrid" id="gdRecacheOptions">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="row_spacing">5</property>
-                                            <property name="column_spacing">5</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="row-spacing">5</property>
+                                            <property name="column-spacing">5</property>
                                             <child>
                                               <object class="GtkLabel" id="lbReRenderThreshold">
                                                 <property name="name">lbSnapRotationTolerance</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="tooltip_text" translatable="yes">When zoomed in on a high-resolution PDF, each re-render can take a long time. Setting this to a large value causes these re-renders to happen less often.
+                                                <property name="can-focus">False</property>
+                                                <property name="tooltip-text" translatable="yes">When zoomed in on a high-resolution PDF, each re-render can take a long time. Setting this to a large value causes these re-renders to happen less often.
 
 Set this to 0% to always re-render on zoom.</property>
                                                 <property name="label" translatable="yes">Re-render when the page's zoom changes by more than </property>
                                                 <property name="xalign">0</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">0</property>
-                                                <property name="top_attach">0</property>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkSpinButton" id="spReRenderThreshold">
                                                 <property name="name">spSnapRotationTolerance</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
+                                                <property name="can-focus">True</property>
                                                 <property name="text" translatable="yes">0.00</property>
-                                                <property name="input_purpose">number</property>
+                                                <property name="input-purpose">number</property>
                                                 <property name="adjustment">adjustmentReRenderThreshold</property>
-                                                <property name="climb_rate">2</property>
+                                                <property name="climb-rate">2</property>
                                                 <property name="numeric">True</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">1</property>
-                                                <property name="top_attach">0</property>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkLabel" id="lbReRenderThresholdEnding">
                                                 <property name="name">lbSnapRotationTolerance</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">%.</property>
                                                 <property name="xalign">0</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">2</property>
-                                                <property name="top_attach">0</property>
+                                                <property name="left-attach">2</property>
+                                                <property name="top-attach">0</property>
                                               </packing>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
                                             </child>
                                           </object>
                                           <packing>
@@ -4639,7 +4850,7 @@ Set this to 0% to always re-render on zoom.</property>
                                 <child type="label">
                                   <object class="GtkLabel" id="headerPdfCaching">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">PDF Cache</property>
                                   </object>
                                 </child>
@@ -4670,61 +4881,61 @@ Set this to 0% to always re-render on zoom.</property>
               <object class="GtkLabel" id="drawingAreaTabLabel">
                 <property name="name">drawingAreaTabLabel</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Drawing Area</property>
               </object>
               <packing>
                 <property name="position">7</property>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="defaultTabBox">
                 <property name="name">defaultTabBox</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_left">5</property>
+                <property name="can-focus">False</property>
+                <property name="margin-left">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid160">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="min_content_width">500</property>
-                    <property name="min_content_height">450</property>
+                    <property name="can-focus">True</property>
+                    <property name="min-content-width">500</property>
+                    <property name="min-content-height">450</property>
                     <child>
                       <object class="GtkViewport" id="sid161">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkBox" id="sid162">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="sid163">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid164">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid165">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="label9">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;Select the tool and Settings if you press the Default Button.&lt;/i&gt;</property>
-                                            <property name="use_markup">True</property>
-                                            <property name="max_width_chars">85</property>
+                                            <property name="use-markup">True</property>
+                                            <property name="max-width-chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -4738,7 +4949,7 @@ Set this to 0% to always re-render on zoom.</property>
                                           <object class="GtkBox" id="hboxDefaultTool">
                                             <property name="name">hboxDefaultTool</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <child>
                                               <placeholder/>
                                             </child>
@@ -4759,11 +4970,11 @@ Set this to 0% to always re-render on zoom.</property>
                                 <child type="label">
                                   <object class="GtkBox" id="box1">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <child>
                                       <object class="GtkImage" id="image2">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="pixbuf">iconsColor-dark/hicolor/scalable/actions/xopp-default.svg</property>
                                       </object>
                                       <packing>
@@ -4775,9 +4986,9 @@ Set this to 0% to always re-render on zoom.</property>
                                     <child>
                                       <object class="GtkLabel" id="label8">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="label" translatable="yes">&lt;b&gt;Default&lt;/b&gt;</property>
-                                        <property name="use_markup">True</property>
+                                        <property name="use-markup">True</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -4815,61 +5026,61 @@ Set this to 0% to always re-render on zoom.</property>
               <object class="GtkLabel" id="defaultTabLabel">
                 <property name="name">defaultTabLabel</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Defaults</property>
               </object>
               <packing>
                 <property name="position">8</property>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="audioRecordingTabBox">
                 <property name="name">audioRecordingTabBox</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_left">5</property>
+                <property name="can-focus">False</property>
+                <property name="margin-left">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid166">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="min_content_width">500</property>
-                    <property name="min_content_height">450</property>
+                    <property name="can-focus">True</property>
+                    <property name="min-content-width">500</property>
+                    <property name="min-content-height">450</property>
                     <child>
                       <object class="GtkViewport" id="sid167">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkBox" id="sid168">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="sid169">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid170">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid171">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="label45">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;Audio recordings are currently stored in a separate folder and referenced from the journal.&lt;/i&gt;</property>
-                                            <property name="use_markup">True</property>
-                                            <property name="max_width_chars">85</property>
+                                            <property name="use-markup">True</property>
+                                            <property name="max-width-chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -4879,36 +5090,58 @@ Set this to 0% to always re-render on zoom.</property>
                                           </packing>
                                         </child>
                                         <child>
+                                          <!-- n-columns=3 n-rows=3 -->
                                           <object class="GtkGrid" id="grid5">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="row_spacing">10</property>
-                                            <property name="column_spacing">10</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="row-spacing">10</property>
+                                            <property name="column-spacing">10</property>
                                             <child>
                                               <object class="GtkLabel" id="label46">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">Storage Folder</property>
                                                 <property name="xalign">0</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">0</property>
-                                                <property name="top_attach">0</property>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkFileChooserButton" id="fcAudioPath">
                                                 <property name="name">fcAudioPath</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="hexpand">True</property>
                                                 <property name="action">select-folder</property>
                                                 <property name="title" translatable="yes">Select Folder</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">1</property>
-                                                <property name="top_attach">0</property>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">0</property>
                                               </packing>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
                                             </child>
                                           </object>
                                           <packing>
@@ -4924,7 +5157,7 @@ Set this to 0% to always re-render on zoom.</property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid172">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Storage Folder</property>
                                   </object>
                                 </child>
@@ -4938,29 +5171,29 @@ Set this to 0% to always re-render on zoom.</property>
                             <child>
                               <object class="GtkFrame" id="sid173">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid174">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid175">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="sid176">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;Specify the audio devices used for recording and playback of audio attachments.
 If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as input / output device.&lt;/i&gt;</property>
-                                            <property name="use_markup">True</property>
+                                            <property name="use-markup">True</property>
                                             <property name="wrap">True</property>
-                                            <property name="max_width_chars">85</property>
+                                            <property name="max-width-chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -4970,56 +5203,72 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                           </packing>
                                         </child>
                                         <child>
+                                          <!-- n-columns=3 n-rows=3 -->
                                           <object class="GtkGrid" id="grid8">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="row_spacing">10</property>
-                                            <property name="column_spacing">10</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="row-spacing">10</property>
+                                            <property name="column-spacing">10</property>
                                             <child>
                                               <object class="GtkLabel" id="label36">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">Input Device</property>
                                                 <property name="xalign">0</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">0</property>
-                                                <property name="top_attach">0</property>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkComboBoxText" id="cbAudioInputDevice">
                                                 <property name="name">cbAudioInputDevice</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">1</property>
-                                                <property name="top_attach">0</property>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkLabel" id="label58">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">Output Device</property>
                                                 <property name="xalign">0</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">0</property>
-                                                <property name="top_attach">1</property>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">1</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkComboBoxText" id="cbAudioOutputDevice">
                                                 <property name="name">cbAudioOutputDevice</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">1</property>
-                                                <property name="top_attach">1</property>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">1</property>
                                               </packing>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
                                             </child>
                                           </object>
                                           <packing>
@@ -5035,7 +5284,7 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                 <child type="label">
                                   <object class="GtkLabel" id="sid177">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Audio Devices</property>
                                   </object>
                                 </child>
@@ -5049,50 +5298,51 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                             <child>
                               <object class="GtkFrame" id="sid178">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid179">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
+                                      <!-- n-columns=3 n-rows=3 -->
                                       <object class="GtkGrid" id="sid180">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="row_spacing">10</property>
-                                        <property name="column_spacing">10</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="row-spacing">10</property>
+                                        <property name="column-spacing">10</property>
                                         <child>
                                           <object class="GtkLabel" id="label59">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">Sample Rate</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">0</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="label61">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">Gain</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">0</property>
-                                            <property name="top_attach">1</property>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">1</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkComboBoxText" id="cbAudioSampleRate">
                                             <property name="name">cbAudioSampleRate</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="active">0</property>
                                             <items>
                                               <item id="16000">16000 Hz</item>
@@ -5102,25 +5352,40 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                             </items>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="spAudioGain">
                                             <property name="name">spAudioGain</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
+                                            <property name="can-focus">True</property>
                                             <property name="adjustment">adjustmentAudioGain</property>
-                                            <property name="climb_rate">0.10000000000000001</property>
+                                            <property name="climb-rate">0.10</property>
                                             <property name="digits">2</property>
                                             <property name="numeric">True</property>
                                             <property name="value">1</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">1</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">1</property>
                                           </packing>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
                                         </child>
                                       </object>
                                     </child>
@@ -5129,7 +5394,7 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                 <child type="label">
                                   <object class="GtkLabel" id="sid181">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Recording Quality</property>
                                   </object>
                                 </child>
@@ -5143,49 +5408,71 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                             <child>
                               <object class="GtkFrame" id="sid1">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid2">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">8</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
+                                      <!-- n-columns=3 n-rows=3 -->
                                       <object class="GtkGrid" id="sid3">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="row_spacing">10</property>
-                                        <property name="column_spacing">10</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="row-spacing">10</property>
+                                        <property name="column-spacing">10</property>
                                         <child>
                                           <object class="GtkLabel" id="label3">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">Default Seek Time (in seconds)</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">0</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="spDefaultSeekTime">
                                             <property name="name">spAudioGain</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
+                                            <property name="can-focus">True</property>
                                             <property name="text" translatable="yes">1,00</property>
                                             <property name="adjustment">adjustmentSeekTime</property>
-                                            <property name="climb_rate">0.10000000000000001</property>
+                                            <property name="climb-rate">0.10</property>
                                             <property name="digits">2</property>
                                             <property name="numeric">True</property>
                                             <property name="value">1</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
                                         </child>
                                       </object>
                                     </child>
@@ -5194,7 +5481,7 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                 <child type="label">
                                   <object class="GtkLabel" id="sid4">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Playback Settings</property>
                                   </object>
                                 </child>
@@ -5208,10 +5495,10 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                             <child>
                               <object class="GtkLabel" id="sid182">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="label" translatable="yes">&lt;i&gt;Changes take only effect on new recordings and playbacks.&lt;/i&gt;</property>
-                                <property name="use_markup">True</property>
-                                <property name="max_width_chars">85</property>
+                                <property name="use-markup">True</property>
+                                <property name="max-width-chars">85</property>
                                 <property name="xalign">0</property>
                               </object>
                               <packing>
@@ -5240,19 +5527,19 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
               <object class="GtkLabel" id="audioRecordingTabLabel">
                 <property name="name">audioRecordingTabLabel</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Audio Recording</property>
               </object>
               <packing>
                 <property name="position">9</property>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="latexTabBox">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_left">5</property>
+                <property name="can-focus">False</property>
+                <property name="margin-left">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <placeholder/>
@@ -5265,61 +5552,61 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
             <child type="tab">
               <object class="GtkLabel" id="latexTabLabel">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">LaTeX</property>
               </object>
               <packing>
                 <property name="position">11</property>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="languageTabBox">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_left">5</property>
+                <property name="can-focus">False</property>
+                <property name="margin-left">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid189">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="can-focus">True</property>
                     <child>
                       <object class="GtkViewport" id="sid190">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkBox" id="sid191">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="sid192">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="margin_left">4</property>
-                                <property name="margin_top">3</property>
-                                <property name="margin_bottom">3</property>
-                                <property name="border_width">2</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
+                                <property name="can-focus">False</property>
+                                <property name="margin-left">4</property>
+                                <property name="margin-top">3</property>
+                                <property name="margin-bottom">3</property>
+                                <property name="border-width">2</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid193">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="bottom_padding">12</property>
-                                    <property name="left_padding">12</property>
-                                    <property name="right_padding">12</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">12</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid194">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="label195">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;Select language (requires restart)&lt;/i&gt;</property>
-                                            <property name="use_markup">True</property>
+                                            <property name="use-markup">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -5330,19 +5617,19 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                         <child>
                                           <object class="GtkFrame" id="sid195">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label_xalign">0.0099999997764825821</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label-xalign">0.009999999776482582</property>
                                             <child>
                                               <object class="GtkAlignment" id="sid196">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="bottom_padding">8</property>
-                                                <property name="left_padding">12</property>
-                                                <property name="right_padding">12</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="bottom-padding">8</property>
+                                                <property name="left-padding">12</property>
+                                                <property name="right-padding">12</property>
                                                 <child>
                                                   <object class="GtkBox" id="hboxLanguageSelect">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="orientation">vertical</property>
                                                     <child>
                                                       <placeholder/>
@@ -5354,7 +5641,7 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                             <child type="label">
                                               <object class="GtkLabel" id="label196">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="label" translatable="yes">Language</property>
                                               </object>
                                             </child>
@@ -5372,7 +5659,7 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                 <child type="label">
                                   <object class="GtkLabel" id="label193">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Language Settings</property>
                                   </object>
                                 </child>
@@ -5402,12 +5689,12 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
             <child type="tab">
               <object class="GtkLabel" id="languageTabLabel">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Language</property>
               </object>
               <packing>
                 <property name="position">11</property>
-                <property name="tab_fill">False</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
           </object>


### PR DESCRIPTION
This PR is a hack for fixing #2889. Currently a proof of concept.

In particular, this replaces the hacky edge panning logic with less terrible (but still bad) timer-based logic: instead of scrolling to "ensure that the selection is visible," the logic has been changed to "scroll up/down at a fixed speed when the selection is slightly out of visible page bounds"

* [x] Do not pan when selection is at the top/bottom of document
* [x] Fix selection position jitter when moving the mouse during panning
* [x] Implement horizontal panning
* [x] Add settings for adjusting panning speed
* [x] Fix selection teleporting when moving across pages. This is caused by the action not resetting when a page is crossed; the current event system assumes that any given action occurs on the same page.

As a workaround for jitter and teleporting, panning will block the next mouse movement from causing the selection to move. The teleportation is fixed entirely, while the jitter is reduced by a significant amount (there is still some present but it is only barely noticeable).