### PR TITLE
fix no autoloading journal for "filename.xopp" and "filename.xoj" problem

### DIFF
--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -2077,7 +2077,7 @@ auto Control::openFile(fs::path filepath, int scrollToPage, bool forceOpen) -> b
 
 auto Control::loadPdf(const fs::path& filepath, int scrollToPage) -> bool {
     LoadHandler loadHandler;
-  
+
     if (settings->isAutoloadPdfXoj()) {
         fs::path f;
         Document* tmp;

--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -2079,13 +2079,12 @@ auto Control::loadPdf(const fs::path& filepath, int scrollToPage) -> bool {
     LoadHandler loadHandler;
 
     if (settings->isAutoloadPdfXoj()) {
-        fs::path f;
         Document* tmp;
-        std::vector<std::string> exts = {".xopp", ".xoj", ".pdf.xopp", ".pdf.xoj"};
-        for (int i = 0; i < exts.size(); i++) {
-            f = filepath;
+        const std::vector<std::string> exts = {".xopp", ".xoj", ".pdf.xopp", ".pdf.xoj"};
+        for (const std::string& ext: exts) {
+            fs::path f = filepath;
             Util::clearExtensions(f, ".pdf");
-            f += exts[i];
+            f += ext;
             tmp = loadHandler.loadDocument(f);
             if (tmp)
                 break;

--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -2080,10 +2080,22 @@ auto Control::loadPdf(const fs::path& filepath, int scrollToPage) -> bool {
 
     if (settings->isAutloadPdfXoj()) {
         fs::path f = filepath;
-        Util::clearExtensions(f);
+        Util::clearExtensions(f, ".pdf");
         f += ".xopp";
         Document* tmp = loadHandler.loadDocument(f);
 
+        if (tmp == nullptr) {
+            f = filepath;
+            Util::clearExtensions(f, ".pdf");
+            f += ".xoj";
+            tmp = loadHandler.loadDocument(f);
+        }
+        if (tmp == nullptr) {
+            f = filepath;
+            Util::clearExtensions(f);
+            f += ".xopp";
+            tmp = loadHandler.loadDocument(f);
+        }
         if (tmp == nullptr) {
             f = filepath;
             Util::clearExtensions(f);

--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -2078,7 +2078,7 @@ auto Control::openFile(fs::path filepath, int scrollToPage, bool forceOpen) -> b
 auto Control::loadPdf(const fs::path& filepath, int scrollToPage) -> bool {
     LoadHandler loadHandler;
   
-    if (settings->isAutloadPdfXoj()) {
+    if (settings->isAutoloadPdfXoj()) {
         fs::path f;
         Document* tmp;
         std::vector<std::string> exts = {".xopp", ".xoj", ".pdf.xopp", ".pdf.xoj"};

--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -2079,30 +2079,17 @@ auto Control::loadPdf(const fs::path& filepath, int scrollToPage) -> bool {
     LoadHandler loadHandler;
 
     if (settings->isAutloadPdfXoj()) {
-        fs::path f = filepath;
-        Util::clearExtensions(f, ".pdf");
-        f += ".xopp";
-        Document* tmp = loadHandler.loadDocument(f);
-
-        if (tmp == nullptr) {
+        fs::path f;
+        Document* tmp;
+        std::vector<std::string> exts = {".xopp", ".xoj", ".pdf.xopp", ".pdf.xoj"};
+        for (int i = 0; i < exts.size(); i++) {
             f = filepath;
             Util::clearExtensions(f, ".pdf");
-            f += ".xoj";
+            f += exts[i];
             tmp = loadHandler.loadDocument(f);
+            if (tmp)
+                break;
         }
-        if (tmp == nullptr) {
-            f = filepath;
-            Util::clearExtensions(f);
-            f += ".xopp";
-            tmp = loadHandler.loadDocument(f);
-        }
-        if (tmp == nullptr) {
-            f = filepath;
-            Util::clearExtensions(f);
-            f += ".xoj";
-            tmp = loadHandler.loadDocument(f);
-        }
-
         if (tmp) {
             this->doc->lock();
             this->doc->clearDocument();


### PR DESCRIPTION
This commit does the following:

If one were to enable journal autoloading (Edit -> Preferences -> Load/Save -> Autoloading Journals)  and if the xournalpp file corresponding to `<name>.pdf` were named `<name>.xopp`, `<name>.xoj`,  `<name>.pdf.xopp` or  `<name>.pdf.xoj`, then loading the pdf would autoload the xournalpp file as well. 

Previously it autoloaded only `<name>.pdf.xopp` and `<name>.pdf.xoj`. The default save file name is `<name>.xopp` for the latest build, so it would be good if the xournalpp file with that name autoloaded too.