### PR TITLE
show floating toolbox on button click

### DIFF
--- a/src/gui/PageView.cpp
+++ b/src/gui/PageView.cpp
@@ -396,6 +396,8 @@ auto XojPageView::onButtonClickEvent(const PositionInputData& pos) -> bool {
 
         control->getWindow()->floatingToolbox->show(wx, wy);
     }
+
+    return true;
 }
 
 auto XojPageView::onButtonDoublePressEvent(const PositionInputData& pos) -> bool {

--- a/src/gui/PageView.cpp
+++ b/src/gui/PageView.cpp
@@ -358,14 +358,7 @@ auto XojPageView::onButtonPressEvent(const PositionInputData& pos) -> bool {
         ImageHandler imgHandler(control, this);
         imgHandler.insertImage(x, y);
     } else if (h->getToolType() == TOOL_FLOATING_TOOLBOX) {
-        gint wx = 0, wy = 0;
-        GtkWidget* widget = xournal->getWidget();
-        gtk_widget_translate_coordinates(widget, gtk_widget_get_toplevel(widget), 0, 0, &wx, &wy);
-
-        wx += std::lround(pos.x) + this->getX();
-        wy += std::lround(pos.y) + this->getY();
-
-        control->getWindow()->floatingToolbox->show(wx, wy);
+        this->showFloatingToolbox(pos);
     }
 
     return true;
@@ -387,14 +380,7 @@ auto XojPageView::onButtonClickEvent(const PositionInputData& pos) -> bool {
     ToolHandler* h = control->getToolHandler();
 
     if (h->getToolType() == TOOL_FLOATING_TOOLBOX) {
-        gint wx = 0, wy = 0;
-        GtkWidget* widget = xournal->getWidget();
-        gtk_widget_translate_coordinates(widget, gtk_widget_get_toplevel(widget), 0, 0, &wx, &wy);
-
-        wx += std::lround(pos.x) + this->getX();
-        wy += std::lround(pos.y) + this->getY();
-
-        control->getWindow()->floatingToolbox->show(wx, wy);
+        this->showFloatingToolbox(pos);
     }
 
     return true;
@@ -537,12 +523,7 @@ auto XojPageView::onButtonReleaseEvent(const PositionInputData& pos) -> bool {
 
             if (doAction)  // pop up a menu
             {
-                gint wx = 0, wy = 0;
-                GtkWidget* widget = xournal->getWidget();
-                gtk_widget_translate_coordinates(widget, gtk_widget_get_toplevel(widget), 0, 0, &wx, &wy);
-                wx += std::lround(pos.x + this->getX());
-                wy += std::lround(pos.y + this->getY());
-                control->getWindow()->floatingToolbox->show(wx, wy);
+                this->showFloatingToolbox(pos);
             }
         }
 
@@ -956,4 +937,17 @@ void XojPageView::elementChanged(Element* elem) {
     } else {
         rerenderElement(elem);
     }
+}
+
+void XojPageView::showFloatingToolbox(const PositionInputData& pos) {
+    Control* control = xournal->getControl();
+
+    gint wx = 0, wy = 0;
+    GtkWidget* widget = xournal->getWidget();
+    gtk_widget_translate_coordinates(widget, gtk_widget_get_toplevel(widget), 0, 0, &wx, &wy);
+
+    wx += std::lround(pos.x) + this->getX();
+    wy += std::lround(pos.y) + this->getY();
+
+    control->getWindow()->floatingToolbox->show(wx, wy);
 }

--- a/src/gui/PageView.cpp
+++ b/src/gui/PageView.cpp
@@ -371,6 +371,33 @@ auto XojPageView::onButtonPressEvent(const PositionInputData& pos) -> bool {
     return true;
 }
 
+auto XojPageView::onButtonClickEvent(const PositionInputData& pos) -> bool {
+    Control* control = xournal->getControl();
+    double x = pos.x;
+    double y = pos.y;
+
+    if (x < 0 || y < 0) {
+        return false;
+    }
+
+    double zoom = xournal->getZoom();
+    x /= zoom;
+    y /= zoom;
+
+    ToolHandler* h = control->getToolHandler();
+
+    if (h->getToolType() == TOOL_FLOATING_TOOLBOX) {
+        gint wx = 0, wy = 0;
+        GtkWidget* widget = xournal->getWidget();
+        gtk_widget_translate_coordinates(widget, gtk_widget_get_toplevel(widget), 0, 0, &wx, &wy);
+
+        wx += std::lround(pos.x) + this->getX();
+        wy += std::lround(pos.y) + this->getY();
+
+        control->getWindow()->floatingToolbox->show(wx, wy);
+    }
+}
+
 auto XojPageView::onButtonDoublePressEvent(const PositionInputData& pos) -> bool {
     // This method assumes that it is called after onButtonPressEvent but before
     // onButtonReleaseEvent

--- a/src/gui/PageView.cpp
+++ b/src/gui/PageView.cpp
@@ -357,9 +357,9 @@ auto XojPageView::onButtonPressEvent(const PositionInputData& pos) -> bool {
     } else if (h->getToolType() == TOOL_IMAGE) {
         ImageHandler imgHandler(control, this);
         imgHandler.insertImage(x, y);
-    } else if (h->getToolType() == TOOL_FLOATING_TOOLBOX) {
-        this->showFloatingToolbox(pos);
     }
+
+    this->onButtonClickEvent(pos);
 
     return true;
 }

--- a/src/gui/PageView.h
+++ b/src/gui/PageView.h
@@ -153,7 +153,7 @@ public:  // event handler
     void onMotionCancelEvent();
 
     /**
-     * for popup windows like the floating toolbox
+     * This event only fires if no input sequence is actively running
      */
     bool onButtonClickEvent(const PositionInputData& pos);
 

--- a/src/gui/PageView.h
+++ b/src/gui/PageView.h
@@ -188,6 +188,11 @@ private:
 
     void setMappedRowCol(int row, int col);  // row, column assigned by mapper during layout.
 
+    /**
+     * Shows the floating toolbox at the location of an input event
+     */
+    void showFloatingToolbox(const PositionInputData& pos);
+
 
 private:
     PageRef page;

--- a/src/gui/PageView.h
+++ b/src/gui/PageView.h
@@ -153,6 +153,11 @@ public:  // event handler
     void onMotionCancelEvent();
 
     /**
+     * for popup windows like the floating toolbox
+     */
+    bool onButtonClickEvent(const PositionInputData& pos);
+
+    /**
      * This method actually repaints the XojPageView, triggering
      * a rerender call if necessary
      */

--- a/src/gui/PageView.h
+++ b/src/gui/PageView.h
@@ -153,7 +153,8 @@ public:  // event handler
     void onMotionCancelEvent();
 
     /**
-     * This event only fires if no input sequence is actively running
+     * This event fires after onButtonPressEvent and also
+     * if no input sequence is actively running and a stylus button was pressed
      */
     bool onButtonClickEvent(const PositionInputData& pos);
 

--- a/src/gui/inputdevices/StylusInputHandler.cpp
+++ b/src/gui/inputdevices/StylusInputHandler.cpp
@@ -43,20 +43,12 @@ auto StylusInputHandler::handleImpl(InputEvent const& event) -> bool {
         } else {
             // No input running but modifier key was pressed
             // Change the tool depending on the key
-            bool toolChanged = changeTool(event);
+            changeTool(event);
 
-            // if this action changed the tool to "floating toolbox", make it pop up
-            if (toolChanged) {
-                ToolHandler* toolHandler = this->inputContext->getToolHandler();
-                if (toolHandler->getToolType() == TOOL_FLOATING_TOOLBOX) {
-                    XojPageView* currentPage = getPageAtCurrentPosition(event);
-                    if (currentPage) {
-                        PositionInputData pos = this->getInputDataRelativeToCurrentPage(currentPage, event);
-                        pos.pressure = this->filterPressure(pos, currentPage);
-
-                        currentPage->onButtonClickEvent(pos);
-                    }
-                }
+            XojPageView* currentPage = getPageAtCurrentPosition(event);
+            if (currentPage) {
+                PositionInputData pos = this->getInputDataRelativeToCurrentPage(currentPage, event);
+                currentPage->onButtonClickEvent(pos);
             }
         }
     }

--- a/src/gui/inputdevices/StylusInputHandler.cpp
+++ b/src/gui/inputdevices/StylusInputHandler.cpp
@@ -43,7 +43,21 @@ auto StylusInputHandler::handleImpl(InputEvent const& event) -> bool {
         } else {
             // No input running but modifier key was pressed
             // Change the tool depending on the key
-            changeTool(event);
+            bool toolChanged = changeTool(event);
+
+            // if this action changed the tool to "floating toolbox", make it pop up
+            if (toolChanged) {
+                ToolHandler* toolHandler = this->inputContext->getToolHandler();
+                if (toolHandler->getToolType() == TOOL_FLOATING_TOOLBOX) {
+                    XojPageView* currentPage = getPageAtCurrentPosition(event);
+                    if (currentPage) {
+                        PositionInputData pos = this->getInputDataRelativeToCurrentPage(currentPage, event);
+                        pos.pressure = this->filterPressure(pos, currentPage);
+
+                        currentPage->onButtonClickEvent(pos);
+                    }
+                }
+            }
         }
     }
 
@@ -137,6 +151,7 @@ void StylusInputHandler::setPressedState(InputEvent const& event) {
                 break;
             case 3:
                 this->modifier3 = true;
+                break;
             default:
                 break;
         }

--- a/src/gui/inputdevices/StylusInputHandler.cpp
+++ b/src/gui/inputdevices/StylusInputHandler.cpp
@@ -143,7 +143,6 @@ void StylusInputHandler::setPressedState(InputEvent const& event) {
                 break;
             case 3:
                 this->modifier3 = true;
-                break;
             default:
                 break;
         }


### PR DESCRIPTION
Pop up the Floating Toolbox (if configured) by pressing a button on your pen without tapping the screen.

Even though this seems to work fine, I am not sure if this is the right way to do this, and open to suggestions how it could be done better.

Closes #2901