### PR TITLE
Add pageTypeConfig to app.getDocumentStructure()

### DIFF
--- a/src/core/plugin/luapi_application.h
+++ b/src/core/plugin/luapi_application.h
@@ -764,6 +764,8 @@ static int applib_getToolInfo(lua_State* L) {
  *       "pageHeight" = number,
  *       "isAnnoated" = bool,
  *       "pageTypeFormat" = string,
+ *       "pageTypeConfig" = string,
+ *       "backgroundColor" = integer,
  *       "pdfBackgroundPageNo" = integer (0, if there is no pdf background page),
  *       "layers" = {
  *         [0] = {
@@ -818,6 +820,14 @@ static int applib_getDocumentStructure(lua_State* L) {
         PageType pt = page->getBackgroundType();
         std::string pageTypeFormat = PageTypeHandler::getStringForPageTypeFormat(pt.format);
         lua_pushstring(L, pageTypeFormat.c_str());
+        lua_settable(L, -3);
+
+        lua_pushliteral(L, "pageTypeConfig");
+        lua_pushstring(L, pt.config.c_str());
+        lua_settable(L, -3);
+
+        lua_pushliteral(L, "backgroundColor");
+        lua_pushinteger(L, int(uint32_t(page->getBackgroundColor())));
         lua_settable(L, -3);
 
         lua_pushliteral(L, "pdfBackgroundPageNo");


### PR DESCRIPTION
I've been playing around with the plugin API and background configs. 
Bizarrely, you can get the format (graph, dotted, ...) of your page/background with getDocumentStructure(), but not the config (line width etc.). This should be included, since a full PageType has both. You can pass both to changeCurrentPageBackground via the plugin API.

I've added it and it seems to work fine, feel free to test it with the changed example plugin in 4a53df667fcc8c8d2cb95813cd99a373f0115161.