### PR TITLE
Preparation for GTK4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON) # enable clang tidy to use correct include
 set_directory_properties(PROPERTIES EP_BASE "${PROJECT_BINARY_DIR}/external")
 
 add_definitions(-D_USE_MATH_DEFINES)
+add_definitions(-DGDK_DISABLE_DEPRECATED -DGTK_DISABLE_DEPRECATED)
 
 # package version
 include(Version)

--- a/src/core/control/ClipboardHandler.cpp
+++ b/src/core/control/ClipboardHandler.cpp
@@ -245,7 +245,7 @@ void ClipboardHandler::setCopyPasteEnabled(bool enabled) {
 }
 
 void ClipboardHandler::ownerChangedCallback(GtkClipboard* clip, GdkEvent* event, ClipboardHandler* handler) {
-    if (event->type == GDK_OWNER_CHANGE) {
+    if (gdk_event_get_event_type(event) == GDK_OWNER_CHANGE) {
         handler->clipboardUpdated(event->owner_change.selection);
     }
 }

--- a/src/core/control/RecentManager.cpp
+++ b/src/core/control/RecentManager.cpp
@@ -10,11 +10,9 @@
 #include "util/i18n.h"
 #include "util/safe_casts.h"
 
-#define MIME "application/x-xoj"
-#define MIME_PDF "application/x-pdf"
-#define GROUP "xournal++"
-
-using std::string;
+constexpr auto const* MIME = "application/x-xoj";
+constexpr auto const* MIME_PDF = "application/x-pdf";
+constexpr auto const* GROUP = "xournal++";
 
 namespace {
 
@@ -40,8 +38,8 @@ void recentManagerChangedCallback(GtkRecentManager* /*manager*/, RecentManager* 
     recentManager->updateMenu();
 }
 
-void recentsMenuActivateCallback(GtkAction* action, RecentManager* recentManager) {
-    auto* info = static_cast<GtkRecentInfo*>(g_object_get_data(G_OBJECT(action), "gtk-recent-info"));
+void recentsMenuActivateCallback(GtkMenuItem* self, RecentManager* recentManager) {
+    auto* info = static_cast<GtkRecentInfo*>(g_object_get_data(G_OBJECT(self), "gtk-recent-info"));
     g_return_if_fail(info != nullptr);
 
     auto p = Util::fromUri(gtk_recent_info_get_uri(info));
@@ -51,7 +49,6 @@ void recentsMenuActivateCallback(GtkAction* action, RecentManager* recentManager
 }
 
 }  // namespace
-
 
 RecentManagerListener::~RecentManagerListener() = default;
 

--- a/src/core/control/pagetype/PageTypeMenu.cpp
+++ b/src/core/control/pagetype/PageTypeMenu.cpp
@@ -1,5 +1,7 @@
 #include "PageTypeMenu.h"
 
+#include <util/gtk4_helper.h>
+
 #include "control/settings/PageTemplateSettings.h"
 #include "control/settings/Settings.h"
 #include "util/i18n.h"
@@ -74,9 +76,8 @@ void PageTypeMenu::addMenuEntry(MainBackgroundPainter* bgPainter, PageTypeInfo* 
         entry = gtk_check_menu_item_new();
 
         GtkWidget* box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 6);
-
-        gtk_container_add(GTK_CONTAINER(box), preview);
-        gtk_container_add(GTK_CONTAINER(box), gtk_label_new(t->name.c_str()));
+        gtk_box_append(GTK_BOX(box), preview);
+        gtk_box_append(GTK_BOX(box), gtk_label_new(t->name.c_str()));
 
         gtk_container_add(GTK_CONTAINER(entry), box);
         gtk_widget_show_all(entry);

--- a/src/core/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp
+++ b/src/core/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp
@@ -99,8 +99,8 @@ void ToolbarAdapter::prepareToolItem(GtkToolItem* it) {
      */
     {
         gtk_widget_realize(GTK_WIDGET(it));
-        GdkScreen* screen = gtk_widget_get_screen(GTK_WIDGET(it));
-        GdkCursor* cursor = gdk_cursor_new_for_display(gdk_screen_get_display(screen), GDK_HAND2);
+        GdkDisplay* display = gtk_widget_get_display(GTK_WIDGET(it));
+        GdkCursor* cursor = gdk_cursor_new_for_display(display, GDK_HAND2);
         g_assert_nonnull(cursor);
         GdkWindow* window = gtk_widget_get_window(GTK_WIDGET(it));
         g_assert_nonnull(window);

--- a/src/core/gui/inputdevices/InputContext.cpp
+++ b/src/core/gui/inputdevices/InputContext.cpp
@@ -270,7 +270,7 @@ void InputContext::printDebug(GdkEvent* event) {
                                    "GDK_PAD_STRIP",
                                    "GDK_PAD_GROUP_MODE",
                                    "GDK_EVENT_LAST"};
-    message += "Event type:\t" + gdkEventTypes[event->type + 1] + "\n";
+    message += "Event type:\t" + gdkEventTypes[gdk_event_get_event_type(event) + 1] + "\n";
 
     std::string gdkInputSources[] = {"GDK_SOURCE_MOUSE",    "GDK_SOURCE_PEN",        "GDK_SOURCE_ERASER",
                                      "GDK_SOURCE_CURSOR",   "GDK_SOURCE_KEYBOARD",   "GDK_SOURCE_TOUCHSCREEN",
@@ -284,8 +284,10 @@ void InputContext::printDebug(GdkEvent* event) {
     InputDeviceClass deviceClass = InputEvents::translateDeviceType(device, this->getSettings());
     message += "Device Class:\t" + gdkInputClasses[deviceClass] + "\n";
 
-    if (event->type == GDK_BUTTON_PRESS || event->type == GDK_DOUBLE_BUTTON_PRESS ||
-        event->type == GDK_TRIPLE_BUTTON_PRESS || event->type == GDK_BUTTON_RELEASE) {
+    if (gdk_event_get_event_type(event) == GDK_BUTTON_PRESS ||
+        gdk_event_get_event_type(event) == GDK_DOUBLE_BUTTON_PRESS ||
+        gdk_event_get_event_type(event) == GDK_TRIPLE_BUTTON_PRESS ||
+        gdk_event_get_event_type(event) == GDK_BUTTON_RELEASE) {
         guint button;
         if (gdk_event_get_button(event, &button)) {
             message += "Button:\t" + std::to_string(button) + "\n";
@@ -294,7 +296,7 @@ void InputContext::printDebug(GdkEvent* event) {
 
 #ifndef DEBUG_INPUT_PRINT_ALL_MOTION_EVENTS
     static bool motionEventBlock = false;
-    if (event->type == GDK_MOTION_NOTIFY) {
+    if (gdk_event_get_event_type(event) == GDK_MOTION_NOTIFY) {
         if (!motionEventBlock) {
             motionEventBlock = true;
             g_message("%s", message.c_str());

--- a/src/core/gui/inputdevices/KeyboardInputHandler.cpp
+++ b/src/core/gui/inputdevices/KeyboardInputHandler.cpp
@@ -16,7 +16,7 @@ auto KeyboardInputHandler::handleImpl(InputEvent const& event) -> bool {
     GtkXournal* xournal = inputContext->getXournal();
     GdkEvent* gdkEvent = event.sourceEvent;
 
-    if (gdkEvent->type == GDK_KEY_PRESS) {
+    if (gdk_event_get_event_type(gdkEvent) == GDK_KEY_PRESS) {
         auto keyEvent = reinterpret_cast<GdkEventKey*>(gdkEvent);
         EditSelection* selection = xournal->selection;
         if (selection) {
@@ -45,7 +45,7 @@ auto KeyboardInputHandler::handleImpl(InputEvent const& event) -> bool {
             }
         }
         return xournal->view->onKeyPressEvent(keyEvent);
-    } else if (gdkEvent->type == GDK_KEY_RELEASE) {
+    } else if (gdk_event_get_event_type(gdkEvent) == GDK_KEY_RELEASE) {
         auto keyEvent = reinterpret_cast<GdkEventKey*>(gdkEvent);
         return inputContext->getView()->onKeyReleaseEvent(keyEvent);
     }

--- a/src/core/gui/widgets/PopupMenuButton.cpp
+++ b/src/core/gui/widgets/PopupMenuButton.cpp
@@ -11,15 +11,10 @@ static void menu_position_func(GtkMenu* menu, int* x, int* y, gboolean* push_in,
 
     GtkTextDirection direction = gtk_widget_get_direction(widget);
 
-    GdkScreen* screen = gtk_widget_get_screen(GTK_WIDGET(menu));
-
-    gint monitor_num = gdk_screen_get_monitor_at_window(screen, gtk_widget_get_window(widget));
-
-    if (monitor_num < 0) {
-        monitor_num = 0;
-    }
-    GdkRectangle monitor;
-    gdk_screen_get_monitor_geometry(screen, monitor_num, &monitor);
+    auto* display = gtk_widget_get_display(GTK_WIDGET(menu));
+    GdkMonitor* monitor = gdk_display_get_monitor_at_window(display, gtk_widget_get_window(widget));
+    GdkRectangle monitor_rect;
+    gdk_monitor_get_geometry(monitor, &monitor_rect);
 
     GtkAllocation arrow_allocation;
     gtk_widget_get_allocation(widget, &arrow_allocation);
@@ -37,11 +32,11 @@ static void menu_position_func(GtkMenu* menu, int* x, int* y, gboolean* push_in,
         *x -= menu_req.width - allocation.width;
     }
 
-    if ((*y + arrow_allocation.height + menu_req.height) <= monitor.y + monitor.height) {
+    if ((*y + arrow_allocation.height + menu_req.height) <= monitor_rect.y + monitor_rect.height) {
         *y += arrow_allocation.height;
-    } else if ((*y - menu_req.height) >= monitor.y) {
+    } else if ((*y - menu_req.height) >= monitor_rect.y) {
         *y -= menu_req.height;
-    } else if (monitor.y + monitor.height - (*y + arrow_allocation.height) > *y) {
+    } else if (monitor_rect.y + monitor_rect.height - (*y + arrow_allocation.height) > *y) {
         *y += arrow_allocation.height;
     } else {
         *y -= menu_req.height;

--- a/src/core/gui/widgets/XournalWidget.cpp
+++ b/src/core/gui/widgets/XournalWidget.cpp
@@ -28,7 +28,7 @@ static void gtk_xournal_get_preferred_height(GtkWidget* widget, gint* minimal_he
 static void gtk_xournal_size_allocate(GtkWidget* widget, GtkAllocation* allocation);
 static void gtk_xournal_realize(GtkWidget* widget);
 static auto gtk_xournal_draw(GtkWidget* widget, cairo_t* cr) -> gboolean;
-static void gtk_xournal_destroy(GtkWidget* object);
+static void gtk_xournal_dispose(GObject* object);
 
 auto gtk_xournal_get_type(void) -> GType {
     static GType gtk_xournal_type = 0;
@@ -76,10 +76,8 @@ auto gtk_xournal_new(XournalView* view, InputContext* inputContext) -> GtkWidget
     return GTK_WIDGET(xoj);
 }
 
-static void gtk_xournal_class_init(GtkXournalClass* klass) {
-    GtkWidgetClass* widget_class = nullptr;
-
-    widget_class = reinterpret_cast<GtkWidgetClass*>(klass);
+static void gtk_xournal_class_init(GtkXournalClass* cptr) {
+    auto* widget_class = reinterpret_cast<GtkWidgetClass*>(cptr);
 
     widget_class->realize = gtk_xournal_realize;
     widget_class->get_preferred_width = gtk_xournal_get_preferred_width;
@@ -88,7 +86,7 @@ static void gtk_xournal_class_init(GtkXournalClass* klass) {
 
     widget_class->draw = gtk_xournal_draw;
 
-    widget_class->destroy = gtk_xournal_destroy;
+    reinterpret_cast<GObjectClass*>(widget_class)->dispose = gtk_xournal_dispose;
 }
 
 auto gtk_xournal_get_visible_area(GtkWidget* widget, XojPageView* p) -> Rectangle<double>* {
@@ -307,10 +305,9 @@ static auto gtk_xournal_draw(GtkWidget* widget, cairo_t* cr) -> gboolean {
     return true;
 }
 
-static void gtk_xournal_destroy(GtkWidget* object) {
+static void gtk_xournal_dispose(GObject* object) {
     g_return_if_fail(object != nullptr);
     g_return_if_fail(GTK_IS_XOURNAL(object));
-
     GtkXournal* xournal = GTK_XOURNAL(object);
 
     delete xournal->selection;

--- a/src/core/gui/widgets/gtkmenutooltogglebutton.cpp
+++ b/src/core/gui/widgets/gtkmenutooltogglebutton.cpp
@@ -198,15 +198,10 @@ static void menu_position_func(GtkMenu* menu, int* x, int* y, gboolean* push_in,
     GtkOrientation orientation = gtk_tool_item_get_orientation(GTK_TOOL_ITEM(button));
     GtkTextDirection direction = gtk_widget_get_direction(widget);
 
-    GdkScreen* screen = gtk_widget_get_screen(GTK_WIDGET(menu));
-
-    gint monitor_num = gdk_screen_get_monitor_at_window(screen, gtk_widget_get_window(widget));
-
-    if (monitor_num < 0) {
-        monitor_num = 0;
-    }
-    GdkRectangle monitor;
-    gdk_screen_get_monitor_geometry(screen, monitor_num, &monitor);
+    auto* display = gtk_widget_get_display(GTK_WIDGET(menu));
+    GdkMonitor* monitor = gdk_display_get_monitor_at_window(display, gtk_widget_get_window(widget));
+    GdkRectangle monitor_rect;
+    gdk_monitor_get_geometry(monitor, &monitor_rect);
 
     GtkAllocation arrow_allocation;
     gtk_widget_get_allocation(priv->arrow_button, &arrow_allocation);
@@ -225,11 +220,11 @@ static void menu_position_func(GtkMenu* menu, int* x, int* y, gboolean* push_in,
             *x -= menu_req.width - allocation.width;
         }
 
-        if ((*y + arrow_allocation.height + menu_req.height) <= monitor.y + monitor.height) {
+        if ((*y + arrow_allocation.height + menu_req.height) <= monitor_rect.y + monitor_rect.height) {
             *y += arrow_allocation.height;
-        } else if ((*y - menu_req.height) >= monitor.y) {
+        } else if ((*y - menu_req.height) >= monitor_rect.y) {
             *y -= menu_req.height;
-        } else if (monitor.y + monitor.height - (*y + arrow_allocation.height) > *y) {
+        } else if (monitor_rect.y + monitor_rect.height - (*y + arrow_allocation.height) > *y) {
             *y += arrow_allocation.height;
         } else {
             *y -= menu_req.height;
@@ -246,8 +241,8 @@ static void menu_position_func(GtkMenu* menu, int* x, int* y, gboolean* push_in,
             *x -= menu_req.width;
         }
 
-        if (*y + menu_req.height > monitor.y + monitor.height &&
-            *y + arrow_allocation.height - monitor.y > monitor.y + monitor.height - *y) {
+        if (*y + menu_req.height > monitor_rect.y + monitor_rect.height &&
+            *y + arrow_allocation.height - monitor_rect.y > monitor_rect.y + monitor_rect.height - *y) {
             *y += arrow_allocation.height - menu_req.height;
         }
     }

--- a/src/core/gui/widgets/gtkmenutooltogglebutton.cpp
+++ b/src/core/gui/widgets/gtkmenutooltogglebutton.cpp
@@ -37,7 +37,7 @@ struct _GtkMenuToolToggleButtonPrivate {
     GtkMenu* menu;
 };
 
-static void gtk_menu_tool_toggle_button_destroy(GtkWidget* object);
+static void gtk_menu_tool_toggle_button_dispose(GObject* object);
 
 static auto menu_deactivate_cb(GtkMenuShell* menu_shell, GtkMenuToolToggleButton* button) -> int;
 
@@ -157,10 +157,9 @@ static void gtk_menu_tool_toggle_button_class_init(GtkMenuToolToggleButtonClass*
 
     object_class->set_property = gtk_menu_tool_toggle_button_set_property;
     object_class->get_property = gtk_menu_tool_toggle_button_get_property;
+    object_class->dispose = gtk_menu_tool_toggle_button_dispose;
     widget_class->state_changed = gtk_menu_tool_toggle_button_state_changed;
     toolitem_class->toolbar_reconfigured = gtk_menu_tool_toggle_button_toolbar_reconfigured;
-
-    widget_class->destroy = gtk_menu_tool_toggle_button_destroy;
 
     /**
      * GtkMenuToolButton::show-menu:
@@ -325,7 +324,7 @@ static void gtk_menu_tool_toggle_button_init(GtkMenuToolToggleButton* button) {
     g_signal_connect(arrow_button, "button-press-event", G_CALLBACK(arrow_button_button_press_event_cb), button);
 }
 
-static void gtk_menu_tool_toggle_button_destroy(GtkWidget* object) {
+static void gtk_menu_tool_toggle_button_dispose(GObject* object) {
     GtkMenuToolToggleButton* button = GTK_MENU_TOOL_TOGGLE_BUTTON(object);
 
     if (button->priv->menu) {

--- a/src/util/include/util/gtk4_helper.h
+++ b/src/util/include/util/gtk4_helper.h
@@ -1,0 +1,23 @@
+/*
+ * Xournal++
+ *
+ * header for missing gtk4 functions (part of the gtk4 port)
+ * will be removed later
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+#include <gtk/gtk.h>
+
+
+void gtk_box_append(GtkBox* box, GtkWidget* child) {
+    constexpr auto default_expand = false;
+    gtk_box_pack_start(GTK_BOX(box), child, default_expand, true, 0);
+}
+
+void gtk_box_remove(GtkBox* box, GtkWidget* child) { gtk_container_remove(GTK_CONTAINER(box), child); }

--- a/src/util/pixbuf-utils.cpp
+++ b/src/util/pixbuf-utils.cpp
@@ -251,8 +251,7 @@ static void convert_no_alpha(guchar* dest_data, int dest_stride, guchar* src_dat
  *
  * Transfers image data from a #cairo_surface_t and converts it to an RGB(A)
  * representation inside a #GdkPixbuf. This allows you to efficiently read
- * individual pixels from cairo surfaces. For #GdkWindows, use
- * gdk_pixbuf_get_from_window() instead.
+ * individual pixels from cairo surfaces.
  *
  * This function will create an RGB pixbuf with 8 bits per channel.
  * The pixbuf will contain an alpha channel if the @surface contains one.


### PR DESCRIPTION
@reviewers, please review commit by commit.

https://docs.gtk.org/gtk4/migrating-3to4.html

 - [x] Do not use deprecated symbols
 - [ ] Enable diagnostic warnings
 - [x] Do not use GTK-specific command line arguments
 - [ ] Do not use widget style properties
 - [x] Review your window creation flags
 - [ ] Stop using direct access to GdkEvent structs
 - [x] Stop using `gdk_pointer_warp()`
 - [x] Stop using non-RGBA visuals
 - [x] Stop using `gtk_widget_set_app_paintable`
 - [x] Stop using `GtkBox` padding, fill and expand child properties
 - [x] Stop using the state argument of `GtkStyleContext` getters
 - [x] Stop using `gdk_pixbuf_get_from_window()` and `gdk_cairo_set_source_window()`
 - [ ] Stop using `GtkButton`'s image-related API
 - [ ] Stop using `GtkWidget` event signals
 - [x] Set a proper application ID
 - [x] Stop using `gtk_main()` and related APIs
 - [ ] Reduce the use of `gtk_widget_destroy()`
 - [x] Stop using the GtkWidget.destroy vfunc
 - [ ] Reduce the use of generic container APIs
 - [ ] Review your use of icon resources
 
 ==== HArder to fullfill, since the API is not fully replaced ====
 
  - [x] Stop using GdkScreen
 