### PR TITLE
Fix version bump error when making 1.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 1.1.1+dev (Unreleased)
+
 ## 1.1.1
 
 Bugfixes from various community contributors.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+xournalpp (1.1.1+dev-1) UNRELEASED; urgency=medium
+
+  * 
+
+ -- Bryan Tan <bryantan@technius.net>  Sun, 13 Feb 2022 13:18:01 -0800
+
 xournalpp (1.1.1-1) unstable; urgency=medium
 
   * This is a new minor version of Xournal++ with many new bug fixes and improvements

--- a/desktop/com.github.xournalpp.xournalpp.appdata.xml
+++ b/desktop/com.github.xournalpp.xournalpp.appdata.xml
@@ -75,6 +75,7 @@
     <!-- Could be automated more:
 	 `git tag -l | grep "^[0-9]*\.[0-9]*\.[0-9]*$`"
     -->
+    <release date="2022-02-13" version="1.1.1+dev" />
     <release date="2022-02-13" version="1.1.1" />
     <release date="2021-07-18" version="1.1.0" />
     <release date="2020-12-17" version="1.0.20" />

--- a/mac-setup/Info.plist
+++ b/mac-setup/Info.plist
@@ -16,9 +16,9 @@
     <string>Xournal++</string>
 
     <key>CFBundleShortVersionString</key>
-    <string>1.1.1</string>
+    <string>1.1.1+dev</string>
     <key>CFBundleVersion</key>
-    <string>1.1.1.0</string>
+    <string>1.1.1+dev.0</string>
     <key>CFBundleInfoDictionaryVersion</key>
     <string>6.0</string>
     <key>NSHumanReadableCopyright</key>

--- a/rpm/fedora/xournalpp.spec
+++ b/rpm/fedora/xournalpp.spec
@@ -6,7 +6,7 @@
 #This spec file is intended for daily development snapshot release
 %global	build_repo https://github.com/xournalpp/xournalpp/
 %global	build_branch master
-%global	version_string 1.1.1
+%global	version_string 1.1.1+dev
 %define	build_commit %(git ls-remote %{build_repo} | grep "refs/heads/%{build_branch}" | cut -c1-41)
 %define	build_shortcommit %(c=%{build_commit}; echo ${c:0:7})
 %global	build_timestamp %(date +"%Y%m%d")

--- a/scripts/release_helper.sh
+++ b/scripts/release_helper.sh
@@ -17,7 +17,7 @@ function current_patch_version() {
 }
 
 function current_suffix_version() {
-    sed -n 's/^set (VERSION_SUFFIX "\([+~][^\"]*\)")/\1/p' "${SCRIPT_PATH}/../CMakeLists.txt"
+    sed -n 's/^set\s*(VERSION_SUFFIX "\([+~][^\"]*\)")/\1/p' "${SCRIPT_PATH}/../CMakeLists.txt"
 }
 
 function current_version() {
@@ -125,10 +125,8 @@ function bump_version() {
     fi
 
     # Update version in the CMakeLists.txt
-    sed -i "s/set (CPACK_PACKAGE_VERSION_MAJOR \"[0-9]\+\")/set (CPACK_PACKAGE_VERSION_MAJOR \"$(parse_major_version $1)\")/g" "${SCRIPT_PATH}/../CMakeLists.txt"
-    sed -i "s/set (CPACK_PACKAGE_VERSION_MINOR \"[0-9]\+\")/set (CPACK_PACKAGE_VERSION_MINOR \"$(parse_minor_version $1)\")/g" "${SCRIPT_PATH}/../CMakeLists.txt"
-    sed -i "s/set (CPACK_PACKAGE_VERSION_PATCH \"[0-9]\+\")/set (CPACK_PACKAGE_VERSION_PATCH \"$(parse_patch_version $1)\")/g" "${SCRIPT_PATH}/../CMakeLists.txt"
-    sed -i "s/set (VERSION_SUFFIX \"[^\"]*\")/set (VERSION_SUFFIX \"$(parse_suffix_version $1)\")/g" "${SCRIPT_PATH}/../CMakeLists.txt"
+    sed -i "s/^        VERSION $(current_major_version).$(current_minor_version).$(current_patch_version)/        VERSION $(parse_major_version "$1").$(parse_minor_version "$1").$(parse_patch_version "$1")/" "${SCRIPT_PATH}"/../CMakeLists.txt
+    sed -i "s/set\s*(VERSION_SUFFIX \"[^\"]*\")/set(VERSION_SUFFIX \"$(parse_suffix_version $1)\")/g" "${SCRIPT_PATH}/../CMakeLists.txt"
 
     # From now on current_*_version functions return the new version
 


### PR DESCRIPTION
Due to the directory structure change, the release helper script was not correctly applied to all files when bumping the version on master branch.

This PR fixes the helper script and corrects the version bump adjustments.