### PR TITLE
Fix crash on scroll with sidebar preview open

### DIFF
--- a/src/control/jobs/Job.cpp
+++ b/src/control/jobs/Job.cpp
@@ -25,11 +25,15 @@ void Job::ref() {
 }
 
 void Job::deleteJob() {
+    this->onDelete();
+
     if (this->afterRunId) {
         g_source_remove(this->afterRunId);
         this->unref();
     }
 }
+
+void Job::onDelete() {}
 
 void Job::execute() { this->run(); }
 

--- a/src/control/jobs/Job.h
+++ b/src/control/jobs/Job.h
@@ -72,6 +72,12 @@ protected:
      */
     virtual void afterRun();
 
+    /**
+     * Called when the job is to be removed from the
+     * scheduler.
+     */
+    virtual void onDelete();
+
 private:
     static bool callAfterCallback(Job* job);
 

--- a/src/control/jobs/PreviewJob.h
+++ b/src/control/jobs/PreviewJob.h
@@ -30,6 +30,7 @@ public:
     PreviewJob(SidebarPreviewBaseEntry* sidebar);
 
 protected:
+    virtual void onDelete() override;
     virtual ~PreviewJob();
 
 public:

--- a/src/control/jobs/XournalScheduler.h
+++ b/src/control/jobs/XournalScheduler.h
@@ -29,7 +29,8 @@ public:
 
 public:
     /**
-     * Remove source, e.g. if a page is removed they don't need to repaint
+     * Remove source, e.g. if a page is removed they don't need to repaint.
+     * Blocks until all jobs that could be using the source have finished.
      */
     void removeSidebar(SidebarPreviewBaseEntry* preview);
     void removePage(XojPageView* view);


### PR DESCRIPTION
## Summary
 * A minor scheduler refactoring to use `std::deque`, `std::mutex`, and `std::condition_variable`.
 * Fixes a crash on scrolling through long PDFs with the sidebar layers preview open.
     * The crash was caused by a `nullptr` (or, possibly sometimes not, we weren't using a `std::atomic` to sync the object that was set to null between threads, but it **did** involve accessing freed memory) de-ref in `PreviewJob.cpp`.  
     * I think a part of this was not waiting for preview jobs to finish, possibly freeing the SidebarPreview (that PreviewJob uses) before letting PreviewJobs finish running.
 
Fixes #2887.
See also #2907.