### PR TITLE
custom plugin folder implemented

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -995,13 +995,13 @@ USE_MDFILE_AS_MAINPAGE =
 # also VERBATIM_HEADERS is set to NO.
 # The default value is: NO.
 
-SOURCE_BROWSER         = NO
+SOURCE_BROWSER         = YES
 
 # Setting the INLINE_SOURCES tag to YES will include the body of functions,
 # classes and enums directly into the documentation.
 # The default value is: NO.
 
-INLINE_SOURCES         = NO
+INLINE_SOURCES         = YES
 
 # Setting the STRIP_CODE_COMMENTS tag to YES will instruct doxygen to hide any
 # special comment blocks from generated source code fragments. Normal C, C++ and
@@ -2331,7 +2331,7 @@ INCLUDED_BY_GRAPH      = YES
 # The default value is: NO.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-CALL_GRAPH             = NO
+CALL_GRAPH             = YES
 
 # If the CALLER_GRAPH tag is set to YES then doxygen will generate a caller
 # dependency graph for every global function or class method.
@@ -2343,7 +2343,7 @@ CALL_GRAPH             = NO
 # The default value is: NO.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-CALLER_GRAPH           = NO
+CALLER_GRAPH           = YES
 
 # If the GRAPHICAL_HIERARCHY tag is set to YES then doxygen will graphical
 # hierarchy of all classes instead of a textual one.

