### PR TITLE
Create pipeline for releases via comments

### DIFF
--- a/azure-pipelines/create-installers.yml
+++ b/azure-pipelines/create-installers.yml
@@ -1,0 +1,120 @@
+trigger:
+  tags:
+    include:
+      - v?*.?*.?*
+    exclude:
+      - nightly
+pr:
+  - master
+  - release-*
+  - hotfix-*
+variables:
+  versionNumber: ''
+  versionTag: ''
+  buildType: 'unknown'
+stages:
+  - stage: SetVersionInformation
+    jobs:
+      - job: 'Versioning'
+        pool:
+          vmImage: 'ubuntu-18.04'
+        displayName: 'Set Build Number'
+        steps:
+          - bash: |
+              mkdir build
+              cd build
+              cmake ..
+              exit 0
+            displayName: 'Create Version Information'
+          - bash: |
+              VER=$(cat VERSION | sed '1q;d')
+              TAG=`date +"%Y%m%d"`
+              echo "##vso[build.updatebuildnumber]${VER}-nightly.${TAG}"
+            name: 'VersionNightly'
+            displayName: 'Set Version Information for Nightly'
+            workingDirectory: ./build
+            condition: or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['runForRelease'], 'False')) # Run for scheduled (nightlies)
+          - bash: |
+              VER=$(cat VERSION | sed '1q;d')
+              echo "##vso[build.updatebuildnumber]${VER}"
+            name: 'VersionRelease'
+            displayName: 'Set Version Information for Release'
+            workingDirectory: ./build
+            condition: or(eq(variables['Build.Reason'], 'IndividualCI'), ne(variables['runForRelease'], 'False')) # Run for non-scheduled (release)
+  - stage: Release
+    jobs:
+      - template: jobs/release_ubuntu.yml
+        parameters:
+          ubuntu_version: 18.04
+          job_name: 'Ubuntu18_04'
+          build_appimage: true
+      - template: jobs/release_ubuntu.yml
+        parameters:
+          ubuntu_version: 20.04
+          job_name: 'Ubuntu20_04'
+      - job: 'Debian'
+        pool:
+          vmImage: 'ubuntu-18.04'
+        container:
+          image: xournalpp/debian-latest-sudo:latest
+        displayName: 'Build for Debian'
+        steps:
+          - bash: |
+              sudo apt-get update
+              sudo apt-get install -y build-essential gcc-8 g++-8 cmake ninja-build libcppunit-dev libgtk-3-dev libpoppler-glib-dev libxml2-dev portaudio19-dev libsndfile-dev liblua5.3-dev \
+                                      libzip-dev gettext lsb-release librsvg2-dev help2man
+            displayName: 'Install dependencies'
+          - template: steps/build_linux.yml
+            parameters:
+              build_type: 'RelWithDebInfo'
+              cmake_flags: '-DCMAKE_DEBUG_INCLUDES_LDFLAGS=ON -DENABLE_CPPUNIT=ON -DDEBUG_COMPILE=ON -DCMAKE_INSTALL_PREFIX=/usr -DCPACK_GENERATOR="TGZ;DEB"'
+              cmake_commands: '--target package'
+          - task: PublishPipelineArtifact@1
+            inputs:
+              artifactName: 'linux-debian-packages'
+              targetPath: '$(System.DefaultWorkingDirectory)/build/packages'
+            displayName: 'Publish packages'
+          
+      - job: Windows
+        pool:
+          vmImage: 'vs2017-win2016'
+        displayName: 'Build for Windows'
+        steps:
+          - template: steps/build_windows.yml
+            parameters:
+              build_type: 'RelWithDebInfo'
+              cmake_flags: '-GNinja -DCMAKE_CXX_FLAGS="-Os -s"'
+          - script: |
+              set PATH=%PATH%;C:\msys64\usr\bin;C:\msys64\mingw64\bin"
+              C:\msys64\usr\bin\bash -lc "./package.sh"
+            workingDirectory: ./windows-setup
+            env:
+              MSYS2_ARCH: x86_64
+              MSYSTEM: MINGW64
+              CHERE_INVOKING: yes
+            displayName: 'Create Setup'
+          - task: PublishPipelineArtifact@0
+            inputs:
+              artifactName: 'windows'
+              targetPath: './windows-setup/xournalpp-setup.exe'
+            displayName: 'Publish Windows Setup'
+
+      - job: macOS
+        pool:
+          vmImage: 'macOS-10.15'
+        displayName: 'Build for macOS'
+        steps:
+          - template: steps/build_mac.yml
+            parameters:
+              build_type: 'RelWithDebInfo'
+              generation_path: '/Users/xournal-dev'
+          - bash: |
+              export PATH="$HOME/.local/bin:/Users/xournal-dev/gtk/inst/bin:$PATH"
+              ./build-app.sh /Users/xournal-dev/gtk
+            workingDirectory: ./mac-setup
+            displayName: 'Create App'
+          - task: PublishPipelineArtifact@0
+            inputs:
+              artifactName: 'macOS'
+              targetPath: './mac-setup/Xournal++.zip'
+            displayName: 'Publish macOS Setup'


### PR DESCRIPTION
This allows collaborators to create installers for all supported OSs in PR's by commenting `\AzurePipelines run create-installers`

This should help with PRs that target Windows or macOS where it is quite the task for somebody to set up a build environment. Hopefully, this will increase testers. I restricted the creation of such installers to collaborators, as not to tax our pipelines too much.