### PR TITLE
Allow Vertical Spacing tool to move elements above line

### DIFF
--- a/src/core/control/tools/VerticalToolHandler.cpp
+++ b/src/core/control/tools/VerticalToolHandler.cpp
@@ -21,11 +21,7 @@ VerticalToolHandler::VerticalToolHandler(Redrawable* view, const PageRef& page, 
 
     for (Element* e: this->elements) {
         this->layer->removeElement(e, false);
-
-        this->jumpY = std::max(this->jumpY, e->getY() + e->getElementHeight());
     }
-
-    this->jumpY = this->page->getHeight() - this->jumpY;
 
     this->crBuffer = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, this->page->getWidth() * zoom,
                                                 (this->page->getHeight() - y) * zoom);
@@ -57,16 +53,8 @@ void VerticalToolHandler::paint(cairo_t* cr, GdkRectangle* rect, double zoom) {
 
     gdk_cairo_set_source_rgba(cr, &selectionColor);
 
-    double y = NAN;
-    double height = NAN;
-
-    if (this->startY < this->endY) {
-        y = this->startY;
-        height = this->endY - this->startY;
-    } else {
-        y = this->endY;
-        height = this->startY - this->endY;
-    }
+    const double y = std::min(this->startY, this->endY);
+    const double height = std::abs(this->startY - this->endY);
 
     cairo_rectangle(cr, 0, y * zoom, this->page->getWidth() * zoom, height * zoom);
 

--- a/src/core/control/tools/VerticalToolHandler.cpp
+++ b/src/core/control/tools/VerticalToolHandler.cpp
@@ -10,7 +10,7 @@
 #include "view/DocumentView.h"
 
 VerticalToolHandler::VerticalToolHandler(Redrawable* view, const PageRef& page, Settings* settings, double y,
-                                         bool initiallyReverse, double zoom):
+                                         bool initiallyReverse, double zoom, GdkWindow* window):
         view(view),
         page(page),
         layer(this->page->getSelectedLayer()),
@@ -20,9 +20,17 @@ VerticalToolHandler::VerticalToolHandler(Redrawable* view, const PageRef& page, 
     this->startY = ySnapped;
     this->endY = ySnapped;
     this->zoom = zoom;
-    this->crBuffer = cairo_image_surface_create(
-            CAIRO_FORMAT_ARGB32, static_cast<int>(this->page->getWidth() * this->zoom),
-            static_cast<int>(std::max(this->startY, this->page->getHeight() - this->startY) * this->zoom));
+
+    const int bufWidth = static_cast<int>(this->page->getWidth() * this->zoom);
+    const int bufHeight = static_cast<int>(std::max(this->startY, this->page->getHeight() - this->startY) * this->zoom);
+
+    if (window) {
+        const int scale = gdk_window_get_scale_factor(window);
+        this->crBuffer = gdk_window_create_similar_image_surface(window, CAIRO_FORMAT_ARGB32, bufWidth * scale,
+                                                                 bufHeight * scale, scale);
+    } else {
+        this->crBuffer = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, bufWidth, bufHeight);
+    }
 
     this->adoptElements(this->spacingSide);
 