--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -157,6 +157,7 @@ void Settings::loadDefault() {
     this->audioGain = 1.0;
     this->defaultSeekTime = 5;
 
+    this->pluginCustomFolderEnabled = false;
     this->pluginEnabled = "";
     this->pluginDisabled = "";
 
@@ -389,6 +390,10 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur) {
         this->darkTheme = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("defaultSaveName")) == 0) {
         this->defaultSaveName = reinterpret_cast<const char*>(value);
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("pluginCustomFolderEnabled")) == 0) {
+        this->pluginCustomFolderEnabled = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("pluginCustomFolder")) == 0) {
+        this->pluginCustomFolder = reinterpret_cast<const char*>(value);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("pluginEnabled")) == 0) {
         this->pluginEnabled = reinterpret_cast<const char*>(value);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("pluginDisabled")) == 0) {
@@ -899,6 +904,8 @@ void Settings::save() {
     WRITE_DOUBLE_PROP(audioGain);
     WRITE_INT_PROP(defaultSeekTime);
 
+    WRITE_BOOL_PROP(pluginCustomFolderEnabled);
+    WRITE_STRING_PROP(pluginCustomFolder);
     WRITE_STRING_PROP(pluginEnabled);
     WRITE_STRING_PROP(pluginDisabled);
 
@@ -1784,6 +1791,30 @@ void Settings::setDefaultSeekTime(unsigned int t) {
         return;
     }
     this->defaultSeekTime = t;
+    save();
+}
+
+auto Settings::isPluginCustomFolderEnabled() const -> bool { return this->pluginCustomFolderEnabled; }
+
+void Settings::setPluginCustomFolderEnabled(bool pluginCustomFolderEnabled) {
+    if (this->pluginCustomFolderEnabled == pluginCustomFolderEnabled) {
+        return;
+    }
+
+    this->pluginCustomFolderEnabled = pluginCustomFolderEnabled;
+
+    save();
+}
+
+auto Settings::getPluginCustomFolder() const -> string const& { return this->pluginCustomFolder; }
+
+void Settings::setPluginCustomFolder(const string& pluginCustomFolder) {
+    if (this->pluginCustomFolder == pluginCustomFolder) {
+        return;
+    }
+
+    this->pluginCustomFolder = pluginCustomFolder;
+
     save();
 }
 

--- a/src/control/settings/Settings.h
+++ b/src/control/settings/Settings.h
@@ -358,6 +358,12 @@ public:
     unsigned int getDefaultSeekTime() const;
     void setDefaultSeekTime(unsigned int t);
 
+    bool isPluginCustomFolderEnabled() const;
+    void setPluginCustomFolderEnabled(bool pluginCustomFolderEnabled);
+
+    string const& getPluginCustomFolder() const;
+    void setPluginCustomFolder(const string& pluginCustomFolder);
+
     string const& getPluginEnabled() const;
     void setPluginEnabled(const string& pluginEnabled);
 
@@ -845,6 +851,7 @@ private:
     string sizeUnit;
 
     /**
+
      * Audio folder for audio recording
      */
     string audioFolder;
@@ -897,6 +904,15 @@ private:
      * The default time by which the playback will seek backwards and forwards
      */
     unsigned int defaultSeekTime{};
+
+    /**
+     *  Enable customized plugin folder
+     */
+    bool pluginCustomFolderEnabled{};
+
+     /* Plugin folder for plugin storage
+     */
+    string pluginCustomFolder;
 
     /**
      * List of enabled plugins (only the one which are not enabled by default)

--- a/src/gui/dialog/SettingsDialog.cpp
+++ b/src/gui/dialog/SettingsDialog.cpp
@@ -126,6 +126,12 @@ SettingsDialog::SettingsDialog(GladeSearchpath* gladeSearchPath, Settings* setti
                      }),
                      this);
 
+    g_signal_connect(get("cbPluginCustomFolderEnabled"), "toggled", G_CALLBACK(+[](GtkToggleButton* togglebutton, SettingsDialog* self) {
+                         self->enableWithCheckbox("cbPluginCustomFolderEnabled", "boxPluginCustomFolder");
+                     }),
+                     this);
+
+
 
     gtk_box_pack_start(GTK_BOX(vbox), callib, false, true, 0);
     gtk_widget_show(callib);
@@ -389,6 +395,9 @@ void SettingsDialog::load() {
 
     gtk_file_chooser_set_uri(GTK_FILE_CHOOSER(get("fcAudioPath")), settings->getAudioFolder().c_str());
 
+    loadCheckbox("cbPluginCustomFolderEnabled", settings->isPluginCustomFolderEnabled());
+    gtk_file_chooser_set_filename(GTK_FILE_CHOOSER(get("fcPluginCustomFolder")), settings->getPluginCustomFolder().c_str());
+
     GtkWidget* spAutosaveTimeout = get("spAutosaveTimeout");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spAutosaveTimeout), settings->getAutosaveTimeout());
 
@@ -528,6 +537,7 @@ void SettingsDialog::load() {
     enableWithCheckbox("cbStrokeFilterEnabled", "cbTrySelectOnStrokeFiltered");
     enableWithCheckbox("cbEnableZoomGestures", "gdStartZoomAtSetting");
     enableWithCheckbox("cbDisableTouchOnPenNear", "boxInternalHandRecognition");
+    enableWithCheckbox("cbPluginCustomFolderEnabled", "boxPluginCustomFolder");
     customHandRecognitionToggled();
     customStylusIconTypeChanged();
     updatePressureSensitivityOptions();
@@ -689,6 +699,8 @@ void SettingsDialog::save() {
     settings->setStabilizerCuspDetection(getCheckbox("cbStabilizerEnableCuspDetection"));
     settings->setStabilizerFinalizeStroke(getCheckbox("cbStabilizerEnableFinalizeStroke"));
 
+    settings->setPluginCustomFolderEnabled(getCheckbox("cbPluginCustomFolderEnabled"));
+
     auto scrollbarHideType =
             static_cast<std::make_unsigned<std::underlying_type<ScrollbarHideType>::type>::type>(SCROLLBAR_HIDE_NONE);
     if (getCheckbox("cbHideHorizontalScrollbar")) {
@@ -761,6 +773,12 @@ void SettingsDialog::save() {
     if (uri != nullptr) {
         settings->setAudioFolder(uri);
         g_free(uri);
+    }
+
+    char* pFolderName = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(get("fcPluginCustomFolder")));
+    if (pFolderName != nullptr) {
+        settings->setPluginCustomFolder(pFolderName);
+        g_free(pFolderName);
     }
 
     GtkWidget* spAutosaveTimeout = get("spAutosaveTimeout");

--- a/src/plugin/PluginController.cpp
+++ b/src/plugin/PluginController.cpp
@@ -10,12 +10,29 @@
 
 #include "Plugin.h"
 #include "StringUtils.h"
+#include "filesystem.h"
 
 
 PluginController::PluginController(Control* control): control(control) {
 #ifdef ENABLE_PLUGINS
-    auto searchPath = control->getGladeSearchPath()->getFirstSearchPath();
-    loadPluginsFrom((searchPath /= "../plugins").lexically_normal());
+    fs::path searchPath;
+    Settings* settings = control->getSettings();
+    // check if we have to use a customize plugin folder
+    if(settings->isPluginCustomFolderEnabled() == true)
+    {
+      // get customized plugin folder name
+      searchPath = settings->getPluginCustomFolder();
+    }
+    else
+    {
+      // use standard plugin folder
+      // get first subdirectory of the applicaiton main directory    
+      searchPath = control->getGladeSearchPath()->getFirstSearchPath();
+      // select plugin subdirectory
+      searchPath = searchPath /= "../plugins";
+    }
+    // load plugins
+    loadPluginsFrom((searchPath).lexically_normal());
 #endif
 }
 

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -1,201 +1,201 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.18"/>
   <object class="GtkAdjustment" id="adjustmentAudioGain">
     <property name="upper">10</property>
     <property name="value">1</property>
-    <property name="step-increment">0.10</property>
+    <property name="step_increment">0.10000000000000001</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentCursorHighlightBorderWidth">
     <property name="upper">30</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">10</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentCursorHighlightRadius">
     <property name="upper">30</property>
     <property name="value">30</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">5</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">5</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentDrawDirModRadius">
     <property name="lower">2</property>
     <property name="upper">1000</property>
     <property name="value">50</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">10</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentHorizontalSpace">
     <property name="upper">1000</property>
     <property name="value">150</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">10</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentIgnoreStylusEvents">
     <property name="lower">1</property>
     <property name="upper">1000</property>
     <property name="value">1</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">10</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentMinimumPressure">
     <property name="upper">1</property>
-    <property name="step-increment">0.01</property>
-    <property name="page-increment">0.5</property>
+    <property name="step_increment">0.01</property>
+    <property name="page_increment">0.5</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentPairsOffset">
     <property name="upper">100</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">1</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentPreloadPagesAfter">
     <property name="upper">99</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">10</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentPreloadPagesBefore">
     <property name="upper">99</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">10</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentPressureMultiplier">
     <property name="lower">0.5</property>
     <property name="upper">4</property>
     <property name="value">1</property>
-    <property name="step-increment">0.05</property>
-    <property name="page-increment">0.5</property>
+    <property name="step_increment">0.050000000000000003</property>
+    <property name="page_increment">0.5</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentReRenderThreshold">
     <property name="upper">900</property>
     <property name="value">10</property>
-    <property name="step-increment">5</property>
-    <property name="page-increment">100</property>
+    <property name="step_increment">5</property>
+    <property name="page_increment">100</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentSeekTime">
     <property name="lower">1</property>
     <property name="upper">90</property>
     <property name="value">5</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">10</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentSnapGridSize">
     <property name="lower">0.01</property>
     <property name="upper">20</property>
     <property name="value">1</property>
-    <property name="step-increment">0.01</property>
-    <property name="page-increment">10</property>
+    <property name="step_increment">0.01</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentSnapGridTolerance">
-    <property name="lower">0.10</property>
+    <property name="lower">0.10000000000000001</property>
     <property name="upper">1</property>
     <property name="value">0.5</property>
-    <property name="step-increment">0.05</property>
-    <property name="page-increment">10</property>
+    <property name="step_increment">0.050000000000000003</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentSnapRotationTolerance">
-    <property name="lower">0.10</property>
+    <property name="lower">0.10000000000000001</property>
     <property name="upper">1</property>
     <property name="value">0.29999999999999999</property>
-    <property name="step-increment">0.05</property>
-    <property name="page-increment">10</property>
+    <property name="step_increment">0.050000000000000003</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentStabilizerDeadzoneRadius">
-    <property name="lower">0.10</property>
+    <property name="lower">0.10000000000000001</property>
     <property name="upper">50</property>
     <property name="value">1.3</property>
-    <property name="step-increment">0.10</property>
-    <property name="page-increment">1</property>
+    <property name="step_increment">0.10000000000000001</property>
+    <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentStabilizerDrag">
     <property name="upper">1</property>
-    <property name="value">0.40</property>
-    <property name="step-increment">0.05</property>
-    <property name="page-increment">0.20</property>
+    <property name="value">0.40000000000000002</property>
+    <property name="step_increment">0.050000000000000003</property>
+    <property name="page_increment">0.20000000000000001</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentStabilizerMass">
     <property name="lower">1</property>
     <property name="upper">30</property>
     <property name="value">5</property>
-    <property name="step-increment">0.10</property>
-    <property name="page-increment">1</property>
+    <property name="step_increment">0.10000000000000001</property>
+    <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentStabilizerSigma">
-    <property name="lower">0.05</property>
+    <property name="lower">0.050000000000000003</property>
     <property name="upper">5</property>
     <property name="value">0.5</property>
-    <property name="step-increment">0.05</property>
-    <property name="page-increment">1</property>
+    <property name="step_increment">0.050000000000000003</property>
+    <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentStabilizingBuffersize">
     <property name="lower">2</property>
     <property name="upper">100</property>
     <property name="value">20</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">10</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentStrokeIgnoreLength">
-    <property name="lower">0.01000000000000001</property>
+    <property name="lower">0.010000000000000011</property>
     <property name="upper">100</property>
     <property name="value">1</property>
-    <property name="step-increment">0.10</property>
-    <property name="page-increment">2</property>
+    <property name="step_increment">0.10000000000000001</property>
+    <property name="page_increment">2</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentStrokeIgnoreTime">
     <property name="upper">1000</property>
     <property name="value">150</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">10</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentStrokeSuccessiveTime">
     <property name="upper">1000</property>
     <property name="value">500</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">10</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentTimeout">
     <property name="lower">1</property>
     <property name="upper">100</property>
     <property name="value">1</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">10</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentTouchTImeout">
     <property name="lower">0.5</property>
     <property name="upper">10</property>
     <property name="value">1</property>
-    <property name="step-increment">0.10</property>
-    <property name="page-increment">10</property>
+    <property name="step_increment">0.10000000000000001</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentVerticalSpace">
     <property name="upper">1000</property>
     <property name="value">150</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">10</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentZoom">
     <property name="lower">50</property>
     <property name="upper">400</property>
     <property name="value">72</property>
-    <property name="step-increment">1</property>
+    <property name="step_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentZoomStartThreshold">
     <property name="upper">100</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">10</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentZoomStep">
-    <property name="lower">0.10</property>
+    <property name="lower">0.10000000000000001</property>
     <property name="upper">50</property>
     <property name="value">10</property>
-    <property name="step-increment">0.5</property>
-    <property name="page-increment">10</property>
+    <property name="step_increment">0.5</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentZoomStepScroll">
-    <property name="lower">0.10</property>
+    <property name="lower">0.10000000000000001</property>
     <property name="upper">50</property>
     <property name="value">2</property>
-    <property name="step-increment">0.5</property>
-    <property name="page-increment">10</property>
+    <property name="step_increment">0.5</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkListStore" id="listStabilizerAveragingMethods">
     <columns>
@@ -233,34 +233,37 @@
   </object>
   <object class="GtkDialog" id="settingsDialog">
     <property name="name">settingsDialog</property>
-    <property name="can-focus">False</property>
-    <property name="border-width">5</property>
+    <property name="can_focus">False</property>
+    <property name="border_width">5</property>
     <property name="title" translatable="yes">Xournal++ Preferences</property>
-    <property name="window-position">center</property>
+    <property name="window_position">center</property>
     <property name="icon">pixmaps/com.github.xournalpp.xournalpp.svg</property>
-    <property name="type-hint">normal</property>
+    <property name="type_hint">normal</property>
     <property name="gravity">center</property>
     <signal name="close" handler="gtk_widget_hide" swapped="no"/>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox3">
         <property name="visible">True</property>
-        <property name="can-focus">False</property>
+        <property name="can_focus">False</property>
         <property name="orientation">vertical</property>
         <property name="spacing">2</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="btSettingsButton">
             <property name="name">btSettingsButton</property>
             <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="layout-style">end</property>
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="btSettingsCancel">
                 <property name="label">gtk-cancel</property>
                 <property name="name">btSettingsCancel</property>
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">True</property>
-                <property name="use-stock">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -273,9 +276,9 @@
                 <property name="label">gtk-ok</property>
                 <property name="name">btSettingsOk</property>
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">True</property>
-                <property name="use-stock">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -287,7 +290,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="pack-type">end</property>
+            <property name="pack_type">end</property>
             <property name="position">0</property>
           </packing>
         </child>
@@ -295,59 +298,59 @@
           <object class="GtkNotebook" id="notebook1">
             <property name="name">notebook1</property>
             <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="tab-pos">left</property>
-            <property name="show-border">False</property>
+            <property name="can_focus">True</property>
+            <property name="tab_pos">left</property>
+            <property name="show_border">False</property>
             <property name="scrollable">True</property>
             <child>
               <object class="GtkBox" id="saveLoadTabBox">
                 <property name="name">saveLoadTabBox</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="margin-left">5</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid01">
                     <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="min-content-width">500</property>
-                    <property name="min-content-height">450</property>
+                    <property name="can_focus">True</property>
+                    <property name="min_content_width">500</property>
+                    <property name="min_content_height">450</property>
                     <child>
                       <object class="GtkViewport" id="sid02">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="shadow-type">none</property>
+                        <property name="can_focus">False</property>
+                        <property name="shadow_type">none</property>
                         <child>
                           <object class="GtkBox" id="sid03">
                             <property name="visible">True</property>
-                            <property name="can-focus">False</property>
+                            <property name="can_focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="sid04">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid05">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="bottom_padding">8</property>
+                                    <property name="left_padding">12</property>
+                                    <property name="right_padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid06">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="label28">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;If the document already was saved you can find it in the same folder with the extension .autosave.xoj
 If the file was not yet saved you can find it in your home directory, in ~/.xournalpp/autosave&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
+                                            <property name="use_markup">True</property>
                                             <property name="wrap">True</property>
-                                            <property name="max-width-chars">85</property>
+                                            <property name="max_width_chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -359,16 +362,16 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                         <child>
                                           <object class="GtkBox" id="sid07">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <child>
                                               <object class="GtkCheckButton" id="cbAutosave">
                                                 <property name="label" translatable="yes">Enable Autosaving</property>
                                                 <property name="name">cbAutosave</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="receives-default">False</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="receives_default">False</property>
                                                 <property name="xalign">0</property>
-                                                <property name="draw-indicator">True</property>
+                                                <property name="draw_indicator">True</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
@@ -380,12 +383,12 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                               <object class="GtkBox" id="boxAutosave">
                                                 <property name="name">boxAutosave</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <child>
                                                   <object class="GtkLabel" id="lbAutosaveTimeout1">
                                                     <property name="name">lbAutosaveTimeout1</property>
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
+                                                    <property name="can_focus">False</property>
                                                     <property name="label" translatable="yes">every</property>
                                                   </object>
                                                   <packing>
@@ -398,7 +401,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                                   <object class="GtkSpinButton" id="spAutosaveTimeout">
                                                     <property name="name">spAutosaveTimeout</property>
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">True</property>
+                                                    <property name="can_focus">True</property>
                                                     <property name="adjustment">adjustmentTimeout</property>
                                                   </object>
                                                   <packing>
@@ -412,7 +415,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                                   <object class="GtkLabel" id="lbAutosaveTimeout2">
                                                     <property name="name">lbAutosaveTimeout2</property>
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
+                                                    <property name="can_focus">False</property>
                                                     <property name="label" translatable="yes">minutes</property>
                                                   </object>
                                                   <packing>
@@ -442,7 +445,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                 <child type="label">
                                   <object class="GtkLabel" id="sid08">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Autosaving</property>
                                   </object>
                                 </child>
@@ -456,27 +459,27 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                             <child>
                               <object class="GtkFrame" id="sid09">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid10">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="left_padding">12</property>
+                                    <property name="right_padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="vbox3">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="label30">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;This name will be proposed if you save a new document.&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
+                                            <property name="use_markup">True</property>
                                             <property name="wrap">True</property>
-                                            <property name="max-width-chars">85</property>
+                                            <property name="max_width_chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -489,7 +492,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                           <object class="GtkEntry" id="txtDefaultSaveName">
                                             <property name="name">txtDefaultSaveName</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
+                                            <property name="can_focus">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -500,13 +503,13 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                         <child>
                                           <object class="GtkBox" id="box14">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <child>
                                               <object class="GtkLabel" id="label31">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">Default name: </property>
-                                                <property name="use-markup">True</property>
+                                                <property name="use_markup">True</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
@@ -518,7 +521,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                               <object class="GtkLabel" id="lbDefaultSavename">
                                                 <property name="name">lbDefaultSavename</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">%F-Note-%H-%M</property>
                                               </object>
                                               <packing>
@@ -538,12 +541,12 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                           <object class="GtkExpander" id="expander1">
                                             <property name="name">expander1</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
+                                            <property name="can_focus">True</property>
                                             <child>
                                               <object class="GtkLabel" id="label33">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="margin-left">20</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="margin_left">20</property>
                                                 <property name="label" translatable="yes">%a		Abbreviated weekday name (e.g. Thu)
 %A		Full weekday name (e.g. Thursday)
 %b		Abbreviated month name (e.g. Aug)
@@ -573,11 +576,11 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             <child type="label">
                                               <object class="GtkBox" id="box15">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <child>
                                                   <object class="GtkImage" id="image1">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
+                                                    <property name="can_focus">False</property>
                                                     <property name="stock">gtk-info</property>
                                                   </object>
                                                   <packing>
@@ -589,8 +592,8 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                                 <child>
                                                   <object class="GtkLabel" id="label32">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
-                                                    <property name="margin-left">3</property>
+                                                    <property name="can_focus">False</property>
+                                                    <property name="margin_left">3</property>
                                                     <property name="label" translatable="yes">Available Placeholders</property>
                                                   </object>
                                                   <packing>
@@ -616,7 +619,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                 <child type="label">
                                   <object class="GtkLabel" id="sid11">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Default Save Name</property>
                                   </object>
                                 </child>
@@ -630,28 +633,28 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                             <child>
                               <object class="GtkFrame" id="sid12">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid13">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="bottom_padding">8</property>
+                                    <property name="left_padding">12</property>
+                                    <property name="right_padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid14">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="sid15">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;If you open a PDF and there is a Xournal file with the same name it will open the xoj file.&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
+                                            <property name="use_markup">True</property>
                                             <property name="wrap">True</property>
-                                            <property name="max-width-chars">85</property>
+                                            <property name="max_width_chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -665,10 +668,10 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             <property name="label" translatable="yes">Enable Autoloading of Journals</property>
                                             <property name="name">cbAutoloadXoj</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
+                                            <property name="draw_indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -683,7 +686,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                 <child type="label">
                                   <object class="GtkLabel" id="sid16">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Autoloading Journals</property>
                                   </object>
                                 </child>
@@ -692,6 +695,109 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
                                 <property name="position">2</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkFrame" id="sid197">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
+                                <child>
+                                  <object class="GtkAlignment" id="sid198">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="bottom_padding">8</property>
+                                    <property name="left_padding">12</property>
+                                    <property name="right_padding">12</property>
+                                    <child>
+                                      <object class="GtkBox" id="sid200">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                          <object class="GtkLabel" id="label47">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="label" translatable="yes">&lt;i&gt;Lua Plugins will be searched either in the standard Plugin folder or in the custom Plugin folder&lt;/i&gt;</property>
+                                            <property name="use_markup">True</property>
+                                            <property name="wrap">True</property>
+                                            <property name="max_width_chars">85</property>
+                                            <property name="xalign">0</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="cbPluginCustomFolderEnabled">
+                                            <property name="label" translatable="yes">use custom Plugin folder</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="xalign">0</property>
+                                            <property name="draw_indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkBox" id="boxPluginCustomFolder">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <child>
+                                              <object class="GtkLabel" id="label48">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="label" translatable="yes">Custom Plugin Folder</property>
+                                                <property name="xalign">0.30000001192092896</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkFileChooserButton" id="fcPluginCustomFolder">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="action">select-folder</property>
+                                                <property name="title" translatable="yes">Select Folder</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">1</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">2</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label">
+                                  <object class="GtkLabel" id="sid199">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="label" translatable="yes">Plugin Folder</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">3</property>
                               </packing>
                             </child>
                           </object>
@@ -711,61 +817,61 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
               <object class="GtkLabel" id="saveLoadTabLabel">
                 <property name="name">saveLoadTabLabel</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Load / Save</property>
               </object>
               <packing>
-                <property name="tab-fill">False</property>
+                <property name="tab_fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="inputTabBox">
                 <property name="name">inputTabBox</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="margin-left">5</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="swInputTab">
                     <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="min-content-width">500</property>
-                    <property name="min-content-height">450</property>
+                    <property name="can_focus">True</property>
+                    <property name="min_content_width">500</property>
+                    <property name="min_content_height">450</property>
                     <child>
                       <object class="GtkViewport" id="wpInputTab">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="shadow-type">none</property>
+                        <property name="can_focus">False</property>
+                        <property name="shadow_type">none</property>
                         <child>
                           <object class="GtkBox" id="bxInputTab">
                             <property name="visible">True</property>
-                            <property name="can-focus">False</property>
+                            <property name="can_focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="sid84">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid85">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="bottom_padding">8</property>
+                                    <property name="left_padding">12</property>
+                                    <property name="right_padding">12</property>
                                     <child>
                                       <object class="GtkBox">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;Assign device classes to each input device of your system. Only change these values if your devices are not correctly matched. (e.g. your pen shows up as touchscreen)&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
+                                            <property name="use_markup">True</property>
                                             <property name="wrap">True</property>
-                                            <property name="max-width-chars">85</property>
+                                            <property name="max_width_chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -778,7 +884,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                           <object class="GtkBox" id="hboxInputDeviceClasses">
                                             <property name="name">hboxInputDeviceClasses</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="orientation">vertical</property>
                                             <child>
                                               <placeholder/>
@@ -797,7 +903,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                 <child type="label">
                                   <object class="GtkLabel" id="sid87">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Input Devices</property>
                                   </object>
                                 </child>
@@ -811,34 +917,34 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                             <child>
                               <object class="GtkFrame" id="sid88">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid89">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="bottom_padding">8</property>
+                                    <property name="left_padding">12</property>
+                                    <property name="right_padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid90">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkCheckButton" id="cbInputSystemDrawOutsideWindow">
                                             <property name="name">cbInputSystemDrawOutsideWindow</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
                                             <property name="xalign">0.5</property>
-                                            <property name="draw-indicator">True</property>
+                                            <property name="draw_indicator">True</property>
                                             <child>
                                               <object class="GtkLabel" id="sid92">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">Enable drawing outside of window &lt;i&gt;(Drawing will not stop at the border of the window)&lt;/i&gt;</property>
-                                                <property name="use-markup">True</property>
+                                                <property name="use_markup">True</property>
                                                 <property name="wrap">True</property>
                                                 <property name="xalign">0</property>
                                               </object>
@@ -854,23 +960,23 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                           <object class="GtkCheckButton" id="cbInputSystemTPCButton">
                                             <property name="name">cbInputSystemTPCButton</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="tooltip-markup" translatable="yes">Drag LEFT from start point acts like shift key is being held.
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="tooltip_markup" translatable="yes">Drag LEFT from start point acts like shift key is being held.
 	    Drag UP acts as if Control key is being held.
 
             Determination Radius: Radius at which modifiers will lock in until finished drawing.
 
 	    &lt;i&gt;Useful for operating without keyboard.&lt;/i&gt;</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
+                                            <property name="draw_indicator">True</property>
                                             <child>
                                               <object class="GtkLabel" id="sid93">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">Merge button events with stylus tip events
 	    &lt;i&gt;(Check this if&lt;/i&gt; "&lt;tt&gt;xsetwacom get *deviceId* TabletPCButton&lt;/tt&gt;" &lt;i&gt;returns&lt;/i&gt; "&lt;tt&gt;on&lt;/tt&gt;"&lt;i&gt;)&lt;/i&gt;</property>
-                                                <property name="use-markup">True</property>
+                                                <property name="use_markup">True</property>
                                                 <property name="wrap">True</property>
                                                 <property name="xalign">0</property>
                                               </object>
@@ -886,19 +992,19 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                           <object class="GtkCheckButton" id="cbEnablePressureInference">
                                             <property name="name">cbEnablePressureInference</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="tooltip-markup" translatable="yes">Slower strokes are assigned a greater pressure than faster strokes, if pressure information is absent.
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="tooltip_markup" translatable="yes">Slower strokes are assigned a greater pressure than faster strokes, if pressure information is absent.
 
 &lt;i&gt;This feature may be useful for devices that lack pressure sensitivity. For example, a mouse or touchscreen.&lt;/i&gt;</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
+                                            <property name="draw_indicator">True</property>
                                             <child>
                                               <object class="GtkLabel" id="sid201">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">Enable Pressure Inference &lt;i&gt;(Guess pressure from drawing speed when device-supplied pressure is not available)&lt;/i&gt;</property>
-                                                <property name="use-markup">True</property>
+                                                <property name="use_markup">True</property>
                                                 <property name="wrap">True</property>
                                                 <property name="xalign">0</property>
                                               </object>
@@ -917,7 +1023,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                 <child type="label">
                                   <object class="GtkLabel" id="sid94">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Options</property>
                                   </object>
                                 </child>
@@ -931,43 +1037,42 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                             <child>
                               <object class="GtkFrame" id="frameStabilizerSettings">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkAlignment" id="alignmentStabilizer">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="bottom-padding">12</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="bottom_padding">12</property>
+                                    <property name="left_padding">12</property>
+                                    <property name="right_padding">12</property>
                                     <child>
-                                      <!-- n-columns=4 n-rows=4 -->
                                       <object class="GtkGrid" id="gridStabilizer">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="column-spacing">10</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="column_spacing">10</property>
                                         <child>
                                           <object class="GtkLabel" id="lbStabilizerAveragingMethod">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="halign">start</property>
-                                            <property name="margin-start">16</property>
+                                            <property name="margin_start">16</property>
                                             <property name="label" translatable="yes">Averaging method</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">1</property>
+                                            <property name="left_attach">0</property>
+                                            <property name="top_attach">1</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkComboBox" id="cbStabilizerAveragingMethods">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="hexpand">True</property>
                                             <property name="model">listStabilizerAveragingMethods</property>
                                             <property name="active">0</property>
-                                            <property name="id-column">0</property>
-                                            <property name="active-id">0</property>
+                                            <property name="id_column">0</property>
+                                            <property name="active_id">0</property>
                                             <child>
                                               <object class="GtkCellRendererText"/>
                                               <attributes>
@@ -977,204 +1082,204 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             </child>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">1</property>
-                                            <property name="top-attach">1</property>
+                                            <property name="left_attach">1</property>
+                                            <property name="top_attach">1</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="lbStabilizerDescription">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;Pick an input stabilization algorithm and its parameters&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
+                                            <property name="use_markup">True</property>
                                             <property name="wrap">True</property>
-                                            <property name="width-chars">85</property>
-                                            <property name="max-width-chars">85</property>
+                                            <property name="width_chars">85</property>
+                                            <property name="max_width_chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">0</property>
+                                            <property name="left_attach">0</property>
+                                            <property name="top_attach">0</property>
                                             <property name="width">4</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="lbStabilizerBuffersize">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Buffersize</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">2</property>
-                                            <property name="top-attach">1</property>
+                                            <property name="left_attach">2</property>
+                                            <property name="top_attach">1</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="sbStabilizerBuffersize">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
+                                            <property name="can_focus">True</property>
                                             <property name="hexpand">True</property>
                                             <property name="text" translatable="yes">20</property>
-                                            <property name="input-purpose">number</property>
+                                            <property name="input_purpose">number</property>
                                             <property name="adjustment">adjustmentStabilizingBuffersize</property>
-                                            <property name="climb-rate">1</property>
-                                            <property name="snap-to-ticks">True</property>
+                                            <property name="climb_rate">1</property>
+                                            <property name="snap_to_ticks">True</property>
                                             <property name="numeric">True</property>
                                             <property name="value">20</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">3</property>
-                                            <property name="top-attach">1</property>
+                                            <property name="left_attach">3</property>
+                                            <property name="top_attach">1</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="lbStabilizerDeadzoneRadius">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Deadzone radius</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">2</property>
-                                            <property name="top-attach">2</property>
+                                            <property name="left_attach">2</property>
+                                            <property name="top_attach">2</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="sbStabilizerDeadzoneRadius">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
+                                            <property name="can_focus">True</property>
                                             <property name="hexpand">True</property>
                                             <property name="text" translatable="yes">1,30</property>
-                                            <property name="input-purpose">number</property>
+                                            <property name="input_purpose">number</property>
                                             <property name="adjustment">adjustmentStabilizerDeadzoneRadius</property>
-                                            <property name="climb-rate">2</property>
+                                            <property name="climb_rate">2</property>
                                             <property name="digits">2</property>
-                                            <property name="snap-to-ticks">True</property>
+                                            <property name="snap_to_ticks">True</property>
                                             <property name="numeric">True</property>
                                             <property name="value">1.3</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">3</property>
-                                            <property name="top-attach">2</property>
+                                            <property name="left_attach">3</property>
+                                            <property name="top_attach">2</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="lbStabilizerDrag">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="tooltip-text" translatable="yes">Drag: If the value is to small, unwanted oscillations may appear. If the value is to high, there will be no stabilization.</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="tooltip_text" translatable="yes">Drag: If the value is to small, unwanted oscillations may appear. If the value is to high, there will be no stabilization.</property>
                                             <property name="label" translatable="yes">Drag</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">2</property>
-                                            <property name="top-attach">2</property>
+                                            <property name="left_attach">2</property>
+                                            <property name="top_attach">2</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="sbStabilizerDrag">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="tooltip-text" translatable="yes">Drag: If the value is to small, unwanted oscillations may appear. If the value is too small, there will be no stabilization.</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="tooltip_text" translatable="yes">Drag: If the value is to small, unwanted oscillations may appear. If the value is too small, there will be no stabilization.</property>
                                             <property name="hexpand">True</property>
                                             <property name="text" translatable="yes">0,4</property>
-                                            <property name="input-purpose">number</property>
+                                            <property name="input_purpose">number</property>
                                             <property name="adjustment">adjustmentStabilizerDrag</property>
-                                            <property name="climb-rate">2</property>
+                                            <property name="climb_rate">2</property>
                                             <property name="digits">2</property>
-                                            <property name="snap-to-ticks">True</property>
+                                            <property name="snap_to_ticks">True</property>
                                             <property name="numeric">True</property>
-                                            <property name="value">0.40</property>
+                                            <property name="value">0.40000000000000002</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">3</property>
-                                            <property name="top-attach">2</property>
+                                            <property name="left_attach">3</property>
+                                            <property name="top_attach">2</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="lbStabilizerMass">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="tooltip-text" translatable="yes">Mass: the higher the mass, the more inertia and the more stabilization</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="tooltip_text" translatable="yes">Mass: the higher the mass, the more inertia and the more stabilization</property>
                                             <property name="label" translatable="yes">Mass</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">2</property>
-                                            <property name="top-attach">3</property>
+                                            <property name="left_attach">2</property>
+                                            <property name="top_attach">3</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="sbStabilizerMass">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="tooltip-text" translatable="yes">Mass: the higher the mass, the more inertia and the more stabilization</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="tooltip_text" translatable="yes">Mass: the higher the mass, the more inertia and the more stabilization</property>
                                             <property name="hexpand">True</property>
                                             <property name="text" translatable="yes">5</property>
-                                            <property name="input-purpose">number</property>
+                                            <property name="input_purpose">number</property>
                                             <property name="adjustment">adjustmentStabilizerMass</property>
-                                            <property name="climb-rate">2</property>
+                                            <property name="climb_rate">2</property>
                                             <property name="digits">2</property>
-                                            <property name="snap-to-ticks">True</property>
+                                            <property name="snap_to_ticks">True</property>
                                             <property name="numeric">True</property>
                                             <property name="value">5</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">3</property>
-                                            <property name="top-attach">3</property>
+                                            <property name="left_attach">3</property>
+                                            <property name="top_attach">3</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="sbStabilizerSigma">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="tooltip-text" translatable="yes">Gaussian parameter: the higher, the more stabilization and the more lag between your cursor and the painting tip.</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="tooltip_text" translatable="yes">Gaussian parameter: the higher, the more stabilization and the more lag between your cursor and the painting tip.</property>
                                             <property name="hexpand">True</property>
                                             <property name="text" translatable="yes">0,50</property>
-                                            <property name="input-purpose">number</property>
+                                            <property name="input_purpose">number</property>
                                             <property name="adjustment">adjustmentStabilizerSigma</property>
-                                            <property name="climb-rate">0.99999999977648257</property>
+                                            <property name="climb_rate">0.99999999977648257</property>
                                             <property name="digits">2</property>
-                                            <property name="snap-to-ticks">True</property>
+                                            <property name="snap_to_ticks">True</property>
                                             <property name="numeric">True</property>
                                             <property name="value">0.5</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">3</property>
-                                            <property name="top-attach">1</property>
+                                            <property name="left_attach">3</property>
+                                            <property name="top_attach">1</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="lbStabilizerSigma">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="tooltip-text" translatable="yes">Gaussian parameter: the higher, the more stabilization and the more lag between your cursor and the painting tip.</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="tooltip_text" translatable="yes">Gaussian parameter: the higher, the more stabilization and the more lag between your cursor and the painting tip.</property>
                                             <property name="label" translatable="yes">σ</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">2</property>
-                                            <property name="top-attach">1</property>
+                                            <property name="left_attach">2</property>
+                                            <property name="top_attach">1</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="lbStabilizerPreprocessor">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="halign">start</property>
-                                            <property name="margin-start">15</property>
+                                            <property name="margin_start">15</property>
                                             <property name="label" translatable="yes">Preprocessor</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">2</property>
+                                            <property name="left_attach">0</property>
+                                            <property name="top_attach">2</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkComboBox" id="cbStabilizerPreprocessors">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="hexpand">True</property>
                                             <property name="model">listStabilizerPreprocessors</property>
                                             <property name="active">0</property>
-                                            <property name="id-column">0</property>
-                                            <property name="active-id">0</property>
+                                            <property name="id_column">0</property>
+                                            <property name="active_id">0</property>
                                             <child>
                                               <object class="GtkCellRendererText"/>
                                               <attributes>
@@ -1184,8 +1289,8 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             </child>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">1</property>
-                                            <property name="top-attach">2</property>
+                                            <property name="left_attach">1</property>
+                                            <property name="top_attach">2</property>
                                           </packing>
                                         </child>
                                         <child>
@@ -1193,15 +1298,15 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             <property name="label" translatable="yes">Cusp detection</property>
                                             <property name="name">cbStabilizerEnableCuspDetection</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
                                             <property name="halign">start</property>
                                             <property name="active">True</property>
-                                            <property name="draw-indicator">True</property>
+                                            <property name="draw_indicator">True</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">2</property>
-                                            <property name="top-attach">3</property>
+                                            <property name="left_attach">2</property>
+                                            <property name="top_attach">3</property>
                                             <property name="width">2</property>
                                           </packing>
                                         </child>
@@ -1210,15 +1315,15 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             <property name="label" translatable="yes">Finalize the stroke</property>
                                             <property name="name">cbStabilizerEnableFinalizeStroke</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="tooltip-text" translatable="yes">Input stabilization can create a gap at the end of your stroke. If enabled, this gap is filled.</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="tooltip_text" translatable="yes">Input stabilization can create a gap at the end of your stroke. If enabled, this gap is filled.</property>
                                             <property name="active">True</property>
-                                            <property name="draw-indicator">True</property>
+                                            <property name="draw_indicator">True</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">3</property>
+                                            <property name="left_attach">0</property>
+                                            <property name="top_attach">3</property>
                                           </packing>
                                         </child>
                                         <child>
@@ -1231,7 +1336,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                 <child type="label">
                                   <object class="GtkLabel" id="lbStabilizerSettings">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Input stabilization</property>
                                   </object>
                                 </child>
@@ -1262,60 +1367,60 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
               <object class="GtkLabel" id="inputTabLabel">
                 <property name="name">inputTabLabel</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Input System</property>
               </object>
               <packing>
                 <property name="position">1</property>
-                <property name="tab-fill">False</property>
+                <property name="tab_fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="mouseTabBox">
                 <property name="name">mouseTabBox</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="margin-left">5</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid17">
                     <property name="visible">True</property>
-                    <property name="can-focus">True</property>
+                    <property name="can_focus">True</property>
                     <child>
                       <object class="GtkViewport" id="sid18">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="shadow-type">none</property>
+                        <property name="can_focus">False</property>
+                        <property name="shadow_type">none</property>
                         <child>
                           <object class="GtkBox" id="sid19">
                             <property name="visible">True</property>
-                            <property name="can-focus">False</property>
+                            <property name="can_focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="sid20">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid21">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="bottom-padding">12</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="bottom_padding">12</property>
+                                    <property name="left_padding">12</property>
+                                    <property name="right_padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid22">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="label23">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;Define which tools will be selected if you press a mouse button. After you release the button the previously selected tool will be selected.&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
+                                            <property name="use_markup">True</property>
                                             <property name="wrap">True</property>
-                                            <property name="max-width-chars">85</property>
+                                            <property name="max_width_chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -1327,20 +1432,20 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                         <child>
                                           <object class="GtkFrame" id="sid23">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label-xalign">0.009999999776482582</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="label_xalign">0.0099999997764825821</property>
                                             <child>
                                               <object class="GtkAlignment" id="sid24">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="bottom-padding">8</property>
-                                                <property name="left-padding">12</property>
-                                                <property name="right-padding">12</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="bottom_padding">8</property>
+                                                <property name="left_padding">12</property>
+                                                <property name="right_padding">12</property>
                                                 <child>
                                                   <object class="GtkBox" id="hboxMidleMouse">
                                                     <property name="name">hboxMidleMouse</property>
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
+                                                    <property name="can_focus">False</property>
                                                     <child>
                                                       <placeholder/>
                                                     </child>
@@ -1351,7 +1456,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             <child type="label">
                                               <object class="GtkLabel" id="sid25">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">Middle Mouse Button</property>
                                               </object>
                                             </child>
@@ -1365,20 +1470,20 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                         <child>
                                           <object class="GtkFrame" id="sid26">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label-xalign">0.009999999776482582</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="label_xalign">0.0099999997764825821</property>
                                             <child>
                                               <object class="GtkAlignment" id="sid27">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="bottom-padding">8</property>
-                                                <property name="left-padding">12</property>
-                                                <property name="right-padding">12</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="bottom_padding">8</property>
+                                                <property name="left_padding">12</property>
+                                                <property name="right_padding">12</property>
                                                 <child>
                                                   <object class="GtkBox" id="hboxRightMouse">
                                                     <property name="name">hboxRightMouse</property>
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
+                                                    <property name="can_focus">False</property>
                                                     <child>
                                                       <placeholder/>
                                                     </child>
@@ -1389,7 +1494,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             <child type="label">
                                               <object class="GtkLabel" id="sid28">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">Right Mouse Button</property>
                                               </object>
                                             </child>
@@ -1407,7 +1512,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                 <child type="label">
                                   <object class="GtkLabel" id="sid29">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Mouse Buttons</property>
                                   </object>
                                 </child>
@@ -1438,62 +1543,62 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
               <object class="GtkLabel" id="mouseTabLabel">
                 <property name="name">mouseTabLabel</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Mouse</property>
               </object>
               <packing>
                 <property name="position">2</property>
-                <property name="tab-fill">False</property>
+                <property name="tab_fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="stylusTabBox">
                 <property name="name">stylusTabBox</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="margin-left">5</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid30">
                     <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="min-content-width">500</property>
-                    <property name="min-content-height">450</property>
+                    <property name="can_focus">True</property>
+                    <property name="min_content_width">500</property>
+                    <property name="min_content_height">450</property>
                     <child>
                       <object class="GtkViewport" id="sid31">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="shadow-type">none</property>
+                        <property name="can_focus">False</property>
+                        <property name="shadow_type">none</property>
                         <child>
                           <object class="GtkBox" id="sid32">
                             <property name="visible">True</property>
-                            <property name="can-focus">False</property>
+                            <property name="can_focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="sid33">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid34">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="bottom_padding">8</property>
+                                    <property name="left_padding">12</property>
+                                    <property name="right_padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid35">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="sid36">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;Pressure Sensitivity allows you to draw lines with different widths, depending on how much pressure you apply to the pen. If your tablet does not support this feature this setting has no effect.&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
+                                            <property name="use_markup">True</property>
                                             <property name="wrap">True</property>
-                                            <property name="max-width-chars">85</property>
+                                            <property name="max_width_chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -1507,10 +1612,10 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             <property name="label" translatable="yes">Enable Pressure Sensitivity</property>
                                             <property name="name">cbSettingPresureSensitivity</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
+                                            <property name="draw_indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -1521,28 +1626,28 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                         <child>
                                           <object class="GtkFrame" id="framePressureSensitivityScale">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label-xalign">0.009999999776482582</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="label_xalign">0.0099999997764825821</property>
                                             <child>
                                               <object class="GtkAlignment" id="alignSensitivityScale">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="bottom-padding">8</property>
-                                                <property name="left-padding">12</property>
-                                                <property name="right-padding">12</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="bottom_padding">8</property>
+                                                <property name="left_padding">12</property>
+                                                <property name="right_padding">12</property>
                                                 <child>
                                                   <object class="GtkBox" id="boxSensitivityScaleOptions">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
+                                                    <property name="can_focus">False</property>
                                                     <property name="orientation">vertical</property>
                                                     <child>
                                                       <object class="GtkLabel" id="lbSensitivityScaleDescription">
                                                         <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
+                                                        <property name="can_focus">False</property>
                                                         <property name="label" translatable="yes">&lt;i&gt;Some devices report unexpectedly small or large pressures. This can be fixed by setting a minimum pressure or scaling the pressure reported by the device.&lt;/i&gt;</property>
-                                                        <property name="use-markup">True</property>
+                                                        <property name="use_markup">True</property>
                                                         <property name="wrap">True</property>
-                                                        <property name="max-width-chars">85</property>
+                                                        <property name="max_width_chars">85</property>
                                                         <property name="xalign">0</property>
                                                       </object>
                                                       <packing>
@@ -1552,61 +1657,60 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                                       </packing>
                                                     </child>
                                                     <child>
-                                                      <!-- n-columns=3 n-rows=2 -->
                                                       <object class="GtkGrid" id="gridPressureSensitivityOptions">
                                                         <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="column-spacing">5</property>
-                                                        <property name="column-homogeneous">True</property>
+                                                        <property name="can_focus">False</property>
+                                                        <property name="column_spacing">5</property>
+                                                        <property name="column_homogeneous">True</property>
                                                         <child>
                                                           <object class="GtkLabel">
                                                             <property name="visible">True</property>
-                                                            <property name="can-focus">False</property>
+                                                            <property name="can_focus">False</property>
                                                             <property name="label" translatable="yes">Minimum Pressure:</property>
                                                           </object>
                                                           <packing>
-                                                            <property name="left-attach">0</property>
-                                                            <property name="top-attach">0</property>
+                                                            <property name="left_attach">0</property>
+                                                            <property name="top_attach">0</property>
                                                           </packing>
                                                         </child>
                                                         <child>
                                                           <object class="GtkLabel">
                                                             <property name="visible">True</property>
-                                                            <property name="can-focus">False</property>
+                                                            <property name="can_focus">False</property>
                                                             <property name="label" translatable="yes">Pressure Multiplier: </property>
                                                           </object>
                                                           <packing>
-                                                            <property name="left-attach">0</property>
-                                                            <property name="top-attach">1</property>
+                                                            <property name="left_attach">0</property>
+                                                            <property name="top_attach">1</property>
                                                           </packing>
                                                         </child>
                                                         <child>
                                                           <object class="GtkScale" id="scaleMinimumPressure">
                                                             <property name="visible">True</property>
-                                                            <property name="can-focus">True</property>
+                                                            <property name="can_focus">True</property>
                                                             <property name="adjustment">adjustmentMinimumPressure</property>
-                                                            <property name="round-digits">1</property>
+                                                            <property name="round_digits">1</property>
                                                             <property name="digits">2</property>
-                                                            <property name="value-pos">right</property>
+                                                            <property name="value_pos">right</property>
                                                           </object>
                                                           <packing>
-                                                            <property name="left-attach">1</property>
-                                                            <property name="top-attach">0</property>
+                                                            <property name="left_attach">1</property>
+                                                            <property name="top_attach">0</property>
                                                             <property name="width">2</property>
                                                           </packing>
                                                         </child>
                                                         <child>
                                                           <object class="GtkScale" id="scalePressureMultiplier">
                                                             <property name="visible">True</property>
-                                                            <property name="can-focus">True</property>
+                                                            <property name="can_focus">True</property>
                                                             <property name="adjustment">adjustmentPressureMultiplier</property>
-                                                            <property name="round-digits">1</property>
+                                                            <property name="round_digits">1</property>
                                                             <property name="digits">2</property>
-                                                            <property name="value-pos">right</property>
+                                                            <property name="value_pos">right</property>
                                                           </object>
                                                           <packing>
-                                                            <property name="left-attach">1</property>
-                                                            <property name="top-attach">1</property>
+                                                            <property name="left_attach">1</property>
+                                                            <property name="top_attach">1</property>
                                                             <property name="width">2</property>
                                                           </packing>
                                                         </child>
@@ -1624,7 +1728,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             <child type="label">
                                               <object class="GtkLabel" id="lbSensitivityScaleHeader">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">Sensitivity Scale</property>
                                               </object>
                                             </child>
@@ -1642,7 +1746,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                 <child type="label">
                                   <object class="GtkLabel" id="sid37">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Pressure Sensitivity</property>
                                   </object>
                                 </child>
@@ -1656,28 +1760,28 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                             <child>
                               <object class="GtkFrame" id="sid183">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid184">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="bottom_padding">8</property>
+                                    <property name="left_padding">12</property>
+                                    <property name="right_padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid185">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="sid186">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;With some setup, pen strokes have artifacts at their beginning. This can be avoided by ignoring the first few events/stroke-points when the pen touches the screen.&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
+                                            <property name="use_markup">True</property>
                                             <property name="wrap">True</property>
-                                            <property name="max-width-chars">85</property>
+                                            <property name="max_width_chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -1689,16 +1793,16 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                         <child>
                                           <object class="GtkBox" id="sid187">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <child>
                                               <object class="GtkCheckButton" id="cbIgnoreFirstStylusEvents">
                                                 <property name="label" translatable="yes">Ignore the first</property>
                                                 <property name="name">cbSettingIgnoreFirstStylusEvents</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="receives-default">False</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="receives_default">False</property>
                                                 <property name="xalign">0</property>
-                                                <property name="draw-indicator">True</property>
+                                                <property name="draw_indicator">True</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
@@ -1710,7 +1814,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                               <object class="GtkSpinButton" id="spNumIgnoredStylusEvents">
                                                 <property name="name">spNrOfIgnoredFirstStylusEvents</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
+                                                <property name="can_focus">True</property>
                                                 <property name="text" translatable="yes">1</property>
                                                 <property name="adjustment">adjustmentIgnoreStylusEvents</property>
                                                 <property name="value">1</property>
@@ -1726,7 +1830,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                               <object class="GtkLabel" id="lbIgnoreFirstStylusEvents">
                                                 <property name="name">lbIgnoreFirstStylusEvents</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">events</property>
                                               </object>
                                               <packing>
@@ -1749,7 +1853,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                 <child type="label">
                                   <object class="GtkLabel" id="sid188">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Artifact workaround</property>
                                   </object>
                                 </child>
@@ -1763,28 +1867,28 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                             <child>
                               <object class="GtkFrame" id="sid38">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid39">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="bottom-padding">12</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="bottom_padding">12</property>
+                                    <property name="left_padding">12</property>
+                                    <property name="right_padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid40">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="sid41">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;Specify the tools that will be selected if a button of the stylus is pressed or the eraser is used. After releasing the button, the previous tool will be selected.&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
+                                            <property name="use_markup">True</property>
                                             <property name="wrap">True</property>
-                                            <property name="max-width-chars">85</property>
+                                            <property name="max_width_chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -1796,20 +1900,20 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                         <child>
                                           <object class="GtkFrame" id="sid42">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label-xalign">0.009999999776482582</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="label_xalign">0.0099999997764825821</property>
                                             <child>
                                               <object class="GtkAlignment" id="sid43">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="bottom-padding">8</property>
-                                                <property name="left-padding">12</property>
-                                                <property name="right-padding">12</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="bottom_padding">8</property>
+                                                <property name="left_padding">12</property>
+                                                <property name="right_padding">12</property>
                                                 <child>
                                                   <object class="GtkBox" id="hboxPenButton1">
                                                     <property name="name">hboxPenButton1</property>
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
+                                                    <property name="can_focus">False</property>
                                                     <child>
                                                       <placeholder/>
                                                     </child>
@@ -1820,7 +1924,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             <child type="label">
                                               <object class="GtkLabel" id="sid44">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">Button 1</property>
                                               </object>
                                             </child>
@@ -1834,20 +1938,20 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                         <child>
                                           <object class="GtkFrame" id="sid45">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label-xalign">0.009999999776482582</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="label_xalign">0.0099999997764825821</property>
                                             <child>
                                               <object class="GtkAlignment" id="sid46">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="bottom-padding">8</property>
-                                                <property name="left-padding">12</property>
-                                                <property name="right-padding">12</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="bottom_padding">8</property>
+                                                <property name="left_padding">12</property>
+                                                <property name="right_padding">12</property>
                                                 <child>
                                                   <object class="GtkBox" id="hboxPenButton2">
                                                     <property name="name">hboxPenButton2</property>
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
+                                                    <property name="can_focus">False</property>
                                                     <child>
                                                       <placeholder/>
                                                     </child>
@@ -1858,7 +1962,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             <child type="label">
                                               <object class="GtkLabel" id="sid47">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">Button 2</property>
                                               </object>
                                             </child>
@@ -1872,20 +1976,20 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                         <child>
                                           <object class="GtkFrame" id="sid48">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label-xalign">0.009999999776482582</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="label_xalign">0.0099999997764825821</property>
                                             <child>
                                               <object class="GtkAlignment" id="sid49">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="bottom-padding">8</property>
-                                                <property name="left-padding">12</property>
-                                                <property name="right-padding">12</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="bottom_padding">8</property>
+                                                <property name="left_padding">12</property>
+                                                <property name="right_padding">12</property>
                                                 <child>
                                                   <object class="GtkBox" id="hboxEraser">
                                                     <property name="name">hboxEraser</property>
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
+                                                    <property name="can_focus">False</property>
                                                     <child>
                                                       <placeholder/>
                                                     </child>
@@ -1896,7 +2000,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             <child type="label">
                                               <object class="GtkLabel" id="sid50">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">Eraser</property>
                                               </object>
                                             </child>
@@ -1914,7 +2018,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                 <child type="label">
                                   <object class="GtkLabel" id="sid51">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Stylus Buttons</property>
                                   </object>
                                 </child>
@@ -1945,62 +2049,62 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
               <object class="GtkLabel" id="stylusTabLabel">
                 <property name="name">stylusTabLabel</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Stylus</property>
               </object>
               <packing>
                 <property name="position">3</property>
-                <property name="tab-fill">False</property>
+                <property name="tab_fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="touchTabBox">
                 <property name="name">touchTabBox</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="margin-left">5</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid52">
                     <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="min-content-width">500</property>
-                    <property name="min-content-height">450</property>
+                    <property name="can_focus">True</property>
+                    <property name="min_content_width">500</property>
+                    <property name="min_content_height">450</property>
                     <child>
                       <object class="GtkViewport" id="sid53">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="shadow-type">none</property>
+                        <property name="can_focus">False</property>
+                        <property name="shadow_type">none</property>
                         <child>
                           <object class="GtkBox" id="sid54">
                             <property name="visible">True</property>
-                            <property name="can-focus">False</property>
+                            <property name="can_focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="sid55">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid56">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="bottom_padding">8</property>
+                                    <property name="left_padding">12</property>
+                                    <property name="right_padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid57">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="sid58">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;You can configure devices, not identified by GTK as touchscreen, to behave as if they were one.&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
+                                            <property name="use_markup">True</property>
                                             <property name="wrap">True</property>
-                                            <property name="max-width-chars">85</property>
+                                            <property name="max_width_chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -2013,7 +2117,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                           <object class="GtkBox" id="hboxTouch">
                                             <property name="name">hboxTouch</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <child>
                                               <placeholder/>
                                             </child>
@@ -2031,7 +2135,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                 <child type="label">
                                   <object class="GtkLabel" id="sid59">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Touchscreen</property>
                                   </object>
                                 </child>
@@ -2045,28 +2149,28 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                             <child>
                               <object class="GtkFrame" id="sid60">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid61">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="bottom_padding">8</property>
+                                    <property name="left_padding">12</property>
+                                    <property name="right_padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid62">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="sid63">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;If your hardware does not support hand recognition, Xournal++ can disable your touchscreen when your pen is near the screen.&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
+                                            <property name="use_markup">True</property>
                                             <property name="wrap">True</property>
-                                            <property name="max-width-chars">85</property>
+                                            <property name="max_width_chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -2080,10 +2184,10 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             <property name="label" translatable="yes">Enable internal Hand Recognition</property>
                                             <property name="name">cbDisableTouchOnPenNear</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
+                                            <property name="draw_indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -2095,43 +2199,42 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                           <object class="GtkBox" id="boxInternalHandRecognition">
                                             <property name="name">boxInternalHandRecognition</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="orientation">vertical</property>
                                             <child>
-                                              <!-- n-columns=3 n-rows=3 -->
                                               <object class="GtkGrid" id="sid64">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="row-spacing">5</property>
-                                                <property name="column-spacing">5</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="row_spacing">5</property>
+                                                <property name="column_spacing">5</property>
                                                 <child>
                                                   <object class="GtkLabel" id="label50">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
+                                                    <property name="can_focus">False</property>
                                                     <property name="label" translatable="yes">Disabling Method</property>
                                                   </object>
                                                   <packing>
-                                                    <property name="left-attach">0</property>
-                                                    <property name="top-attach">0</property>
+                                                    <property name="left_attach">0</property>
+                                                    <property name="top_attach">0</property>
                                                   </packing>
                                                 </child>
                                                 <child>
                                                   <object class="GtkLabel" id="label55">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
+                                                    <property name="can_focus">False</property>
                                                     <property name="label" translatable="yes">Timeout</property>
                                                     <property name="xalign">0</property>
                                                   </object>
                                                   <packing>
-                                                    <property name="left-attach">0</property>
-                                                    <property name="top-attach">1</property>
+                                                    <property name="left_attach">0</property>
+                                                    <property name="top_attach">1</property>
                                                   </packing>
                                                 </child>
                                                 <child>
                                                   <object class="GtkComboBoxText" id="cbTouchDisableMethod">
                                                     <property name="name">cbTouchDisableMethod</property>
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
+                                                    <property name="can_focus">False</property>
                                                     <property name="active">0</property>
                                                     <items>
                                                       <item translatable="yes">Autodetect</item>
@@ -2140,46 +2243,37 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                                     </items>
                                                   </object>
                                                   <packing>
-                                                    <property name="left-attach">1</property>
-                                                    <property name="top-attach">0</property>
+                                                    <property name="left_attach">1</property>
+                                                    <property name="top_attach">0</property>
                                                   </packing>
                                                 </child>
                                                 <child>
                                                   <object class="GtkSpinButton" id="spTouchDisableTimeout">
                                                     <property name="name">spTouchDisableTimeout</property>
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">True</property>
+                                                    <property name="can_focus">True</property>
                                                     <property name="adjustment">adjustmentTouchTImeout</property>
-                                                    <property name="climb-rate">0.5</property>
+                                                    <property name="climb_rate">0.5</property>
                                                     <property name="digits">1</property>
                                                     <property name="value">1</property>
                                                   </object>
                                                   <packing>
-                                                    <property name="left-attach">1</property>
-                                                    <property name="top-attach">1</property>
+                                                    <property name="left_attach">1</property>
+                                                    <property name="top_attach">1</property>
                                                   </packing>
                                                 </child>
                                                 <child>
                                                   <object class="GtkLabel" id="label56">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
+                                                    <property name="can_focus">False</property>
                                                     <property name="label" translatable="yes">s &lt;i&gt;(after which the touchscreen will be reactivated again)&lt;/i&gt;</property>
-                                                    <property name="use-markup">True</property>
+                                                    <property name="use_markup">True</property>
                                                     <property name="xalign">0</property>
                                                   </object>
                                                   <packing>
-                                                    <property name="left-attach">2</property>
-                                                    <property name="top-attach">1</property>
+                                                    <property name="left_attach">2</property>
+                                                    <property name="top_attach">1</property>
                                                   </packing>
-                                                </child>
-                                                <child>
-                                                  <placeholder/>
-                                                </child>
-                                                <child>
-                                                  <placeholder/>
-                                                </child>
-                                                <child>
-                                                  <placeholder/>
                                                 </child>
                                                 <child>
                                                   <placeholder/>
@@ -2195,28 +2289,28 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                               <object class="GtkFrame" id="boxCustomTouchDisableSettings">
                                                 <property name="name">boxCustomTouchDisableSettings</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label-xalign">0.009999999776482582</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="label_xalign">0.0099999997764825821</property>
                                                 <child>
                                                   <object class="GtkAlignment" id="sid65">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
-                                                    <property name="bottom-padding">8</property>
-                                                    <property name="left-padding">12</property>
-                                                    <property name="right-padding">12</property>
+                                                    <property name="can_focus">False</property>
+                                                    <property name="bottom_padding">8</property>
+                                                    <property name="left_padding">12</property>
+                                                    <property name="right_padding">12</property>
                                                     <child>
                                                       <object class="GtkBox" id="sid66">
                                                         <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
+                                                        <property name="can_focus">False</property>
                                                         <property name="orientation">vertical</property>
                                                         <child>
                                                           <object class="GtkLabel" id="label54">
                                                             <property name="visible">True</property>
-                                                            <property name="can-focus">False</property>
+                                                            <property name="can_focus">False</property>
                                                             <property name="label" translatable="yes">&lt;i&gt;Specify commands that are called once Hand Recognition triggers. The commands will be executed in the UI Thread, make sure they are not blocking!&lt;/i&gt;</property>
-                                                            <property name="use-markup">True</property>
+                                                            <property name="use_markup">True</property>
                                                             <property name="wrap">True</property>
-                                                            <property name="max-width-chars">85</property>
+                                                            <property name="max_width_chars">85</property>
                                                             <property name="xalign">0</property>
                                                           </object>
                                                           <packing>
@@ -2226,57 +2320,56 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                                           </packing>
                                                         </child>
                                                         <child>
-                                                          <!-- n-columns=3 n-rows=3 -->
                                                           <object class="GtkGrid" id="grid3">
                                                             <property name="visible">True</property>
-                                                            <property name="can-focus">False</property>
-                                                            <property name="row-spacing">5</property>
-                                                            <property name="column-spacing">5</property>
+                                                            <property name="can_focus">False</property>
+                                                            <property name="row_spacing">5</property>
+                                                            <property name="column_spacing">5</property>
                                                             <child>
                                                             <object class="GtkLabel" id="label52">
                                                             <property name="visible">True</property>
-                                                            <property name="can-focus">False</property>
+                                                            <property name="can_focus">False</property>
                                                             <property name="label" translatable="yes">Enable</property>
                                                             <property name="xalign">0</property>
                                                             </object>
                                                             <packing>
-                                                            <property name="left-attach">0</property>
-                                                            <property name="top-attach">0</property>
+                                                            <property name="left_attach">0</property>
+                                                            <property name="top_attach">0</property>
                                                             </packing>
                                                             </child>
                                                             <child>
                                                             <object class="GtkLabel" id="label53">
                                                             <property name="visible">True</property>
-                                                            <property name="can-focus">False</property>
+                                                            <property name="can_focus">False</property>
                                                             <property name="label" translatable="yes">Disable</property>
                                                             </object>
                                                             <packing>
-                                                            <property name="left-attach">0</property>
-                                                            <property name="top-attach">1</property>
+                                                            <property name="left_attach">0</property>
+                                                            <property name="top_attach">1</property>
                                                             </packing>
                                                             </child>
                                                             <child>
                                                             <object class="GtkEntry" id="txtEnableTouchCommand">
                                                             <property name="name">txtEnableTouchCommand</property>
                                                             <property name="visible">True</property>
-                                                            <property name="can-focus">True</property>
+                                                            <property name="can_focus">True</property>
                                                             <property name="hexpand">True</property>
                                                             </object>
                                                             <packing>
-                                                            <property name="left-attach">1</property>
-                                                            <property name="top-attach">0</property>
+                                                            <property name="left_attach">1</property>
+                                                            <property name="top_attach">0</property>
                                                             </packing>
                                                             </child>
                                                             <child>
                                                             <object class="GtkEntry" id="txtDisableTouchCommand">
                                                             <property name="name">txtDisableTouchCommand</property>
                                                             <property name="visible">True</property>
-                                                            <property name="can-focus">True</property>
+                                                            <property name="can_focus">True</property>
                                                             <property name="hexpand">True</property>
                                                             </object>
                                                             <packing>
-                                                            <property name="left-attach">1</property>
-                                                            <property name="top-attach">1</property>
+                                                            <property name="left_attach">1</property>
+                                                            <property name="top_attach">1</property>
                                                             </packing>
                                                             </child>
                                                             <child>
@@ -2284,12 +2377,12 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                                             <property name="label" translatable="yes">Test</property>
                                                             <property name="name">btTestEnable</property>
                                                             <property name="visible">True</property>
-                                                            <property name="can-focus">True</property>
-                                                            <property name="receives-default">True</property>
+                                                            <property name="can_focus">True</property>
+                                                            <property name="receives_default">True</property>
                                                             </object>
                                                             <packing>
-                                                            <property name="left-attach">2</property>
-                                                            <property name="top-attach">0</property>
+                                                            <property name="left_attach">2</property>
+                                                            <property name="top_attach">0</property>
                                                             </packing>
                                                             </child>
                                                             <child>
@@ -2297,22 +2390,13 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                                             <property name="label" translatable="yes">Test</property>
                                                             <property name="name">btTestDisable</property>
                                                             <property name="visible">True</property>
-                                                            <property name="can-focus">True</property>
-                                                            <property name="receives-default">True</property>
+                                                            <property name="can_focus">True</property>
+                                                            <property name="receives_default">True</property>
                                                             </object>
                                                             <packing>
-                                                            <property name="left-attach">2</property>
-                                                            <property name="top-attach">1</property>
+                                                            <property name="left_attach">2</property>
+                                                            <property name="top_attach">1</property>
                                                             </packing>
-                                                            </child>
-                                                            <child>
-                                                            <placeholder/>
-                                                            </child>
-                                                            <child>
-                                                            <placeholder/>
-                                                            </child>
-                                                            <child>
-                                                            <placeholder/>
                                                             </child>
                                                           </object>
                                                           <packing>
@@ -2328,7 +2412,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                                 <child type="label">
                                                   <object class="GtkLabel" id="sid67">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
+                                                    <property name="can_focus">False</property>
                                                     <property name="label" translatable="yes">Custom Commands (for Method "Custom")</property>
                                                   </object>
                                                 </child>
@@ -2353,7 +2437,7 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                 <child type="label">
                                   <object class="GtkLabel" id="sid68">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Hand Recognition</property>
                                   </object>
                                 </child>
@@ -2367,26 +2451,26 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                             <child>
                               <object class="GtkFrame" id="sid69">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid70">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="bottom_padding">8</property>
+                                    <property name="left_padding">12</property>
+                                    <property name="right_padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid71">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="sid72">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;Use pinch gestures to zoom journal pages.&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
+                                            <property name="use_markup">True</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -2400,10 +2484,10 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                             <property name="label" translatable="yes">Enable zoom gestures (requires restart)</property>
                                             <property name="name">cbEnableZoomGestures</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
+                                            <property name="draw_indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -2412,48 +2496,47 @@ If the file was not yet saved you can find it in your home directory, in ~/.xour
                                           </packing>
                                         </child>
                                         <child>
-                                          <!-- n-columns=3 n-rows=1 -->
                                           <object class="GtkGrid" id="gdStartZoomAtSetting">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="tooltip-text" translatable="yes">When drawing with touch, two-finger gestures intended to pan the view can instead cause it to zoom, causing performance issues. 
+                                            <property name="can_focus">False</property>
+                                            <property name="tooltip_text" translatable="yes">When drawing with touch, two-finger gestures intended to pan the view can instead cause it to zoom, causing performance issues. 
 This setting can make it easier to draw with touch. </property>
                                             <child>
                                               <object class="GtkLabel" id="label2">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">Start zooming after a distance </property>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">0</property>
-                                                <property name="top-attach">0</property>
+                                                <property name="left_attach">0</property>
+                                                <property name="top_attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkSpinButton" id="spTouchZoomStartThreshold">
                                                 <property name="name">spTouchDisableTimeout</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
+                                                <property name="can_focus">True</property>
                                                 <property name="text" translatable="yes">1.0</property>
                                                 <property name="adjustment">adjustmentZoomStartThreshold</property>
-                                                <property name="climb-rate">0.5</property>
+                                                <property name="climb_rate">0.5</property>
                                                 <property name="digits">1</property>
                                                 <property name="value">1</property>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">1</property>
-                                                <property name="top-attach">0</property>
+                                                <property name="left_attach">1</property>
+                                                <property name="top_attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkLabel" id="label4">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">% greater than the initial distance between the two touches.</property>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">2</property>
-                                                <property name="top-attach">0</property>
+                                                <property name="left_attach">2</property>
+                                                <property name="top_attach">0</property>
                                               </packing>
                                             </child>
                                           </object>
@@ -2470,7 +2553,7 @@ This setting can make it easier to draw with touch. </property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid73">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Zoom Gestures</property>
                                   </object>
                                 </child>
@@ -2484,28 +2567,28 @@ This setting can make it easier to draw with touch. </property>
                             <child>
                               <object class="GtkFrame" id="frameTouchDrawing">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkAlignment" id="touchDrawingFrameAlignment">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="bottom_padding">8</property>
+                                    <property name="left_padding">12</property>
+                                    <property name="right_padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="boxTouchDrawing">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="lblTouchDrawingDescription">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;Use the touchscreen like a multi-touch-aware pen.&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
+                                            <property name="use_markup">True</property>
                                             <property name="wrap">True</property>
-                                            <property name="max-width-chars">85</property>
+                                            <property name="max_width_chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -2519,11 +2602,11 @@ This setting can make it easier to draw with touch. </property>
                                             <property name="label" translatable="yes">Enable touch drawing</property>
                                             <property name="name">cbTouchDrawing</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="tooltip-text" translatable="yes">Use two fingers to pan/zoom and one finger to use the selected tool.</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="tooltip_text" translatable="yes">Use two fingers to pan/zoom and one finger to use the selected tool.</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
+                                            <property name="draw_indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -2538,7 +2621,7 @@ This setting can make it easier to draw with touch. </property>
                                 <child type="label">
                                   <object class="GtkLabel" id="headerTouchDrawingFrame">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Touch Drawing</property>
                                   </object>
                                 </child>
@@ -2569,68 +2652,68 @@ This setting can make it easier to draw with touch. </property>
               <object class="GtkLabel" id="touchTabLabel">
                 <property name="name">touchTabLabel</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Touchscreen</property>
               </object>
               <packing>
                 <property name="position">4</property>
-                <property name="tab-fill">False</property>
+                <property name="tab_fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="viewTabBox">
                 <property name="name">viewTabBox</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="margin-left">5</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid95">
                     <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="min-content-width">500</property>
-                    <property name="min-content-height">450</property>
+                    <property name="can_focus">True</property>
+                    <property name="min_content_width">500</property>
+                    <property name="min_content_height">450</property>
                     <child>
                       <object class="GtkViewport" id="sid96">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="shadow-type">none</property>
+                        <property name="can_focus">False</property>
+                        <property name="shadow_type">none</property>
                         <child>
                           <object class="GtkBox" id="sid97">
                             <property name="visible">True</property>
-                            <property name="can-focus">False</property>
+                            <property name="can_focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="sid98">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid99">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="bottom-padding">12</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="bottom_padding">12</property>
+                                    <property name="left_padding">12</property>
+                                    <property name="right_padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid100">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkBox" id="vbox6">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="halign">start</property>
                                             <child>
                                               <object class="GtkCheckButton" id="cbHideMenubarStartup">
                                                 <property name="label" translatable="yes">Show Menubar on Startup</property>
                                                 <property name="name">cbHideMenubarStartup</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="receives-default">False</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="receives_default">False</property>
                                                 <property name="xalign">0</property>
-                                                <property name="draw-indicator">True</property>
+                                                <property name="draw_indicator">True</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
@@ -2641,10 +2724,10 @@ This setting can make it easier to draw with touch. </property>
                                             <child>
                                               <object class="GtkLabel" id="sid101">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="margin-left">5</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="margin_left">5</property>
                                                 <property name="label" translatable="yes">&lt;i&gt;Toggle visibility of menubar with F10&lt;/i&gt;</property>
-                                                <property name="use-markup">True</property>
+                                                <property name="use_markup">True</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
@@ -2663,95 +2746,94 @@ This setting can make it easier to draw with touch. </property>
                                           <object class="GtkFrame" id="colorsFrame">
                                             <property name="name">colorsFrame</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label-xalign">0.009999999776482582</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="label_xalign">0.0099999997764825821</property>
                                             <child>
                                               <object class="GtkAlignment" id="sid102">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="bottom-padding">8</property>
-                                                <property name="left-padding">12</property>
-                                                <property name="right-padding">12</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="bottom_padding">8</property>
+                                                <property name="left_padding">12</property>
+                                                <property name="right_padding">12</property>
                                                 <child>
-                                                  <!-- n-columns=3 n-rows=4 -->
                                                   <object class="GtkGrid" id="grid2">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
+                                                    <property name="can_focus">False</property>
                                                     <child>
                                                       <object class="GtkLabel" id="label10">
                                                         <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
+                                                        <property name="can_focus">False</property>
                                                         <property name="hexpand">True</property>
                                                         <property name="label" translatable="yes">Border color for current page and other selections</property>
                                                         <property name="justify">right</property>
                                                         <property name="xalign">0</property>
                                                       </object>
                                                       <packing>
-                                                        <property name="left-attach">0</property>
-                                                        <property name="top-attach">0</property>
+                                                        <property name="left_attach">0</property>
+                                                        <property name="top_attach">0</property>
                                                       </packing>
                                                     </child>
                                                     <child>
                                                       <object class="GtkColorButton" id="colorBorder">
                                                         <property name="name">colorBorder</property>
                                                         <property name="visible">True</property>
-                                                        <property name="can-focus">True</property>
-                                                        <property name="receives-default">True</property>
+                                                        <property name="can_focus">True</property>
+                                                        <property name="receives_default">True</property>
                                                         <property name="title" translatable="yes">Border color</property>
                                                       </object>
                                                       <packing>
-                                                        <property name="left-attach">1</property>
-                                                        <property name="top-attach">0</property>
+                                                        <property name="left_attach">1</property>
+                                                        <property name="top_attach">0</property>
                                                       </packing>
                                                     </child>
                                                     <child>
                                                       <object class="GtkLabel" id="label13">
                                                         <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
+                                                        <property name="can_focus">False</property>
                                                         <property name="label" translatable="yes">Background color between pages</property>
                                                         <property name="xalign">0</property>
                                                       </object>
                                                       <packing>
-                                                        <property name="left-attach">0</property>
-                                                        <property name="top-attach">1</property>
+                                                        <property name="left_attach">0</property>
+                                                        <property name="top_attach">1</property>
                                                       </packing>
                                                     </child>
                                                     <child>
                                                       <object class="GtkColorButton" id="colorBackground">
                                                         <property name="name">colorBackground</property>
                                                         <property name="visible">True</property>
-                                                        <property name="can-focus">True</property>
-                                                        <property name="receives-default">True</property>
-                                                        <property name="margin-top">5</property>
+                                                        <property name="can_focus">True</property>
+                                                        <property name="receives_default">True</property>
+                                                        <property name="margin_top">5</property>
                                                       </object>
                                                       <packing>
-                                                        <property name="left-attach">1</property>
-                                                        <property name="top-attach">1</property>
+                                                        <property name="left_attach">1</property>
+                                                        <property name="top_attach">1</property>
                                                       </packing>
                                                     </child>
                                                     <child>
                                                       <object class="GtkLabel" id="label57">
                                                         <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
+                                                        <property name="can_focus">False</property>
                                                         <property name="label" translatable="yes">Selection Color (Text, Stroke Selection etc.)</property>
                                                         <property name="xalign">0</property>
                                                       </object>
                                                       <packing>
-                                                        <property name="left-attach">0</property>
-                                                        <property name="top-attach">2</property>
+                                                        <property name="left_attach">0</property>
+                                                        <property name="top_attach">2</property>
                                                       </packing>
                                                     </child>
                                                     <child>
                                                       <object class="GtkColorButton" id="colorSelection">
                                                         <property name="name">colorSelection</property>
                                                         <property name="visible">True</property>
-                                                        <property name="can-focus">True</property>
-                                                        <property name="receives-default">True</property>
-                                                        <property name="margin-top">5</property>
+                                                        <property name="can_focus">True</property>
+                                                        <property name="receives_default">True</property>
+                                                        <property name="margin_top">5</property>
                                                       </object>
                                                       <packing>
-                                                        <property name="left-attach">1</property>
-                                                        <property name="top-attach">2</property>
+                                                        <property name="left_attach">1</property>
+                                                        <property name="top_attach">2</property>
                                                       </packing>
                                                     </child>
                                                     <child>
@@ -2759,28 +2841,16 @@ This setting can make it easier to draw with touch. </property>
                                                         <property name="label" translatable="yes">Dark Theme (requires restart)</property>
                                                         <property name="name">cbDarkTheme</property>
                                                         <property name="visible">True</property>
-                                                        <property name="can-focus">True</property>
-                                                        <property name="receives-default">False</property>
+                                                        <property name="can_focus">True</property>
+                                                        <property name="receives_default">False</property>
                                                         <property name="xalign">0</property>
-                                                        <property name="draw-indicator">True</property>
+                                                        <property name="draw_indicator">True</property>
                                                       </object>
                                                       <packing>
-                                                        <property name="left-attach">0</property>
-                                                        <property name="top-attach">3</property>
+                                                        <property name="left_attach">0</property>
+                                                        <property name="top_attach">3</property>
                                                         <property name="width">2</property>
                                                       </packing>
-                                                    </child>
-                                                    <child>
-                                                      <placeholder/>
-                                                    </child>
-                                                    <child>
-                                                      <placeholder/>
-                                                    </child>
-                                                    <child>
-                                                      <placeholder/>
-                                                    </child>
-                                                    <child>
-                                                      <placeholder/>
                                                     </child>
                                                   </object>
                                                 </child>
@@ -2789,7 +2859,7 @@ This setting can make it easier to draw with touch. </property>
                                             <child type="label">
                                               <object class="GtkLabel" id="sid103">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">Colors</property>
                                               </object>
                                             </child>
@@ -2807,9 +2877,9 @@ This setting can make it easier to draw with touch. </property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid104">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Global</property>
-                                    <property name="use-markup">True</property>
+                                    <property name="use_markup">True</property>
                                   </object>
                                 </child>
                               </object>
@@ -2822,29 +2892,29 @@ This setting can make it easier to draw with touch. </property>
                             <child>
                               <object class="GtkFrame" id="sid105">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid106">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="bottom_padding">8</property>
+                                    <property name="left_padding">12</property>
+                                    <property name="right_padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="vbox15">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkBox">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="spacing">5</property>
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">Cursor icon for pen</property>
                                                 <property name="xalign">0</property>
                                               </object>
@@ -2858,7 +2928,7 @@ This setting can make it easier to draw with touch. </property>
                                               <object class="GtkComboBoxText" id="cbStylusCursorType">
                                                 <property name="name">cbStylusCursorType</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="active">0</property>
                                                 <items>
                                                   <item id="none" translatable="yes" context="stylus cursor uses no icon">No icon</item>
@@ -2880,217 +2950,207 @@ This setting can make it easier to draw with touch. </property>
                                           </packing>
                                         </child>
                                         <child>
-                                          <!-- n-columns=3 n-rows=3 -->
                                           <object class="GtkGrid" id="highlightCursorGrid">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="column-homogeneous">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="column_homogeneous">True</property>
                                             <child>
                                               <object class="GtkCheckButton" id="cbHighlightPosition">
                                                 <property name="label" translatable="yes">Highlight cursor position</property>
                                                 <property name="name">cbHighlightPosition</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="receives-default">False</property>
-                                                <property name="tooltip-text" translatable="yes">Draw a transparent circle around the cursor</property>
-                                                <property name="draw-indicator">True</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="receives_default">False</property>
+                                                <property name="tooltip_text" translatable="yes">Draw a transparent circle around the cursor</property>
+                                                <property name="draw_indicator">True</property>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">0</property>
-                                                <property name="top-attach">0</property>
+                                                <property name="left_attach">0</property>
+                                                <property name="top_attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkBox">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <child>
                                                   <object class="GtkColorButton" id="cursorHighlightColor">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">True</property>
-                                                    <property name="receives-default">True</property>
-                                                    <property name="use-alpha">True</property>
+                                                    <property name="can_focus">True</property>
+                                                    <property name="receives_default">True</property>
+                                                    <property name="use_alpha">True</property>
                                                     <property name="title" translatable="yes">Choose the color to use for "Highlight cursor position"</property>
-                                                    <property name="show-editor">True</property>
+                                                    <property name="show_editor">True</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
                                                     <property name="fill">True</property>
-                                                    <property name="pack-type">end</property>
+                                                    <property name="pack_type">end</property>
                                                     <property name="position">0</property>
                                                   </packing>
                                                 </child>
                                                 <child>
                                                   <object class="GtkLabel">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
+                                                    <property name="can_focus">False</property>
                                                     <property name="label" translatable="yes">Circle Color</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
                                                     <property name="fill">True</property>
                                                     <property name="padding">10</property>
-                                                    <property name="pack-type">end</property>
+                                                    <property name="pack_type">end</property>
                                                     <property name="position">1</property>
                                                   </packing>
                                                 </child>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">1</property>
-                                                <property name="top-attach">1</property>
+                                                <property name="left_attach">1</property>
+                                                <property name="top_attach">1</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkBox">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <child>
                                                   <object class="GtkLabel">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
+                                                    <property name="can_focus">False</property>
                                                     <property name="label" translatable="yes">pixels</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
                                                     <property name="fill">True</property>
-                                                    <property name="pack-type">end</property>
+                                                    <property name="pack_type">end</property>
                                                     <property name="position">0</property>
                                                   </packing>
                                                 </child>
                                                 <child>
                                                   <object class="GtkSpinButton" id="cursorHighlightRadius">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">True</property>
-                                                    <property name="input-purpose">number</property>
+                                                    <property name="can_focus">True</property>
+                                                    <property name="input_purpose">number</property>
                                                     <property name="adjustment">adjustmentCursorHighlightRadius</property>
                                                     <property name="numeric">True</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
                                                     <property name="fill">True</property>
-                                                    <property name="pack-type">end</property>
+                                                    <property name="pack_type">end</property>
                                                     <property name="position">1</property>
                                                   </packing>
                                                 </child>
                                                 <child>
                                                   <object class="GtkLabel">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
+                                                    <property name="can_focus">False</property>
                                                     <property name="label" translatable="yes">Radius</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
                                                     <property name="fill">True</property>
-                                                    <property name="pack-type">end</property>
+                                                    <property name="pack_type">end</property>
                                                     <property name="position">3</property>
                                                   </packing>
                                                 </child>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">0</property>
-                                                <property name="top-attach">1</property>
+                                                <property name="left_attach">0</property>
+                                                <property name="top_attach">1</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkBox">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <child>
                                                   <object class="GtkLabel">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
+                                                    <property name="can_focus">False</property>
                                                     <property name="label" translatable="yes">pixels</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
                                                     <property name="fill">True</property>
-                                                    <property name="pack-type">end</property>
+                                                    <property name="pack_type">end</property>
                                                     <property name="position">0</property>
                                                   </packing>
                                                 </child>
                                                 <child>
                                                   <object class="GtkSpinButton" id="cursorHighlightBorderWidth">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">True</property>
+                                                    <property name="can_focus">True</property>
                                                     <property name="text" translatable="yes">30</property>
-                                                    <property name="input-purpose">number</property>
+                                                    <property name="input_purpose">number</property>
                                                     <property name="adjustment">adjustmentCursorHighlightBorderWidth</property>
                                                     <property name="numeric">True</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
                                                     <property name="fill">True</property>
-                                                    <property name="pack-type">end</property>
+                                                    <property name="pack_type">end</property>
                                                     <property name="position">1</property>
                                                   </packing>
                                                 </child>
                                                 <child>
                                                   <object class="GtkLabel">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
+                                                    <property name="can_focus">False</property>
                                                     <property name="label" translatable="yes">Border Width</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
                                                     <property name="fill">True</property>
-                                                    <property name="pack-type">end</property>
+                                                    <property name="pack_type">end</property>
                                                     <property name="position">3</property>
                                                   </packing>
                                                 </child>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">0</property>
-                                                <property name="top-attach">2</property>
+                                                <property name="left_attach">0</property>
+                                                <property name="top_attach">2</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkBox">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <child>
                                                   <object class="GtkColorButton" id="cursorHighlightBorderColor">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">True</property>
-                                                    <property name="receives-default">True</property>
-                                                    <property name="use-alpha">True</property>
+                                                    <property name="can_focus">True</property>
+                                                    <property name="receives_default">True</property>
+                                                    <property name="use_alpha">True</property>
                                                     <property name="title" translatable="yes">Choose the color to use for "Highlight cursor position"</property>
-                                                    <property name="show-editor">True</property>
+                                                    <property name="show_editor">True</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
                                                     <property name="fill">True</property>
-                                                    <property name="pack-type">end</property>
+                                                    <property name="pack_type">end</property>
                                                     <property name="position">0</property>
                                                   </packing>
                                                 </child>
                                                 <child>
                                                   <object class="GtkLabel">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
+                                                    <property name="can_focus">False</property>
                                                     <property name="label" translatable="yes">Border Color</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
                                                     <property name="fill">True</property>
                                                     <property name="padding">10</property>
-                                                    <property name="pack-type">end</property>
+                                                    <property name="pack_type">end</property>
                                                     <property name="position">1</property>
                                                   </packing>
                                                 </child>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">1</property>
-                                                <property name="top-attach">2</property>
+                                                <property name="left_attach">1</property>
+                                                <property name="top_attach">2</property>
                                               </packing>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
                                             </child>
                                             <child>
                                               <placeholder/>
@@ -3109,7 +3169,7 @@ This setting can make it easier to draw with touch. </property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid107">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Cursor</property>
                                   </object>
                                 </child>
@@ -3123,29 +3183,29 @@ This setting can make it easier to draw with touch. </property>
                             <child>
                               <object class="GtkFrame" id="sid108">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid109">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="bottom_padding">8</property>
+                                    <property name="left_padding">12</property>
+                                    <property name="right_padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="box19">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkCheckButton" id="cbShowSidebarRight">
                                             <property name="label" translatable="yes">Show sidebar on the right side</property>
                                             <property name="name">cbShowSidebarRight</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
+                                            <property name="draw_indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -3158,10 +3218,10 @@ This setting can make it easier to draw with touch. </property>
                                             <property name="label" translatable="yes">Show vertical scrollbar on the left side</property>
                                             <property name="name">cbShowScrollbarLeft</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
+                                            <property name="draw_indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -3176,7 +3236,7 @@ This setting can make it easier to draw with touch. </property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid110">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Left / Right-Handed</property>
                                   </object>
                                 </child>
@@ -3190,28 +3250,28 @@ This setting can make it easier to draw with touch. </property>
                             <child>
                               <object class="GtkFrame" id="sid111">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid112">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="bottom_padding">8</property>
+                                    <property name="left_padding">12</property>
+                                    <property name="right_padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="box42">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkCheckButton" id="cbHideHorizontalScrollbar">
                                             <property name="label" translatable="yes">Hide the horizontal scrollbar</property>
                                             <property name="name">cbHideHorizontalScrollbar</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="draw-indicator">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="draw_indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -3224,9 +3284,9 @@ This setting can make it easier to draw with touch. </property>
                                             <property name="label" translatable="yes">Hide the vertical scrollbar</property>
                                             <property name="name">cbHideVerticalScrollbar</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="draw-indicator">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="draw_indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -3238,9 +3298,9 @@ This setting can make it easier to draw with touch. </property>
                                           <object class="GtkCheckButton" id="cbDisableScrollbarFadeout">
                                             <property name="label" translatable="yes">Disable scrollbar fade out</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="draw-indicator">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="draw_indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -3255,7 +3315,7 @@ This setting can make it easier to draw with touch. </property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid113">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Scrollbars</property>
                                   </object>
                                 </child>
@@ -3269,29 +3329,29 @@ This setting can make it easier to draw with touch. </property>
                             <child>
                               <object class="GtkFrame" id="sid114">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid115">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="bottom_padding">8</property>
+                                    <property name="left_padding">12</property>
+                                    <property name="right_padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="vbox9">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkCheckButton" id="cbHideFullscreenMenubar">
                                             <property name="label" translatable="yes">Hide Menubar</property>
                                             <property name="name">cbHideFullscreenMenubar</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
+                                            <property name="draw_indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -3304,10 +3364,10 @@ This setting can make it easier to draw with touch. </property>
                                             <property name="label" translatable="yes">Hide Sidebar</property>
                                             <property name="name">cbHideFullscreenSidebar</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
+                                            <property name="draw_indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -3322,7 +3382,7 @@ This setting can make it easier to draw with touch. </property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid116">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Fullscreen</property>
                                   </object>
                                 </child>
@@ -3336,29 +3396,29 @@ This setting can make it easier to draw with touch. </property>
                             <child>
                               <object class="GtkFrame" id="sid117">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid118">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="bottom_padding">8</property>
+                                    <property name="left_padding">12</property>
+                                    <property name="right_padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="vbox1">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkCheckButton" id="cbHidePresentationMenubar">
                                             <property name="label" translatable="yes">Hide Menubar</property>
                                             <property name="name">cbHidePresentationMenubar</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
+                                            <property name="draw_indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -3371,10 +3431,10 @@ This setting can make it easier to draw with touch. </property>
                                             <property name="label" translatable="yes">Hide Sidebar</property>
                                             <property name="name">cbHidePresentationSidebar</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
+                                            <property name="draw_indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -3384,11 +3444,11 @@ This setting can make it easier to draw with touch. </property>
                                         </child>
                                         <child>
                                           <object class="GtkBox" id="box8">
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <child>
                                               <object class="GtkLabel" id="label16">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">Select toolbar:</property>
                                               </object>
                                               <packing>
@@ -3401,7 +3461,7 @@ This setting can make it easier to draw with touch. </property>
                                               <object class="GtkComboBoxText" id="comboboxtext1">
                                                 <property name="name">comboboxtext1</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
@@ -3423,7 +3483,7 @@ This setting can make it easier to draw with touch. </property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid119">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Presentation Mode</property>
                                   </object>
                                 </child>
@@ -3437,82 +3497,81 @@ This setting can make it easier to draw with touch. </property>
                             <child>
                               <object class="GtkFrame">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkAlignment">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="left-padding">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="left_padding">12</property>
                                     <child>
-                                      <!-- n-columns=2 n-rows=3 -->
                                       <object class="GtkGrid">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="column-spacing">10</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="column_spacing">10</property>
                                         <child>
                                           <object class="GtkLabel">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="halign">start</property>
                                             <property name="label" translatable="yes">Pre-load pages before</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">0</property>
+                                            <property name="left_attach">0</property>
+                                            <property name="top_attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="halign">start</property>
                                             <property name="label" translatable="yes">Pre-load pages after</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">1</property>
+                                            <property name="left_attach">0</property>
+                                            <property name="top_attach">1</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="preloadPagesBefore">
                                             <property name="name">preloadPagesBefore</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="input-purpose">number</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="input_purpose">number</property>
                                             <property name="adjustment">adjustmentPreloadPagesBefore</property>
                                             <property name="numeric">True</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">1</property>
-                                            <property name="top-attach">0</property>
+                                            <property name="left_attach">1</property>
+                                            <property name="top_attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="preloadPagesAfter">
                                             <property name="name">preloadPagesAfter</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="input-purpose">number</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="input_purpose">number</property>
                                             <property name="adjustment">adjustmentPreloadPagesAfter</property>
                                             <property name="numeric">True</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">1</property>
-                                            <property name="top-attach">1</property>
+                                            <property name="left_attach">1</property>
+                                            <property name="top_attach">1</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkCheckButton" id="cbEagerPageCleanup">
                                             <property name="label" translatable="yes">Clear cached paged while scrolling</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="draw-indicator">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="draw_indicator">True</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">2</property>
+                                            <property name="left_attach">0</property>
+                                            <property name="top_attach">2</property>
                                             <property name="width">2</property>
                                           </packing>
                                         </child>
@@ -3523,7 +3582,7 @@ This setting can make it easier to draw with touch. </property>
                                 <child type="label">
                                   <object class="GtkLabel">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Performance</property>
                                   </object>
                                 </child>
@@ -3554,142 +3613,132 @@ This setting can make it easier to draw with touch. </property>
               <object class="GtkLabel" id="viewTabLabel">
                 <property name="name">viewTabLabel</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">View</property>
               </object>
               <packing>
                 <property name="position">5</property>
-                <property name="tab-fill">False</property>
+                <property name="tab_fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="zoomTabBox">
                 <property name="name">zoomTabBox</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="margin-left">5</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid120">
                     <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="min-content-width">500</property>
-                    <property name="min-content-height">450</property>
+                    <property name="can_focus">True</property>
+                    <property name="min_content_width">500</property>
+                    <property name="min_content_height">450</property>
                     <child>
                       <object class="GtkViewport" id="sid121">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="shadow-type">none</property>
+                        <property name="can_focus">False</property>
+                        <property name="shadow_type">none</property>
                         <child>
                           <object class="GtkBox" id="sid122">
                             <property name="visible">True</property>
-                            <property name="can-focus">False</property>
+                            <property name="can_focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="sid123">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid124">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="bottom_padding">8</property>
+                                    <property name="left_padding">12</property>
+                                    <property name="right_padding">12</property>
                                     <child>
-                                      <!-- n-columns=3 n-rows=3 -->
                                       <object class="GtkGrid" id="sid125">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="column-spacing">5</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="column_spacing">5</property>
                                         <child>
                                           <object class="GtkLabel" id="settingZoomCtrlScrollSpeedLabel">
                                             <property name="name">settingZoomCtrlScrollSpeedLabel</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Speed for Ctrl + Scroll</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">0</property>
+                                            <property name="left_attach">0</property>
+                                            <property name="top_attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="spZoomStepScroll">
                                             <property name="name">spZoomStepScroll</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
+                                            <property name="can_focus">True</property>
                                             <property name="adjustment">adjustmentZoomStepScroll</property>
                                             <property name="digits">1</property>
                                             <property name="numeric">True</property>
                                             <property name="value">2</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">1</property>
-                                            <property name="top-attach">0</property>
+                                            <property name="left_attach">1</property>
+                                            <property name="top_attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="settingZoomStepSpeedLabel">
                                             <property name="name">settingZoomStepSpeedLabel</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Speed for a Zoomstep</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">1</property>
+                                            <property name="left_attach">0</property>
+                                            <property name="top_attach">1</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="spZoomStep">
                                             <property name="name">spZoomStep</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="margin-top">5</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="margin_top">5</property>
                                             <property name="adjustment">adjustmentZoomStep</property>
                                             <property name="digits">1</property>
                                             <property name="numeric">True</property>
                                             <property name="value">10</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">1</property>
-                                            <property name="top-attach">1</property>
+                                            <property name="left_attach">1</property>
+                                            <property name="top_attach">1</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="sid126">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">%</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">2</property>
-                                            <property name="top-attach">0</property>
+                                            <property name="left_attach">2</property>
+                                            <property name="top_attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="sid127">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">%</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">2</property>
-                                            <property name="top-attach">1</property>
+                                            <property name="left_attach">2</property>
+                                            <property name="top_attach">1</property>
                                           </packing>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
                                         </child>
                                       </object>
                                     </child>
@@ -3698,7 +3747,7 @@ This setting can make it easier to draw with touch. </property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid128">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Zoom Speed</property>
                                   </object>
                                 </child>
@@ -3712,27 +3761,27 @@ This setting can make it easier to draw with touch. </property>
                             <child>
                               <object class="GtkFrame" id="sid129">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid130">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="bottom_padding">8</property>
+                                    <property name="left_padding">12</property>
+                                    <property name="right_padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid131">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="sid132">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;To make sure on 100% zoom the size of elements is natural. (requires restart)&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
-                                            <property name="max-width-chars">85</property>
+                                            <property name="use_markup">True</property>
+                                            <property name="max_width_chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -3744,16 +3793,16 @@ This setting can make it easier to draw with touch. </property>
                                         <child>
                                           <object class="GtkBox" id="box5">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="orientation">vertical</property>
                                             <child>
                                               <object class="GtkLabel" id="label21">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="margin-top">5</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="margin_top">5</property>
                                                 <property name="label" translatable="yes">&lt;i&gt;Put a ruler on your screen and move the slider until both rulers match.&lt;/i&gt;</property>
-                                                <property name="use-markup">True</property>
-                                                <property name="max-width-chars">85</property>
+                                                <property name="use_markup">True</property>
+                                                <property name="max_width_chars">85</property>
                                                 <property name="xalign">0</property>
                                               </object>
                                               <packing>
@@ -3766,11 +3815,11 @@ This setting can make it easier to draw with touch. </property>
                                               <object class="GtkScale" id="zoomCallibSlider">
                                                 <property name="name">zoomCallibSlider</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="margin-top">10</property>
-                                                <property name="margin-bottom">20</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="margin_top">10</property>
+                                                <property name="margin_bottom">20</property>
                                                 <property name="adjustment">adjustmentZoom</property>
-                                                <property name="round-digits">0</property>
+                                                <property name="round_digits">0</property>
                                                 <property name="digits">0</property>
                                               </object>
                                               <packing>
@@ -3783,7 +3832,7 @@ This setting can make it easier to draw with touch. </property>
                                               <object class="GtkBox" id="zoomVBox">
                                                 <property name="name">zoomVBox</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="orientation">vertical</property>
                                                 <child>
                                                   <placeholder/>
@@ -3798,7 +3847,7 @@ This setting can make it easier to draw with touch. </property>
                                             <child>
                                               <object class="GtkLabel" id="label22">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">The unit of the ruler is cm</property>
                                               </object>
                                               <packing>
@@ -3821,7 +3870,7 @@ This setting can make it easier to draw with touch. </property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid133">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Display DPI Calibration</property>
                                   </object>
                                 </child>
@@ -3852,62 +3901,62 @@ This setting can make it easier to draw with touch. </property>
               <object class="GtkLabel" id="zoomTabLabel">
                 <property name="name">zoomTabLabel</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Zoom</property>
               </object>
               <packing>
                 <property name="position">6</property>
-                <property name="tab-fill">False</property>
+                <property name="tab_fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="drawingAreaTabBox">
                 <property name="name">drawingAreaTabBox</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="margin-left">5</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid134">
                     <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="min-content-width">500</property>
-                    <property name="min-content-height">450</property>
+                    <property name="can_focus">True</property>
+                    <property name="min_content_width">500</property>
+                    <property name="min_content_height">450</property>
                     <child>
                       <object class="GtkViewport" id="sid135">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="shadow-type">none</property>
+                        <property name="can_focus">False</property>
+                        <property name="shadow_type">none</property>
                         <child>
                           <object class="GtkBox" id="sid136">
                             <property name="visible">True</property>
-                            <property name="can-focus">False</property>
+                            <property name="can_focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="sid137">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid138">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="bottom_padding">8</property>
+                                    <property name="left_padding">12</property>
+                                    <property name="right_padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="box41">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="label37">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;If you add additional space beside the pages you can choose the area of the screen you would like to work on.&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
+                                            <property name="use_markup">True</property>
                                             <property name="wrap">True</property>
-                                            <property name="max-width-chars">85</property>
+                                            <property name="max_width_chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -3917,111 +3966,101 @@ This setting can make it easier to draw with touch. </property>
                                           </packing>
                                         </child>
                                         <child>
-                                          <!-- n-columns=3 n-rows=3 -->
                                           <object class="GtkGrid" id="sid139">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="row-spacing">5</property>
-                                            <property name="column-spacing">5</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="row_spacing">5</property>
+                                            <property name="column_spacing">5</property>
                                             <child>
                                               <object class="GtkCheckButton" id="cbAddVerticalSpace">
                                                 <property name="name">cbAddVerticalSpace</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="receives-default">False</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="receives_default">False</property>
                                                 <property name="xalign">0</property>
-                                                <property name="draw-indicator">True</property>
+                                                <property name="draw_indicator">True</property>
                                                 <child>
                                                   <object class="GtkLabel" id="label38">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
+                                                    <property name="can_focus">False</property>
                                                     <property name="label" translatable="yes">Add additional vertical space of</property>
-                                                    <property name="use-markup">True</property>
+                                                    <property name="use_markup">True</property>
                                                   </object>
                                                 </child>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">0</property>
-                                                <property name="top-attach">0</property>
+                                                <property name="left_attach">0</property>
+                                                <property name="top_attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkCheckButton" id="cbAddHorizontalSpace">
                                                 <property name="name">cbAddHorizontalSpace</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="receives-default">False</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="receives_default">False</property>
                                                 <property name="xalign">0</property>
-                                                <property name="draw-indicator">True</property>
+                                                <property name="draw_indicator">True</property>
                                                 <child>
                                                   <object class="GtkLabel" id="label39">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
+                                                    <property name="can_focus">False</property>
                                                     <property name="label" translatable="yes">Add additional horizontal space of</property>
-                                                    <property name="use-markup">True</property>
+                                                    <property name="use_markup">True</property>
                                                     <property name="ellipsize">end</property>
                                                   </object>
                                                 </child>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">0</property>
-                                                <property name="top-attach">1</property>
+                                                <property name="left_attach">0</property>
+                                                <property name="top_attach">1</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkSpinButton" id="spAddVerticalSpace">
                                                 <property name="name">spAddVerticalSpace</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
+                                                <property name="can_focus">True</property>
                                                 <property name="adjustment">adjustmentVerticalSpace</property>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">1</property>
-                                                <property name="top-attach">0</property>
+                                                <property name="left_attach">1</property>
+                                                <property name="top_attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkSpinButton" id="spAddHorizontalSpace">
                                                 <property name="name">spAddHorizontalSpace</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
+                                                <property name="can_focus">True</property>
                                                 <property name="adjustment">adjustmentHorizontalSpace</property>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">1</property>
-                                                <property name="top-attach">1</property>
+                                                <property name="left_attach">1</property>
+                                                <property name="top_attach">1</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkLabel" id="sid140">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">pixels</property>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">2</property>
-                                                <property name="top-attach">0</property>
+                                                <property name="left_attach">2</property>
+                                                <property name="top_attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkLabel" id="sid141">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">pixels</property>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">2</property>
-                                                <property name="top-attach">1</property>
+                                                <property name="left_attach">2</property>
+                                                <property name="top_attach">1</property>
                                               </packing>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
                                             </child>
                                           </object>
                                           <packing>
@@ -4037,7 +4076,7 @@ This setting can make it easier to draw with touch. </property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid142">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Scrolling outside the page</property>
                                   </object>
                                 </child>
@@ -4051,71 +4090,49 @@ This setting can make it easier to draw with touch. </property>
                             <child>
                               <object class="GtkFrame" id="sid143">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid144">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="bottom_padding">8</property>
+                                    <property name="left_padding">12</property>
+                                    <property name="right_padding">12</property>
                                     <child>
-                                      <!-- n-columns=3 n-rows=3 -->
                                       <object class="GtkGrid" id="grid4">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="column-spacing">5</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="column_spacing">5</property>
                                         <child>
                                           <object class="GtkLabel" id="label58a">
                                             <property name="name">label58a</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="tooltip-markup" translatable="yes">Offset first page this many pages when &lt;b&gt;Pair Pages&lt;/b&gt; enabled</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="tooltip_markup" translatable="yes">Offset first page this many pages when &lt;b&gt;Pair Pages&lt;/b&gt; enabled</property>
                                             <property name="label" translatable="yes">First Page Offset </property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">0</property>
+                                            <property name="left_attach">0</property>
+                                            <property name="top_attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="spPairsOffset">
                                             <property name="name">spPairsOffset</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="tooltip-text" translatable="yes">Usually 0 or 1</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="tooltip_text" translatable="yes">Usually 0 or 1</property>
                                             <property name="valign">start</property>
-                                            <property name="max-width-chars">0</property>
+                                            <property name="max_width_chars">0</property>
                                             <property name="adjustment">adjustmentPairsOffset</property>
                                             <property name="numeric">True</property>
-                                            <property name="update-policy">if-valid</property>
+                                            <property name="update_policy">if-valid</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">1</property>
-                                            <property name="top-attach">0</property>
+                                            <property name="left_attach">1</property>
+                                            <property name="top_attach">0</property>
                                           </packing>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
                                         </child>
                                       </object>
                                     </child>
@@ -4124,7 +4141,7 @@ This setting can make it easier to draw with touch. </property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid145">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Paired Pages</property>
                                   </object>
                                 </child>
@@ -4138,87 +4155,68 @@ This setting can make it easier to draw with touch. </property>
                             <child>
                               <object class="GtkFrame" id="sid150">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid151">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="bottom_padding">8</property>
+                                    <property name="left_padding">12</property>
+                                    <property name="right_padding">12</property>
                                     <child>
-                                      <!-- n-columns=3 n-rows=3 -->
                                       <object class="GtkGrid" id="grid6">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="column-spacing">5</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="column_spacing">5</property>
                                         <child>
                                           <object class="GtkCheckButton" id="cbDrawDirModsEnabled">
                                             <property name="label" translatable="yes">Enable  with determination radius of </property>
                                             <property name="name">cbDrawDirModsEnabled</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="tooltip-markup" translatable="yes">Drag LEFT from start point acts like shift key is being held.
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="tooltip_markup" translatable="yes">Drag LEFT from start point acts like shift key is being held.
 Drag UP acts as if Control key is being held.
 
 Determination Radius: Radius at which modifiers will lock in until finished drawing.
 
 &lt;i&gt;Useful for operating without keyboard.&lt;/i&gt;</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
+                                            <property name="draw_indicator">True</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">0</property>
+                                            <property name="left_attach">0</property>
+                                            <property name="top_attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="spDrawDirModsRadius">
                                             <property name="name">spDrawDirModsRadius</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
+                                            <property name="can_focus">True</property>
                                             <property name="valign">start</property>
-                                            <property name="max-width-chars">0</property>
+                                            <property name="max_width_chars">0</property>
                                             <property name="adjustment">adjustmentDrawDirModRadius</property>
                                             <property name="numeric">True</property>
-                                            <property name="update-policy">if-valid</property>
+                                            <property name="update_policy">if-valid</property>
                                             <property name="value">50</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">1</property>
-                                            <property name="top-attach">0</property>
+                                            <property name="left_attach">1</property>
+                                            <property name="top_attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="sid152">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">pixels</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">2</property>
-                                            <property name="top-attach">0</property>
+                                            <property name="left_attach">2</property>
+                                            <property name="top_attach">0</property>
                                           </packing>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
                                         </child>
                                       </object>
                                     </child>
@@ -4227,7 +4225,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                 <child type="label">
                                   <object class="GtkLabel" id="sid153">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Drawing Tools - Set Modifiers by Draw Direction (Experimental)</property>
                                   </object>
                                 </child>
@@ -4241,58 +4239,33 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                             <child>
                               <object class="GtkFrame" id="sid 155">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkAlignment">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="left-padding">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="left_padding">12</property>
                                     <child>
-                                      <!-- n-columns=3 n-rows=3 -->
                                       <object class="GtkGrid">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <child>
                                           <object class="GtkCheckButton" id="cbRestoreLineWidthEnabled">
                                             <property name="label" translatable="yes">Preserve line width</property>
                                             <property name="name">cbRestoreLineWidthEnabled</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="tooltip-markup" translatable="yes">After resizing a selection, the line width of all strokes will be the same as before the resizing operation. </property>
-                                            <property name="margin-bottom">2</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="tooltip_markup" translatable="yes">After resizing a selection, the line width of all strokes will be the same as before the resizing operation. </property>
+                                            <property name="margin_bottom">2</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
+                                            <property name="draw_indicator">True</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">0</property>
+                                            <property name="left_attach">0</property>
+                                            <property name="top_attach">0</property>
                                           </packing>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
                                         </child>
                                       </object>
                                     </child>
@@ -4301,7 +4274,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                 <child type="label">
                                   <object class="GtkLabel">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Resizing</property>
                                   </object>
                                 </child>
@@ -4315,120 +4288,110 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                             <child>
                               <object class="GtkFrame" id="sid146">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid147">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="bottom_padding">8</property>
+                                    <property name="left_padding">12</property>
+                                    <property name="right_padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="box51">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <property name="spacing">6</property>
                                         <child>
-                                          <!-- n-columns=3 n-rows=3 -->
                                           <object class="GtkGrid" id="sid148">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="row-spacing">5</property>
-                                            <property name="column-spacing">5</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="row_spacing">5</property>
+                                            <property name="column_spacing">5</property>
                                             <child>
                                               <object class="GtkLabel" id="lbSnapRotationTolerance">
                                                 <property name="name">lbSnapRotationTolerance</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">Rotation snapping tolerance</property>
                                                 <property name="xalign">0</property>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">0</property>
-                                                <property name="top-attach">0</property>
+                                                <property name="left_attach">0</property>
+                                                <property name="top_attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkLabel" id="lbSnapGridTolerance">
                                                 <property name="name">lbSnapGridTolerance</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">Grid snapping tolerance</property>
                                                 <property name="xalign">0</property>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">0</property>
-                                                <property name="top-attach">1</property>
+                                                <property name="left_attach">0</property>
+                                                <property name="top_attach">1</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkSpinButton" id="spSnapRotationTolerance">
                                                 <property name="name">spSnapRotationTolerance</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
+                                                <property name="can_focus">True</property>
                                                 <property name="adjustment">adjustmentSnapRotationTolerance</property>
-                                                <property name="climb-rate">0.05</property>
+                                                <property name="climb_rate">0.050000000000000003</property>
                                                 <property name="digits">2</property>
-                                                <property name="value">0.20</property>
+                                                <property name="value">0.20000000000000001</property>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">1</property>
-                                                <property name="top-attach">0</property>
+                                                <property name="left_attach">1</property>
+                                                <property name="top_attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkSpinButton" id="spSnapGridTolerance">
                                                 <property name="name">spSnapGridTolerance</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
+                                                <property name="can_focus">True</property>
                                                 <property name="adjustment">adjustmentSnapGridTolerance</property>
-                                                <property name="climb-rate">0.05</property>
+                                                <property name="climb_rate">0.050000000000000003</property>
                                                 <property name="digits">2</property>
                                                 <property name="value">0.25</property>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">1</property>
-                                                <property name="top-attach">1</property>
+                                                <property name="left_attach">1</property>
+                                                <property name="top_attach">1</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkLabel" id="lbSnapGridSize">
                                                 <property name="name">lbSnapGridSize</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">Grid size</property>
                                                 <property name="xalign">0</property>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">0</property>
-                                                <property name="top-attach">2</property>
+                                                <property name="left_attach">0</property>
+                                                <property name="top_attach">2</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkSpinButton" id="spSnapGridSize">
                                                 <property name="name">spSnapGridSize</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
+                                                <property name="can_focus">True</property>
                                                 <property name="adjustment">adjustmentSnapGridSize</property>
-                                                <property name="climb-rate">0.01</property>
+                                                <property name="climb_rate">0.01</property>
                                                 <property name="digits">2</property>
                                                 <property name="value">1</property>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">1</property>
-                                                <property name="top-attach">2</property>
+                                                <property name="left_attach">1</property>
+                                                <property name="top_attach">2</property>
                                               </packing>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
                                             </child>
                                           </object>
                                           <packing>
@@ -4441,11 +4404,11 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                           <object class="GtkCheckButton" id="cbSnapRecognizedShapesEnabled">
                                             <property name="label" translatable="yes">Use snapping for recognized shapes</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="tooltip-text" translatable="yes">If activated, shapes that have been recognized by the shape recognizer will be snapped to the grid automatically. This may lead to unexpected results if you have the shape recognizer turned on while writing.</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="tooltip_text" translatable="yes">If activated, shapes that have been recognized by the shape recognizer will be snapped to the grid automatically. This may lead to unexpected results if you have the shape recognizer turned on while writing.</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
+                                            <property name="draw_indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -4460,7 +4423,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                 <child type="label">
                                   <object class="GtkLabel" id="sid149">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Snapping</property>
                                   </object>
                                 </child>
@@ -4474,129 +4437,128 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                             <child>
                               <object class="GtkFrame" id="sid154">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid155">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="bottom_padding">8</property>
+                                    <property name="left_padding">12</property>
+                                    <property name="right_padding">12</property>
                                     <child>
-                                      <!-- n-columns=4 n-rows=3 -->
                                       <object class="GtkGrid" id="grid1">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="column-spacing">5</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="column_spacing">5</property>
                                         <child>
                                           <object class="GtkCheckButton" id="cbStrokeFilterEnabled">
                                             <property name="label" translatable="yes">Enable Tap action</property>
                                             <property name="name">cbStrokeFilterEnabled</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="tooltip-markup" translatable="yes">Do not draw for inputs of short time and length unless it comes in short succession. Instead, show floating toolbox.</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="tooltip_markup" translatable="yes">Do not draw for inputs of short time and length unless it comes in short succession. Instead, show floating toolbox.</property>
                                             <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
+                                            <property name="draw_indicator">True</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">0</property>
+                                            <property name="left_attach">0</property>
+                                            <property name="top_attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="sid156">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Ignore Time (ms)</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">1</property>
-                                            <property name="top-attach">0</property>
+                                            <property name="left_attach">1</property>
+                                            <property name="top_attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="spStrokeIgnoreTime">
                                             <property name="name">spStrokeIgnoreTime</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="tooltip-markup" translatable="yes">How short (time)  AND...
+                                            <property name="can_focus">True</property>
+                                            <property name="tooltip_markup" translatable="yes">How short (time)  AND...
 
 &lt;i&gt;Recommended: 150ms&lt;/i&gt;</property>
                                             <property name="valign">start</property>
-                                            <property name="max-width-chars">0</property>
+                                            <property name="max_width_chars">0</property>
                                             <property name="adjustment">adjustmentStrokeIgnoreTime</property>
                                             <property name="numeric">True</property>
-                                            <property name="update-policy">if-valid</property>
+                                            <property name="update_policy">if-valid</property>
                                             <property name="value">150</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">1</property>
-                                            <property name="top-attach">1</property>
+                                            <property name="left_attach">1</property>
+                                            <property name="top_attach">1</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="spStrokeIgnoreLength">
                                             <property name="name">spStrokeIgnoreLength</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="tooltip-markup" translatable="yes">How short (screen mm)  of the stroke  AND...
+                                            <property name="can_focus">True</property>
+                                            <property name="tooltip_markup" translatable="yes">How short (screen mm)  of the stroke  AND...
 
 &lt;i&gt;Recommended: 1 mm&lt;/i&gt;</property>
                                             <property name="valign">start</property>
-                                            <property name="max-width-chars">0</property>
+                                            <property name="max_width_chars">0</property>
                                             <property name="adjustment">adjustmentStrokeIgnoreLength</property>
                                             <property name="digits">2</property>
                                             <property name="numeric">True</property>
-                                            <property name="update-policy">if-valid</property>
+                                            <property name="update_policy">if-valid</property>
                                             <property name="value">1</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">2</property>
-                                            <property name="top-attach">1</property>
+                                            <property name="left_attach">2</property>
+                                            <property name="top_attach">1</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="sid157">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Max Length (mm)</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">2</property>
-                                            <property name="top-attach">0</property>
+                                            <property name="left_attach">2</property>
+                                            <property name="top_attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="sid158">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Successive (ms)</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">3</property>
-                                            <property name="top-attach">0</property>
+                                            <property name="left_attach">3</property>
+                                            <property name="top_attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="spStrokeSuccessiveTime">
                                             <property name="name">spStrokeSuccessiveTime</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="tooltip-markup" translatable="yes">... AND How much time must have passed since last stroke.
+                                            <property name="can_focus">True</property>
+                                            <property name="tooltip_markup" translatable="yes">... AND How much time must have passed since last stroke.
 
 &lt;i&gt;Recommended: 500ms&lt;/i&gt;</property>
                                             <property name="valign">start</property>
-                                            <property name="max-width-chars">0</property>
+                                            <property name="max_width_chars">0</property>
                                             <property name="adjustment">adjustmentStrokeSuccessiveTime</property>
                                             <property name="numeric">True</property>
-                                            <property name="update-policy">if-valid</property>
+                                            <property name="update_policy">if-valid</property>
                                             <property name="value">500</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">3</property>
-                                            <property name="top-attach">1</property>
+                                            <property name="left_attach">3</property>
+                                            <property name="top_attach">1</property>
                                           </packing>
                                         </child>
                                         <child>
@@ -4604,31 +4566,31 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                             <property name="label" translatable="yes">Try to select object first.</property>
                                             <property name="name">cbTrySelectOnStrokeFiltered</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="tooltip-markup" translatable="yes">Try to select object first; if nothing selected then show floating toolbox if enabled.</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="tooltip_markup" translatable="yes">Try to select object first; if nothing selected then show floating toolbox if enabled.</property>
                                             <property name="xalign">0</property>
-                                            <property name="yalign">0.4399999976158142</property>
-                                            <property name="draw-indicator">True</property>
+                                            <property name="yalign">0.43999999761581421</property>
+                                            <property name="draw_indicator">True</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">1</property>
-                                            <property name="top-attach">2</property>
+                                            <property name="left_attach">1</property>
+                                            <property name="top_attach">2</property>
                                             <property name="width">3</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="label1">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="tooltip-text" translatable="yes">All three conditions must be met before stroke is ignored.
+                                            <property name="can_focus">False</property>
+                                            <property name="tooltip_text" translatable="yes">All three conditions must be met before stroke is ignored.
 It must be short in time and length and we can't have ignored another stroke recently.</property>
                                             <property name="halign">end</property>
                                             <property name="label" translatable="yes">Settings:</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">1</property>
+                                            <property name="left_attach">0</property>
+                                            <property name="top_attach">1</property>
                                           </packing>
                                         </child>
                                         <child>
@@ -4636,16 +4598,16 @@ It must be short in time and length and we can't have ignored another stroke rec
                                             <property name="label" translatable="yes">Show Floating Toolbox</property>
                                             <property name="name">cbDoActionOnStrokeFiltered</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="tooltip-markup" translatable="yes">Try to select object first; if nothing selected then show floating toolbox if enabled.</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="tooltip_markup" translatable="yes">Try to select object first; if nothing selected then show floating toolbox if enabled.</property>
                                             <property name="xalign">0</property>
                                             <property name="yalign">0.43000000715255737</property>
-                                            <property name="draw-indicator">True</property>
+                                            <property name="draw_indicator">True</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">2</property>
+                                            <property name="left_attach">0</property>
+                                            <property name="top_attach">2</property>
                                           </packing>
                                         </child>
                                       </object>
@@ -4655,7 +4617,7 @@ It must be short in time and length and we can't have ignored another stroke rec
                                 <child type="label">
                                   <object class="GtkLabel" id="sid159">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Action on Tool Tap</property>
                                   </object>
                                 </child>
@@ -4669,29 +4631,29 @@ It must be short in time and length and we can't have ignored another stroke rec
                             <child>
                               <object class="GtkFrame" id="framePDFCacheOptions">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkAlignment" id="alignPDFCacheOptions">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="bottom_padding">8</property>
+                                    <property name="left_padding">12</property>
+                                    <property name="right_padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="boxReRenderSetting">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="lblReRenderMoreOftenWhileZooming">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;Re-render PDF backgrounds more often while zooming for better render quality. 
 &lt;b&gt;Note:&lt;/b&gt; This should not affect print quality.&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
+                                            <property name="use_markup">True</property>
                                             <property name="wrap">True</property>
-                                            <property name="max-width-chars">85</property>
+                                            <property name="max_width_chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -4701,55 +4663,54 @@ It must be short in time and length and we can't have ignored another stroke rec
                                           </packing>
                                         </child>
                                         <child>
-                                          <!-- n-columns=3 n-rows=1 -->
                                           <object class="GtkGrid" id="gdRecacheOptions">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="row-spacing">5</property>
-                                            <property name="column-spacing">5</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="row_spacing">5</property>
+                                            <property name="column_spacing">5</property>
                                             <child>
                                               <object class="GtkLabel" id="lbReRenderThreshold">
                                                 <property name="name">lbSnapRotationTolerance</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="tooltip-text" translatable="yes">When zoomed in on a high-resolution PDF, each re-render can take a long time. Setting this to a large value causes these re-renders to happen less often.
+                                                <property name="can_focus">False</property>
+                                                <property name="tooltip_text" translatable="yes">When zoomed in on a high-resolution PDF, each re-render can take a long time. Setting this to a large value causes these re-renders to happen less often.
 
 Set this to 0% to always re-render on zoom.</property>
                                                 <property name="label" translatable="yes">Re-render when the page's zoom changes by more than </property>
                                                 <property name="xalign">0</property>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">0</property>
-                                                <property name="top-attach">0</property>
+                                                <property name="left_attach">0</property>
+                                                <property name="top_attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkSpinButton" id="spReRenderThreshold">
                                                 <property name="name">spSnapRotationTolerance</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
+                                                <property name="can_focus">True</property>
                                                 <property name="text" translatable="yes">0.00</property>
-                                                <property name="input-purpose">number</property>
+                                                <property name="input_purpose">number</property>
                                                 <property name="adjustment">adjustmentReRenderThreshold</property>
-                                                <property name="climb-rate">2</property>
+                                                <property name="climb_rate">2</property>
                                                 <property name="numeric">True</property>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">1</property>
-                                                <property name="top-attach">0</property>
+                                                <property name="left_attach">1</property>
+                                                <property name="top_attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkLabel" id="lbReRenderThresholdEnding">
                                                 <property name="name">lbSnapRotationTolerance</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">%.</property>
                                                 <property name="xalign">0</property>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">2</property>
-                                                <property name="top-attach">0</property>
+                                                <property name="left_attach">2</property>
+                                                <property name="top_attach">0</property>
                                               </packing>
                                             </child>
                                           </object>
@@ -4766,7 +4727,7 @@ Set this to 0% to always re-render on zoom.</property>
                                 <child type="label">
                                   <object class="GtkLabel" id="headerPdfCaching">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">PDF Cache</property>
                                   </object>
                                 </child>
@@ -4797,61 +4758,61 @@ Set this to 0% to always re-render on zoom.</property>
               <object class="GtkLabel" id="drawingAreaTabLabel">
                 <property name="name">drawingAreaTabLabel</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Drawing Area</property>
               </object>
               <packing>
                 <property name="position">7</property>
-                <property name="tab-fill">False</property>
+                <property name="tab_fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="defaultTabBox">
                 <property name="name">defaultTabBox</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="margin-left">5</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid160">
                     <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="min-content-width">500</property>
-                    <property name="min-content-height">450</property>
+                    <property name="can_focus">True</property>
+                    <property name="min_content_width">500</property>
+                    <property name="min_content_height">450</property>
                     <child>
                       <object class="GtkViewport" id="sid161">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="shadow-type">none</property>
+                        <property name="can_focus">False</property>
+                        <property name="shadow_type">none</property>
                         <child>
                           <object class="GtkBox" id="sid162">
                             <property name="visible">True</property>
-                            <property name="can-focus">False</property>
+                            <property name="can_focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="sid163">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid164">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="bottom_padding">8</property>
+                                    <property name="left_padding">12</property>
+                                    <property name="right_padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid165">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="label9">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;Select the tool and Settings if you press the Default Button.&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
-                                            <property name="max-width-chars">85</property>
+                                            <property name="use_markup">True</property>
+                                            <property name="max_width_chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -4865,7 +4826,7 @@ Set this to 0% to always re-render on zoom.</property>
                                           <object class="GtkBox" id="hboxDefaultTool">
                                             <property name="name">hboxDefaultTool</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <child>
                                               <placeholder/>
                                             </child>
@@ -4886,11 +4847,11 @@ Set this to 0% to always re-render on zoom.</property>
                                 <child type="label">
                                   <object class="GtkBox" id="box1">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <child>
                                       <object class="GtkImage" id="image2">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="pixbuf">pixmaps/default.svg</property>
                                       </object>
                                       <packing>
@@ -4902,9 +4863,9 @@ Set this to 0% to always re-render on zoom.</property>
                                     <child>
                                       <object class="GtkLabel" id="label8">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="label" translatable="yes">&lt;b&gt;Default&lt;/b&gt;</property>
-                                        <property name="use-markup">True</property>
+                                        <property name="use_markup">True</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -4942,61 +4903,62 @@ Set this to 0% to always re-render on zoom.</property>
               <object class="GtkLabel" id="defaultTabLabel">
                 <property name="name">defaultTabLabel</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Defaults</property>
               </object>
               <packing>
                 <property name="position">8</property>
-                <property name="tab-fill">False</property>
+                <property name="tab_fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="audioRecordingTabBox">
                 <property name="name">audioRecordingTabBox</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="margin-left">5</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid166">
                     <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="min-content-width">500</property>
-                    <property name="min-content-height">450</property>
+                    <property name="can_focus">True</property>
+                    <property name="min_content_width">500</property>
+                    <property name="min_content_height">450</property>
                     <child>
                       <object class="GtkViewport" id="sid167">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="shadow-type">none</property>
+                        <property name="can_focus">False</property>
+                        <property name="shadow_type">none</property>
                         <child>
                           <object class="GtkBox" id="sid168">
                             <property name="visible">True</property>
-                            <property name="can-focus">False</property>
+                            <property name="can_focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="sid169">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid170">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="bottom_padding">8</property>
+                                    <property name="left_padding">12</property>
+                                    <property name="right_padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid171">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="label45">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;Audio recordings are currently stored in a separate folder and referenced from the journal.&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
-                                            <property name="max-width-chars">85</property>
+                                            <property name="use_markup">True</property>
+                                            <property name="single_line_mode">True</property>
+                                            <property name="max_width_chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -5006,58 +4968,36 @@ Set this to 0% to always re-render on zoom.</property>
                                           </packing>
                                         </child>
                                         <child>
-                                          <!-- n-columns=3 n-rows=3 -->
                                           <object class="GtkGrid" id="grid5">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="row-spacing">10</property>
-                                            <property name="column-spacing">10</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="row_spacing">10</property>
+                                            <property name="column_spacing">10</property>
                                             <child>
                                               <object class="GtkLabel" id="label46">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">Storage Folder</property>
                                                 <property name="xalign">0</property>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">0</property>
-                                                <property name="top-attach">0</property>
+                                                <property name="left_attach">0</property>
+                                                <property name="top_attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkFileChooserButton" id="fcAudioPath">
                                                 <property name="name">fcAudioPath</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="hexpand">True</property>
                                                 <property name="action">select-folder</property>
                                                 <property name="title" translatable="yes">Select Folder</property>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">1</property>
-                                                <property name="top-attach">0</property>
+                                                <property name="left_attach">1</property>
+                                                <property name="top_attach">0</property>
                                               </packing>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
                                             </child>
                                           </object>
                                           <packing>
@@ -5073,7 +5013,7 @@ Set this to 0% to always re-render on zoom.</property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid172">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Storage Folder</property>
                                   </object>
                                 </child>
@@ -5087,29 +5027,29 @@ Set this to 0% to always re-render on zoom.</property>
                             <child>
                               <object class="GtkFrame" id="sid173">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid174">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="bottom_padding">8</property>
+                                    <property name="left_padding">12</property>
+                                    <property name="right_padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid175">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="sid176">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;Specify the audio devices used for recording and playback of audio attachments.
 If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as input / output device.&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
+                                            <property name="use_markup">True</property>
                                             <property name="wrap">True</property>
-                                            <property name="max-width-chars">85</property>
+                                            <property name="max_width_chars">85</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
@@ -5119,72 +5059,56 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                           </packing>
                                         </child>
                                         <child>
-                                          <!-- n-columns=3 n-rows=3 -->
                                           <object class="GtkGrid" id="grid8">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="row-spacing">10</property>
-                                            <property name="column-spacing">10</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="row_spacing">10</property>
+                                            <property name="column_spacing">10</property>
                                             <child>
                                               <object class="GtkLabel" id="label36">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">Input Device</property>
                                                 <property name="xalign">0</property>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">0</property>
-                                                <property name="top-attach">0</property>
+                                                <property name="left_attach">0</property>
+                                                <property name="top_attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkComboBoxText" id="cbAudioInputDevice">
                                                 <property name="name">cbAudioInputDevice</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">1</property>
-                                                <property name="top-attach">0</property>
+                                                <property name="left_attach">1</property>
+                                                <property name="top_attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkLabel" id="label58">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">Output Device</property>
                                                 <property name="xalign">0</property>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">0</property>
-                                                <property name="top-attach">1</property>
+                                                <property name="left_attach">0</property>
+                                                <property name="top_attach">1</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkComboBoxText" id="cbAudioOutputDevice">
                                                 <property name="name">cbAudioOutputDevice</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">1</property>
-                                                <property name="top-attach">1</property>
+                                                <property name="left_attach">1</property>
+                                                <property name="top_attach">1</property>
                                               </packing>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
                                             </child>
                                           </object>
                                           <packing>
@@ -5200,7 +5124,7 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                 <child type="label">
                                   <object class="GtkLabel" id="sid177">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Audio Devices</property>
                                   </object>
                                 </child>
@@ -5214,51 +5138,50 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                             <child>
                               <object class="GtkFrame" id="sid178">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid179">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="bottom_padding">8</property>
+                                    <property name="left_padding">12</property>
+                                    <property name="right_padding">12</property>
                                     <child>
-                                      <!-- n-columns=3 n-rows=3 -->
                                       <object class="GtkGrid" id="sid180">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="row-spacing">10</property>
-                                        <property name="column-spacing">10</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="row_spacing">10</property>
+                                        <property name="column_spacing">10</property>
                                         <child>
                                           <object class="GtkLabel" id="label59">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Sample Rate</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">0</property>
+                                            <property name="left_attach">0</property>
+                                            <property name="top_attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="label61">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Gain</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">1</property>
+                                            <property name="left_attach">0</property>
+                                            <property name="top_attach">1</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkComboBoxText" id="cbAudioSampleRate">
                                             <property name="name">cbAudioSampleRate</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="active">0</property>
                                             <items>
                                               <item id="16000">16000 Hz</item>
@@ -5268,40 +5191,25 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                             </items>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">1</property>
-                                            <property name="top-attach">0</property>
+                                            <property name="left_attach">1</property>
+                                            <property name="top_attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="spAudioGain">
                                             <property name="name">spAudioGain</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
+                                            <property name="can_focus">True</property>
                                             <property name="adjustment">adjustmentAudioGain</property>
-                                            <property name="climb-rate">0.10</property>
+                                            <property name="climb_rate">0.10000000000000001</property>
                                             <property name="digits">2</property>
                                             <property name="numeric">True</property>
                                             <property name="value">1</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">1</property>
-                                            <property name="top-attach">1</property>
+                                            <property name="left_attach">1</property>
+                                            <property name="top_attach">1</property>
                                           </packing>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
                                         </child>
                                       </object>
                                     </child>
@@ -5310,7 +5218,7 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                 <child type="label">
                                   <object class="GtkLabel" id="sid181">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Recording Quality</property>
                                   </object>
                                 </child>
@@ -5324,71 +5232,49 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                             <child>
                               <object class="GtkFrame" id="sid1">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid2">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="bottom_padding">8</property>
+                                    <property name="left_padding">12</property>
+                                    <property name="right_padding">12</property>
                                     <child>
-                                      <!-- n-columns=3 n-rows=3 -->
                                       <object class="GtkGrid" id="sid3">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="row-spacing">10</property>
-                                        <property name="column-spacing">10</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="row_spacing">10</property>
+                                        <property name="column_spacing">10</property>
                                         <child>
                                           <object class="GtkLabel" id="label3">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Default Seek Time (in seconds)</property>
                                             <property name="xalign">0</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">0</property>
+                                            <property name="left_attach">0</property>
+                                            <property name="top_attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="spDefaultSeekTime">
                                             <property name="name">spAudioGain</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
+                                            <property name="can_focus">True</property>
                                             <property name="text" translatable="yes">1,00</property>
                                             <property name="adjustment">adjustmentSeekTime</property>
-                                            <property name="climb-rate">0.10</property>
+                                            <property name="climb_rate">0.10000000000000001</property>
                                             <property name="digits">2</property>
                                             <property name="numeric">True</property>
                                             <property name="value">1</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">1</property>
-                                            <property name="top-attach">0</property>
+                                            <property name="left_attach">1</property>
+                                            <property name="top_attach">0</property>
                                           </packing>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
                                         </child>
                                       </object>
                                     </child>
@@ -5397,7 +5283,7 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                 <child type="label">
                                   <object class="GtkLabel" id="sid4">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Playback Settings</property>
                                   </object>
                                 </child>
@@ -5411,10 +5297,10 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                             <child>
                               <object class="GtkLabel" id="sid182">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
+                                <property name="can_focus">False</property>
                                 <property name="label" translatable="yes">&lt;i&gt;Changes take only effect on new recordings and playbacks.&lt;/i&gt;</property>
-                                <property name="use-markup">True</property>
-                                <property name="max-width-chars">85</property>
+                                <property name="use_markup">True</property>
+                                <property name="max_width_chars">85</property>
                                 <property name="xalign">0</property>
                               </object>
                               <packing>
@@ -5443,19 +5329,19 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
               <object class="GtkLabel" id="audioRecordingTabLabel">
                 <property name="name">audioRecordingTabLabel</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Audio Recording</property>
               </object>
               <packing>
                 <property name="position">9</property>
-                <property name="tab-fill">False</property>
+                <property name="tab_fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="latexTabBox">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="margin-left">5</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <placeholder/>
@@ -5468,61 +5354,61 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
             <child type="tab">
               <object class="GtkLabel" id="latexTabLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">LaTeX</property>
               </object>
               <packing>
                 <property name="position">11</property>
-                <property name="tab-fill">False</property>
+                <property name="tab_fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="languageTabBox">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="margin-left">5</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid189">
                     <property name="visible">True</property>
-                    <property name="can-focus">True</property>
+                    <property name="can_focus">True</property>
                     <child>
                       <object class="GtkViewport" id="sid190">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="shadow-type">none</property>
+                        <property name="can_focus">False</property>
+                        <property name="shadow_type">none</property>
                         <child>
                           <object class="GtkBox" id="sid191">
                             <property name="visible">True</property>
-                            <property name="can-focus">False</property>
+                            <property name="can_focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="sid192">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="margin-left">4</property>
-                                <property name="margin-top">3</property>
-                                <property name="margin-bottom">3</property>
-                                <property name="border-width">2</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="margin_left">4</property>
+                                <property name="margin_top">3</property>
+                                <property name="margin_bottom">3</property>
+                                <property name="border_width">2</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkAlignment" id="sid193">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="bottom-padding">12</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="bottom_padding">12</property>
+                                    <property name="left_padding">12</property>
+                                    <property name="right_padding">12</property>
                                     <child>
                                       <object class="GtkBox" id="sid194">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="label195">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;Select language (requires restart)&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
+                                            <property name="use_markup">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -5533,19 +5419,19 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                         <child>
                                           <object class="GtkFrame" id="sid195">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label-xalign">0.009999999776482582</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="label_xalign">0.0099999997764825821</property>
                                             <child>
                                               <object class="GtkAlignment" id="sid196">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="bottom-padding">8</property>
-                                                <property name="left-padding">12</property>
-                                                <property name="right-padding">12</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="bottom_padding">8</property>
+                                                <property name="left_padding">12</property>
+                                                <property name="right_padding">12</property>
                                                 <child>
                                                   <object class="GtkBox" id="hboxLanguageSelect">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
+                                                    <property name="can_focus">False</property>
                                                     <property name="orientation">vertical</property>
                                                     <child>
                                                       <placeholder/>
@@ -5557,7 +5443,7 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                             <child type="label">
                                               <object class="GtkLabel" id="label196">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">Language</property>
                                               </object>
                                             </child>
@@ -5575,7 +5461,7 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                 <child type="label">
                                   <object class="GtkLabel" id="label193">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Language Settings</property>
                                   </object>
                                 </child>
@@ -5605,12 +5491,12 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
             <child type="tab">
               <object class="GtkLabel" id="languageTabLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Language</property>
               </object>
               <packing>
                 <property name="position">11</property>
-                <property name="tab-fill">False</property>
+                <property name="tab_fill">False</property>
               </packing>
             </child>
           </object>


### PR DESCRIPTION
implemented a user selectable custom plugin folder. The user can choose if he wants to use the standard plugin folder or a selectable custom plugin folder. Changes are made to the UI also.
Tests were made on Ubuntu 18.04 only.
Because PluginController::loadPluginsFrom can no deal with url file path names I used the gtk_file_chooser_get_filename to retrieve the path name (see 
char* pFolderName = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(get("fcPluginCustomFolder"))); 
in settingsdialog.cpp. Uncertain if this will work on Win and Mac also.
