### PR TITLE
add export option for pdf, svg, png to plugin API

### DIFF
--- a/plugins/Export/main.lua
+++ b/plugins/Export/main.lua
@@ -1,0 +1,36 @@
+-- Register all Toolbar actions and intialize all UI stuff
+function initUi()
+  app.registerUi({["menu"] = "Export to pdf", ["callback"] = "exportPdf", ["accelerator"] = "<Shift><Alt>p"});
+  app.registerUi({["menu"] = "Export to svg", ["callback"] = "exportSvg", ["accelerator"] = "<Shift><Alt>s"});
+  app.registerUi({["menu"] = "Export to png", ["callback"] = "exportPng", ["accelerator"] = "<Shift><Alt>n"});
+end
+
+local DEFAULT_PATH = "/tmp/temp"  -- change this to get a different default path for xopp-files that have not been saved yet
+
+function exportPdf()
+  local pdfName = getStem() .. "_export.pdf"
+  app.export({["outputFile"] = pdfName})
+  -- use the "range", "background" and "progressiveMode" fields for more customization
+end
+
+function exportSvg()  
+  local svgName = getStem() .. "_export.svg"
+  app.export({["outputFile"] = svgName})
+  -- use the "range", "background" for more customization
+end
+
+function exportPng()
+  local pngName = getStem() .. "_export.png"
+  app.export({["outputFile"] = pngName})
+  -- use the "range", "background" and "pngDpi", "pngWidth" or "pngHeight" fields for more customization
+end
+
+function getStem()
+  local xoppName = app.getDocumentStructure()["xoppFilename"]
+  if (xoppName ~= "" and xoppName ~= nil) then 
+    return xoppName:match("(.+)%..+$")
+  else
+    print("Exporting to default path. Consider saving the xopp-file before exporting! ")
+    return DEFAULT_PATH
+  end
+end

--- a/plugins/Export/plugin.ini
+++ b/plugins/Export/plugin.ini
@@ -1,0 +1,15 @@
+[about]
+## Author / Copyright notice
+author=Roland Lötscher
+
+description=Export to pdf, svg and png.
+
+## If the plugin is packed with Xournal++, use
+## <xournalpp> then it gets the same version number
+version=<xournalpp>
+
+[default]
+enabled=false
+
+[plugin]
+mainfile=main.lua

