### PR TITLE
Improve Stroke's display in StrokeView and StrokeHandler

### DIFF
--- a/src/config-debug.h.in
+++ b/src/config-debug.h.in
@@ -42,3 +42,8 @@
  * Draw a border around all painted rects
  */
 #cmakedefine DEBUG_SHOW_PAINT_BOUNDS
+
+/**
+ * Draw the mask in StrokeView
+ */
+#cmakedefine DEBUG_SHOW_MASK

--- a/src/control/tools/BaseStrokeHandler.cpp
+++ b/src/control/tools/BaseStrokeHandler.cpp
@@ -31,7 +31,7 @@ void BaseStrokeHandler::draw(cairo_t* cr) {
     int dpiScaleFactor = xournal->getDpiScaleFactor();
 
     cairo_scale(cr, zoom * dpiScaleFactor, zoom * dpiScaleFactor);
-    view.drawStroke(cr, stroke, 0);
+    view.drawStroke(cr, stroke);
 }
 
 auto BaseStrokeHandler::onKeyEvent(GdkEventKey* event) -> bool {

--- a/src/control/tools/SplineHandler.cpp
+++ b/src/control/tools/SplineHandler.cpp
@@ -91,7 +91,7 @@ void SplineHandler::draw(cairo_t* cr) {
     // create stroke and draw spline
     this->updateStroke();
     if (this->getKnotCount() > 1) {
-        view.drawStroke(cr, stroke, 0);
+        view.drawStroke(cr, stroke);
     }
 }
 

--- a/src/control/tools/StrokeHandler.cpp
+++ b/src/control/tools/StrokeHandler.cpp
@@ -37,13 +37,20 @@ void StrokeHandler::draw(cairo_t* cr) {
         return;
     }
 
+    if (this->fullRedraw) {
+        /**
+         * Erase the mask entirely in this case
+         */
+        cairo_set_operator(crMask, CAIRO_OPERATOR_CLEAR);
+        cairo_paint(crMask);
+
+        cairo_set_operator(crMask, CAIRO_OPERATOR_SOURCE);
+        view.drawStroke(crMask, stroke, true);
+    }
     DocumentView::applyColor(cr, stroke);
 
-    if (stroke->getToolType() == STROKE_TOOL_HIGHLIGHTER) {
-        cairo_set_operator(cr, CAIRO_OPERATOR_MULTIPLY);
-    } else {
-        cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
-    }
+    cairo_set_operator(
+            cr, stroke->getToolType() == STROKE_TOOL_HIGHLIGHTER ? CAIRO_OPERATOR_MULTIPLY : CAIRO_OPERATOR_OVER);
 
     cairo_mask_surface(cr, surfMask, 0, 0);
 }
