### PR TITLE
Extend Lua API to get info on tools

### DIFF
--- a/plugins/Example/main.lua
+++ b/plugins/Example/main.lua
@@ -17,40 +17,4 @@ end
 function exampleCallback()
   result = app.msgbox("Test123", {[1] = "Yes", [2] = "No"});
   print("result = " .. result)
-
-  toolInfo = app.getToolInfo("active")
-  print("active tool: " .. toolInfo["type"])
-  print("active size (name): " .. toolInfo["size"]["name"])
-  print("active size (value): " .. toolInfo["size"]["value"])
-  print("active color: " .. string.format("0x%06x", toolInfo["color"]))
-  print("active fill opacity: " .. tostring(toolInfo["fillOpacity"]))
-  print("active drawing type: " .. toolInfo["drawingType"])
-  print("active line style: " .. toolInfo["lineStyle"])
-
-  penInfo = app.getToolInfo("pen")
-  print("pen size (name): " .. penInfo["size"]["name"])
-  print("pen size (value): " .. penInfo["size"]["value"])
-  print("pen filled: " .. tostring(penInfo["filled"]))
-  print("pen fill opacity: " .. tostring(penInfo["fillOpacity"]))
-  print("pen color: " .. string.format("0x%06x", penInfo["color"]))
-  print("pen drawing type: " .. penInfo["drawingType"])
-  print("pen line style: " .. penInfo["lineStyle"])
-
-  highlighterInfo = app.getToolInfo("highlighter")
-  print("highlighter size (name): " .. highlighterInfo["size"]["name"])
-  print("highlighter size (value): " .. highlighterInfo["size"]["value"])
-  print("highlighter filled: " .. tostring(highlighterInfo["filled"]))
-  print("highlighter fill opacity: " .. tostring(highlighterInfo["fillOpacity"]))
-  print("highlighter color: " .. string.format("0x%06x", highlighterInfo["color"]))
-  print("highlighter drawing type: " .. highlighterInfo["drawingType"])
-
-  eraserInfo = app.getToolInfo("eraser")
-  print("eraser type: " .. eraserInfo["type"])
-  print("eraser size (name): " .. tostring(eraserInfo["size"]["name"]))
-  print("eraser size (value): " .. tostring(eraserInfo["size"]["value"]))
-
-  textInfo = app.getToolInfo("text")
-  print("text font (name): " .. textInfo["font"]["name"])
-  print("text font (size): " .. tostring(textInfo["font"]["size"]))
-  print("text color: " .. string.format("0x%06x", textInfo["color"]))
 end

--- a/plugins/Example/main.lua
+++ b/plugins/Example/main.lua
@@ -17,4 +17,40 @@ end
 function exampleCallback()
   result = app.msgbox("Test123", {[1] = "Yes", [2] = "No"});
   print("result = " .. result)
+
+  toolInfo = app.getToolInfo("active")
+  print("active tool: " .. toolInfo["type"])
+  print("active size (name): " .. toolInfo["size"]["name"])
+  print("active size (value): " .. toolInfo["size"]["value"])
+  print("active color: " .. string.format("0x%06x", toolInfo["color"]))
+  print("active fill opacity: " .. tostring(toolInfo["fillOpacity"]))
+  print("active drawing type: " .. toolInfo["drawingType"])
+  print("active line style: " .. toolInfo["lineStyle"])
+
+  penInfo = app.getToolInfo("pen")
+  print("pen size (name): " .. penInfo["size"]["name"])
+  print("pen size (value): " .. penInfo["size"]["value"])
+  print("pen filled: " .. tostring(penInfo["filled"]))
+  print("pen fill opacity: " .. tostring(penInfo["fillOpacity"]))
+  print("pen color: " .. string.format("0x%06x", penInfo["color"]))
+  print("pen drawing type: " .. penInfo["drawingType"])
+  print("pen line style: " .. penInfo["lineStyle"])
+
+  highlighterInfo = app.getToolInfo("highlighter")
+  print("highlighter size (name): " .. highlighterInfo["size"]["name"])
+  print("highlighter size (value): " .. highlighterInfo["size"]["value"])
+  print("highlighter filled: " .. tostring(highlighterInfo["filled"]))
+  print("highlighter fill opacity: " .. tostring(highlighterInfo["fillOpacity"]))
+  print("highlighter color: " .. string.format("0x%06x", highlighterInfo["color"]))
+  print("highlighter drawing type: " .. highlighterInfo["drawingType"])
+
+  eraserInfo = app.getToolInfo("eraser")
+  print("eraser type: " .. eraserInfo["type"])
+  print("eraser size (name): " .. tostring(eraserInfo["size"]["name"]))
+  print("eraser size (value): " .. tostring(eraserInfo["size"]["value"]))
+
+  textInfo = app.getToolInfo("text")
+  print("text font (name): " .. textInfo["font"]["name"])
+  print("text font (size): " .. tostring(textInfo["font"]["size"]))
+  print("text color: " .. string.format("0x%06x", textInfo["color"]))
 end


### PR DESCRIPTION
New API:
```lua
app.getToolInfo("active")
app.getToolInfo("pen")
app.getToolInfo("highlighter")
app.getToolInfo("eraser")
app.getToolInfo("text")
```

Example output (from the test plugin):

```
active tool: eraser
active size (name): thin
active size (value): 2.83
active color: 0x000000
active fill opacity: -1
active drawing type: default
active line style: plain
pen size (name): medium
pen size (value): 1.41
pen filled: false
pen fill opacity: 127
pen color: 0x00c0ff
pen drawing type: strokeRecognizer
pen line style: dash
highlighter size (name): medium
highlighter size (value): 8.5
highlighter filled: false
highlighter fill opacity: 87
highlighter color: 0x00c0ff
highlighter drawing type: arrow
eraser type: default
eraser size (name): thin
eraser size (value): 2.83
text font (name): Sans
text font (size): 20.0
text color: 0x00c0ff
```

Closes #3332

**Edit:** updated example output and API function calls