### PR TITLE
Streamline package descriptions and update appdata xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,26 +40,27 @@ Stroke recognizer and other parts are based on Xournal Code, which you can find 
 
 Xournal++ features:
 
-- Support for pen pressure, e.g. Wacom Tablet
-- Support for annotating PDFs
+- Supports pressure senstive styluses and digital pen tables (e.g. Wacom, Huion, XP Pen, etc. tablets)
+- Paper backgrounds for notetaking, scratch paper, or whiteboarding
+- Annotate on top of PDFs
+- Export to a variety of formats including SVG, PNG and PDF, both from the GUI and command line
+- Different drawing tools (e.g.pen, highlighter) and stroke styles (e.g. solid, dotted)
+- Shape drawing (line, arrow, circle, rectangle, spline)
 - Fill shape functionality
-- PDF Export (with and without paper style)
-- PNG Export (with and without transparent background)
-- Allows mapping different tools / colors etc. to stylus buttons / mouse buttons
-- Sidebar with Page Previews with advanced page sorting, PDF Bookmarks and Layers (can be individually hidden, editing layer can be selected)
+- Shape resizing and rotation
+- Rotation and grid snapping for precise alignment of objects
+- Input stabilization for smoother writing/drawing
+- Text tool for adding text in different fonts, colors and sizes
 - Enhanced support for image insertion
 - Eraser with multiple configurations
-- Significantly reduced memory usage and code to detect memory leaks compared to Xournal
-- LaTeX support (requires a working LaTeX installation)
-- bug reporting, auto-save, and auto backup tools
-- Customizable toolbar with multiple configurations, e.g. to optimize toolbar for portrait / landscape
+- LaTeX support (requires a working LaTeX installation) with customizeable template
+- Sidebar with Page Previews with advanced page sorting, PDF Bookmarks and Layers (can be individually hidden/edited)
+- Allows mapping different tools/colors etc. to stylus/mouse buttons
+- Customizeable toolbar with multiple configurations, e.g. to optimize toolbar for portrait/landscape
 - Page Template definitions
-- Shape drawing (line, arrow, circle, rect, splines)
-- Shape resizing and rotation
-- Rotation snapping every 15 degrees
-- Rect snapping to grid
+- Bug reporting, auto-save, and auto backup tools
 - Audio recording and playback alongside with handwritten notes
-- Multi Language Support like English, German (Deutsch), Italian (Italiano)...
+- Multi language support (over 20 languages supported)
 - Plugins using Lua scripting
 
 ## Mobile & web app

--- a/debian/control
+++ b/debian/control
@@ -20,23 +20,25 @@ Description: Xournal++ - Open source hand note-taking program
  .
  Xournal++ features:
  .
-  - Support for Pen pressure, e.g. Wacom Tablet
-  - Support for annotating PDFs
+  - Supports pressure senstive styluses and digital pen tables (e.g. Wacom, Huion, XP Pen, etc. tablets)
+  - Paper backgrounds for notetaking, scratch paper, or whiteboarding
+  - Annotate on top of PDFs
+  - Export to a variety of formats including SVG, PNG and PDF, both from the GUI and command line
+  - Different drawing tools (e.g.pen, highlighter) and stroke styles (e.g. solid, dotted)
+  - Shape drawing (line, arrow, circle, rectangle, spline)
   - Fill shape functionality
-  - PDF Export (with and without paper style)
-  - PNG Export (with and without transparent background)
-  - Allows maping different tools/colors etc. to stylus/mouse buttons
-  - Sidebar with Page Previews with page sorting, PDF Bookmarks and Layers
+  - Shape resizing and rotation
+  - Rotation and grid snapping for precise alignment of objects
+  - Input stabilization for smoother writing/drawing
+  - Text tool for adding text in different fonts, colors and sizes
   - Enhanced support for image insertion
   - Eraser with multiple configurations
-  - LaTeX support (requires a working LaTeX install)
-  - Bug reporting, autosave, and auto backup tools
-  - Customizeable toolbar, with multiple configurations
+  - LaTeX support (requires a working LaTeX installation) with customizeable template
+  - Sidebar with Page Previews with advanced page sorting, PDF Bookmarks and Layers (can be individually hidden/edited)
+  - Allows maping different tools/colors etc. to stylus/mouse buttons
+  - Customizeable toolbar with multiple configurations, e.g. to optimize toolbar for portrait/landscape
   - Page Template definitions
-  - Shape drawing (line, arrow, circle, rect)
-  - Shape resizing and rotation
-  - Rotation snapping every 45 degrees
-  - Rect snapping to grid
+  - Bug reporting, autosave, and auto backup tools
   - Audio recording and playback alongside with handwritten notes
