### PR TITLE
fix: Crash on startup with no recent files

### DIFF
--- a/src/control/RecentManager.cpp
+++ b/src/control/RecentManager.cpp
@@ -105,6 +105,9 @@ auto RecentManager::sortRecentsEntries(GtkRecentInfo* a, GtkRecentInfo* b) -> gi
 
 auto RecentManager::getMostRecent() -> GtkRecentInfo* {
     GList* filteredItemsXoj = filterRecent(gtk_recent_manager_get_items(gtk_recent_manager_get_default()), true);
+    if (filteredItemsXoj == nullptr) {
+        return nullptr;
+    }
     auto mostRecent = static_cast<GtkRecentInfo*>(filteredItemsXoj->data);
 
     gtk_recent_info_ref(mostRecent);

--- a/src/control/RecentManager.h
+++ b/src/control/RecentManager.h
@@ -80,6 +80,7 @@ public:
 
     /**
      * Returns the most recent xoj item from the underlying GtkRecentManager
+     * or nullptr, if no recent files exist
      */
     GtkRecentInfo* getMostRecent();
 
@@ -91,7 +92,7 @@ private:
      * @param xoj   Returns xoj files if xoj is set, pdf files otherwise
      *
      * @return      A pointer to a GList containing the relevant GtkRecentInfo%s sorted according to their
-     *              modification dates
+     *              modification dates or nullptr if no recent files match Xournal File Extension
      */
     static GList* filterRecent(GList* items, bool xoj);
     void addRecentMenu(GtkRecentInfo* info, int i);

--- a/src/control/XournalMain.cpp
+++ b/src/control/XournalMain.cpp
@@ -536,8 +536,11 @@ void on_startup(GApplication* application, XMPtr app_data) {
             opened = app_data->control->newFile("", p);
         }
     } else if (app_data->control->getSettings()->isAutoloadMostRecent()) {
-        if (auto p = Util::fromUri(gtk_recent_info_get_uri(app_data->control->getRecentManager()->getMostRecent()))) {
-            opened = app_data->control->openFile(*p);
+        auto most_recent = app_data->control->getRecentManager()->getMostRecent();
+        if (most_recent != nullptr) {
+            if (auto p = Util::fromUri(gtk_recent_info_get_uri(most_recent))) {
+                opened = app_data->control->openFile(*p);
+            }
         }
     }
 


### PR DESCRIPTION
- Add nullptr check to getMostRecent method
- Add nullptr check to on_startup function
- Change method descriptions to make explicit that nullptrs can be returned

Fixes #3734