### PR TITLE
Fix undo when moving across pages

### DIFF
--- a/src/control/UndoRedoController.cpp
+++ b/src/control/UndoRedoController.cpp
@@ -18,9 +18,7 @@ void UndoRedoController::before() {
     if (selection != nullptr) {
         layer = selection->getSourceLayer();
         sourcePage = selection->getSourcePage();
-        for (Element* e: *selection->getElements()) {
-            elements.push_back(e);
-        }
+        for (Element* e: *selection->getElements()) { elements.push_back(e); }
     }
 
     control->clearSelection();

--- a/src/control/UndoRedoController.cpp
+++ b/src/control/UndoRedoController.cpp
@@ -14,8 +14,10 @@ UndoRedoController::~UndoRedoController() {
 
 void UndoRedoController::before() {
     EditSelection* selection = control->getWindow()->getXournal()->getSelection();
+
     if (selection != nullptr) {
         layer = selection->getSourceLayer();
+        sourcePage = selection->getSourcePage();
         for (Element* e: *selection->getElements()) {
             elements.push_back(e);
         }
@@ -36,11 +38,10 @@ void UndoRedoController::after() {
 
     Document* doc = control->getDocument();
 
-    PageRef page = control->getCurrentPage();
-    size_t pageNo = doc->indexOf(page);
+    size_t pageNo = doc->indexOf(sourcePage);
     XojPageView* view = control->getWindow()->getXournal()->getViewFor(pageNo);
 
-    if (!view || !page) {
+    if (!view || !sourcePage) {
         return;
     }
 
@@ -54,7 +55,7 @@ void UndoRedoController::after() {
         visibleElements.push_back(e);
     }
     if (!visibleElements.empty()) {
-        auto* selection = new EditSelection(control->getUndoRedoHandler(), visibleElements, view, page);
+        auto* selection = new EditSelection(control->getUndoRedoHandler(), visibleElements, view, sourcePage);
         control->getWindow()->getXournal()->setSelection(selection);
     }
 }

--- a/src/control/UndoRedoController.h
+++ b/src/control/UndoRedoController.h
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include "model/PageRef.h"
+
 #include "XournalType.h"
 
 class Control;
@@ -48,7 +49,7 @@ private:
     /**
      * Page of the selection before change
      */
-    PageRef sourcePage{}; 
+    PageRef sourcePage{};
 
     /**
      * Selected elements

--- a/src/control/UndoRedoController.h
+++ b/src/control/UndoRedoController.h
@@ -14,6 +14,7 @@
 #include <string>
 #include <vector>
 
+#include "model/PageRef.h"
 #include "XournalType.h"
 
 class Control;
@@ -43,6 +44,11 @@ private:
      * Layer of the selection before change
      */
     Layer* layer = nullptr;
+
+    /**
+     * Page of the selection before change
+     */
+    PageRef sourcePage{}; 
 
     /**
      * Selected elements


### PR DESCRIPTION
Fixes #3047 partially (I couldn't reproduce the infinite loop either)

The issue was that when creating a second page and moving a stroke from the second to the first `EditSelection::getSourceLayer` is not updated. The error then occurs because `UndoRedoController::layer` refers to the second page where the elements were already moved to but the PageRef given to ElementSelection does not (in `UndoRedoController::after`).
All of this is of course avoided if the selection is empty.

Note: Scrolling down to the second page after moving the stroke to the first also 'fixes' the issue.