### PR TITLE
Fix some IMEs not working in text tool on Windows

### DIFF
--- a/src/gui/TextEditor.cpp
+++ b/src/gui/TextEditor.cpp
@@ -38,6 +38,7 @@ TextEditor::TextEditor(XojPageView* gui, GtkWidget* widget, Text* text, bool own
     g_object_get(settings, "gtk-cursor-blink-timeout", &this->cursorBlinkTimeout, nullptr);
 
     this->imContext = gtk_im_multicontext_new();
+    gtk_im_context_set_client_window(this->imContext, gtk_widget_get_window(this->widget));
     gtk_im_context_focus_in(this->imContext);
 
     g_signal_connect(this->imContext, "commit", G_CALLBACK(iMCommitCallback), this);
@@ -1048,7 +1049,6 @@ void TextEditor::paint(cairo_t* cr, GdkRectangle* repaintRect, double zoom) {
     cairo_stroke(cr);
 
     // Notify the IM of the app's window and cursor position.
-    gtk_im_context_set_client_window(this->imContext, gtk_widget_get_window(this->widget));
     GdkRectangle cursorRect;
     cursorRect.x = static_cast<int>(zoom * x0 + x1 + zoom * cX);
     cursorRect.y = static_cast<int>(zoom * y0 + y1 + zoom * cY);


### PR DESCRIPTION
Fixes #1997, tested on a fresh Windows build on master.

Without setting the window of the input context at the beginning, the input method callbacks are not invoked.