### PR TITLE
avoid crash from wrong action group/type spelling

### DIFF
--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -933,6 +933,10 @@ void Control::actionPerformed(ActionType type, ActionGroup group, GdkEvent* even
             showAbout();
             break;
 
+        case ACTION_NONE:
+            // do nothing
+            break;
+
         default:
             g_warning("Unhandled action event: %s / %s (%i / %i)", ActionType_toString(type).c_str(),
                       ActionGroup_toString(group).c_str(), type, group);
@@ -2721,9 +2725,7 @@ void Control::clipboardPasteXournal(ObjectInputStream& in) {
         g_warning("could not paste, Exception occurred: %s", e.what());
         Stacktrace::printStracktrace();
         if (selection) {
-            for (Element* e: *selection->getElements()) {
-                delete e;
-            }
+            for (Element* e: *selection->getElements()) { delete e; }
             delete selection;
         }
     }

--- a/src/enums/generateConvert.php
+++ b/src/enums/generateConvert.php
@@ -96,7 +96,7 @@ function writeCppFile($output, $name, $values) {
 		fwrite($fp, "\n");
 	}
 
-	fwrite($fp, $tab . "g_error(\"Invalid enum value for $name: «%s»\", value.c_str());\n");
+	fwrite($fp, $tab . "g_warning(\"Invalid enum value for $name: «%s»\", value.c_str());\n");
 	fwrite($fp, $tab . "return {$values[0]};\n");
 
 	

--- a/src/enums/generated/ActionGroup.generated.cpp
+++ b/src/enums/generated/ActionGroup.generated.cpp
@@ -116,7 +116,7 @@ auto ActionGroup_fromString(const string& value) -> ActionGroup {
         return GROUP_ZOOM_FIT;
     }
 
-    g_error("Invalid enum value for ActionGroup: \"%s\"", value.c_str());
+    g_warning("Invalid enum value for ActionGroup: \"%s\"", value.c_str());
     return GROUP_NOGROUP;
 }
 

--- a/src/enums/generated/ActionType.generated.cpp
+++ b/src/enums/generated/ActionType.generated.cpp
@@ -608,7 +608,7 @@ auto ActionType_fromString(const string& value) -> ActionType {
         return ACTION_NOT_SELECTED;
     }
 
-    g_error("Invalid enum value for ActionType: \"%s\"", value.c_str());
+    g_warning("Invalid enum value for ActionType: \"%s\"", value.c_str());
     return ACTION_NONE;
 }
 


### PR DESCRIPTION
Fixes a crash reported in https://github.com/xournalpp/xournalpp/issues/919#issuecomment-821897950 resulting from wrong action type or group names, than can be called from a plugin.