### PR TITLE
curl split archive

### DIFF
--- a/azure-pipelines/steps/build_mac.yml
+++ b/azure-pipelines/steps/build_mac.yml
@@ -12,8 +12,8 @@ steps:
       sudo mkdir "${{parameters.generation_path}}"
       sudo chown $USER "${{parameters.generation_path}}"
       cd "${{parameters.generation_path}}"
-      curl -L -o gtk-bin.tar.gz https://github.com/xournalpp/xournalpp-pipeline-dependencies/raw/macos-10.15-jhbuild/gtk/gtk-bin.tar.gz
-      tar -xzf gtk-bin.tar.gz
+      curl -L -O https://github.com/xournalpp/xournalpp-pipeline-dependencies/raw/macos-10.15-jhbuild/gtk/gtk-bin.tar.gz.a[a-e]
+      cat gtk-bin.tar.gz.* | tar -xz
     displayName: 'Unpack GTK'
   - bash: |
       curl -L -o libxml.tar.gz https://github.com/xournalpp/xournalpp-pipeline-dependencies/raw/macos-10.15-jhbuild/libxml/libxml.tar.gz


### PR DESCRIPTION
The GTK blob for MacOS is now split into 5 parts. In the pipeline, these parts are all downloaded and then extracted together.