### PR TITLE
Add hh length modifier to g_strdup_printf message.

### DIFF
--- a/src/util/serializing/ObjectInputStream.cpp
+++ b/src/util/serializing/ObjectInputStream.cpp
@@ -241,7 +241,7 @@ auto ObjectInputStream::getType(char type) -> string {
     } else if (type == 'm') {
         ret = "Image";
     } else {
-        char* str = g_strdup_printf("Unknown type: %02x (%c)", type, type);
+        char* str = g_strdup_printf("Unknown type: %02hhx (%c)", type, type);
         ret = str;
         g_free(str);
     }


### PR DESCRIPTION
The hh length modifier is added to specify that the x conversion
specifier applies to a char argument.