### PR TITLE
Fix null pointer dereference when no page spinner is used

### DIFF
--- a/src/gui/toolbarMenubar/ToolPageSpinner.cpp
+++ b/src/gui/toolbarMenubar/ToolPageSpinner.cpp
@@ -24,26 +24,26 @@ ToolPageSpinner::~ToolPageSpinner() {
 
 auto ToolPageSpinner::getPageSpinner() -> SpinPageAdapter* { return pageSpinner; }
 
-void ToolPageSpinner::setPageInfo(const size_t pagecount, const size_t pdfpage) {
-    this->pagecount = pagecount;
-    this->pdfpage = pdfpage;
+void ToolPageSpinner::setPageInfo(const size_t pageCount, const size_t pdfPage) {
+    this->pageCount = pageCount;
+    this->pdfPage = pdfPage;
     if (this->lbPageNo) {
         updateLabels();
     }
 }
 
 void ToolPageSpinner::updateLabels() {
-    string ofString = FS(C_F("Page {pagenumber} \"of {pagecount}\"", " of {1}") % this->pagecount);
+    string ofString = FS(C_F("Page {pagenumber} \"of {pagecount}\"", " of {1}") % this->pageCount);
     if (this->orientation == GTK_ORIENTATION_HORIZONTAL) {
         string pdfString;
-        if (this->pdfpage > 0) {  // zero means that theres no pdf currently
-            pdfString = string(", ") + FS(_F("PDF Page {1}") % this->pdfpage);
+        if (this->pdfPage > 0) {  // zero means that theres no pdf currently
+            pdfString = string(", ") + FS(_F("PDF Page {1}") % this->pdfPage);
         }
         gtk_label_set_text(GTK_LABEL(lbPageNo), (ofString + pdfString).c_str());
     } else {
         gtk_label_set_text(GTK_LABEL(lbPageNo), ofString.c_str());
-        if (this->pdfpage > 0) {  // zero means that theres no pdf currently
-            gtk_label_set_text(GTK_LABEL(lbVerticalPdfPage), FS(_F("PDF {1}") % this->pdfpage).c_str());
+        if (this->pdfPage > 0) {  // zero means that theres no pdf currently
+            gtk_label_set_text(GTK_LABEL(lbVerticalPdfPage), FS(_F("PDF {1}") % this->pdfPage).c_str());
             if (gtk_widget_get_parent(this->lbVerticalPdfPage) == nullptr) {
                 // re-add pdf label if it has been removed previously
                 gtk_box_pack_start(GTK_BOX(box), this->lbVerticalPdfPage, false, false, 0);
@@ -70,7 +70,7 @@ auto ToolPageSpinner::newItem() -> GtkToolItem* {
     GtkWidget* spinner = gtk_spin_button_new_with_range(0, 1, 1);
     gtk_orientable_set_orientation(reinterpret_cast<GtkOrientable*>(spinner), orientation);
     g_object_ref_sink(spinner);
-
+    this->pageSpinner->setWidget(spinner);  // takes ownership of spinner reference
 
     if (this->lbPageNo) {
         g_object_unref(this->lbPageNo);
@@ -96,7 +96,6 @@ auto ToolPageSpinner::newItem() -> GtkToolItem* {
         gtk_widget_set_halign(this->lbPageNo, GTK_ALIGN_BASELINE);
         gtk_widget_set_halign(lbVerticalPdfPage, GTK_ALIGN_BASELINE);
     }
-    this->pageSpinner->setWidget(spinner);  // takes ownership of spinner reference
 
     if (this->box) {
         g_object_unref(this->box);

--- a/src/gui/toolbarMenubar/ToolPageSpinner.h
+++ b/src/gui/toolbarMenubar/ToolPageSpinner.h
@@ -48,5 +48,10 @@ private:
     GtkWidget* box = nullptr;
     GtkWidget* lbPageNo = nullptr;
     GtkWidget* lbVerticalPdfPage = nullptr;
-    size_t pagecount, pdfpage;
+
+    /** The current page of the document. */
+    size_t pageCount = 0;
+
+    /** The current page in the background PDF, or 0 if there is no PDF. */
+    size_t pdfPage = 0;
 };

--- a/src/gui/widgets/SpinPageAdapter.cpp
+++ b/src/gui/widgets/SpinPageAdapter.cpp
@@ -1,11 +1,6 @@
 #include "SpinPageAdapter.h"
 
-SpinPageAdapter::SpinPageAdapter() {
-    this->lastTimeoutId = 0;
-    this->min = 0;
-    this->max = 1;
-    this->page = -1;
-}
+SpinPageAdapter::SpinPageAdapter() {}
 
 SpinPageAdapter::~SpinPageAdapter() {
     if (this->hasWidget()) {
@@ -15,7 +10,7 @@ SpinPageAdapter::~SpinPageAdapter() {
 
 auto SpinPageAdapter::pageNrSpinChangedTimerCallback(SpinPageAdapter* adapter) -> bool {
     adapter->lastTimeoutId = 0;
-    adapter->page = gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(adapter->widget));
+    adapter->page = static_cast<size_t>(gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(adapter->widget)));
 
     adapter->firePageChanged();
     return false;
@@ -47,8 +42,9 @@ void SpinPageAdapter::setWidget(GtkWidget* widget) {
             g_signal_connect(this->widget, "value-changed", G_CALLBACK(pageNrSpinChangedCallback), this);
     this->lastTimeoutId = 0;
 
-    gtk_spin_button_set_range(GTK_SPIN_BUTTON(this->widget), min, max);
-    gtk_spin_button_set_value(GTK_SPIN_BUTTON(this->widget), this->page);
+    gtk_spin_button_set_range(GTK_SPIN_BUTTON(this->widget), static_cast<double>(this->min),
+                              static_cast<double>(this->max));
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(this->widget), static_cast<double>(this->page));
 }
 
 void SpinPageAdapter::removeWidget() {

--- a/src/gui/widgets/SpinPageAdapter.cpp
+++ b/src/gui/widgets/SpinPageAdapter.cpp
@@ -39,7 +39,7 @@ bool SpinPageAdapter::hasWidget() { return this->widget != nullptr; }
 
 void SpinPageAdapter::setWidget(GtkWidget* widget) {
     // only one widget is supported and the previous widget has to be removed via removeWidget
-    assert(!this->hasWidget());
+    g_assert(!this->hasWidget());
     g_assert_nonnull(widget);
 
     this->widget = widget;
@@ -52,7 +52,7 @@ void SpinPageAdapter::setWidget(GtkWidget* widget) {
 }
 
 void SpinPageAdapter::removeWidget() {
-    assert(this->hasWidget());
+    g_assert(this->hasWidget());
 
     g_signal_handler_disconnect(this->widget, this->pageNrSpinChangedHandlerId);
 
@@ -63,13 +63,17 @@ auto SpinPageAdapter::getPage() const -> int { return this->page; }
 
 void SpinPageAdapter::setPage(size_t page) {
     this->page = page;
-    gtk_spin_button_set_value(GTK_SPIN_BUTTON(this->widget), page);
+    if (this->widget) {
+        gtk_spin_button_set_value(GTK_SPIN_BUTTON(this->widget), static_cast<double>(page));
+    }
 }
 
 void SpinPageAdapter::setMinMaxPage(size_t min, size_t max) {
     this->min = min;
     this->max = max;
-    gtk_spin_button_set_range(GTK_SPIN_BUTTON(this->widget), min, max);
+    if (this->widget) {
+        gtk_spin_button_set_range(GTK_SPIN_BUTTON(this->widget), static_cast<double>(min), static_cast<double>(max));
+    }
 }
 
 void SpinPageAdapter::addListener(SpinPageListener* listener) { this->listener.push_back(listener); }

--- a/src/gui/widgets/SpinPageAdapter.h
+++ b/src/gui/widgets/SpinPageAdapter.h
@@ -50,14 +50,15 @@ private:
     void firePageChanged();
 
 private:
-    GtkWidget* widget;
-    gulong pageNrSpinChangedHandlerId;
-    size_t page;
+    GtkWidget* widget = nullptr;
+    gulong pageNrSpinChangedHandlerId = 0;
+    size_t page = 0;
 
-    int lastTimeoutId;
+    guint lastTimeoutId = 0;
     std::list<SpinPageListener*> listener;
 
-    size_t min, max;
+    size_t min = 0;
+    size_t max = 0;
 };
 
 class SpinPageListener {


### PR DESCRIPTION
Fixes #3114. I've only tested this on Linux but I believe it should also work for Windows.