### PR TITLE
Working version of markdown

### DIFF
--- a/resources/markdown_template.tex
+++ b/resources/markdown_template.tex
@@ -1,0 +1,48 @@
+% This template uses the scontents package, which is only available on relatively recent TeX distributions. In case it is not available on your system, use the legacy_template.tex
+\documentclass[varwidth=true, crop, border=5pt]{standalone}
+
+% Packages
+% \usepackage{amsmath}
+% \usepackage{amssymb}
+\usepackage{xcolor}
+
+\usepackage[fencedCode,definitionLists,pipeTables,tableCaptions]{markdown}
+% code syntax highlighting
+\usepackage{minted}
+
+
+% for storing in memory verbatim content to be reused later
+\usepackage{scontents}
+
+% Blank formula checking
+\usepackage{ifthen}
+\newlength{\pheight}
+
+% User input
+\begin{scontents}[store-env=preview]
+    %%XPP_TOOL_INPUT%%
+\end{scontents}
+
+% Command to set colour globally
+\makeatletter
+\newcommand{\globalcolor}[1]{%
+  \color{#1}\global\let\default@color\current@color
+}
+\makeatother
+
+% Set the color globally
+% \definecolor{xpp_font_color}{HTML}{%%XPP_TEXT_COLOR%%}
+% \AtBeginDocument{\globalcolor{xpp_font_color}}
+
+\begin{document}
+
+
+  % Check if the formula is empty
+  \settoheight{\pheight}{\getstored[1]{preview}}%
+  \ifthenelse{\pheight=0}{\GenericError{}{xournalpp:blankformula}{}{}}
+
+  % Render the user input
+  \begin{markdown}
+    %%XPP_TOOL_INPUT%%
+  \end{markdown}
+\end{document}

--- a/src/control/settings/LatexSettings.h
+++ b/src/control/settings/LatexSettings.h
@@ -20,8 +20,8 @@ public:
     bool autoCheckDependencies{true};
     fs::path globalTemplatePath{};
 #ifdef __APPLE__
-    std::string genCmd{"/Library/TeX/texbin/pdflatex -halt-on-error -interaction=nonstopmode '{}'"};
+    std::string genCmd{"/Library/TeX/texbin/pdflatex -halt-on-error --shell-escape -interaction=nonstopmode '{}'"};
 #else
-    std::string genCmd{"pdflatex -halt-on-error -interaction=nonstopmode '{}'"};
+    std::string genCmd{"pdflatex -halt-on-error --shell-escape -interaction=nonstopmode '{}'"};
 #endif
 };


### PR DESCRIPTION
This PR introduces Markdown formatting through LaTeX. More customized text editing has been a feature that was long requested: https://github.com/xournalpp/xournalpp/issues/729, https://github.com/xournalpp/xournalpp/issues/1092, and makes Xournal++ text editing significantly more powerful.

To enable it, a user just has to change the template to `markdown_template.tex`

Here is what is now possible:

![image](https://user-images.githubusercontent.com/39338488/134205339-64941a4b-a985-48ed-ad76-2cc0ad472198.png)

Here is the text I wrote in the Latex box:
```markdown

An h1 header
============


Paragraphs are separated by a blank line. 

2nd paragraph. *Italic*, **bold**, and `monospace`. Itemized lists look like:

* this one
* that one
* the other one

> Block quotes are
> written like so.
>
> They can span multiple paragraphs,
> if you like.

Let's use a horizontal line to separate the text:

***

An h2 header
------------

Here's a numbered list

1. first item
2. second item
3. third item

Here's \textcolor{red}{red} text and \textcolor{green}{green} text. Here's some \colorbox{yellow}{highlighted} text.

Here's a code sample you can do by indenting 4 spaces or using 3 backticks or 3 strikethrough symbols:

~~~python

for i in 1 .. 10:
  print("Hello World")
~~~


And here's a **table**:  \newline

| Right | Left |
|:------:|:-----:|
|  12   |  12  |
| 123   |  123 |
|   1   |    1 | 

```

Summarizing introduced possibilities:
* H1 and H2 headings
* Ordered and Unordered Lists
* In-line bold, italic, and monospace
* Colouring of specific text instead of everything in the textbox. You can use `xcolor` commands such as `\color{green}` to color everything green under the command, `\textcolor{red}{Hello}` to color just the text contained inside brackets
* Tables
* Highlighted code
* Hyperlinks and footnotes

**all within the same textbox and by using markdown syntax**

------------

**Some Notes**:

* Testing the configuration generates an error, despite the code working correctly. The error appears to be caused by the markdown template I wrote but I haven't been able to figure out why. 
![image](https://user-images.githubusercontent.com/39338488/134206545-5eb87f7d-6879-4f51-89e4-5cac4785e3c8.png)
* Adding `#` anywhere in the markdown box invalidates the whole LaTex, so we should warn users not to use it. Looks like a [known issue](https://www.overleaf.com/learn/latex/Articles/How_to_write_in_Markdown_on_Overleaf). There may be a couple more special characters that the markdown environment doesn't accept: `^,&,_``. Instead of using `#` for headers, use `===` for level 1 and `---` for level 2 headings.
* I've added a starting string that works for both the LaTex template and the markdown template, `3x` instead of `x^2` since the `^` is not accepted by the markdown environment.
* It would be really useful to have each template specify their own starting string (within the TEX template as a first line comment maybe), but I'm not sure how difficult that would be to implement. The markdown template will not render the first line properly(no clue why) unless you start with a blank line, so a better starting string for the markdown template would be `\n3x`. This won't work for the LaTeX template, so users will have to manually add a new line on first row if they want first line to be rendered correctly. Another reason this will be useful is we can create a template for tables, another one for writing code, which would be mostly identical to the markdown template but have different starting strings.
* I've added the option to colour the markdown text based on the current Text color, same way as the Tex tool, but I purposefully haven't enabled it (lines 34-35 in `markdown_template.tex` are commented out) yet.  It seems better to have the text be black by default and then allow users to colour it whichever way they want through the xcolor commands.
