### PR TITLE
Switch to FontConfig Backend for Cairo-Pango on Windows

### DIFF
--- a/src/Xournalpp.cpp
+++ b/src/Xournalpp.cpp
@@ -37,7 +37,7 @@ auto main(int argc, char* argv[]) -> int {
 
 #ifdef _WIN32
     // Switch to the FontConfig backend for Pango - See #3371
-    setenv("PANGOCAIRO_BACKEND", "fc", true);
+    _putenv_s("PANGOCAIRO_BACKEND", "fc");
 #endif
 
     // Use this two line to test the crash handler...

--- a/src/Xournalpp.cpp
+++ b/src/Xournalpp.cpp
@@ -35,6 +35,11 @@ auto main(int argc, char* argv[]) -> int {
     Log::initlog();
 #endif
 
+#ifdef _WIN32
+    // Switch to the FontConfig backend for Pango - See #3371
+    setenv("PANGOCAIRO_BACKEND", "fc", true);
+#endif
+
     // Use this two line to test the crash handler...
     // int* crash = nullptr;
     // *crash = 0;


### PR DESCRIPTION
This is a quick and dirty try to enable logging for Pango (see https://stackoverflow.com/a/26618242).

I'll rebase this once I got a working fix. For now, I'm too lazy to always fully rebuild the `release-1.1` branch when switching between PRs :wink: 