### PR TITLE
generateConvert script: Change «, » to "

### DIFF
--- a/src/enums/generateConvert.php
+++ b/src/enums/generateConvert.php
@@ -96,7 +96,7 @@ function writeCppFile($output, $name, $values) {
 		fwrite($fp, "\n");
 	}
 
-	fwrite($fp, $tab . "g_warning(\"Invalid enum value for $name: «%s»\", value.c_str());\n");
+	fwrite($fp, $tab . "g_warning(\"Invalid enum value for $name: \\\"%s\\\"\", value.c_str());\n");
 	fwrite($fp, $tab . "return {$values[0]};\n");
 
 	


### PR DESCRIPTION
## Summary
 * Makes `generateConvert.php`'s output match the current contents of the `*.generated.cpp` files.