### PR TITLE
Settings: Allow disabling GTK inertial touch scrolling.

### DIFF
--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -114,6 +114,7 @@ void Settings::loadDefault() {
     this->snapGridSize = DEFAULT_GRID_SIZE;
 
     this->touchDrawing = false;
+    this->gtkTouchInertialScrolling = true;
 
     this->defaultSaveName = _("%F-Note-%H-%M");
 
@@ -465,6 +466,8 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur) {
         this->snapGridTolerance = tempg_ascii_strtod(reinterpret_cast<const char*>(value), nullptr);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("touchDrawing")) == 0) {
         this->touchDrawing = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("gtkTouchInertialScrolling")) == 0) {
+        this->gtkTouchInertialScrolling = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("pressureGuessing")) == 0) {
         this->pressureGuessing = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("scrollbarHideType")) == 0) {
@@ -891,6 +894,7 @@ void Settings::save() {
     SAVE_DOUBLE_PROP(snapGridSize);
 
     SAVE_BOOL_PROP(touchDrawing);
+    SAVE_BOOL_PROP(gtkTouchInertialScrolling);
     SAVE_BOOL_PROP(pressureGuessing);
 
     SAVE_UINT_PROP(selectionBorderColor);
@@ -1268,6 +1272,17 @@ void Settings::setTouchDrawingEnabled(bool b) {
     }
 
     this->touchDrawing = b;
+    save();
+}
+
+auto Settings::getGtkTouchInertialScrollingEnabled() const -> bool { return this->gtkTouchInertialScrolling; };
+
+void Settings::setGtkTouchInertialScrollingEnabled(bool b) {
+    if (this->gtkTouchInertialScrolling == b) {
+        return;
+    }
+
+    this->gtkTouchInertialScrolling = b;
     save();
 }
 

--- a/src/control/settings/Settings.h
+++ b/src/control/settings/Settings.h
@@ -270,6 +270,9 @@ public:
     bool getTouchDrawingEnabled() const;
     void setTouchDrawingEnabled(bool b);
 
+    bool getGtkTouchInertialScrollingEnabled() const;
+    void setGtkTouchInertialScrollingEnabled(bool b);
+
     bool isPressureGuessingEnabled() const;
     void setPressureGuessingEnabled(bool b);
 
@@ -892,13 +895,15 @@ private:
      */
     double snapRotationTolerance{};
 
-
     /// Grid size for Snapping
     double snapGridSize{};
 
-
-    // Touchscreens act like multi-touch-aware pens.
+    /// Touchscreens act like multi-touch-aware pens.
     bool touchDrawing{};
+
+    /// True iff we use GTK's built-in kinetic/inertial scrolling
+    /// for touchscreen devices. If false, we use our own.
+    bool gtkTouchInertialScrolling{};
 
     /**
      * Infer pressure from speed when device pressure

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -287,7 +287,7 @@ void MainWindow::setGtkTouchscreenScrollingEnabled(bool enabled) {
 
     Util::execInUiThread(
             [=]() {
-                bool touchScrollEnabled = gtkTouchscreenScrollingEnabled.load();
+                const bool touchScrollEnabled = gtkTouchscreenScrollingEnabled.load();
 
                 gtk_scrolled_window_set_kinetic_scrolling(GTK_SCROLLED_WINDOW(winXournal), touchScrollEnabled);
             },

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -275,6 +275,12 @@ void MainWindow::setGtkTouchscreenScrollingForDeviceMapping() {
 }
 
 void MainWindow::setGtkTouchscreenScrollingEnabled(bool enabled) {
+    bool useGtkInertialScroll = control->getSettings()->getGtkTouchInertialScrollingEnabled();
+
+    if (!useGtkInertialScroll) {
+        enabled = false;
+    }
+
     if (enabled == gtkTouchscreenScrollingEnabled.load() || winXournal == nullptr) {
         return;
     }
@@ -283,8 +289,9 @@ void MainWindow::setGtkTouchscreenScrollingEnabled(bool enabled) {
 
     Util::execInUiThread(
             [=]() {
-                gtk_scrolled_window_set_kinetic_scrolling(GTK_SCROLLED_WINDOW(winXournal),
-                                                          gtkTouchscreenScrollingEnabled.load());
+                bool touchScrollEnabled = gtkTouchscreenScrollingEnabled.load();
+
+                gtk_scrolled_window_set_kinetic_scrolling(GTK_SCROLLED_WINDOW(winXournal), touchScrollEnabled);
             },
             G_PRIORITY_HIGH);
 }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -275,9 +275,7 @@ void MainWindow::setGtkTouchscreenScrollingForDeviceMapping() {
 }
 
 void MainWindow::setGtkTouchscreenScrollingEnabled(bool enabled) {
-    bool useGtkInertialScroll = control->getSettings()->getGtkTouchInertialScrollingEnabled();
-
-    if (!useGtkInertialScroll) {
+    if (!control->getSettings()->getGtkTouchInertialScrollingEnabled()) {
         enabled = false;
     }
 

--- a/src/gui/dialog/SettingsDialog.cpp
+++ b/src/gui/dialog/SettingsDialog.cpp
@@ -357,6 +357,7 @@ void SettingsDialog::load() {
     loadCheckbox("cbDisableScrollbarFadeout", settings->isScrollbarFadeoutDisabled());
     loadCheckbox("cbEnablePressureInference", settings->isPressureGuessingEnabled());
     loadCheckbox("cbTouchDrawing", settings->getTouchDrawingEnabled());
+    loadCheckbox("cbDisableGtkInertialScroll", !settings->getGtkTouchInertialScrollingEnabled());
     const bool ignoreStylusEventsEnabled = settings->getIgnoredStylusEvents() != 0;  // 0 means disabled, >0 enabled
     loadCheckbox("cbIgnoreFirstStylusEvents", ignoreStylusEventsEnabled);
     loadCheckbox("cbInputSystemTPCButton", settings->getInputSystemTPCButtonEnabled());
@@ -682,6 +683,7 @@ void SettingsDialog::save() {
     settings->setAreStockIconsUsed(getCheckbox("cbStockIcons"));
     settings->setPressureGuessingEnabled(getCheckbox("cbEnablePressureInference"));
     settings->setTouchDrawingEnabled(getCheckbox("cbTouchDrawing"));
+    settings->setGtkTouchInertialScrollingEnabled(!getCheckbox("cbDisableGtkInertialScroll"));
     settings->setInputSystemTPCButtonEnabled(getCheckbox("cbInputSystemTPCButton"));
     settings->setInputSystemDrawOutsideWindowEnabled(getCheckbox("cbInputSystemDrawOutsideWindow"));
     settings->setScrollbarFadeoutDisabled(getCheckbox("cbDisableScrollbarFadeout"));

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -2585,6 +2585,74 @@ This setting can make it easier to draw with touch. </property>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
+                                <property name="position">3</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkFrame" id="frameTouchScrolling">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.01</property>
+                                <child>
+                                  <object class="GtkAlignment" id="touchScrollingFrameAlignment">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
+                                    <child>
+                                      <object class="GtkBox" id="boxTouchScrolling">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                          <object class="GtkLabel" id="lblTouchKineticScrollDisableDescription">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">&lt;i&gt;Disabling GTK's built-in touchscreen scrolling can work around scrolling bugs on some platforms. Consider changing this setting if you experience jumps/sudden changes in scroll position when attempting to scroll with a touchscreen.&lt;/i&gt;</property>
+                                            <property name="use-markup">True</property>
+                                            <property name="wrap">True</property>
+                                            <property name="max-width-chars">85</property>
+                                            <property name="xalign">0</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="cbDisableGtkInertialScroll">
+                                            <property name="label" translatable="yes">Disable GTK's built-in inertial scroll functionality (requires restart).</property>
+                                            <property name="name">cbTouchDrawing</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-text" translatable="yes">Use two fingers to pan/zoom and one finger to use the selected tool.</property>
+                                            <property name="xalign">0</property>
+                                            <property name="draw-indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label">
+                                  <object class="GtkLabel" id="headerTouchScrollingFrame">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">Touch Scrolling</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
                                 <property name="position">4</property>
                               </packing>
                             </child>


### PR DESCRIPTION
## Summary
 * On my Fedora 34 tablet (Wayland/KDE Plasma), GTK's default touchscreen scroll handling causes the view to jump rapidly while attempting to scroll.
 * Disabling GTK's inertial scroll behavior works around the issue.

![Added setting with description: "Disabling GTK's built-in touchscreen scrolling can work around scrolling bugs on some platforms. Consider changing this setting if you experience jumps/sudden changes in scroll position when attempting to scroll with a touchscreen." Below this is a checkbox with label "Disable GTK's built-in inertial scroll functionality (requires restart)."](https://user-images.githubusercontent.com/46334387/132605321-c09c4fb5-14f1-47a9-9ba1-44e107567824.png)

