### PR TITLE
Extend input method check for gcin

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -58,6 +58,7 @@ Henrik Dick <hen-di@web.de>
 Henry Heino <46334387+personalizedrefrigerator@users.noreply.github.com>
 Henry Heino <personalizedrefrigerator@gmail.com>
 Holzfeind, Daniel Georg <git@holzfeind.net>
+Huan-Cheng Chang <hello@changhc.me>
 Jan Hrdina <jan.hrdka@gmail.com>
 Jason Vander Woude <jasonvwoude@gmail.com>
 John Doe <johndoe@0.0>

--- a/src/control/XournalMain.cpp
+++ b/src/control/XournalMain.cpp
@@ -383,10 +383,16 @@ using XMPtr = XournalMainPrivate*;
 
 /// Checks for input method compatibility and ensures it
 void ensure_input_model_compatibility() {
+    char* unsupportedImModules[] = {"xim", "gcin"};
     const char* imModule = g_getenv("GTK_IM_MODULE");
-    if (imModule != nullptr && strcmp(imModule, "ibus") != 0) {
-        g_setenv("GTK_IM_MODULE", "ibus", true);
-        g_warning("Unsupported input method: %s, changed to: ibus", imModule);
+    if (imModule != nullptr) {
+        for (int i = 0; i < 2; i++) {
+            if (strcmp(imModule, unsupportedImModules[i]) == 0) {
+                g_setenv("GTK_IM_MODULE", "ibus", true);
+                g_warning("Unsupported input method: %s, changed to: ibus", imModule);
+                break;
+            }
+        }
     }
 }
 

--- a/src/control/XournalMain.cpp
+++ b/src/control/XournalMain.cpp
@@ -384,9 +384,9 @@ using XMPtr = XournalMainPrivate*;
 /// Checks for input method compatibility and ensures it
 void ensure_input_model_compatibility() {
     const char* imModule = g_getenv("GTK_IM_MODULE");
-    if (imModule != nullptr && strcmp(imModule, "xim") == 0) {
+    if (imModule != nullptr && strcmp(imModule, "ibus") != 0) {
         g_setenv("GTK_IM_MODULE", "ibus", true);
-        g_warning("Unsupported input method: xim, changed to: ibus");
+        g_warning("Unsupported input method: %s, changed to: ibus", imModule);
     }
 }
 

--- a/src/control/XournalMain.cpp
+++ b/src/control/XournalMain.cpp
@@ -385,7 +385,7 @@ using XMPtr = XournalMainPrivate*;
 void ensure_input_model_compatibility() {
     const char* imModule = g_getenv("GTK_IM_MODULE");
     if (imModule != nullptr) {
-        std::string imModuleString { imModule };
+        std::string imModuleString{imModule};
         if (imModuleString == "xim" || imModuleString == "gcin") {
             g_setenv("GTK_IM_MODULE", "ibus", true);
             g_warning("Unsupported input method: %s, changed to: ibus", imModule);

--- a/src/control/XournalMain.cpp
+++ b/src/control/XournalMain.cpp
@@ -383,15 +383,12 @@ using XMPtr = XournalMainPrivate*;
 
 /// Checks for input method compatibility and ensures it
 void ensure_input_model_compatibility() {
-    char* unsupportedImModules[] = {"xim", "gcin"};
     const char* imModule = g_getenv("GTK_IM_MODULE");
     if (imModule != nullptr) {
-        for (int i = 0; i < 2; i++) {
-            if (strcmp(imModule, unsupportedImModules[i]) == 0) {
-                g_setenv("GTK_IM_MODULE", "ibus", true);
-                g_warning("Unsupported input method: %s, changed to: ibus", imModule);
-                break;
-            }
+        std::string imModuleString { imModule };
+        if (imModuleString == "xim" || imModuleString == "gcin") {
+            g_setenv("GTK_IM_MODULE", "ibus", true);
+            g_warning("Unsupported input method: %s, changed to: ibus", imModule);
         }
     }
 }


### PR DESCRIPTION
Following #470 and #530, this PR extends the input method check to cover any input method that is not ibus.

In my case, I'm using `gcin`, an input method for Traditional Chinese. This is not covered in the current check, so xournalpp crashes every time I try to add some text to my pdf documents. My change will make the check more comprehensive than checking only against `xim`.

Edit: checking against `xim` and `gcin` only now.

#### Test output
```
$ echo $GTK_IM_MODULE
gcin
$ ./src/xournalpp
** Message: 18:15:22.754: TEXTDOMAINDIR = (null), PACKAGE_LOCALE_DIR = /usr/local/share/locale, chosen directory = /usr/local/share/locale            
                                                                                                                                                      
** (xournalpp:18484): WARNING **: 18:15:22.754: Unsupported input method: gcin, changed to: ibus                                                      
ALSA lib pcm_dmix.c:1089:(snd_pcm_dmix_open) unable to open slave                                                                                     
ALSA lib pcm.c:2642:(snd_pcm_open_noupdate) Unknown PCM cards.pcm.rear                                                                                
ALSA lib pcm.c:2642:(snd_pcm_open_noupdate) Unknown PCM cards.pcm.center_lfe                                                                          
ALSA lib pcm.c:2642:(snd_pcm_open_noupdate) Unknown PCM cards.pcm.side                                                                                
ALSA lib pcm_route.c:869:(find_matching_chmap) Found no matching channel map                                                                          
ALSA lib pcm_oss.c:377:(_snd_pcm_oss_open) Unknown field port                                                                                         
ALSA lib pcm_oss.c:377:(_snd_pcm_oss_open) Unknown field port                                                                                         
ALSA lib pcm_usb_stream.c:486:(_snd_pcm_usb_stream_open) Invalid type for card                                                                        
ALSA lib pcm_usb_stream.c:486:(_snd_pcm_usb_stream_open) Invalid type for card                                                                        
ALSA lib pcm_dmix.c:1089:(snd_pcm_dmix_open) unable to open slave                                                                                     
** Message: 18:15:22.788: Plugin "MigrateFontSizes" UI initialized 
```