### PR TITLE
FillOpacity minor changes:

### DIFF
--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -976,7 +976,7 @@ void Control::selectFillAlpha(bool pen) {
         alpha = toolHandler->getHighlighterFill();
     }
 
-    FillOpacityDialog dlg(gladeSearchPath, alpha);
+    FillOpacityDialog dlg(gladeSearchPath, alpha, pen);
     dlg.show(getGtkWindow());
 
     if (dlg.getResultAlpha() == -1) {

--- a/src/gui/dialog/FillOpacityDialog.cpp
+++ b/src/gui/dialog/FillOpacityDialog.cpp
@@ -1,7 +1,7 @@
 #include "FillOpacityDialog.h"
 
-FillOpacityDialog::FillOpacityDialog(GladeSearchpath* gladeSearchPath, int alpha):
-        GladeGui(gladeSearchPath, "fillOpacity.glade", "fillOpacityDialog") {
+FillOpacityDialog::FillOpacityDialog(GladeSearchpath* gladeSearchPath, int alpha, bool pen):
+        GladeGui(gladeSearchPath, "fillOpacity.glade", "fillOpacityDialog"), pen(pen) {
     GtkWidget* scaleAlpha = get("scaleAlpha");
 
     gtk_range_set_value(GTK_RANGE(scaleAlpha), static_cast<int>(alpha / 255.0 * 100));
@@ -28,8 +28,7 @@ void FillOpacityDialog::setPreviewImage(int alpha) {
 
     cairo_set_operator(cr, CAIRO_OPERATOR_SOURCE);
     cairo_set_source_rgb(cr, 255, 255, 255);
-    cairo_rectangle(cr, 0, 0, PREVIEW_WIDTH, PREVIEW_WIDTH);
-    cairo_fill(cr);
+    cairo_paint(cr);
 
     cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
     cairo_set_source_rgba(cr, 0, 0x80 / 255.0, 0, alpha / 255.0);
@@ -37,17 +36,21 @@ void FillOpacityDialog::setPreviewImage(int alpha) {
                     PREVIEW_HEIGTH - PREVIEW_BORDER * 2);
     cairo_fill(cr);
 
-    cairo_set_line_width(cr, 5);
-    cairo_set_operator(cr, CAIRO_OPERATOR_SOURCE);
-    cairo_set_source_rgb(cr, 0, 0x80 / 255.0, 0);
-    cairo_rectangle(cr, PREVIEW_BORDER, PREVIEW_BORDER, PREVIEW_WIDTH - PREVIEW_BORDER * 2,
-                    PREVIEW_HEIGTH - PREVIEW_BORDER * 2);
-    cairo_stroke(cr);
+    if (pen) {
+        cairo_set_line_width(cr, 5);
+        cairo_set_operator(cr, CAIRO_OPERATOR_SOURCE);
+        cairo_set_source_rgb(cr, 0, 0x80 / 255.0, 0);
+        cairo_rectangle(cr, PREVIEW_BORDER, PREVIEW_BORDER, PREVIEW_WIDTH - PREVIEW_BORDER * 2,
+                        PREVIEW_HEIGTH - PREVIEW_BORDER * 2);
+        cairo_stroke(cr);
+    }
 
     cairo_destroy(cr);
 
     GtkWidget* preview = get("imgPreview");
     gtk_image_set_from_surface(GTK_IMAGE(preview), surface);
+
+    cairo_surface_destroy(surface);
 }
 
 auto FillOpacityDialog::getResultAlpha() const -> int { return resultAlpha; }

--- a/src/gui/dialog/FillOpacityDialog.h
+++ b/src/gui/dialog/FillOpacityDialog.h
@@ -15,7 +15,7 @@
 
 class FillOpacityDialog: public GladeGui {
 public:
-    FillOpacityDialog(GladeSearchpath* gladeSearchPath, int alpha);
+    FillOpacityDialog(GladeSearchpath* gladeSearchPath, int alpha, bool pen);
     virtual ~FillOpacityDialog();
 
 public:
@@ -28,4 +28,5 @@ private:
 
 private:
     int resultAlpha = -1;
+    bool pen;
 };

--- a/ui/fillOpacity.glade
+++ b/ui/fillOpacity.glade
@@ -3,7 +3,7 @@
 <interface>
   <requires lib="gtk+" version="3.0"/>
   <object class="GtkAdjustment" id="adjustment1">
-    <property name="lower">1</property>
+    <property name="lower">5</property>
     <property name="upper">100</property>
     <property name="step-increment">1</property>
     <property name="page-increment">10</property>


### PR DESCRIPTION
        * Make FillOpacityDialog's preview depend on the tool
        * Destroy leaked cairo_surface
        * Add minimal value for stroke filling alpha

This relates to #3480 and [this comment](https://github.com/xournalpp/xournalpp/pull/3480#discussion_r736771322).
I made a separate PR as it touches somewhat independent parts of the code.
This is ready for review.