### PR TITLE
show full path in error dialog box when background pdf is not found

### DIFF
--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -2009,15 +2009,15 @@ auto Control::openFile(fs::path filepath, int scrollToPage, bool forceOpen) -> b
         !loadHandler.getMissingPdfFilename().empty()) {
         // give the user a second chance to select a new PDF filepath, or to discard the PDF
 
-        string missingFilePath = loadHandler.getMissingPdfFilename();
-        string msg1 =
+        fs::path missingFilePath = fs::path(loadHandler.getMissingPdfFilename());
+        std::string msg1 =
                 FS(_F("The attached background file {1} could not be found. It might have been moved, renamed or "
                       "deleted.\nIt was last seen at: {2}") %
-                   fs::path(missingFilePath).filename().string() % fs::path(missingFilePath).parent_path().string());
-        string msg2 =
+                   missingFilePath.filename().string() % missingFilePath.parent_path().string());
+        std::string msg2 =
                 FS(_F("The background file {1} could not be found. It might have been moved, renamed or deleted.\nIt "
                       "was last seen at: {2}") %
-                   fs::path(missingFilePath).filename().string() % fs::path(missingFilePath).parent_path().string());
+                   missingFilePath.filename().string() % missingFilePath.parent_path().string());
         GtkWidget* dialog =
                 gtk_message_dialog_new(getGtkWindow(), GTK_DIALOG_MODAL, GTK_MESSAGE_QUESTION, GTK_BUTTONS_NONE, "%s",
                                        loadHandler.isAttachedPdfMissing() ? _(msg1.c_str()) : _(msg2.c_str()));

--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -2009,10 +2009,20 @@ auto Control::openFile(fs::path filepath, int scrollToPage, bool forceOpen) -> b
         !loadHandler.getMissingPdfFilename().empty()) {
         // give the user a second chance to select a new PDF filepath, or to discard the PDF
 
+        string missingFilePath = loadHandler.getMissingPdfFilename();
         GtkWidget* dialog = gtk_message_dialog_new(
                 getGtkWindow(), GTK_DIALOG_MODAL, GTK_MESSAGE_QUESTION, GTK_BUTTONS_NONE, "%s",
-                loadHandler.isAttachedPdfMissing() ? _("The attached background PDF could not be found.") :
-                                                     _("The background PDF could not be found."));
+                loadHandler.isAttachedPdfMissing() ?
+                        _(string("The attached background file " + fs::path(missingFilePath).filename().string() +
+                                 " could not be found. It might have been moved, renamed, or deleted.\nIt was last "
+                                 "seen at: " +
+                                 fs::path(missingFilePath).parent_path().string())
+                                  .c_str()) :
+                        _(string("The background file " + fs::path(missingFilePath).filename().string() +
+                                 " could not be found. It might have been moved, renamed, or deleted.\nIt was last "
+                                 "seen at: " +
+                                 fs::path(missingFilePath).parent_path().string())
+                                  .c_str()));
 
         gtk_dialog_add_button(GTK_DIALOG(dialog), _("Select another PDF"), 1);
         gtk_dialog_add_button(GTK_DIALOG(dialog), _("Remove PDF Background"), 2);

--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -2010,19 +2010,17 @@ auto Control::openFile(fs::path filepath, int scrollToPage, bool forceOpen) -> b
         // give the user a second chance to select a new PDF filepath, or to discard the PDF
 
         string missingFilePath = loadHandler.getMissingPdfFilename();
-        GtkWidget* dialog = gtk_message_dialog_new(
-                getGtkWindow(), GTK_DIALOG_MODAL, GTK_MESSAGE_QUESTION, GTK_BUTTONS_NONE, "%s",
-                loadHandler.isAttachedPdfMissing() ?
-                        _(string("The attached background file " + fs::path(missingFilePath).filename().string() +
-                                 " could not be found. It might have been moved, renamed, or deleted.\nIt was last "
-                                 "seen at: " +
-                                 fs::path(missingFilePath).parent_path().string())
-                                  .c_str()) :
-                        _(string("The background file " + fs::path(missingFilePath).filename().string() +
-                                 " could not be found. It might have been moved, renamed, or deleted.\nIt was last "
-                                 "seen at: " +
-                                 fs::path(missingFilePath).parent_path().string())
-                                  .c_str()));
+        string msg1 =
+                FS(_F("The attached background file {1} could not be found. It might have been moved, renamed or "
+                      "deleted.\nIt was last seen at: {2}") %
+                   fs::path(missingFilePath).filename().string() % fs::path(missingFilePath).parent_path().string());
+        string msg2 =
+                FS(_F("The background file {1} could not be found. It might have been moved, renamed or deleted.\nIt "
+                      "was last seen at: {2}") %
+                   fs::path(missingFilePath).filename().string() % fs::path(missingFilePath).parent_path().string());
+        GtkWidget* dialog =
+                gtk_message_dialog_new(getGtkWindow(), GTK_DIALOG_MODAL, GTK_MESSAGE_QUESTION, GTK_BUTTONS_NONE, "%s",
+                                       loadHandler.isAttachedPdfMissing() ? _(msg1.c_str()) : _(msg2.c_str()));
 
         gtk_dialog_add_button(GTK_DIALOG(dialog), _("Select another PDF"), 1);
         gtk_dialog_add_button(GTK_DIALOG(dialog), _("Remove PDF Background"), 2);

--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -2009,18 +2009,18 @@ auto Control::openFile(fs::path filepath, int scrollToPage, bool forceOpen) -> b
         !loadHandler.getMissingPdfFilename().empty()) {
         // give the user a second chance to select a new PDF filepath, or to discard the PDF
 
-        fs::path missingFilePath = fs::path(loadHandler.getMissingPdfFilename());
-        std::string msg1 =
+        const fs::path missingFilePath = fs::path(loadHandler.getMissingPdfFilename());
+        const std::string msg1 =
                 FS(_F("The attached background file {1} could not be found. It might have been moved, renamed or "
                       "deleted.\nIt was last seen at: {2}") %
                    missingFilePath.filename().string() % missingFilePath.parent_path().string());
-        std::string msg2 =
+        const std::string msg2 =
                 FS(_F("The background file {1} could not be found. It might have been moved, renamed or deleted.\nIt "
                       "was last seen at: {2}") %
                    missingFilePath.filename().string() % missingFilePath.parent_path().string());
         GtkWidget* dialog =
                 gtk_message_dialog_new(getGtkWindow(), GTK_DIALOG_MODAL, GTK_MESSAGE_QUESTION, GTK_BUTTONS_NONE, "%s",
-                                       loadHandler.isAttachedPdfMissing() ? _(msg1.c_str()) : _(msg2.c_str()));
+                                       loadHandler.isAttachedPdfMissing() ? msg1.c_str() : msg2.c_str());
 
         gtk_dialog_add_button(GTK_DIALOG(dialog), _("Select another PDF"), 1);
         gtk_dialog_add_button(GTK_DIALOG(dialog), _("Remove PDF Background"), 2);


### PR DESCRIPTION
Fix #2646 by mentioning the missing pdf name and its parent path.