### PR TITLE
Use uint16_t for PaletteIndex rather than size_t

### DIFF
--- a/src/core/gui/toolbarMenubar/model/ColorPalette.cpp
+++ b/src/core/gui/toolbarMenubar/model/ColorPalette.cpp
@@ -70,7 +70,8 @@ auto Palette::parseHeaderLine(const std::string& line) -> bool {
 }
 
 auto Palette::parseColorLine(const std::string& line) -> bool {
-    NamedColor color{namedColors.size()};
+    uint16_t nextIndex = this->size();
+    NamedColor color{nextIndex};
     std::istringstream iss{line};
     if (iss >> color) {
         namedColors.emplace_back(std::move(color));
@@ -90,9 +91,9 @@ auto Palette::parseLineFallback(int lineNumber) const -> const bool {
     throw std::invalid_argument(FS(FORMAT_STR("The line {1} is malformed.") % lineNumber));
 }
 
-auto Palette::getColorAt(size_t i) const -> NamedColor const& {
-    if (i >= namedColors.size()) {
-        i = i % namedColors.size();
+auto Palette::getColorAt(uint16_t i) const -> NamedColor const& {
+    if (i >= this->size()) {
+        i = i % this->size();
         g_warning("There are more Coloritems in the Toolbar than your Palette defines.\n"
                   "Hence, cycling through palette from the beginning.");
     }
@@ -100,7 +101,7 @@ auto Palette::getColorAt(size_t i) const -> NamedColor const& {
     return namedColors.at(i);
 }
 
-auto Palette::size() const -> size_t { return namedColors.size(); }
+auto Palette::size() const -> uint16_t { return static_cast<uint16_t>(namedColors.size()); }
 
 
 auto Palette::default_palette() -> const std::string {

--- a/src/core/gui/toolbarMenubar/model/ColorPalette.h
+++ b/src/core/gui/toolbarMenubar/model/ColorPalette.h
@@ -112,9 +112,9 @@ struct Palette {
     /**
      * @brief Get the number of namedColors part of the palette
      *
-     * @return size_t number of namedColors in palette
+     * @return uint16_t number of namedColors in palette
      */
-    size_t size() const;
+    uint16_t size() const;
 
     /**
      * @brief Get a NamedColor from the palette
@@ -122,7 +122,7 @@ struct Palette {
      * @param i palette index
      * @return NamedColor of palette at palette index
      */
-    NamedColor const& getColorAt(size_t i) const;
+    NamedColor const& getColorAt(uint16_t i) const;
 
 
 private:
@@ -133,17 +133,17 @@ private:
     fs::path filepath;
 
     /**
-     * @brief Vector containing all colors of the palette
-     *
-     */
-    std::vector<NamedColor> namedColors;
-
-    /**
      * @brief Map containing the key value pairs of the gpl header
      * e.g. "Palette Name", "Description"
      *
      */
     std::map<std::string, std::string> header;
+
+    /**
+     * @brief Vector containing all colors of the palette
+     *
+     */
+    std::vector<NamedColor> namedColors;
 
     /**
      * @brief Verify if line contains the expected "GIMP Palette" string

--- a/src/util/NamedColor.cpp
+++ b/src/util/NamedColor.cpp
@@ -7,7 +7,7 @@
 NamedColor::NamedColor():
         paletteIndex{0}, name{"Custom Color"}, colorU16{ColorU16{}}, color{Color(0u)}, isPaletteColor{false} {}
 
-NamedColor::NamedColor(const size_t& paletteIndex):
+NamedColor::NamedColor(const uint16_t& paletteIndex):
         paletteIndex{paletteIndex},
         name{"Fallback Color"},
         colorU16{ColorU16{}},
@@ -51,6 +51,6 @@ auto NamedColor::getColorU16() const -> ColorU16 { return colorU16; }
 
 auto NamedColor::getColor() const -> Color { return color; }
 
-auto NamedColor::getIndex() const -> size_t { return paletteIndex; };
+auto NamedColor::getIndex() const -> uint16_t { return paletteIndex; };
 
 auto NamedColor::getName() const -> std::string { return name; };

--- a/src/util/include/util/NamedColor.h
+++ b/src/util/include/util/NamedColor.h
@@ -43,7 +43,7 @@ struct NamedColor {
      *
      * @param paletteIndex
      */
-    NamedColor(const size_t& paletteIndex);
+    NamedColor(const uint16_t& paletteIndex);
 
     /**
      * @brief Construct a new NamedColor instance
@@ -81,9 +81,9 @@ struct NamedColor {
     /**
      * @brief Get the Index of the NamedColor inside the Palette
      *
-     * @return size_t index
+     * @return uint16_t index
      */
-    size_t getIndex() const;
+    uint16_t getIndex() const;
 
     /**
      * @brief Get the Name of the NamedColor
@@ -98,7 +98,7 @@ private:
      * This is useful for loading the toolbar from the toolbar.ini
      *
      */
-    size_t paletteIndex;
+    uint16_t paletteIndex;
 
     std::string name;
     ColorU16 colorU16;


### PR DESCRIPTION
This fixes a problem on 32bit machines reported at https://github.com/xournalpp/xournalpp/pull/2379#pullrequestreview-814967220
where the two constructors for `NamedColor(const size_t&)` and `NamedColor(const Color&)` are ambiguous as `Color == uint32_t`.