### PR TITLE
Fix contstruct typo.

### DIFF
--- a/src/control/tools/EditSelection.cpp
+++ b/src/control/tools/EditSelection.cpp
@@ -49,14 +49,14 @@ EditSelection::EditSelection(UndoRedoHandler* undo, const PageRef& page, XojPage
         width(0),
         height(0),
         snappedBounds(Rectangle<double>{}) {
-    contstruct(undo, view, page);
+    construct(undo, view, page);
 }
 
 EditSelection::EditSelection(UndoRedoHandler* undo, Selection* selection, XojPageView* view):
         snappingHandler(view->getXournal()->getControl()->getSettings()) {
     calcSizeFromElements(selection->selectedElements);
 
-    contstruct(undo, view, view->getPage());
+    construct(undo, view, view->getPage());
 
     // Construct the insert order
     std::vector<std::pair<Element*, Layer::ElementIndex>> order;
@@ -76,7 +76,7 @@ EditSelection::EditSelection(UndoRedoHandler* undo, Selection* selection, XojPag
 EditSelection::EditSelection(UndoRedoHandler* undo, Element* e, XojPageView* view, const PageRef& page):
         snappingHandler(view->getXournal()->getControl()->getSettings()) {
     calcSizeFromElements(std::vector<Element*>{e});
-    contstruct(undo, view, page);
+    construct(undo, view, page);
 
     addElement(e, this->sourceLayer->indexOf(e));
     this->sourceLayer->removeElement(e, false);
@@ -88,7 +88,7 @@ EditSelection::EditSelection(UndoRedoHandler* undo, const vector<Element*>& elem
                              const PageRef& page):
         snappingHandler(view->getXournal()->getControl()->getSettings()) {
     calcSizeFromElements(elements);
-    contstruct(undo, view, page);
+    construct(undo, view, page);
 
     for (Element* e: elements) {
         addElement(e, this->sourceLayer->indexOf(e));
@@ -128,7 +128,7 @@ void EditSelection::calcSizeFromElements(vector<Element*> elements) {
     snappedBounds = rect;
 }
 
-void EditSelection::contstruct(UndoRedoHandler* undo, XojPageView* view, const PageRef& sourcePage) {
+void EditSelection::construct(UndoRedoHandler* undo, XojPageView* view, const PageRef& sourcePage) {
     this->view = view;
     this->undo = undo;
     this->sourcePage = sourcePage;

--- a/src/control/tools/EditSelection.h
+++ b/src/control/tools/EditSelection.h
@@ -47,7 +47,7 @@ private:
     /**
      * Our internal constructor
      */
-    void contstruct(UndoRedoHandler* undo, XojPageView* view, const PageRef& sourcePage);
+    void construct(UndoRedoHandler* undo, XojPageView* view, const PageRef& sourcePage);
 
     /**
      * Calculate the size from the element list


### PR DESCRIPTION
Replace 'contstruct' with 'construct' in all occurrences in source code.