### PR TITLE
Added system cursor as pen cursor option.

### DIFF
--- a/src/control/settings/Settings.cpp
+++ b/src/control/settings/Settings.cpp
@@ -847,7 +847,7 @@ void Settings::save() {
     ATTACH_COMMENT("Which gui elements are hidden if you are in Presentation mode, separated by a colon (,)");
 
     xmlNode = saveProperty("stylusCursorType", stylusCursorTypeToString(this->stylusCursorType), root);
-    ATTACH_COMMENT("The cursor icon used with a stylus, allowed values are \"none\", \"dot\", \"big\"");
+    ATTACH_COMMENT("The cursor icon used with a stylus, allowed values are \"none\", \"dot\", \"big\", \"arrow\"");
 
     SAVE_BOOL_PROP(highlightPosition);
     SAVE_UINT_PROP(cursorHighlightColor);

--- a/src/control/settings/SettingsEnums.cpp
+++ b/src/control/settings/SettingsEnums.cpp
@@ -10,6 +10,9 @@ auto stylusCursorTypeFromString(const std::string& stylusCursorTypeStr) -> Stylu
     if (stylusCursorTypeStr == "big") {
         return STYLUS_CURSOR_BIG;
     }
+    if (stylusCursorTypeStr == "arrow") {
+        return STYLUS_CURSOR_ARROW;
+    }
     g_warning("Settings::Unknown stylus cursor type: %s\n", stylusCursorTypeStr.c_str());
     return STYLUS_CURSOR_DOT;
 }

--- a/src/control/settings/SettingsEnums.h
+++ b/src/control/settings/SettingsEnums.h
@@ -66,6 +66,7 @@ enum StylusCursorType {
     STYLUS_CURSOR_NONE = 0,
     STYLUS_CURSOR_DOT = 1,
     STYLUS_CURSOR_BIG = 2,
+    STYLUS_CURSOR_ARROW = 3,
 };
 
 constexpr auto buttonToString(Button button) -> const char* {
@@ -97,6 +98,8 @@ constexpr auto stylusCursorTypeToString(StylusCursorType stylusCursorType) -> co
             return "dot";
         case STYLUS_CURSOR_BIG:
             return "big";
+        case STYLUS_CURSOR_ARROW:
+            return "arrow";
         default:
             return "unknown";
     }

--- a/src/gui/XournalppCursor.cpp
+++ b/src/gui/XournalppCursor.cpp
@@ -400,6 +400,10 @@ auto XournalppCursor::getPenCursor() -> GdkCursor* {
         setCursor(CRSR_BLANK_CURSOR);
         return nullptr;
     }
+    if (control->getSettings()->getStylusCursorType() == STYLUS_CURSOR_ARROW) {
+        setCursor(CRSR_ARROW);
+        return nullptr;
+    }
     if (this->drawDirActive) {
         return createCustomDrawDirCursor(48, this->drawDirShift, this->drawDirCtrl);
     }

