### PR TITLE
Fix typo in the documentation of a CMakeLists.txt.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,7 +29,7 @@ add_library (xournalpp-test-base OBJECT
 
 ## ------------------------
 
-# These dirs are xournalpp only so it's safe to add then recursively
+# These dirs are xournalpp only so it's safe to add them recursively
 file (GLOB_RECURSE util_sources_SOURCES_RECURSE
   util/*.cpp
 )


### PR DESCRIPTION
The word 'then' is replaced by 'them' in a sentence in a comment for the
CMakeLists.txt of the unit tests.