### PR TITLE
Fix undo layer rename

### DIFF
--- a/src/control/layer/LayerController.h
+++ b/src/control/layer/LayerController.h
@@ -112,4 +112,6 @@ private:
     std::list<LayerCtrlListener*> listener;
 
     size_t selectedPage;
+
+    friend class LayerRenameUndoAction;
 };

--- a/src/gui/dialog/RenameLayerDialog.cpp
+++ b/src/gui/dialog/RenameLayerDialog.cpp
@@ -22,7 +22,8 @@ RenameLayerDialog::RenameLayerDialog(GladeSearchpath* gladeSearchPath, UndoRedoH
 void RenameLayerDialog::renameSuccessful(GtkButton* bttn, RenameLayerDialog* rld) {
     std::string newName = gtk_entry_get_text(GTK_ENTRY(rld->get("layerNameEntry")));
 
-    rld->undo->addUndoAction(std::make_unique<LayerRenameUndoAction>(rld->l, newName, rld->lc->getCurrentLayerName()));
+    rld->undo->addUndoAction(
+            std::make_unique<LayerRenameUndoAction>(rld->lc, rld->l, newName, rld->lc->getCurrentLayerName()));
 
     rld->lc->setCurrentLayerName(newName);
     gtk_window_close(GTK_WINDOW(rld->window));

--- a/src/undo/LayerRenameUndoAction.cpp
+++ b/src/undo/LayerRenameUndoAction.cpp
@@ -11,12 +11,10 @@ auto LayerRenameUndoAction::getText() -> std::string { return _("Rename layer");
 
 auto LayerRenameUndoAction::undo(Control* control) -> bool {
     layer->setName(oldName);
-    control->getLayerController()->setCurrentLayerName(layer->getName());
     return true;
 }
 
 auto LayerRenameUndoAction::redo(Control* control) -> bool {
     layer->setName(newName);
-    control->getLayerController()->setCurrentLayerName(layer->getName());
     return true;
 }

--- a/src/undo/LayerRenameUndoAction.cpp
+++ b/src/undo/LayerRenameUndoAction.cpp
@@ -2,8 +2,13 @@
 
 #include "i18n.h"
 
-LayerRenameUndoAction::LayerRenameUndoAction(Layer* layer, const std::string& newName, const std::string& oldName):
-        UndoAction("LayerUndoAction"), layer(layer), newName(newName), oldName(oldName) {}
+LayerRenameUndoAction::LayerRenameUndoAction(LayerController* layerController, Layer* layer, const std::string& newName,
+                                             const std::string& oldName):
+        UndoAction("LayerUndoAction"),
+        layerController(layerController),
+        layer(layer),
+        newName(newName),
+        oldName(oldName) {}
 
 LayerRenameUndoAction::~LayerRenameUndoAction() = default;
 
@@ -11,10 +16,12 @@ auto LayerRenameUndoAction::getText() -> std::string { return _("Rename layer");
 
 auto LayerRenameUndoAction::undo(Control* control) -> bool {
     layer->setName(oldName);
+    layerController->fireRebuildLayerMenu();
     return true;
 }
 
 auto LayerRenameUndoAction::redo(Control* control) -> bool {
     layer->setName(newName);
+    layerController->fireRebuildLayerMenu();
     return true;
 }

--- a/src/undo/LayerRenameUndoAction.h
+++ b/src/undo/LayerRenameUndoAction.h
@@ -22,7 +22,8 @@ class XojPage;
 
 class LayerRenameUndoAction: public UndoAction {
 public:
-    LayerRenameUndoAction(Layer* layer, const std::string& newName, const std::string& oldName);
+    LayerRenameUndoAction(LayerController* layerController, Layer* layer, const std::string& newName,
+                          const std::string& oldName);
     virtual ~LayerRenameUndoAction();
 
 public:
@@ -32,6 +33,7 @@ public:
 
 private:
     Layer* layer;
+    LayerController* layerController;
     std::string newName;
     std::string oldName;
 };


### PR DESCRIPTION
Fixes #3257. Since nobody touched that issue in a few days, here's a PR with what I suggested there.

1. There was an definite error in the undo/redo logic, simple fix.
2. For the correct change to properly reflect in the UI, I figured calling `fireRebuildLayerMenu()` would be good, so we give the undo action a `LayerController*` as  well and let it reach in there when it need to. (Seems fine?)