### PR TITLE
Prevent installation of Google test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,19 +148,10 @@ add_includes_ldflags ("${SNDFILE_LDFLAGS}" "${SNDFILE_INCLUDE_DIRS}")
 ## Additional features ##
 # Testing Framework: gtest
 option (ENABLE_GTEST "Enable gtest build for xournalpp application" OFF)
-if (ENABLE_GTEST)
-    include(FetchContent)
-    FetchContent_Declare(
-        googletest
-        URL https://github.com/google/googletest/archive/refs/tags/release-1.11.0.zip
-    )
-	# Prevent reloading if already downloaed
-	set(FETCHCONTENT_UPDATES_DISCONNECTED ON)
-    # For Windows: Prevent overriding the parent project's compiler/linker settings
-    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-    FetchContent_MakeAvailable(googletest)
+if(ENABLE_GTEST)
 	enable_testing()
-endif (ENABLE_GTEST)
+endif()
+
 
 # Plugins / scripting
 find_package (Lua 5.3 EXACT)
@@ -269,6 +260,9 @@ add_subdirectory (src)
 
 ## Man page generation ##
 add_subdirectory (man)
+
+## Tests ##
+# ./test is added via src to enable cleaner includes
 
 ## Final targets and installing ##
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -139,5 +139,5 @@ install (TARGETS xournalpp
 )
 
 if (ENABLE_GTEST)
-  add_subdirectory (${CMAKE_SOURCE_DIR}/test ${CMAKE_BINARY_DIR}/test)
+  add_subdirectory (${CMAKE_SOURCE_DIR}/test ${CMAKE_BINARY_DIR}/test EXCLUDE_FROM_ALL)
 endif (ENABLE_GTEST)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,13 +17,30 @@ if(MACOSX)
     set(CMAKE_BUILD_WITH_INSTALL_RPATH ON)
 endif()
 
+
+# Download and Build GoogleTest
+include(FetchContent)
+FetchContent_Declare(
+    googletest
+    URL https://github.com/google/googletest/archive/refs/tags/release-1.11.0.zip
+)
+# Prevent reloading if already downloaed
+set(FETCHCONTENT_UPDATES_DISCONNECTED ON)
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+
+# Prevent GoogleTest from being installed with xournalpp
+# This is not strictly necessary as add_subdirectory is called on ./test with
+# EXCLUDE_FROM_ALL, but better safe than sorry
+option(INSTALL_GTEST "Enable installation of googletest." OFF)
+FetchContent_MakeAvailable(googletest)
+
 # Load configure file including constants and helper Macros
 configure_file (
     config-test.h.in
     config-test.h
     ESCAPE_QUOTES @ONLY
 )
-include(GoogleTest)
 
 
 ###############################################################################
@@ -49,10 +66,11 @@ target_link_libraries (test-units ${xournalpp_LDFLAGS} std::filesystem gtest_mai
 target_include_directories(test-units PRIVATE "${PROJECT_BINARY_DIR}/test")
 
 ###############################################################################
-# Register Tests
+# Discover and Register Tests
 ###############################################################################
 # MacOs needs a bit longer to find the tests on azure
 # Hence, set the timeout to 30s (default 5s)
+include(GoogleTest)
 gtest_discover_tests(test-units DISCOVERY_TIMEOUT 30)
 
 


### PR DESCRIPTION
Fixes #3561 

 - move `FetchContent`, ... to `./test/CMakeLists.txt`
 - `add_subdirectory` for tests with `EXCLUDE_FROM_ALL`
 - set option `INSTALL_GTEST` to `OFF`