### PR TITLE
Fix latex problems

### DIFF
--- a/resources/legacy_template.tex
+++ b/resources/legacy_template.tex
@@ -1,12 +1,9 @@
-% This template uses the scontents package, which is only available on relatively recent TeX distributions. In case it is not available on your system, use the legacy_template.tex
+% This template avoids the scontents package, which is only available on relatively recent TeX distributions
 \documentclass[varwidth=true, crop, border=5pt]{standalone}
 
 % Packages
 \usepackage{amsmath}
 \usepackage{amssymb}
-
-% for storing in memory verbatim content to be reused later
-\usepackage{scontents}
 
 % Blank formula checking
 \usepackage{ifthen}
@@ -17,18 +14,17 @@
 \definecolor{xpp_font_color}{HTML}{%%XPP_TEXT_COLOR%%}
 
 % User input
-\begin{scontents}[store-env=preview]
-	\( 
-	\displaystyle
+\def\preview{\( 
+    \displaystyle
     %%XPP_TOOL_INPUT%%
-	\)
-\end{scontents}
+    \)%
+}
 
 \begin{document}
   % Check if the formula is empty
-  \settoheight{\pheight}{\getstored[1]{preview}}%
+  \settoheight{\pheight}{\preview}
   \ifthenelse{\pheight=0}{\GenericError{}{xournalpp:blankformula}{}{}}
 
   % Render the user input
-  \textcolor{xpp_font_color}{\getstored[1]{preview}}
+  \textcolor{xpp_font_color}{\preview}
 \end{document}

--- a/src/control/settings/LatexSettings.h
+++ b/src/control/settings/LatexSettings.h
@@ -19,5 +19,9 @@ class LatexSettings {
 public:
     bool autoCheckDependencies{true};
     fs::path globalTemplatePath{};
+#ifdef __APPLE__
+    std::string genCmd{"/Library/TeX/texbin/pdflatex -halt-on-error -interaction=nonstopmode '{}'"};
+#else
     std::string genCmd{"pdflatex -halt-on-error -interaction=nonstopmode '{}'"};
+#endif
 };


### PR DESCRIPTION
Fixes #2206 by adding a legacy LaTeX template, which works on older TeX distributions, that don't have the scontents package (which is needed for things like syntax highlighting via the `lslisting` package and other things that require verbatim inclusion of LaTeX formulas)
Fixes #3048 and fixes #1723 by adding the path to the pdflatex binary for MacOS (where the PATH environment variable is not passed to GUI applications when launched from GUI).

