### PR TITLE
Correct wrong assumption on location of build dir

### DIFF
--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -13,9 +13,9 @@ if (HELP2MAN)
 
   add_custom_command(
       OUTPUT ${MAN_FILE}
-      COMMAND ${HELP2MAN} --no-info -i ${MAN_INCLUDE} -o ${MAN_PAGE} --version-string=${PROJECT_VERSION} --name="open-source hand note-taking program" ${CMAKE_SOURCE_DIR}/build/src/xournalpp
+      COMMAND ${HELP2MAN} --no-info -i ${MAN_INCLUDE} -o ${MAN_PAGE} --version-string=${PROJECT_VERSION} --name="open-source hand note-taking program" ${CMAKE_BINARY_DIR}/src/xournalpp
       COMMAND gzip -n -f -9 ${MAN_PAGE}
-      DEPENDS ${CMAKE_SOURCE_DIR}/build/src/xournalpp
+      DEPENDS ${CMAKE_BINARY_DIR}/src/xournalpp
   )
 
   set(MAN_PAGE_THUMBNAILER "${CMAKE_CURRENT_BINARY_DIR}/xournalpp-thumbnailer.1")
@@ -23,12 +23,12 @@ if (HELP2MAN)
 
   add_custom_command(
       OUTPUT ${MAN_FILE_THUMBNAILER}
-      COMMAND ${HELP2MAN} --no-info  --no-discard-stderr -o ${MAN_PAGE_THUMBNAILER} --version-string=${PROJECT_VERSION} --name="creates thumbnails" ${CMAKE_SOURCE_DIR}/build/src/xoj-preview-extractor/xournalpp-thumbnailer
+      COMMAND ${HELP2MAN} --no-info  --no-discard-stderr -o ${MAN_PAGE_THUMBNAILER} --version-string=${PROJECT_VERSION} --name="creates thumbnails" ${CMAKE_BINARY_DIR}/src/xoj-preview-extractor/xournalpp-thumbnailer
       COMMAND gzip -n -f -9 ${MAN_PAGE_THUMBNAILER}
-      DEPENDS ${CMAKE_SOURCE_DIR}/build/src/xoj-preview-extractor/xournalpp-thumbnailer
+      DEPENDS ${CMAKE_BINARY_DIR}/src/xoj-preview-extractor/xournalpp-thumbnailer
   )
 
-  add_custom_target(manpage ALL DEPENDS ${MAN_FILE} ${MAN_FILE_THUMBNAILER} ${xournalpp})
+  add_custom_target(manpage ALL DEPENDS ${MAN_FILE} ${MAN_FILE_THUMBNAILER})
   install(FILES ${MAN_FILE} ${MAN_FILE_THUMBNAILER} DESTINATION "share/man/man1")
 else(HELP2MAN)
   message("help2man is missing; no man pages will be generated")


### PR DESCRIPTION
This PR should fix the failure of building the PPA packages on Launchpad.
The problem lies in the DEPENDS field in the man page generation: 
``` 
make[4]: *** No rule to make target '../build/src/xournalpp', needed by 'man/xournalpp.1.gz'. Stop.
``` 
The assumption that the `CMAKE_BINARY_DIR` is the `build` subdirectory of the `CMAKE_SOURCE_DIR` does not need to be valid