### PR TITLE
Fix ToolType serialization bug.

### DIFF
--- a/src/control/ToolEnums.cpp
+++ b/src/control/ToolEnums.cpp
@@ -114,7 +114,7 @@ auto toolTypeToString(ToolType type) -> string {
         case TOOL_SELECT_OBJECT:
             return "selectObject";
         case TOOL_PLAY_OBJECT:
-            return "PlayObject";
+            return "playObject";
         case TOOL_VERTICAL_SPACE:
             return "verticalSpace";
         case TOOL_HAND:


### PR DESCRIPTION
The following serialization invariant was found to not
hold for ToolType:

    fromString(toString(x)) == x

The reason was a mismatch in serialization:

    toolTypeToString(TOOL_PLAY_OBJECT) == "PlayObject"
    toolTypeFromString("playObject") == TOOL_PLAY_OBJECT)

This probably had the effect of incorrectly serializing. We correct this
by changing the return value of  toolTypeToString to match the camelCase
style seen in its other return values.