### PR TITLE
Change autosave dir to ~/.cache/xournalpp/autosaves

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -179,7 +179,7 @@ void Control::renameLastAutosaveFile() {
     Util::clearExtensions(renamed);
     if (!filename.empty() && filename.string().front() != '.') {
         // This file must be a fresh, unsaved document. Since this file is
-        // already in ~/.xournalpp/autosave/, we need to change the renamed filename.
+        // already in the autosave directory, we need to change the renamed filename.
         renamed += ".old.autosave.xopp";
     } else {
         // The file is a saved document with the form ".<filename>.autosave.xopp"

--- a/src/util/PathUtil.cpp
+++ b/src/util/PathUtil.cpp
@@ -193,7 +193,7 @@ auto Util::getGettextFilepath(const char* localeDir) -> fs::path {
 }
 
 auto Util::getAutosaveFilepath() -> fs::path {
-    fs::path p(getConfigSubfolder("autosave"));
+    fs::path p(getCacheSubfolder("autosaves"));
     p /= std::to_string(getPid()) + ".xopp";
     return p;
 }

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -354,7 +354,7 @@
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">&lt;i&gt;If the document already was saved you can find it in the same folder with the extension .autosave.xoj
-If the file was not yet saved you can find it in your home directory, in ~/.xournalpp/autosave&lt;/i&gt;</property>
+If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt;/i&gt;</property>
                                             <property name="use-markup">True</property>
                                             <property name="wrap">True</property>
                                             <property name="max-width-chars">85</property>


### PR DESCRIPTION
- updated path used in code
- updated translations

Closes #3348

In the original issue there were two directories for autosaves discussed. `~/.local/share/xournalpp/autosave` and `~/.cache/xournalpp/autosave`. I decided to go with the cache directory since this would be the first one I would search for autosaves.

I'm pretty sure that I did something wrong with the translation files so please explain me quickly what I've should done with those. Should I've just changed xournalpp.pot and then ran make?
