### PR TITLE
(Minor) Fix format specifiers to match types

### DIFF
--- a/src/control/xml/SizeTAttribute.cpp
+++ b/src/control/xml/SizeTAttribute.cpp
@@ -7,7 +7,7 @@ SizeTAttribute::SizeTAttribute(const char* name, size_t value): XMLAttribute(nam
 SizeTAttribute::~SizeTAttribute() = default;
 
 void SizeTAttribute::writeOut(OutputStream* out) {
-    char* str = g_strdup_printf("%ull", value);
+    char* str = g_strdup_printf("%zu", value);
     out->write(str);
     g_free(str);
 }

--- a/src/gui/dialog/AboutDialog.cpp
+++ b/src/gui/dialog/AboutDialog.cpp
@@ -12,7 +12,7 @@ AboutDialog::AboutDialog(GladeSearchpath* gladeSearchPath): GladeGui(gladeSearch
     gtk_label_set_markup(GTK_LABEL(get("lbRevId")), GIT_COMMIT_ID);
 
     char gtkVersion[10];
-    sprintf(gtkVersion, "%d.%d.%d", gtk_get_major_version(), gtk_get_minor_version(), gtk_get_micro_version());
+    sprintf(gtkVersion, "%u.%u.%u", gtk_get_major_version(), gtk_get_minor_version(), gtk_get_micro_version());
 
     gtk_label_set_markup(GTK_LABEL(get("lbGtkVersion")), gtkVersion);
 

--- a/src/model/Document.cpp
+++ b/src/model/Document.cpp
@@ -259,7 +259,7 @@ auto Document::fillPageLabels(GtkTreeModel* treeModel, GtkTreePath* path, GtkTre
 
     gchar* pageLabel = nullptr;
     if (page != npos) {
-        pageLabel = g_strdup_printf("%lu", page + 1);
+        pageLabel = g_strdup_printf("%zu", page + 1);
     }
     gtk_tree_store_set(GTK_TREE_STORE(treeModel), iter, DOCUMENT_LINKS_COLUMN_PAGE_NUMBER, pageLabel, -1);
     g_free(pageLabel);


### PR DESCRIPTION
The `size_t` format specifier is `%zu` and the
`gtk_get_*_version()` functions return `guint`,
to be printed with `%u`. The changes reflect this.