-  - Multi Language Support, English, German, Italian, ...
+  - Multi language support (over 20 languages supported)
   - Plugins using Lua scripting

--- a/desktop/com.github.xournalpp.xournalpp.appdata.xml
+++ b/desktop/com.github.xournalpp.xournalpp.appdata.xml
@@ -52,16 +52,13 @@
   <url type="homepage">https://xournalpp.github.io/</url>
   <screenshots>
     <screenshot type="default">
-      <image>https://i.imgur.com/Muc4nmw.png</image>
+      <image>https://user-images.githubusercontent.com/40485433/122611342-70fe3a80-d081-11eb-916a-92e570a1a416.png</image>
     </screenshot>
     <screenshot>
-      <image>https://raw.githubusercontent.com/xournalpp/xournalpp/master/readme/background.png</image>
+      <image>https://user-images.githubusercontent.com/40485433/122599842-42776400-d06f-11eb-82a2-c006dcd0c36a.png</image>
     </screenshot>
     <screenshot>
-      <image>https://i.imgur.com/awHSGG9.png</image>
-    </screenshot>
-    <screenshot>
-      <image>https://i.imgur.com/3uxu40d.png</image>
+      <image>https://user-images.githubusercontent.com/40485433/122599858-47d4ae80-d06f-11eb-9dc4-1e546c78b632.png</image>
     </screenshot>
   </screenshots>
   <launchable type="desktop-id">com.github.xournalpp.xournalpp.desktop</launchable>

--- a/desktop/com.github.xournalpp.xournalpp.appdata.xml
+++ b/desktop/com.github.xournalpp.xournalpp.appdata.xml
@@ -21,26 +21,27 @@
    </p>
     <p>Xournal++ features:</p>
     <ul>
-      <li>Support for Pen pressure, e.g. Wacom Tablet</li>
-      <li>Support for annotating PDFs</li>
+      <li>Supports pressure senstive styluses and digital pen tables (e.g. Wacom, Huion, XP Pen, etc. tablets)</li>
+      <li>Paper backgrounds for notetaking, scratch paper, or whiteboarding</li>
+      <li>Annotate on top of PDFs</li>
+      <li>Export to a variety of formats including SVG, PNG and PDF, both from the GUI and command line</li>
+      <li>Different drawing tools (e.g.pen, highlighter) and stroke styles (e.g. solid, dotted)</li>
+      <li>Shape drawing (line, arrow, circle, rectangle, spline)</li>
       <li>Fill shape functionality</li>
-      <li>PDF Export (with and without paper style)</li>
-      <li>PNG Export (with and without transparent background)</li>
-      <li>Allow to map different tools / colors etc. to stylus buttons / mouse buttons</li>
-      <li>Sidebar with Page Previews with advanced page sorting, PDF Bookmarks and Layers</li>
+      <li>Shape resizing and rotation</li>
+      <li>Rotation and grid snapping for precise alignment of objects</li>
+      <li>Input stabilization for smoother writing/drawing</li>
+      <li>Text tool for adding text in different fonts, colors and sizes</li>
       <li>Enhanced support for image insertion</li>
       <li>Eraser with multiple configurations</li>
-      <li>Significantly reduced memory usage and code to detect memory leaks compared to Xournal</li>
-      <li>LaTeX support (requires a working LaTeX install)</li>
-      <li>Bug reporting, autosave, and auto backup tools</li>
-      <li>Customizeable toolbar, with multiple configurations, e.g. to optimize toolbar for portrait/landscape</li>
+      <li>LaTeX support (requires a working LaTeX installation) with customizeable template</li>
+      <li>Sidebar with Page Previews with advanced page sorting, PDF Bookmarks and Layers (can be individually hidden/edited)</li>
+      <li>Allows mapping different tools/colors etc. to stylus/mouse buttons</li>
+      <li>Customizeable toolbar with multiple configurations, e.g. to optimize toolbar for portrait/landscape</li>
       <li>Page Template definitions</li>
-      <li>Shape drawing (line, arrow, circle, rect)</li>
-      <li>Shape resizing and rotation</li>
-      <li>Rotation snapping every 15 degrees</li>
-      <li>Rect snapping to grid</li>
+      <li>Bug reporting, autosave, and auto backup tools</li>
       <li>Audio recording and playback alongside with handwritten notes</li>
-      <li>Multi Language Support, Like English, German (Deutsch), Italian (Italiano)...</li>
+      <li>Multi language support (over 20 languages supported)</li>
       <li>Plugins using Lua scripting</li>
     </ul>
   </description>

