### PR TITLE
Fixup using new Gtk blob

### DIFF
--- a/azure-pipelines/steps/build_mac.yml
+++ b/azure-pipelines/steps/build_mac.yml
@@ -44,6 +44,16 @@ steps:
      make install INSTALL_TOP="${{parameters.generation_path}}"/gtk/inst
     displayName: 'Get Lua'
   - bash: |
+    # Cppunit will not be required any longer after the migration to gtest (in version 1.2)
+    cd "${{parameters.generation_path}}"
+    curl -L -o cppunit.tar.gz https://dev-www.libreoffice.org/src/cppunit-1.15.1.tar.gz
+    tar zxf cppunit.tar.gz
+    cd cppunit-1.15.1
+    ./configure --prefix="${{parameters.generation_path}}"/gtk/inst
+    make
+    make install
+    displayName: 'Get Cppunit'
+  - bash: |
       export PKG_CONFIG_PATH="${{parameters.generation_path}}"/gtk/inst/lib/pkgconfig:"${{parameters.generation_path}}"/gtk/inst/share/pkgconfig:/Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.8/lib/pkgconfig
       export PREFIX="${{parameters.generation_path}}"/gtk/inst
       export PATH="$HOME/.local/bin:"${{parameters.generation_path}}"/gtk/inst/bin:$PATH"

--- a/mac-setup/build-app.sh
+++ b/mac-setup/build-app.sh
@@ -50,7 +50,7 @@ mkdir -p ./Xournal++.app/Contents/Resources/etc/gtk-2.0/
 gdk-pixbuf-query-loaders >./Xournal++.app/Contents/Resources/etc/gtk-2.0/gdk-pixbuf.loaders
 sed -i -e "s:$1/inst/:@executable_path/../Resources/:g" ./Xournal++.app/Contents/Resources/etc/gtk-2.0/gdk-pixbuf.loaders
 # Replace old loaders cache location with new one in builtin launcher script, see https://gitlab.gnome.org/GNOME/gtk-mac-bundler/-/issues/12
-sed -i -e "s:$bundle_etc/gtk-2.0/gdk-pixbuf.loaders:$bundle_lib/gdk-pixbuf-2.0/2.10.0/loaders.cache:g" ./Xournal++.app/Contents/MacOS/xournalpp
+sed -i -e "s:bundle_etc/gtk-2.0/gdk-pixbuf.loaders:bundle_lib/gdk-pixbuf-2.0/2.10.0/loaders.cache:g" ./Xournal++.app/Contents/MacOS/xournalpp
 
 echo "Copy GTK Schema"
 mkdir -p ./Xournal++.app/Contents/Resources/share/glib-2.0/schemas


### PR DESCRIPTION
The release 1.1 branch uses `cppunit` for unit tests, which is not required in the master branch any more due to the migration to `gtest`. The new `gtk` blob for macos does not include `cppunit`, so it must be fetched during the build process. 
Moreover the new `gtk` blob uses a different loader cache location compared to the old one, so this needs update, too.