### PR TITLE
 Fix some blank messageboxes that shows no context except the 'OK' button

### DIFF
--- a/src/util/XojMsgBox.cpp
+++ b/src/util/XojMsgBox.cpp
@@ -22,7 +22,7 @@ void XojMsgBox::showErrorToUser(GtkWindow* win, const string& msg) {
 
     GtkWidget* dialog =
             gtk_message_dialog_new_with_markup(win, GTK_DIALOG_MODAL, GTK_MESSAGE_ERROR, GTK_BUTTONS_OK, nullptr);
-    gtk_message_dialog_set_markup(GTK_MESSAGE_DIALOG(dialog), msg.c_str());
+    gtk_message_dialog_set_markup(GTK_MESSAGE_DIALOG(dialog), g_markup_escape_text(msg.c_str(), -1));
     if (win != nullptr) {
         gtk_window_set_transient_for(GTK_WINDOW(dialog), win);
     }
@@ -40,7 +40,7 @@ auto XojMsgBox::showPluginMessage(const string& pluginName, const string& msg, c
 
     GtkWidget* dialog = gtk_message_dialog_new_with_markup(defaultWindow, GTK_DIALOG_MODAL, GTK_MESSAGE_ERROR,
                                                            GTK_BUTTONS_NONE, nullptr);
-    gtk_message_dialog_set_markup(GTK_MESSAGE_DIALOG(dialog), header.c_str());
+    gtk_message_dialog_set_markup(GTK_MESSAGE_DIALOG(dialog), g_markup_escape_text(header.c_str(), -1));
 
     if (defaultWindow != nullptr) {
         gtk_window_set_transient_for(GTK_WINDOW(dialog), defaultWindow);
@@ -52,9 +52,7 @@ auto XojMsgBox::showPluginMessage(const string& pluginName, const string& msg, c
     g_object_set_property(G_OBJECT(dialog), "secondary-text", &val);
     g_value_unset(&val);
 
-    for (auto& kv: button) {
-        gtk_dialog_add_button(GTK_DIALOG(dialog), kv.second.c_str(), kv.first);
-    }
+    for (auto& kv: button) { gtk_dialog_add_button(GTK_DIALOG(dialog), kv.second.c_str(), kv.first); }
 
     int res = gtk_dialog_run(GTK_DIALOG(dialog));
     gtk_widget_destroy(dialog);

--- a/src/util/XojMsgBox.cpp
+++ b/src/util/XojMsgBox.cpp
@@ -22,12 +22,15 @@ void XojMsgBox::showErrorToUser(GtkWindow* win, const string& msg) {
 
     GtkWidget* dialog =
             gtk_message_dialog_new_with_markup(win, GTK_DIALOG_MODAL, GTK_MESSAGE_ERROR, GTK_BUTTONS_OK, nullptr);
-    gtk_message_dialog_set_markup(GTK_MESSAGE_DIALOG(dialog), g_markup_escape_text(msg.c_str(), -1));
+
+    char* formattedMsg = g_markup_escape_text(msg.c_str(), -1);
+    gtk_message_dialog_set_markup(GTK_MESSAGE_DIALOG(dialog), formattedMsg);
     if (win != nullptr) {
         gtk_window_set_transient_for(GTK_WINDOW(dialog), win);
     }
     gtk_dialog_run(GTK_DIALOG(dialog));
     gtk_widget_destroy(dialog);
+    g_free(formattedMsg);
 }
 
 auto XojMsgBox::showPluginMessage(const string& pluginName, const string& msg, const map<int, string>& button,
@@ -40,7 +43,8 @@ auto XojMsgBox::showPluginMessage(const string& pluginName, const string& msg, c
 
     GtkWidget* dialog = gtk_message_dialog_new_with_markup(defaultWindow, GTK_DIALOG_MODAL, GTK_MESSAGE_ERROR,
                                                            GTK_BUTTONS_NONE, nullptr);
-    gtk_message_dialog_set_markup(GTK_MESSAGE_DIALOG(dialog), g_markup_escape_text(header.c_str(), -1));
+    char* formattedHeader = g_markup_escape_text(header.c_str(), -1);
+    gtk_message_dialog_set_markup(GTK_MESSAGE_DIALOG(dialog), formattedHeader);
 
     if (defaultWindow != nullptr) {
         gtk_window_set_transient_for(GTK_WINDOW(dialog), defaultWindow);
@@ -56,6 +60,7 @@ auto XojMsgBox::showPluginMessage(const string& pluginName, const string& msg, c
 
     int res = gtk_dialog_run(GTK_DIALOG(dialog));
     gtk_widget_destroy(dialog);
+    g_free(formattedHeader);
     return res;
 }
 


### PR DESCRIPTION
This is a solution to one of the issues mentioned in #3104. The reason why the message box was empty was because `g_markup_escape_text()` wasn't called on the message strings before passing it to `gtk_message_dialog_set_markup()`.
Before:
![image](https://user-images.githubusercontent.com/63693789/124959033-6d365600-e038-11eb-89e3-7b647e2894d9.png)
After:
![image](https://user-images.githubusercontent.com/63693789/124959136-88a16100-e038-11eb-86a1-54100e8184ee.png)