--- a/desktop/com.github.xournalpp.xournalpp.appdata.xml
+++ b/desktop/com.github.xournalpp.xournalpp.appdata.xml
@@ -48,8 +48,8 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0</project_license>
   <url type="bugtracker">https://github.com/xournalpp/xournalpp/issues</url>
-  <url type="help">https://github.com/xournalpp/xournalpp/wiki/User-Manual</url>
-  <url type="homepage">https://github.com/xournalpp/xournalpp</url>
+  <url type="help">https://xournalpp.github.io/community/help/</url>
+  <url type="homepage">https://xournalpp.github.io/</url>
   <screenshots>
     <screenshot type="default">
       <image>https://i.imgur.com/Muc4nmw.png</image>
@@ -80,6 +80,9 @@
     <!-- Could be automated more:
 	 `git tag -l | grep "^[0-9]*\.[0-9]*\.[0-9]*$`"
     -->
+    <release date="2020-12-17" version="1.0.20" />
+    <release date="2020-10-21" version="1.0.19" />
+    <release date="2020-04-15" version="1.0.18" />
     <release date="2020-02-02" version="1.0.17" />
     <release date="2019-11-10" version="1.0.16" />
     <release date="2019-10-15" version="1.0.15" />

--- a/package_description
+++ b/package_description
@@ -6,23 +6,25 @@ Supports pen input from devices such as Wacom Tablets.
 .
 Xournal++ features:
 .
- - Support for Pen pressure, e.g. Wacom Tablet
- - Support for annotating PDFs
+ - Supports pressure senstive styluses and digital pen tables (e.g. Wacom, Huion, XP Pen, etc. tablets)
+ - Paper backgrounds for notetaking, scratch paper, or whiteboarding
+ - Annotate on top of PDFs
+ - Export to a variety of formats including SVG, PNG and PDF, both from the GUI and command line
+ - Different drawing tools (e.g.pen, highlighter) and stroke styles (e.g. solid, dotted)
+ - Shape drawing (line, arrow, circle, rectangle, spline)
  - Fill shape functionality
- - PDF Export (with and without paper style)
- - PNG Export (with and without transparent background)
- - Allows maping different tools/colors etc. to stylus/mouse buttons
- - Sidebar with Page Previews with page sorting, PDF Bookmarks and Layers
+ - Shape resizing and rotation
+ - Rotation and grid snapping for precise alignment of objects
+ - Input stabilization for smoother writing/drawing
+ - Text tool for adding text in different fonts, colors and sizes
  - Enhanced support for image insertion
  - Eraser with multiple configurations
- - LaTeX support (requires a working LaTeX install)
- - Bug reporting, autosave, and auto backup tools
- - Customizeable toolbar, with multiple configurations
+ - LaTeX support (requires a working LaTeX installation) with customizeable template
+ - Sidebar with Page Previews with advanced page sorting, PDF Bookmarks and Layers (can be individually hidden/edited)
+ - Allows maping different tools/colors etc. to stylus/mouse buttons
+ - Customizeable toolbar with multiple configurations, e.g. to optimize toolbar for portrait/landscape
  - Page Template definitions
- - Shape drawing (line, arrow, circle, rect)
- - Shape resizing and rotation
- - Rotation snapping every 45 degrees
- - Rect snapping to grid
+ - Bug reporting, autosave, and auto backup tools
  - Audio recording and playback alongside with handwritten notes
- - Multi Language Support, English, German, Italian, ...
+ - Multi language support (over 20 languages supported)
  - Plugins using Lua scripting


### PR DESCRIPTION
We have four variants of a package description in Xournal++
1. the one from the `package_description` file
2. the one in the `README.md`
3. the one in `debian/control`
4. the one in the `com.github.xournalpp.xournalpp.appdata.xml` file (that is used for the `flatpak`). 

I streamlined them and made them all equal up to formatting details. I have also updated the appdata xml-file to some degree.

The appdata xml-file refers to four images, which are already seven years old, i.e. pretty outdated. We should create new images, that show how Xournal++ looks now and what we can do with it now.  Has anybody a nice .xopp-file that could be used to create such an image?

I think we need at least:
- an image for notetaking, maybe with multiple layers
- an image for PDF-annotation
- an image for using LaTeX formulas, maybe something showing off the power we gained with the customizable template, like code-highlighting or drawing with `TikZ` or function graphs via `TikZ/pgfplots`
- maybe something with customizable toolbars or floating toolbox (although that is not new)

Any suggestions?

Three of the 7-year old images that are currently referred to are located on [imgur.com](https://imgur.com/). Is that a good place for these images or should be include the new images in the repository or somewhere else? Note that these images will be shown to tons of Linux users when looking for Xournal++ in the software center or on the flathub website.