### PR TITLE
Enable linking with gperftools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,14 @@ list(APPEND pkg-module-spec "libzip >= 1.0.1")
 list(APPEND pkg-module-spec "portaudiocpp >= 12")
 list(APPEND pkg-module-spec "sndfile >= 1.0.25")
 list(APPEND pkg-module-spec "librsvg-2.0 >= 2.40")
+
+# Profiling
+option (ENABLE_PROFILING "Link with gperftools" OFF)
+if (ENABLE_PROFILING)
+  list(APPEND pkg-module-spec "libprofiler >= 2.5")
+  list(APPEND pkg-module-spec "libtcmalloc >= 2.5")
+endif (ENABLE_PROFILING)
+
 pkg_check_modules(ExternalModules REQUIRED IMPORTED_TARGET ${pkg-module-spec})
 
 if (#[[${CMAKE_VERSION} VERSION_LESS "3.18" AND]] ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
@@ -306,6 +314,7 @@ Configuration:
     GTEST enabled:              ${ENABLE_GTEST}
     GCOV enabled:               ${DEV_ENABLE_GCOV}
     Filesystem library:         ${CXX_FILESYSTEM_NAMESPACE}
+    Profiling enabled:          ${ENABLE_PROFILING}
 ")
 
 option(CMAKE_DEBUG_INCLUDES_LDFLAGS "List include dirs and ldflags for xournalpp target" OFF)


### PR DESCRIPTION
This PR adds an option to enable linking with gperftools, which can be used to profile the application.

How to profile:
1. Install `gperftools` through your distro package manager (`google-perftools` on Debian/Ubuntu).
2. Enable the profiling flag: `cmake .. -DENABLE_PROFILING=on`.
3. Compile the application. Check that libprofiler is linked: `ldd ./xournalpp | grep libprofiler`
4. Run the application using the appropriate environment variables. E.g., `CPUPROFILE=/tmp/xournalpp.prof ./xournalpp`
5. Use `pprof` to view the profile in text format, or export to callgrind format and view in `kcachegrind`.