### PR TITLE
Make TextEditor pass events to IM first

### DIFF
--- a/src/core/control/XournalMain.cpp
+++ b/src/core/control/XournalMain.cpp
@@ -303,7 +303,7 @@ void ensure_input_model_compatibility() {
     const char* imModule = g_getenv("GTK_IM_MODULE");
     if (imModule != nullptr) {
         std::string imModuleString{imModule};
-        if (imModuleString == "xim" || imModuleString == "gcin") {
+        if (imModuleString == "xim") {
             g_warning("Unsupported input method: %s", imModule);
         }
     }

--- a/src/core/gui/PageView.cpp
+++ b/src/core/gui/PageView.cpp
@@ -624,6 +624,20 @@ auto XojPageView::onButtonReleaseEvent(const PositionInputData& pos) -> bool {
 }
 
 auto XojPageView::onKeyPressEvent(GdkEventKey* event) -> bool {
+    if (this->textEditor) {
+        if (this->textEditor->onKeyPressEvent(event)) {
+            return true;
+        }
+    } else if (this->inputHandler) {
+        if (this->inputHandler->onKeyEvent(event)) {
+            return true;
+        }
+    } else if (this->verticalSpace) {
+        if (this->verticalSpace->onKeyPressEvent(event)) {
+            return true;
+        }
+    }
+
     // Esc leaves text edition
     if (event->keyval == GDK_KEY_Escape) {
         if (this->textEditor) {
@@ -637,20 +651,6 @@ auto XojPageView::onKeyPressEvent(GdkEventKey* event) -> bool {
 
         return false;
     }
-
-    if (this->textEditor) {
-        return this->textEditor->onKeyPressEvent(event);
-    }
-
-
-    if (this->inputHandler) {
-        return this->inputHandler->onKeyEvent(event);
-    }
-
-    if (this->verticalSpace) {
-        return this->verticalSpace->onKeyPressEvent(event);
-    }
-
 
     return false;
 }

--- a/src/core/gui/TextEditor.cpp
+++ b/src/core/gui/TextEditor.cpp
@@ -253,10 +253,6 @@ auto TextEditor::imDeleteSurroundingCallback(GtkIMContext* context, gint offset,
 }
 
 auto TextEditor::onKeyPressEvent(GdkEventKey* event) -> bool {
-    if (gtk_bindings_activate_event(G_OBJECT(this->textWidget), event)) {
-        return true;
-    }
-
     bool retval = false;
     bool obscure = false;
 
@@ -265,6 +261,8 @@ auto TextEditor::onKeyPressEvent(GdkEventKey* event) -> bool {
     GtkTextMark* insert = gtk_text_buffer_get_insert(this->buffer);
     gtk_text_buffer_get_iter_at_mark(this->buffer, &iter, insert);
     bool canInsert = gtk_text_iter_can_insert(&iter, true);
+
+    // IME needs to handle the input first so the candidate window works correctly
     if (gtk_im_context_filter_keypress(this->imContext, event)) {
         this->needImReset = true;
         if (!canInsert) {
@@ -272,6 +270,8 @@ auto TextEditor::onKeyPressEvent(GdkEventKey* event) -> bool {
         }
         obscure = canInsert;
         retval = true;
+    } else if (gtk_bindings_activate_event(G_OBJECT(this->textWidget), event)) {
+        return true;
     } else if ((event->state & modifiers) == GDK_CONTROL_MASK) {
         // Bold text
         if (event->keyval == GDK_KEY_b || event->keyval == GDK_KEY_B) {


### PR DESCRIPTION
When using gcin as IM, I usually use arrows key to select candidates, or escape key to leave candidate menu. But in xournal++ text editor if I wanted to do the same, the cursor gets moved instead with arrow keys, and the whole text box gets closed with escpae key. This PR move event handling of IM before the text editor event handling and escap key handling so character selection.

With this PR, gcin now works pretty well with xournal++, so it can probably be removed from here https://github.com/xournalpp/xournalpp/blob/3d8dc4bc8b1cbc1230062937dd9ff19039834b00/src/core/control/XournalMain.cpp#L306-L308
(I don't have xim installed to check, but this might fix its issue as well).

@tattsan tagging you because you were testing with xim on my other PR, maybe you can help me test this one as well. Much thanks.
