### PR TITLE
Replace Element custom serialization with typical.

### DIFF
--- a/src/control/tools/EditSelection.cpp
+++ b/src/control/tools/EditSelection.cpp
@@ -1040,7 +1040,7 @@ void EditSelection::drawDeleteRect(cairo_t* cr, double x, double y, double zoom)
 
 auto EditSelection::getView() -> XojPageView* { return this->view; }
 
-void EditSelection::serialize(ObjectOutputStream& out) {
+void EditSelection::serialize(ObjectOutputStream& out) const {
     out.writeObject("EditSelection");
 
     out.writeDouble(this->x);

--- a/src/control/tools/EditSelection.h
+++ b/src/control/tools/EditSelection.h
@@ -240,7 +240,7 @@ public:
 
 public:
     // Serialize interface
-    void serialize(ObjectOutputStream& out);
+    void serialize(ObjectOutputStream& out) const;
     void readSerialized(ObjectInputStream& in);
 
 private:

--- a/src/control/tools/EditSelectionContents.cpp
+++ b/src/control/tools/EditSelectionContents.cpp
@@ -549,7 +549,7 @@ auto EditSelectionContents::copySelection(PageRef page, XojPageView* view, doubl
     return new InsertsUndoAction(page, layer, new_elems);
 }
 
-void EditSelectionContents::serialize(ObjectOutputStream& out) {
+void EditSelectionContents::serialize(ObjectOutputStream& out) const {
     out.writeObject("EditSelectionContents");
 
     out.writeDouble(this->originalBounds.x);

--- a/src/control/tools/EditSelectionContents.h
+++ b/src/control/tools/EditSelectionContents.h
@@ -156,8 +156,8 @@ public:
 
 public:
     // Serialize interface
-    void serialize(ObjectOutputStream& out);
-    void readSerialized(ObjectInputStream& in);
+    void serialize(ObjectOutputStream& out) const override;
+    void readSerialized(ObjectInputStream& in) override;
 
 private:
     /**

--- a/src/model/AudioElement.cpp
+++ b/src/model/AudioElement.cpp
@@ -14,10 +14,10 @@ void AudioElement::setTimestamp(size_t timestamp) { this->timestamp = timestamp;
 
 auto AudioElement::getTimestamp() const -> size_t { return this->timestamp; }
 
-void AudioElement::serializeAudioElement(ObjectOutputStream& out) {
+void AudioElement::serialize(ObjectOutputStream& out) const {
     out.writeObject("AudioElement");
 
-    serializeElement(out);
+    this->Element::serialize(out);
 
     out.writeString(this->audioFilename);
     out.writeSizeT(this->timestamp);
@@ -25,10 +25,10 @@ void AudioElement::serializeAudioElement(ObjectOutputStream& out) {
     out.endObject();
 }
 
-void AudioElement::readSerializedAudioElement(ObjectInputStream& in) {
+void AudioElement::readSerialized(ObjectInputStream& in) {
     in.readObject("AudioElement");
 
-    readSerializedElement(in);
+    this->Element::readSerialized(in);
 
     this->audioFilename = in.readString();
     this->timestamp = in.readSizeT();

--- a/src/model/AudioElement.h
+++ b/src/model/AudioElement.h
@@ -37,8 +37,8 @@ public:
     virtual bool intersects(double x, double y, double halfSize, double* gap) = 0;
 
 protected:
-    void serializeAudioElement(ObjectOutputStream& out);
-    void readSerializedAudioElement(ObjectInputStream& in);
+    void serialize(ObjectOutputStream& out) const override;
+    void readSerialized(ObjectInputStream& in) override;
 
     void cloneAudioData(const AudioElement* other);
 

--- a/src/model/Element.cpp
+++ b/src/model/Element.cpp
@@ -119,7 +119,7 @@ auto Element::isInSelection(ShapeContainer* container) -> bool {
 auto Element::rescaleOnlyAspectRatio() -> bool { return false; }
 auto Element::rescaleWithMirror() -> bool { return false; }
 
-void Element::serializeElement(ObjectOutputStream& out) const {
+void Element::serialize(ObjectOutputStream& out) const {
     out.writeObject("Element");
 
     out.writeDouble(this->x);
@@ -129,7 +129,7 @@ void Element::serializeElement(ObjectOutputStream& out) const {
     out.endObject();
 }
 
-void Element::readSerializedElement(ObjectInputStream& in) {
+void Element::readSerialized(ObjectInputStream& in) {
     in.readObject("Element");
 
     this->x = in.readDouble();

--- a/src/model/Element.h
+++ b/src/model/Element.h
@@ -73,12 +73,12 @@ public:
      */
     virtual Element* clone() = 0;
 
+    void serialize(ObjectOutputStream& out) const;
+    void readSerialized(ObjectInputStream& in);
+
 private:
 protected:
     virtual void calcSize() const = 0;
-
-    void serializeElement(ObjectOutputStream& out) const;
-    void readSerializedElement(ObjectInputStream& in);
 
 protected:
     // If the size has been calculated

--- a/src/model/Font.cpp
+++ b/src/model/Font.cpp
@@ -22,7 +22,7 @@ void XojFont::operator=(const XojFont& font) {
     this->size = font.size;
 }
 
-void XojFont::serialize(ObjectOutputStream& out) {
+void XojFont::serialize(ObjectOutputStream& out) const {
     out.writeObject("XojFont");
 
     out.writeString(this->name);

--- a/src/model/Font.h
+++ b/src/model/Font.h
@@ -35,7 +35,7 @@ public:
 
 public:
     // Serialize interface
-    void serialize(ObjectOutputStream& out);
+    void serialize(ObjectOutputStream& out) const;
     void readSerialized(ObjectInputStream& in);
 
 private:

--- a/src/model/Image.cpp
+++ b/src/model/Image.cpp
@@ -101,10 +101,10 @@ void Image::scale(double x0, double y0, double fx, double fy, double rotation,
 
 void Image::rotate(double x0, double y0, double th) {}
 
-void Image::serialize(ObjectOutputStream& out) {
+void Image::serialize(ObjectOutputStream& out) const {
     out.writeObject("Image");
 
-    serializeElement(out);
+    this->Element::serialize(out);
 
     out.writeDouble(this->width);
     out.writeDouble(this->height);
@@ -117,7 +117,7 @@ void Image::serialize(ObjectOutputStream& out) {
 void Image::readSerialized(ObjectInputStream& in) {
     in.readObject("Image");
 
-    readSerializedElement(in);
+    this->Element::readSerialized(in);
 
     this->width = in.readDouble();
     this->height = in.readDouble();

--- a/src/model/Image.h
+++ b/src/model/Image.h
@@ -41,8 +41,8 @@ public:
 
 public:
     // Serialize interface
-    void serialize(ObjectOutputStream& out);
-    void readSerialized(ObjectInputStream& in);
+    void serialize(ObjectOutputStream& out) const override;
+    void readSerialized(ObjectInputStream& in) override;
 
 private:
     void calcSize() const override;

--- a/src/model/LineStyle.cpp
+++ b/src/model/LineStyle.cpp
@@ -26,7 +26,7 @@ void LineStyle::operator=(const LineStyle& other) {
 }
 
 
-void LineStyle::serialize(ObjectOutputStream& out) {
+void LineStyle::serialize(ObjectOutputStream& out) const {
     out.writeObject("LineStyle");
 
     out.writeData(this->dashes, this->dashCount, sizeof(double));

--- a/src/model/LineStyle.h
+++ b/src/model/LineStyle.h
@@ -27,7 +27,7 @@ public:
 
 public:
     // Serialize interface
-    void serialize(ObjectOutputStream& out);
+    void serialize(ObjectOutputStream& out) const;
     void readSerialized(ObjectInputStream& in);
 
 public:

--- a/src/model/Stroke.cpp
+++ b/src/model/Stroke.cpp
@@ -69,10 +69,10 @@ auto Stroke::cloneStroke() const -> Stroke* {
 
 auto Stroke::clone() -> Element* { return this->cloneStroke(); }
 
-void Stroke::serialize(ObjectOutputStream& out) {
+void Stroke::serialize(ObjectOutputStream& out) const {
     out.writeObject("Stroke");
 
-    serializeAudioElement(out);
+    this->AudioElement::serialize(out);
 
     out.writeDouble(this->width);
 
@@ -90,7 +90,7 @@ void Stroke::serialize(ObjectOutputStream& out) {
 void Stroke::readSerialized(ObjectInputStream& in) {
     in.readObject("Stroke");
 
-    readSerializedAudioElement(in);
+    this->AudioElement::readSerialized(in);
 
     this->width = in.readDouble();
 

--- a/src/model/Stroke.h
+++ b/src/model/Stroke.h
@@ -104,7 +104,7 @@ public:
 
 public:
     // Serialize interface
-    void serialize(ObjectOutputStream& out) override;
+    void serialize(ObjectOutputStream& out) const override;
     void readSerialized(ObjectInputStream& in) override;
 
     bool rescaleWithMirror() override;

--- a/src/model/TexImage.cpp
+++ b/src/model/TexImage.cpp
@@ -121,10 +121,10 @@ void TexImage::rotate(double x0, double y0, double th) {
     // Rotation for TexImages not yet implemented
 }
 
-void TexImage::serialize(ObjectOutputStream& out) {
+void TexImage::serialize(ObjectOutputStream& out) const {
     out.writeObject("TexImage");
 
-    serializeElement(out);
+    this->Element::serialize(out);
 
     out.writeDouble(this->width);
     out.writeDouble(this->height);
@@ -138,7 +138,7 @@ void TexImage::serialize(ObjectOutputStream& out) {
 void TexImage::readSerialized(ObjectInputStream& in) {
     in.readObject("TexImage");
 
-    readSerializedElement(in);
+    this->Element::readSerialized(in);
 
     this->width = in.readDouble();
     this->height = in.readDouble();

--- a/src/model/TexImage.h
+++ b/src/model/TexImage.h
@@ -66,8 +66,8 @@ public:
 
 public:
     // Serialize interface
-    void serialize(ObjectOutputStream& out);
-    void readSerialized(ObjectInputStream& in);
+    void serialize(ObjectOutputStream& out) const override;
+    void readSerialized(ObjectInputStream& in) override;
 
 private:
     void calcSize() const override;

--- a/src/model/Text.cpp
+++ b/src/model/Text.cpp
@@ -105,10 +105,10 @@ auto Text::intersects(double x, double y, double halfEraserSize, double* gap) ->
     return x >= x1 && x <= x2 && y >= y1 && y <= y2;
 }
 
-void Text::serialize(ObjectOutputStream& out) {
+void Text::serialize(ObjectOutputStream& out) const {
     out.writeObject("Text");
 
-    serializeAudioElement(out);
+    this->AudioElement::serialize(out);
 
     out.writeString(this->text);
 
@@ -120,7 +120,7 @@ void Text::serialize(ObjectOutputStream& out) {
 void Text::readSerialized(ObjectInputStream& in) {
     in.readObject("Text");
 
-    readSerializedAudioElement(in);
+    this->AudioElement::readSerialized(in);
 
     this->text = in.readString();
 

--- a/src/model/Text.h
+++ b/src/model/Text.h
@@ -52,7 +52,7 @@ public:
 
 public:
     // Serialize interface
-    void serialize(ObjectOutputStream& out) override;
+    void serialize(ObjectOutputStream& out) const override;
     void readSerialized(ObjectInputStream& in) override;
 
 protected:

--- a/src/util/serializing/Serializeable.h
+++ b/src/util/serializing/Serializeable.h
@@ -20,7 +20,7 @@ extern const char* XML_VERSION_STR;
 
 class Serializeable {
 public:
-    virtual void serialize(ObjectOutputStream& out) = 0;
+    virtual void serialize(ObjectOutputStream& out) const = 0;
     virtual void readSerialized(ObjectInputStream& in) = 0;
 
     virtual ~Serializeable() = default;


### PR DESCRIPTION
Element uses custom serialization methods instead of providing
methods for the Serializable subclass. Since Element appears to subclass
Serializable anyway, we remove the custom methods and replace them by
functions from the Serializable subclass. The only other difference is
that the serialization methods are not protected anymore, but public.