### PR TITLE
Background pdf overwriting

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -1651,9 +1651,7 @@ void Control::undoRedoPageChanged(PageRef page) {
     }
 }
 
-void Control::undoRedoFakeSaved() {
-    this->undoRedo->documentSaved();
-}
+void Control::undoRedoFakeSaved() { this->undoRedo->documentSaved(); }
 
 void Control::selectTool(ToolType type) {
     toolHandler->selectTool(type);
@@ -2198,7 +2196,7 @@ auto Control::annotatePdf(fs::path filepath, bool /*attachPdf*/, bool attachToDo
         }
     }
 
-    //TODO: we should have closed before??
+    // TODO: we should have closed before??
     /* this->discardDocument(); */
 
     getCursor()->setCursorBusy(true);

--- a/src/core/control/Control.h
+++ b/src/core/control/Control.h
@@ -270,6 +270,7 @@ public:
     // UndoRedoListener interface
     void undoRedoChanged();
     void undoRedoPageChanged(PageRef page);
+    void undoRedoFakeSaved();
 
 public:
     // ProgressListener interface
@@ -291,7 +292,6 @@ public:
      * Discards the document, preparing the editor for a new document.
      */
     void discardDocument();
-
 protected:
     /**
      * This callback is used by used to be called later in the UI Thread

--- a/src/core/control/Control.h
+++ b/src/core/control/Control.h
@@ -292,6 +292,7 @@ public:
      * Discards the document, preparing the editor for a new document.
      */
     void discardDocument();
+
 protected:
     /**
      * This callback is used by used to be called later in the UI Thread

--- a/src/core/control/Control.h
+++ b/src/core/control/Control.h
@@ -71,7 +71,7 @@ public:
     // Menu File
     bool newFile(std::string pageTemplate = "", fs::path filepath = {});
     bool openFile(fs::path filepath = "", int scrollToPage = -1, bool forceOpen = false);
-    bool annotatePdf(fs::path filepath, bool attachPdf, bool attachToDocument);
+    bool annotatePdf(fs::path filepath, bool attachPdf, bool attachToDocument, bool forceDiscard = false);
     void print();
     void exportAsPdf();
     void exportAs();
@@ -98,7 +98,7 @@ public:
      * @param allowCancel Whether the user should be able to cancel closing the document.
      * @return true if the user closed the document, otherwise false.
      */
-    bool close(bool allowDestroy = false, bool allowCancel = true);
+    bool closeDocumentInteractively(bool allowDestroy = false, bool allowCancel = true);
 
     // Asks user to replace an existing file when saving / exporting, since we add the extension
     // after the OK, we need to check manually
@@ -287,6 +287,11 @@ public:
 
     void clipboardPaste(Element* e);
 
