### PR TITLE
Xournal++ version string in PDF metadata

### DIFF
--- a/src/pdf/base/XojCairoPdfExport.cpp
+++ b/src/pdf/base/XojCairoPdfExport.cpp
@@ -5,6 +5,7 @@
 #include <stack>
 
 #include <cairo-pdf.h>
+#include <config.h>
 
 #include "view/DocumentView.h"
 
@@ -34,6 +35,7 @@ auto XojCairoPdfExport::startPdf(const fs::path& file) -> bool {
 
 #if CAIRO_VERSION >= CAIRO_VERSION_ENCODE(1, 16, 0)
     cairo_pdf_surface_set_metadata(surface, CAIRO_PDF_METADATA_TITLE, doc->getFilepath().filename().u8string().c_str());
+    cairo_pdf_surface_set_metadata(surface, CAIRO_PDF_METADATA_CREATOR, PROJECT_STRING);
     GtkTreeModel* tocModel = doc->getContentsModel();
     this->populatePdfOutline(tocModel);
 #endif


### PR DESCRIPTION
This PR sets Ciaros `CAIRO_PDF_METADATA_CREATOR` Metadata to the current Xournal++ version string. Exported PDFs will now have the version string in the PDF attributes
![Bildschirmfoto vom 2021-10-28 21-22-38](https://user-images.githubusercontent.com/22816159/139321804-87a872e9-14db-481c-a7dd-42917cfef5b2.png)

See also: https://cairographics.org/manual/cairo-PDF-Surfaces.html#cairo-pdf-metadata-t