### PR TITLE
Fix ObjectInputStream::getNextObjectName on MacOs

### DIFF
--- a/src/util/serializing/ObjectInputStream.cpp
+++ b/src/util/serializing/ObjectInputStream.cpp
@@ -19,7 +19,7 @@ T readTypeFromSStream(std::istringstream& istream) {
     return output;
 }
 
-size_t ObjectInputStream::pos() { return len - istream.str().size(); }
+size_t ObjectInputStream::pos() { return istream.tellg(); }
 
 auto ObjectInputStream::read(const char* data, int data_len) -> bool {
     istream.clear();
@@ -55,13 +55,12 @@ auto ObjectInputStream::readObject() -> std::string {
 }
 
 auto ObjectInputStream::getNextObjectName() -> std::string {
-    std::streambuf* pBuffer = istream.rdbuf();
-    std::streamsize pos = len - pBuffer->in_avail();
+    auto position = istream.tellg();
 
     checkType('{');
     std::string name = readString();
 
-    pBuffer->pubseekpos(pos);
+    istream.seekg(position);
     return name;
 }
 


### PR DESCRIPTION
From issues of #2729, it seems that the function `ObjectInputStream::getNextObjectName` is broken on MacOs. It moves the stream's position forward while it should not.
This fixes that by simplifying the function.

It could fix #2246 (@xournalpp/core Could anyone with access to a Mac confirm that?)

~~[ ] Add test for selection serialization (that would then test `ObjectInputStream::getNextObjectName`)~~ Edit: Won't do here. It'd required to refactor:

- Make `ElementContainer` inherit from `Serializable` and move bits from `Control::clipboardPasteXournal` and `EditSelection::serialize` there.
- Add a test `testReadElementContainer` in `unit_tests/util/ObjectIOStreamTest.cpp`.

It goes beyond the scope of this PR.