### PR TITLE
WIP: PDF Caching Improvements

### DIFF
--- a/src/control/PdfCache.cpp
+++ b/src/control/PdfCache.cpp
@@ -1,131 +1,67 @@
 #include "PdfCache.h"
 
 #include <algorithm>
+#include <cassert>
 #include <cstdio>
 #include <utility>
 
-class PdfCacheEntry {
+#include <cairo.h>
+
+// For _1, _2, ...
+using namespace std::placeholders;
+
+class PdfCache::CacheEntry: public QuadTreeCache {
 public:
-    /**
-     *   Cache [img], the result of rendering [popplerPage] with
-     * the given [zoom].
-     *  A change in the document's zoom causes a change in the
-     * quality of the PDF backgrounds (zoomed in => need a higher
-     * quality rendering).
-     *
-     * @param popplerPage
-     * @param img is the result of rendering popplerPage
-     * @param zoom is the zoom at which the page was rendered.
-     */
-    PdfCacheEntry(XojPdfPageSPtr popplerPage, cairo_surface_t* img, double zoom) {
-        this->popplerPage = std::move(popplerPage);
-        this->rendered = img;
-        this->zoom = zoom;
-    }
+    CacheEntry(XojPdfPageSPtr page, const Rect& pageRect, const CacheParams& settings);
+    int getPageId() const { return page_->getPageId(); };
 
-    ~PdfCacheEntry() {
-        this->popplerPage = nullptr;
-        cairo_surface_destroy(this->rendered);
-        this->rendered = nullptr;
-    }
+    void rerender(cairo_t* cr, const Rect& rect) { page_->render(cr, rect); }
 
-    double zoom;
-    XojPdfPageSPtr popplerPage;
-    cairo_surface_t* rendered;
+private:
+    XojPdfPageSPtr page_;
+    Rect pageRect_;
+    RenderFn pageRenderFn_;
 };
 
-PdfCache::PdfCache(int size) {
-    this->size = size;
-
-    g_mutex_init(&this->renderMutex);
+PdfCache::CacheEntry::CacheEntry(XojPdfPageSPtr page, const Rect& pageRect, const CacheParams& settings):
+        page_{page}, QuadTreeCache(std::bind(&CacheEntry::rerender, this, _1, _2), pageRect, settings) {
+    assert(page_ != nullptr);
 }
 
-PdfCache::~PdfCache() {
-    clearCache();
-    this->size = 0;
-}
+PdfCache::PdfCache(size_t size) { cacheSettings_.maxSize = size; }
 
-void PdfCache::setZoom(double zoom) { this->zoom = zoom; }
+// Need to define a destructor so we can have a unique_ptr
+// to a forward-declared class.
+PdfCache::~PdfCache() {}
 
-void PdfCache::setRefreshThreshold(double threshold) { this->zoomRefreshThreshold = threshold; }
+void PdfCache::clear() { data_.clear(); }
 
-void PdfCache::setAnyZoomChangeCausesRecache(bool b) { this->zoomClearsCache = b; }
-
-void PdfCache::clearCache() {
-    for (PdfCacheEntry* e: this->data) {
-        delete e;
-    }
-    this->data.clear();
-}
-
-auto PdfCache::lookup(const XojPdfPageSPtr& popplerPage) -> PdfCacheEntry* {
-    for (PdfCacheEntry* e: this->data) {
-        if (e->popplerPage->getPageId() == popplerPage->getPageId()) {
-            return e;
+auto PdfCache::lookup(XojPdfPageSPtr page) -> std::shared_ptr<PdfCache::CacheEntry> {
+    for (const auto& entry: data_) {
+        if (entry->getPageId() == page->getPageId()) {
+            return entry;
         }
     }
 
-    return nullptr;
+    Rectangle<double> pageRect{0.0, 0.0, page->getWidth(), page->getHeight()};
+    std::shared_ptr<CacheEntry> newEntry = std::make_shared<CacheEntry>(page, pageRect, cacheSettings_);
+
+    if (data_.size() > 0) {
+        // All entries should, together, have size <= maxSize.
+        // Have the new entry contribute to this total.
+        newEntry->constrainSizeWith(*data_.front());
+    }
+
+    data_.push_back(newEntry);
+    return newEntry;
 }
 
-PdfCacheEntry* PdfCache::cache(XojPdfPageSPtr popplerPage, cairo_surface_t* img, double zoom) {
-    while (this->data.size() > this->size) {
-        delete this->data.back();
-        this->data.pop_back();
-    }
+void PdfCache::render(cairo_t* cr, const XojPdfPageSPtr& popplerPage, Rectangle<double> srcRegion, double zoom) {
+    std::lock_guard lock{renderMutex_};
 
-    auto* ne = new PdfCacheEntry(std::move(popplerPage), img, zoom);
-    this->data.push_front(ne);
+    Rectangle<double> dstRegion{srcRegion};
+    dstRegion *= zoom;
 
-    return ne;
-}
-
-void PdfCache::render(cairo_t* cr, const XojPdfPageSPtr& popplerPage, double zoom) {
-    g_mutex_lock(&this->renderMutex);
-
-    this->setZoom(zoom);
-
-    PdfCacheEntry* cacheResult = lookup(popplerPage);
-    bool needsRefresh{cacheResult == nullptr};
-
-    if (cacheResult != nullptr) {
-        double averagedZoom = (this->zoom + cacheResult->zoom) / 2.0;
-        double percentZoomChange = std::abs(cacheResult->zoom - this->zoom) * 100.0 / averagedZoom;
-
-        // If we do have a cached result, is its rendering quality
-        // acceptable for our current zoom?
-        needsRefresh = this->zoom > 1.0 && percentZoomChange > this->zoomRefreshThreshold
-
-                       // Has the user requested that we **always** clear the cache on zoom?
-                       || this->zoomClearsCache && this->zoom != cacheResult->zoom;
-    }
-
-    if (needsRefresh) {
-        double renderZoom = std::max(zoom, 1.0);
-
-        auto* img = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, popplerPage->getWidth() * renderZoom,
-                                               popplerPage->getHeight() * renderZoom);
-        cairo_t* cr2 = cairo_create(img);
-
-        cairo_scale(cr2, renderZoom, renderZoom);
-        popplerPage->render(cr2, false);
-        cairo_destroy(cr2);
-
-        cacheResult = cache(popplerPage, img, renderZoom);
-    }
-
-    cairo_matrix_t mOriginal;
-    cairo_matrix_t mScaled;
-    cairo_get_matrix(cr, &mOriginal);
-    cairo_get_matrix(cr, &mScaled);
-    mScaled.xx = this->zoom / cacheResult->zoom;
-    mScaled.yy = this->zoom / cacheResult->zoom;
-    mScaled.xy = 0;
-    mScaled.yx = 0;
-    cairo_set_matrix(cr, &mScaled);
-    cairo_set_source_surface(cr, cacheResult->rendered, 0, 0);
-    cairo_paint(cr);
-    cairo_set_matrix(cr, &mOriginal);
-
-    g_mutex_unlock(&this->renderMutex);
+    std::shared_ptr<CacheEntry> entry = lookup(popplerPage);
+    entry->render(cr, srcRegion, dstRegion);
 }

--- a/src/control/PdfCache.cpp
+++ b/src/control/PdfCache.cpp
@@ -56,11 +56,11 @@ auto PdfCache::lookup(XojPdfPageSPtr page) -> std::shared_ptr<PdfCache::CacheEnt
     return newEntry;
 }
 
-void PdfCache::render(cairo_t* cr, const XojPdfPageSPtr& popplerPage, Rectangle<double> srcRegion, double zoom) {
+void PdfCache::render(cairo_t* cr, const XojPdfPageSPtr& popplerPage, Rectangle<double> dstRegion, double zoom) {
     std::lock_guard lock{renderMutex_};
 
-    Rectangle<double> dstRegion{srcRegion};
-    dstRegion *= zoom;
+    Rectangle<double> srcRegion{dstRegion};
+    srcRegion *= 1.0/zoom;
 
     std::shared_ptr<CacheEntry> entry = lookup(popplerPage);
     entry->render(cr, srcRegion, dstRegion);

--- a/src/control/jobs/ImageExport.cpp
+++ b/src/control/jobs/ImageExport.cpp
@@ -150,7 +150,8 @@ void ImageExport::exportImagePage(int pageId, int id, double zoomRatio, ExportGr
         auto pgNo = page->getPdfPageNr();
         XojPdfPageSPtr popplerPage = doc->getPdfPage(pgNo);
 
-        PdfView::drawPage(nullptr, popplerPage, cr, zoomRatio, page->getWidth(), page->getHeight());
+        Rectangle<double> renderRect{0.0, 0.0, page->getWidth(), page->getHeight()};
+        PdfView::drawPage(nullptr, popplerPage, cr, zoomRatio, page->getWidth(), page->getHeight(), renderRect);
     }
 
     view.drawPage(page, this->cr, true, exportBackground == EXPORT_BACKGROUND_NONE,

--- a/src/control/jobs/PreviewJob.cpp
+++ b/src/control/jobs/PreviewJob.cpp
@@ -57,8 +57,10 @@ void PreviewJob::drawBackgroundPdf(Document* doc) {
     int pgNo = this->sidebarPreview->page->getPdfPageNr();
     XojPdfPageSPtr popplerPage = doc->getPdfPage(pgNo);
 
-    PdfView::drawPage(this->sidebarPreview->sidebar->getCache(), popplerPage, cr2, zoom,
-                      this->sidebarPreview->page->getWidth(), this->sidebarPreview->page->getHeight());
+    Rectangle<double> fullPage{0.0, 0.0, this->sidebarPreview->page->getWidth(),
+                               this->sidebarPreview->page->getHeight()};
+    PdfView::drawPage(this->sidebarPreview->sidebar->getCache(), popplerPage, cr2, zoom, fullPage.width,
+                      fullPage.height, fullPage);
 }
 
 void PreviewJob::drawPage() {

--- a/src/control/jobs/RenderJob.cpp
+++ b/src/control/jobs/RenderJob.cpp
@@ -1,6 +1,7 @@
 #include "RenderJob.h"
 
 #include <cmath>
+#include <iostream>
 
 #include "control/Control.h"
 #include "control/ToolHandler.h"
@@ -45,7 +46,7 @@ void RenderJob::rerenderRectangle(Rectangle<double> const& rect) {
         auto pgNo = view->page->getPdfPageNr();
         XojPdfPageSPtr popplerPage = doc->getPdfPage(pgNo);
         PdfCache* cache = view->xournal->getCache();
-        PdfView::drawPage(cache, popplerPage, crRect, zoom, pageWidth, pageHeight);
+        PdfView::drawPage(cache, popplerPage, crRect, zoom, pageWidth, pageHeight, rect);
     }
 
     doc->lock();
@@ -115,7 +116,9 @@ void RenderJob::run() {
 
         bool backgroundVisible = this->view->page->isLayerVisible(0);
         if (backgroundVisible) {
-            PdfView::drawPage(this->view->xournal->getCache(), popplerPage, cr2, zoom, width, height);
+            std::cout << "P: " << width << ", " << height << std::endl;
+            Rectangle<double> fullPage{0, 0, width, height};
+            PdfView::drawPage(this->view->xournal->getCache(), popplerPage, cr2, zoom, width, height, fullPage);
         }
         localView.drawPage(this->view->page, cr2, false);
 

--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -144,8 +144,7 @@ void Settings::loadDefault() {
 
     this->touchZoomStartThreshold = 0.0;
 
-    this->pageRerenderThreshold = 5.0;
-    this->pdfPageCacheSize = 10;
+    this->pdfCacheSize_px = 1024 * 1024 * 32;
     this->preloadPagesBefore = 3U;
     this->preloadPagesAfter = 5U;
     this->eagerPageCleanup = true;
@@ -425,10 +424,8 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur) {
         this->presentationHideElements = reinterpret_cast<const char*>(value);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("touchZoomStartThreshold")) == 0) {
         this->touchZoomStartThreshold = g_ascii_strtod(reinterpret_cast<const char*>(value), nullptr);
-    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("pageRerenderThreshold")) == 0) {
-        this->pageRerenderThreshold = g_ascii_strtod(reinterpret_cast<const char*>(value), nullptr);
-    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("pdfPageCacheSize")) == 0) {
-        this->pdfPageCacheSize = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("pdfCacheSize_px")) == 0) {
+        this->pdfCacheSize_px = g_ascii_strtoull(reinterpret_cast<const char*>(value), nullptr, 10);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("preloadPagesBefore")) == 0) {
         this->preloadPagesBefore = g_ascii_strtoull(reinterpret_cast<const char*>(value), nullptr, 10);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("preloadPagesAfter")) == 0) {
@@ -898,11 +895,13 @@ void Settings::save() {
     SAVE_UINT_PROP(selectionMarkerColor);
 
     SAVE_DOUBLE_PROP(touchZoomStartThreshold);
-    SAVE_DOUBLE_PROP(pageRerenderThreshold);
 
-    SAVE_INT_PROP(pdfPageCacheSize);
-    ATTACH_COMMENT("The count of rendered PDF pages which will be cached.");
+    SAVE_UINT_PROP(pdfCacheSize_px);
+    ATTACH_COMMENT("The maximum number of pixels in the PDF page cache. Each pixel is 4 bytes.");
+
     SAVE_UINT_PROP(preloadPagesBefore);
+    ATTACH_COMMENT("The count of rendered PDF pages which will be cached.");
+
     SAVE_UINT_PROP(preloadPagesAfter);
     SAVE_BOOL_PROP(eagerPageCleanup);
 
@@ -1703,24 +1702,13 @@ void Settings::setTouchZoomStartThreshold(double threshold) {
     save();
 }
 
+auto Settings::getPdfCacheSize() const -> size_t { return this->pdfCacheSize_px; }
 
-auto Settings::getPDFPageRerenderThreshold() const -> double { return this->pageRerenderThreshold; }
-void Settings::setPDFPageRerenderThreshold(double threshold) {
-    if (this->pageRerenderThreshold == threshold) {
+void Settings::setPdfCacheSize(size_t size) {
+    if (this->pdfCacheSize_px == size) {
         return;
     }
-
-    this->pageRerenderThreshold = threshold;
-    save();
-}
-
-auto Settings::getPdfPageCacheSize() const -> int { return this->pdfPageCacheSize; }
-
-void Settings::setPdfPageCacheSize(int size) {
-    if (this->pdfPageCacheSize == size) {
-        return;
-    }
-    this->pdfPageCacheSize = size;
+    this->pdfCacheSize_px = size;
     save();
 }
 

--- a/src/control/settings/Settings.h
+++ b/src/control/settings/Settings.h
@@ -329,15 +329,12 @@ public:
     Color getBackgroundColor() const;
     void setBackgroundColor(Color color);
 
-    // Re-render pages if document zoom differs from the last render zoom by the given threshold.
-    double getPDFPageRerenderThreshold() const;
-    void setPDFPageRerenderThreshold(double threshold);
-
     double getTouchZoomStartThreshold() const;
     void setTouchZoomStartThreshold(double threshold);
 
-    int getPdfPageCacheSize() const;
-    [[maybe_unused]] void setPdfPageCacheSize(int size);
+    // Gets maximum size of PDF cache in pixels.
+    size_t getPdfCacheSize() const;
+    [[maybe_unused]] void setPdfCacheSize(size_t size);
 
     unsigned int getPreloadPagesBefore() const;
     void setPreloadPagesBefore(unsigned int n);
@@ -834,15 +831,10 @@ private:
     std::string presentationHideElements;
 
     /**
-     *  The count of pages which will be cached
+     *  The number of pixels that will be stored in the PDF cache.
+     *  (number of bytes stored in the cache / 4).
      */
-    int pdfPageCacheSize{};
-
-    /**
-     *  Percentage by which the page's zoom must change
-     * for PDF pages to re-render while zooming.
-     */
-    double pageRerenderThreshold{};
+    size_t pdfCacheSize_px{};
 
     /**
      * Don't start zooming with touch until the difference in distances between the

--- a/src/gui/XournalView.cpp
+++ b/src/gui/XournalView.cpp
@@ -35,7 +35,7 @@ std::pair<size_t, size_t> XournalView::preloadPageBounds(size_t page, size_t max
 
 XournalView::XournalView(GtkWidget* parent, Control* control, ScrollHandling* scrollHandling):
         scrollHandling(scrollHandling), control(control) {
-    this->cache = new PdfCache(control->getSettings()->getPdfPageCacheSize());
+    this->cache = new PdfCache(control->getSettings()->getPdfCacheSize());
 
     registerListener(control);
 
@@ -472,8 +472,6 @@ void XournalView::zoomChanged() {
     XojPageView* view = getViewFor(currentPage);
 
     ZoomControl* zoom = control->getZoomControl();
-    this->cache->setAnyZoomChangeCausesRecache(false);  // We're zooming -- no need for repeated re-renders.
-    this->cache->setRefreshThreshold(control->getSettings()->getPDFPageRerenderThreshold());
 
     if (!view) {
         return;
@@ -695,7 +693,7 @@ void XournalView::documentChanged(DocumentChangeType type) {
     }
     viewPages.clear();
 
-    this->cache->clearCache();
+    this->cache->clear();
 
     Document* doc = control->getDocument();
     doc->lock();

--- a/src/gui/dialog/SettingsDialog.cpp
+++ b/src/gui/dialog/SettingsDialog.cpp
@@ -434,9 +434,6 @@ void SettingsDialog::load() {
     GtkWidget* spDrawDirModsRadius = get("spDrawDirModsRadius");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spDrawDirModsRadius), settings->getDrawDirModsRadius());
 
-    GtkWidget* spReRenderThreshold = get("spReRenderThreshold");
-    gtk_spin_button_set_value(GTK_SPIN_BUTTON(spReRenderThreshold), settings->getPDFPageRerenderThreshold());
-
     GtkWidget* spTouchZoomStartThreshold = get("spTouchZoomStartThreshold");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spTouchZoomStartThreshold), settings->getTouchZoomStartThreshold());
 
@@ -814,20 +811,16 @@ void SettingsDialog::save() {
     settings->setDrawDirModsRadius(drawDirModsRadius);
 
     GtkWidget* spStrokeIgnoreTime = get("spStrokeIgnoreTime");
-    int strokeIgnoreTime = gtk_spin_button_get_value(GTK_SPIN_BUTTON(spStrokeIgnoreTime));
+    int strokeIgnoreTime = static_cast<int>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(spStrokeIgnoreTime)));
     GtkWidget* spStrokeIgnoreLength = get("spStrokeIgnoreLength");
     double strokeIgnoreLength = gtk_spin_button_get_value(GTK_SPIN_BUTTON(spStrokeIgnoreLength));
     GtkWidget* spStrokeSuccessiveTime = get("spStrokeSuccessiveTime");
-    int strokeSuccessiveTime = gtk_spin_button_get_value(GTK_SPIN_BUTTON(spStrokeSuccessiveTime));
+    int strokeSuccessiveTime = static_cast<int>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(spStrokeSuccessiveTime)));
     settings->setStrokeFilter(strokeIgnoreTime, strokeIgnoreLength, strokeSuccessiveTime);
 
     GtkWidget* spTouchZoomStartThreshold = get("spTouchZoomStartThreshold");
     double zoomStartThreshold = gtk_spin_button_get_value(GTK_SPIN_BUTTON(spTouchZoomStartThreshold));
     settings->setTouchZoomStartThreshold(zoomStartThreshold);
-
-    GtkWidget* spReRenderThreshold = get("spReRenderThreshold");
-    double rerenderThreshold = gtk_spin_button_get_value(GTK_SPIN_BUTTON(spReRenderThreshold));
-    settings->setPDFPageRerenderThreshold(rerenderThreshold);
 
 
     settings->setDisplayDpi(dpi);
@@ -896,7 +889,7 @@ void SettingsDialog::save() {
 
     settings->setAudioGain(static_cast<double>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spAudioGain")))));
     settings->setDefaultSeekTime(
-            static_cast<double>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spDefaultSeekTime")))));
+            static_cast<unsigned int>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spDefaultSeekTime")))));
 
     for (DeviceClassConfigGui* deviceClassConfigGui: this->deviceClassConfigs) {
         deviceClassConfigGui->saveSettings();

--- a/src/gui/sidebar/previews/base/SidebarPreviewBase.cpp
+++ b/src/gui/sidebar/previews/base/SidebarPreviewBase.cpp
@@ -11,7 +11,7 @@ SidebarPreviewBase::SidebarPreviewBase(Control* control, GladeGui* gui, SidebarT
         AbstractSidebarPage(control, toolbar) {
     this->layoutmanager = new SidebarLayout();
 
-    this->cache = new PdfCache(control->getSettings()->getPdfPageCacheSize());
+    this->cache = new PdfCache(control->getSettings()->getPdfCacheSize());
 
     this->iconViewPreview = gtk_layout_new(nullptr, nullptr);
     g_object_ref(this->iconViewPreview);
@@ -82,7 +82,7 @@ auto SidebarPreviewBase::getWidget() -> GtkWidget* { return this->scrollPreview;
 
 void SidebarPreviewBase::documentChanged(DocumentChangeType type) {
     if (type == DOCUMENT_CHANGE_COMPLETE || type == DOCUMENT_CHANGE_CLEARED) {
-        this->cache->clearCache();
+        this->cache->clear();
         updatePreviews();
     }
 }

--- a/src/pdf/base/XojPdfPage.cpp
+++ b/src/pdf/base/XojPdfPage.cpp
@@ -2,8 +2,21 @@
 
 XojPdfRectangle::XojPdfRectangle() = default;
 
+XojPdfRectangle::XojPdfRectangle(const Rectangle<double>& rect):
+        x1{rect.x}, y1{rect.y}, x2{x1 + rect.width}, y2{y1 + rect.height} {}
+
 XojPdfRectangle::XojPdfRectangle(double x1, double y1, double x2, double y2): x1(x1), y1(y1), x2(x2), y2(y2) {}
 
 XojPdfPage::XojPdfPage() = default;
 
 XojPdfPage::~XojPdfPage() = default;
+
+void XojPdfPage::render(cairo_t* cr, XojPdfRectangle region) {
+    cairo_save(cr);
+    cairo_rectangle(cr, region.x1, region.y1, region.x2, region.y2);
+    cairo_clip(cr);
+
+    this->render(cr, false);
+
+    cairo_restore(cr);
+}

--- a/src/pdf/base/XojPdfPage.h
+++ b/src/pdf/base/XojPdfPage.h
@@ -17,10 +17,12 @@
 
 #include <cairo.h>
 
+#include "Rectangle.h"
 
 class XojPdfRectangle {
 public:
     XojPdfRectangle();
+    XojPdfRectangle(const Rectangle<double>& rect);
     XojPdfRectangle(double x1, double y1, double x2, double y2);
 
 public:
@@ -39,11 +41,19 @@ public:
     virtual double getWidth() = 0;
     virtual double getHeight() = 0;
 
-    virtual void render(cairo_t* cr, bool forPrinting = false) = 0;
+    virtual void render(cairo_t* cr, bool forPrinting = false) = 0; // NOLINT(google-default-arguments)
+
+    /**
+     * @param cr is the target context.
+     * @param region is the region of this page to be rendered.
+     *
+     * Assumes forPrinting = false.
+     */
+    virtual void render(cairo_t* cr, XojPdfRectangle region);
 
     virtual std::vector<XojPdfRectangle> findText(std::string& text) = 0;
 
-    virtual int getPageId() = 0;
+    virtual int getPageId() const = 0;
 
 private:
 };

--- a/src/pdf/popplerapi/PopplerGlibPage.cpp
+++ b/src/pdf/popplerapi/PopplerGlibPage.cpp
@@ -50,8 +50,7 @@ auto PopplerGlibPage::getHeight() -> double {
     return height;
 }
 
-void PopplerGlibPage::render(cairo_t* cr, bool forPrinting)  // NOLINT(google-default-arguments)
-{
+void PopplerGlibPage::render(cairo_t* cr, bool forPrinting) {
     if (forPrinting) {
         poppler_page_render_for_printing(page, cr);
     } else {
@@ -59,7 +58,7 @@ void PopplerGlibPage::render(cairo_t* cr, bool forPrinting)  // NOLINT(google-de
     }
 }
 
-auto PopplerGlibPage::getPageId() -> int { return poppler_page_get_index(page); }
+auto PopplerGlibPage::getPageId() const -> int { return poppler_page_get_index(const_cast<PopplerPage*>(page)); }
 
 auto PopplerGlibPage::findText(std::string& text) -> std::vector<XojPdfRectangle> {
     std::vector<XojPdfRectangle> findings;

--- a/src/pdf/popplerapi/PopplerGlibPage.h
+++ b/src/pdf/popplerapi/PopplerGlibPage.h
@@ -24,14 +24,14 @@ public:
     PopplerGlibPage& operator=(const PopplerGlibPage& other);
 
 public:
-    virtual double getWidth();
-    virtual double getHeight();
+    virtual double getWidth() override;
+    virtual double getHeight() override;
 
-    virtual void render(cairo_t* cr, bool forPrinting = false);  // NOLINT(google-default-arguments)
+    virtual void render(cairo_t* cr, bool forPrinting) override;
 
-    virtual std::vector<XojPdfRectangle> findText(std::string& text);
+    virtual std::vector<XojPdfRectangle> findText(std::string& text) override;
 
-    virtual int getPageId();
+    virtual int getPageId() const override;
 
 private:
     PopplerPage* page;

--- a/src/util/QuadTreeCache.cpp
+++ b/src/util/QuadTreeCache.cpp
@@ -1,0 +1,639 @@
+#include "QuadTreeCache.h"
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <chrono>
+#include <cmath>
+#include <memory>
+
+#include <cairo.h>
+
+using Timestamp = std::chrono::time_point<std::chrono::steady_clock>;
+
+struct CacheState {
+    size_t cacheSize = 0;
+};
+
+class QuadTreeCache::Node {
+public:
+    /**
+     * @param fn Renders a region from the cache's source.
+     * @param region The region in cache coordinates
+     *   this node is responsible for.
+     * @param cacheSettings is owned by the cache this node belongs
+     *   to and specifies cache properties. It should not change after this
+     *   is constructed.
+     * @param cacheState stores cache-global properties.
+     */
+    Node(RenderFn fn, const Rect& region, const CacheParams* cacheSettings, std::shared_ptr<CacheState> cacheState);
+    ~Node();
+
+    /**
+     * @brief Renders this. Should not run concurrently with another render for the
+     *   same node.
+     * @param cr Context this is drawn onto.
+     * @param srcRegion The region in cache-space. May or may not be in this.
+     * @param dstRegion The region in screen-space. Should have same aspect ratio
+     *   as srcRegion (this may be enforced at runtime).
+     * @return true iff srcRegion has a subregion in this.
+     */
+    bool render(cairo_t* cr, const Rect& srcRegion, const Rect& dstRegion);
+
+    /**
+     * @brief Cleans up the cache such that the size of the cache is less than
+     *   the target cache size.
+     * @param currentZoom Only clear/cleanup nodes with zoom (as by getZoom) greater
+     *   than targetZoom.
+     */
+    void cleanup(double currentZoom);
+
+    /**
+     * @param region is marked as needing a redraw.
+     */
+    void damage(const Rect& region);
+
+    /**
+     * @brief Clears cached data associated with this.
+     * @return The number of pixels cleared.
+     */
+    size_t clear();
+
+protected:
+    enum QuadIdentifier { TOP_LEFT = 0, TOP_RIGHT = 1, BOT_LEFT = 2, BOT_RIGHT = 3 };
+
+    /**
+     * @return How much this is scaled (at most, if scaling differs in this)
+     *  to fit source space.
+     *  If this has children, returns max({ c.getZoom() : c \in children_ }).
+     */
+    double getZoom() const;
+
+    /** @return true iff this has associated pixels. */
+    bool isEmpty() const;
+
+private:
+    /**
+     * Splits this into four nodes. Does nothing if already split.
+     */
+    void divide();
+
+    /**
+     * Joins this' children into a single node.
+     */
+    size_t join();
+
+    /**
+     * Sets the timestamp associated with this to now.
+     */
+    void updateTimestamp();
+
+    /**
+     * @brief Render to cr from rendered_.
+     * @param cr Context to render to.
+     * @param src The rectangle to render from. This must be in region_.
+     * @param dst Where src maps to in output coordinates. Must have the same
+     *   aspect ratio as src.
+     * @return Whether we could render to dst from rendered_.
+     */
+    bool renderFromSelf(cairo_t* cr, const Rect& src, const Rect& dst);
+
+    /**
+     * @brief Clears image data associated with this node until a given number of
+     *   pixels have been freed.
+     *
+     * @param quota Target number of pixels to free.
+     * @param targetZoom If a region's internalToSrc_ratio_ (its zoom) is greater than
+     *  this, it will be freed.
+     * @return The number of pixels freed.
+     */
+    size_t cleanupByZoom(size_t quota, double targetZoom);
+    size_t cleanupByTimestamp(size_t quota);
+
+    /**
+     * @brief Clears the rendered image associated directly with this node (and not
+     * its children). Does nothing if rendered_ == nullptr.
+     * @returns The number of pixels freed by freeing the rendering associated with
+     *   this node.
+     */
+    size_t clearRendered();
+
+    /** @return the number of pixels cleared. */
+    size_t clearChildren();
+
+    /** @return true iff this has child nodes. */
+    bool hasChildren() const;
+
+    /**
+     * @return the number of pixels that would have to be cached for a full render of this.
+     */
+    size_t getUncachedPx() const;
+
+    /**
+     * @param childIdx the index of the child \in [0, 4).
+     * @return the rectangle in source space for the child with index, childIdx.
+     */
+    Rect determineChildRect(size_t childIdx) const;
+
+    /**
+     * @param childIdx the index of the child \in [0, 4).
+     * @return the rectangle in internal space (relative to rendered_) for the child.
+     * @see #determineChildRect for a rectangle in source space.
+     */
+    Rect getInternalQuadrant(size_t quadrant) const;
+
+    /**
+     * Get children of this in decreasing order by zoom.
+     */
+    std::array<QuadIdentifier, 4> getChildrenByZoom() const;
+
+    /**
+     * Get children of this in increasing order by timestamp.
+     */
+    std::array<QuadIdentifier, 4> getChildrenByTimestamp() const;
+
+private:
+    // Renders pixels from the cache's source.
+    RenderFn renderFn_;
+
+    // Region in the cache's source this node is responsible for.
+    Rect region_;
+
+    // Ptr to settings for the entire cache.
+    const CacheParams* cacheSettings_;
+
+    // Cache-global state.
+    std::shared_ptr<CacheState> cacheState_;
+
+    // List of nullable children of this. In the order,
+    // { TOP_LEFT, TOP_RIGHT, BOTTOM_LEFT, BOTTOM_RIGHT }.
+    std::array<std::unique_ptr<Node>, 4> children_;
+
+    // Owned and nullable. Cached render of data managed by this. Must be
+    // freed with cairo_surface_destroy.
+    cairo_surface_t* rendered_{nullptr};
+
+    // Size of rendered_ image surface (or the size it would be, if it's null).
+    size_t internalWidth_, internalHeight_;
+
+    // Conversion factor:
+    //  (pixels in rendered_) * internalToSrc_ratio -> (pixels in this->region_)
+    double internalToSrc_ratio_;
+
+    // Timestamp of last call to render for this.
+    Timestamp lastUsedTimestamp_;
+};
+
+
+QuadTreeCache::QuadTreeCache(RenderFn renderFn, const Rect& pageRect, const CacheParams& cacheSettings):
+        cacheSettings_{cacheSettings},
+        root_{std::make_unique<Node>(std::move(renderFn), pageRect, &cacheSettings_, std::make_shared<CacheState>())} {}
+
+// We need to define a destructor so root_ can delete itself
+// (QuadTreeCache::Node is forward-declared in QuadTreeCache.h).
+QuadTreeCache::~QuadTreeCache() {}
+
+void QuadTreeCache::damage(const Rect& region) { root_->damage(region); }
+
+void QuadTreeCache::render(cairo_t* cr, const Rect& srcRegion, const Rect& dstRegion) {
+    if (srcRegion.area() == 0.0 || dstRegion.area() == 0.0) {
+        return;
+    }
+
+    root_->render(cr, srcRegion, dstRegion);
+
+    double currentZoom = dstRegion.width / srcRegion.width;
+    root_->cleanup(currentZoom);
+}
+
+void QuadTreeCache::clear() { root_->clear(); }
+
+
+QuadTreeCache::Node::Node(RenderFn fn, const Rect& region, const CacheParams* cacheSettings,
+                          std::shared_ptr<CacheState> cacheState):
+        renderFn_{std::move(fn)},
+        region_{region},
+        cacheSettings_{cacheSettings},
+        cacheState_{cacheState},
+        children_{nullptr, nullptr, nullptr, nullptr} {
+    double ratioSquared = static_cast<double>(cacheSettings_->entrySize) / region_.width / region_.height;
+    internalToSrc_ratio_ = std::sqrt(ratioSquared);
+
+    internalWidth_ = static_cast<size_t>(region_.width / internalToSrc_ratio_);
+    internalHeight_ = static_cast<size_t>(region_.height / internalToSrc_ratio_);
+
+    assert(internalWidth_ * internalHeight_ == cacheSettings_->entrySize);
+
+    updateTimestamp();
+}
+
+QuadTreeCache::Node::~Node() { clearRendered(); }
+
+void QuadTreeCache::Node::updateTimestamp() { lastUsedTimestamp_ = std::chrono::steady_clock::now(); }
+
+bool QuadTreeCache::Node::render(cairo_t* cr, const Rect& srcRegion, const Rect& dstRegion) {
+    double srcToDst_ratio = dstRegion.width / srcRegion.width;
+    std::optional<Rect> srcInThis = region_.intersects(srcRegion);
+
+    // Source and destination regions should have the same aspect ratios.
+    assert(std::abs(srcRegion.height * srcToDst_ratio - dstRegion.height) < 0.1);
+
+    // Does srcRegion overlap with this?
+    if (!srcInThis.has_value()) {
+        return false;
+    }
+
+    // Some part of this will be used. As such,
+    // we update the last used timestamp.
+    updateTimestamp();
+
+    Rect& trimmedSrcRegion = srcInThis.value();
+    Rect trimmedDstRegion{dstRegion};
+
+    // Trim the destination region such that it continues to
+    // match the source region.
+    {
+        double dx_src = trimmedSrcRegion.x - srcRegion.x;
+        double dy_src = trimmedSrcRegion.y - srcRegion.y;
+        double dwidth_src = trimmedSrcRegion.width - srcRegion.width;
+        double dheight_src = trimmedSrcRegion.height - srcRegion.height;
+
+        trimmedDstRegion.x += dx_src * srcToDst_ratio;
+        trimmedDstRegion.y += dy_src * srcToDst_ratio;
+        trimmedDstRegion.width += dwidth_src * srcToDst_ratio;
+        trimmedDstRegion.height += dheight_src * srcToDst_ratio;
+    }
+
+    if (!renderFromSelf(cr, trimmedSrcRegion, trimmedDstRegion)) {
+        return true;
+    }
+
+    // Otherwise, we're rendering from children of this.
+
+    // Ensure we have children.
+    divide();
+
+    for (const auto& child: children_) { child->render(cr, trimmedSrcRegion, trimmedDstRegion); }
+
+    return true;
+}
+
+bool QuadTreeCache::Node::renderFromSelf(cairo_t* cr, const Rect& src, const Rect& dst) {
+    if (!rendered_ && hasChildren()) {
+        return false;
+    }
+
+    double srcToDst_ratio = dst.width / src.width;
+
+    // src and dst should have the same aspect ratio.
+    assert(std::abs(src.height * srcToDst_ratio - dst.height) < 0.1);
+
+    // A requirement of renderToSelf is that dst, src \subseteq this->region_.
+    // As such,
+    double internalToDst_ratio = internalToSrc_ratio_ * srcToDst_ratio;
+
+    // Don't overscale when rendering.
+    if (internalToDst_ratio > cacheSettings_->maxZoom) {
+        return false;
+    }
+
+    cairo_surface_t* rendered = this->rendered_;
+
+    if (!rendered) {
+        rendered = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, static_cast<int>(internalWidth_),
+                                              static_cast<int>(internalHeight_));
+        cairo_t* cr2 = cairo_create(rendered);
+
+        cairo_scale(cr2, 1.0 / internalToSrc_ratio_, 1.0 / internalToSrc_ratio_);
+        renderFn_(cr2, region_);
+        cairo_destroy(cr2);
+
+        size_t internalSize = internalWidth_ * internalHeight_;
+        cacheState_->cacheSize += internalSize;
+
+        this->rendered_ = rendered;
+    }
+
+    // Render!
+    // TODO: Use a mutex here, if we decide to parallelize rendering.
+    cairo_matrix_t mOriginal;
+    cairo_matrix_t mScaled;
+    cairo_get_matrix(cr, &mOriginal);
+    cairo_get_matrix(cr, &mScaled);
+    mScaled.xx = internalToDst_ratio;
+    mScaled.yy = internalToDst_ratio;
+    mScaled.xy = 0;
+    mScaled.yx = 0;
+    cairo_set_matrix(cr, &mScaled);
+
+    double renderAtX = dst.x / internalToDst_ratio;
+    double renderAtY = dst.y / internalToDst_ratio;
+
+    cairo_set_source_surface(cr, rendered, renderAtX, renderAtY);
+    cairo_paint(cr);
+    cairo_set_matrix(cr, &mOriginal);
+
+    if (rendered != this->rendered_) {
+        cairo_surface_destroy(rendered);
+        rendered = nullptr;
+    }
+
+    return true;
+}
+
+size_t QuadTreeCache::Node::getUncachedPx() const {
+    // Base case: We don't need to add anything to the cache.
+    if (rendered_) {
+        return 0;
+    }
+
+    // Base case: No children, nothing rendered.
+    if (!hasChildren()) {
+        return internalWidth_ * internalHeight_;
+    }
+
+    size_t result = 0;
+    for (size_t i = 0; i < children_.size(); i++) { result += children_[i]->getUncachedPx(); }
+
+    return result;
+}
+
+void QuadTreeCache::Node::divide() {
+    // Clear cached data associated directly with this.
+    clearRendered();
+
+    if (!hasChildren()) {
+        for (size_t i = TOP_LEFT; i <= BOT_RIGHT; i++) {
+            Rect childRegion = determineChildRect(i);
+            children_[i] = std::make_unique<Node>(renderFn_, childRegion, cacheSettings_, cacheState_);
+        }
+
+        assert(hasChildren());
+    }
+}
+
+size_t QuadTreeCache::Node::join() {
+    // Must have children to join.
+    if (!hasChildren()) {
+        return 0;
+    }
+
+    // If we'll do less rendering if we just clear this' children,
+    if (getUncachedPx() > internalWidth_ * internalHeight_) {
+        return clearChildren();
+    }
+
+    assert(rendered_ == nullptr);
+
+    size_t bytesFreed = 0;
+
+    rendered_ = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, static_cast<int>(internalWidth_),
+                                           static_cast<int>(internalHeight_));
+    cairo_t* cr = cairo_create(rendered_);
+
+    for (size_t i = TOP_LEFT; i <= BOT_RIGHT; i++) {
+        Node& child = *children_[i];
+
+        child.render(cr, child.region_, getInternalQuadrant(i));
+        bytesFreed += child.clear();
+
+        children_[i] = nullptr;
+    }
+
+    cairo_destroy(cr);
+
+    assert(bytesFreed > internalWidth_ * internalHeight_);
+    bytesFreed -= internalWidth_ * internalHeight_;
+
+    return bytesFreed;
+}
+
+size_t QuadTreeCache::Node::clearChildren() {
+    if (!hasChildren()) {
+        return 0;
+    }
+
+    size_t result = 0;
+
+    for (size_t i = 0; i < children_.size(); i++) {
+        result += children_[i]->clear();
+        children_[i] = nullptr;
+    }
+
+    return result;
+}
+
+bool QuadTreeCache::Node::hasChildren() const {
+    // If one child is null, they all should be.
+    // Otherwise, none should be null.
+    assert(children_[TOP_LEFT] == children_[TOP_RIGHT] && children_[BOT_LEFT] == children_[BOT_RIGHT] &&
+           children_[TOP_RIGHT] == children_[BOT_RIGHT]);
+
+    return children_[TOP_LEFT] != nullptr;
+}
+
+QuadTreeCache::Rect QuadTreeCache::Node::determineChildRect(size_t childIdx) const {
+    Rect childRegion{region_};
+    childRegion.width /= 2.0;
+    childRegion.height /= 2.0;
+
+    if (childIdx == TOP_RIGHT || childIdx == BOT_RIGHT) {
+        childRegion.x += childRegion.width;
+    }
+
+    if (childIdx == BOT_LEFT || childIdx == BOT_RIGHT) {
+        childRegion.y += childRegion.height;
+    }
+
+    return childRegion;
+}
+
+QuadTreeCache::Rect QuadTreeCache::Node::getInternalQuadrant(size_t quadrant) const {
+    double quadrantWidth = static_cast<double>(internalWidth_) / 2.0;
+    double quadrantHeight = static_cast<double>(internalHeight_) / 2.0;
+    double quadrantX = 0.0, quadrantY = 0.0;
+
+    if (quadrant == TOP_RIGHT || quadrant == BOT_RIGHT) {
+        quadrantX = quadrantWidth;
+    }
+
+    if (quadrant == BOT_LEFT || quadrant == BOT_RIGHT) {
+        quadrantY = quadrantHeight;
+    }
+
+    return {quadrantX, quadrantY, quadrantWidth, quadrantHeight};
+}
+
+void QuadTreeCache::Node::damage(const Rect& region) {
+    std::optional<Rect> intersection = region_.intersects(region);
+
+    if (!intersection) {
+        return;
+    }
+
+    if (hasChildren()) {
+        for (int i = 0; i < children_.size(); i++) { children_[i]->damage(region); }
+    }
+
+    clearRendered();
+}
+
+size_t QuadTreeCache::Node::clearRendered() {
+    size_t result = 0;
+
+    if (rendered_ != nullptr) {
+        cairo_surface_destroy(rendered_);
+        rendered_ = nullptr;
+
+        result = internalWidth_ * internalHeight_;
+    }
+
+    assert(cacheState_->cacheSize >= result);
+    cacheState_->cacheSize -= result;
+
+    return result;
+}
+
+double QuadTreeCache::Node::getZoom() const {
+    if (rendered_) {
+        return internalToSrc_ratio_;
+    }
+
+    double result = 0.0;
+    for (size_t i = 0; i < children_.size(); i++) { result = std::max(result, children_[i]->getZoom()); }
+
+    return result;
+}
+
+bool QuadTreeCache::Node::isEmpty() const {
+    if (hasChildren()) {
+        for (size_t i = 0; i < children_.size(); i++) {
+            if (!children_[i]->isEmpty()) {
+                return false;
+            }
+        }
+
+        return true;
+    } else {
+        return rendered_ == nullptr;
+    }
+}
+
+auto QuadTreeCache::Node::getChildrenByZoom() const -> std::array<QuadTreeCache::Node::QuadIdentifier, 4> {
+    assert(hasChildren());
+
+    std::array<QuadIdentifier, 4> result{TOP_LEFT, TOP_RIGHT, BOT_LEFT, BOT_RIGHT};
+
+    std::sort(result.begin(), result.end(), [=](const QuadIdentifier& a, const QuadIdentifier& b) -> bool {
+        // Returns true iff a goes before (less than) b.
+        return children_[a]->getZoom() > children_[b]->getZoom();
+    });
+
+    return result;
+}
+
+auto QuadTreeCache::Node::getChildrenByTimestamp() const -> std::array<QuadTreeCache::Node::QuadIdentifier, 4> {
+    assert(hasChildren());
+
+    std::array<QuadIdentifier, 4> result{TOP_LEFT, TOP_RIGHT, BOT_LEFT, BOT_RIGHT};
+
+    std::sort(result.begin(), result.end(), [=](const QuadIdentifier& a, const QuadIdentifier& b) -> bool {
+        // Returns true iff a should go before b in the result.
+        return children_[a]->lastUsedTimestamp_ < children_[b]->lastUsedTimestamp_;
+    });
+
+    return result;
+}
+
+size_t QuadTreeCache::Node::cleanupByZoom(size_t quota, double targetZoom) {
+    if (quota <= 0) {
+        return 0;
+    }
+
+    size_t result = 0;
+
+    if (hasChildren()) {
+        // Children by zoom, decreasing order.
+        std::array<QuadIdentifier, 4> childrenByZoom = getChildrenByZoom();
+
+        // Clean up until we reach our quota, or we can't clean up anymore.
+        for (size_t i = 0; i < childrenByZoom.size(); i++) {
+            QuadIdentifier childId = childrenByZoom[i];
+            Node& child = *children_[childId];
+
+            assert(quota >= result);
+
+            if (child.getZoom() > targetZoom) {
+                result += child.cleanupByZoom(quota - result, targetZoom);
+            } else {
+                break;
+            }
+
+            if (quota <= result) {
+                break;
+            }
+        }
+
+        // If we can join and downsample this' children while
+        // keeping within the target zoom, do so.
+        if (getZoom() <= targetZoom && result < quota) {
+            result += join();
+        }
+    }
+
+    if (isEmpty()) {
+        clear();
+    }
+
+    return result;
+}
+
+void QuadTreeCache::Node::cleanup(double currentZoom) {
+    // TODO: Add a mutex here for thread safety.
+    if (cacheState_->cacheSize > cacheSettings_->maxSize) {
+        size_t quota = cacheState_->cacheSize - cacheSettings_->maxSize;
+
+        if (cacheSettings_->uncachePolicy == DecachePolicy::VIEWPORT_THEN_LRU) {
+            size_t cleared = cleanupByZoom(quota, currentZoom * cacheSettings_->maxZoom);
+
+            if (cleared >= quota) {
+                return;
+            }
+
+            quota -= cleared;
+        }
+
+        cleanupByTimestamp(quota);
+    }
+}
+
+size_t QuadTreeCache::Node::cleanupByTimestamp(size_t quota) {
+    if (quota <= 0) {
+        return 0;
+    }
+
+    if (!hasChildren()) {
+        return clearRendered();
+    }
+
+    size_t result = 0;
+    std::array<QuadIdentifier, 4> childrenByTimestamp = getChildrenByTimestamp();
+
+    for (size_t i = 0; i < childrenByTimestamp.size(); i++) {
+        result += children_[i]->cleanupByTimestamp(quota - result);
+
+        if (result >= quota) {
+            break;
+        }
+    }
+
+    if (isEmpty()) {
+        // If we're empty, we may still need to trim null nodes.
+        // clear does this.
+        result += clear();
+    }
+
+    return result;
+}
+
+size_t QuadTreeCache::Node::clear() { return clearRendered() + clearChildren(); }

--- a/src/util/QuadTreeCache.h
+++ b/src/util/QuadTreeCache.h
@@ -1,0 +1,110 @@
+/*
+ * Xournal++
+ *
+ * A quad-tree cache.
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+#include <functional>
+#include <memory>
+
+#include <cairo.h>
+
+#include "Rectangle.h"
+
+class QuadTreeCache {
+public:
+    /**
+     * Specifies the order in which regions are removed from the cache
+     * (or rendered quality of a region lowered).
+     *
+     * VIEWPORT_THEN_LRU causes the cache to assume that the most recently rendered
+     *  region predicts the zoom and viewport size of future renders; it assumes that
+     *  we can safely reduce the quality of regions with >= the most recent zoom.
+     *
+     * LRU doesn't take the viewport into account and removes least recently used regions
+     *  from the cache.
+     */
+    enum class DecachePolicy { VIEWPORT_THEN_LRU, LRU };
+
+    struct CacheParams {
+        /**
+         * The size (in rendered pixels) of each node in the tree.
+         * This should be a square number.
+         */
+        size_t entrySize{512 * 512};
+
+        /**
+         * The maximum amount a region can be scaled before it needs to be
+         * re-cached with a greater size.
+         */
+        double maxZoom{1.0};
+
+        /**
+         * The maximum size (in rendered pixels) of the cache.
+         * If the cache gets lager than this, it starts removing
+         * regions from the cache.
+         */
+        size_t maxSize{static_cast<size_t>(-1)};
+
+        /**
+         * See {@link QuadTreeCache::DecachePolicy}
+         */
+        DecachePolicy uncachePolicy{DecachePolicy::VIEWPORT_THEN_LRU};
+    };
+
+public:
+    using Rect = Rectangle<double>;
+    using RenderFn = std::function<void(cairo_t*, const Rect&)>;
+
+    /**
+     * @param renderFn Renders a given rectangle to a given cairo context.
+     *  This function is used to populate the cache with data. Call damage(Rect)
+     *  to force a region's re-render.
+     * @param pageRect Gives the region of pixels managed by this in cache/renderFn-coordinates.
+     * @param cacheSettings Specifies cache behavior.
+     */
+    QuadTreeCache(RenderFn renderFn, const Rect& pageRect, const CacheParams& cacheSettings);
+    ~QuadTreeCache();
+
+    /**
+     * @brief Invalidate/mark a region to be re-rendered. This might be done if
+     *   (for example) this cache's source changes in that region.
+     * @param region A region that must be re-rendered before drawing again.
+     */
+    void damage(const Rect& region);
+
+    /**
+     * @brief Render a region from the cache and the cache's source.
+     * @param cr The target, to which the cache is rendered (at coordinates specified by dstRegion).
+     * @param srcRegion The region to fetch from the cache (or fetch from this cache's source, or fetch
+     *   from this cache's source and store in this cache).
+     * @param dstRegion The region to render to the context. The cache will ensure that what is rendered
+     *
+     *
+     * For example,
+     *   cache.render(some_context, Rect { 1.0, 1.0, 2.0, 2.0 }, Rect { 0.0, 0.0, 1.0, 1.0 });
+     *  renders a rectangle stored in the cache at (1, 1) with width and height 2 to a region at (0, 0)
+     *  on some_context.
+     *  It may call renderFn, or render from the cache (if the region is available).
+     *
+     */
+    void render(cairo_t* cr, const Rect& srcRegion, const Rect& dstRegion);
+
+    /**
+     * @brief Clears cached data.
+     */
+    void clear();
+
+private:
+    CacheParams cacheSettings_;
+
+    class Node;
+    std::unique_ptr<Node> root_;
+};

--- a/src/view/PdfView.cpp
+++ b/src/view/PdfView.cpp
@@ -1,5 +1,7 @@
 #include "PdfView.h"
 
+#include <iostream>
+
 #include <config.h>
 
 #include "i18n.h"
@@ -8,8 +10,8 @@ PdfView::PdfView() = default;
 
 PdfView::~PdfView() = default;
 
-void PdfView::drawPage(PdfCache* cache, const XojPdfPageSPtr& popplerPage, cairo_t* cr, double zoom, double width,
-                       double height, bool forPrinting) {
+void PdfView::drawPage(PdfCache* cache, const XojPdfPageSPtr& popplerPage, cairo_t* cr, double zoom, double fullWidth,
+                       double fullHeight, Rectangle<double> regionToUpdate, bool forPrinting) {
     if (popplerPage) {
         if (!forPrinting) {
             cairo_set_source_rgb(cr, 1., 1., 1.);
@@ -17,7 +19,8 @@ void PdfView::drawPage(PdfCache* cache, const XojPdfPageSPtr& popplerPage, cairo
         }
 
         if (cache && !forPrinting) {
-            cache->render(cr, popplerPage, zoom);
+            std::cout << "DR: " << regionToUpdate.width << ", " << regionToUpdate.height << "." << std::endl;
+            cache->render(cr, popplerPage, regionToUpdate, zoom);
         } else {
             popplerPage->render(cr, forPrinting);
         }
@@ -31,7 +34,7 @@ void PdfView::drawPage(PdfCache* cache, const XojPdfPageSPtr& popplerPage, cairo
         std::string strMissing = _("PDF background missing");
 
         cairo_text_extents(cr, strMissing.c_str(), &extents);
-        cairo_move_to(cr, width / 2 - extents.width / 2, height / 2 - extents.height / 2);
+        cairo_move_to(cr, fullWidth / 2 - extents.width / 2, fullHeight / 2 - extents.height / 2);
         cairo_show_text(cr, strMissing.c_str());
     }
 }

--- a/src/view/PdfView.cpp
+++ b/src/view/PdfView.cpp
@@ -19,8 +19,12 @@ void PdfView::drawPage(PdfCache* cache, const XojPdfPageSPtr& popplerPage, cairo
         }
 
         if (cache && !forPrinting) {
-            std::cout << "DR: " << regionToUpdate.width << ", " << regionToUpdate.height << "." << std::endl;
             cache->render(cr, popplerPage, regionToUpdate, zoom);
+
+            cairo_set_line_width(cr, 4.0);
+            cairo_set_source_rgb(cr, 0, 255, 0);
+            cairo_rectangle(cr, regionToUpdate.x, regionToUpdate.y, regionToUpdate.width, regionToUpdate.height);
+            cairo_stroke(cr);
         } else {
             popplerPage->render(cr, forPrinting);
         }

--- a/src/view/PdfView.h
+++ b/src/view/PdfView.h
@@ -22,6 +22,6 @@ private:
     virtual ~PdfView();
 
 public:
-    static void drawPage(PdfCache* cache, const XojPdfPageSPtr& popplerPage, cairo_t* cr, double zoom, double width,
-                         double height, bool forPrinting = false);
+    static void drawPage(PdfCache* cache, const XojPdfPageSPtr& popplerPage, cairo_t* cr, double zoom, double fullWidth,
+                         double fullHeight, Rectangle<double> regionToUpdate, bool forPrinting = false);
 };


### PR DESCRIPTION
## Goal
To reduce memory usage and render time for large PDFs.

Hopefully, this will fix #2515.

## To-do
 * [ ] Implement `QuadTreeCache`
     * [x] Implementation of `QuadTreeCache` datastructure.
     * [ ] Have `PdfCacheEntry` use the new cache.
         * [ ] Something that can (mostly) render PDFs using the cache.
         * [ ] Remove debug print statements.
         * [ ] Fix sub-region re-render (very important for next to-do item)
![sub-regions of pages don't render properly](https://user-images.githubusercontent.com/46334387/113434526-fbde6b80-9395-11eb-80be-38267a873628.png)
     * [ ] `RenderJob`: Render pages using the viewport on/after scrolling and zooming (rather than just re-render the entire page). **Speedup should only be observable after completing this item!**
     * [ ] Fix vertical/horizontal line artifacts from `QuadTreeCache`
     * [ ]  Implement tests for `QuadTreeCache`
 * [ ] Verify speedup
 * [ ] Test everything