### PR TITLE
Use `fs::path::u8string` everywhere

### DIFF
--- a/src/core/control/AudioController.cpp
+++ b/src/core/control/AudioController.cpp
@@ -30,7 +30,7 @@ auto AudioController::startRecording() -> bool {
 
         g_message("Start recording");
 
-        bool isRecording = this->audioRecorder->start((getAudioFolder() / data).string());
+        bool isRecording = this->audioRecorder->start((getAudioFolder() / data).u8string());
 
         if (!isRecording) {
             audioFilename = "";

--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -1996,7 +1996,7 @@ auto Control::openFile(fs::path filepath, int scrollToPage, bool forceOpen) -> b
         !loadHandler.getMissingPdfFilename().empty()) {
         // give the user a second chance to select a new PDF filepath, or to discard the PDF
 
-        const fs::path missingFilePath = fs::path(loadHandler.getMissingPdfFilename());
+        const fs::path missingFilePath = fs::u8path(loadHandler.getMissingPdfFilename());
         const std::string msg1 =
                 FS(_F("The attached background file {1} could not be found. It might have been moved, renamed or "
                       "deleted.\nIt was last seen at: {2}") %

--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -177,7 +177,7 @@ void Control::renameLastAutosaveFile() {
     auto const& filename = this->lastAutosaveFilename;
     auto renamed = Util::getAutosaveFilepath();
     Util::clearExtensions(renamed);
-    if (!filename.empty() && filename.u8string().front() != '.') {
+    if (!filename.empty() && filename.native().front() != '.') {
         // This file must be a fresh, unsaved document. Since this file is
         // already in the autosave directory, we need to change the renamed filename.
         renamed += ".old.autosave.xopp";

--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -177,7 +177,7 @@ void Control::renameLastAutosaveFile() {
     auto const& filename = this->lastAutosaveFilename;
     auto renamed = Util::getAutosaveFilepath();
     Util::clearExtensions(renamed);
-    if (!filename.empty() && filename.string().front() != '.') {
+    if (!filename.empty() && filename.u8string().front() != '.') {
         // This file must be a fresh, unsaved document. Since this file is
         // already in the autosave directory, we need to change the renamed filename.
         renamed += ".old.autosave.xopp";
@@ -186,8 +186,9 @@ void Control::renameLastAutosaveFile() {
         renamed += filename.filename();
     }
 
-    g_message("%s", FS(_F("Autosave renamed from {1} to {2}") % this->lastAutosaveFilename.string() % renamed.string())
-                            .c_str());
+    g_message("%s",
+              FS(_F("Autosave renamed from {1} to {2}") % this->lastAutosaveFilename.u8string() % renamed.u8string())
+                      .c_str());
 
     if (!fs::exists(filename)) {
         this->save(false);
@@ -1969,7 +1970,7 @@ auto Control::openFile(fs::path filepath, int scrollToPage, bool forceOpen) -> b
         bool attachPdf = false;
         XojOpenDlg dlg(getGtkWindow(), this->settings);
         filepath = dlg.showOpenDialog(false, attachPdf);
-        g_message("%s", (_F("file: {1}") % filepath.string()).c_str());
+        g_message("%s", (_F("file: {1}") % filepath.u8string()).c_str());
     }
 
     if (filepath.empty() || (!forceOpen && !shouldFileOpen(filepath))) {
@@ -1999,11 +2000,11 @@ auto Control::openFile(fs::path filepath, int scrollToPage, bool forceOpen) -> b
         const std::string msg1 =
                 FS(_F("The attached background file {1} could not be found. It might have been moved, renamed or "
                       "deleted.\nIt was last seen at: {2}") %
-                   missingFilePath.filename().string() % missingFilePath.parent_path().string());
+                   missingFilePath.filename().u8string() % missingFilePath.parent_path().u8string());
         const std::string msg2 =
                 FS(_F("The background file {1} could not be found. It might have been moved, renamed or deleted.\nIt "
                       "was last seen at: {2}") %
-                   missingFilePath.filename().string() % missingFilePath.parent_path().string());
+                   missingFilePath.filename().u8string() % missingFilePath.parent_path().u8string());
         GtkWidget* dialog =
                 gtk_message_dialog_new(getGtkWindow(), GTK_DIALOG_MODAL, GTK_MESSAGE_QUESTION, GTK_BUTTONS_NONE, "%s",
                                        loadHandler.isAttachedPdfMissing() ? msg1.c_str() : msg2.c_str());

--- a/src/core/control/CrashHandler.cpp
+++ b/src/core/control/CrashHandler.cpp
@@ -37,6 +37,6 @@ void emergencySave() {
     if (!handler.getErrorMessage().empty()) {
         g_error("%s", FC(_F("Error: {1}") % handler.getErrorMessage()));
     } else {
-        g_warning("%s", FC(_F("Successfully saved document to \"{1}\"") % filepath.string()));
+        g_warning("%s", FC(_F("Successfully saved document to \"{1}\"") % filepath.u8string()));
     }
 }

--- a/src/core/control/LatexController.cpp
+++ b/src/core/control/LatexController.cpp
@@ -49,7 +49,7 @@ auto LatexController::findTexDependencies() -> LatexController::FindDependencySt
     if (fs::is_regular_file(templatePath)) {
         std::ifstream is(templatePath, std::ios_base::binary);
         if (!is.is_open()) {
-            g_message("%s", templatePath.string().c_str());
+            g_message("%s", templatePath.u8string().c_str());
             string msg = _("Global template file does not exist. Please check your settings.");
             return LatexController::FindDependencyStatus(false, msg);
         }

--- a/src/core/control/XournalMain.cpp
+++ b/src/core/control/XournalMain.cpp
@@ -99,8 +99,8 @@ auto migrateSettings() -> MigrateResult {
             if (!fs::is_directory(oldPath)) {
                 continue;
             }
-            g_message("Migrating configuration from %s to %s", oldPath.string().c_str(),
-                      newConfigPath.string().c_str());
+            g_message("Migrating configuration from %s to %s", oldPath.u8string().c_str(),
+                      newConfigPath.u8string().c_str());
             Util::ensureFolderExists(newConfigPath.parent_path());
             try {
                 fs::copy(oldPath, newConfigPath, fs::copy_options::recursive);
@@ -146,7 +146,7 @@ void checkForErrorlog() {
     msg += FS(_F("You're using \"{1}/{2}\" branch. Send Bugreport will direct you to this repo's issue tracker.") %
               GIT_ORIGIN_OWNER % GIT_BRANCH);
     msg += "\n";
-    msg += FS(_F("The most recent log file name: {1}") % errorList[0].string());
+    msg += FS(_F("The most recent log file name: {1}") % errorList[0].u8string());
 
     GtkWidget* dialog = gtk_message_dialog_new(nullptr, GTK_DIALOG_MODAL, GTK_MESSAGE_QUESTION, GTK_BUTTONS_NONE, "%s",
                                                msg.c_str());
@@ -363,7 +363,7 @@ void initResourcePath(GladeSearchpath* gladePath, const gchar* relativePathAndFi
     std::string msg =
             FS(_F("<span foreground='red' size='x-large'>Missing the needed UI file:\n<b>{1}</b></span>\nCould "
                   "not find them at any location.\n  Not relative\n  Not in the Working Path\n  Not in {2}") %
-               relativePathAndFile % Util::getDataPath().string());
+               relativePathAndFile % Util::getDataPath().u8string());
 
     if (!failIfNotFound) {
         msg += _("\n\nWill now attempt to run without this file.");
@@ -419,7 +419,7 @@ void on_startup(GApplication* application, XMPtr app_data) {
     auto& globalLatexTemplatePath = app_data->control->getSettings()->latexSettings.globalTemplatePath;
     if (globalLatexTemplatePath.empty()) {
         globalLatexTemplatePath = findResourcePath("resources/") / "default_template.tex";
-        g_message("Using default latex template in %s", globalLatexTemplatePath.string().c_str());
+        g_message("Using default latex template in %s", globalLatexTemplatePath.u8string().c_str());
         app_data->control->getSettings()->save();
     }
 

--- a/src/core/control/jobs/AutosaveJob.cpp
+++ b/src/core/control/jobs/AutosaveJob.cpp
@@ -39,7 +39,7 @@ void AutosaveJob::run() {
 
     control->renameLastAutosaveFile();
 
-    g_message("%s", FS(_F("Autosaving to {1}") % filepath.string()).c_str());
+    g_message("%s", FS(_F("Autosaving to {1}") % filepath.u8string()).c_str());
 
     handler.saveTo(filepath);
 

--- a/src/core/control/latex/LatexGenerator.cpp
+++ b/src/core/control/latex/LatexGenerator.cpp
@@ -49,7 +49,7 @@ auto LatexGenerator::asyncRun(const fs::path& texDir, const std::string& texFile
         return res;
     };
 
-    auto texFilePath = (Util::getLongPath(texDir) / "tex.tex").string();
+    auto texFilePath = (Util::getLongPath(texDir) / "tex.tex").u8string();
     for (auto i = cmd.find(u8"{}"); i != std::string::npos; i = cmd.find(u8"{}", i + texFilePath.length())) {
         cmd.replace(i, 2, texFilePath);
     }

--- a/src/core/control/settings/MetadataManager.cpp
+++ b/src/core/control/settings/MetadataManager.cpp
@@ -2,7 +2,7 @@
 
 #include <algorithm>  // std::sort
 #include <fstream>
-#include <iomanip> // std::quoted
+#include <iomanip>  // std::quoted
 #include <sstream>
 
 #include <fcntl.h>

--- a/src/core/control/settings/MetadataManager.cpp
+++ b/src/core/control/settings/MetadataManager.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>  // std::sort
 #include <fstream>
+#include <iomanip> // std::quoted
 #include <sstream>
 
 #include <fcntl.h>
@@ -169,7 +170,7 @@ void MetadataManager::storeMetadata(MetadataEntry* m) {
 
     ofstream out(path);
     out << "XOJ-METADATA/1.0\n";
-    out << m->path.u8string() << "\n";
+    out << std::quoted(m->path.u8string()) << "\n";
     out << "page=" << m->page << "\n";
     out << "zoom=" << m->zoom << "\n";
     out.close();

--- a/src/core/control/settings/MetadataManager.cpp
+++ b/src/core/control/settings/MetadataManager.cpp
@@ -28,13 +28,13 @@ MetadataManager::~MetadataManager() { documentChanged(); }
 void MetadataManager::deleteMetadataFile(fs::path const& path) {
     // be careful, delete the Metadata file, NOT the Document!
     if (path.extension() != ".metadata") {
-        g_warning("Try to delete non-metadata file: %s", path.string().c_str());
+        g_warning("Try to delete non-metadata file: %s", path.u8string().c_str());
         return;
     }
 
     try {
         fs::remove(path);
-    } catch (fs::filesystem_error const&) { g_warning("Could not delete metadata file %s", path.string().c_str()); }
+    } catch (fs::filesystem_error const&) { g_warning("Could not delete metadata file %s", path.u8string().c_str()); }
 }
 
 /**
@@ -93,7 +93,7 @@ auto MetadataManager::loadMetadataFile(fs::path const& path, fs::path const& fil
     string line;
     ifstream infile(path);
 
-    auto time = file.stem().string();
+    auto time = file.stem().u8string();
     entry.time = strtoll(time.c_str(), nullptr, 10);
 
     if (!getline(infile, line) || line != "XOJ-METADATA/1.0") {
@@ -169,7 +169,7 @@ void MetadataManager::storeMetadata(MetadataEntry* m) {
 
     ofstream out(path);
     out << "XOJ-METADATA/1.0\n";
-    out << m->path << "\n";
+    out << m->path.u8string() << "\n";
     out << "page=" << m->page << "\n";
     out << "zoom=" << m->zoom << "\n";
     out.close();

--- a/src/core/control/settings/MetadataManager.cpp
+++ b/src/core/control/settings/MetadataManager.cpp
@@ -109,7 +109,9 @@ auto MetadataManager::loadMetadataFile(fs::path const& path, fs::path const& fil
         return entry;
     }
     istringstream iss(line);
-    iss >> entry.path;
+    std::string pathStr;
+    iss >> std::quoted(pathStr);
+    entry.path = fs::u8path(pathStr);
 
     if (!getline(infile, line) || line.length() < 6 || line.substr(0, 5) != "page=") {
         deleteMetadataFile(path);

--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -639,7 +639,7 @@ auto Settings::load() -> bool {
     xmlKeepBlanksDefault(0);
 
     if (!fs::exists(filepath)) {
-        g_warning("configfile does not exist %s\n", filepath.string().c_str());
+        g_warning("configfile does not exist %s\n", filepath.u8string().c_str());
         return false;
     }
 
@@ -652,14 +652,14 @@ auto Settings::load() -> bool {
 
     xmlNodePtr cur = xmlDocGetRootElement(doc);
     if (cur == nullptr) {
-        g_message("The settings file \"%s\" is empty", filepath.string().c_str());
+        g_message("The settings file \"%s\" is empty", filepath.u8string().c_str());
         xmlFreeDoc(doc);
 
         return false;
     }
 
     if (xmlStrcmp(cur->name, reinterpret_cast<const xmlChar*>("settings"))) {
-        g_message("File \"%s\" is of the wrong type", filepath.string().c_str());
+        g_message("File \"%s\" is of the wrong type", filepath.u8string().c_str());
         xmlFreeDoc(doc);
 
         return false;

--- a/src/core/control/xojfile/LoadHandler.cpp
+++ b/src/core/control/xojfile/LoadHandler.cpp
@@ -354,7 +354,8 @@ void LoadHandler::parseBgPixmap() {
         img.loadFile(fileToLoad, &error);
 
         if (error) {
-            error("%s", FC(_F("Could not read image: {1}. Error message: {2}") % fileToLoad.string() % error->message));
+            error("%s",
+                  FC(_F("Could not read image: {1}. Error message: {2}") % fileToLoad.u8string() % error->message));
             g_error_free(error);
         }
 
@@ -378,17 +379,17 @@ void LoadHandler::parseBgPixmap() {
         g_input_stream_close(inputStream, nullptr, nullptr);
 
         if (error) {
-            error("%s", FC(_F("Could not read image: {1}. Error message: {2}") % filepath.string() % error->message));
+            error("%s", FC(_F("Could not read image: {1}. Error message: {2}") % filepath.u8string() % error->message));
             g_error_free(error);
         }
 
         this->page->setBackgroundImage(img);
     } else if (!strcmp(domain, "clone")) {
         gchar* endptr = nullptr;
-        auto const& filename = filepath.string();
+        auto const& filename = filepath.u8string();
         size_t nr = static_cast<size_t>(g_ascii_strtoull(filename.c_str(), &endptr, 10));
         if (endptr == filename.c_str()) {
-            error("%s", FC(_F("Could not read page number for cloned background image: {1}.") % filepath.string()));
+            error("%s", FC(_F("Could not read page number for cloned background image: {1}.") % filepath.u8string()));
         }
         PageRef p = pages[nr];
 
@@ -555,7 +556,7 @@ void LoadHandler::parseStroke() {
         } else {
             auto tempFile = getTempFileForPath(fn);
             if (!tempFile.empty()) {
-                stroke->setAudioFilename(tempFile.string());
+                stroke->setAudioFilename(tempFile.u8string());
             }
         }
     }
@@ -635,7 +636,7 @@ void LoadHandler::parseText() {
         } else {
             auto tempFile = getTempFileForPath(fn);
             if (!tempFile.empty()) {
-                text->setAudioFilename(tempFile.string());
+                text->setAudioFilename(tempFile.u8string());
             }
         }
     }
@@ -920,7 +921,7 @@ void LoadHandler::parserText(GMarkupParseContext* context, const gchar* text, gs
                 handler->stroke->setPressure(handler->pressureBuffer);
                 handler->pressureBuffer.clear();
             } else {
-                g_warning("%s", FC(_F("xoj-File: {1}") % handler->filepath.string().c_str()));
+                g_warning("%s", FC(_F("xoj-File: {1}") % handler->filepath.u8string().c_str()));
                 g_warning("%s", FC(_F("Wrong number of points, got {1}, expected {2}") %
                                    handler->pressureBuffer.size() % (handler->stroke->getPointCount() - 1)));
             }
@@ -1011,7 +1012,7 @@ auto LoadHandler::readZipAttachment(fs::path const& filename, gpointer& data, gs
     zip_stat_t attachmentFileStat;
     int statStatus = zip_stat(this->zipFp, filename.u8string().c_str(), 0, &attachmentFileStat);
     if (statStatus != 0) {
-        error("%s", FC(_F("Could not open attachment: {1}. Error message: {2}") % filename.string() %
+        error("%s", FC(_F("Could not open attachment: {1}. Error message: {2}") % filename.u8string() %
                        zip_error_strerror(zip_get_error(this->zipFp))));
         return false;
     }
@@ -1019,15 +1020,15 @@ auto LoadHandler::readZipAttachment(fs::path const& filename, gpointer& data, gs
     if (attachmentFileStat.valid & ZIP_STAT_SIZE) {
         length = attachmentFileStat.size;
     } else {
-        error("%s",
-              FC(_F("Could not open attachment: {1}. Error message: No valid file size provided") % filename.string()));
+        error("%s", FC(_F("Could not open attachment: {1}. Error message: No valid file size provided") %
+                       filename.u8string()));
         return false;
     }
 
     zip_file_t* attachmentFile = zip_fopen(this->zipFp, filename.u8string().c_str(), 0);
 
     if (!attachmentFile) {
-        error("%s", FC(_F("Could not open attachment: {1}. Error message: {2}") % filename.string() %
+        error("%s", FC(_F("Could not open attachment: {1}. Error message: {2}") % filename.u8string() %
                        zip_error_strerror(zip_get_error(this->zipFp))));
         return false;
     }
@@ -1040,7 +1041,7 @@ auto LoadHandler::readZipAttachment(fs::path const& filename, gpointer& data, gs
             g_free(data);
             zip_fclose(attachmentFile);
             error("%s", FC(_F("Could not open attachment: {1}. Error message: No valid file size provided") %
-                           filename.string()));
+                           filename.u8string()));
             return false;
         }
 
@@ -1058,7 +1059,7 @@ auto LoadHandler::getTempFileForPath(fs::path const& filename) -> fs::path {
         return string(static_cast<char*>(tmpFilename));
     }
 
-    error("%s", FC(_F("Requested temporary file was not found for attachment {1}") % filename.string()));
+    error("%s", FC(_F("Requested temporary file was not found for attachment {1}") % filename.u8string()));
     return "";
 }
 

--- a/src/core/control/xojfile/SaveHandler.cpp
+++ b/src/core/control/xojfile/SaveHandler.cpp
@@ -221,7 +221,7 @@ void SaveHandler::visitPage(XmlNode* root, PageRef p, Document* doc, int id) {
                 }
             } else {
                 background->setAttrib("domain", "absolute");
-                background->setAttrib("filename", doc->getPdfFilepath().string());
+                background->setAttrib("filename", doc->getPdfFilepath().u8string());
             }
         }
         background->setAttrib("pageno", p->getPdfPageNr() + 1);
@@ -246,7 +246,7 @@ void SaveHandler::visitPage(XmlNode* root, PageRef p, Document* doc, int id) {
             p->getBackgroundImage().setCloneId(id);
         } else {
             background->setAttrib("domain", "absolute");
-            background->setAttrib("filename", p->getBackgroundImage().getFilepath().string());
+            background->setAttrib("filename", p->getBackgroundImage().getFilepath().u8string());
             p->getBackgroundImage().setCloneId(id);
         }
     } else {

--- a/src/core/plugin/Plugin.cpp
+++ b/src/core/plugin/Plugin.cpp
@@ -172,7 +172,7 @@ void Plugin::addPluginToLuaPath() {
 
     // prepend the path of the current plugin
     auto curPath = this->path / "?.lua";
-    std::string combinedPath = curPath.string() + ";" + luaPath;
+    std::string combinedPath = curPath.u8string() + ";" + luaPath;
 
     // get rid of the std::string on the stack we just pushed
     lua_pop(lua.get(), 1);
@@ -212,9 +212,9 @@ void Plugin::loadScript() {
 
     // Load but don't run the Lua script
     auto luafile = path / mainfile;
-    if (luaL_loadfile(lua.get(), luafile.string().c_str())) {
+    if (luaL_loadfile(lua.get(), luafile.u8string().c_str())) {
         // Error out if file can't be read
-        g_warning("Could not run plugin Lua file: \"%s\"", luafile.string().c_str());
+        g_warning("Could not run plugin Lua file: \"%s\"", luafile.u8string().c_str());
         this->valid = false;
         return;
     }
@@ -234,7 +234,7 @@ void Plugin::loadScript() {
         button.insert(std::pair<int, std::string>(0, _("OK")));
         XojMsgBox::showPluginMessage(name, errMsg, button, true);
 
-        g_warning("Could not run plugin Lua file: \"%s\", error: \"%s\"", luafile.string().c_str(), errMsg);
+        g_warning("Could not run plugin Lua file: \"%s\", error: \"%s\"", luafile.u8string().c_str(), errMsg);
         this->valid = false;
         return;
     }

--- a/src/core/plugin/PluginController.cpp
+++ b/src/core/plugin/PluginController.cpp
@@ -28,9 +28,9 @@ void PluginController::loadPluginsFrom(fs::path const& path) {
     try {
         for (auto const& f: fs::directory_iterator(path)) {
             const auto& pluginPath = f.path();
-            auto plugin = std::make_unique<Plugin>(control, pluginPath.filename().string(), pluginPath);
+            auto plugin = std::make_unique<Plugin>(control, pluginPath.filename().u8string(), pluginPath);
             if (!plugin->isValid()) {
-                g_warning("Error loading plugin \"%s\"", f.path().string().c_str());
+                g_warning("Error loading plugin \"%s\"", f.path().u8string().c_str());
                 continue;
             }
 
@@ -47,7 +47,7 @@ void PluginController::loadPluginsFrom(fs::path const& path) {
             this->plugins.emplace_back(std::move(plugin));
         }
     } catch (fs::filesystem_error const& e) {
-        g_warning("Could not open plugin dir: \"%s\"", path.string().c_str());
+        g_warning("Could not open plugin dir: \"%s\"", path.u8string().c_str());
         return;
     }
 #endif

--- a/src/core/plugin/luapi_application.h
+++ b/src/core/plugin/luapi_application.h
@@ -889,11 +889,11 @@ static int applib_getDocumentStructure(lua_State* L) {
     lua_settable(L, -3);
 
     lua_pushliteral(L, "pdfBackgroundFilename");
-    lua_pushstring(L, doc->getPdfFilepath().string().c_str());
+    lua_pushstring(L, doc->getPdfFilepath().u8string().c_str());
     lua_settable(L, -3);
 
     lua_pushliteral(L, "xoppFilename");
-    lua_pushstring(L, doc->getFilepath().string().c_str());
+    lua_pushstring(L, doc->getFilepath().u8string().c_str());
     lua_settable(L, -3);
 
     return 1;

--- a/src/core/plugin/luapi_application.h
+++ b/src/core/plugin/luapi_application.h
@@ -1213,7 +1213,7 @@ static int applib_export(lua_State* L) {
         luaL_error(L, "Missing output file!");
     }
 
-    fs::path file = fs::path(outputFile);
+    fs::path file = fs::u8path(outputFile);
     auto extension = file.extension();
 
     if (extension == ".pdf") {

--- a/src/util/PathUtil.cpp
+++ b/src/util/PathUtil.cpp
@@ -76,7 +76,7 @@ auto Util::hasXournalFileExt(const fs::path& path) -> bool {
 }
 
 auto Util::hasPdfFileExt(const fs::path& path) -> bool {
-    return StringUtils::toLowerCase(path.extension().u8string()) == ".pdf";
+    return StringUtils::toLowerCase(path.extension().native()) == ".pdf";
 }
 
 auto Util::clearExtensions(fs::path& path, const std::string& ext) -> void {

--- a/src/util/PathUtil.cpp
+++ b/src/util/PathUtil.cpp
@@ -81,7 +81,7 @@ auto Util::hasPdfFileExt(const fs::path& path) -> bool {
 
 auto Util::clearExtensions(fs::path& path, const std::string& ext) -> void {
     auto rm_ext = [&path](const std::string ext) {
-        if (StringUtils::toLowerCase(path.extension().u8string()) == StringUtils::toLowerCase(ext)) {
+        if (StringUtils::toLowerCase(path.extension().native()) == StringUtils::toLowerCase(ext)) {
             path.replace_extension("");
         }
     };

--- a/src/util/PathUtil.cpp
+++ b/src/util/PathUtil.cpp
@@ -65,23 +65,23 @@ auto Util::readString(fs::path const& path, bool showErrorToUser) -> std::option
 }
 
 auto Util::getEscapedPath(const fs::path& path) -> std::string {
-    std::string escaped = path.string();
+    std::string escaped = path.u8string();
     StringUtils::replaceAllChars(escaped, {replace_pair('\\', "\\\\"), replace_pair('\"', "\\\"")});
     return escaped;
 }
 
 auto Util::hasXournalFileExt(const fs::path& path) -> bool {
-    auto extension = StringUtils::toLowerCase(path.extension().string());
+    auto extension = StringUtils::toLowerCase(path.extension().u8string());
     return extension == ".xoj" || extension == ".xopp";
 }
 
 auto Util::hasPdfFileExt(const fs::path& path) -> bool {
-    return StringUtils::toLowerCase(path.extension().string()) == ".pdf";
+    return StringUtils::toLowerCase(path.extension().u8string()) == ".pdf";
 }
 
 auto Util::clearExtensions(fs::path& path, const std::string& ext) -> void {
     auto rm_ext = [&path](const std::string ext) {
-        if (StringUtils::toLowerCase(path.extension().string()) == StringUtils::toLowerCase(ext)) {
+        if (StringUtils::toLowerCase(path.extension().u8string()) == StringUtils::toLowerCase(ext)) {
             path.replace_extension("");
         }
     };
@@ -298,7 +298,7 @@ bool Util::safeRenameFile(fs::path const& from, fs::path const& to) {
         // Attempt copy and delete
         g_warning("Renaming file %s to %s failed with %s. This may happen when source and target are on different "
                   "filesystems. Attempt to copy the file.",
-                  fe.path1().string().c_str(), fe.path2().string().c_str(), fe.what());
+                  fe.path1().u8string().c_str(), fe.path2().u8string().c_str(), fe.what());
         fs::copy_file(from, to, fs::copy_options::overwrite_existing);
         fs::remove(from);
     }

--- a/src/util/PathUtil.cpp
+++ b/src/util/PathUtil.cpp
@@ -71,7 +71,7 @@ auto Util::getEscapedPath(const fs::path& path) -> std::string {
 }
 
 auto Util::hasXournalFileExt(const fs::path& path) -> bool {
-    auto extension = StringUtils::toLowerCase(path.extension().u8string());
+    auto extension = StringUtils::toLowerCase(path.extension().native());
     return extension == ".xoj" || extension == ".xopp";
 }
 

--- a/src/util/PathUtil.cpp
+++ b/src/util/PathUtil.cpp
@@ -193,7 +193,7 @@ auto Util::getGettextFilepath(const char* localeDir) -> fs::path {
     const char* dir = (gettextEnv) ? directories.c_str() : localeDir;
     g_message("TEXTDOMAINDIR = %s, Platform-specific locale dir = %s, chosen directory = %s", gettextEnv, localeDir,
               dir);
-    return fs::path(dir);
+    return fs::u8path(dir);
 }
 
 auto Util::getAutosaveFilepath() -> fs::path {

--- a/test/unit_tests/util/PathTest.cpp
+++ b/test/unit_tests/util/PathTest.cpp
@@ -67,7 +67,7 @@ TEST(UtilPath, testClearExtensions) {
     // The following tests use the generic separator which works on all systems
     auto b = fs::path("/test/asdf.TXT");
     Util::clearExtensions(b);
-    EXPECT_EQ(string("/test/asdf.TXT"), b.u8string());
+    EXPECT_EQ(string(u8"/test/asdf.TXT"), b.u8string());
     Util::clearExtensions(b, ".txt");
     EXPECT_EQ(string("/test/asdf"), b.u8string());
 

--- a/test/unit_tests/util/PathTest.cpp
+++ b/test/unit_tests/util/PathTest.cpp
@@ -55,65 +55,65 @@ TEST(UtilPath, testClearExtensions) {
     auto a = fs::path("C:") / "test" / "abc" / "xyz.txt";
     fs::path old_path(a);
     Util::clearExtensions(a);
-    EXPECT_EQ(old_path.string(), a.string());
+    EXPECT_EQ(old_path.u8string(), a.u8string());
 
     a = fs::path("C:") / "test" / "abc" / "xyz";
     old_path = a;
     a += ".xopp";
     Util::clearExtensions(a);
-    EXPECT_EQ(old_path.string(), a.string());
+    EXPECT_EQ(old_path.u8string(), a.u8string());
 
 
     // The following tests use the generic separator which works on all systems
     auto b = fs::path("/test/asdf.TXT");
     Util::clearExtensions(b);
-    EXPECT_EQ(string("/test/asdf.TXT"), b.string());
+    EXPECT_EQ(string("/test/asdf.TXT"), b.u8string());
     Util::clearExtensions(b, ".txt");
-    EXPECT_EQ(string("/test/asdf"), b.string());
+    EXPECT_EQ(string("/test/asdf"), b.u8string());
 
     b = fs::path("/test/asdf.asdf/asdf");
     Util::clearExtensions(b);
-    EXPECT_EQ(string("/test/asdf.asdf/asdf"), b.string());
+    EXPECT_EQ(string("/test/asdf.asdf/asdf"), b.u8string());
 
     b = fs::path("/test/asdf.PDF");
     Util::clearExtensions(b);
-    EXPECT_EQ(string("/test/asdf.PDF"), b.string());
+    EXPECT_EQ(string("/test/asdf.PDF"), b.u8string());
     Util::clearExtensions(b, ".pdf");
-    EXPECT_EQ(string("/test/asdf"), b.string());
+    EXPECT_EQ(string("/test/asdf"), b.u8string());
 
     b = fs::path("/test/asdf.PDF.xoj");
     Util::clearExtensions(b);
-    EXPECT_EQ(string("/test/asdf.PDF"), b.string());
+    EXPECT_EQ(string("/test/asdf.PDF"), b.u8string());
 
     b = fs::path("/test/asdf.PDF.xoj");
     Util::clearExtensions(b, ".Pdf");
-    EXPECT_EQ(string("/test/asdf"), b.string());
+    EXPECT_EQ(string("/test/asdf"), b.u8string());
 
     b = fs::path("/test/asdf.pdf.pdf");
     Util::clearExtensions(b, ".pdf");
-    EXPECT_EQ(string("/test/asdf.pdf"), b.string());
+    EXPECT_EQ(string("/test/asdf.pdf"), b.u8string());
 
     b = fs::path("/test/asdf.xopp.xopp");
     Util::clearExtensions(b);
-    EXPECT_EQ(string("/test/asdf.xopp"), b.string());
+    EXPECT_EQ(string("/test/asdf.xopp"), b.u8string());
 
     b = fs::path("/test/asdf.PDF.xopp");
     Util::clearExtensions(b);
-    EXPECT_EQ(string("/test/asdf.PDF"), b.string());
+    EXPECT_EQ(string("/test/asdf.PDF"), b.u8string());
 
     b = fs::path("/test/asdf.SVG.xopp");
     Util::clearExtensions(b, ".svg");
-    EXPECT_EQ(string("/test/asdf"), b.string());
+    EXPECT_EQ(string("/test/asdf"), b.u8string());
 
     b = fs::path("/test/asdf.xoj");
     Util::clearExtensions(b);
-    EXPECT_EQ(string("/test/asdf"), b.string());
+    EXPECT_EQ(string("/test/asdf"), b.u8string());
 
     b = fs::path("/test/asdf.xopp");
     Util::clearExtensions(b);
-    EXPECT_EQ(string("/test/asdf"), b.string());
+    EXPECT_EQ(string("/test/asdf"), b.u8string());
 
     b = fs::path("/test/asdf.pdf");
     Util::clearExtensions(b);
-    EXPECT_EQ(string("/test/asdf.pdf"), b.string());
+    EXPECT_EQ(string("/test/asdf.pdf"), b.u8string());
 }


### PR DESCRIPTION
... since conversion in `fs::path::string` is unspecified if `value_type` is not char (like on Windows).

This also fixes an "Illegal byte sequence" exception in my Clang build when using funny file names (e.g. '🌍🌎🌏🛰🚀.xopp') thrown here:
https://github.com/xournalpp/xournalpp/blob/2bea77ca5c91fb0f2dad2a4f2dec91e382eeedd5/src/core/control/settings/MetadataManager.cpp#L172
...and maybe others I haven't hit.
