### PR TITLE
Proposed fix for bug #3274

### DIFF
--- a/src/core/gui/inputdevices/StylusInputHandler.cpp
+++ b/src/core/gui/inputdevices/StylusInputHandler.cpp
@@ -158,16 +158,18 @@ void StylusInputHandler::setPressedState(InputEvent const& event) {
                 break;
             case 2:
                 this->modifier2 = false;
+                if (this->inputContext->getSettings()->getInputSystemTPCButtonEnabled()) {
+                   this->deviceClassPressed = false;
+                }
                 break;
             case 3:
                 this->modifier3 = false;
+                if (this->inputContext->getSettings()->getInputSystemTPCButtonEnabled()) {
+                   this->deviceClassPressed = false;
+                }
             default:
                 break;
         }
-    }
-
-    if (this->inputContext->getSettings()->getInputSystemTPCButtonEnabled()) {
-        this->deviceClassPressed = this->deviceClassPressed || this->modifier2 || this->modifier3;
     }
 }
 


### PR DESCRIPTION
This fixes the named bug and some other related bugs that arise when the option "merge button events with stylus tip events" is ticked in the input system preference options.