### PR TITLE
Fixed #3330: Allow characters after final dot in filename

### DIFF
--- a/src/control/jobs/SaveJob.cpp
+++ b/src/control/jobs/SaveJob.cpp
@@ -87,10 +87,11 @@ auto SaveJob::save() -> bool {
 
     doc->lock();
     h.prepareSave(doc);
-    fs::path const filepath = doc->getFilepath();
+    fs::path filepath = doc->getFilepath();
     doc->unlock();
 
-    auto const target = fs::path{filepath}.replace_extension(".xopp");
+    Util::clearExtensions(filepath, ".pdf");
+    auto const target = fs::path{filepath}.concat(".xopp");
 
     if (doc->shouldCreateBackupOnSave()) {
         try {


### PR DESCRIPTION
This PR removes .pdf, .xopp and .xoj extensions (if any) and then appends xopp to the filename, rather than the simple replace_extension that was happening previously (because of which the text after the last dot in the filename was lost, as replace_extension used to replace that text thinking it was the extension).

Old code (in `SaveJob::save`)
```cpp
fs::path const filepath = doc->getFilepath();
auto const target = fs::path{filepath}.replace_extension(".xopp");
```
New code:
```cpp
fs::path filepath = doc->getFilepath();
Util::clearExtensions(filepath, ".pdf");
auto const target = fs::path{filepath}.concat(".xopp");
```