--- a/src/gui/dialog/SettingsDialog.cpp
+++ b/src/gui/dialog/SettingsDialog.cpp
@@ -297,7 +297,8 @@ void SettingsDialog::customHandRecognitionToggled() {
 void SettingsDialog::customStylusIconTypeChanged() {
     GtkWidget* cbStylusCursorType = get("cbStylusCursorType");
     int stylusCursorType = gtk_combo_box_get_active(GTK_COMBO_BOX(cbStylusCursorType));
-    bool showCursorHighlightOptions = (stylusCursorType != STYLUS_CURSOR_NONE && stylusCursorType != STYLUS_CURSOR_ARROW);
+    bool showCursorHighlightOptions = 
+            (stylusCursorType != STYLUS_CURSOR_NONE && stylusCursorType != STYLUS_CURSOR_ARROW);
     gtk_widget_set_sensitive(get("highlightCursorGrid"), showCursorHighlightOptions);
 }
 

--- a/src/gui/dialog/SettingsDialog.cpp
+++ b/src/gui/dialog/SettingsDialog.cpp
@@ -297,7 +297,7 @@ void SettingsDialog::customHandRecognitionToggled() {
 void SettingsDialog::customStylusIconTypeChanged() {
     GtkWidget* cbStylusCursorType = get("cbStylusCursorType");
     int stylusCursorType = gtk_combo_box_get_active(GTK_COMBO_BOX(cbStylusCursorType));
-    bool showCursorHighlightOptions = 
+    bool showCursorHighlightOptions =
             (stylusCursorType != STYLUS_CURSOR_NONE && stylusCursorType != STYLUS_CURSOR_ARROW);
     gtk_widget_set_sensitive(get("highlightCursorGrid"), showCursorHighlightOptions);
 }

--- a/src/gui/dialog/SettingsDialog.cpp
+++ b/src/gui/dialog/SettingsDialog.cpp
@@ -297,7 +297,7 @@ void SettingsDialog::customHandRecognitionToggled() {
 void SettingsDialog::customStylusIconTypeChanged() {
     GtkWidget* cbStylusCursorType = get("cbStylusCursorType");
     int stylusCursorType = gtk_combo_box_get_active(GTK_COMBO_BOX(cbStylusCursorType));
-    bool showCursorHighlightOptions = stylusCursorType != STYLUS_CURSOR_NONE;
+    bool showCursorHighlightOptions = (stylusCursorType != STYLUS_CURSOR_NONE && stylusCursorType != STYLUS_CURSOR_ARROW);
     gtk_widget_set_sensitive(get("highlightCursorGrid"), showCursorHighlightOptions);
 }
 
@@ -482,6 +482,9 @@ void SettingsDialog::load() {
             break;
         case STYLUS_CURSOR_BIG:
             gtk_combo_box_set_active(GTK_COMBO_BOX(get("cbStylusCursorType")), 2);
+            break;
+        case STYLUS_CURSOR_ARROW:
+            gtk_combo_box_set_active(GTK_COMBO_BOX(get("cbStylusCursorType")), 3);
             break;
         case STYLUS_CURSOR_DOT:
         default:
@@ -738,6 +741,9 @@ void SettingsDialog::save() {
             break;
         case 2:
             settings->setStylusCursorType(STYLUS_CURSOR_BIG);
+            break;
+        case 3:
+            settings->setStylusCursorType(STYLUS_CURSOR_ARROW);
             break;
         case 1:
         default:

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -2999,6 +2999,7 @@ This setting can make it easier to draw with touch. </property>
                                                   <item id="none" translatable="yes" context="stylus cursor uses no icon">No icon</item>
                                                   <item id="dot" translatable="yes" context="stylus cursor uses a small dot">Small dot icon</item>
                                                   <item id="big" translatable="yes" context="stylus cursor uses a big pen icon">Big pen icon</item>
+                                                  <item id="arrow" translatable="yes" context="stylus cursor uses system cursor">System cursor</item>
                                                 </items>
                                               </object>
                                               <packing>


### PR DESCRIPTION
# Addition of the option to use system cursor (default mouse pointer) as a pen cursor

This option is accessible under `Edit > Preferences > View > Cursor > Cursor icon for pen` as a fourth option. Changing the input device type for a pen device from Pen to Mouse in `Edit > Preferences > Input System > Input Devices` gives us the default system cursor on hover, but the cursor reverts to one of the three existing Pen cursor icons (_No icon_, _Small dot icon_, and _Big pen icon_) upon 'pressing down' on the paper.

The original purpose of this minor modification was that I simply preferred using the default mouse pointer as my pen cursor, but since this feature is present in other popular note-taking apps such as OneNote, there may be other users who are used to drawing with their system cursor that may receive benefit from it as well. 

Additionally, educators require clear cursors to teach their students while sharing or recording their screen. Those who find the _Small dot icon_ too small and the _Big pen icon_ too big and/or distracting may want to use their default system cursor as well, since students are used to seeing default cursors, can easily identify them, and will focus on the content being written instead of an interesting cursor shape that they may have not seen before. 

Therefore, it is reasonable for the system cursor to be permanently available as a pen cursor option for said users who are migrating to Xournal++ from other note-taking applications. As tiny an addition as it is, it still adds to the customisability of Xournal++ and promotes its standing as a great free and open-source alternative to proprietary note-taking software.

### Code changes

As I do not have prior experience in C++ and much of what I see in the files are alien to me, I tried my best to identify code for the other cursor options across all relevant files, copied, pasted and edited them to reach the desired outcome. Similar to the _No icon_ cursor, the system cursor option is only applicable to the Pen tool (including shape tools when the Pen tool is active). The _Small dot icon_ cursor is retained for the Highlighter tool (including shape tools when the Highlighter tool is active). This is due to the conventional arrow shape of default system cursors which is impractical to use as a highlighting cursor (it may be hard for some users to trace their highlights with an arrow). 

### Tests

I tested the new cursor option with the Pen, Eraser, Highlighter, Shape tools (including stroke recogniser). All work as expected. If the option is selected when the app is closed, it will remain selected when the app is opened again. 

### Some teeny-tiny trade-offs

These trade-offs are partly due to my inexperience in C++. I encountered bugs while trying to make it possible for _Highlight cursor position_ to be enabled when using the system cursor. I do not find this essential though, as users who want their cursor position to be clearly emphasised may prefer to use _Highlight cursor position_ together with the _Big pen icon_ anyway. So currently, selecting the system cursor will disable _Highlight cursor position_.

As the code for this system cursor option is derived from that of the _No icon_ cursor, if the experimental feature _Drawing Tools - Set Modifiers by Draw Direction_ is enabled, it still works as expected, but the small screentips **SHIFT** and **CONTROL** will not appear when drawing up or to the left. They will appear when the cursor option selected is either _Small dot icon_ or _Big pen icon_. 
