### PR TITLE
Test out new gtk blob

### DIFF
--- a/azure-pipelines/steps/build_mac.yml
+++ b/azure-pipelines/steps/build_mac.yml
@@ -12,7 +12,7 @@ steps:
       sudo mkdir "${{parameters.generation_path}}"
       sudo chown $USER "${{parameters.generation_path}}"
       cd "${{parameters.generation_path}}"
-      curl -L -O https://github.com/xournalpp/xournalpp-pipeline-dependencies/raw/macos-10.15-jhbuild/gtk/gtk-bin.tar.gz.a[a-e]
+      curl -L -O https://github.com/xournalpp/xournalpp-pipeline-dependencies/raw/macos-10.15-jhbuild/gtk/gtk-bin.tar.gz.a[a-c]
       cat gtk-bin.tar.gz.* | tar -xz
     displayName: 'Unpack GTK'
   - bash: |

--- a/mac-setup/build-app.sh
+++ b/mac-setup/build-app.sh
@@ -49,6 +49,8 @@ export GDK_PIXBUF_MODULE_FILE="$bundle_etc/gtk-2.0/gdk-pixbuf.loaders"
 mkdir -p ./Xournal++.app/Contents/Resources/etc/gtk-2.0/
 gdk-pixbuf-query-loaders >./Xournal++.app/Contents/Resources/etc/gtk-2.0/gdk-pixbuf.loaders
 sed -i -e "s:$1/inst/:@executable_path/../Resources/:g" ./Xournal++.app/Contents/Resources/etc/gtk-2.0/gdk-pixbuf.loaders
+# Replace old loaders cache location with new one in builtin launcher script, see https://gitlab.gnome.org/GNOME/gtk-mac-bundler/-/issues/12
+sed -i -e "s:bundle_etc/gtk-2.0/gdk-pixbuf.loaders:bundle_lib/gdk-pixbuf-2.0/2.10.0/loaders.cache:g" ./Xournal++.app/Contents/MacOS/xournalpp
 
 echo "Copy GTK Schema"
 mkdir -p ./Xournal++.app/Contents/Resources/share/glib-2.0/schemas


### PR DESCRIPTION
The new Gtk blob updates several libraries, in particular
Gtk `3.24.28 -> 3.24.30` (with patches for MacOS Monterey)
Openjpeg `2.3.0 -> 2.4.0`
Poppler `0.72 -> 22.01`
Portaudio `19.06 -> 19.07`

Added GtkSourceView `4.8.1`

Most significantly it should work on MacOS Monterey. This needs to be tested.
