### PR TITLE
fix page preview for same-length PDFs

### DIFF
--- a/src/gui/sidebar/previews/page/SidebarPreviewPages.cpp
+++ b/src/gui/sidebar/previews/page/SidebarPreviewPages.cpp
@@ -187,11 +187,6 @@ void SidebarPreviewPages::updatePreviews() {
     doc->lock();
     size_t len = doc->getPageCount();
 
-    if (this->previews.size() == len) {
-        doc->unlock();
-        return;
-    }
-
     for (SidebarPreviewBaseEntry* p: this->previews) { delete p; }
     this->previews.clear();
 


### PR DESCRIPTION
If you open xournalpp (thus have a 1 page "empty" document) and then
annotate or open a 1 page PDF then the page preview is not updated. The
same happens if you open a document of any length and then annotate a
PDF with the same page length.

The reason is that SidebarPreviewPages::updatePreviews() does not do
anything if the number of pages has not changed. This check has been
there for a long time but is questionable: updatePreviews() is called
only for one reason, namely to update the previews.

So remove the check and fix the issue.

Note that this issue does not arise if you open another document
(instead of opening or annotating a PDF, which is the same): In this
case, the underlying Document object is newly created.