### PR TITLE
Fix several LaTeX-dialog-related memory bugs

### DIFF
--- a/src/control/LatexController.cpp
+++ b/src/control/LatexController.cpp
@@ -31,8 +31,11 @@ LatexController::LatexController(Control* control):
 }
 
 LatexController::~LatexController() {
-    g_cancellable_cancel(updating_cancellable);
-    g_object_unref(updating_cancellable);
+    if (updating_cancellable) {
+        g_cancellable_cancel(updating_cancellable);
+        g_object_unref(updating_cancellable);
+    }
+
     this->control = nullptr;
 }
 
@@ -205,6 +208,8 @@ void LatexController::onPdfRenderComplete(GObject* procObj, GAsyncResult* res, L
     }
 
     g_clear_object(&self->updating_cancellable);
+    g_clear_object(&proc);
+
     self->updateStatus();
     if (shouldUpdate) {
         self->triggerImageUpdate(currentTex);

--- a/src/gui/dialog/LatexDialog.cpp
+++ b/src/gui/dialog/LatexDialog.cpp
@@ -54,7 +54,9 @@ void LatexDialog::setTempRender(PopplerDocument* pdf) {
 
     poppler_page_render(page, cr);
 
+    // Free resources.
     cairo_destroy(cr);
+    g_clear_object(&page);
 
     // Update GTK widget
     gtk_image_set_from_surface(GTK_IMAGE(this->texTempRender), this->scaledRender);

--- a/src/model/TexImage.cpp
+++ b/src/model/TexImage.cpp
@@ -25,7 +25,6 @@ void TexImage::freeImageAndPdf() {
 
 auto TexImage::clone() -> Element* {
     auto* img = new TexImage();
-    img->loadData(std::string(this->binaryData), nullptr);
     img->x = this->x;
     img->y = this->y;
     img->setColor(this->getColor());
@@ -34,7 +33,13 @@ auto TexImage::clone() -> Element* {
     img->text = this->text;
     img->snappedBounds = this->snappedBounds;
     img->sizeCalculated = this->sizeCalculated;
+
     img->pdf = this->pdf;
+    g_object_ref(this->pdf);
+
+    img->loadData(std::string(this->binaryData), nullptr);
+
+
     return img;
 }
 
@@ -85,6 +90,7 @@ auto TexImage::loadData(std::string&& bytes, GError** err) -> bool {
         if (!this->width && !this->height) {
             PopplerPage* page = poppler_document_get_page(this->pdf, 0);
             poppler_page_get_size(page, &this->width, &this->height);
+            g_object_unref(page);
         }
     } else if (type == "PNG") {
         this->image = cairo_image_surface_create_from_png_stream(

--- a/src/view/DocumentView.cpp
+++ b/src/view/DocumentView.cpp
@@ -117,6 +117,8 @@ void DocumentView::drawTexImage(cairo_t* cr, TexImage* texImage) {
         cairo_translate(cr, texImage->getX(), texImage->getY());
         cairo_scale(cr, xFactor, yFactor);
         poppler_page_render(page, cr);
+
+        g_clear_object(&page);
     } else if (img != nullptr) {
         int width = cairo_image_surface_get_width(img);
         int height = cairo_image_surface_get_height(img);


### PR DESCRIPTION
Most of the issues: `poppler_document_get_page()` results were not `g_object_unref`ed.
Others:
 * Process object wasn't unref'ed in `LatexController`
 * On LaTeX dialog close, a null `GCancellable` object pointer could be unreffed, causing a warning.
 * `TexImage::clone()` set its clone's `pdf` pointer to its own PDF pointer, without increasing its reference count.