### PR TITLE
Add unit tests for serialization in ToolEnum.

### DIFF
--- a/azure-pipelines/continuous-integration.yml
+++ b/azure-pipelines/continuous-integration.yml
@@ -66,6 +66,7 @@ stages:
               export PATH="$HOME/.local/bin:/Users/xournal-dev/gtk/inst/bin:$PATH"
               install_name_tool -add_rpath /Users/xournal-dev/gtk/inst/lib/. test/test-loadHandler
               install_name_tool -add_rpath /Users/xournal-dev/gtk/inst/lib/. test/test-util
+              install_name_tool -add_rpath /Users/xournal-dev/gtk/inst/lib/. test/test-toolEnums
               CI=true ctest --verbose
             workingDirectory: ./build
             displayName: 'Run tests'

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -50,10 +50,15 @@ add_executable (test-loadHandler $<TARGET_OBJECTS:xournalpp-core> $<TARGET_OBJEC
 add_dependencies (test-loadHandler xournalpp-core xournalpp-test-base util)
 target_link_libraries (test-loadHandler ${xournalpp_LDFLAGS} ${CppUnit_LDFLAGS} std::filesystem)
 
+# ToolEnums
+add_executable (test-toolEnums $<TARGET_OBJECTS:xournalpp-core> $<TARGET_OBJECTS:xournalpp-test-base>
+    control/ToolEnumsTest.cpp
+)
+add_dependencies (test-toolEnums xournalpp-core xournalpp-test-base)
+target_link_libraries (test-toolEnums ${xournalpp_LDFLAGS} ${CppUnit_LDFLAGS})
+
 ## CTest ##
 add_test (util test-util)
 add_test (LoadHandler test-loadHandler)
-
-
-
+add_test (ToolEnums test-toolEnums)
 

--- a/test/control/ToolEnumsTest.cpp
+++ b/test/control/ToolEnumsTest.cpp
@@ -1,0 +1,57 @@
+/*
+ * Xournal++
+ *
+ * This file is part of the Xournal UnitTests
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#include <string>
+
+#include <cppunit/extensions/HelperMacros.h>
+
+#include "control/ToolEnums.h"
+
+
+class ToolEnumsTest: public CppUnit::TestFixture {
+    CPPUNIT_TEST_SUITE(ToolEnumsTest);
+
+    CPPUNIT_TEST(testToolSizeSerialization);
+    CPPUNIT_TEST(testToolTypeSerialization);
+
+    CPPUNIT_TEST_SUITE_END();
+
+public:
+    /**
+     * Test whether the invariant
+     *     fromString(toString(x)) == x
+     * holds.
+     */
+    void testToolSizeSerialization() {
+        for (unsigned int i = 0; i <= TOOL_SIZE_NONE; i++) {
+            auto toolSize = static_cast<ToolSize>(i);
+            std::string s = toolSizeToString(toolSize);
+            CPPUNIT_ASSERT(s.empty() == false);
+            CPPUNIT_ASSERT_EQUAL(toolSize, toolSizeFromString(s));
+        }
+    }
+
+    /**
+     * Test whether the invariant
+     *     fromString(toString(x)) == x
+     * holds.
+     */
+    void testToolTypeSerialization() {
+        for (unsigned int i = 0; i < TOOL_END_ENTRY; i++) {
+            auto toolType = static_cast<ToolType>(i);
+            std::string s = toolTypeToString(toolType);
+            CPPUNIT_ASSERT(s.empty() == false);
+            CPPUNIT_ASSERT_EQUAL(toolType, toolTypeFromString(s));
+        }
+    }
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(ToolEnumsTest);


### PR DESCRIPTION
Checks the following invariant:

    fromString(toString(x)) == x

for all enum values of ToolSize and ToolType.

This check is motivated by a bug discovered, where this invariant failed
to hold, because one string was "playObject", while another was
"PlayObject".

We also modify continuous-integration.yml, since macOS unit tests are
not automatically discovered, to include our unit test binary
test-toolEnums.