### PR TITLE
Fix #3655: Use stod for loading doubles

### DIFF
--- a/src/core/view/background/BackgroundConfig.cpp
+++ b/src/core/view/background/BackgroundConfig.cpp
@@ -1,8 +1,10 @@
 #include "BackgroundConfig.h"
 
+#include <sstream>
 #include <utility>
 
 #include "util/StringUtils.h"
+#include "util/serdesstream.h"
 
 using std::string;
 
@@ -42,7 +44,8 @@ auto BackgroundConfig::loadValue(const string& key, int& value) const -> bool {
 auto BackgroundConfig::loadValue(const string& key, double& value) const -> bool {
     string str;
     if (loadValue(key, str)) {
-        value = std::stoul(str, nullptr, 10);
+        auto valueStream = serdes_stream<std::istringstream>(str);
+        valueStream >> value;
         return true;
     }
 


### PR DESCRIPTION
Fix BackgroundConfig::loadValue for doubles (used for loading in background configs from pagetemplates.ini) by using stod instead of stoul to preserve the decimal places of the configured value, which would be truncated otherwise (see #3655)

This relies on the locale for LC_NUMERIC to be "C" (e2a1f97327d94818cdecb19795308f8aed3177eb). There's been some discussion about this in #3611. Because of that, I'm not sure if using stod is the best way to fix this (as stod is locale-dependent).

If the locale was a locale which uses a comma as the decimal separator (for example de_DE.UTF-8), there would be two problems:
- Different configs work differently on different locales (lw=1.2 will work on en_US, but if that config is shared with a user with a de_DE locale, it won't work for that user without changing the decimal separator)
- Users using a locale with comma as decimal separator will only be able to use scientific notation, since "," would be interpreted as a separator for the key-value pairs of the config (e.g. config=lw=1.2,m1=40)

So maybe using GLib's [ascii_strtod](https://docs.gtk.org/glib/func.ascii_strtod.html) would be a better option. 
Another way would be using istringstream an imbuing C-locale. Doesn't seem like a bad option either.