--- a/src/core/control/ExportHelper.cpp
+++ b/src/core/control/ExportHelper.cpp
@@ -1,0 +1,114 @@
+#include "ExportHelper.h"
+
+namespace ExportHelper {
+
+/**
+ * @brief Export the input file as a bunch of image files (one per page)
+ * @param input Path to the input file
+ * @param output Path to the output file(s)
+ * @param range Page range to be parsed. If range=nullptr, exports the whole file
+ * @param pngDpi Set dpi for Png files. Non positive values are ignored
+ * @param pngWidth Set the width for Png files. Non positive values are ignored
+ * @param pngHeight Set the height for Png files. Non positive values are ignored
+ * @param exportBackground If EXPORT_BACKGROUND_NONE, the exported image file has transparent background
+ *
+ *  The priority is: pngDpi overwrites pngWidth overwrites pngHeight
+ *
+ * @return 0 on success, -3 on export failure
+ */
+auto exportImg(Document* doc, const char* output, const char* range, int pngDpi, int pngWidth, int pngHeight,
+               ExportBackgroundType exportBackground) -> int {
+
+    fs::path const path(output);
+
+    ExportGraphicsFormat format = EXPORT_GRAPHICS_PNG;
+
+    if (path.extension() == ".svg") {
+        format = EXPORT_GRAPHICS_SVG;
+    }
+
+    PageRangeVector exportRange;
+    if (range) {
+        exportRange = PageRange::parse(range, int(doc->getPageCount()));
+    } else {
+        exportRange.push_back(new PageRangeEntry(0, int(doc->getPageCount() - 1)));
+    }
+
+    DummyProgressListener progress;
+
+    ImageExport imgExport(doc, path, format, exportBackground, exportRange);
+
+    if (format == EXPORT_GRAPHICS_PNG) {
+        if (pngDpi > 0) {
+            imgExport.setQualityParameter(EXPORT_QUALITY_DPI, pngDpi);
+        } else if (pngWidth > 0) {
+            imgExport.setQualityParameter(EXPORT_QUALITY_WIDTH, pngWidth);
+        } else if (pngHeight > 0) {
+            imgExport.setQualityParameter(EXPORT_QUALITY_HEIGHT, pngHeight);
+        }
+    }
+
+    imgExport.exportGraphics(&progress);
+
+    for (PageRangeEntry* e: exportRange) { delete e; }
+    exportRange.clear();
+
+    std::string errorMsg = imgExport.getLastErrorMsg();
+    if (!errorMsg.empty()) {
+        g_message("Error exporting image: %s\n", errorMsg.c_str());
+    }
+
+    g_message("%s", _("Image file successfully created"));
+
+    return 0;  // no error
+}
+
+/**
+ * @brief Export the input file as pdf
+ * @param input Path to the input file
+ * @param output Path to the output file
+ * @param range Page range to be parsed. If range=nullptr, exports the whole file
+ * @param exportBackground If EXPORT_BACKGROUND_NONE, the exported pdf file has white background
+ * @param progressiveMode If true, then for each xournalpp page, instead of rendering one PDF page, the page layers are
+ * rendered one by one to produce as many pages as there are layers.
+ *
+ * @return 0 on success, -3 on export failure
+ */
+auto exportPdf(Document* doc, const char* output, const char* range, ExportBackgroundType exportBackground,
+               bool progressiveMode) -> int {
+
+    GFile* file = g_file_new_for_commandline_arg(output);
+
+    XojPdfExport* pdfe = XojPdfExportFactory::createExport(doc, nullptr);
+    pdfe->setExportBackground(exportBackground);
+    char* cpath = g_file_get_path(file);
+    std::string path = cpath;
+    g_free(cpath);
+    g_object_unref(file);
+
+    bool exportSuccess;  // Return of the export job
+
+    if (range) {
+        // Parse the range
+        PageRangeVector exportRange = PageRange::parse(range, doc->getPageCount());
+        // Do the export
+        exportSuccess = pdfe->createPdf(path, exportRange, progressiveMode);
+        // Clean up
+        for (PageRangeEntry* e: exportRange) { delete e; }
+        exportRange.clear();
+    } else {
+        exportSuccess = pdfe->createPdf(path, progressiveMode);
+    }
+
+    if (!exportSuccess) {
+        g_error("%s", pdfe->getLastError().c_str());
+        // delete pdfe; Unreachable. Todo: use std::unique_ptr
+    }
+    delete pdfe;
+
+    g_message("%s", _("PDF file successfully created"));
+
+    return 0;  // no error
+}
+
+}  // namespace ExportHelper

