### PR TITLE
Temporary hotfix for zoom fit loop

### DIFF
--- a/src/control/zoom/ZoomControl.cpp
+++ b/src/control/zoom/ZoomControl.cpp
@@ -303,11 +303,18 @@ void ZoomControl::zoom100() {
 }
 
 void ZoomControl::zoomFit() {
+    // TODO: properly fix the zoom fit infinite recursion
+    if (this->isZoomFittingNow) {
+        return;
+    }
+
+    this->isZoomFittingNow = true;
     if (this->isZoomFitMode() && !this->zoomPresentationMode && this->zoom != this->zoomFitValue) {
         startZoomSequence();
         this->zoomSequenceChange(this->zoomFitValue, false);
         endZoomSequence();
     }
+    this->isZoomFittingNow = false;
 }
 
 void ZoomControl::zoomPresentation() {

--- a/src/control/zoom/ZoomControl.h
+++ b/src/control/zoom/ZoomControl.h
@@ -239,4 +239,5 @@ private:
 
     size_t current_page = static_cast<size_t>(-1);
     size_t last_page = static_cast<size_t>(-1);
+    bool isZoomFittingNow = false;
 };


### PR DESCRIPTION
Fixes #3036. This is a **temporary** fix for the infinite recursing zoom fit issue so that users of 1.1.0 won't get crashes. A quick run with the test file provided in #3036 suggests that the infinite recursing issue is caused, in part, by jumpy/nonlinear scrolling during the zoom (which should be improved by #2837).