### PR TITLE
Fix clang-tidy modernize-use-override

### DIFF
--- a/src/core/control/Control.h
+++ b/src/core/control/Control.h
@@ -63,7 +63,11 @@ class Control:
         public ProgressListener {
 public:
     Control(GApplication* gtkApp, GladeSearchpath* gladeSearchPath);
-    virtual ~Control();
+    Control(Control const&) = delete;
+    Control(Control&&) = delete;
+    auto operator=(Control const&) -> Control& = delete;
+    auto operator=(Control&&) -> Control& = delete;
+    ~Control() override;
 
     void initWindow(MainWindow* win);
 
@@ -113,31 +117,31 @@ public:
     // Menu Help
     void showAbout();
 
-    virtual void actionPerformed(ActionType type, ActionGroup group, GdkEvent* event, GtkMenuItem* menuitem,
-                                 GtkToolButton* toolbutton, bool enabled);
+    void actionPerformed(ActionType type, ActionGroup group, GdkEvent* event, GtkMenuItem* menuitem,
+                         GtkToolButton* toolbutton, bool enabled) override;
 
     /**
      * @brief Update the Cursor and the Toolbar based on the active color
      *
      */
-    virtual void toolColorChanged();
+    void toolColorChanged() override;
     /**
      * @brief Change the color of the current selection based on the active Tool
      *
      */
-    virtual void changeColorOfSelection();
-    virtual void setCustomColorSelected();
-    virtual void toolChanged();
-    virtual void toolSizeChanged();
-    virtual void toolFillChanged();
-    virtual void toolLineStyleChanged();
+    void changeColorOfSelection() override;
+    void setCustomColorSelected() override;
+    void toolChanged() override;
+    void toolSizeChanged() override;
+    void toolFillChanged() override;
+    void toolLineStyleChanged() override;
 
     void selectTool(ToolType type);
     void selectDefaultTool();
 
     void updatePageNumbers(size_t page, size_t pdfPage);
 
-    virtual void fileOpened(fs::path const& path);
+    void fileOpened(fs::path const& path) override;
 
     /**
      * Save current state (selected tool etc.)
@@ -266,22 +270,22 @@ public:
 
 public:
     // UndoRedoListener interface
-    void undoRedoChanged();
-    void undoRedoPageChanged(PageRef page);
+    void undoRedoChanged() override;
+    void undoRedoPageChanged(PageRef page) override;
 
 public:
     // ProgressListener interface
-    void setMaximumState(int max);
-    void setCurrentState(int state);
+    void setMaximumState(int max) override;
+    void setCurrentState(int state) override;
 
 public:
     // ClipboardListener interface
-    virtual void clipboardCutCopyEnabled(bool enabled);
-    virtual void clipboardPasteEnabled(bool enabled);
-    virtual void clipboardPasteText(std::string text);
-    virtual void clipboardPasteImage(GdkPixbuf* img);
-    virtual void clipboardPasteXournal(ObjectInputStream& in);
-    virtual void deleteSelection();
+    void clipboardCutCopyEnabled(bool enabled) override;
+    void clipboardPasteEnabled(bool enabled) override;
+    void clipboardPasteText(std::string text) override;
+    void clipboardPasteImage(GdkPixbuf* img) override;
+    void clipboardPasteXournal(ObjectInputStream& in) override;
+    void deleteSelection() override;
 
     void clipboardPaste(Element* e);
 

--- a/src/core/control/PageBackgroundChangeController.h
+++ b/src/core/control/PageBackgroundChangeController.h
@@ -31,27 +31,27 @@ class PageBackgroundChangeController:
         public PageTypeApplyListener {
 public:
     PageBackgroundChangeController(Control* control);
-    virtual ~PageBackgroundChangeController() = default;
+    ~PageBackgroundChangeController() override = default;
 
 public:
     virtual void changeCurrentPageBackground(PageType& pageType);
-    virtual void changeCurrentPageBackground(PageTypeInfo* info);
+    void changeCurrentPageBackground(PageTypeInfo* info) override;
     void changeAllPagesBackground(const PageType& pt);
     void insertNewPage(size_t position);
     GtkWidget* getMenu();
 
     // DocumentListener
 public:
-    virtual void documentChanged(DocumentChangeType type);
-    virtual void pageSizeChanged(size_t page);
-    virtual void pageChanged(size_t page);
-    virtual void pageInserted(size_t page);
-    virtual void pageDeleted(size_t page);
-    virtual void pageSelected(size_t page);
+    void documentChanged(DocumentChangeType type) override;
+    void pageSizeChanged(size_t page) override;
+    void pageChanged(size_t page) override;
+    void pageInserted(size_t page) override;
+    void pageDeleted(size_t page) override;
+    void pageSelected(size_t page) override;
 
     // PageTypeApplyListener
 public:
-    virtual void applySelectedPageBackground(bool allPages, ApplyPageTypeSource src);
+    void applySelectedPageBackground(bool allPages, ApplyPageTypeSource src) override;
 
 private:
     /**

--- a/src/core/control/ScrollHandler.h
+++ b/src/core/control/ScrollHandler.h
@@ -26,7 +26,7 @@ class Control;
 class ScrollHandler: public SpinPageListener {
 public:
     ScrollHandler(Control* control);
-    virtual ~ScrollHandler();
+    ~ScrollHandler() override;
 
 public:
     void goToPreviousPage();
@@ -43,7 +43,7 @@ public:
     bool isPageVisible(size_t page, int* visibleHeight = nullptr);
 
 public:
-    virtual void pageChanged(size_t page);
+    void pageChanged(size_t page) override;
 
 private:
     void scrollToSpinPage();

--- a/src/core/control/Tool.h
+++ b/src/core/control/Tool.h
@@ -34,7 +34,7 @@ public:
      * @param t tool to use as basis for new copy.
      */
     Tool(const Tool& t);
-    virtual ~Tool();
+    ~Tool() override;
 
 public:
     std::string getName() const;

--- a/src/core/control/jobs/AutosaveJob.h
+++ b/src/core/control/jobs/AutosaveJob.h
@@ -24,13 +24,13 @@ public:
     AutosaveJob(Control* control);
 
 protected:
-    virtual ~AutosaveJob();
+    ~AutosaveJob() override;
 
 public:
-    virtual void run();
-    void afterRun();
+    void run() override;
+    void afterRun() override;
 
-    virtual JobType getType();
+    JobType getType() override;
 
 private:
     Control* control = nullptr;

--- a/src/core/control/jobs/BaseExportJob.h
+++ b/src/core/control/jobs/BaseExportJob.h
@@ -33,10 +33,10 @@ public:
     BaseExportJob(Control* control, const std::string& name);
 
 protected:
-    virtual ~BaseExportJob();
+    ~BaseExportJob() override;
 
 public:
-    virtual void afterRun();
+    void afterRun() override;
 
 public:
     virtual bool showFilechooser();

--- a/src/core/control/jobs/BlockingJob.h
+++ b/src/core/control/jobs/BlockingJob.h
@@ -26,12 +26,12 @@ public:
     BlockingJob(Control* control, const std::string& name);
 
 protected:
-    virtual ~BlockingJob();
+    ~BlockingJob() override;
 
 public:
-    void execute();
+    void execute() override;
 
-    virtual JobType getType();
+    JobType getType() override;
 
 protected:
     static bool finished(Control* control);

--- a/src/core/control/jobs/CustomExportJob.h
+++ b/src/core/control/jobs/CustomExportJob.h
@@ -26,18 +26,18 @@ public:
     CustomExportJob(Control* control);
 
 protected:
-    virtual ~CustomExportJob();
+    ~CustomExportJob() override;
 
 public:
-    void run();
+    void run() override;
 
 public:
-    virtual bool showFilechooser();
+    bool showFilechooser() override;
 
 protected:
-    virtual void afterRun();
+    void afterRun() override;
 
-    virtual void addFilterToDialog();
+    void addFilterToDialog() override;
 
     /**
      * Create one Graphics file per page

--- a/src/core/control/jobs/PdfExportJob.h
+++ b/src/core/control/jobs/PdfExportJob.h
@@ -18,13 +18,13 @@ public:
     PdfExportJob(Control* control);
 
 protected:
-    virtual ~PdfExportJob();
+    ~PdfExportJob() override;
 
 public:
-    void run();
+    void run() override;
 
 protected:
-    virtual void addFilterToDialog();
+    void addFilterToDialog() override;
     bool testAndSetFilepath(fs::path file) override;
 
 private:

--- a/src/core/control/jobs/PreviewJob.h
+++ b/src/core/control/jobs/PreviewJob.h
@@ -30,15 +30,15 @@ public:
     PreviewJob(SidebarPreviewBaseEntry* sidebar);
 
 protected:
-    virtual void onDelete() override;
-    virtual ~PreviewJob();
+    void onDelete() override;
+    ~PreviewJob() override;
 
 public:
-    virtual void* getSource();
+    void* getSource() override;
 
-    virtual void run();
+    void run() override;
 
-    virtual JobType getType();
+    JobType getType() override;
 
 private:
     void initGraphics();

--- a/src/core/control/jobs/ProgressListener.h
+++ b/src/core/control/jobs/ProgressListener.h
@@ -21,8 +21,8 @@ public:
 
 class DummyProgressListener: public ProgressListener {
 public:
-    virtual void setMaximumState(int max){};
-    virtual void setCurrentState(int state){};
+    void setMaximumState(int max) override{};
+    void setCurrentState(int state) override{};
 
-    virtual ~DummyProgressListener(){};
+    ~DummyProgressListener() override{};
 };

--- a/src/core/control/jobs/RenderJob.h
+++ b/src/core/control/jobs/RenderJob.h
@@ -28,14 +28,14 @@ public:
     RenderJob(XojPageView* view);
 
 protected:
-    virtual ~RenderJob() = default;
+    ~RenderJob() override = default;
 
 public:
-    virtual JobType getType();
+    JobType getType() override;
 
-    void* getSource();
+    void* getSource() override;
 
-    void run();
+    void run() override;
 
 private:
     /**

--- a/src/core/control/jobs/SaveJob.h
+++ b/src/core/control/jobs/SaveJob.h
@@ -22,17 +22,17 @@ public:
     SaveJob(Control* control);
 
 protected:
-    virtual ~SaveJob();
+    ~SaveJob() override;
 
 public:
-    virtual void run();
+    void run() override;
 
     bool save();
 
     static void updatePreview(Control* control);
 
 protected:
-    virtual void afterRun();
+    void afterRun() override;
 
 private:
     std::string lastError;

--- a/src/core/control/jobs/XournalScheduler.h
+++ b/src/core/control/jobs/XournalScheduler.h
@@ -24,7 +24,7 @@
 class XournalScheduler: public Scheduler {
 public:
     XournalScheduler();
-    virtual ~XournalScheduler();
+    ~XournalScheduler() override;
 
 public:
     /**

--- a/src/core/control/tools/ArrowHandler.h
+++ b/src/core/control/tools/ArrowHandler.h
@@ -16,10 +16,10 @@
 class ArrowHandler: public BaseStrokeHandler {
 public:
     ArrowHandler(XournalView* xournal, XojPageView* redrawable, const PageRef& page);
-    virtual ~ArrowHandler();
+    ~ArrowHandler() override;
 
 private:
-    virtual void drawShape(Point& currentPoint, const PositionInputData& pos);
+    void drawShape(Point& currentPoint, const PositionInputData& pos) override;
 
 private:
 };

--- a/src/core/control/tools/BaseStrokeHandler.h
+++ b/src/core/control/tools/BaseStrokeHandler.h
@@ -25,16 +25,16 @@ public:
     BaseStrokeHandler(XournalView* xournal, XojPageView* redrawable, const PageRef& page, bool flipShift = false,
                       bool flipControl = false);
 
-    virtual ~BaseStrokeHandler();
+    ~BaseStrokeHandler() override;
 
-    void draw(cairo_t* cr);
+    void draw(cairo_t* cr) override;
 
-    void onMotionCancelEvent();
-    bool onMotionNotifyEvent(const PositionInputData& pos);
-    void onButtonReleaseEvent(const PositionInputData& pos);
-    void onButtonPressEvent(const PositionInputData& pos);
-    void onButtonDoublePressEvent(const PositionInputData& pos);
-    virtual bool onKeyEvent(GdkEventKey* event);
+    void onMotionCancelEvent() override;
+    bool onMotionNotifyEvent(const PositionInputData& pos) override;
+    void onButtonReleaseEvent(const PositionInputData& pos) override;
+    void onButtonPressEvent(const PositionInputData& pos) override;
+    void onButtonDoublePressEvent(const PositionInputData& pos) override;
+    bool onKeyEvent(GdkEventKey* event) override;
 
 private:
     virtual void drawShape(Point& currentPoint, const PositionInputData& pos) = 0;

--- a/src/core/control/tools/CoordinateSystemHandler.h
+++ b/src/core/control/tools/CoordinateSystemHandler.h
@@ -17,10 +17,10 @@ class CoordinateSystemHandler: public BaseStrokeHandler {
 public:
     CoordinateSystemHandler(XournalView* xournal, XojPageView* redrawable, const PageRef& page, bool flipShift = false,
                             bool flipControl = false);
-    virtual ~CoordinateSystemHandler();
+    ~CoordinateSystemHandler() override;
 
 private:
-    virtual void drawShape(Point& currentPoint, const PositionInputData& pos);
+    void drawShape(Point& currentPoint, const PositionInputData& pos) override;
 
 private:
     Point startPoint;

--- a/src/core/control/tools/EditSelection.h
+++ b/src/core/control/tools/EditSelection.h
@@ -41,7 +41,7 @@ public:
     EditSelection(UndoRedoHandler* undo, Selection* selection, XojPageView* view);
     EditSelection(UndoRedoHandler* undo, Element* e, XojPageView* view, const PageRef& page);
     EditSelection(UndoRedoHandler* undo, const std::vector<Element*>& elements, XojPageView* view, const PageRef& page);
-    virtual ~EditSelection();
+    ~EditSelection() override;
 
 private:
     /**
@@ -164,7 +164,7 @@ public:
     /**
      * Returns all containing elements of this selection
      */
-    std::vector<Element*>* getElements();
+    std::vector<Element*>* getElements() override;
     const std::vector<Element*>* getElements() const;
 
     /**
@@ -240,8 +240,8 @@ public:
 
 public:
     // Serialize interface
-    void serialize(ObjectOutputStream& out) const;
-    void readSerialized(ObjectInputStream& in);
+    void serialize(ObjectOutputStream& out) const override;
+    void readSerialized(ObjectInputStream& in) override;
 
 private:
     /**

--- a/src/core/control/tools/EditSelectionContents.h
+++ b/src/core/control/tools/EditSelectionContents.h
@@ -37,7 +37,7 @@ class EditSelectionContents: public ElementContainer, public Serializable {
 public:
     EditSelectionContents(xoj::util::Rectangle<double> bounds, xoj::util::Rectangle<double> snappedBounds,
                           const PageRef& sourcePage, Layer* sourceLayer, XojPageView* sourceView);
-    virtual ~EditSelectionContents();
+    ~EditSelectionContents() override;
 
 public:
     /**
@@ -88,7 +88,7 @@ public:
     /**
      * Returns all containing elements of this selection
      */
-    std::vector<Element*>* getElements();
+    std::vector<Element*>* getElements() override;
     const std::vector<Element*>* getElements() const;
 
     /**

--- a/src/core/control/tools/EllipseHandler.h
+++ b/src/core/control/tools/EllipseHandler.h
@@ -17,10 +17,10 @@ class EllipseHandler: public BaseStrokeHandler {
 public:
     EllipseHandler(XournalView* xournal, XojPageView* redrawable, const PageRef& page, bool flipShift = false,
                    bool flipControl = false);
-    virtual ~EllipseHandler();
+    ~EllipseHandler() override;
 
 private:
-    virtual void drawShape(Point& currentPoint, const PositionInputData& pos);
+    void drawShape(Point& currentPoint, const PositionInputData& pos) override;
 
 private:
     Point startPoint;

--- a/src/core/control/tools/RectangleHandler.h
+++ b/src/core/control/tools/RectangleHandler.h
@@ -17,10 +17,10 @@ class RectangleHandler: public BaseStrokeHandler {
 public:
     RectangleHandler(XournalView* xournal, XojPageView* redrawable, const PageRef& page, bool flipShift = false,
                      bool flipControl = false);
-    virtual ~RectangleHandler();
+    ~RectangleHandler() override;
 
 private:
-    virtual void drawShape(Point& currentPoint, const PositionInputData& pos);
+    void drawShape(Point& currentPoint, const PositionInputData& pos) override;
 
 private:
     Point startPoint;

--- a/src/core/control/tools/RulerHandler.h
+++ b/src/core/control/tools/RulerHandler.h
@@ -16,10 +16,10 @@
 class RulerHandler: public BaseStrokeHandler {
 public:
     RulerHandler(XournalView* xournal, XojPageView* redrawable, const PageRef& page);
-    virtual ~RulerHandler();
+    ~RulerHandler() override;
 
 private:
-    virtual void drawShape(Point& currentPoint, const PositionInputData& pos);
+    void drawShape(Point& currentPoint, const PositionInputData& pos) override;
 
 private:
 };

--- a/src/core/control/tools/Selection.h
+++ b/src/core/control/tools/Selection.h
@@ -23,7 +23,7 @@
 class Selection: public ShapeContainer {
 public:
     Selection(Redrawable* view);
-    virtual ~Selection();
+    ~Selection() override;
 
 public:
     virtual bool finalize(PageRef page) = 0;
@@ -48,14 +48,14 @@ protected:
 class RectSelection: public Selection {
 public:
     RectSelection(double x, double y, Redrawable* view);
-    virtual ~RectSelection();
+    ~RectSelection() override;
 
 public:
-    virtual bool finalize(PageRef page);
-    virtual void paint(cairo_t* cr, GdkRectangle* rect, double zoom);
-    virtual void currentPos(double x, double y);
-    virtual bool contains(double x, double y);
-    virtual bool userTapped(double zoom);
+    bool finalize(PageRef page) override;
+    void paint(cairo_t* cr, GdkRectangle* rect, double zoom) override;
+    void currentPos(double x, double y) override;
+    bool contains(double x, double y) override;
+    bool userTapped(double zoom) override;
 
 private:
     double sx;

--- a/src/core/control/tools/SplineHandler.h
+++ b/src/core/control/tools/SplineHandler.h
@@ -36,16 +36,16 @@ class SplineSegment;
 class SplineHandler: public InputHandler {
 public:
     SplineHandler(XournalView* xournal, XojPageView* redrawable, const PageRef& page);
-    virtual ~SplineHandler();
+    ~SplineHandler() override;
 
-    void draw(cairo_t* cr);
+    void draw(cairo_t* cr) override;
 
-    void onMotionCancelEvent();
-    bool onMotionNotifyEvent(const PositionInputData& pos);
-    void onButtonReleaseEvent(const PositionInputData& pos);
-    void onButtonPressEvent(const PositionInputData& pos);
-    void onButtonDoublePressEvent(const PositionInputData& pos);
-    virtual bool onKeyEvent(GdkEventKey* event);
+    void onMotionCancelEvent() override;
+    bool onMotionNotifyEvent(const PositionInputData& pos) override;
+    void onButtonReleaseEvent(const PositionInputData& pos) override;
+    void onButtonPressEvent(const PositionInputData& pos) override;
+    void onButtonDoublePressEvent(const PositionInputData& pos) override;
+    bool onKeyEvent(GdkEventKey* event) override;
 
 private:
     void finalizeSpline();

--- a/src/core/control/tools/StrokeHandler.h
+++ b/src/core/control/tools/StrokeHandler.h
@@ -33,16 +33,16 @@ class Active;
 class StrokeHandler: public InputHandler {
 public:
     StrokeHandler(XournalView* xournal, XojPageView* redrawable, const PageRef& page);
-    virtual ~StrokeHandler();
+    ~StrokeHandler() override;
 
-    void draw(cairo_t* cr);
+    void draw(cairo_t* cr) override;
 
-    void onMotionCancelEvent();
-    bool onMotionNotifyEvent(const PositionInputData& pos);
-    void onButtonReleaseEvent(const PositionInputData& pos);
-    void onButtonPressEvent(const PositionInputData& pos);
-    void onButtonDoublePressEvent(const PositionInputData& pos);
-    bool onKeyEvent(GdkEventKey* event);
+    void onMotionCancelEvent() override;
+    bool onMotionNotifyEvent(const PositionInputData& pos) override;
+    void onButtonReleaseEvent(const PositionInputData& pos) override;
+    void onButtonPressEvent(const PositionInputData& pos) override;
+    void onButtonDoublePressEvent(const PositionInputData& pos) override;
+    bool onKeyEvent(GdkEventKey* event) override;
 
     /**
      * @brief Add a straight line to the stroke (if the movement is valid).

--- a/src/core/control/tools/StrokeStabilizer.h
+++ b/src/core/control/tools/StrokeStabilizer.h
@@ -112,19 +112,19 @@ protected:
 class Active: public Base {
 public:
     Active(bool finalize): finalize(finalize) {}
-    virtual ~Active() = default;
+    ~Active() override = default;
 
     /**
      * @brief Fill the possible gap between the last painted point and the last event received by the stabilizer.
      * It does so by creating a quadraticSplineTo the last event's coordinates
      */
-    virtual void finalizeStroke() override;
+    void finalizeStroke() override;
 
     /**
      * @brief Compute stabilized coordinates for the event and paints the obtained point
      * @param pos The MotionNotify event information
      */
-    virtual void processEvent(const PositionInputData& pos) override {
+    void processEvent(const PositionInputData& pos) override {
         Event ev(pos);
         averageAndPaint(ev, pos.timestamp);
     }
@@ -204,15 +204,15 @@ class Deadzone: virtual public Active {
 public:
     Deadzone(bool finalize, double dzRadius, bool cuspDetection):
             Active(finalize), deadzoneRadius(dzRadius), cuspDetection(cuspDetection) {}
-    virtual ~Deadzone() = default;
+    ~Deadzone() override = default;
 
     /**
      * @brief Compute stabilized coordinates for the event and paints the obtained point
      * @param pos The MotionNotify event information
      */
-    virtual void processEvent(const PositionInputData& pos) override;
+    void processEvent(const PositionInputData& pos) override;
 
-    [[maybe_unused]] virtual auto getInfo() -> std::string override {
+    [[maybe_unused]] auto getInfo() -> std::string override {
         return "Deadzone stabilizer with deadzoneRadius = " + std::to_string(deadzoneRadius) +
                ", cusp detection = " + (cuspDetection ? "on" : "off");
     }
@@ -222,19 +222,19 @@ protected:
      * @brief Upon initialization, record the first event for the stabilizer's benefits.
      * @param pos The first event
      */
-    virtual void recordFirstEvent(const PositionInputData& pos) override;
+    void recordFirstEvent(const PositionInputData& pos) override;
 
     /**
      * @brief Record the event corresponding to last painted point
      * @param ev The event corresponding to last painted point
      */
-    virtual inline void setLastPaintedEvent(const Event& ev) override { lastPaintedEvent = ev; }
+    inline void setLastPaintedEvent(const Event& ev) override { lastPaintedEvent = ev; }
 
     /**
      * @brief Get the last event received by the stabilizer
      * @return The last event
      */
-    virtual inline Event getLastEvent() override { return lastEvent; }
+    inline Event getLastEvent() override { return lastEvent; }
 
 private:
     /**
@@ -270,7 +270,7 @@ private:
     /**
      * @brief Tweak the stroke's pressure values upon finalizing the stroke
      */
-    virtual void rebalanceStrokePressures() override;
+    void rebalanceStrokePressures() override;
 };
 
 /**
@@ -285,15 +285,15 @@ class Inertia: virtual public Active {
 public:
     Inertia(bool finalize, double drag, double mass):
             Active(finalize), mass(mass), oneMinusDrag(1 - drag), speed{0.0, 0.0} {}
-    virtual ~Inertia() = default;
+    ~Inertia() override = default;
 
     /**
      * @brief Compute stabilized coordinates for the event and paints the obtained point
      * @param pos The MotionNotify event information
      */
-    virtual void processEvent(const PositionInputData& pos) override;
+    void processEvent(const PositionInputData& pos) override;
 
-    [[maybe_unused]] virtual auto getInfo() -> std::string override {
+    [[maybe_unused]] auto getInfo() -> std::string override {
         return "Inertia stabilizer with mass = " + std::to_string(mass) +
                ", drag = " + std::to_string(1 - oneMinusDrag);
     }
@@ -303,19 +303,19 @@ protected:
      * @brief Upon initialization, record the first event for the stabilizer's benefits.
      * @param pos The first event
      */
-    virtual void recordFirstEvent(const PositionInputData& pos) override;
+    void recordFirstEvent(const PositionInputData& pos) override;
 
     /**
      * @brief Record the event corresponding to last painted point
      * @param ev The event corresponding to last painted point
      */
-    virtual inline void setLastPaintedEvent(const Event& ev) override { lastPaintedEvent = ev; }
+    inline void setLastPaintedEvent(const Event& ev) override { lastPaintedEvent = ev; }
 
     /**
      * @brief Get the last event received by the stabilizer
      * @return The last event
      */
-    virtual inline Event getLastEvent() override { return lastEvent; }
+    inline Event getLastEvent() override { return lastEvent; }
 
 private:
     /**
@@ -346,7 +346,7 @@ private:
     /**
      * @brief Tweak the stroke's pressure values upon finalizing the stroke
      */
-    virtual void rebalanceStrokePressures() override;
+    void rebalanceStrokePressures() override;
 };
 
 
@@ -360,9 +360,9 @@ private:
 class VelocityGaussian: virtual public Active {
 public:
     VelocityGaussian(bool finalize, double sigma): Active(finalize), twoSigmaSquared(2 * sigma * sigma) {}
-    virtual ~VelocityGaussian() = default;
+    ~VelocityGaussian() override = default;
 
-    [[maybe_unused]] virtual auto getInfo() -> std::string override {
+    [[maybe_unused]] auto getInfo() -> std::string override {
         return "Velocity-based gaussian weight stabilizer with "
                "2σ² = " +
                std::to_string(twoSigmaSquared);
@@ -373,7 +373,7 @@ protected:
      * @brief Upon initialization, record the first event for the stabilizer's benefits.
      * @param pos The first event
      */
-    virtual void recordFirstEvent(const PositionInputData& pos) override;
+    void recordFirstEvent(const PositionInputData& pos) override;
 
     /**
      * @brief Use the buffer to average the input's position and paint the resulting point
@@ -387,7 +387,7 @@ protected:
      * @param ev New event to push to the buffer
      * @param timestamp The timestamp of that event
      */
-    virtual void resetBuffer(Event& ev, guint32 timestamp) override;
+    void resetBuffer(Event& ev, guint32 timestamp) override;
 
     /**
      * @brief Structure containing the event's information relevant to the VelocityGaussian stabilizer
@@ -413,7 +413,7 @@ private:
      * @brief Get the last event received by the stabilizer
      * @return The last event
      */
-    virtual Event getLastEvent() override;
+    Event getLastEvent() override;
 
     /**
      * @brief The Gaussian parameter
@@ -429,9 +429,9 @@ private:
 class Arithmetic: virtual public Active {
 public:
     Arithmetic(bool finalize, size_t buffersize): Active(finalize), bufferLength(buffersize), eventBuffer(buffersize) {}
-    virtual ~Arithmetic() = default;
+    ~Arithmetic() override = default;
 
-    [[maybe_unused]] virtual auto getInfo() -> std::string override {
+    [[maybe_unused]] auto getInfo() -> std::string override {
         return "Arithmetic stabilizer with bufferLength " + std::to_string(bufferLength);
     }
 
@@ -440,7 +440,7 @@ protected:
      * @brief Upon initialization, record the first event for the stabilizer's benefits.
      * @param pos The first event
      */
-    virtual void recordFirstEvent(const PositionInputData& pos) override;
+    void recordFirstEvent(const PositionInputData& pos) override;
 
     /**
      * @brief Use the buffer to average the input's position and paint the resulting point
@@ -454,7 +454,7 @@ protected:
      * @param ev New event to push to the buffer
      * @param timestamp The timestamp of that event
      */
-    virtual void resetBuffer(Event& ev, guint32 timestamp) override;
+    void resetBuffer(Event& ev, guint32 timestamp) override;
 
     /**
      * @brief The maximal length of the buffer
@@ -473,7 +473,7 @@ private:
      * @brief Get the last event received by the stabilizer
      * @return The last event received
      */
-    virtual Event getLastEvent() override;
+    Event getLastEvent() override;
 };
 
 
@@ -485,9 +485,9 @@ class ArithmeticDeadzone: public Arithmetic, public Deadzone {
 public:
     ArithmeticDeadzone(bool finalize, size_t buffersize, double dzRadius, bool cuspDetection):
             Active(finalize), Arithmetic(finalize, buffersize), Deadzone(finalize, dzRadius, cuspDetection) {}
-    virtual ~ArithmeticDeadzone() = default;
+    ~ArithmeticDeadzone() override = default;
 
-    [[maybe_unused]] virtual auto getInfo() -> std::string override {
+    [[maybe_unused]] auto getInfo() -> std::string override {
         return "Hybrid stabilizer:\n   * " + Arithmetic::getInfo() + "\n   * " + Deadzone::getInfo();
     }
 
@@ -496,7 +496,7 @@ private:
      * @brief Upon initialization, record the first event for the stabilizer's benefits.
      * @param pos The first event
      */
-    virtual inline void recordFirstEvent(const PositionInputData& pos) override {
+    inline void recordFirstEvent(const PositionInputData& pos) override {
         Arithmetic::recordFirstEvent(pos);
         Deadzone::recordFirstEvent(pos);
     }
@@ -511,9 +511,9 @@ class ArithmeticInertia: public Arithmetic, public Inertia {
 public:
     ArithmeticInertia(bool finalize, size_t buffersize, double drag, double mass):
             Active(finalize), Arithmetic(finalize, buffersize), Inertia(finalize, drag, mass) {}
-    virtual ~ArithmeticInertia() = default;
+    ~ArithmeticInertia() override = default;
 
-    [[maybe_unused]] virtual auto getInfo() -> std::string override {
+    [[maybe_unused]] auto getInfo() -> std::string override {
         return "Hybrid stabilizer:\n   * " + Arithmetic::getInfo() + "\n   * " + Inertia::getInfo();
     }
 
@@ -522,7 +522,7 @@ private:
      * @brief Upon initialization, record the first event for the stabilizer's benefits.
      * @param pos The first event
      */
-    virtual inline void recordFirstEvent(const PositionInputData& pos) override {
+    inline void recordFirstEvent(const PositionInputData& pos) override {
         Arithmetic::recordFirstEvent(pos);
         Inertia::recordFirstEvent(pos);
     }
@@ -537,9 +537,9 @@ class VelocityGaussianDeadzone: public VelocityGaussian, public Deadzone {
 public:
     VelocityGaussianDeadzone(bool finalize, double sigma, double dzRadius, bool cuspDetection):
             Active(finalize), VelocityGaussian(finalize, sigma), Deadzone(finalize, dzRadius, cuspDetection) {}
-    virtual ~VelocityGaussianDeadzone() = default;
+    ~VelocityGaussianDeadzone() override = default;
 
-    [[maybe_unused]] virtual auto getInfo() -> std::string override {
+    [[maybe_unused]] auto getInfo() -> std::string override {
         return "Hybrid stabilizer:\n   * " + VelocityGaussian::getInfo() + "\n   * " + Deadzone::getInfo();
     }
 
@@ -548,7 +548,7 @@ private:
      * @brief Upon initialization, record the first event for the stabilizer's benefits.
      * @param pos The first event
      */
-    virtual inline void recordFirstEvent(const PositionInputData& pos) override {
+    inline void recordFirstEvent(const PositionInputData& pos) override {
         VelocityGaussian::recordFirstEvent(pos);
         Deadzone::recordFirstEvent(pos);
     }
@@ -563,9 +563,9 @@ class VelocityGaussianInertia: public VelocityGaussian, public Inertia {
 public:
     VelocityGaussianInertia(bool finalize, double sigma, double drag, double mass):
             Active(finalize), VelocityGaussian(finalize, sigma), Inertia(finalize, drag, mass) {}
-    virtual ~VelocityGaussianInertia() = default;
+    ~VelocityGaussianInertia() override = default;
 
-    [[maybe_unused]] virtual auto getInfo() -> std::string override {
+    [[maybe_unused]] auto getInfo() -> std::string override {
         return "Hybrid stabilizer:\n   * " + VelocityGaussian::getInfo() + "\n   * " + Inertia::getInfo();
     }
 
@@ -574,7 +574,7 @@ private:
      * @brief Upon initialization, record the first event for the stabilizer's benefits.
      * @param pos The first event
      */
-    virtual inline void recordFirstEvent(const PositionInputData& pos) override {
+    inline void recordFirstEvent(const PositionInputData& pos) override {
         VelocityGaussian::recordFirstEvent(pos);
         Inertia::recordFirstEvent(pos);
     }

--- a/src/core/control/xml/DoubleArrayAttribute.h
+++ b/src/core/control/xml/DoubleArrayAttribute.h
@@ -20,10 +20,10 @@
 class DoubleArrayAttribute: public XMLAttribute {
 public:
     DoubleArrayAttribute(const char* name, std::vector<double>&& values);
-    virtual ~DoubleArrayAttribute();
+    ~DoubleArrayAttribute() override;
 
 public:
-    virtual void writeOut(OutputStream* out);
+    void writeOut(OutputStream* out) override;
 
 private:
     std::vector<double> values;

--- a/src/core/control/xml/DoubleAttribute.h
+++ b/src/core/control/xml/DoubleAttribute.h
@@ -20,10 +20,10 @@
 class DoubleAttribute: public XMLAttribute {
 public:
     DoubleAttribute(const char* name, double value);
-    virtual ~DoubleAttribute();
+    ~DoubleAttribute() override;
 
 public:
-    virtual void writeOut(OutputStream* out);
+    void writeOut(OutputStream* out) override;
 
 private:
     double value;

--- a/src/core/control/xml/IntAttribute.h
+++ b/src/core/control/xml/IntAttribute.h
@@ -16,10 +16,10 @@
 class IntAttribute: public XMLAttribute {
 public:
     IntAttribute(const char* name, int value);
-    virtual ~IntAttribute();
+    ~IntAttribute() override;
 
 public:
-    virtual void writeOut(OutputStream* out);
+    void writeOut(OutputStream* out) override;
 
 private:
     int value;

--- a/src/core/control/xml/SizeTAttribute.h
+++ b/src/core/control/xml/SizeTAttribute.h
@@ -16,10 +16,10 @@
 class SizeTAttribute: public XMLAttribute {
 public:
     SizeTAttribute(const char* name, size_t value);
-    virtual ~SizeTAttribute();
+    ~SizeTAttribute() override;
 
 public:
-    virtual void writeOut(OutputStream* out);
+    void writeOut(OutputStream* out) override;
 
 private:
     size_t value;

--- a/src/core/control/xml/TextAttribute.h
+++ b/src/core/control/xml/TextAttribute.h
@@ -16,10 +16,10 @@
 class TextAttribute: public XMLAttribute {
 public:
     TextAttribute(std::string name, std::string value);
-    virtual ~TextAttribute();
+    ~TextAttribute() override;
 
 public:
-    virtual void writeOut(OutputStream* out);
+    void writeOut(OutputStream* out) override;
 
 private:
     std::string value;

--- a/src/core/control/xml/XmlImageNode.h
+++ b/src/core/control/xml/XmlImageNode.h
@@ -23,7 +23,7 @@ public:
 
     static cairo_status_t pngWriteFunction(XmlImageNode* image, const unsigned char* data, unsigned int length);
 
-    virtual void writeOut(OutputStream* out);
+    void writeOut(OutputStream* out) override;
 
 private:
     cairo_surface_t* img;

--- a/src/core/control/xml/XmlStrokeNode.h
+++ b/src/core/control/xml/XmlStrokeNode.h
@@ -23,7 +23,7 @@ public:
 public:
     void setWidth(double width, const double* widths, int widthsLength);
 
-    virtual void writeOut(OutputStream* out);
+    void writeOut(OutputStream* out) override;
 
 private:
     Point* points;

--- a/src/core/control/xml/XmlTexNode.h
+++ b/src/core/control/xml/XmlTexNode.h
@@ -19,7 +19,7 @@ public:
     virtual ~XmlTexNode();
 
 public:
-    virtual void writeOut(OutputStream* out);
+    void writeOut(OutputStream* out) override;
 
 private:
     /**

--- a/src/core/control/zoom/ZoomControl.h
+++ b/src/core/control/zoom/ZoomControl.h
@@ -35,7 +35,7 @@ class DocumentListener;
 class ZoomControl: public DocumentListener {
 public:
     ZoomControl() = default;
-    virtual ~ZoomControl() = default;
+    ~ZoomControl() override = default;
 
     /**
      * Zoom one step
@@ -166,8 +166,8 @@ protected:
     void fireZoomChanged();
     void fireZoomRangeValueChanged();
 
-    void pageSizeChanged(size_t page);
-    void pageSelected(size_t page);
+    void pageSizeChanged(size_t page) override;
+    void pageSelected(size_t page) override;
 
 private:
     void zoomFit();

--- a/src/core/gui/MainWindow.h
+++ b/src/core/gui/MainWindow.h
@@ -35,16 +35,16 @@ class PdfFloatingToolbox;
 class MainWindow: public GladeGui, public LayerCtrlListener {
 public:
     MainWindow(GladeSearchpath* gladeSearchPath, Control* control);
-    virtual ~MainWindow();
+    ~MainWindow() override;
 
     // LayerCtrlListener
 public:
-    virtual void rebuildLayerMenu();
-    virtual void layerVisibilityChanged();
+    void rebuildLayerMenu() override;
+    void layerVisibilityChanged() override;
 
     FloatingToolbox* floatingToolbox;
 public:
-    virtual void show(GtkWindow* parent);
+    void show(GtkWindow* parent) override;
 
     void setRecentMenu(GtkWidget* submenu);
     void toolbarSelected(ToolbarData* d);

--- a/src/core/gui/PageView.h
+++ b/src/core/gui/PageView.h
@@ -41,16 +41,16 @@ class XournalView;
 class XojPageView: public Redrawable, public PageListener {
 public:
     XojPageView(XournalView* xournal, const PageRef& page);
-    virtual ~XojPageView();
+    ~XojPageView() override;
 
 public:
     void updatePageSize(double width, double height);
 
-    virtual void rerenderPage();
-    virtual void rerenderRect(double x, double y, double width, double height);
+    void rerenderPage() override;
+    void rerenderRect(double x, double y, double width, double height) override;
 
-    virtual void repaintPage();
-    virtual void repaintArea(double x1, double y1, double x2, double y2);
+    void repaintPage() override;
+    void repaintArea(double x1, double y1, double x2, double y2) override;
 
     void setSelected(bool selected);
 
@@ -71,7 +71,7 @@ public:
 
     bool actionDelete();
 
-    void deleteViewBuffer();
+    void deleteViewBuffer() override;
 
     /**
      * Returns whether this PageView contains the
@@ -135,13 +135,13 @@ public:
      * Returns the x coordinate of this XojPageView with
      * respect to the display
      */
-    int getX() const;
+    int getX() const override;
 
     /**
      * Returns the y coordinate of this XojPageView with
      * respect to the display
      */
-    int getY() const;
+    int getY() const override;
 
     TexImage* getSelectedTex();
     Text* getSelectedText();
@@ -174,10 +174,10 @@ public:  // event handler
     void paintPageSync(cairo_t* cr, GdkRectangle* rect);
 
 public:  // listener
-    void rectChanged(xoj::util::Rectangle<double>& rect);
-    void rangeChanged(Range& range);
-    void pageChanged();
-    void elementChanged(Element* elem);
+    void rectChanged(xoj::util::Rectangle<double>& rect) override;
+    void rangeChanged(Range& range) override;
+    void pageChanged() override;
+    void elementChanged(Element* elem) override;
 
 private:
     void handleScrollEvent(GdkEventButton* event);

--- a/src/core/gui/XournalView.h
+++ b/src/core/gui/XournalView.h
@@ -34,7 +34,7 @@ class HandRecognition;
 class XournalView: public DocumentListener, public ZoomListener {
 public:
     XournalView(GtkWidget* parent, Control* control, ScrollHandling* scrollHandling);
-    virtual ~XournalView();
+    ~XournalView() override;
 
 public:
     bool paint(GtkWidget* widget, GdkEventExpose* event);
@@ -118,16 +118,16 @@ public:
 
 public:
     // ZoomListener interface
-    void zoomChanged();
+    void zoomChanged() override;
 
 public:
     // DocumentListener interface
-    void pageSelected(size_t page);
-    void pageSizeChanged(size_t page);
-    void pageChanged(size_t page);
-    void pageInserted(size_t page);
-    void pageDeleted(size_t page);
-    void documentChanged(DocumentChangeType type);
+    void pageSelected(size_t page) override;
+    void pageSizeChanged(size_t page) override;
+    void pageChanged(size_t page) override;
+    void pageInserted(size_t page) override;
+    void pageDeleted(size_t page) override;
+    void documentChanged(DocumentChangeType type) override;
 
 public:
     bool onKeyPressEvent(GdkEventKey* event);

--- a/src/core/gui/dialog/DeviceClassConfigGui.h
+++ b/src/core/gui/dialog/DeviceClassConfigGui.h
@@ -23,14 +23,14 @@ class SettingsDialog;
 class DeviceClassConfigGui: public GladeGui {
 public:
     DeviceClassConfigGui(GladeSearchpath* gladeSearchPath, GtkWidget* w, Settings* settings, const InputDevice& device);
-    virtual ~DeviceClassConfigGui();
+    ~DeviceClassConfigGui() override;
 
 public:
     void loadSettings();
     void saveSettings();
 
     // Not implemented! This is not a dialog!
-    virtual void show(GtkWindow* parent);
+    void show(GtkWindow* parent) override;
 
 private:
     static void cbSelectCallback(GtkComboBox* widget, DeviceClassConfigGui* gui);

--- a/src/core/gui/dialog/FillOpacityDialog.h
+++ b/src/core/gui/dialog/FillOpacityDialog.h
@@ -16,10 +16,10 @@
 class FillOpacityDialog: public GladeGui {
 public:
     FillOpacityDialog(GladeSearchpath* gladeSearchPath, int alpha, bool pen);
-    virtual ~FillOpacityDialog();
+    ~FillOpacityDialog() override;
 
 public:
-    virtual void show(GtkWindow* parent);
+    void show(GtkWindow* parent) override;
 
     int getResultAlpha() const;
 

--- a/src/core/gui/dialog/GotoDialog.h
+++ b/src/core/gui/dialog/GotoDialog.h
@@ -16,10 +16,10 @@
 class GotoDialog: public GladeGui {
 public:
     GotoDialog(GladeSearchpath* gladeSearchPath, int maxPage);
-    virtual ~GotoDialog();
+    ~GotoDialog() override;
 
 public:
-    virtual void show(GtkWindow* parent);
+    void show(GtkWindow* parent) override;
 
     // returns the selected page or -1 if closed
     int getSelectedPage() const;

--- a/src/core/gui/dialog/LatexDialog.h
+++ b/src/core/gui/dialog/LatexDialog.h
@@ -22,13 +22,13 @@ public:
     LatexDialog(const LatexDialog& other) = delete;
     LatexDialog& operator=(const LatexDialog& other) = delete;
     LatexDialog(GladeSearchpath* gladeSearchPath);
-    virtual ~LatexDialog();
+    ~LatexDialog() override;
 
 public:
     /**
      * Show the dialog.
      */
-    virtual void show(GtkWindow* parent);
+    void show(GtkWindow* parent) override;
 
     /**
      * Show the dialog, optionally selecting the text field contents by default.

--- a/src/core/gui/dialog/LatexSettingsPanel.h
+++ b/src/core/gui/dialog/LatexSettingsPanel.h
@@ -23,7 +23,7 @@ public:
     LatexSettingsPanel& operator=(const LatexSettingsPanel&) = delete;
     LatexSettingsPanel(const LatexSettingsPanel&&) = delete;
     LatexSettingsPanel& operator=(const LatexSettingsPanel&&) = delete;
-    virtual ~LatexSettingsPanel();
+    ~LatexSettingsPanel() override;
 
     void show(GtkWindow* parent) override;
 

--- a/src/core/gui/dialog/PageTemplateDialog.h
+++ b/src/core/gui/dialog/PageTemplateDialog.h
@@ -28,17 +28,17 @@ public:
     PageTemplateDialog(PageTemplateDialog&&) = delete;
     PageTemplateDialog& operator=(PageTemplateDialog&) = delete;
     PageTemplateDialog&& operator=(PageTemplateDialog&&) = delete;
-    virtual ~PageTemplateDialog();
+    ~PageTemplateDialog() override;
 
 public:
-    virtual void show(GtkWindow* parent);
+    void show(GtkWindow* parent) override;
 
     /**
      * The dialog was confirmed / saved
      */
     bool isSaved() const;
 
-    void changeCurrentPageBackground(PageTypeInfo* info);
+    void changeCurrentPageBackground(PageTypeInfo* info) override;
 
 private:
     void showPageSizeDialog();

--- a/src/core/gui/dialog/ToolbarManageDialog.h
+++ b/src/core/gui/dialog/ToolbarManageDialog.h
@@ -19,10 +19,10 @@ class ToolbarModel;
 class ToolbarManageDialog: public GladeGui {
 public:
     ToolbarManageDialog(GladeSearchpath* gladeSearchPath, ToolbarModel* model);
-    virtual ~ToolbarManageDialog();
+    ~ToolbarManageDialog() override;
 
 public:
-    virtual void show(GtkWindow* parent);
+    void show(GtkWindow* parent) override;
 
 private:
     static void treeSelectionChangedCallback(GtkTreeSelection* selection, ToolbarManageDialog* dlg);

--- a/src/core/gui/dialog/backgroundSelect/BackgroundSelectDialogBase.h
+++ b/src/core/gui/dialog/backgroundSelect/BackgroundSelectDialogBase.h
@@ -25,11 +25,11 @@ class BackgroundSelectDialogBase: public GladeGui {
 public:
     BackgroundSelectDialogBase(GladeSearchpath* gladeSearchPath, Document* doc, Settings* settings,
                                const std::string& glade, const std::string& mainWnd);
-    ~BackgroundSelectDialogBase();
+    ~BackgroundSelectDialogBase() override;
 
 public:
     Settings* getSettings();
-    virtual void show(GtkWindow* parent);
+    void show(GtkWindow* parent) override;
     virtual void setSelected(int selected);
 
 protected:

--- a/src/core/gui/dialog/backgroundSelect/ImageElementView.h
+++ b/src/core/gui/dialog/backgroundSelect/ImageElementView.h
@@ -22,28 +22,28 @@
 class ImageElementView: public BaseElementView {
 public:
     ImageElementView(int id, BackgroundSelectDialogBase* dlg);
-    ~ImageElementView();
+    ~ImageElementView() override;
 
 protected:
     /**
      * Paint the contents (without border / selection)
      */
-    virtual void paintContents(cairo_t* cr);
+    void paintContents(cairo_t* cr) override;
 
     /**
      * Get the width in pixel, without shadow / border
      */
-    virtual int getContentWidth();
+    int getContentWidth() override;
 
     /**
      * Get the height in pixel, without shadow / border
      */
-    virtual int getContentHeight();
+    int getContentHeight() override;
 
     /**
      * Will be called before getContentWidth() / getContentHeight(), can be overwritten
      */
-    virtual void calcSize();
+    void calcSize() override;
 
 private:
     double zoom = 1;

--- a/src/core/gui/dialog/backgroundSelect/ImagesDialog.h
+++ b/src/core/gui/dialog/backgroundSelect/ImagesDialog.h
@@ -24,12 +24,12 @@ class BackgroundImage;
 class ImagesDialog: public BackgroundSelectDialogBase {
 public:
     ImagesDialog(GladeSearchpath* gladeSearchPath, Document* doc, Settings* settings);
-    virtual ~ImagesDialog();
+    ~ImagesDialog() override;
 
 public:
     BackgroundImage getSelectedImage();
     bool shouldShowFilechooser();
-    virtual void show(GtkWindow* parent);
+    void show(GtkWindow* parent) override;
 
 private:
     /**

--- a/src/core/gui/dialog/backgroundSelect/PdfElementView.h
+++ b/src/core/gui/dialog/backgroundSelect/PdfElementView.h
@@ -24,23 +24,23 @@ class PdfPagesDialog;
 class PdfElementView: public BaseElementView {
 public:
     PdfElementView(int id, XojPdfPageSPtr page, PdfPagesDialog* dlg);
-    ~PdfElementView();
+    ~PdfElementView() override;
 
 protected:
     /**
      * Paint the contents (without border / selection)
      */
-    virtual void paintContents(cairo_t* cr);
+    void paintContents(cairo_t* cr) override;
 
     /**
      * Get the width in pixel, without shadow / border
      */
-    virtual int getContentWidth();
+    int getContentWidth() override;
 
     /**
      * Get the height in pixel, without shadow / border
      */
-    virtual int getContentHeight();
+    int getContentHeight() override;
 
 public:
     bool isUsed() const;

--- a/src/core/gui/dialog/backgroundSelect/PdfPagesDialog.h
+++ b/src/core/gui/dialog/backgroundSelect/PdfPagesDialog.h
@@ -21,10 +21,10 @@
 class PdfPagesDialog: public BackgroundSelectDialogBase {
 public:
     PdfPagesDialog(GladeSearchpath* gladeSearchPath, Document* doc, Settings* settings);
-    virtual ~PdfPagesDialog();
+    ~PdfPagesDialog() override;
 
 public:
-    virtual void show(GtkWindow* parent);
+    void show(GtkWindow* parent) override;
     void updateOkButton();
     static double getZoom();
     int getSelectedPage();

--- a/src/core/gui/dialog/toolbarCustomize/ToolbarCustomizeDialog.h
+++ b/src/core/gui/dialog/toolbarCustomize/ToolbarCustomizeDialog.h
@@ -30,10 +30,10 @@ struct _ColorToolItemDragData;
 class ToolbarCustomizeDialog: public GladeGui {
 public:
     ToolbarCustomizeDialog(GladeSearchpath* gladeSearchPath, MainWindow* win, ToolbarDragDropHandler* handler);
-    virtual ~ToolbarCustomizeDialog();
+    ~ToolbarCustomizeDialog() override;
 
 public:
-    virtual void show(GtkWindow* parent);
+    void show(GtkWindow* parent) override;
 
     void rebuildIconview();
     void rebuildColorIcons();

--- a/src/core/gui/inputdevices/StylusInputHandler.h
+++ b/src/core/gui/inputdevices/StylusInputHandler.h
@@ -22,7 +22,7 @@ class InputContext;
 class StylusInputHandler: public PenInputHandler {
 public:
     explicit StylusInputHandler(InputContext* inputContext);
-    ~StylusInputHandler();
+    ~StylusInputHandler() override;
 
     bool handleImpl(InputEvent const& event) override;
 

--- a/src/core/gui/inputdevices/touchdisable/TouchDisableCustom.h
+++ b/src/core/gui/inputdevices/touchdisable/TouchDisableCustom.h
@@ -20,11 +20,11 @@
 class TouchDisableCustom: public TouchDisableInterface {
 public:
     TouchDisableCustom(std::string enableCommand, std::string disableCommand);
-    virtual ~TouchDisableCustom();
+    ~TouchDisableCustom() override;
 
 public:
-    virtual void enableTouch();
-    virtual void disableTouch();
+    void enableTouch() override;
+    void disableTouch() override;
 
 private:
     std::string enableCommand;

--- a/src/core/gui/sidebar/AbstractSidebarPage.h
+++ b/src/core/gui/sidebar/AbstractSidebarPage.h
@@ -27,7 +27,7 @@ class SidebarToolbar;
 class AbstractSidebarPage: public DocumentListener, public SidebarToolbarActionListener {
 public:
     AbstractSidebarPage(Control* control, SidebarToolbar* toolbar);
-    virtual ~AbstractSidebarPage();
+    ~AbstractSidebarPage() override;
 
 public:
     virtual void enableSidebar() = 0;

--- a/src/core/gui/sidebar/Sidebar.h
+++ b/src/core/gui/sidebar/Sidebar.h
@@ -27,7 +27,7 @@ class SidebarPageButton;
 class Sidebar: public DocumentListener, public SidebarToolbarActionListener {
 public:
     Sidebar(GladeGui* gui, Control* control);
-    virtual ~Sidebar();
+    ~Sidebar() override;
 
 private:
     void initPages(GtkWidget* sidebarContents, GladeGui* gui);
@@ -38,7 +38,7 @@ public:
     /**
      * Called when an action is performed
      */
-    virtual void actionPerformed(SidebarActions action);
+    void actionPerformed(SidebarActions action) override;
 
 public:
     /**
@@ -75,7 +75,7 @@ public:
 
 public:
     // DocumentListener interface
-    virtual void documentChanged(DocumentChangeType type);
+    void documentChanged(DocumentChangeType type) override;
 
 private:
     /**

--- a/src/core/gui/sidebar/indextree/SidebarIndexPage.h
+++ b/src/core/gui/sidebar/indextree/SidebarIndexPage.h
@@ -25,36 +25,36 @@ class Control;
 class SidebarIndexPage: public AbstractSidebarPage {
 public:
     SidebarIndexPage(Control* control, SidebarToolbar* toolbar);
-    virtual ~SidebarIndexPage();
+    ~SidebarIndexPage() override;
 
 public:
-    virtual void enableSidebar();
-    virtual void disableSidebar();
+    void enableSidebar() override;
+    void disableSidebar() override;
 
     /**
      * @overwrite
      */
-    virtual std::string getName();
+    std::string getName() override;
 
     /**
      * @overwrite
      */
-    virtual std::string getIconName();
+    std::string getIconName() override;
 
     /**
      * @overwrite
      */
-    virtual bool hasData();
+    bool hasData() override;
 
     /**
      * @overwrite
      */
-    virtual GtkWidget* getWidget();
+    GtkWidget* getWidget() override;
 
     /**
      * @overwrite
      */
-    virtual void selectPageNr(size_t page, size_t pdfPage);
+    void selectPageNr(size_t page, size_t pdfPage) override;
 
     /**
      * Select page in the tree
@@ -64,7 +64,7 @@ public:
     /**
      * @overwrite
      */
-    virtual void documentChanged(DocumentChangeType type);
+    void documentChanged(DocumentChangeType type) override;
 
 private:
     /**

--- a/src/core/gui/sidebar/previews/base/SidebarPreviewBase.h
+++ b/src/core/gui/sidebar/previews/base/SidebarPreviewBase.h
@@ -28,11 +28,11 @@ class SidebarToolbar;
 class SidebarPreviewBase: public AbstractSidebarPage {
 public:
     SidebarPreviewBase(Control* control, GladeGui* gui, SidebarToolbar* toolbar);
-    virtual ~SidebarPreviewBase();
+    ~SidebarPreviewBase() override;
 
 public:
-    virtual void enableSidebar();
-    virtual void disableSidebar();
+    void enableSidebar() override;
+    void disableSidebar() override;
 
     /**
      * Layout the pages to the current size of the sidebar
@@ -47,12 +47,12 @@ public:
     /**
      * @overwrite
      */
-    virtual bool hasData();
+    bool hasData() override;
 
     /**
      * @overwrite
      */
-    virtual GtkWidget* getWidget();
+    GtkWidget* getWidget() override;
 
     /**
      * Gets the zoom factor for the previews
@@ -66,9 +66,9 @@ public:
 
 public:
     // DocumentListener interface (only the part handled by SidebarPreviewBase)
-    virtual void documentChanged(DocumentChangeType type);
-    virtual void pageInserted(size_t page);
-    virtual void pageDeleted(size_t page);
+    void documentChanged(DocumentChangeType type) override;
+    void pageInserted(size_t page) override;
+    void pageDeleted(size_t page) override;
 
 protected:
     /**

--- a/src/core/gui/sidebar/previews/layer/SidebarPreviewLayerEntry.h
+++ b/src/core/gui/sidebar/previews/layer/SidebarPreviewLayerEntry.h
@@ -20,23 +20,23 @@ class SidebarPreviewLayerEntry: public SidebarPreviewBaseEntry {
 public:
     SidebarPreviewLayerEntry(SidebarPreviewBase* sidebar, const PageRef& page, int layer, const std::string& layerName,
                              size_t index, bool stacked);
-    virtual ~SidebarPreviewLayerEntry();
+    ~SidebarPreviewLayerEntry() override;
 
 public:
-    virtual int getHeight();
+    int getHeight() override;
 
     /**
      * @return What should be rendered
      * @override
      */
-    virtual PreviewRenderType getRenderType();
+    PreviewRenderType getRenderType() override;
 
     /**
      * @return The layer to be rendered
      */
     int getLayer() const;
 
-    virtual GtkWidget* getWidget();
+    GtkWidget* getWidget() override;
 
     /**
      * Set the value of the visible checkbox
@@ -44,7 +44,7 @@ public:
     void setVisibleCheckbox(bool enabled);
 
 protected:
-    virtual void mouseButtonPressCallback();
+    void mouseButtonPressCallback() override;
     void checkboxToggled();
 
 private:

--- a/src/core/gui/sidebar/previews/layer/SidebarPreviewLayers.h
+++ b/src/core/gui/sidebar/previews/layer/SidebarPreviewLayers.h
@@ -22,35 +22,35 @@
 class SidebarPreviewLayers: public SidebarPreviewBase, public LayerCtrlListener {
 public:
     SidebarPreviewLayers(Control* control, GladeGui* gui, SidebarToolbar* toolbar, bool stacked);
-    virtual ~SidebarPreviewLayers();
+    ~SidebarPreviewLayers() override;
 
 public:
-    virtual void rebuildLayerMenu();
-    virtual void layerVisibilityChanged();
+    void rebuildLayerMenu() override;
+    void layerVisibilityChanged() override;
 
 public:
     /**
      * Called when an action is performed
      */
-    void actionPerformed(SidebarActions action);
+    void actionPerformed(SidebarActions action) override;
 
-    void enableSidebar();
-
-    /**
-     * @overwrite
-     */
-    virtual std::string getName();
+    void enableSidebar() override;
 
     /**
      * @overwrite
      */
-    virtual std::string getIconName();
+    std::string getName() override;
+
+    /**
+     * @overwrite
+     */
+    std::string getIconName() override;
 
     /**
      * Update the preview images
      * @overwrite
      */
-    virtual void updatePreviews();
+    void updatePreviews() override;
 
     /**
      * Select a layer
@@ -67,8 +67,8 @@ protected:
 
 public:
     // DocumentListener interface (only the part which is not handled by SidebarPreviewBase)
-    virtual void pageSizeChanged(size_t page);
-    virtual void pageChanged(size_t page);
+    void pageSizeChanged(size_t page) override;
+    void pageChanged(size_t page) override;
 
 private:
     /**

--- a/src/core/gui/sidebar/previews/page/SidebarPreviewPageEntry.h
+++ b/src/core/gui/sidebar/previews/page/SidebarPreviewPageEntry.h
@@ -22,18 +22,18 @@ class SidebarPreviewPages;
 class SidebarPreviewPageEntry: public SidebarPreviewBaseEntry {
 public:
     SidebarPreviewPageEntry(SidebarPreviewPages* sidebar, const PageRef& page);
-    virtual ~SidebarPreviewPageEntry();
+    ~SidebarPreviewPageEntry() override;
 
 public:
     /**
      * @return What should be rendered
      * @override
      */
-    virtual PreviewRenderType getRenderType();
+    PreviewRenderType getRenderType() override;
 
 protected:
     SidebarPreviewPages* sidebar;
-    virtual void mouseButtonPressCallback();
+    void mouseButtonPressCallback() override;
 
 private:
     friend class PreviewJob;

--- a/src/core/gui/sidebar/previews/page/SidebarPreviewPages.h
+++ b/src/core/gui/sidebar/previews/page/SidebarPreviewPages.h
@@ -23,31 +23,31 @@
 class SidebarPreviewPages: public SidebarPreviewBase {
 public:
     SidebarPreviewPages(Control* control, GladeGui* gui, SidebarToolbar* toolbar);
-    virtual ~SidebarPreviewPages();
+    ~SidebarPreviewPages() override;
 
 public:
     /**
      * Called when an action is performed
      */
-    void actionPerformed(SidebarActions action);
+    void actionPerformed(SidebarActions action) override;
 
-    void enableSidebar();
-
-    /**
-     * @overwrite
-     */
-    virtual std::string getName();
+    void enableSidebar() override;
 
     /**
      * @overwrite
      */
-    virtual std::string getIconName();
+    std::string getName() override;
+
+    /**
+     * @overwrite
+     */
+    std::string getIconName() override;
 
     /**
      * Update the preview images
      * @overwrite
      */
-    virtual void updatePreviews();
+    void updatePreviews() override;
 
     /**
      * Opens the page preview context menu, at the current cursor position, for
@@ -57,11 +57,11 @@ public:
 
 public:
     // DocumentListener interface (only the part which is not handled by SidebarPreviewBase)
-    virtual void pageSizeChanged(size_t page);
-    virtual void pageChanged(size_t page);
-    virtual void pageSelected(size_t page);
-    virtual void pageInserted(size_t page);
-    virtual void pageDeleted(size_t page);
+    void pageSizeChanged(size_t page) override;
+    void pageChanged(size_t page) override;
+    void pageSelected(size_t page) override;
+    void pageInserted(size_t page) override;
+    void pageDeleted(size_t page) override;
 
 private:
     /**

--- a/src/core/gui/toolbarMenubar/AbstractItem.h
+++ b/src/core/gui/toolbarMenubar/AbstractItem.h
@@ -22,17 +22,17 @@
 class AbstractItem: public ActionEnabledListener, public ActionSelectionListener {
 public:
     AbstractItem(std::string id, ActionHandler* handler, ActionType action, GtkWidget* menuitem = nullptr);
-    virtual ~AbstractItem();
+    ~AbstractItem() override;
 
 public:
-    virtual void actionSelected(ActionGroup group, ActionType action);
+    void actionSelected(ActionGroup group, ActionType action) override;
 
     /**
      * Override this method
      */
     virtual void selected(ActionGroup group, ActionType action);
 
-    virtual void actionEnabledAction(ActionType action, bool enabled);
+    void actionEnabledAction(ActionType action, bool enabled) override;
     virtual void activated(GdkEvent* event, GtkMenuItem* menuitem, GtkToolButton* toolbutton);
 
     virtual std::string getId() const;

--- a/src/core/gui/toolbarMenubar/AbstractSliderItem.h
+++ b/src/core/gui/toolbarMenubar/AbstractSliderItem.h
@@ -39,10 +39,10 @@ public:
      * @param range The minimum/maximum/step in internal units. {@see #scaleFunc}.
      */
     AbstractSliderItem(std::string id, ActionHandler* handler, ActionType type, SliderRange range);
-    virtual ~AbstractSliderItem();
+    ~AbstractSliderItem() override;
 
-    virtual GtkToolItem* createItem(bool horizontal) override;
-    virtual GtkToolItem* createTmpItem(bool horizontal) override;
+    GtkToolItem* createItem(bool horizontal) override;
+    GtkToolItem* createTmpItem(bool horizontal) override;
 
 protected:
     GtkToolItem* newItem() override;
@@ -90,7 +90,7 @@ protected:
     /**
      * @param enabled `true` iff the slider should respond to user input.
      */
-    virtual void enable(bool enabled) override;
+    void enable(bool enabled) override;
 
     /**
      * @param x Actual value of the slider.

--- a/src/core/gui/toolbarMenubar/AbstractToolItem.h
+++ b/src/core/gui/toolbarMenubar/AbstractToolItem.h
@@ -16,10 +16,10 @@
 class AbstractToolItem: public AbstractItem {
 public:
     AbstractToolItem(std::string id, ActionHandler* handler, ActionType type, GtkWidget* menuitem = nullptr);
-    virtual ~AbstractToolItem();
+    ~AbstractToolItem() override;
 
 public:
-    virtual void selected(ActionGroup group, ActionType action);
+    void selected(ActionGroup group, ActionType action) override;
     virtual GtkToolItem* createItem(bool horizontal);
     virtual GtkToolItem* createTmpItem(bool horizontal);
     void setPopupMenu(GtkWidget* popupMenu);
@@ -50,7 +50,7 @@ public:
     /**
      * Enable / Disable the tool item
      */
-    virtual void enable(bool enabled);
+    void enable(bool enabled) override;
 
 protected:
     virtual GtkToolItem* newItem() = 0;

--- a/src/core/gui/toolbarMenubar/ColorToolItem.h
+++ b/src/core/gui/toolbarMenubar/ColorToolItem.h
@@ -25,16 +25,16 @@ class ColorToolItem: public AbstractToolItem {
 public:
     ColorToolItem(ActionHandler* handler, ToolHandler* toolHandler, GtkWindow* parent, NamedColor namedColor,
                   bool selektor = false);
-    virtual ~ColorToolItem();
+    ~ColorToolItem() override;
 
 public:
-    virtual void actionSelected(ActionGroup group, ActionType action);
+    void actionSelected(ActionGroup group, ActionType action) override;
     void enableColor(Color color);
-    virtual void activated(GdkEvent* event, GtkMenuItem* menuitem, GtkToolButton* toolbutton);
+    void activated(GdkEvent* event, GtkMenuItem* menuitem, GtkToolButton* toolbutton) override;
 
-    virtual std::string getToolDisplayName() const;
-    virtual GtkWidget* getNewToolIcon() const;
-    virtual GdkPixbuf* getNewToolPixbuf() const;
+    std::string getToolDisplayName() const override;
+    GtkWidget* getNewToolIcon() const override;
+    GdkPixbuf* getNewToolPixbuf() const override;
 
     std::string getId() const final;
 
@@ -43,10 +43,10 @@ public:
     /**
      * Enable / Disable the tool item
      */
-    virtual void enable(bool enabled);
+    void enable(bool enabled) override;
 
 protected:
-    virtual GtkToolItem* newItem();
+    GtkToolItem* newItem() override;
     bool isSelector() const;
 
     /**

--- a/src/core/gui/toolbarMenubar/FontButton.h
+++ b/src/core/gui/toolbarMenubar/FontButton.h
@@ -24,25 +24,25 @@ class FontButton: public AbstractToolItem {
 public:
     FontButton(ActionHandler* handler, GladeGui* gui, std::string id, ActionType type, std::string description,
                GtkWidget* menuitem = nullptr);
-    virtual ~FontButton();
+    ~FontButton() override;
 
 public:
-    virtual void activated(GdkEvent* event, GtkMenuItem* menuitem, GtkToolButton* toolbutton);
+    void activated(GdkEvent* event, GtkMenuItem* menuitem, GtkToolButton* toolbutton) override;
     void setFont(XojFont& font);
     XojFont getFont() const;
-    virtual std::string getToolDisplayName() const;
+    std::string getToolDisplayName() const override;
     void showFontDialog();
 
 protected:
-    virtual GtkToolItem* createItem(bool horizontal);
-    virtual GtkToolItem* createTmpItem(bool horizontal);
-    virtual GtkToolItem* newItem();
+    GtkToolItem* createItem(bool horizontal) override;
+    GtkToolItem* createTmpItem(bool horizontal) override;
+    GtkToolItem* newItem() override;
 
     static GtkWidget* newFontButton();
     static void setFontFontButton(GtkWidget* fontButton, XojFont& font);
 
-    virtual GtkWidget* getNewToolIcon() const;
-    virtual GdkPixbuf* getNewToolPixbuf() const;
+    GtkWidget* getNewToolIcon() const override;
+    GdkPixbuf* getNewToolPixbuf() const override;
 
 private:
     GtkWidget* fontButton = nullptr;

--- a/src/core/gui/toolbarMenubar/MenuItem.h
+++ b/src/core/gui/toolbarMenubar/MenuItem.h
@@ -19,7 +19,7 @@
 class MenuItem: public AbstractItem {
 public:
     MenuItem(ActionHandler* handler, GtkWidget* widget, ActionType type, ActionGroup group = GROUP_NOGROUP);
-    virtual ~MenuItem();
+    ~MenuItem() override;
 
 private:
 };

--- a/src/core/gui/toolbarMenubar/ToolButton.h
+++ b/src/core/gui/toolbarMenubar/ToolButton.h
@@ -22,7 +22,7 @@ public:
     ToolButton(ActionHandler* handler, std::string id, ActionType type, ActionGroup group, bool toolToggleOnlyEnable,
                std::string iconName, std::string description, GtkWidget* menuitem = nullptr);
 
-    virtual ~ToolButton();
+    ~ToolButton() override;
 
 public:
     /**
@@ -35,14 +35,14 @@ public:
     GtkWidget* registerPopupMenuEntry(const std::string& name, const std::string& iconName = "");
 
     void updateDescription(const std::string& description);
-    virtual std::string getToolDisplayName() const;
+    std::string getToolDisplayName() const override;
     void setActive(bool active);
 
 protected:
-    virtual GtkToolItem* newItem();
+    GtkToolItem* newItem() override;
 
-    virtual GtkWidget* getNewToolIcon() const;
-    virtual GdkPixbuf* getNewToolPixbuf() const;
+    GtkWidget* getNewToolIcon() const override;
+    GdkPixbuf* getNewToolPixbuf() const override;
 
 private:
     std::string iconName;

--- a/src/core/gui/toolbarMenubar/ToolDrawCombocontrol.h
+++ b/src/core/gui/toolbarMenubar/ToolDrawCombocontrol.h
@@ -25,13 +25,13 @@ class ToolDrawType;
 class ToolDrawCombocontrol: public ToolButton {
 public:
     ToolDrawCombocontrol(ToolMenuHandler* toolMenuHandler, ActionHandler* handler, std::string id);
-    virtual ~ToolDrawCombocontrol();
+    ~ToolDrawCombocontrol() override;
 
 public:
-    virtual void selected(ActionGroup group, ActionType action);
+    void selected(ActionGroup group, ActionType action) override;
 
 protected:
-    virtual GtkToolItem* newItem();
+    GtkToolItem* newItem() override;
     void createMenuItem(const std::string& name, const std::string& icon, ActionType type);
 
 private:

--- a/src/core/gui/toolbarMenubar/ToolPageLayer.h
+++ b/src/core/gui/toolbarMenubar/ToolPageLayer.h
@@ -26,15 +26,15 @@ class ToolPageLayer: public AbstractToolItem, public LayerCtrlListener {
 public:
     ToolPageLayer(LayerController* lc, GladeGui* gui, ActionHandler* handler, std::string id, ActionType type,
                   IconNameHelper iconNameHelper);
-    virtual ~ToolPageLayer();
+    ~ToolPageLayer() override;
 
 public:
-    virtual std::string getToolDisplayName() const;
+    std::string getToolDisplayName() const override;
 
     // LayerCtrlListener
 public:
-    virtual void rebuildLayerMenu();
-    virtual void layerVisibilityChanged();
+    void rebuildLayerMenu() override;
+    void layerVisibilityChanged() override;
 
 protected:
     GtkWidget* createSpecialMenuEntry(const std::string& name);
@@ -55,9 +55,9 @@ protected:
      */
     void updateLayerData();
 
-    virtual GtkToolItem* newItem();
-    virtual GtkWidget* getNewToolIcon() const;
-    virtual GdkPixbuf* getNewToolPixbuf() const;
+    GtkToolItem* newItem() override;
+    GtkWidget* getNewToolIcon() const override;
+    GdkPixbuf* getNewToolPixbuf() const override;
 
 private:
     void createLayerMenuItem(const std::string& text, int layerId);

--- a/src/core/gui/toolbarMenubar/ToolPdfCombocontrol.h
+++ b/src/core/gui/toolbarMenubar/ToolPdfCombocontrol.h
@@ -13,13 +13,13 @@ class ToolMenuHandler;
 class ToolPdfCombocontrol: public ToolButton {
 public:
     ToolPdfCombocontrol(ToolMenuHandler* toolMenuHandler, ActionHandler* handler, std::string id);
-    virtual ~ToolPdfCombocontrol();
+    ~ToolPdfCombocontrol() override;
 
 public:
-    virtual void selected(ActionGroup group, ActionType action);
+    void selected(ActionGroup group, ActionType action) override;
 
 protected:
-    virtual GtkToolItem* newItem();
+    GtkToolItem* newItem() override;
     void addMenuitem(const std::string& text, const std::string& icon, ActionType type, ActionGroup group);
 
 private:

--- a/src/core/gui/toolbarMenubar/ToolSelectCombocontrol.h
+++ b/src/core/gui/toolbarMenubar/ToolSelectCombocontrol.h
@@ -24,13 +24,13 @@ class ToolMenuHandler;
 class ToolSelectCombocontrol: public ToolButton {
 public:
     ToolSelectCombocontrol(ToolMenuHandler* toolMenuHandler, ActionHandler* handler, std::string id);
-    virtual ~ToolSelectCombocontrol();
+    ~ToolSelectCombocontrol() override;
 
 public:
-    virtual void selected(ActionGroup group, ActionType action);
+    void selected(ActionGroup group, ActionType action) override;
 
 protected:
-    virtual GtkToolItem* newItem();
+    GtkToolItem* newItem() override;
     void addMenuitem(const std::string& text, const std::string& icon, ActionType type, ActionGroup group);
 
 private:

--- a/src/core/gui/toolbarMenubar/ToolZoomSlider.h
+++ b/src/core/gui/toolbarMenubar/ToolZoomSlider.h
@@ -25,7 +25,7 @@ class ToolZoomSlider: public AbstractSliderItem, public ZoomListener {
 public:
     ToolZoomSlider(std::string id, ActionHandler* handler, ActionType type, ZoomControl* zoom,
                    IconNameHelper iconNameHelper);
-    virtual ~ToolZoomSlider();
+    ~ToolZoomSlider() override;
 
 protected:
     void onSliderChanged(double value) override;
@@ -33,16 +33,16 @@ protected:
     void onSliderButtonRelease() override;
     void onSliderHoverScroll() override;
     std::string formatSliderValue(double value) const override;
-    virtual void configure(GtkRange* slider, bool isHorizontal) const;
+    void configure(GtkRange* slider, bool isHorizontal) const override;
 
     void zoomChanged() override;
     void zoomRangeValuesChanged() override;
 
-    virtual std::string getToolDisplayName() const override;
+    std::string getToolDisplayName() const override;
 
 protected:
-    virtual GtkWidget* getNewToolIcon() const override;
-    virtual GdkPixbuf* getNewToolPixbuf() const override;
+    GtkWidget* getNewToolIcon() const override;
+    GdkPixbuf* getNewToolPixbuf() const override;
 
     double scaleFunc(double x) const override;
     double scaleFuncInv(double x) const override;

--- a/src/core/model/Element.h
+++ b/src/core/model/Element.h
@@ -71,8 +71,8 @@ public:
      */
     virtual Element* clone() = 0;
 
-    void serialize(ObjectOutputStream& out) const;
-    void readSerialized(ObjectInputStream& in);
+    void serialize(ObjectOutputStream& out) const override;
+    void readSerialized(ObjectInputStream& in) override;
 
 private:
 protected:

--- a/src/core/model/Font.h
+++ b/src/core/model/Font.h
@@ -22,7 +22,7 @@
 class XojFont: public Serializable {
 public:
     XojFont();
-    virtual ~XojFont();
+    ~XojFont() override;
 
 public:
     std::string getName() const;
@@ -35,8 +35,8 @@ public:
 
 public:
     // Serialize interface
-    void serialize(ObjectOutputStream& out) const;
-    void readSerialized(ObjectInputStream& in);
+    void serialize(ObjectOutputStream& out) const override;
+    void readSerialized(ObjectInputStream& in) override;
 
 private:
     void updateFontDesc();

--- a/src/core/model/Image.h
+++ b/src/core/model/Image.h
@@ -20,7 +20,7 @@
 class Image: public Element {
 public:
     Image();
-    virtual ~Image();
+    ~Image() override;
 
 public:
     void setWidth(double width);
@@ -31,13 +31,13 @@ public:
     void setImage(GdkPixbuf* img);
     cairo_surface_t* getImage() const;
 
-    virtual void scale(double x0, double y0, double fx, double fy, double rotation, bool restoreLineWidth);
-    virtual void rotate(double x0, double y0, double th);
+    void scale(double x0, double y0, double fx, double fy, double rotation, bool restoreLineWidth) override;
+    void rotate(double x0, double y0, double th) override;
 
     /**
      * @overwrite
      */
-    virtual Element* clone();
+    Element* clone() override;
 
 public:
     // Serialize interface

--- a/src/core/model/LineStyle.h
+++ b/src/core/model/LineStyle.h
@@ -21,14 +21,14 @@ class LineStyle: public Serializable {
 public:
     LineStyle();
     LineStyle(const LineStyle& other);
-    virtual ~LineStyle();
+    ~LineStyle() override;
 
     void operator=(const LineStyle& other);
 
 public:
     // Serialize interface
-    void serialize(ObjectOutputStream& out) const;
-    void readSerialized(ObjectInputStream& in);
+    void serialize(ObjectOutputStream& out) const override;
+    void readSerialized(ObjectInputStream& in) override;
 
 public:
     /**

--- a/src/core/model/TexImage.h
+++ b/src/core/model/TexImage.h
@@ -27,7 +27,7 @@ public:
     TexImage& operator=(const TexImage&) = delete;
     TexImage(const TexImage&&) = delete;
     TexImage&& operator=(const TexImage&&) = delete;
-    virtual ~TexImage();
+    ~TexImage() override;
 
 public:
     void setWidth(double width);
@@ -50,14 +50,14 @@ public:
      */
     PopplerDocument* getPdf() const;
 
-    virtual void scale(double x0, double y0, double fx, double fy, double rotation, bool restoreLineWidth);
-    virtual void rotate(double x0, double y0, double th);
+    void scale(double x0, double y0, double fx, double fy, double rotation, bool restoreLineWidth) override;
+    void rotate(double x0, double y0, double th) override;
 
     // text tag to alow latex
     void setText(std::string text);
     std::string getText() const;
 
-    virtual Element* clone();
+    Element* clone() override;
 
     /**
      * @return true if the binary data (PNG or PDF) was loaded successfully.

--- a/src/core/pdf/base/XojCairoPdfExport.h
+++ b/src/core/pdf/base/XojCairoPdfExport.h
@@ -21,17 +21,17 @@
 class XojCairoPdfExport: public XojPdfExport {
 public:
     XojCairoPdfExport(Document* doc, ProgressListener* progressListener);
-    virtual ~XojCairoPdfExport();
+    ~XojCairoPdfExport() override;
 
 public:
-    virtual bool createPdf(fs::path const& file, bool progressiveMode);
-    virtual bool createPdf(fs::path const& file, PageRangeVector& range, bool progressiveMode);
-    virtual std::string getLastError();
+    bool createPdf(fs::path const& file, bool progressiveMode) override;
+    bool createPdf(fs::path const& file, PageRangeVector& range, bool progressiveMode) override;
+    std::string getLastError() override;
 
     /**
      * Export without background
      */
-    virtual void setExportBackground(ExportBackgroundType exportBackground);
+    void setExportBackground(ExportBackgroundType exportBackground) override;
 
 private:
     bool startPdf(const fs::path& file);

--- a/src/core/pdf/base/XojPdfDocument.h
+++ b/src/core/pdf/base/XojPdfDocument.h
@@ -25,23 +25,23 @@ class XojPdfDocument: XojPdfDocumentInterface {
 public:
     XojPdfDocument();
     XojPdfDocument(const XojPdfDocument& doc);
-    virtual ~XojPdfDocument();
+    ~XojPdfDocument() override;
 
 public:
     XojPdfDocument& operator=(const XojPdfDocument& doc);
     bool operator==(XojPdfDocument& doc);
-    void assign(XojPdfDocumentInterface* doc);
-    bool equals(XojPdfDocumentInterface* doc);
+    void assign(XojPdfDocumentInterface* doc) override;
+    bool equals(XojPdfDocumentInterface* doc) override;
 
 public:
-    bool save(fs::path const& file, GError** error);
-    bool load(fs::path const& file, std::string password, GError** error);
-    bool load(gpointer data, gsize length, std::string password, GError** error);
-    bool isLoaded();
+    bool save(fs::path const& file, GError** error) override;
+    bool load(fs::path const& file, std::string password, GError** error) override;
+    bool load(gpointer data, gsize length, std::string password, GError** error) override;
+    bool isLoaded() override;
 
-    XojPdfPageSPtr getPage(size_t page);
-    size_t getPageCount();
-    XojPdfBookmarkIterator* getContentsIter();
+    XojPdfPageSPtr getPage(size_t page) override;
+    size_t getPageCount() override;
+    XojPdfBookmarkIterator* getContentsIter() override;
 
 private:
     XojPdfDocumentInterface* doc;

--- a/src/core/pdf/popplerapi/PopplerGlibAction.h
+++ b/src/core/pdf/popplerapi/PopplerGlibAction.h
@@ -26,11 +26,11 @@ class LinkDestination;
 class PopplerGlibAction: public XojPdfAction {
 public:
     PopplerGlibAction(PopplerAction* action, PopplerDocument* document);
-    virtual ~PopplerGlibAction();
+    ~PopplerGlibAction() override;
 
 public:
-    virtual XojLinkDest* getDestination();
-    virtual std::string getTitle();
+    XojLinkDest* getDestination() override;
+    std::string getTitle() override;
 
 private:
     void linkFromDest(LinkDestination* link, PopplerDest* pDest);

--- a/src/core/pdf/popplerapi/PopplerGlibDocument.h
+++ b/src/core/pdf/popplerapi/PopplerGlibDocument.h
@@ -21,21 +21,21 @@ class PopplerGlibDocument: public XojPdfDocumentInterface {
 public:
     PopplerGlibDocument();
     PopplerGlibDocument(const PopplerGlibDocument& doc);
-    virtual ~PopplerGlibDocument();
+    ~PopplerGlibDocument() override;
 
 public:
-    virtual void assign(XojPdfDocumentInterface* doc);
-    virtual bool equals(XojPdfDocumentInterface* doc);
+    void assign(XojPdfDocumentInterface* doc) override;
+    bool equals(XojPdfDocumentInterface* doc) override;
 
 public:
-    virtual bool save(fs::path const& filepath, GError** error);
-    virtual bool load(fs::path const& filepath, std::string password, GError** error);
-    virtual bool load(gpointer data, gsize length, std::string password, GError** error);
-    virtual bool isLoaded();
+    bool save(fs::path const& filepath, GError** error) override;
+    bool load(fs::path const& filepath, std::string password, GError** error) override;
+    bool load(gpointer data, gsize length, std::string password, GError** error) override;
+    bool isLoaded() override;
 
-    virtual XojPdfPageSPtr getPage(size_t page);
-    virtual size_t getPageCount();
-    virtual XojPdfBookmarkIterator* getContentsIter();
+    XojPdfPageSPtr getPage(size_t page) override;
+    size_t getPageCount() override;
+    XojPdfBookmarkIterator* getContentsIter() override;
 
 private:
     PopplerDocument* document = nullptr;

--- a/src/core/pdf/popplerapi/PopplerGlibPage.h
+++ b/src/core/pdf/popplerapi/PopplerGlibPage.h
@@ -24,12 +24,12 @@ public:
     PopplerGlibPage& operator=(const PopplerGlibPage& other);
 
 public:
-    virtual double getWidth();
-    virtual double getHeight();
+    double getWidth() override;
+    double getHeight() override;
 
-    virtual void render(cairo_t* cr, bool forPrinting = false);  // NOLINT(google-default-arguments)
+    void render(cairo_t* cr, bool forPrinting = false) override;  // NOLINT(google-default-arguments)
 
-    virtual std::vector<XojPdfRectangle> findText(std::string& text);
+    std::vector<XojPdfRectangle> findText(std::string& text) override;
 
     std::string selectText(const XojPdfRectangle& rect, XojPdfPageSelectionStyle style) override;
 
@@ -38,7 +38,7 @@ public:
     TextSelection selectTextLines(const XojPdfRectangle& rect, XojPdfPageSelectionStyle style) override;
 
 
-    virtual int getPageId();
+    int getPageId() override;
 
 private:
     PopplerPage* page;

--- a/src/core/pdf/popplerapi/PopplerGlibPageBookmarkIterator.h
+++ b/src/core/pdf/popplerapi/PopplerGlibPageBookmarkIterator.h
@@ -24,13 +24,13 @@
 class PopplerGlibPageBookmarkIterator: public XojPdfBookmarkIterator {
 public:
     PopplerGlibPageBookmarkIterator(PopplerIndexIter* iter, PopplerDocument* document);
-    virtual ~PopplerGlibPageBookmarkIterator();
+    ~PopplerGlibPageBookmarkIterator() override;
 
 public:
-    virtual bool next();
-    virtual bool isOpen();
-    virtual XojPdfBookmarkIterator* getChildIter();
-    virtual XojPdfAction* getAction();
+    bool next() override;
+    bool isOpen() override;
+    XojPdfBookmarkIterator* getChildIter() override;
+    XojPdfAction* getAction() override;
 
 private:
     PopplerIndexIter* iter;

--- a/src/core/undo/ArrangeUndoAction.h
+++ b/src/core/undo/ArrangeUndoAction.h
@@ -22,12 +22,12 @@ public:
     using InsertOrder = std::deque<std::pair<Element*, Layer::ElementIndex>>;
 
     ArrangeUndoAction(const PageRef& page, Layer* layer, std::string desc, InsertOrder oldOrder, InsertOrder newOrder);
-    virtual ~ArrangeUndoAction() override;
+    ~ArrangeUndoAction() override;
 
 public:
-    virtual bool undo(Control* control) override;
-    virtual bool redo(Control* control) override;
-    virtual std::string getText() override;
+    bool undo(Control* control) override;
+    bool redo(Control* control) override;
+    std::string getText() override;
 
 private:
     void applyRearrange();

--- a/src/core/undo/ColorUndoAction.h
+++ b/src/core/undo/ColorUndoAction.h
@@ -25,12 +25,12 @@ class Redrawable;
 class ColorUndoAction: public UndoAction {
 public:
     ColorUndoAction(const PageRef& page, Layer* layer);
-    virtual ~ColorUndoAction();
+    ~ColorUndoAction() override;
 
 public:
-    virtual bool undo(Control* control);
-    virtual bool redo(Control* control);
-    virtual std::string getText();
+    bool undo(Control* control) override;
+    bool redo(Control* control) override;
+    std::string getText() override;
 
     void addStroke(Element* e, Color originalColor, Color newColor);
 

--- a/src/core/undo/CopyUndoAction.h
+++ b/src/core/undo/CopyUndoAction.h
@@ -20,13 +20,13 @@
 class CopyUndoAction: public UndoAction {
 public:
     CopyUndoAction(const PageRef& pageref, int pageNr);
-    virtual ~CopyUndoAction();
+    ~CopyUndoAction() override;
 
 public:
-    virtual bool undo(Control* control);
-    virtual bool redo(Control* control);
+    bool undo(Control* control) override;
+    bool redo(Control* control) override;
 
-    virtual std::string getText();
+    std::string getText() override;
 
 private:
     int pageNr;

--- a/src/core/undo/EmergencySaveRestore.h
+++ b/src/core/undo/EmergencySaveRestore.h
@@ -21,13 +21,13 @@
 class EmergencySaveRestore: public UndoAction {
 public:
     EmergencySaveRestore();
-    virtual ~EmergencySaveRestore();
+    ~EmergencySaveRestore() override;
 
 public:
-    virtual bool undo(Control* control);
-    virtual bool redo(Control* control);
+    bool undo(Control* control) override;
+    bool redo(Control* control) override;
 
-    virtual std::string getText();
+    std::string getText() override;
 
 private:
 };

--- a/src/core/undo/FillUndoAction.h
+++ b/src/core/undo/FillUndoAction.h
@@ -21,12 +21,12 @@ class Stroke;
 class FillUndoAction: public UndoAction {
 public:
     FillUndoAction(const PageRef& page, Layer* layer);
-    virtual ~FillUndoAction();
+    ~FillUndoAction() override;
 
 public:
-    virtual bool undo(Control* control);
-    virtual bool redo(Control* control);
-    virtual std::string getText();
+    bool undo(Control* control) override;
+    bool redo(Control* control) override;
+    std::string getText() override;
 
     void addStroke(Stroke* s, int originalFill, int newFill);
 

--- a/src/core/undo/FontUndoAction.h
+++ b/src/core/undo/FontUndoAction.h
@@ -26,12 +26,12 @@ class XojFont;
 class FontUndoAction: public UndoAction {
 public:
     FontUndoAction(const PageRef& page, Layer* layer);
-    virtual ~FontUndoAction();
+    ~FontUndoAction() override;
 
 public:
-    virtual bool undo(Control* control);
-    virtual bool redo(Control* control);
-    virtual std::string getText();
+    bool undo(Control* control) override;
+    bool redo(Control* control) override;
+    std::string getText() override;
 
     void addStroke(Text* e, XojFont& oldFont, XojFont& newFont);
 

--- a/src/core/undo/InsertDeletePageUndoAction.h
+++ b/src/core/undo/InsertDeletePageUndoAction.h
@@ -20,13 +20,13 @@
 class InsertDeletePageUndoAction: public UndoAction {
 public:
     InsertDeletePageUndoAction(const PageRef& page, int pagePos, bool inserted);
-    virtual ~InsertDeletePageUndoAction();
+    ~InsertDeletePageUndoAction() override;
 
 public:
-    virtual bool undo(Control* control);
-    virtual bool redo(Control* control);
+    bool undo(Control* control) override;
+    bool redo(Control* control) override;
 
-    virtual std::string getText();
+    std::string getText() override;
 
 private:
     bool insertPage(Control* control);

--- a/src/core/undo/InsertLayerUndoAction.h
+++ b/src/core/undo/InsertLayerUndoAction.h
@@ -23,13 +23,13 @@ class LayerController;
 class InsertLayerUndoAction: public UndoAction {
 public:
     InsertLayerUndoAction(LayerController* layerController, const PageRef& page, Layer* layer, int layerPosition);
-    virtual ~InsertLayerUndoAction();
+    ~InsertLayerUndoAction() override;
 
 public:
-    virtual bool undo(Control* control);
-    virtual bool redo(Control* control);
+    bool undo(Control* control) override;
+    bool redo(Control* control) override;
 
-    virtual std::string getText();
+    std::string getText() override;
 
 private:
     int layerPosition;

--- a/src/core/undo/InsertUndoAction.h
+++ b/src/core/undo/InsertUndoAction.h
@@ -20,13 +20,13 @@ class Redrawable;
 class InsertUndoAction: public UndoAction {
 public:
     InsertUndoAction(const PageRef& page, Layer* layer, Element* element);
-    virtual ~InsertUndoAction();
+    ~InsertUndoAction() override;
 
 public:
-    virtual bool undo(Control* control);
-    virtual bool redo(Control* control);
+    bool undo(Control* control) override;
+    bool redo(Control* control) override;
 
-    virtual std::string getText();
+    std::string getText() override;
 
 private:
     Layer* layer;
@@ -36,13 +36,13 @@ private:
 class InsertsUndoAction: public UndoAction {
 public:
     InsertsUndoAction(const PageRef& page, Layer* layer, std::vector<Element*> elements);
-    virtual ~InsertsUndoAction();
+    ~InsertsUndoAction() override;
 
 public:
-    virtual bool undo(Control* control);
-    virtual bool redo(Control* control);
+    bool undo(Control* control) override;
+    bool redo(Control* control) override;
 
-    virtual std::string getText();
+    std::string getText() override;
 
 private:
     Layer* layer;

--- a/src/core/undo/LayerRenameUndoAction.h
+++ b/src/core/undo/LayerRenameUndoAction.h
@@ -24,7 +24,7 @@ class LayerRenameUndoAction: public UndoAction {
 public:
     LayerRenameUndoAction(LayerController* layerController, Layer* layer, const std::string& newName,
                           const std::string& oldName);
-    virtual ~LayerRenameUndoAction();
+    ~LayerRenameUndoAction() override;
 
 public:
     std::string getText() override;

--- a/src/core/undo/MoveLayerUndoAction.h
+++ b/src/core/undo/MoveLayerUndoAction.h
@@ -24,13 +24,13 @@ class MoveLayerUndoAction: public UndoAction {
 public:
     MoveLayerUndoAction(LayerController* layerController, const PageRef& page, Layer* layer, int oldLayerPos,
                         int newLayerPos);
-    virtual ~MoveLayerUndoAction();
+    ~MoveLayerUndoAction() override;
 
 public:
-    virtual bool undo(Control* control);
-    virtual bool redo(Control* control);
+    bool undo(Control* control) override;
+    bool redo(Control* control) override;
 
-    virtual std::string getText();
+    std::string getText() override;
 
 private:
     int oldLayerPos;

--- a/src/core/undo/MoveUndoAction.h
+++ b/src/core/undo/MoveUndoAction.h
@@ -21,13 +21,13 @@ class MoveUndoAction: public UndoAction {
 public:
     MoveUndoAction(Layer* sourceLayer, const PageRef& sourcePage, std::vector<Element*>* selected, double mx, double my,
                    Layer* targetLayer, PageRef targetPage);
-    virtual ~MoveUndoAction();
+    ~MoveUndoAction() override;
 
 public:
-    virtual bool undo(Control* control);
-    virtual bool redo(Control* control);
-    std::vector<PageRef> getPages();
-    virtual std::string getText();
+    bool undo(Control* control) override;
+    bool redo(Control* control) override;
+    std::vector<PageRef> getPages() override;
+    std::string getText() override;
 
 private:
     void switchLayer(std::vector<Element*>* entries, Layer* oldLayer, Layer* newLayer);

--- a/src/core/undo/PageBackgroundChangedUndoAction.h
+++ b/src/core/undo/PageBackgroundChangedUndoAction.h
@@ -21,13 +21,13 @@ class PageBackgroundChangedUndoAction: public UndoAction {
 public:
     PageBackgroundChangedUndoAction(const PageRef& page, const PageType& origType, int origPdfPage,
                                     BackgroundImage origBackgroundImage, double origW, double origH);
-    virtual ~PageBackgroundChangedUndoAction();
+    ~PageBackgroundChangedUndoAction() override;
 
 public:
-    virtual bool undo(Control* control);
-    virtual bool redo(Control* control);
+    bool undo(Control* control) override;
+    bool redo(Control* control) override;
 
-    virtual std::string getText();
+    std::string getText() override;
 
 private:
     PageType origType;

--- a/src/core/undo/RecognizerUndoAction.h
+++ b/src/core/undo/RecognizerUndoAction.h
@@ -20,15 +20,15 @@ class Stroke;
 class RecognizerUndoAction: public UndoAction {
 public:
     RecognizerUndoAction(const PageRef& page, Layer* layer, Stroke* original, Stroke* recognized);
-    virtual ~RecognizerUndoAction();
+    ~RecognizerUndoAction() override;
 
 public:
     void addSourceElement(Stroke* s);
 
-    virtual bool undo(Control* control);
-    virtual bool redo(Control* control);
+    bool undo(Control* control) override;
+    bool redo(Control* control) override;
 
-    virtual std::string getText();
+    std::string getText() override;
 
 private:
     Layer* layer;

--- a/src/core/undo/RemoveLayerUndoAction.h
+++ b/src/core/undo/RemoveLayerUndoAction.h
@@ -19,13 +19,13 @@ class LayerController;
 class RemoveLayerUndoAction: public UndoAction {
 public:
     RemoveLayerUndoAction(LayerController* layerController, const PageRef& page, Layer* layer, int layerPos);
-    virtual ~RemoveLayerUndoAction();
+    ~RemoveLayerUndoAction() override;
 
 public:
-    virtual bool undo(Control* control);
-    virtual bool redo(Control* control);
+    bool undo(Control* control) override;
+    bool redo(Control* control) override;
 
-    virtual std::string getText();
+    std::string getText() override;
 
 private:
     LayerController* layerController;

--- a/src/core/undo/RotateUndoAction.h
+++ b/src/core/undo/RotateUndoAction.h
@@ -16,12 +16,12 @@
 class RotateUndoAction: public UndoAction {
 public:
     RotateUndoAction(const PageRef& page, std::vector<Element*>* elements, double x0, double y0, double rotation);
-    virtual ~RotateUndoAction();
+    ~RotateUndoAction() override;
 
 public:
-    virtual bool undo(Control* control);
-    virtual bool redo(Control* control);
-    virtual std::string getText();
+    bool undo(Control* control) override;
+    bool redo(Control* control) override;
+    std::string getText() override;
 
 private:
     void applyRotation(double rotation);

--- a/src/core/undo/ScaleUndoAction.h
+++ b/src/core/undo/ScaleUndoAction.h
@@ -17,12 +17,12 @@ class ScaleUndoAction: public UndoAction {
 public:
     ScaleUndoAction(const PageRef& page, std::vector<Element*>* elements, double x0, double y0, double fx, double fy,
                     double rotation, bool restoreLineWidth);
-    virtual ~ScaleUndoAction();
+    ~ScaleUndoAction() override;
 
 public:
-    virtual bool undo(Control* control);
-    virtual bool redo(Control* control);
-    virtual std::string getText();
+    bool undo(Control* control) override;
+    bool redo(Control* control) override;
+    std::string getText() override;
 
 private:
     void applyScale(double fx, double fy, bool restoreLineWidth);

--- a/src/core/undo/SizeUndoAction.h
+++ b/src/core/undo/SizeUndoAction.h
@@ -21,12 +21,12 @@ class Stroke;
 class SizeUndoAction: public UndoAction {
 public:
     SizeUndoAction(const PageRef& page, Layer* layer);
-    virtual ~SizeUndoAction();
+    ~SizeUndoAction() override;
 
 public:
-    virtual bool undo(Control* control);
-    virtual bool redo(Control* control);
-    virtual std::string getText();
+    bool undo(Control* control) override;
+    bool redo(Control* control) override;
+    std::string getText() override;
 
     void addStroke(Stroke* s, double originalWidth, double newWidth, std::vector<double> originalPressure,
                    std::vector<double> newPressure, int pressureCount);

--- a/src/core/undo/SwapUndoAction.h
+++ b/src/core/undo/SwapUndoAction.h
@@ -21,13 +21,13 @@ class SwapUndoAction: public UndoAction {
 public:
     SwapUndoAction(size_t pageNr, bool moveUp, const PageRef& swappedPage, const PageRef& otherPage);
 
-    virtual ~SwapUndoAction();
+    ~SwapUndoAction() override;
 
 public:
-    virtual bool undo(Control* control);
-    virtual bool redo(Control* control);
-    std::vector<PageRef> getPages();
-    virtual std::string getText();
+    bool undo(Control* control) override;
+    bool redo(Control* control) override;
+    std::vector<PageRef> getPages() override;
+    std::string getText() override;
 
 private:
     void swap(Control* control);

--- a/src/core/undo/TextBoxUndoAction.h
+++ b/src/core/undo/TextBoxUndoAction.h
@@ -21,13 +21,13 @@ class XojPage;
 class TextBoxUndoAction: public UndoAction {
 public:
     TextBoxUndoAction(const PageRef& page, Layer* layer, Element* element, Element* oldelement);
-    virtual ~TextBoxUndoAction();
+    ~TextBoxUndoAction() override;
 
 public:
-    virtual bool undo(Control* control);
-    virtual bool redo(Control* control);
+    bool undo(Control* control) override;
+    bool redo(Control* control) override;
 
-    virtual std::string getText();
+    std::string getText() override;
 
 private:
     Layer* layer;

--- a/src/core/undo/TextUndoAction.h
+++ b/src/core/undo/TextUndoAction.h
@@ -21,13 +21,13 @@ class TextEditor;
 class TextUndoAction: public UndoAction {
 public:
     TextUndoAction(const PageRef& page, Layer* layer, Text* text, std::string lastText, TextEditor* textEditor);
-    virtual ~TextUndoAction();
+    ~TextUndoAction() override;
 
 public:
-    virtual bool undo(Control* control);
-    virtual bool redo(Control* control);
+    bool undo(Control* control) override;
+    bool redo(Control* control) override;
 
-    virtual std::string getText();
+    std::string getText() override;
 
     std::string getUndoText();
 

--- a/src/core/view/background/DottedBackgroundPainter.h
+++ b/src/core/view/background/DottedBackgroundPainter.h
@@ -20,16 +20,16 @@
 class DottedBackgroundPainter: public BaseBackgroundPainter {
 public:
     DottedBackgroundPainter();
-    virtual ~DottedBackgroundPainter();
+    ~DottedBackgroundPainter() override;
 
 public:
-    virtual void paint();
+    void paint() override;
     void paintBackgroundDotted();
 
     /**
      * Reset all used configuration values
      */
-    virtual void resetConfig();
+    void resetConfig() override;
 
 private:
 };

--- a/src/core/view/background/GraphBackgroundPainter.h
+++ b/src/core/view/background/GraphBackgroundPainter.h
@@ -20,14 +20,14 @@
 class GraphBackgroundPainter: public BaseBackgroundPainter {
 public:
     GraphBackgroundPainter();
-    virtual ~GraphBackgroundPainter();
+    ~GraphBackgroundPainter() override;
 
 public:
-    virtual void paint();
+    void paint() override;
     void paintBackgroundGraph();
 
     /**
      * Reset all used configuration values
      */
-    virtual void resetConfig();
+    void resetConfig() override;
 };

--- a/src/core/view/background/IsometricBackgroundPainter.h
+++ b/src/core/view/background/IsometricBackgroundPainter.h
@@ -20,15 +20,15 @@
 class IsometricBackgroundPainter: public BaseBackgroundPainter {
 public:
     IsometricBackgroundPainter(bool drawLines);
-    virtual ~IsometricBackgroundPainter() override;
+    ~IsometricBackgroundPainter() override;
 
 public:
-    virtual void paint() override;
+    void paint() override;
 
     /**
      * Reset all used configuration values
      */
-    virtual void resetConfig() override;
+    void resetConfig() override;
 
 private:
     bool drawLines;

--- a/src/core/view/background/LineBackgroundPainter.h
+++ b/src/core/view/background/LineBackgroundPainter.h
@@ -20,15 +20,15 @@
 class LineBackgroundPainter: public BaseBackgroundPainter {
 public:
     LineBackgroundPainter(bool verticalLine);
-    virtual ~LineBackgroundPainter();
+    ~LineBackgroundPainter() override;
 
 public:
-    virtual void paint();
+    void paint() override;
 
     /**
      * Reset all used configuration values
      */
-    virtual void resetConfig();
+    void resetConfig() override;
 
 
     void paintBackgroundRuled();

--- a/src/util/include/util/OutputStream.h
+++ b/src/util/include/util/OutputStream.h
@@ -34,12 +34,12 @@ public:
 class GzOutputStream: public OutputStream {
 public:
     GzOutputStream(fs::path file);
-    virtual ~GzOutputStream();
+    ~GzOutputStream() override;
 
 public:
-    virtual void write(const char* data, int len);
+    void write(const char* data, int len) override;
 
-    virtual void close();
+    void close() override;
 
     std::string& getLastError();
 

--- a/src/util/include/util/serializing/BinObjectEncoding.h
+++ b/src/util/include/util/serializing/BinObjectEncoding.h
@@ -16,10 +16,10 @@
 class BinObjectEncoding: public ObjectEncoding {
 public:
     BinObjectEncoding();
-    virtual ~BinObjectEncoding();
+    ~BinObjectEncoding() override;
 
 public:
-    virtual void addData(const void* data, int len);
+    void addData(const void* data, int len) override;
 
 private:
 };

--- a/src/util/include/util/serializing/HexObjectEncoding.h
+++ b/src/util/include/util/serializing/HexObjectEncoding.h
@@ -16,10 +16,10 @@
 class HexObjectEncoding: public ObjectEncoding {
 public:
     HexObjectEncoding();
-    virtual ~HexObjectEncoding();
+    ~HexObjectEncoding() override;
 
 public:
-    virtual void addData(const void* data, int len);
+    void addData(const void* data, int len) override;
 
 private:
 };

--- a/src/util/include/util/serializing/InputStreamException.h
+++ b/src/util/include/util/serializing/InputStreamException.h
@@ -19,7 +19,7 @@
 class InputStreamException: public std::exception {
 public:
     InputStreamException(const std::string& message, const std::string& filename, int line);
-    virtual ~InputStreamException();
+    ~InputStreamException() override;
 
 public:
     virtual const char* what();


### PR DESCRIPTION
For a more modern codebase.
Used ` run-clang-tidy -fix -checks=-*,modernize-use-override -header-filter=.*`