### PR TITLE
Remove the .xopp~ backup file after a successful save

### DIFF
--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -2406,7 +2406,7 @@ auto Control::saveAs() -> bool {
         return false;
     }
 
-    // no lock needed, this is an uncritically operation
+    // no lock needed, this is an uncritical operation
     auto const shouldCreateBackup = this->doc->shouldCreateBackupOnSave();
     this->doc->setCreateBackupOnSave(false);
     bool s = save();

--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -2407,8 +2407,11 @@ auto Control::saveAs() -> bool {
     }
 
     // no lock needed, this is an uncritically operation
+    auto const shouldCreateBackup = this->doc->shouldCreateBackupOnSave();
     this->doc->setCreateBackupOnSave(false);
-    return save();
+    bool s = save();
+    this->doc->setCreateBackupOnSave(shouldCreateBackup);
+    return s;
 }
 
 void Control::resetSavedStatus() {

--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -2407,11 +2407,8 @@ auto Control::saveAs() -> bool {
     }
 
     // no lock needed, this is an uncritical operation
-    auto const shouldCreateBackup = this->doc->shouldCreateBackupOnSave();
     this->doc->setCreateBackupOnSave(false);
-    bool s = save();
-    this->doc->setCreateBackupOnSave(shouldCreateBackup);
-    return s;
+    return save();
 }
 
 void Control::resetSavedStatus() {

--- a/src/control/jobs/SaveJob.cpp
+++ b/src/control/jobs/SaveJob.cpp
@@ -92,8 +92,9 @@ auto SaveJob::save() -> bool {
 
     Util::clearExtensions(filepath, ".pdf");
     auto const target = fs::path{filepath}.concat(".xopp");
+    auto const createBackup = doc->shouldCreateBackupOnSave();
 
-    if (doc->shouldCreateBackupOnSave()) {
+    if (createBackup) {
         try {
             // Note: The backup must be created for the target as this is the filepath
             // which will be written to. Do not use the `filepath` variable!
@@ -102,7 +103,6 @@ auto SaveJob::save() -> bool {
             g_warning("Could not create backup! Failed with %s", fe.what());
             return false;
         }
-        doc->setCreateBackupOnSave(false);
     }
 
     doc->lock();
@@ -117,5 +117,15 @@ auto SaveJob::save() -> bool {
         }
         return false;
     }
+
+    if(createBackup) {
+        try {
+            // If a backup was created it can be removed now since no error occured during the save
+            fs::remove(fs::path{target} += "~");
+        } catch (fs::filesystem_error const& fe) {
+            g_warning("Could not delete backup! Failed with %s", fe.what());
+        }
+    }
+
     return true;
 }

--- a/src/control/jobs/SaveJob.cpp
+++ b/src/control/jobs/SaveJob.cpp
@@ -116,15 +116,11 @@ auto SaveJob::save() -> bool {
             g_error("%s", this->lastError.c_str());
         }
         return false;
-    }
-
-    if(createBackup) {
+    } else if (createBackup) {
         try {
             // If a backup was created it can be removed now since no error occured during the save
             fs::remove(fs::path{target} += "~");
-        } catch (fs::filesystem_error const& fe) {
-            g_warning("Could not delete backup! Failed with %s", fe.what());
-        }
+        } catch (fs::filesystem_error const& fe) { g_warning("Could not delete backup! Failed with %s", fe.what()); }
     }
 
     return true;

--- a/src/control/jobs/SaveJob.cpp
+++ b/src/control/jobs/SaveJob.cpp
@@ -121,6 +121,8 @@ auto SaveJob::save() -> bool {
             // If a backup was created it can be removed now since no error occured during the save
             fs::remove(fs::path{target} += "~");
         } catch (fs::filesystem_error const& fe) { g_warning("Could not delete backup! Failed with %s", fe.what()); }
+    } else {
+        doc->setCreateBackupOnSave(true);
     }
 
     return true;

--- a/src/control/xojfile/LoadHandler.cpp
+++ b/src/control/xojfile/LoadHandler.cpp
@@ -244,7 +244,7 @@ auto LoadHandler::parseXml() -> bool {
         return false;
     }
 
-    doc.setCreateBackupOnSave(this->fileVersion >= 3);
+    doc.setCreateBackupOnSave(true);
 
     return valid;
 }

--- a/src/model/Document.h
+++ b/src/model/Document.h
@@ -143,7 +143,7 @@ private:
     GtkTreeModel* contentsModel = nullptr;
 
     /**
-     *  create a backup before save, because the original file was an older fileversion
+     *  create a backup before save
      */
     bool createBackupOnSave = false;
 


### PR DESCRIPTION
This also fixes the problem that after the first save or save as after opening a file on all subsequent saves no backup file was created.