### PR TITLE
attempt to fix gtk-mac-bundler

### DIFF
--- a/mac-setup/build-app.sh
+++ b/mac-setup/build-app.sh
@@ -25,10 +25,13 @@ rm ./Xournal++.zip
 echo "prepare gtk-mac-bundler"
 if [ ! -d "gtk-mac-bundler" ]; then
   git clone https://gitlab.gnome.org/GNOME/gtk-mac-bundler.git
+  # Temporarily use fixed commit, since the neweer commit 9ecfd3d097371a98530f9cf537e5cb1926501fcd seems to have a corrupted Makefile
+  git checkout 8bc37b7feed7d6c87b8b01d682e43ac15d6c1862
   cd gtk-mac-bundler || exit
 else
   cd gtk-mac-bundler || exit
   git pull
+  git checkout 8bc37b7feed7d6c87b8b01d682e43ac15d6c1862
 fi
 
 make install


### PR DESCRIPTION
Since Nov. 22 (after a [commit](https://gitlab.gnome.org/GNOME/gtk-mac-bundler/-/commit/9ecfd3d097371a98530f9cf537e5cb1926501fcd) to the gtk-mac-bundler that changed the Makefile) the MacOS pipeline fails (in the Create App step) reporting

```
prepare gtk-mac-bundler
Cloning into 'gtk-mac-bundler'...
usage: mkdir [-pv] [-m mode] directory ...
make: *** [install] Error 64
create package

./build-app.sh: line 41: gtk-mac-bundler: command not found
```

This PR should fix the problem temporarly until a proper fix is found.