### PR TITLE
Attempt to fix copies #2278(comment)

### DIFF
--- a/readme/MacBuild.md
+++ b/readme/MacBuild.md
@@ -1,5 +1,5 @@
 # Xournal++ MacOS .app Build
-hi
+
 Do not install macports or homebrew. If you have installed it, you need to
 create a new user, and use this for the whole process. jhbuild does not work,
 if there is such an environment installed.

--- a/readme/MacBuild.md
+++ b/readme/MacBuild.md
@@ -1,4 +1,5 @@
 # Xournal++ MacOS .app Build
+hi
 Do not install macports or homebrew. If you have installed it, you need to
 create a new user, and use this for the whole process. jhbuild does not work,
 if there is such an environment installed.

--- a/src/util/include/util/serializing/ObjectInputStream.h
+++ b/src/util/include/util/serializing/ObjectInputStream.h
@@ -39,6 +39,16 @@ public:
 
     void readData(void** data, int* len);
     cairo_surface_t* readImage();
+    
+    struct AlignmentInt{ //referenced https://stackoverflow.com/questions/11983311/c-4-bytes-aligned-data & https://stackoverflow.com/questions/28727914/what-does-misaligned-address-error-mean#:~:text=%22Misaligned%20address%22%20usually%20means%20that,bit%20integer%20from%20address%200x1001).
+        char c;
+        __attribute__((__aligned__(4))) int32_t member;
+    }
+    struct AlignmentDouble{ //referenced https://stackoverflow.com/questions/11983311/c-4-bytes-aligned-data & https://stackoverflow.com/questions/28727914/what-does-misaligned-address-error-mean#:~:text=%22Misaligned%20address%22%20usually%20means%20that,bit%20integer%20from%20address%200x1001).
+        char c;
+        __attribute__((__aligned__(8))) double32_t member;
+    }
+
 
 private:
     void checkType(char type);