--- a/src/core/control/ExportHelper.cpp
+++ b/src/core/control/ExportHelper.cpp
@@ -79,7 +79,7 @@ auto exportPdf(Document* doc, const char* output, const char* range, ExportBackg
 
     GFile* file = g_file_new_for_commandline_arg(output);
 
-    XojPdfExport* pdfe = XojPdfExportFactory::createExport(doc, nullptr);
+    std::unique_ptr<XojPdfExport> pdfe = XojPdfExportFactory::createExport(doc, nullptr);
     pdfe->setExportBackground(exportBackground);
     char* cpath = g_file_get_path(file);
     std::string path = cpath;
@@ -102,9 +102,7 @@ auto exportPdf(Document* doc, const char* output, const char* range, ExportBackg
 
     if (!exportSuccess) {
         g_error("%s", pdfe->getLastError().c_str());
-        // delete pdfe; Unreachable. Todo: use std::unique_ptr
     }
-    delete pdfe;
 
     g_message("%s", _("PDF file successfully created"));
 

--- a/src/core/control/ExportHelper.h
+++ b/src/core/control/ExportHelper.h
@@ -1,0 +1,57 @@
+/*
+ * Xournal++
+ *
+ * Helper functions to iterate over devices
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+#include <libintl.h>
+
+#include "control/jobs/ImageExport.h"
+#include "control/jobs/ProgressListener.h"
+#include "control/xojfile/LoadHandler.h"
+#include "pdf/base/XojPdfExport.h"
+#include "pdf/base/XojPdfExportFactory.h"
+#include "util/i18n.h"
+
+namespace ExportHelper {
+
+/**
+ * @brief Export the input file as a bunch of image files (one per page)
+ * @param doc Document to export
+ * @param output Path to the output file(s)
+ * @param range Page range to be parsed. If range=nullptr, exports the whole file
+ * @param pngDpi Set dpi for Png files. Non positive values are ignored
+ * @param pngWidth Set the width for Png files. Non positive values are ignored
+ * @param pngHeight Set the height for Png files. Non positive values are ignored
+ * @param exportBackground If EXPORT_BACKGROUND_NONE, the exported image file has transparent background
+ *
+ *  The priority is: pngDpi overwrites pngWidth overwrites pngHeight
+ *
+ * @return 0 on success, -2 on failure opening the input file, -3 on export failure
+ */
+int exportImg(Document* doc, const char* output, const char* range, int pngDpi, int pngWidth, int pngHeight,
+              ExportBackgroundType exportBackground);
+
+/**
+ * @brief Export the input file as pdf
+ * @param doc Document to export
+ * @param output Path to the output file
+ * @param range Page range to be parsed. If range=nullptr, exports the whole file
+ * @param exportBackground If EXPORT_BACKGROUND_NONE, the exported pdf file has white background
+ * @param progressiveMode If true, then for each xournalpp page, instead of rendering one PDF page, the page layers are
+ * rendered one by one to produce as many pages as there are layers.
+ *
+ * @return 0 on success, -2 on failure opening the input file, -3 on export failure
+ */
+int exportPdf(Document* doc, const char* output, const char* range, ExportBackgroundType exportBackground,
+              bool progressiveMode);
+
+
+}  // namespace ExportHelper

--- a/src/core/control/jobs/CustomExportJob.cpp
+++ b/src/core/control/jobs/CustomExportJob.cpp
@@ -133,7 +133,7 @@ void CustomExportJob::run() {
         // the ui is blocked, so there should be no changes...
         Document* doc = control->getDocument();
 
-        XojPdfExport* pdfe = XojPdfExportFactory::createExport(doc, control);
+        std::unique_ptr<XojPdfExport> pdfe = XojPdfExportFactory::createExport(doc, control);
 
         pdfe->setExportBackground(exportBackground);
 
@@ -141,7 +141,6 @@ void CustomExportJob::run() {
             this->errorMsg = pdfe->getLastError();
         }
 
-        delete pdfe;
     } else {
         exportGraphics();
     }

--- a/src/core/control/jobs/PdfExportJob.cpp
+++ b/src/core/control/jobs/PdfExportJob.cpp
@@ -28,7 +28,7 @@ void PdfExportJob::run() {
     Document* doc = control->getDocument();
 
     doc->lock();
-    XojPdfExport* pdfe = XojPdfExportFactory::createExport(doc, control);
+    std::unique_ptr<XojPdfExport> pdfe = XojPdfExportFactory::createExport(doc, control);
     doc->unlock();
 
     if (!pdfe->createPdf(this->filepath, false)) {
@@ -37,6 +37,4 @@ void PdfExportJob::run() {
             callAfterRun();
         }
     }
-
-    delete pdfe;
 }

--- a/src/core/pdf/base/XojPdfExportFactory.cpp
+++ b/src/core/pdf/base/XojPdfExportFactory.cpp
@@ -8,6 +8,6 @@ XojPdfExportFactory::XojPdfExportFactory() = default;
 
 XojPdfExportFactory::~XojPdfExportFactory() = default;
 
-auto XojPdfExportFactory::createExport(Document* doc, ProgressListener* listener) -> XojPdfExport* {
-    return new XojCairoPdfExport(doc, listener);
+auto XojPdfExportFactory::createExport(Document* doc, ProgressListener* listener) -> std::unique_ptr<XojPdfExport> {
+    return std::make_unique<XojCairoPdfExport>(doc, listener);
 }

--- a/src/core/pdf/base/XojPdfExportFactory.h
+++ b/src/core/pdf/base/XojPdfExportFactory.h
@@ -26,7 +26,7 @@ private:
     virtual ~XojPdfExportFactory();
 
 public:
-    static XojPdfExport* createExport(Document* doc, ProgressListener* listener);
+    static std::unique_ptr<XojPdfExport> createExport(Document* doc, ProgressListener* listener);
 
 private:
 };

--- a/src/core/plugin/luapi_application.h
+++ b/src/core/plugin/luapi_application.h
@@ -787,6 +787,7 @@ static int applib_getToolInfo(lua_State* L) {
  *   }
  *   "currentPage" = integer,
  *   "pdfBackgroundFilename" = string (empty if there is none)
+ *   "xoppFilename" = string (empty if there is none)
  * }
  *
  * Example: local docStructure = app.getDocumentStructure()
