### PR TITLE
Fix 3637 - properly order copied text in clipboard

### DIFF
--- a/src/core/control/ClipboardHandler.cpp
+++ b/src/core/control/ClipboardHandler.cpp
@@ -64,9 +64,9 @@ auto ClipboardHandler::cut() -> bool {
 
 auto ElementCompareFunc(Element* a, Element* b) -> bool {
     if (a->getY() == b->getY()) {
-        return (a->getX() - b->getX()) > 0;
+        return (a->getX() - b->getX()) < 0;
     }
-    return (a->getY() - b->getY()) > 0;
+    return (a->getY() - b->getY()) < 0;
 }
 
 static GdkAtom atomSvg1 = gdk_atom_intern_static_string("image/svg");


### PR DESCRIPTION
#3042 introduced #3637 because `g_list` and `std` do not have the same standard of `Compare` functions.
In a `g_list`, A < B if `Compare(A,B) < 0`. With `std`, A < B if `Compare(A, B) == true`.

Merging in 24 hours if no objections are raised.