--- a/src/core/control/tools/VerticalToolHandler.h
+++ b/src/core/control/tools/VerticalToolHandler.h
@@ -26,7 +26,12 @@
 
 class VerticalToolHandler: public ElementContainer {
 public:
-    VerticalToolHandler(Redrawable* view, const PageRef& page, Settings* settings, double y, double zoom);
+    /**
+     * @param initiallyReverse Set this to true if the user has the reverse mode
+     * button (e.g., Ctrl) held down when a vertical selection is started.
+     */
+    VerticalToolHandler(Redrawable* view, const PageRef& page, Settings* settings, double y, bool initiallyReverse,
+                        double zoom);
     ~VerticalToolHandler() override;
     VerticalToolHandler(VerticalToolHandler&) = delete;
     VerticalToolHandler& operator=(VerticalToolHandler&) = delete;
@@ -34,22 +39,67 @@ public:
     VerticalToolHandler&& operator=(VerticalToolHandler&&) = delete;
 
     void paint(cairo_t* cr, GdkRectangle* rect, double zoom);
+
+    /** Update the tool state with the new spacing position */
     void currentPos(double x, double y);
+
+    bool onKeyPressEvent(GdkEventKey* event);
+    bool onKeyReleaseEvent(GdkEventKey* event);
 
     std::unique_ptr<MoveUndoAction> finalize();
 
     std::vector<Element*>* getElements() override;
 
 private:
+    enum class Side {
+        /** elements above the reference line */
+        Above = -1,
+        /** elements below the reference line */
+        Below = 1,
+    };
+
+    /**
+     * Clear the currently moved elements, and then select all elements
+     * above/below startY (depending on the side) to use for the spacing.
+     * Lastly, redraw the elements to the buffer.
+     */
+    void adoptElements(Side side);
+
+    /**
+     * Recreate the buffer if the new zoom value is higher.
+     */
+    void updateZoom(double newZoom);
+
+    /**
+     * Clear the buffer and redraw the elements being spaced.
+     */
+    void redrawBuffer();
+
+    GdkWindow* window;
     Redrawable* view = nullptr;
     PageRef page;
     Layer* layer = nullptr;
     std::vector<Element*> elements;
 
+    /**
+     * Image buffer containing a rendering of the elements being spaced. This
+     * buffer is rendered below the endY if direction is below, or above the
+     * endY if the direction is above.
+     */
     cairo_surface_t* crBuffer = nullptr;
 
     double startY = 0;
     double endY = 0;
+
+    /**
+     * Indicates whether to move elements above (negative) or below (positive) the anchor line.
+     */
+    Side spacingSide;
+
+    /**
+     * Current zoom level.
+     */
+    double zoom;  // TODO: listen to zoom change in case zoom is changed during spacing
 
     /**
      * The handler for snapping points

--- a/src/core/control/tools/VerticalToolHandler.h
+++ b/src/core/control/tools/VerticalToolHandler.h
@@ -28,6 +28,10 @@ class VerticalToolHandler: public ElementContainer {
 public:
     VerticalToolHandler(Redrawable* view, const PageRef& page, Settings* settings, double y, double zoom);
     ~VerticalToolHandler() override;
+    VerticalToolHandler(VerticalToolHandler&) = delete;
+    VerticalToolHandler& operator=(VerticalToolHandler&) = delete;
+    VerticalToolHandler(VerticalToolHandler&&) = delete;
+    VerticalToolHandler&& operator=(VerticalToolHandler&&) = delete;
 
     void paint(cairo_t* cr, GdkRectangle* rect, double zoom);
     void currentPos(double x, double y);
@@ -46,11 +50,6 @@ private:
 
     double startY = 0;
     double endY = 0;
-
-    /**
-     * When we create a new page
-     */
-    double jumpY = 0;
 
     /**
      * The handler for snapping points

--- a/src/core/control/tools/VerticalToolHandler.h
+++ b/src/core/control/tools/VerticalToolHandler.h
@@ -16,6 +16,7 @@
 
 #include <cairo.h>
 
+#include "control/zoom/ZoomListener.h"
 #include "gui/Redrawable.h"
 #include "model/PageRef.h"
 #include "undo/MoveUndoAction.h"
@@ -23,15 +24,19 @@
 
 #include "SnapToGridInputHandler.h"
 
+class ZoomControl;
 
-class VerticalToolHandler: public ElementContainer {
+/**
+ * Handler class for the Vertical Spacing tool.
+ */
+class VerticalToolHandler: public ElementContainer, public ZoomListener {
 public:
     /**
      * @param initiallyReverse Set this to true if the user has the reverse mode
      * button (e.g., Ctrl) held down when a vertical selection is started.
      */
     VerticalToolHandler(Redrawable* view, const PageRef& page, Settings* settings, double y, bool initiallyReverse,
-                        double zoom, GdkWindow* window);
+                        ZoomControl* zoomControl, GdkWindow* window);
     ~VerticalToolHandler() override;
     VerticalToolHandler(VerticalToolHandler&) = delete;
     VerticalToolHandler& operator=(VerticalToolHandler&) = delete;
@@ -49,6 +54,8 @@ public:
     std::unique_ptr<MoveUndoAction> finalize();
 
     std::vector<Element*>* getElements() override;
+
+    void zoomChanged() override;
 
 private:
     enum class Side {
@@ -76,9 +83,9 @@ private:
     void redrawBuffer();
 
     GdkWindow* window;
-    Redrawable* view = nullptr;
+    Redrawable* view;
     PageRef page;
-    Layer* layer = nullptr;
+    Layer* layer;
     std::vector<Element*> elements;
 
     /**
@@ -88,18 +95,19 @@ private:
      */
     cairo_surface_t* crBuffer = nullptr;
 
-    double startY = 0;
-    double endY = 0;
+    double startY;
+    double endY;
 
     /**
-     * Indicates whether to move elements above (negative) or below (positive) the anchor line.
+     * Indicates whether to move elements above or below the anchor line.
      */
     Side spacingSide;
 
     /**
      * Current zoom level.
      */
-    double zoom;  // TODO: listen to zoom change in case zoom is changed during spacing
+    double zoom;
+    ZoomControl* zoomControl;
 
     /**
      * The handler for snapping points

--- a/src/core/control/tools/VerticalToolHandler.h
+++ b/src/core/control/tools/VerticalToolHandler.h
@@ -31,7 +31,7 @@ public:
      * button (e.g., Ctrl) held down when a vertical selection is started.
      */
     VerticalToolHandler(Redrawable* view, const PageRef& page, Settings* settings, double y, bool initiallyReverse,
-                        double zoom);
+                        double zoom, GdkWindow* window);
     ~VerticalToolHandler() override;
     VerticalToolHandler(VerticalToolHandler&) = delete;
     VerticalToolHandler& operator=(VerticalToolHandler&) = delete;

--- a/src/core/control/zoom/ZoomControl.cpp
+++ b/src/core/control/zoom/ZoomControl.cpp
@@ -1,5 +1,6 @@
 #include "ZoomControl.h"
 
+#include <algorithm>
 #include <cmath>
 
 #include "control/Control.h"
@@ -205,6 +206,12 @@ auto ZoomControl::getScrollPositionAfterZoom() const -> utl::Point<double> {
 
 
 void ZoomControl::addZoomListener(ZoomListener* l) { this->listener.emplace_back(l); }
+
+void ZoomControl::removeZoomListener(ZoomListener* l) {
+    if (auto it = std::find(this->listener.begin(), this->listener.end(), l); it != this->listener.end()) {
+        this->listener.erase(it);
+    }
+}
 
 void ZoomControl::initZoomHandler(GtkWidget* window, GtkWidget* widget, XournalView* v, Control* c) {
     this->control = c;

--- a/src/core/control/zoom/ZoomControl.h
+++ b/src/core/control/zoom/ZoomControl.h
@@ -118,6 +118,7 @@ public:
     bool updateZoomPresentationValue(size_t pageNo = 0);
 
     void addZoomListener(ZoomListener* listener);
+    void removeZoomListener(ZoomListener* listener);
 
     void initZoomHandler(GtkWidget* window, GtkWidget* widget, XournalView* v, Control* c);
 

--- a/src/core/gui/PageView.cpp
+++ b/src/core/gui/PageView.cpp
@@ -318,7 +318,9 @@ auto XojPageView::onButtonPressEvent(const PositionInputData& pos) -> bool {
         this->inEraser = true;
     } else if (h->getToolType() == TOOL_VERTICAL_SPACE) {
         g_assert_null(this->verticalSpace);
-        this->verticalSpace = new VerticalToolHandler(this, this->page, this->settings, y, pos.isControlDown(), zoom);
+        auto* window = gtk_widget_get_window(xournal->getWidget());
+        this->verticalSpace =
+                new VerticalToolHandler(this, this->page, this->settings, y, pos.isControlDown(), zoom, window);
     } else if (h->getToolType() == TOOL_SELECT_RECT || h->getToolType() == TOOL_SELECT_REGION ||
                h->getToolType() == TOOL_PLAY_OBJECT || h->getToolType() == TOOL_SELECT_OBJECT ||
                h->getToolType() == TOOL_SELECT_PDF_TEXT_LINEAR || h->getToolType() == TOOL_SELECT_PDF_TEXT_RECT) {

--- a/src/core/gui/PageView.cpp
+++ b/src/core/gui/PageView.cpp
@@ -317,6 +317,7 @@ auto XojPageView::onButtonPressEvent(const PositionInputData& pos) -> bool {
         this->eraser->erase(x, y);
         this->inEraser = true;
     } else if (h->getToolType() == TOOL_VERTICAL_SPACE) {
+        g_assert_null(this->verticalSpace);
         this->verticalSpace = new VerticalToolHandler(this, this->page, this->settings, y, zoom);
     } else if (h->getToolType() == TOOL_SELECT_RECT || h->getToolType() == TOOL_SELECT_REGION ||
                h->getToolType() == TOOL_PLAY_OBJECT || h->getToolType() == TOOL_SELECT_OBJECT ||

--- a/src/core/gui/PageView.cpp
+++ b/src/core/gui/PageView.cpp
@@ -318,7 +318,7 @@ auto XojPageView::onButtonPressEvent(const PositionInputData& pos) -> bool {
         this->inEraser = true;
     } else if (h->getToolType() == TOOL_VERTICAL_SPACE) {
         g_assert_null(this->verticalSpace);
-        this->verticalSpace = new VerticalToolHandler(this, this->page, this->settings, y, zoom);
+        this->verticalSpace = new VerticalToolHandler(this, this->page, this->settings, y, pos.isControlDown(), zoom);
     } else if (h->getToolType() == TOOL_SELECT_RECT || h->getToolType() == TOOL_SELECT_REGION ||
                h->getToolType() == TOOL_PLAY_OBJECT || h->getToolType() == TOOL_SELECT_OBJECT ||
                h->getToolType() == TOOL_SELECT_PDF_TEXT_LINEAR || h->getToolType() == TOOL_SELECT_PDF_TEXT_RECT) {
@@ -644,6 +644,10 @@ auto XojPageView::onKeyPressEvent(GdkEventKey* event) -> bool {
         return this->inputHandler->onKeyEvent(event);
     }
 
+    if (this->verticalSpace) {
+        return this->verticalSpace->onKeyPressEvent(event);
+    }
+
 
     return false;
 }
@@ -662,6 +666,10 @@ auto XojPageView::onKeyReleaseEvent(GdkEventKey* event) -> bool {
             }
         }
 
+        return true;
+    }
+
+    if (this->verticalSpace && this->verticalSpace->onKeyReleaseEvent(event)) {
         return true;
     }
 

--- a/src/core/gui/PageView.cpp
+++ b/src/core/gui/PageView.cpp
@@ -319,8 +319,10 @@ auto XojPageView::onButtonPressEvent(const PositionInputData& pos) -> bool {
     } else if (h->getToolType() == TOOL_VERTICAL_SPACE) {
         g_assert_null(this->verticalSpace);
         auto* window = gtk_widget_get_window(xournal->getWidget());
+        auto* zoomControl = this->getXournal()->getControl()->getZoomControl();
         this->verticalSpace =
-                new VerticalToolHandler(this, this->page, this->settings, y, pos.isControlDown(), zoom, window);
+                new VerticalToolHandler(this, this->page, this->settings, y, pos.isControlDown(), zoomControl, window);
+        zoomControl->addZoomListener(this->verticalSpace);
     } else if (h->getToolType() == TOOL_SELECT_RECT || h->getToolType() == TOOL_SELECT_REGION ||
                h->getToolType() == TOOL_PLAY_OBJECT || h->getToolType() == TOOL_SELECT_OBJECT ||
                h->getToolType() == TOOL_SELECT_PDF_TEXT_LINEAR || h->getToolType() == TOOL_SELECT_PDF_TEXT_RECT) {
@@ -587,6 +589,7 @@ auto XojPageView::onButtonReleaseEvent(const PositionInputData& pos) -> bool {
 
     if (this->verticalSpace) {
         control->getUndoRedoHandler()->addUndoAction(this->verticalSpace->finalize());
+        this->getXournal()->getControl()->getZoomControl()->removeZoomListener(this->verticalSpace);
         delete this->verticalSpace;
         this->verticalSpace = nullptr;
     }

--- a/src/core/gui/PageView.h
+++ b/src/core/gui/PageView.h
@@ -235,7 +235,7 @@ private:
     /**
      * Vertical Space
      */
-    VerticalToolHandler* verticalSpace = nullptr;
+    VerticalToolHandler* verticalSpace{};
 
     /**
      * Search handling


### PR DESCRIPTION
Currently, the Vertical Spacing tool works as follows:
* The user clicks and holds to set an "anchor" line.
* By dragging down some distance `y`, all elements on the same page below the anchor line are pushed down by `y` units.
* If the user drags _up_ above the anchor line instead, all elements on the same page below the anchor line are _pulled_ up by `y` units.

**Updated PR description**:

This PR allows users to also select elements above the anchor line using Ctrl. The behavior is the same as when selecting below the line; i.e. if selecting below the line, the elements are translated in the same direction as the mouse movement and by the same amount.

TODO:
* [x] Select elements above anchor line using <kbd>Ctrl</kbd>.
* [x] Clean up the code

---

**Old PR description**:

This PR modifies the behavior of Vertical Spacing so that dragging above the anchor line by `y` units will instead push all elements _above_ the anchor line upwards by `y` units.


Comparison (**Note: the videos are outdated and correspond to the "Old PR description"**): 

https://user-images.githubusercontent.com/1066652/130134724-15af6906-0e29-4c4a-a0e6-ae4d421930a8.mp4

https://user-images.githubusercontent.com/1066652/130134743-86624a4f-9bf2-40bb-8151-4fb3a532d95b.mp4