### PR TITLE
Fix inconsistent display of filled highlighter strokes

### DIFF
--- a/src/view/StrokeView.cpp
+++ b/src/view/StrokeView.cpp
@@ -80,6 +80,8 @@ void StrokeView::drawNoPressure() {
         // Do not apply the alpha here, else the border and the fill
         // are visible instead of one homogeneous area
         DocumentView::applyColor(cr, s, 255);
+        // The operator will be reset (to CAIRO_OPERATOR_MULTIPLY) by cairo_pop_group_to_source below
+        cairo_set_operator(cr, CAIRO_OPERATOR_SOURCE);
         drawFillStroke();
         group = true;
     }
@@ -95,7 +97,6 @@ void StrokeView::drawNoPressure() {
 
     if (group) {
         cairo_pop_group_to_source(cr);
-
         if (noAlpha) {
             // Currently drawing -> transparent applied on blitting
             cairo_paint(cr);


### PR DESCRIPTION
Fix #2904

This is a quick fix. Some refactoring of `StrokeView` would also be beneficial to improve the logic, optimize and reduce the computational cost, but that'd require more work and goes beyond the scope of this simple bugfix PR.