### PR TITLE
Bugfix: corrected behaviour of StringUtils::rtrim

### DIFF
--- a/src/util/StringUtils.cpp
+++ b/src/util/StringUtils.cpp
@@ -64,7 +64,7 @@ auto StringUtils::ltrim(std::string str) -> std::string {
 }
 
 auto StringUtils::rtrim(std::string str) -> std::string {
-    str.erase(str.find_last_not_of(TRIM_CHARS) + 1);
+    str.erase(str.find_last_not_of(TRIM_CHARS) + 1, str.size());
     return str;
 }
 


### PR DESCRIPTION
StringUtils::rtrim previously only deleted the first (from left)
TRIM_CHAR from the input string