### PR TITLE
Update appdata screenshots and avoid deprecated mimetypes tag

### DIFF
--- a/desktop/com.github.xournalpp.xournalpp.appdata.xml
+++ b/desktop/com.github.xournalpp.xournalpp.appdata.xml
@@ -65,12 +65,10 @@
   <provides>
     <id>xournalpp.desktop</id>
     <binary>xournalpp</binary>
+    <mediatype>application/x-xojpp</mediatype>
+    <mediatype>application/x-xopp</mediatype>
+    <mediatype>application/x-xopt</mediatype>
   </provides>
-  <mimetypes>
-    <mimetype>application/x-xojpp</mimetype>
-    <mimetype>application/x-xopp</mimetype>
-    <mimetype>application/x-xopt</mimetype>
-  </mimetypes>
   <update_contact>webmaster_AT_huberulrich.de</update_contact>
   <content_rating type="oars-1.0" />
   <releases>

--- a/desktop/com.github.xournalpp.xournalpp.appdata.xml
+++ b/desktop/com.github.xournalpp.xournalpp.appdata.xml
@@ -52,13 +52,13 @@
   <url type="homepage">https://xournalpp.github.io/</url>
   <screenshots>
     <screenshot type="default">
-      <image>https://user-images.githubusercontent.com/40485433/122611342-70fe3a80-d081-11eb-916a-92e570a1a416.png</image>
+      <image>https://raw.githubusercontent.com/xournalpp/xournalpp-examples/main/appdata/screenshots/note_taking_1600x900.png</image>
     </screenshot>
     <screenshot>
-      <image>https://user-images.githubusercontent.com/40485433/122599842-42776400-d06f-11eb-82a2-c006dcd0c36a.png</image>
+      <image>https://raw.githubusercontent.com/xournalpp/xournalpp-examples/main/appdata/screenshots/pdf_annotation_1600x900.png</image>
     </screenshot>
     <screenshot>
-      <image>https://user-images.githubusercontent.com/40485433/122599858-47d4ae80-d06f-11eb-9dc4-1e546c78b632.png</image>
+      <image>https://raw.githubusercontent.com/xournalpp/xournalpp-examples/main/appdata/screenshots/LaTeX_with_customized_preamble_1600x900.png</image>
     </screenshot>
   </screenshots>
   <launchable type="desktop-id">com.github.xournalpp.xournalpp.desktop</launchable>


### PR DESCRIPTION
I have updated the AppStream metadata to satisfy all of the following tests:

- `appstream-util validate com.github.xournalpp.xournalpp.appdata.xml`
- `appstream-util validate-relax com.github.xournalpp.xournalpp.appdata.xml`
- `appstreamcli validate com.github.xournalpp.xournalpp.appdata.xml`
- `flatpak run org.freedesktop.appstream-glib validate com.github.xournalpp.xournalpp.appdata.xml`

See also https://freedesktop.org/software/appstream/docs/chap-Metadata.html
and https://github.com/flathub/flathub/wiki/App-Requirements#Appstream
for the requirements