### PR TITLE
Update the web link in menu help > help

### DIFF
--- a/src/util/XojMsgBox.cpp
+++ b/src/util/XojMsgBox.cpp
@@ -52,9 +52,7 @@ auto XojMsgBox::showPluginMessage(const string& pluginName, const string& msg, c
     g_object_set_property(G_OBJECT(dialog), "secondary-text", &val);
     g_value_unset(&val);
 
-    for (auto& kv: button) {
-        gtk_dialog_add_button(GTK_DIALOG(dialog), kv.second.c_str(), kv.first);
-    }
+    for (auto& kv: button) { gtk_dialog_add_button(GTK_DIALOG(dialog), kv.second.c_str(), kv.first); }
 
     int res = gtk_dialog_run(GTK_DIALOG(dialog));
     gtk_widget_destroy(dialog);
@@ -74,7 +72,7 @@ auto XojMsgBox::replaceFileQuestion(GtkWindow* win, const string& msg) -> int {
     return res;
 }
 
-constexpr auto* XOJ_HELP = "https://github.com/xournalpp/xournalpp/wiki/User-Manual";
+constexpr auto* XOJ_HELP = "https://xournalpp.github.io/community/help/";
 
 void XojMsgBox::showHelp(GtkWindow* win) {
 #ifdef _WIN32


### PR DESCRIPTION
The website is already more complete than the user manual and it links to the user manual, so I suggest to direct help seeking users to the website [help page](https://xournalpp.github.io/community/help/) and not to the user manual any more.