### PR TITLE
Update Portaudio to version 19.7 on MS Windows

### DIFF
--- a/windows-setup/build-portaudio.sh
+++ b/windows-setup/build-portaudio.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-PA_CHECKSUM=56c596bba820d90df7d057d8f6a0ec6bf9ab82e8
-PA_FILENAME=pa_stable_v190600_20161030.tgz
+PA_CHECKSUM=b7e9b9c53d993f6d110487ef56a3d4529d21b2f1
+PA_FILENAME=pa_stable_v190700_20210406.tgz
 
 # go to script directory
 cd "${0%/*}"
 
-wget http://www.portaudio.com/archives/${PA_FILENAME}
+wget http://files.portaudio.com/archives/${PA_FILENAME}
 
 #Check the checksum of the downloaded archive
 printf "Checking integrity of downloaded files..."


### PR DESCRIPTION
Portaudio has been updated to version 19.7 on April 6, 2021, see http://files.portaudio.com/download.html. On MS Windows Portaudio is built from source in the build process and the build script downloads from a hard-coded tar-ball filename. I have updated the filename and the corresponding checksum.