### PR TITLE
ensure lgi loads Gtk 3

### DIFF
--- a/plugins/MigrateFontSizes/main.lua
+++ b/plugins/MigrateFontSizes/main.lua
@@ -27,7 +27,7 @@ function showDialog()
   end
 
   --lgi module has been found
-  local Gtk = lgi.Gtk
+  local Gtk = lgi.require("Gtk", "3.0")
   local Gdk = lgi.Gdk
   local assert = lgi.assert
   local builder = Gtk.Builder()


### PR DESCRIPTION
This PR is needed for systems that provide both Gtk 3 and Gtk 4, like the flatpak with Gnome 41 runtime currently does. See https://github.com/flathub/com.github.xournalpp.xournalpp/pull/31