### PR TITLE
Remove mentions of CppUnit in all READMEs

### DIFF
--- a/cmake/README.md
+++ b/cmake/README.md
@@ -50,14 +50,7 @@ Here you can find complete list of Xournal++ CMake flags (sorted by categories).
 
 | Variable name        | Default | Description
 | -------------------- | ------- | -----------
-| `ENABLE_CPPUNIT`     | OFF     | Build CppUnit test instead of xournalpp application
-
-
-## `TEST` – optional features of CppUnit tests
-
-| Variable name      | Default | Description
-| ------------------ | ------- | -----------
-| `TEST_CHECK_SPEED` | OFF     | Show speed benchmarks for some tests
+| `ENABLE_GTEST`       | OFF     | Download and build GoogleTest (if not previously done) and build tests instead of xournalpp application
 
 
 ## `PATH` – here you can specify alternative location of these binaries (there are no defaults)

--- a/readme/LinuxBuild.md
+++ b/readme/LinuxBuild.md
@@ -23,13 +23,13 @@ The minimum required CMake version is 3.10, but we recommend to use >=3.15.
 
 #### For Arch
 ```bash
-sudo pacman -S cmake gtk3 base-devel libxml2 cppunit portaudio libsndfile \
+sudo pacman -S cmake gtk3 base-devel libxml2 portaudio libsndfile \
 poppler-glib texlive-bin texlive-pictures gettext libzip lua53 lua53-lgi
 ```
 
 #### For Fedora/CentOS/RHEL:
 ```bash
-sudo dnf install gcc-c++ cmake gtk3-devel libxml2-devel cppunit-devel portaudio-devel libsndfile-devel \
+sudo dnf install gcc-c++ cmake gtk3-devel libxml2-devel portaudio-devel libsndfile-devel \
 poppler-glib-devel texlive-scheme-basic texlive-dvipng 'tex(standalone.cls)' gettext libzip-devel \
 librsvg2-devel lua-devel lua-lgi
 ```
@@ -37,12 +37,12 @@ librsvg2-devel lua-devel lua-lgi
 #### For Ubuntu/Debian and Raspberry Pi OS:
 ````bash
 sudo apt-get install cmake libgtk-3-dev libpoppler-glib-dev portaudio19-dev libsndfile-dev \
-libcppunit-dev dvipng texlive libxml2-dev liblua5.3-dev libzip-dev librsvg2-dev gettext lua-lgi
+dvipng texlive libxml2-dev liblua5.3-dev libzip-dev librsvg2-dev gettext lua-lgi
 ````
 
 #### For openSUSE:
 ```bash
-sudo zypper install cmake gtk3-devel cppunit-devel portaudio-devel libsndfile-devel \
+sudo zypper install cmake gtk3-devel portaudio-devel libsndfile-devel \
 texlive-dvipng texlive libxml2-devel libpoppler-glib-devel libzip-devel librsvg-devel lua-lgi
 ```
 
@@ -50,7 +50,7 @@ texlive-dvipng texlive libxml2-devel libpoppler-glib-devel libzip-devel librsvg-
 ```bash
 sudo eopkg it -c system.devel
 sudo eopkg it cmake libgtk-3-devel libxml2-devel poppler-devel libzip-devel \
-portaudio-devel libsndfile-devel alsa-lib-devel cppunit-devel lua-devel \
+portaudio-devel libsndfile-devel alsa-lib-devel lua-devel \
 librsvg-devel gettext
 ```
 

--- a/readme/WindowsBuild.md
+++ b/readme/WindowsBuild.md
@@ -29,7 +29,6 @@ pacman -S mingw-w64-x86_64-toolchain \
           mingw-w64-x86_64-cmake \
           mingw-w64-x86_64-ninja \
           patch \
-          mingw-w64-x86_64-cppunit \
           make \
           mingw-w64-x86_64-imagemagick
 ```


### PR DESCRIPTION
This fixes  #3560.

The only places where the string "cppunit" now still exists is in the
migration guide for existing tests and in some legacy testcases.