### PR TITLE
Add null check to device in InputEvent's handler

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -99,6 +99,7 @@ PellelNitram <starwars31337@gmail.com>
 Plailect <plailect@gmail.com>
 Pēteris Birkants <peteris.birkants@gmail.com>
 Rasmus Thomsen <oss@cogitri.dev>
+Rio Liu <rio.liu@r26.me>
 Rob Frohne <rob.frohne@wallawalla.edu>
 Romano Giannetti <romano@rgtti.com>
 Ruo Li <rli@math.pku.edu.cn>

--- a/src/control/XournalMain.cpp
+++ b/src/control/XournalMain.cpp
@@ -387,8 +387,7 @@ void ensure_input_model_compatibility() {
     if (imModule != nullptr) {
         std::string imModuleString{imModule};
         if (imModuleString == "xim" || imModuleString == "gcin") {
-            g_setenv("GTK_IM_MODULE", "ibus", true);
-            g_warning("Unsupported input method: %s, changed to: ibus", imModule);
+            g_warning("Unsupported input method: %s", imModule);
         }
     }
 }

--- a/src/gui/TextEditor.cpp
+++ b/src/gui/TextEditor.cpp
@@ -38,7 +38,7 @@ TextEditor::TextEditor(XojPageView* gui, GtkWidget* widget, Text* text, bool own
     g_object_get(settings, "gtk-cursor-blink-timeout", &this->cursorBlinkTimeout, nullptr);
 
     this->imContext = gtk_im_multicontext_new();
-    gtk_im_context_set_client_window(this->imContext, gtk_widget_get_window(this->widget));
+    gtk_im_context_set_client_window(this->imContext, gtk_widget_get_parent_window(this->widget));
     gtk_im_context_focus_in(this->imContext);
 
     g_signal_connect(this->imContext, "commit", G_CALLBACK(iMCommitCallback), this);

--- a/src/gui/inputdevices/InputContext.cpp
+++ b/src/gui/inputdevices/InputContext.cpp
@@ -68,10 +68,14 @@ auto InputContext::eventCallback(GtkWidget* widget, GdkEvent* event, InputContex
 auto InputContext::handle(GdkEvent* sourceEvent) -> bool {
     printDebug(sourceEvent);
 
+    GdkDevice* sourceDevice = gdk_event_get_source_device(sourceEvent);
+    if (sourceDevice == NULL) {
+        return false;
+    }
+
     InputEvent event = InputEvents::translateEvent(sourceEvent, this->getSettings());
 
     // Add the device to the list of known devices if it is currently unknown
-    GdkDevice* sourceDevice = gdk_event_get_source_device(sourceEvent);
     GdkInputSource inputSource = gdk_device_get_source(sourceDevice);
     if (inputSource != GDK_SOURCE_KEYBOARD && gdk_device_get_device_type(sourceDevice) != GDK_DEVICE_TYPE_MASTER &&
         this->knownDevices.find(std::string(event.deviceName)) == this->knownDevices.end()) {


### PR DESCRIPTION
Didn't have much progress on #3507 so opening this instead for now.

This PR makes `InputContext::handle` to return early if the event device is null, which would cause translateEvent to throw otherwise.

Related issue #3500