### PR TITLE
Fix crash on scroll with sidebar preview open

### DIFF
--- a/src/control/jobs/PreviewJob.h
+++ b/src/control/jobs/PreviewJob.h
@@ -16,6 +16,8 @@
 
 #include <gtk/gtk.h>
 
+#include "gui/sidebar/previews/base/SidebarPreviewBaseEntry.h"
+
 #include "Job.h"
 #include "XournalType.h"
 
@@ -62,6 +64,12 @@ private:
      * Zoom factor
      */
     double zoom = 0;
+
+    /**
+     * ID for sidebar's onDestroy listener (for cases where the sidebar
+     * is destroyed before this).
+     */
+    SidebarPreviewBaseEntry::OnDestroyListenerID previewDestroyListenerID{};
 
     /**
      * Sidebar preview

--- a/src/gui/sidebar/previews/base/SidebarPreviewBaseEntry.cpp
+++ b/src/gui/sidebar/previews/base/SidebarPreviewBaseEntry.cpp
@@ -28,6 +28,8 @@ SidebarPreviewBaseEntry::SidebarPreviewBaseEntry(SidebarPreviewBase* sidebar, co
 }
 
 SidebarPreviewBaseEntry::~SidebarPreviewBaseEntry() {
+    for (const auto& [id, listener]: this->onDestroyListeners) { listener(); }
+
     this->sidebar->getControl()->getScheduler()->removeSidebar(this);
     this->page = nullptr;
 
@@ -38,6 +40,18 @@ SidebarPreviewBaseEntry::~SidebarPreviewBaseEntry() {
         cairo_surface_destroy(this->crBuffer);
         this->crBuffer = nullptr;
     }
+}
+
+auto SidebarPreviewBaseEntry::addOnDestroyListener(OnDestroyListener&& listener) -> OnDestroyListenerID {
+    OnDestroyListenerID resultListenerID = nextOnDestroyListenerID;
+    nextOnDestroyListenerID++;
+
+    this->onDestroyListeners.emplace(resultListenerID, listener);
+    return resultListenerID;
+}
+
+void SidebarPreviewBaseEntry::removeOnDestroyListener(const OnDestroyListenerID& id) {
+    this->onDestroyListeners.erase(id);
 }
 
 auto SidebarPreviewBaseEntry::drawCallback(GtkWidget* widget, cairo_t* cr, SidebarPreviewBaseEntry* preview)

--- a/src/gui/sidebar/previews/base/SidebarPreviewBaseEntry.h
+++ b/src/gui/sidebar/previews/base/SidebarPreviewBaseEntry.h
@@ -11,8 +11,9 @@
 
 #pragma once
 
+#include <functional>
+#include <map>
 #include <string>
-#include <vector>
 
 #include <gtk/gtk.h>
 
@@ -65,6 +66,9 @@ private:
     static gboolean drawCallback(GtkWidget* widget, cairo_t* cr, SidebarPreviewBaseEntry* preview);
 
 protected:
+    using OnDestroyListener = std::function<void(void)>;
+    using OnDestroyListenerID = int;
+
     virtual void mouseButtonPressCallback() = 0;
 
     virtual int getWidgetWidth();
@@ -72,6 +76,12 @@ protected:
 
     virtual void drawLoadingPage();
     virtual void paint(cairo_t* cr);
+
+    /**
+     * @brief Adds a listener that will be called once -- when this is destroyed.
+     */
+    OnDestroyListenerID addOnDestroyListener(OnDestroyListener&& listener);
+    void removeOnDestroyListener(const OnDestroyListenerID& listenerID);
 
 private:
 protected:
@@ -104,6 +114,12 @@ protected:
      * Buffer because of performance reasons
      */
     cairo_surface_t* crBuffer = nullptr;
+
+    /**
+     * onDestroy listeners
+     */
+    std::map<OnDestroyListenerID, OnDestroyListener> onDestroyListeners;
+    OnDestroyListenerID nextOnDestroyListenerID{0};
 
     friend class PreviewJob;
 };


### PR DESCRIPTION
A `PreviewJob`'s `SidebarPreviewBaseEntry` could be deleted before the `PreviewJob` could run (when scrolling quickly). This is handled by adding an `OnDestroyListener` to the `SidebarPreviewBaseEntry` class.

This is a bit of a band-aid fix.

Should fix #2887.