### PR TITLE
Try to find out what improved macOS behaviour in #2729

### DIFF
--- a/src/control/tools/StrokeHandler.cpp
+++ b/src/control/tools/StrokeHandler.cpp
@@ -269,7 +269,7 @@ void StrokeHandler::onButtonReleaseEvent(const PositionInputData& pos) {
     page->fireElementChanged(stroke);
 
     // Manually force the rendering of the stroke, if no motion event occurred between, that would rerender the page.
-    if (stroke->getPointCount() == 2) {
+    if (stroke->getPointCount() == 2 || (stroke->getToolType() == STROKE_TOOL_HIGHLIGHTER && stroke->getFill() != -1)) {
         this->redrawable->rerenderElement(stroke);
     }
 


### PR DESCRIPTION
This follows up on the discussion started in [this post](https://github.com/xournalpp/xournalpp/pull/2729#issuecomment-885898684) about how something in #2729 improves the fluidity of strokes under macOS. 

@rolandlo Could you try out those two commits and tell me if the improvement is still there?
It should work with the second commit, but I also hope it works with the first...

(with the second commit, some features will not work. Some functions are just dummies so that it compiles)