### PR TITLE
Hide, rather than disable, contents tab when unavailable

### DIFF
--- a/src/gui/sidebar/Sidebar.cpp
+++ b/src/gui/sidebar/Sidebar.cpp
@@ -51,7 +51,7 @@ void Sidebar::initPages(GtkWidget* sidebarContents, GladeGui* gui) {
 
     gtk_widget_show_all(GTK_WIDGET(this->tbSelectPage));
 
-    updateEnableDisableButtons();
+    updateVisibleTabs();
 }
 
 void Sidebar::buttonClicked(GtkToolButton* toolbutton, SidebarPageButton* buttonData) {
@@ -117,12 +117,12 @@ void Sidebar::setSelectedPage(size_t page) {
     }
 }
 
-void Sidebar::updateEnableDisableButtons() {
+void Sidebar::updateVisibleTabs() {
     size_t i = 0;
     size_t selected = npos;
 
     for (AbstractSidebarPage* p: this->pages) {
-        gtk_widget_set_sensitive(GTK_WIDGET(p->tabButton), p->hasData());
+        gtk_widget_set_visible(GTK_WIDGET(p->tabButton), p->hasData());
 
         if (p->hasData() && selected == npos) {
             selected = i;
@@ -158,7 +158,7 @@ auto Sidebar::getControl() -> Control* { return this->control; }
 
 void Sidebar::documentChanged(DocumentChangeType type) {
     if (type == DOCUMENT_CHANGE_CLEARED || type == DOCUMENT_CHANGE_COMPLETE || type == DOCUMENT_CHANGE_PDF_BOOKMARKS) {
-        updateEnableDisableButtons();
+        updateVisibleTabs();
     }
 }
 

--- a/src/gui/sidebar/Sidebar.h
+++ b/src/gui/sidebar/Sidebar.h
@@ -54,9 +54,9 @@ public:
     void setSelectedPage(size_t page);
 
     /**
-     * Enable active and siable inactive buttons, select first active page
+     * Show/hide tabs based on whether they have content. Select first active tab (page).
      */
-    void updateEnableDisableButtons();
+    void updateVisibleTabs();
 
     /**
      * Temporary disable Sidebar (e.g. while saving)


### PR DESCRIPTION
# Summary
 * Hides, rather than disables, the "contents" tab in the sidebar when the tab would be empty
 * This saves space in the tab area at the top of the toolbar

## XOPP Without PDF Background
![Contents tab is invisible when not editing a PDF with contents](https://user-images.githubusercontent.com/46334387/131783764-c25d5d9b-ac1a-4fe1-8880-06e4a588c0ec.png)

## PDF Without Bookmarks
![Contents tab still invisible: PDF with no table of contents](https://user-images.githubusercontent.com/46334387/131783844-d739964e-2beb-4f20-abd4-c9023cfaa560.png)

## PDF With Bookmarks
![Contents tab is shown](https://user-images.githubusercontent.com/46334387/131783948-c5391753-115f-4197-b34e-48cd3ae1749b.png)


