### PR TITLE
fix working directory for Windows start menu entry

### DIFF
--- a/windows-setup/xournalpp.nsi
+++ b/windows-setup/xournalpp.nsi
@@ -267,9 +267,11 @@ Section "Xournal++" SecXournalpp
 	WriteRegDWORD SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\Xournal++" "NoRepair" 1
 
 	!insertmacro MUI_STARTMENU_WRITE_BEGIN Application
-		;Create shortcuts
+		;Create shortcuts and set working directory for Xournal++ to the bin subfolder to make localizations work
 		CreateDirectory "$SMPROGRAMS\$StartMenuFolder"
+		SetOutPath "$INSTDIR\bin"
 		CreateShortcut "$SMPROGRAMS\$StartMenuFolder\Xournal++.lnk" '"$INSTDIR\bin\xournalpp.exe"'
+		SetOutPath "$INSTDIR"
 		CreateShortcut "$SMPROGRAMS\$StartMenuFolder\Uninstall.lnk" '"$INSTDIR\Uninstall.exe"'
 		
 		!insertmacro RefreshShellIconCreate "$SMPROGRAMS\$StartMenuFolder\Xournal++.lnk"


### PR DESCRIPTION
This PR sets the working directory of the start menu link for Xournal++ to be the bin subfolder of the installaioin folder. This makes "../share/locale" point  to the correct locale directory.

It only works for launching Xournal++ from the start menu. It does not work from the context menu of a xopp-file or when running Xournal++ from terminal, when the present working directory is not the bin subfolder of the installation directory.

An alternative would be to use the TEXTDOMAINDIR environment variable or to use the execution path or maybe some resource path.

**Edit:** Fixed some typos