--- a/src/util/serializing/ObjectInputStream.cpp
+++ b/src/util/serializing/ObjectInputStream.cpp
@@ -66,22 +66,49 @@ auto ObjectInputStream::getNextObjectName() -> std::string {
 
 void ObjectInputStream::endObject() { checkType('}'); }
 
-auto ObjectInputStream::readInt() -> int {
+auto ObjectInputStream::readInt() -> int { //referenced https://stackoverflow.com/questions/11983311/c-4-bytes-aligned-data 
     checkType('i');
-    return readTypeFromSStream<int>(istream);
+    std::istringstream obj = readTypeFromSStream<int>(istream);
+    string strObj = strObj.str();
+    string num =  "";
+    for(int i = 0; i < obj.length(); i++){
+        AlignmentInt number = strObj.at(i);
+        num+=number;
+    }
+    int readValue = stoi(num);
+    return readValue;
+    
 }
 
-auto ObjectInputStream::readDouble() -> double {
+auto ObjectInputStream::readDouble() -> double { //referenced https://stackoverflow.com/questions/11983311/c-4-bytes-aligned-data 
     checkType('d');
-    return readTypeFromSStream<double>(istream);
+    std::istringstream obj = readTypeFromSStream<double>(istream);
+    string strObj = strObj.str();
+    string num =  "";
+    for(int i = 0; i < obj.length(); i++){
+        AlignmentDouble number = strObj.at(i);
+        num+=number;
+    }
+    double readValue = stod(num);
+    return readValue;
 }
 
-auto ObjectInputStream::readSizeT() -> size_t {
+auto ObjectInputStream::readSizeT() -> size_t { //referenced https://stackoverflow.com/questions/11983311/c-4-bytes-aligned-data 
     checkType('l');
-    return readTypeFromSStream<size_t>(istream);
+    std::istringstream obj = readTypeFromSStream<size_t>(istream);
+    string strObj = strObj.str();
+    string num =  "";
+    for(int i = 0; i < obj.length(); i++){
+        char number = alignof(strObj.at(i));
+        num+=number;
+    }
+    int readValue = (size_t)(num);
+    return readValue;
+    
 }
 
-auto ObjectInputStream::readString() -> std::string {
+auto ObjectInputStream::readString() -> std::string { //referenced https://stackoverflow.com/questions/11983311/c-4-bytes-aligned-data 
+
     checkType('s');
 
     size_t lenString = (size_t)readTypeFromSStream<int>(istream);
@@ -91,7 +118,7 @@ auto ObjectInputStream::readString() -> std::string {
     }
 
     std::string output;
-    output.resize(lenString);
+    output.resize(lenString, 4);
 
     istream.read(&output[0], (long)lenString);
 

--- a/src/util/serializing/ObjectInputStream.cpp
+++ b/src/util/serializing/ObjectInputStream.cpp
@@ -66,7 +66,7 @@ auto ObjectInputStream::getNextObjectName() -> std::string {
 
 void ObjectInputStream::endObject() { checkType('}'); }
 
-auto ObjectInputStream::readInt() -> int { //referenced https://stackoverflow.com/questions/11983311/c-4-bytes-aligned-data 
+auto ObjectInputStream::readInt() -> int { //referenced https://stackoverflow.com/questions/11983311/c-4-bytes-aligned-data & https://stackoverflow.com/questions/28727914/what-does-misaligned-address-error-mean#:~:text=%22Misaligned%20address%22%20usually%20means%20that,bit%20integer%20from%20address%200x1001).
     checkType('i');
     std::istringstream obj = readTypeFromSStream<int>(istream);
     string strObj = strObj.str();
@@ -80,7 +80,7 @@ auto ObjectInputStream::readInt() -> int { //referenced https://stackoverflow.co
     
 }
 
-auto ObjectInputStream::readDouble() -> double { //referenced https://stackoverflow.com/questions/11983311/c-4-bytes-aligned-data 
+auto ObjectInputStream::readDouble() -> double { //referenced https://stackoverflow.com/questions/11983311/c-4-bytes-aligned-data & https://stackoverflow.com/questions/28727914/what-does-misaligned-address-error-mean#:~:text=%22Misaligned%20address%22%20usually%20means%20that,bit%20integer%20from%20address%200x1001).
     checkType('d');
     std::istringstream obj = readTypeFromSStream<double>(istream);
     string strObj = strObj.str();
@@ -93,7 +93,7 @@ auto ObjectInputStream::readDouble() -> double { //referenced https://stackoverf
     return readValue;
 }
 
-auto ObjectInputStream::readSizeT() -> size_t { //referenced https://stackoverflow.com/questions/11983311/c-4-bytes-aligned-data 
+auto ObjectInputStream::readSizeT() -> size_t { //referenced https://stackoverflow.com/questions/11983311/c-4-bytes-aligned-data & https://stackoverflow.com/questions/28727914/what-does-misaligned-address-error-mean#:~:text=%22Misaligned%20address%22%20usually%20means%20that,bit%20integer%20from%20address%200x1001).
     checkType('l');
     std::istringstream obj = readTypeFromSStream<size_t>(istream);
     string strObj = strObj.str();
@@ -107,7 +107,7 @@ auto ObjectInputStream::readSizeT() -> size_t { //referenced https://stackoverfl
     
 }
 
-auto ObjectInputStream::readString() -> std::string { //referenced https://stackoverflow.com/questions/11983311/c-4-bytes-aligned-data 
+auto ObjectInputStream::readString() -> std::string { //referenced https://stackoverflow.com/questions/11983311/c-4-bytes-aligned-data & https://stackoverflow.com/questions/28727914/what-does-misaligned-address-error-mean#:~:text=%22Misaligned%20address%22%20usually%20means%20that,bit%20integer%20from%20address%200x1001).
 
     checkType('s');
 


### PR DESCRIPTION
I found this error on the issues page of Xournal++: "Refactor ObjectInputStream to use std::stringstream #2278". I did research into this error and referenced the two links below when coding a potential fix. I am running into errors when it comes to my solution as it may have to do with the actual build of the project itself or the code but I feel based on my research, this could serve as a potential solution. I basically used alignment structs paired with istringstream objects to correct the misalignment issue mentioned in #2278.  

https://stackoverflow.com/questions/28727914/what-does-misaligned-address-error-mean#:~:text=%22Misaligned%20address%22%20usually%20means%20that,bit%20integer%20from%20address%200x1001). 

https://stackoverflow.com/questions/11983311/c-4-bytes-aligned-data 