### PR TITLE
update macos build scripts

### DIFF
--- a/mac-setup/build-libzip.sh
+++ b/mac-setup/build-libzip.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -x
 export PATH="$HOME/.new_local/bin:$PATH"
 
-curl -L https://libzip.org/download/libzip-1.5.2.tar.gz -o libzip.tar.gz
+curl -L https://libzip.org/download/libzip-1.8.0.tar.gz -o libzip.tar.gz
 tar xf libzip.tar.gz
 cd libzip-* || exit
 mkdir build

--- a/mac-setup/build-poppler.sh
+++ b/mac-setup/build-poppler.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -x
 export PATH="$HOME/.new_local/bin:$PATH"
 
-curl -L https://github.com/uclouvain/openjpeg/archive/v2.3.0.tar.gz -o openjpeg.tar.gz
+curl -L https://github.com/uclouvain/openjpeg/archive/v2.4.0.tar.gz -o openjpeg.tar.gz
 tar xf openjpeg.tar.gz
 cd openjpeg-* || exit
 mkdir build
@@ -19,13 +19,13 @@ export LIBRARY_PATH="$HOME/gtk/inst/lib:$LIBRARY_PATH"
 jhbuild build freetype fontconfig
 jhbuild buildone -acf cairo
 
-curl https://poppler.freedesktop.org/poppler-0.72.0.tar.xz -o poppler.tar.xz
+curl https://poppler.freedesktop.org/poppler-21.12.0.tar.xz -o poppler.tar.xz
 tar xf poppler.tar.xz
 cd poppler-* || exit
 mkdir build
 cd build || exit
 echo "Build Poppler"
 pwd
-"$HOME"/gtk/inst/bin/cmake -DCMAKE_INSTALL_PREFIX:PATH="$HOME"/gtk/inst ..
+"$HOME"/gtk/inst/bin/cmake -DCMAKE_INSTALL_PREFIX:PATH="$HOME"/gtk/inst -DENABLE_QT5=OFF -DENABLE_QT6=OFF -DENABLE_BOOST=OFF ..
 make -j8
 make install

--- a/mac-setup/build-poppler.sh
+++ b/mac-setup/build-poppler.sh
@@ -19,7 +19,7 @@ export LIBRARY_PATH="$HOME/gtk/inst/lib:$LIBRARY_PATH"
 jhbuild build freetype fontconfig
 jhbuild buildone -acf cairo
 
-curl https://poppler.freedesktop.org/poppler-21.12.0.tar.xz -o poppler.tar.xz
+curl https://poppler.freedesktop.org/poppler-22.01.0.tar.xz -o poppler.tar.xz
 tar xf poppler.tar.xz
 cd poppler-* || exit
 mkdir build

--- a/mac-setup/build-portaudio.sh
+++ b/mac-setup/build-portaudio.sh
@@ -4,7 +4,7 @@ export LIBRARY_PATH="$HOME/gtk/inst/lib:$LIBRARY_PATH"
 # go to script directory
 cd "${0%/*}" || exit
 
-curl -L http://www.portaudio.com/archives/pa_stable_v190600_20161030.tgz -o pa_stable_v190600_20161030.tgz
+curl -L http://files.portaudio.com/archives/pa_stable_v190700_20210406.tgz -o pa_stable_v190700_20210406.tgz
 tar xzf pa_stable_*.tgz
 
 cd portaudio || exit

--- a/mac-setup/build-sndfile.sh
+++ b/mac-setup/build-sndfile.sh
@@ -15,6 +15,3 @@ cd build || exit
 "$HOME"/gtk/inst/bin/cmake -DCMAKE_INSTALL_PREFIX:PATH="$HOME"/gtk/inst ..
 make -j8
 make install
-
-# Fix linker flags
-cp portaudio-2.0.pc "$HOME"/gtk/inst/lib/pkgconfig


### PR DESCRIPTION
Updating the build scripts for poppler (including openjpeg), libzip and portaudio, so they use the latest version.