### PR TITLE
Fix a bug that makes single point stroke pressureless

### DIFF
--- a/src/control/tools/StrokeHandler.h
+++ b/src/control/tools/StrokeHandler.h
@@ -58,6 +58,11 @@ public:
      */
     void paintTo(const Point& point);
 
+    /**
+     * @brief paints a single dot
+     */
+    void paintDot(const double x, const double y, const double width) const;
+
 protected:
     /**
      * @brief Unconditionally add a segment to the stroke.
@@ -99,6 +104,7 @@ private:
     std::unique_ptr<StrokeStabilizer::Base> stabilizer;
 
     bool hasPressure;
+    bool firstPointPressureChange = false;
 
     friend class StrokeStabilizer::Active;
 


### PR DESCRIPTION
This supposedly fixes #1534:

![dots](https://user-images.githubusercontent.com/17818041/130679739-55855fd0-9be4-4ac2-ad96-d89bbf15cfd5.png)

Some workarounds are needed for pressureless devices as well and pressure inference. I will add them later if this works on all available pressure sensitive devices.

Testing on various devices is necessary. For anyone trying this PR out:

- it's easier to get single-point strokes when zoomed in to maximum.
- if you open `Xournal++` from a terminal, you get a "single dot" message for every such single-point stroke.