### PR TITLE
Fix Windows Azure Pipeline

### DIFF
--- a/azure-pipelines/steps/build_windows.yml
+++ b/azure-pipelines/steps/build_windows.yml
@@ -8,7 +8,6 @@ steps:
   # Copy of msys2-blob as a temporary fix for Windows CI
   - script: |
       set PATH=C:\msys64\usr\bin;C:\msys64\mingw64\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem
-      pacman --noconfirm -Sy
       pacman --noconfirm -S mingw-w64-x86_64-imagemagick mingw-w64-x86_64-ninja mingw-w64-x86_64-cppunit mingw-w64-x86_64-poppler mingw-w64-x86_64-gtk3 mingw-w64-x86_64-libsndfile mingw-w64-x86_64-libzip mingw-w64-x86_64-lua
     env:
       MSYS2_ARCH: x86_64


### PR DESCRIPTION
Removing the updating of the package index like in this PR works, as my test on my personal dev.azure pipeline shows, and it does now uses Cairo 1.17.4-2. This is needed to have good pdf exports. So I suggest to merge this PR. From [the pipeline](https://dev.azure.com/rolandlo/xournalpp/_build/results?buildId=51&view=logs&j=5502ea34-1a31-5d2e-665e-0754f4413bc7&t=4d4fe241-2267-54df-e534-736dc4ac6f29):
```
downloading mingw-w64-x86_64-cairo-1.17.4-2-any.pkg.tar.zst...
``` 
