### PR TITLE
Plugin API: getActiveToolName

### DIFF
--- a/plugins/Example/main.lua
+++ b/plugins/Example/main.lua
@@ -16,5 +16,6 @@ end
 -- Callback if the menu item is executed
 function exampleCallback()
   result = app.msgbox("Test123", {[1] = "Yes", [2] = "No"});
-  print("result = " .. result)
+  print("result = " .. result);
+  print("current tool = " .. app.getActiveToolName());
 end

--- a/src/plugin/luapi_application.h
+++ b/src/plugin/luapi_application.h
@@ -425,6 +425,27 @@ static int applib_changeToolColor(lua_State* L) {
     return 1;
 }
 
+/**
+ * Get the name of the tool currently in use.
+ *
+ * Example 1: app.getActiveToolName() -> "none"
+ * When no tool is selected.
+ *
+ * Example 2: app.getActiveToolName() -> "pen"
+ *
+ * Example 3: app.getActiveToolName() -> "hand"
+ */
+static int applib_getActiveToolName(lua_State* L) {
+    Plugin* plugin = Plugin::getPluginFromLua(L);
+    Control* ctrl = plugin->getControl();
+    ToolHandler* toolHandler = ctrl->getToolHandler();
+
+    std::string toolName = toolTypeToString(toolHandler->getToolType());
+
+    lua_pushstring(L, toolName.c_str());
+    return 1;
+}
+
 /*
  * Select Background Pdf Page for Current Page
  * First argument is an integer (page number) and the second argument is a boolean (isRelative)
@@ -882,6 +903,7 @@ static const luaL_Reg applib[] = {{"msgbox", applib_msgbox},
                                   {"sidebarAction", applib_sidebarAction},
                                   {"layerAction", applib_layerAction},
                                   {"changeToolColor", applib_changeToolColor},
+                                  {"getActiveToolName", applib_getActiveToolName},
                                   {"changeCurrentPageBackground", applib_changeCurrentPageBackground},
                                   {"changeBackgroundPdfPageNr", applib_changeBackgroundPdfPageNr},
                                   {"getDocumentStructure", applib_getDocumentStructure},


### PR DESCRIPTION
## Summary
 * Adds a new function to the plugin API, `getActiveToolName`, which returns the name of the currently-active tool using the already-existing `toolTypeToString` function.