### PR TITLE
[Experiment] CAIRO_FILTER_FAST, CAIRO_ANTIALIAS_FAST

### DIFF
--- a/src/gui/widgets/XournalWidget.cpp
+++ b/src/gui/widgets/XournalWidget.cpp
@@ -264,6 +264,11 @@ static auto gtk_xournal_draw(GtkWidget* widget, cairo_t* cr) -> gboolean {
 
     cairo_clip_extents(cr, &x1, &y1, &x2, &y2);
 
+    // Improve performance of cairo_scale (see
+    // https://stackoverflow.com/questions/59549863/poor-performance-when-downscaling-surfaces)
+    cairo_pattern_set_filter(cairo_get_source(cr), CAIRO_FILTER_FAST);
+    cairo_set_antialias(cr, CAIRO_ANTIALIAS_FAST);
+
     // Draw background
     Settings* settings = xournal->view->getControl()->getSettings();
     Util::cairo_set_source_rgbi(cr, settings->getBackgroundColor());


### PR DESCRIPTION
This PR **may** make rendering/drawing faster when zoomed in/out far. It may also have little/no effect.

**TODO**:
 * [ ] Benchmark and compare speed
 * [ ] Any reduction in quality?