+    /**
+     * Discards the document, preparing the editor for a new document.
+     */
+    void discardDocument();
+
 protected:
     /**
      * This callback is used by used to be called later in the UI Thread
@@ -326,10 +331,6 @@ protected:
     bool loadPdf(fs::path const& filepath, int scrollToPage);
 
 private:
-    /**
-     * "Closes" the document, preparing the editor for a new document.
-     */
-    void closeDocument();
 
     /**
      * Applies the preferred language to the UI

--- a/src/core/control/jobs/BaseExportJob.cpp
+++ b/src/core/control/jobs/BaseExportJob.cpp
@@ -27,19 +27,20 @@ void BaseExportJob::addFileFilterToDialog(const string& name, const string& patt
     gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(dialog), filter);
 }
 
-auto BaseExportJob::checkOverwriteBackgroundPDF(fs::path const& file) const -> bool {
+auto BaseExportJob::checkOverwriteBackgroundPDF(fs::path const& file) -> bool {
     auto backgroundPDF = control->getDocument()->getPdfFilepath();
     // If there is no background, we can return
     try {
         if (!fs::exists(backgroundPDF)) {
             return true;
         }
-        // If the new file name (with the selected extension) is the previously selected pdf, warn the user
-
+        // If the new file name (with the selected extension) is the previously selected pdf
         if (fs::weakly_canonical(file) == fs::weakly_canonical(backgroundPDF)) {
-            string msg = _("Do not overwrite the background PDF! This will cause errors!");
-            XojMsgBox::showErrorToUser(control->getGtkWindow(), msg);
-            return false;
+            auto msg = std::string(_("You are attempting to overwrite the background PDF."));
+            int response = XojMsgBox::overwriteBackgroundQuestion(control->getGtkWindow(), msg);
+            this->overwriteBackground = response == GTK_RESPONSE_ACCEPT || response == GTK_RESPONSE_REJECT;
+            this->makeBackgroundBackup = response == GTK_RESPONSE_ACCEPT;
+            return this->overwriteBackground;
         }
     } catch (fs::filesystem_error const& fe) {
         g_warning("%s", fe.what());
@@ -80,7 +81,8 @@ auto BaseExportJob::showFilechooser() -> bool {
         auto file = Util::fromGFilename(gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog)));
         Util::clearExtensions(file);
         // Since we add the extension after the OK button, we have to check manually on existing files
-        if (testAndSetFilepath(std::move(file)) && control->askToReplace(this->filepath)) {
+        if (testAndSetFilepath(std::move(file)) &&
+            (this->overwriteBackground || control->askToReplace(this->filepath))) {
             break;
         }
     }

--- a/src/core/control/jobs/BaseExportJob.cpp
+++ b/src/core/control/jobs/BaseExportJob.cpp
@@ -111,4 +111,10 @@ void BaseExportJob::afterRun() {
     if (!this->errorMsg.empty()) {
         XojMsgBox::showErrorToUser(control->getGtkWindow(), this->errorMsg);
     }
+    printf("after run baseexportjob\n");
+    /* if (this->overwriteBackground && !this->makeBackgroundBackup) { */
+    /*     fs::path tmp = this->control->getDocument()->getPdfFilepath(); */
+    /*     // open new doc */
+    /*     printf("%s\n", tmp.c_str()); */
+    /* } */
 }

--- a/src/core/control/jobs/BaseExportJob.h
+++ b/src/core/control/jobs/BaseExportJob.h
@@ -46,10 +46,14 @@ protected:
     void initDialog();
     virtual void addFilterToDialog() = 0;
     void addFileFilterToDialog(const std::string& name, const std::string& pattern);
-    bool checkOverwriteBackgroundPDF(fs::path const& file) const;
+    bool checkOverwriteBackgroundPDF(fs::path const& file);
     virtual bool testAndSetFilepath(fs::path file);
 
 private:
+public:
+    bool overwriteBackground = false;
+    bool makeBackgroundBackup = true;
+
 protected:
     GtkWidget* dialog = nullptr;
 

--- a/src/core/control/jobs/CustomExportJob.cpp
+++ b/src/core/control/jobs/CustomExportJob.cpp
@@ -151,4 +151,5 @@ void CustomExportJob::afterRun() {
     if (!this->lastError.empty()) {
         XojMsgBox::showErrorToUser(control->getGtkWindow(), this->lastError);
     }
+    printf("after run custom\n");
 }

--- a/src/core/control/jobs/PdfExportJob.cpp
+++ b/src/core/control/jobs/PdfExportJob.cpp
@@ -3,6 +3,7 @@
 #include "control/Control.h"
 #include "pdf/base/XojPdfExport.h"
 #include "pdf/base/XojPdfExportFactory.h"
+#include "util/XojMsgBox.h"
 #include "util/i18n.h"
 
 PdfExportJob::PdfExportJob(Control* control): BaseExportJob(control, _("PDF Export")) {}

