### PR TITLE
Fix simple implicit type conversions

### DIFF
--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -1400,10 +1400,8 @@ void Control::changePageBackgroundColor() {
 void Control::setViewPairedPages(bool enabled) {
     settings->setShowPairedPages(enabled);
     fireActionSelected(GROUP_PAIRED_PAGES, enabled ? ACTION_VIEW_PAIRED_PAGES : ACTION_NOT_SELECTED);
-
-    auto currentPage = getCurrentPageNo();
     win->getXournal()->layoutPages();
-    scrollHandler->scrollToPage(currentPage);
+    scrollHandler->scrollToPage(getCurrentPageNo());
 }
 
 void Control::setViewPresentationMode(bool enabled) {
@@ -1441,18 +1439,15 @@ void Control::setViewPresentationMode(bool enabled) {
     // disable selection of scroll hand tool
     fireEnableAction(ACTION_TOOL_HAND, !enabled);
     fireActionSelected(GROUP_PRESENTATION_MODE, enabled ? ACTION_VIEW_PRESENTATION_MODE : ACTION_NOT_SELECTED);
-
-    auto currentPage = getCurrentPageNo();
     win->getXournal()->layoutPages();
-    scrollHandler->scrollToPage(currentPage);
+    scrollHandler->scrollToPage(getCurrentPageNo());
 }
 
 void Control::setPairsOffset(int numOffset) {
     settings->setPairsOffset(numOffset);
     fireActionSelected(GROUP_PAIRED_PAGES, numOffset ? ACTION_SET_PAIRS_OFFSET : ACTION_NOT_SELECTED);
-    auto currentPage = getCurrentPageNo();
     win->getXournal()->layoutPages();
-    scrollHandler->scrollToPage(currentPage);
+    scrollHandler->scrollToPage(getCurrentPageNo());
 }
 
 void Control::setViewColumns(int numColumns) {
@@ -1492,9 +1487,8 @@ void Control::setViewColumns(int numColumns) {
 
     fireActionSelected(GROUP_FIXED_ROW_OR_COLS, action);
 
-    auto currentPage = getCurrentPageNo();
     win->getXournal()->layoutPages();
-    scrollHandler->scrollToPage(currentPage);
+    scrollHandler->scrollToPage(getCurrentPageNo());
 }
 
 void Control::setViewRows(int numRows) {
@@ -1534,9 +1528,8 @@ void Control::setViewRows(int numRows) {
 
     fireActionSelected(GROUP_FIXED_ROW_OR_COLS, action);
 
-    auto currentPage = getCurrentPageNo();
     win->getXournal()->layoutPages();
-    scrollHandler->scrollToPage(currentPage);
+    scrollHandler->scrollToPage(getCurrentPageNo());
 }
 
 void Control::setViewLayoutVert(bool vert) {
@@ -1552,9 +1545,8 @@ void Control::setViewLayoutVert(bool vert) {
 
     fireActionSelected(GROUP_LAYOUT_HORIZONTAL, action);
 
-    auto currentPage = getCurrentPageNo();
     win->getXournal()->layoutPages();
-    scrollHandler->scrollToPage(currentPage);
+    scrollHandler->scrollToPage(getCurrentPageNo());
 }
 
 void Control::setViewLayoutR2L(bool r2l) {
@@ -1570,9 +1562,8 @@ void Control::setViewLayoutR2L(bool r2l) {
 
     fireActionSelected(GROUP_LAYOUT_LR, action);
 
-    auto currentPage = getCurrentPageNo();
     win->getXournal()->layoutPages();
-    scrollHandler->scrollToPage(currentPage);
+    scrollHandler->scrollToPage(getCurrentPageNo());
 }
 
 void Control::setViewLayoutB2T(bool b2t) {
@@ -1588,9 +1579,8 @@ void Control::setViewLayoutB2T(bool b2t) {
 
     fireActionSelected(GROUP_LAYOUT_TB, action);
 
-    auto currentPage = getCurrentPageNo();
     win->getXournal()->layoutPages();
-    scrollHandler->scrollToPage(currentPage);
+    scrollHandler->scrollToPage(getCurrentPageNo());
 }
 
 /**
@@ -1909,9 +1899,8 @@ void Control::showSettings() {
     if (verticalSpace != settings->getAddVerticalSpace() || horizontalSpace != settings->getAddHorizontalSpace() ||
         verticalSpaceAmount != settings->getAddVerticalSpaceAmount() ||
         horizontalSpaceAmount != settings->getAddHorizontalSpaceAmount()) {
-        auto currentPage = getCurrentPageNo();
         win->getXournal()->layoutPages();
-        scrollHandler->scrollToPage(currentPage);
+        scrollHandler->scrollToPage(getCurrentPageNo());
     }
 
     if (stylusCursorType != settings->getStylusCursorType() || highlightPosition != settings->isHighlightPosition()) {

--- a/src/control/LatexController.cpp
+++ b/src/control/LatexController.cpp
@@ -71,8 +71,8 @@ auto LatexController::findTexDependencies() -> LatexController::FindDependencySt
  */
 void LatexController::findSelectedTexElement() {
     this->doc->lock();
-    int pageNr = this->control->getCurrentPageNo();
-    if (pageNr == -1) {
+    auto pageNr = this->control->getCurrentPageNo();
+    if (pageNr == npos) {
         this->doc->unlock();
         return;
     }

--- a/src/control/ScrollHandler.cpp
+++ b/src/control/ScrollHandler.cpp
@@ -41,7 +41,7 @@ void ScrollHandler::scrollToPage(const PageRef& page, double top) {
     auto p = doc->indexOf(page);
     doc->unlock();
 
-    if (p != -1) {
+    if (p != npos) {
         scrollToPage(p, top);
     }
 }

--- a/src/control/jobs/ImageExport.cpp
+++ b/src/control/jobs/ImageExport.cpp
@@ -147,7 +147,7 @@ void ImageExport::exportImagePage(int pageId, int id, double zoomRatio, ExportGr
     }
 
     if (page->getBackgroundType().isPdfPage() && (exportBackground >= EXPORT_BACKGROUND_UNRULED)) {
-        int pgNo = page->getPdfPageNr();
+        auto pgNo = page->getPdfPageNr();
         XojPdfPageSPtr popplerPage = doc->getPdfPage(pgNo);
 
         PdfView::drawPage(nullptr, popplerPage, cr, zoomRatio, page->getWidth(), page->getHeight());
@@ -170,7 +170,7 @@ void ImageExport::exportImagePage(int pageId, int id, double zoomRatio, ExportGr
 void ImageExport::exportGraphics(ProgressListener* stateListener) {
     // don't lock the page here for the whole flow, else we get a dead lock...
     // the ui is blocked, so there should be no changes...
-    int count = doc->getPageCount();
+    auto count = doc->getPageCount();
 
     bool onePage =
             ((this->exportRange.size() == 1) && (this->exportRange[0]->getFirst() == this->exportRange[0]->getLast()));

--- a/src/control/jobs/RenderJob.cpp
+++ b/src/control/jobs/RenderJob.cpp
@@ -42,7 +42,7 @@ void RenderJob::rerenderRectangle(Rectangle<double> const& rect) {
 
     bool backgroundVisible = view->page->isLayerVisible(0);
     if (backgroundVisible && view->page->getBackgroundType().isPdfPage()) {
-        int pgNo = view->page->getPdfPageNr();
+        auto pgNo = view->page->getPdfPageNr();
         XojPdfPageSPtr popplerPage = doc->getPdfPage(pgNo);
         PdfCache* cache = view->xournal->getCache();
         PdfView::drawPage(cache, popplerPage, crRect, zoom, pageWidth, pageHeight);
@@ -103,7 +103,7 @@ void RenderJob::run() {
         doc->lock();
 
         if (this->view->page->getBackgroundType().isPdfPage()) {
-            int pgNo = this->view->page->getPdfPageNr();
+            auto pgNo = this->view->page->getPdfPageNr();
             popplerPage = doc->getPdfPage(pgNo);
         }
 

--- a/src/control/jobs/SaveJob.cpp
+++ b/src/control/jobs/SaveJob.cpp
@@ -61,7 +61,7 @@ void SaveJob::updatePreview(Control* control) {
         cairo_scale(cr, zoom, zoom);
 
         if (page->getBackgroundType().isPdfPage()) {
-            int pgNo = page->getPdfPageNr();
+            auto pgNo = page->getPdfPageNr();
             XojPdfPageSPtr popplerPage = doc->getPdfPage(pgNo);
             if (popplerPage) {
                 popplerPage->render(cr, false);

--- a/src/control/layer/LayerController.cpp
+++ b/src/control/layer/LayerController.cpp
@@ -153,7 +153,7 @@ void LayerController::deleteCurrentLayer() {
     control->clearSelectionEndText();
 
     PageRef p = getCurrentPage();
-    int pId = selectedPage;
+    auto pId = selectedPage;
     if (!p) {
         return;
     }
@@ -181,7 +181,7 @@ void LayerController::moveCurrentLayer(bool up) {
     control->clearSelectionEndText();
 
     PageRef p = getCurrentPage();
-    int pId = selectedPage;
+    auto pId = selectedPage;
     if (!p) {
         return;
     }
@@ -226,7 +226,7 @@ void LayerController::copyCurrentLayer() {
     control->clearSelectionEndText();
 
     PageRef p = getCurrentPage();
-    int pId = selectedPage;
+    auto pId = selectedPage;
     if (!p) {
         return;
     }

--- a/src/control/tools/EditSelection.cpp
+++ b/src/control/tools/EditSelection.cpp
@@ -561,7 +561,7 @@ void EditSelection::mouseMove(double mouseX, double mouseY, bool alt) {
 
     if (v && v != this->view) {
         XournalView* xournal = this->view->getXournal();
-        int pageNr = xournal->getControl()->getDocument()->indexOf(v->getPage());
+        auto pageNr = xournal->getControl()->getDocument()->indexOf(v->getPage());
 
         xournal->pageSelected(pageNr);
 

--- a/src/control/xojfile/LoadHandler.cpp
+++ b/src/control/xojfile/LoadHandler.cpp
@@ -666,9 +666,9 @@ void LoadHandler::parseTexImage() {
 
     const char* imText = LoadHandlerHelper::getAttrib("text", false, this);
     const char* compatibilityTest = LoadHandlerHelper::getAttrib("texlength", true, this);
-    int imTextLen = strlen(imText);
+    auto imTextLen = strlen(imText);
     if (compatibilityTest != nullptr) {
-        imTextLen = LoadHandlerHelper::getAttribInt("texlength", this);
+        imTextLen = LoadHandlerHelper::getAttribSizeT("texlength", this);
     }
 
     this->teximage = new TexImage();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -719,8 +719,8 @@ void MainWindow::rebuildLayerMenu() { layerVisibilityChanged(); }
 void MainWindow::layerVisibilityChanged() {
     LayerController* lc = control->getLayerController();
 
-    int layer = lc->getCurrentLayerId();
-    int maxLayer = lc->getLayerCount();
+    auto layer = lc->getCurrentLayerId();
+    auto maxLayer = lc->getLayerCount();
 
     control->fireEnableAction(ACTION_DELETE_LAYER, layer > 0);
     control->fireEnableAction(ACTION_GOTO_NEXT_LAYER, layer < maxLayer);

--- a/src/gui/PageView.cpp
+++ b/src/gui/PageView.cpp
@@ -128,9 +128,9 @@ auto XojPageView::searchTextOnPage(string& text, int* occures, double* top) -> b
             return true;
         }
 
-        int pNr = this->page->getPdfPageNr();
+        auto pNr = this->page->getPdfPageNr();
         XojPdfPageSPtr pdf = nullptr;
-        if (pNr != -1) {
+        if (pNr != npos) {
             Document* doc = xournal->getControl()->getDocument();
 
             doc->lock();

--- a/src/gui/dialog/backgroundSelect/PdfPagesDialog.cpp
+++ b/src/gui/dialog/backgroundSelect/PdfPagesDialog.cpp
@@ -23,7 +23,7 @@ PdfPagesDialog::PdfPagesDialog(GladeSearchpath* gladeSearchPath, Document* doc, 
         PageRef p = doc->getPage(i);
 
         if (p->getBackgroundType().isPdfPage()) {
-            int pdfPage = p->getPdfPageNr();
+            auto pdfPage = p->getPdfPageNr();
             if (pdfPage >= 0 && pdfPage < static_cast<int>(elements.size())) {
                 (dynamic_cast<PdfElementView*>(elements[p->getPdfPageNr()]))->setUsed(true);
             }

--- a/src/gui/dialog/backgroundSelect/PdfPagesDialog.cpp
+++ b/src/gui/dialog/backgroundSelect/PdfPagesDialog.cpp
@@ -24,7 +24,7 @@ PdfPagesDialog::PdfPagesDialog(GladeSearchpath* gladeSearchPath, Document* doc, 
 
         if (p->getBackgroundType().isPdfPage()) {
             auto pdfPage = p->getPdfPageNr();
-            if (pdfPage >= 0 && pdfPage < static_cast<int>(elements.size())) {
+            if (pdfPage >= 0 && pdfPage < elements.size()) {
                 (dynamic_cast<PdfElementView*>(elements[p->getPdfPageNr()]))->setUsed(true);
             }
         }

--- a/src/gui/sidebar/indextree/SidebarIndexPage.cpp
+++ b/src/gui/sidebar/indextree/SidebarIndexPage.cpp
@@ -92,7 +92,7 @@ void SidebarIndexPage::askInsertPdfPage(size_t pdfPage) {
         return;
     }
 
-    int position = 0;
+    size_t position = 0;
 
     Document* doc = control->getDocument();
 

--- a/src/gui/toolbarMenubar/FontButton.cpp
+++ b/src/gui/toolbarMenubar/FontButton.cpp
@@ -24,7 +24,7 @@ void FontButton::activated(GdkEvent* event, GtkMenuItem* menuitem, GtkToolButton
 
     string name = gtk_font_button_get_font_name(button);
 
-    int pos = name.find_last_of(' ');
+    auto pos = name.find_last_of(' ');
     this->font.setName(name.substr(0, pos));
     this->font.setSize(std::stod(name.substr(pos + 1)));
 

--- a/src/gui/toolbarMenubar/ToolPageLayer.cpp
+++ b/src/gui/toolbarMenubar/ToolPageLayer.cpp
@@ -211,7 +211,7 @@ void ToolPageLayer::updateMenu() {
  * Update selected layer, update visible layer
  */
 void ToolPageLayer::updateLayerData() {
-    int layerId = lc->getCurrentLayerId();
+    auto layerId = lc->getCurrentLayerId();
 
     inMenuUpdate = true;
 

--- a/src/model/Document.cpp
+++ b/src/model/Document.cpp
@@ -255,11 +255,11 @@ auto Document::fillPageLabels(GtkTreeModel* treeModel, GtkTreePath* path, GtkTre
         return false;
     }
 
-    int page = doc->findPdfPage(link->dest->getPdfPage());
+    auto page = doc->findPdfPage(link->dest->getPdfPage());
 
     gchar* pageLabel = nullptr;
     if (page != -1) {
-        pageLabel = g_strdup_printf("%i", page + 1);
+        pageLabel = g_strdup_printf("%lu", page + 1);
     }
     gtk_tree_store_set(GTK_TREE_STORE(treeModel), iter, DOCUMENT_LINKS_COLUMN_PAGE_NUMBER, pageLabel, -1);
     g_free(pageLabel);

--- a/src/model/Document.cpp
+++ b/src/model/Document.cpp
@@ -258,7 +258,7 @@ auto Document::fillPageLabels(GtkTreeModel* treeModel, GtkTreePath* path, GtkTre
     auto page = doc->findPdfPage(link->dest->getPdfPage());
 
     gchar* pageLabel = nullptr;
-    if (page != -1) {
+    if (page != npos) {
         pageLabel = g_strdup_printf("%lu", page + 1);
     }
     gtk_tree_store_set(GTK_TREE_STORE(treeModel), iter, DOCUMENT_LINKS_COLUMN_PAGE_NUMBER, pageLabel, -1);

--- a/src/undo/GroupUndoAction.cpp
+++ b/src/undo/GroupUndoAction.cpp
@@ -3,9 +3,7 @@
 GroupUndoAction::GroupUndoAction(): UndoAction("GroupUndoAction") {}
 
 GroupUndoAction::~GroupUndoAction() {
-    for (int i = actions.size() - 1; i >= 0; i--) {
-        delete actions[i];
-    }
+    for (auto i = actions.size() - 1; i >= 0; i--) { delete actions[i]; }
 
     actions.clear();
 }
@@ -40,18 +38,14 @@ auto GroupUndoAction::getPages() -> std::vector<PageRef> {
 
 auto GroupUndoAction::redo(Control* control) -> bool {
     bool result = true;
-    for (auto& action: actions) {
-        result = result && action->redo(control);
-    }
+    for (auto& action: actions) { result = result && action->redo(control); }
 
     return result;
 }
 
 auto GroupUndoAction::undo(Control* control) -> bool {
     bool result = true;
-    for (int i = actions.size() - 1; i >= 0; i--) {
-        result = result && actions[i]->undo(control);
-    }
+    for (auto& action: actions) { result = result && action->undo(control); }
 
     return result;
 }

--- a/src/undo/InsertDeletePageUndoAction.cpp
+++ b/src/undo/InsertDeletePageUndoAction.cpp
@@ -70,7 +70,7 @@ auto InsertDeletePageUndoAction::deletePage(Control* control) -> bool {
     // It's not great practise but it works.
     // doc->lock();
     auto pNr = doc->indexOf(page);
-    if (pNr == -1) {
+    if (pNr == npos) {
         //	doc->unlock();
         // this should not happen
         return false;

--- a/src/undo/InsertDeletePageUndoAction.cpp
+++ b/src/undo/InsertDeletePageUndoAction.cpp
@@ -69,7 +69,7 @@ auto InsertDeletePageUndoAction::deletePage(Control* control) -> bool {
     // unlocking the UndoRedoHandler's lock inside here.
     // It's not great practise but it works.
     // doc->lock();
-    int pNr = doc->indexOf(page);
+    auto pNr = doc->indexOf(page);
     if (pNr == -1) {
         //	doc->unlock();
         // this should not happen

--- a/src/undo/InsertLayerUndoAction.cpp
+++ b/src/undo/InsertLayerUndoAction.cpp
@@ -40,7 +40,7 @@ auto InsertLayerUndoAction::undo(Control* control) -> bool {
 auto InsertLayerUndoAction::redo(Control* control) -> bool {
     layerController->insertLayer(this->page, this->layer, layerPosition);
     Document* doc = control->getDocument();
-    int id = doc->indexOf(this->page);
+    auto id = doc->indexOf(this->page);
     control->getWindow()->getXournal()->layerChanged(id);
 
     this->undone = false;

--- a/src/undo/PageBackgroundChangedUndoAction.cpp
+++ b/src/undo/PageBackgroundChangedUndoAction.cpp
@@ -30,7 +30,7 @@ auto PageBackgroundChangedUndoAction::undo(Control* control) -> bool {
     this->newH = this->page->getHeight();
 
     Document* doc = control->getDocument();
-    int pageNr = doc->indexOf(this->page);
+    auto pageNr = doc->indexOf(this->page);
     if (pageNr == -1) {
         return false;
     }
@@ -55,7 +55,7 @@ auto PageBackgroundChangedUndoAction::undo(Control* control) -> bool {
 auto PageBackgroundChangedUndoAction::redo(Control* control) -> bool {
     Document* doc = control->getDocument();
 
-    int pageNr = doc->indexOf(this->page);
+    auto pageNr = doc->indexOf(this->page);
 
     if (pageNr == -1) {
         return false;

--- a/src/undo/PageBackgroundChangedUndoAction.cpp
+++ b/src/undo/PageBackgroundChangedUndoAction.cpp
@@ -31,7 +31,7 @@ auto PageBackgroundChangedUndoAction::undo(Control* control) -> bool {
 
     Document* doc = control->getDocument();
     auto pageNr = doc->indexOf(this->page);
-    if (pageNr == -1) {
+    if (pageNr == npos) {
         return false;
     }
 
@@ -57,7 +57,7 @@ auto PageBackgroundChangedUndoAction::redo(Control* control) -> bool {
 
     auto pageNr = doc->indexOf(this->page);
 
-    if (pageNr == -1) {
+    if (pageNr == npos) {
         return false;
     }
 

--- a/src/undo/RemoveLayerUndoAction.cpp
+++ b/src/undo/RemoveLayerUndoAction.cpp
@@ -30,7 +30,7 @@ auto RemoveLayerUndoAction::getText() -> std::string { return _("Delete layer");
 auto RemoveLayerUndoAction::undo(Control* control) -> bool {
     layerController->insertLayer(this->page, this->layer, this->layerPos);
     Document* doc = control->getDocument();
-    int id = doc->indexOf(this->page);
+    auto id = doc->indexOf(this->page);
     control->getWindow()->getXournal()->layerChanged(id);
     this->undone = true;
 
@@ -40,7 +40,7 @@ auto RemoveLayerUndoAction::undo(Control* control) -> bool {
 auto RemoveLayerUndoAction::redo(Control* control) -> bool {
     Document* doc = control->getDocument();
     layerController->removeLayer(page, layer);
-    int id = doc->indexOf(this->page);
+    auto id = doc->indexOf(this->page);
     control->getWindow()->getXournal()->layerChanged(id);
 
     this->undone = false;


### PR DESCRIPTION
My first contribute to a c++ project - hopefully quiet some "useful".

Only changed places which seem to be local variables and were using wrong type. 

My IDE (Clion - JetBrains) does no longer complain about incorrect type of these variables, building works and application was tested for some minutes with different tasks including wacom tablet.

If my contribution is ok for you i could also try to do more major stuff like easy issues or fixing some of the other implicit type conversions. 

For me as beginner to this project it is quiet strange why page-related variables (count, current page id etc.) are (signed) integer instead of size_t which should be on all common plattforms at least that big like int and will show any errors/tips in IDEs.