### PR TITLE
Add open most recent document on application startup

### DIFF
--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -2078,7 +2078,7 @@ auto Control::openFile(fs::path filepath, int scrollToPage, bool forceOpen) -> b
 auto Control::loadPdf(const fs::path& filepath, int scrollToPage) -> bool {
     LoadHandler loadHandler;
 
-    if (settings->isAutloadPdfXoj()) {
+    if (settings->isAutoloadPdfXoj()) {
         fs::path f = filepath;
         Util::clearExtensions(f);
         f += ".xopp";
@@ -2866,6 +2866,8 @@ auto Control::getTextEditor() -> TextEditor* {
 }
 
 auto Control::getGladeSearchPath() -> GladeSearchpath* { return this->gladeSearchPath; }
+
+auto Control::getRecentManager() -> RecentManager* { return recent; }
 
 auto Control::getSettings() -> Settings* { return settings; }
 

--- a/src/control/Control.h
+++ b/src/control/Control.h
@@ -230,6 +230,7 @@ public:
     void setClipboardHandlerSelection(EditSelection* selection);
 
     MetadataManager* getMetadataManager();
+    RecentManager* getRecentManager();
     Settings* getSettings();
     ToolHandler* getToolHandler();
     ZoomControl* getZoomControl();

--- a/src/control/RecentManager.cpp
+++ b/src/control/RecentManager.cpp
@@ -105,6 +105,10 @@ auto RecentManager::getMostRecent() -> GtkRecentInfo* {
     GList* filteredItemsXoj = filterRecent(gtk_recent_manager_get_items(gtk_recent_manager_get_default()), true);
     auto mostRecent = static_cast<GtkRecentInfo*>(filteredItemsXoj->data);
 
+    gtk_recent_info_ref(mostRecent);
+    for (GList* l = filteredItemsXoj; l != nullptr; l = l->next) {
+        gtk_recent_info_unref(static_cast<GtkRecentInfo*>(l->data));
+    }
     g_list_free(filteredItemsXoj);
 
     return mostRecent;

--- a/src/control/RecentManager.cpp
+++ b/src/control/RecentManager.cpp
@@ -101,6 +101,15 @@ auto RecentManager::sortRecentsEntries(GtkRecentInfo* a, GtkRecentInfo* b) -> gi
     return tp_a != tp_b ? (tp_a < tp_b ? 1 : -1) : 0;
 }
 
+auto RecentManager::getMostRecent() -> GtkRecentInfo* {
+    GList* filteredItemsXoj = filterRecent(gtk_recent_manager_get_items(gtk_recent_manager_get_default()), true);
+    auto mostRecent = static_cast<GtkRecentInfo*>(filteredItemsXoj->data);
+
+    g_list_free(filteredItemsXoj);
+
+    return mostRecent;
+}
+
 auto RecentManager::filterRecent(GList* items, bool xoj) -> GList* {
     GList* filteredItems = nullptr;
 

--- a/src/control/RecentManager.h
+++ b/src/control/RecentManager.h
@@ -79,6 +79,11 @@ public:
      */
     void addListener(RecentManagerListener* l);
 
+    /**
+     * Returns the most recent xoj item from the underlying GtkRecentManager
+     */
+    GtkRecentInfo* getMostRecent();
+
 private:
     /**
      * Filters a list of GtkRecentInfo according to their file types

--- a/src/control/XournalMain.cpp
+++ b/src/control/XournalMain.cpp
@@ -560,6 +560,10 @@ void on_startup(GApplication* application, XMPtr app_data) {
             XojMsgBox::showErrorToUser(static_cast<GtkWindow*>(*app_data->win), msg);
             opened = app_data->control->newFile("", p);
         }
+    } else if (app_data->control->getSettings()->isAutoloadMostRecent()) {
+        if (auto p = Util::fromUri(gtk_recent_info_get_uri(app_data->control->getRecentManager()->getMostRecent()))) {
+            opened = app_data->control->openFile(*p);
+        }
     }
 
     app_data->control->getScheduler()->start();

--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -74,7 +74,9 @@ void Settings::loadDefault() {
 
     this->menubarVisible = true;
 
+    this->autoloadMostRecent = true;
     this->autoloadPdfXoj = true;
+
     this->stylusCursorType = STYLUS_CURSOR_DOT;
     this->highlightPosition = false;
     this->cursorHighlightColor = 0x80FFFF00;  // Yellow with 50% opacity
@@ -372,6 +374,8 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur) {
         this->numPairsOffset = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("presentationMode")) == 0) {
         this->presentationMode = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("autoloadMostRecent")) == 0) {
+        this->autoloadMostRecent = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("autoloadPdfXoj")) == 0) {
         this->autoloadPdfXoj = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("stylusCursorType")) == 0) {
@@ -853,6 +857,7 @@ void Settings::save() {
     ATTACH_COMMENT(
             "Hides scroolbars in the main window, allowed values: \"none\", \"horizontal\", \"vertical\", \"both\"");
 
+    SAVE_BOOL_PROP(autoloadMostRecent);
     SAVE_BOOL_PROP(autoloadPdfXoj);
     SAVE_STRING_PROP(defaultSaveName);
 
@@ -1297,7 +1302,17 @@ void Settings::setScrollbarHideType(ScrollbarHideType type) {
     save();
 }
 
-auto Settings::isAutloadPdfXoj() const -> bool { return this->autoloadPdfXoj; }
+auto Settings::isAutoloadMostRecent() const -> bool { return this->autoloadMostRecent; }
+
+void Settings::setAutoloadMostRecent(bool load) {
+    if (this->autoloadMostRecent == load) {
+        return;
+    }
+    this->autoloadMostRecent = load;
+    save();
+}
+
+auto Settings::isAutoloadPdfXoj() const -> bool { return this->autoloadPdfXoj; }
 
 void Settings::setAutoloadPdfXoj(bool load) {
     if (this->autoloadPdfXoj == load) {

--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -74,7 +74,7 @@ void Settings::loadDefault() {
 
     this->menubarVisible = true;
 
-    this->autoloadMostRecent = true;
+    this->autoloadMostRecent = false;
     this->autoloadPdfXoj = true;
 
     this->stylusCursorType = STYLUS_CURSOR_DOT;

--- a/src/control/settings/Settings.h
+++ b/src/control/settings/Settings.h
@@ -235,8 +235,10 @@ public:
     void setViewLayoutB2T(bool b2t);
     bool getViewLayoutB2T() const;
 
+    bool isAutoloadMostRecent() const;
+    void setAutoloadMostRecent(bool load);
 
-    bool isAutloadPdfXoj() const;
+    bool isAutoloadPdfXoj() const;
     void setAutoloadPdfXoj(bool load);
 
     int getAutosaveTimeout() const;
@@ -741,6 +743,11 @@ private:
      * Automatically load filename.pdf.xoj / .pdf.xopp instead of filename.pdf (true/false)
      */
     bool autoloadPdfXoj{};
+
+    /**
+     * Automatically load most recent document on application startup (true/false)
+     */
+    bool autoloadMostRecent{};
 
     /**
      * Automatically save documents for crash recovery each x minutes

--- a/src/gui/dialog/SettingsDialog.cpp
+++ b/src/gui/dialog/SettingsDialog.cpp
@@ -336,7 +336,8 @@ void SettingsDialog::load() {
     loadCheckbox("cbEnableZoomGestures", settings->isZoomGesturesEnabled());
     loadCheckbox("cbShowSidebarRight", settings->isSidebarOnRight());
     loadCheckbox("cbShowScrollbarLeft", settings->isScrollbarOnLeft());
-    loadCheckbox("cbAutoloadXoj", settings->isAutloadPdfXoj());
+    loadCheckbox("cbAutoloadMostRecent", settings->isAutoloadMostRecent());
+    loadCheckbox("cbAutoloadXoj", settings->isAutoloadPdfXoj());
     loadCheckbox("cbAutosave", settings->isAutosaveEnabled());
     loadCheckbox("cbAddVerticalSpace", settings->getAddVerticalSpace());
     loadCheckbox("cbAddHorizontalSpace", settings->getAddHorizontalSpace());
@@ -660,6 +661,7 @@ void SettingsDialog::save() {
     settings->setZoomGesturesEnabled(getCheckbox("cbEnableZoomGestures"));
     settings->setSidebarOnRight(getCheckbox("cbShowSidebarRight"));
     settings->setScrollbarOnLeft(getCheckbox("cbShowScrollbarLeft"));
+    settings->setAutoloadMostRecent(getCheckbox("cbAutoloadMostRecent"));
     settings->setAutoloadPdfXoj(getCheckbox("cbAutoloadXoj"));
     settings->setAutosaveEnabled(getCheckbox("cbAutosave"));
     settings->setAddVerticalSpace(getCheckbox("cbAddVerticalSpace"));

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -645,14 +645,15 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                         <property name="can_focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
-                                          <object class="GtkLabel" id="sid15">
+                                          <object class="GtkCheckButton" id="cbAutoloadXoj">
+                                            <property name="label" translatable="yes">Enable Autoloading of Journals</property>
+                                            <property name="name">cbAutoloadXoj</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">&lt;i&gt;If you open a PDF and there is a Xournal file with the same name it will open the xoj file.&lt;/i&gt;</property>
-                                            <property name="use_markup">True</property>
-                                            <property name="wrap">True</property>
-                                            <property name="max_width_chars">85</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-text" translatable="yes">If you open a PDF and there is a Xournal file with the same name it will open the xoj file.</property>
                                             <property name="xalign">0</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -661,12 +662,13 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkCheckButton" id="cbAutoloadXoj">
-                                            <property name="label" translatable="yes">Enable Autoloading of Journals</property>
-                                            <property name="name">cbAutoloadXoj</property>
+                                          <object class="GtkCheckButton" id="cbAutoloadMostRecent">
+                                            <property name="label" translatable="yes">Enable autoloading of most recent file on application startup</property>
+                                            <property name="name">cbAutoloadMostRecent</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-text" translatable="yes">If enabled Xournal++ will open the most recent document automatically that you can continue editing your last saved document.</property>
                                             <property name="xalign">0</property>
                                             <property name="draw_indicator">True</property>
                                           </object>
@@ -683,8 +685,8 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                 <child type="label">
                                   <object class="GtkLabel" id="sid16">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="label" translatable="yes">Autoloading Journals</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">Autoloading</property>
                                   </object>
                                 </child>
                               </object>


### PR DESCRIPTION
Implements #3020.

I'm open for improvements as it is my second PR for a c++ project.

Changes on the settings dialog could be adjusted to be a completely new container to not touch existing things but i though it makes sense to put this setting and autoloading journal (pdf) into the same container.

![image](https://user-images.githubusercontent.com/18467288/114916807-835fbc00-9e25-11eb-9e2f-533b10d6fdb4.png)