@@ -129,32 +136,21 @@ void StrokeHandler::drawSegmentTo(const Point& point) {
     Range rg(prevPoint.x, prevPoint.y);
     rg.addPoint(point.x, point.y);
 
-    if ((stroke->getFill() != -1 || stroke->getLineStyle().hasDashes()) &&
-        !(stroke->getFill() != -1 && stroke->getToolType() == STROKE_TOOL_HIGHLIGHTER)) {
-        // Clear surface
-
-        // for debugging purposes
-        // cairo_set_source_rgba(crMask, 1, 0, 0, 1);
-        cairo_set_source_rgba(crMask, 0, 0, 0, 0);
-        cairo_rectangle(crMask, 0, 0, cairo_image_surface_get_width(surfMask),
-                        cairo_image_surface_get_height(surfMask));
-        cairo_fill(crMask);
-
-        view.drawStroke(crMask, stroke, 0, 1, true, true);
-
+    if (stroke->getFill() != -1) {
+        /**
+         * Add the first point to the redraw range, so that the filling is painted.
+         * Note: the actual stroke painting will only happen in this->draw() which is called less often
+         */
         const Point& firstPoint = stroke->getPointVector().front();
         rg.addPoint(firstPoint.x, firstPoint.y);
-    } else {
+    } else if (!this->fullRedraw) {
         Stroke lastSegment;
 
         lastSegment.addPoint(prevPoint);
         lastSegment.addPoint(point);
         lastSegment.setWidth(width);
 
-        cairo_set_operator(crMask, CAIRO_OPERATOR_OVER);
-        cairo_set_source_rgba(crMask, 1, 1, 1, 1);
-
-        view.drawStroke(crMask, &lastSegment, 0, 1, false);
+        view.drawStroke(crMask, &lastSegment, true);
     }
 
     width = prevPoint.z != Point::NO_PRESSURE ? prevPoint.z : width;
@@ -258,19 +254,11 @@ void StrokeHandler::onButtonReleaseEvent(const PositionInputData& pos) {
         }
     }
 
-    if (stroke->getFill() != -1 && stroke->getToolType() == STROKE_TOOL_HIGHLIGHTER) {
-        // The stroke is not filled on drawing time
-        // If the stroke has fill values, it needs to be re-rendered
-        // else the fill will not be visible.
-
-        view.drawStroke(crMask, stroke, 0, 1, true, true);
-    }
-
     layer->addElement(stroke);
     page->fireElementChanged(stroke);
 
     // Manually force the rendering of the stroke, if no motion event occurred between, that would rerender the page.
-    if (stroke->getPointCount() == 2 || (stroke->getToolType() == STROKE_TOOL_HIGHLIGHTER && stroke->getFill() != -1)) {
+    if (stroke->getPointCount() == 2) {
         this->redrawable->rerenderElement(stroke);
     }
 
@@ -335,6 +323,7 @@ void StrokeHandler::onButtonPressEvent(const PositionInputData& pos) {
     destroySurface();
 
     double zoom = xournal->getZoom();
+
     PageRef page = redrawable->getPage();
 
     int dpiScaleFactor = xournal->getDpiScaleFactor();
@@ -362,6 +351,7 @@ void StrokeHandler::onButtonPressEvent(const PositionInputData& pos) {
         createStroke(Point(this->buttonDownPoint.x, this->buttonDownPoint.y));
 
         this->hasPressure = this->stroke->getToolType() == STROKE_TOOL_PEN && pos.pressure != Point::NO_PRESSURE;
+        this->fullRedraw = this->stroke->getFill() != -1 || stroke->getLineStyle().hasDashes();
 
         stabilizer->initialize(this, zoom, pos);
     }

--- a/src/control/tools/StrokeHandler.h
+++ b/src/control/tools/StrokeHandler.h
@@ -101,6 +101,8 @@ private:
 
     bool hasPressure;
 
+    bool fullRedraw;
+
     friend class StrokeStabilizer::Active;
 
     static constexpr double MAX_WIDTH_VARIATION = 0.3;

--- a/src/view/DocumentView.cpp
+++ b/src/view/DocumentView.cpp
@@ -25,9 +25,9 @@ void DocumentView::setMarkAudioStroke(bool markAudioStroke) { this->markAudioStr
 void DocumentView::applyColor(cairo_t* cr, Stroke* s) {
     if (s->getToolType() == STROKE_TOOL_HIGHLIGHTER) {
         if (s->getFill() != -1) {
-            applyColor(cr, s, s->getFill());
+            applyColor(cr, s, static_cast<uint8_t>(s->getFill()));
         } else {
-            applyColor(cr, s, 120);
+            applyColor(cr, s, StrokeView::HIGHLIGHTER_ALPHA);
         }
     } else {
         applyColor(cr, static_cast<Element*>(s));
@@ -40,21 +40,16 @@ void DocumentView::applyColor(cairo_t* cr, Color c, uint8_t alpha) {
     Util::cairo_set_source_rgbi(cr, c, alpha / 255.0);
 }
 
-void DocumentView::drawStroke(cairo_t* cr, Stroke* s, int startPoint, double scaleFactor, bool changeSource,
-                              bool noAlpha) const {
+void DocumentView::drawStroke(cairo_t* cr, Stroke* s, bool noColor) const {
     if (s->getPointCount() < 2) {
         // Should not happen
         g_warning("DocumentView::drawStroke empty stroke...");
         return;
     }
 
-    StrokeView sv(cr, s, startPoint, scaleFactor, noAlpha);
+    StrokeView sv(cr, s);
 
-    if (changeSource) {
-        sv.changeCairoSource(this->markAudioStroke);
-    }
-
-    sv.paint(this->dontRenderEditingStroke);
+    sv.paint(this->dontRenderEditingStroke, this->markAudioStroke, noColor);
 }
 
 void DocumentView::drawText(cairo_t* cr, Text* t) const {

--- a/src/view/DocumentView.h
+++ b/src/view/DocumentView.h
@@ -48,8 +48,7 @@ public:
                   bool hideImageBackground = false, bool hideRulingBackground = false);
 
 
-    void drawStroke(cairo_t* cr, Stroke* s, int startPoint = 0, double scaleFactor = 1, bool changeSource = true,
-                    bool noAlpha = false) const;
+    void drawStroke(cairo_t* cr, Stroke* s, bool noColor = false) const;
 
     static void applyColor(cairo_t* cr, Stroke* s);
     static void applyColor(cairo_t* cr, Color c, uint8_t alpha = 0xff);

--- a/src/view/StrokeView.h
+++ b/src/view/StrokeView.h
@@ -11,46 +11,49 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include <gtk/gtk.h>
 
 class Stroke;
 
 class StrokeView {
 public:
-    StrokeView(cairo_t* cr, Stroke* s, int startPoint, double scaleFactor, bool noAlpha);
+    StrokeView(cairo_t* cr, Stroke* s);
     ~StrokeView() = default;
 
 public:
-    void paint(bool dontRenderEditingStroke);
-
     /**
-     * Change cairo source, used to draw highlighter transparent,
-     * but only if not currently drawing and so on (yes, complicated)
+     * @brief Paint the given stroke.
+     * @param dontRenderEditingStroke If true, and if the stroke is currently being (partially) erased, then render only
+     * the not-yet-erased parts. (Typically set to true, except for previews and export jobs)
+     * @param markAudioStroke If true, the stroke is faded out if it has no audio playback attached.
+     * @param noColor If true, paint as if on a colorblind mask (only the alpha values are painted).
      */
-    void changeCairoSource(bool markAudioStroke);
+    void paint(bool dontRenderEditingStroke, bool markAudioStroke, bool noColor = false) const;
 
 private:
-    void drawFillStroke();
-    void applyDashed(double offset);
+    inline void pathToCairo() const;
     static void drawErasableStroke(cairo_t* cr, Stroke* s);
 
     /**
      * No pressure sensitivity, one line is drawn
      */
-    void drawNoPressure();
+    void drawNoPressure() const;
 
     /**
      * Draw a stroke with pressure, for this multiple
      * lines with different widths needs to be drawn
      */
-    void drawWithPressure();
+    void drawWithPressure() const;
 
 
 private:
     cairo_t* cr;
+    mutable cairo_t* crEffective;
     Stroke* s;
 
-    int startPoint;
-    double scaleFactor;
-    bool noAlpha;
+public:
+    static constexpr uint8_t HIGHLIGHTER_ALPHA = 120;
+    static constexpr double MINIMAL_ALPHA = 10;
 };


### PR DESCRIPTION
This PR solves various stroke's display issues by refactoring the class `StrokeView`.
The solved issues are:

- Filled highlighter strokes were not filled when being drawn
- Various display issues of the fadeout supposed to happen when a stroke has no audio attached and the `play Audio` tool is selected.

Here is a video with both behaviours (none of the strokes have audio attached here...).

https://user-images.githubusercontent.com/17818041/137598650-8c54c0e1-1fee-4a6d-a0c0-96e7db227721.mp4

Obviously, there is an intersection with #2874 (but only in `StrokeView`). The two PRs could be merged. In particular, this solves the issue raised [in this post](https://github.com/xournalpp/xournalpp/pull/2874#pullrequestreview-751185320)