### PR TITLE
Move git repo info to separate config header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,12 @@ configure_file(
 )
 
 configure_file(
+        src/config-git.h.in
+        src/config-git.h
+        ESCAPE_QUOTES @ONLY
+)
+
+configure_file(
         src/config-paths.h.in
         src/config-paths.h
         ESCAPE_QUOTES @ONLY

--- a/src/config-git.h.in
+++ b/src/config-git.h.in
@@ -1,0 +1,40 @@
+/*
+ * Xournal++
+ *
+ * Current git repo info
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+
+/* --- Current git repo info --- */
+
+/**
+ * Origin URL of current repository
+ */
+constexpr auto GIT_ORIGIN_URL = "@GIT_ORIGIN_URL@";
+
+/**
+ * Git origin repo owner
+ */
+constexpr auto GIT_ORIGIN_OWNER = "@GIT_ORIGIN_OWNER@";
+
+/**
+ * Git origin repo name
+ */
+constexpr auto GIT_ORIGIN_REPO = "@GIT_ORIGIN_REPO@";
+
+/**
+ * Current branch of git repo
+ */
+constexpr auto GIT_BRANCH = "@GIT_BRANCH@";
+
+/**
+ * Current git commit id (with "-dirty" appended if dirty source tree)
+ */
+constexpr auto GIT_COMMIT_ID = "@RELEASE_IDENTIFIER@";

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -44,34 +44,6 @@ constexpr auto PROJECT_URL = "@PROJECT_URL@";
 constexpr int FILE_FORMAT_VERSION = @DEV_FILE_FORMAT_VERSION@;
 
 
-/* --- Current git repo info --- */
-
-/**
- * Origin URL of current repository
- */
-constexpr auto GIT_ORIGIN_URL = "@GIT_ORIGIN_URL@";
-
-/**
- * Git origin repo owner
- */
-constexpr auto GIT_ORIGIN_OWNER = "@GIT_ORIGIN_OWNER@";
-
-/**
- * Git origin repo name
- */
-constexpr auto GIT_ORIGIN_REPO = "@GIT_ORIGIN_REPO@";
-
-/**
- * Current branch of git repo
- */
-constexpr auto GIT_BRANCH = "@GIT_BRANCH@";
-
-/**
- * Current git commit id (with "-dirty" appended if dirty source tree)
- */
-constexpr auto GIT_COMMIT_ID = "@RELEASE_IDENTIFIER@";
-
-
 /* --- I18N --- */
 
 /**

--- a/src/core/control/XournalMain.cpp
+++ b/src/core/control/XournalMain.cpp
@@ -20,6 +20,7 @@
 #include "Control.h"
 #include "ExportHelper.h"
 #include "config-dev.h"
+#include "config-git.h"
 #include "config-paths.h"
 #include "config.h"
 #include "filesystem.h"

--- a/src/core/gui/dialog/AboutDialog.cpp
+++ b/src/core/gui/dialog/AboutDialog.cpp
@@ -1,12 +1,12 @@
 #include "AboutDialog.h"
 
-#include <config.h>
 #include <gtk/gtk.h>
 
 #include "util/StringUtils.h"
 #include "util/i18n.h"
 
 #include "config-git.h"
+#include "config.h"
 
 AboutDialog::AboutDialog(GladeSearchpath* gladeSearchPath): GladeGui(gladeSearchPath, "about.glade", "aboutDialog") {
     gtk_label_set_markup(GTK_LABEL(get("lbBuildDate")), __DATE__ ", " __TIME__);

--- a/src/core/gui/dialog/AboutDialog.cpp
+++ b/src/core/gui/dialog/AboutDialog.cpp
@@ -6,6 +6,8 @@
 #include "util/StringUtils.h"
 #include "util/i18n.h"
 
+#include "config-git.h"
+
 AboutDialog::AboutDialog(GladeSearchpath* gladeSearchPath): GladeGui(gladeSearchPath, "about.glade", "aboutDialog") {
     gtk_label_set_markup(GTK_LABEL(get("lbBuildDate")), __DATE__ ", " __TIME__);
     gtk_label_set_markup(GTK_LABEL(get("lbVersion")), PROJECT_VERSION);


### PR DESCRIPTION
This reduces build tasks after checkout from ~120 to 2 object files and their dependencies.