### PR TITLE
Fix: clear undoRedo properly on close

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -2485,17 +2485,17 @@ auto Control::close(const bool allowDestroy, const bool allowCancel) -> bool {
         }
     }
 
-    if (allowDestroy && discard) {
-        this->closeDocument();
+    if (discard) {
+        this->closeDocument(allowDestroy);
     }
     return true;
 }
 
-void Control::closeDocument() {
+void Control::closeDocument(bool destroy) {
     this->undoRedo->clearContents();
 
     this->doc->lock();
-    this->doc->clearDocument(true);
+    this->doc->clearDocument(destroy);
     this->doc->unlock();
 
     this->undoRedoChanged();

--- a/src/core/control/Control.h
+++ b/src/core/control/Control.h
@@ -327,7 +327,7 @@ private:
     /**
      * "Closes" the document, preparing the editor for a new document.
      */
-    void closeDocument();
+    void closeDocument(bool destroy = true);
 
     /**
      * Applies the preferred language to the UI


### PR DESCRIPTION
Fixes #2878.

#### Explanation
`Control::close` checks if there is anything not yet saved and closes the document if a user chooses to discard the changes. However, it does not actually clean up `undoRedo` if the target file should not be destroyed. I'm not sure about the rationale behind this.

Anyway, I change the code to clear `undoRedo` whenever a user chooses to discard unsaved changes. It is `Control::closeDocument`, which is called by `Control::close`, that actually determines whether a file should be destroyed. It was defaulted to destroy all files when it was called. I just changed it to letting the caller decide whether the file should be cleaned up.

The question now is: is there any use case where we don't want to clear `undoRedo` after we close a file?

#### Test
The bug case mentioned in the issue is fixed with the changes.