### PR TITLE
Add maim&xclip option to screenshot plugin

### DIFF
--- a/plugins/QuickScreenshot/main.lua
+++ b/plugins/QuickScreenshot/main.lua
@@ -59,6 +59,8 @@ function go()
   local windowsUtilities = {} -- list of windows programs here
   local macUtilities = {} -- list of macOS programs here
   local elseUtilities = -- list of programs for other systems
+                        -- maim and xclip are not listed, because they
+                        -- are the default
     { "scrot --overwrite --select --silent "
 -- gnome-screenshot behaves oddly (pollutes the window)
 -- the line is added here to be indicative of what
@@ -74,6 +76,13 @@ function go()
   elseif operatingSystem == "Darwin" then
     app.msgbox("macOS not supported yet.", {[1] = "OK"})
   else
+    -- Skip all the detection of tools in case maim and xclip are
+	-- installed. Then a screenshot is made with maim and saved to the
+	-- clipboard, skipping all other tools
+    if existsUtility("maim") and existsUtility("xclip") then
+      os.execute("maim -s | xclip -selection clipboard -t image/png")
+      return
+    end
     -- This becomes true if at least one screenshot
     -- utility is available on the system
     local foundUtility = false


### PR DESCRIPTION
Add the default option to use "maim" and "xclip" to copy selections from the screen into the system clipboard.
This allows for a Linux user who has maim and xclip installed to simply select part of the screen and paste it using ctrl+v or by pasting using the "paste" button in xournal++.
This is better than before because it does not require saving temporary files. The previous option of using scrot and saving in a temp file still exists and is used as a fallback