--- a/src/core/control/jobs/PdfExportJob.cpp
+++ b/src/core/control/jobs/PdfExportJob.cpp
@@ -49,18 +49,19 @@ void PdfExportJob::afterRun() {
     /* if (!this->errorMsg.empty()) { */
     /*     XojMsgBox::showErrorToUser(control->getGtkWindow(), this->errorMsg); */
     /* } */
-    //TODO: what is with custom export job?
+    // TODO: what is with custom export job?
     printf("after run pdfexportjob\n");
     if (this->overwriteBackground) {
         if (this->makeBackgroundBackup) {
-            /* We previously changed the background pdf to the backup. Keep the document open as is but fake a saving action. */
+            /* We previously changed the background pdf to the backup. Keep the document open as is but fake a saving
+             * action. */
             this->control->undoRedoFakeSaved();
         } else {
             /* We previously saved the background pdf temporarily and changed the background to it. */
             fs::path tmp = this->control->getDocument()->getPdfFilepath();
             /* Discard old changes and load newly created pdf file. */
-            this->control->discardDocument(); // TODO: calling discardDocument and newFile here should not
-            this->control->newFile();         //       be needed but it doesn't work without both of them
+            this->control->discardDocument();  // TODO: calling discardDocument and newFile here should not
+            this->control->newFile();          //       be needed but it doesn't work without both of them
             this->control->annotatePdf(this->filepath, true, true, true);
             /* Remove the tmp background pdf. */
             remove(tmp);

--- a/src/core/control/jobs/PdfExportJob.cpp
+++ b/src/core/control/jobs/PdfExportJob.cpp
@@ -26,6 +26,7 @@ auto PdfExportJob::testAndSetFilepath(fs::path file) -> bool {
 
 
 void PdfExportJob::run() {
+    printf("now exporting\n");
     Document* doc = control->getDocument();
 
     doc->lock();
@@ -37,7 +38,32 @@ void PdfExportJob::run() {
         if (control->getWindow()) {
             callAfterRun();
         }
+    } else {
+        callAfterRun();
     }
 
     delete pdfe;
+}
+
+void PdfExportJob::afterRun() {
+    /* if (!this->errorMsg.empty()) { */
+    /*     XojMsgBox::showErrorToUser(control->getGtkWindow(), this->errorMsg); */
+    /* } */
+    //TODO: what is with custom export job?
+    printf("after run pdfexportjob\n");
+    if (this->overwriteBackground) {
+        if (this->makeBackgroundBackup) {
+            /* We previously changed the background pdf to the backup. Keep the document open as is but fake a saving action. */
+            this->control->undoRedoFakeSaved();
+        } else {
+            /* We previously saved the background pdf temporarily and changed the background to it. */
+            fs::path tmp = this->control->getDocument()->getPdfFilepath();
+            /* Discard old changes and load newly created pdf file. */
+            this->control->discardDocument(); // TODO: calling discardDocument and newFile here should not
+            this->control->newFile();         //       be needed but it doesn't work without both of them
+            this->control->annotatePdf(this->filepath, true, true, true);
+            /* Remove the tmp background pdf. */
+            remove(tmp);
+        }
+    }
 }

--- a/src/core/control/jobs/PdfExportJob.h
+++ b/src/core/control/jobs/PdfExportJob.h
@@ -19,6 +19,7 @@ public:
 
 protected:
     virtual ~PdfExportJob();
+    virtual void afterRun();
 
 public:
     void run();

--- a/src/core/model/Document.cpp
+++ b/src/core/model/Document.cpp
@@ -277,6 +277,25 @@ void Document::updateIndexPageNumbers() {
     }
 }
 
+// TODO: rename and factor out code from readPdf
+auto Document::readPdf2(const fs::path& filename) -> bool {
+    GError* popplerError = nullptr;
+    lock();
+    if (!pdfDocument.load(filename, password, &popplerError)) {
+        if (popplerError) {
+            lastError = FS(_F("Document not loaded! ({1}), {2}") % filename.u8string() % popplerError->message);
+            g_error_free(popplerError);
+        } else {
+            lastError = FS(_F("Document not loaded! ({1}), {2}") % filename.u8string() % "");
+        }
+        unlock();
+        return false;
+    }
+    unlock();
+    this->pdfFilepath = filename;
+    return true;
+}
+
 auto Document::readPdf(const fs::path& filename, bool initPages, bool attachToDocument, gpointer data, gsize length)
         -> bool {
     GError* popplerError = nullptr;

--- a/src/core/model/Document.h
+++ b/src/core/model/Document.h
@@ -36,6 +36,7 @@ public:
 public:
     enum DocumentType { XOPP, XOJ, PDF };
 
+    bool readPdf2(const fs::path& filename);
     bool readPdf(const fs::path& filename, bool initPages, bool attachToDocument, gpointer data = nullptr,
                  gsize length = 0);
 

--- a/src/util/XojMsgBox.cpp
+++ b/src/util/XojMsgBox.cpp
@@ -80,6 +80,22 @@ auto XojMsgBox::replaceFileQuestion(GtkWindow* win, const string& msg) -> int {
     return res;
 }
 
+auto XojMsgBox::overwriteBackgroundQuestion(GtkWindow* win, const string& msg) -> int {
+    GtkWidget* dialog =
+            gtk_message_dialog_new(win, GTK_DIALOG_MODAL, GTK_MESSAGE_QUESTION, GTK_BUTTONS_NONE, "%s", msg.c_str());
+    if (win != nullptr) {
+        gtk_window_set_transient_for(GTK_WINDOW(dialog), win);
+    }
+    // TODO: reformulate dialog?
+    gtk_dialog_add_button(GTK_DIALOG(dialog), _("Select another name"), GTK_RESPONSE_CANCEL);
+    gtk_dialog_add_button(GTK_DIALOG(dialog), _("Overwrite, no backup"), GTK_RESPONSE_REJECT);
+    auto backupBtn = gtk_dialog_add_button(GTK_DIALOG(dialog), _("Overwrite, but make backup"), GTK_RESPONSE_ACCEPT);
+    gtk_widget_grab_focus(backupBtn);
+    int res = gtk_dialog_run(GTK_DIALOG(dialog));
+    gtk_widget_destroy(dialog);
+    return res;
+}
+
 constexpr auto* XOJ_HELP = "https://xournalpp.github.io/community/help/";
 
 void XojMsgBox::showHelp(GtkWindow* win) {

--- a/src/util/include/util/XojMsgBox.h
+++ b/src/util/include/util/XojMsgBox.h
@@ -31,5 +31,6 @@ public:
     static int showPluginMessage(const std::string& pluginName, const std::string& msg,
                                  const std::map<int, std::string>& button, bool error = false);
     static int replaceFileQuestion(GtkWindow* win, const std::string& msg);
+    static int overwriteBackgroundQuestion(GtkWindow* win, const std::string& msg);
     static void showHelp(GtkWindow* win);
 };


### PR DESCRIPTION
Closes #2363

When trying to overwrite the background pdf the user gets a choice window with 3 buttons:
- Cancel
- Overwrite, don't make backup
- Overwrite, but make backup

When the user selects "don't backup" the background pdf will be saved to a tmp file. This should then get deleted once the export is through. Then xournalpp opens the newly created pdf, therefore discarding the stored changes.

When the user selects "make backup" the background pdf is just reloaded and the user can do further edits.

TODO:
- [ ] add a note that modifications are not possible anymore after selecting "no backup"
- [x] delete tmp file
- [x] discard changes when tmp file used
- [x] when using "make backup" it might be annoying for the user that we are still asked if we want to discard the pdf when loading a new one / quitting (solved through faking that we saved the document)
- [ ] make backup extension consistent with other backups
- [ ] further TODOs in code