### PR TITLE
fix zoomSlider scale marks

### DIFF
--- a/src/gui/toolbarMenubar/ToolZoomSlider.cpp
+++ b/src/gui/toolbarMenubar/ToolZoomSlider.cpp
@@ -82,9 +82,8 @@ void ToolZoomSlider::updateScaleMarks() {
     }
 
     gtk_scale_clear_marks(GTK_SCALE(this->slider));
-    gtk_scale_add_mark(GTK_SCALE(this->slider), scaleFunc(zoom->getZoom100Value()),
-                       horizontal ? GTK_POS_BOTTOM : GTK_POS_RIGHT, nullptr);
-    gtk_scale_add_mark(GTK_SCALE(this->slider), scaleFunc(zoom->getZoomFitValue()),
+    gtk_scale_add_mark(GTK_SCALE(this->slider), scaleFunc(1.0), horizontal ? GTK_POS_BOTTOM : GTK_POS_RIGHT, nullptr);
+    gtk_scale_add_mark(GTK_SCALE(this->slider), scaleFunc(zoom->getZoomFitValue() / zoom->getZoom100Value()),
                        horizontal ? GTK_POS_BOTTOM : GTK_POS_RIGHT, nullptr);
 }
 


### PR DESCRIPTION
Fixes #2923. 
The problem was that the `zoom100Value` is only 1, if the `displayDpi` is set to 72. 