### PR TITLE
Sidebar Toolbar: Fix abrupt background color change in Adwaita theme

### DIFF
--- a/ui/main.glade
+++ b/ui/main.glade
@@ -219,8 +219,8 @@
                             <property name="use-underline">True</property>
                             <property name="use-stock">True</property>
                             <signal name="activate" handler="ACTION_SAVE_AS" swapped="no"/>
-                            <accelerator key="s" signal="activate" modifiers="GDK_SHIFT_MASK | GDK_CONTROL_MASK"/>
                             <accelerator key="u" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                            <accelerator key="s" signal="activate" modifiers="GDK_SHIFT_MASK | GDK_CONTROL_MASK"/>
                           </object>
                         </child>
                         <child>
@@ -968,8 +968,8 @@
                             <property name="use-underline">True</property>
                             <property name="use-stock">True</property>
                             <signal name="activate" handler="ACTION_ZOOM_IN" swapped="no"/>
-                            <accelerator key="plus" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                             <accelerator key="KP_Add" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                            <accelerator key="plus" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                           </object>
                         </child>
                         <child>
@@ -981,8 +981,8 @@
                             <property name="use-underline">True</property>
                             <property name="use-stock">True</property>
                             <signal name="activate" handler="ACTION_ZOOM_OUT" swapped="no"/>
-                            <accelerator key="minus" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                             <accelerator key="KP_Subtract" signal="activate" modifiers="GDK_CONTROL_MASK"/>
+                            <accelerator key="minus" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                           </object>
                         </child>
                         <child>
@@ -2127,6 +2127,9 @@
                                     <property name="name">tbSelectSidebarPage</property>
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
+                                    <style>
+                                      <class name="inline-toolbar"/>
+                                    </style>
                                   </object>
                                   <packing>
                                     <property name="expand">True</property>
@@ -2161,7 +2164,6 @@
                                 </child>
                                 <style>
                                   <class name="linked"/>
-                                  <class name="inline-toolbar"/>
                                 </style>
                               </object>
                               <packing>


### PR DESCRIPTION
## Before
![image](https://user-images.githubusercontent.com/46334387/113451956-f1cd6480-93b7-11eb-9262-5976c07cc5a2.png)

## After
![image](https://user-images.githubusercontent.com/46334387/113451979-01e54400-93b8-11eb-8079-642b7f362623.png)

The `inline-toolbar` CSS class was previously applied to the parent of this toolbar (containing outline, layer preview, etc.), rather than the toolbar itself, causing a sudden change in background color. This PR moves the `inline-toolbar` class from the toolbar's parent to the toolbar itself.
