### PR TITLE
Fix touchscreen zooming when using vertical/horziontal spacing. Fixes #3298

### DIFF
--- a/src/gui/inputdevices/TouchInputHandler.cpp
+++ b/src/gui/inputdevices/TouchInputHandler.cpp
@@ -107,15 +107,7 @@ void TouchInputHandler::scrollMotion(InputEvent const& event) {
 }
 
 void TouchInputHandler::zoomStart() {
-    // Take horizontal and vertical padding of view into account when calculating the center of the gesture
-    int vPadding = inputContext->getSettings()->getAddVerticalSpace() ?
-                           inputContext->getSettings()->getAddVerticalSpaceAmount() :
-                           0;
-    int hPadding = inputContext->getSettings()->getAddHorizontalSpace() ?
-                           inputContext->getSettings()->getAddHorizontalSpaceAmount() :
-                           0;
-
-    auto center = (this->priLastRel + this->secLastRel) / 2.0 - utl::Point<double>{double(hPadding), double(vPadding)};
+    auto center = (this->priLastRel + this->secLastRel) / 2.0;
 
     this->startZoomDistance = this->priLastAbs.distance(this->secLastAbs);
 


### PR DESCRIPTION
The spacing compensation was added to the zoom center in touchInputHandler and in ZoomControl when starting a touch pinch gesture. This caused the pinch to zoom gesture to not be centered on the zoom origin when using vertical/horizontal spacing.
This PR simply removes the duplicated offset compensation from the touchInputHandler since it's already handled by the generic zoom controller.