### PR TITLE
Cleaned up PrintHandler - made more verbose - set parent

### DIFF
--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -2226,9 +2226,8 @@ auto Control::annotatePdf(fs::path filepath, bool /*attachPdf*/, bool attachToDo
 }
 
 void Control::print() {
-    PrintHandler print;
     this->doc->lock();
-    print.print(this->doc, getCurrentPageNo());
+    PrintHandler::print(this->doc, getCurrentPageNo(), this->getGtkWindow());
     this->doc->unlock();
 }
 

--- a/src/control/PrintHandler.cpp
+++ b/src/control/PrintHandler.cpp
@@ -2,20 +2,21 @@
 
 #include <cmath>
 
-#include "control/settings/Settings.h"
+#include <gtk/gtk.h>
+#include <util/safe_casts.h>
+
 #include "model/Document.h"
 #include "view/DocumentView.h"
 
 #include "PathUtil.h"
+#include "XojMsgBox.h"
+#include "i18n.h"
 
-PrintHandler::PrintHandler() = default;
-
-PrintHandler::~PrintHandler() = default;
-
-void PrintHandler::drawPage(GtkPrintOperation* operation, GtkPrintContext* context, int pageNr, PrintHandler* handler) {
+namespace {
+void drawPage(GtkPrintOperation* /*operation*/, GtkPrintContext* context, int pageNr, Document* doc) {
     cairo_t* cr = gtk_print_context_get_cairo_context(context);
 
-    PageRef page = handler->doc->getPage(pageNr);
+    PageRef page = doc->getPage(static_cast<size_t>(pageNr));
     if (!page) {
         return;
     }
@@ -29,8 +30,7 @@ void PrintHandler::drawPage(GtkPrintOperation* operation, GtkPrintContext* conte
     }
 
     if (page->getBackgroundType().isPdfPage()) {
-        int pgNo = page->getPdfPageNr();
-        XojPdfPageSPtr popplerPage = handler->doc->getPdfPage(pgNo);
+        XojPdfPageSPtr popplerPage = doc->getPdfPage(page->getPdfPageNr());
         if (popplerPage) {
             popplerPage->render(cr, true);
         }
@@ -40,9 +40,9 @@ void PrintHandler::drawPage(GtkPrintOperation* operation, GtkPrintContext* conte
     view.drawPage(page, cr, true /* dont render eraseable */);
 }
 
-void PrintHandler::requestPageSetup(GtkPrintOperation* operation, GtkPrintContext* context, gint pageNr,
-                                    GtkPageSetup* setup, PrintHandler* handler) {
-    PageRef page = handler->doc->getPage(pageNr);
+void requestPageSetup(GtkPrintOperation* /*op*/, GtkPrintContext* /*ctx*/, int pageNr, GtkPageSetup* setup,
+                      Document* doc) {
+    PageRef page = doc->getPage(static_cast<size_t>(pageNr));  // Can't be negative
     if (!page) {
         return;
     }
@@ -61,38 +61,48 @@ void PrintHandler::requestPageSetup(GtkPrintOperation* operation, GtkPrintContex
     gtk_paper_size_free(size);
 }
 
-void PrintHandler::print(Document* doc, int currentPage) {
+inline void handlePrintError(GError*& error, const char* message) {
+    if (error) {
+        g_warning(message, error->message);
+        g_error_free(error);
+        error = nullptr;
+    }
+}
+}  // namespace
+
+void PrintHandler::print(Document* doc, size_t currentPage, GtkWindow* parent) {
+    GtkPrintSettings* settings{};
     auto filepath = Util::getConfigFile(PRINT_CONFIG_FILE);
-
-    GtkPrintSettings* settings = gtk_print_settings_new_from_file(filepath.u8string().c_str(), nullptr);
-
+    if (fs::exists(filepath)) {
+        GError* error{};
+        settings = gtk_print_settings_new_from_file(filepath.u8string().c_str(), &error);
+        handlePrintError(error, "Loading print settings failed with: %s");
+    }
     if (settings == nullptr) {
         settings = gtk_print_settings_new();
     }
 
-    this->doc = doc;
-
     GtkPrintOperation* op = gtk_print_operation_new();
     gtk_print_operation_set_print_settings(op, settings);
-    gtk_print_operation_set_n_pages(op, doc->getPageCount());
-    gtk_print_operation_set_current_page(op, currentPage);
+    gtk_print_operation_set_n_pages(op, strict_cast<int>(doc->getPageCount()));
+    gtk_print_operation_set_current_page(op, strict_cast<int>(currentPage));
     gtk_print_operation_set_job_name(op, "Xournal++");
     gtk_print_operation_set_unit(op, GTK_UNIT_POINTS);
     gtk_print_operation_set_use_full_page(op, true);
-    g_signal_connect(op, "draw_page", G_CALLBACK(drawPage), this);
-    g_signal_connect(op, "request-page-setup", G_CALLBACK(requestPageSetup), this);
+    g_signal_connect(op, "draw_page", G_CALLBACK(drawPage), doc);
+    g_signal_connect(op, "request-page-setup", G_CALLBACK(requestPageSetup), doc);
 
-    GtkPrintOperationResult res =
-            gtk_print_operation_run(op, GTK_PRINT_OPERATION_ACTION_PRINT_DIALOG, nullptr, nullptr);
-    if (res == GTK_PRINT_OPERATION_RESULT_APPLY) {
-        g_object_unref(settings);
+    GError* error{};
+    GtkPrintOperationResult res = gtk_print_operation_run(op, GTK_PRINT_OPERATION_ACTION_PRINT_DIALOG, parent, &error);
+    g_object_unref(settings);
+    if (GTK_PRINT_OPERATION_RESULT_APPLY == res) {
         settings = gtk_print_operation_get_print_settings(op);
         gtk_print_settings_to_file(settings, filepath.u8string().c_str(), nullptr);
-
-        settings = nullptr;
+    } else if (GTK_PRINT_OPERATION_RESULT_ERROR == res) {
+        constexpr auto msg = "Running print operation failed with %s";
+        XojMsgBox::showErrorToUser(nullptr, _(msg));
+        handlePrintError(error, msg);
     }
 
     g_object_unref(op);
-
-    this->doc = nullptr;
 }

--- a/src/control/PrintHandler.h
+++ b/src/control/PrintHandler.h
@@ -11,30 +11,12 @@
 
 #pragma once
 
-#include <string>
-#include <vector>
-
 #include <gtk/gtk.h>
 
 #include "XournalType.h"
 
 class Document;
-class Settings;
-class SElement;
 
-class PrintHandler {
-public:
-    PrintHandler();
-    virtual ~PrintHandler();
-
-public:
-    void print(Document* doc, int currentPage);
-
-private:
-    static void drawPage(GtkPrintOperation* operation, GtkPrintContext* context, int pageNr, PrintHandler* handler);
-    static void requestPageSetup(GtkPrintOperation* operation, GtkPrintContext* context, gint pageNr,
-                                 GtkPageSetup* setup, PrintHandler* handler);
-
-private:
-    Document* doc = nullptr;
-};
+namespace PrintHandler {
+void print(Document* doc, size_t currentPage, GtkWindow* parent);
+}


### PR DESCRIPTION
PrintHandler uses now the actual GtkWindow.
PrintHandler is now more verbose and implements error handling.

Might fix #2974 
Effects #2995