### PR TITLE
Fix deadlock in SidebarPreviewPages

### DIFF
--- a/src/gui/sidebar/previews/page/SidebarPreviewPages.cpp
+++ b/src/gui/sidebar/previews/page/SidebarPreviewPages.cpp
@@ -183,13 +183,12 @@ void SidebarPreviewPages::actionPerformed(SidebarActions action) {
 }
 
 void SidebarPreviewPages::updatePreviews() {
-    Document* doc = this->getControl()->getDocument();
-    doc->lock();
-    size_t len = doc->getPageCount();
-
     for (SidebarPreviewBaseEntry* p: this->previews) { delete p; }
     this->previews.clear();
 
+    Document* doc = this->getControl()->getDocument();
+    doc->lock();
+    size_t len = doc->getPageCount();
     for (size_t i = 0; i < len; i++) {
         SidebarPreviewBaseEntry* p = new SidebarPreviewPageEntry(this, doc->getPage(i));
         this->previews.push_back(p);


### PR DESCRIPTION
This is a quick fix for #3712. In the long term, we should refactor the sidebar logic so that side effects (e.g., scheduling cleanup jobs) are clearly separated from the basic functionality.