@@ -892,6 +893,10 @@ static int applib_getDocumentStructure(lua_State* L) {
 
     lua_pushliteral(L, "pdfBackgroundFilename");
     lua_pushstring(L, doc->getPdfFilepath().string().c_str());
+    lua_settable(L, -3);
+
+    lua_pushliteral(L, "xoppFilename");
+    lua_pushstring(L, doc->getFilepath().string().c_str());
     lua_settable(L, -3);
 
     return 1;

--- a/src/core/plugin/luapi_application.h
+++ b/src/core/plugin/luapi_application.h
@@ -18,6 +18,8 @@
 #include "control/Control.h"
 #include "control/PageBackgroundChangeController.h"
 #include "control/Tool.h"
+#include "control/jobs/ImageExport.h"
+#include "control/jobs/ProgressListener.h"
 #include "control/layer/LayerController.h"
 #include "control/pagetype/PageTypeHandler.h"
 #include "gui/XournalView.h"
@@ -25,6 +27,8 @@
 #include "model/Font.h"
 #include "model/StrokeStyle.h"
 #include "model/Text.h"
+#include "pdf/base/XojPdfExport.h"
+#include "pdf/base/XojPdfExportFactory.h"
 #include "util/StringUtils.h"
 #include "util/XojMsgBox.h"
 #include "util/safe_casts.h"
@@ -1157,6 +1161,134 @@ static int applib_getDisplayDpi(lua_State* L) {
 }
 
 
+/**
+ * Exports the current document as a pdf or as a svg or png image
+
+ * Example 1:
+ * app.export({["outputFile"] = "Test.pdf", ["range"] = "2-5; 7", ["background"] = "none", ["progressiveMode"] = true})
+ * uses progressiveMode, so for each page of the document, instead of rendering one PDF page, the page layers are
+ * rendered one by one to produce as many pages as there are layers.
+ *
+ * Example 2:
+ * app.export({["outputFile"] = "Test.svg", ["range"] = "3-", ["background"] = "unruled"})
+ *
+ * Example 3:
+ * app.export({["outputFile"] = "Test.png", ["range"] = "1-2", ["background"] = "all", ["pngWidth"] = 800})
+ **/
+static int applib_export(lua_State* L) {
+    Plugin* plugin = Plugin::getPluginFromLua(L);
+    Control* control = plugin->getControl();
+    Document* doc = control->getDocument();
+
+    // discard any extra arguments passed in
+    lua_settop(L, 1);
+    luaL_checktype(L, 1, LUA_TTABLE);
+
+    lua_getfield(L, 1, "outputFile");
+    lua_getfield(L, 1, "range");
+    lua_getfield(L, 1, "background");
+    lua_getfield(L, 1, "progressiveMode");
+    lua_getfield(L, 1, "pngDpi");
+    lua_getfield(L, 1, "pngWidth");
+    lua_getfield(L, 1, "dpiHeight");
+
+    const char* outputFile = luaL_optstring(L, -7, nullptr);
+    const char* range = luaL_optstring(L, -6, nullptr);
+    const char* background = luaL_optstring(L, -5, "all");
+    bool progressiveMode = lua_toboolean(L, -4);  // true unless nil or false
+    int pngDpi = luaL_optinteger(L, -3, -1);
+    int pngWidth = luaL_optinteger(L, -2, -1);
+    int pngHeight = luaL_optinteger(L, -1, -1);
+
+    ExportBackgroundType bgType = EXPORT_BACKGROUND_ALL;
+    if (strcmp(background, "unruled") == 0) {
+        bgType = EXPORT_BACKGROUND_UNRULED;
+    } else if (strcmp(background, "none") == 0) {
+        bgType = EXPORT_BACKGROUND_NONE;
+    }
+
+    if (outputFile == nullptr) {
+        luaL_error(L, "Missing output file!");
+    }
+
+    fs::path file = fs::path(outputFile);
+    auto extension = file.extension();
+
+    if (extension == ".pdf") {
+        // exportPdf("test.xopp", outputFile, range, bgType, progressiveMode);
+        GFile* file = g_file_new_for_commandline_arg(outputFile);
+
+        XojPdfExport* pdfe = XojPdfExportFactory::createExport(doc, nullptr);
+        pdfe->setExportBackground(bgType);
+        char* cpath = g_file_get_path(file);
+        std::string path = cpath;
+        g_free(cpath);
+        g_object_unref(file);
+
+        bool exportSuccess;  // Return of the export job
+
+        if (range) {
+            PageRangeVector exportRange = PageRange::parse(range, doc->getPageCount());
+            exportSuccess = pdfe->createPdf(path, exportRange, progressiveMode);
+            for (PageRangeEntry* e: exportRange) { delete e; }
+            exportRange.clear();
+        } else {
+            exportSuccess = pdfe->createPdf(path, progressiveMode);
+        }
+
+        if (!exportSuccess) {
+            g_error("%s", pdfe->getLastError().c_str());
+        }
+        delete pdfe;
+
+        g_message("%s %s", _("PDF file successfully exported to"), outputFile);
+    } else if (extension == ".svg" || extension == ".png") {
+        // exportImg("test.xopp", outputFile, range, bgType, pngDpi, pngWidth, pngHeight);
+
+        ExportGraphicsFormat format = (extension == ".svg") ? EXPORT_GRAPHICS_SVG : EXPORT_GRAPHICS_PNG;
+
+        PageRangeVector exportRange;
+        if (range) {
+            exportRange = PageRange::parse(range, int(doc->getPageCount()));
+        } else {
+            exportRange.push_back(new PageRangeEntry(0, int(doc->getPageCount() - 1)));
+        }
+
+        DummyProgressListener progress;
+
+        ImageExport imgExport(doc, file, format, bgType, exportRange);
+
+        if (format == EXPORT_GRAPHICS_PNG) {
+            if (pngDpi > 0) {
+                imgExport.setQualityParameter(EXPORT_QUALITY_DPI, pngDpi);
+            } else if (pngWidth > 0) {
+                imgExport.setQualityParameter(EXPORT_QUALITY_WIDTH, pngWidth);
+            } else if (pngHeight > 0) {
+                imgExport.setQualityParameter(EXPORT_QUALITY_HEIGHT, pngHeight);
+            }
+        }
+
+        imgExport.exportGraphics(&progress);
+
+        for (PageRangeEntry* e: exportRange) { delete e; }
+        exportRange.clear();
+
+        std::string errorMsg = imgExport.getLastErrorMsg();
+        if (!errorMsg.empty()) {
+            g_message("Error exporting image: %s\n", errorMsg.c_str());
+        }
+
+        g_message("%s %s-*%s", _("Image file successfully created with pattern"), file.stem().string().c_str(),
+                  file.extension().string().c_str());
+    }
+
+    // Make sure to remove all vars which are put to the stack before!
+    lua_pop(L, 7);
+
+    return 1;
+}
+
+
 /*
  * The full Lua Plugin API.
  * See above for example usage of each function.
@@ -1184,6 +1316,7 @@ static const luaL_Reg applib[] = {{"msgbox", applib_msgbox},
                                   {"setBackgroundName", applib_setBackgroundName},
                                   {"scaleTextElements", applib_scaleTextElements},
                                   {"getDisplayDpi", applib_getDisplayDpi},
+                                  {"export", applib_export},
                                   // Placeholder
                                   //	{"MSG_BT_OK", nullptr},
 


### PR DESCRIPTION
This PR (when finished) closes #3565

Export already works. In the plugin you just need to add a line like

```lua 
app.export({["outputFile"] = "/home/USERNAME/Test.pdf", ["range"] = "2-5; 7", ["background"] = "all", ["progressiveMode"] = false})
```

(for pdf) or 

``` lua
app.export({["outputFile"] = "/home/USERNAME/Test.svg", ["range"] = "2-5; 7", ["background"] = "all"})
```

(for svg) or

``` lua
app.export({["outputFile"] = "/home/USERNAME/Test.png", ["range"] = "2-5; 7", ["background"] = "all", ["pngDpi"] = 300})
```
(for png). It's still a hack, since I mostly copied code from `XournalMain.cpp` (`exportPdf` and `exportImg` functions), but probably already usable.
 
The filename generation will be left to the plugin. I have added a "xoppFilename" field to the `app.getDocumentStructure()` table, so that only some string manipulations are needed.

**Edit:** Updated the information and removed the "pngDpi" field in the svg case, since it does not apply there.