### PR TITLE
Generate portable install for Windows in release pipeline

### DIFF
--- a/azure-pipelines/continuous-integration.yml
+++ b/azure-pipelines/continuous-integration.yml
@@ -35,7 +35,7 @@ stages:
 
       - job: 'Windows'
         pool:
-          vmImage: 'vs2017-win2016'
+          vmImage: 'windows-2019'
         displayName: 'Test Xournal++ on Windows'
         steps:
           - template: steps/build_windows.yml

--- a/azure-pipelines/create-installers.yml
+++ b/azure-pipelines/create-installers.yml
@@ -73,7 +73,7 @@ stages:
 
       - job: Windows
         pool:
-          vmImage: 'vs2017-win2016'
+          vmImage: 'windows-2019'
         displayName: 'Build for Windows'
         steps:
           - template: steps/build_windows.yml

--- a/azure-pipelines/dependencies/msys2-blob.yml
+++ b/azure-pipelines/dependencies/msys2-blob.yml
@@ -8,7 +8,7 @@ trigger:
 pr: none
 
 pool:
-  vmImage: 'vs2017-win2016'
+  vmImage: 'windows-2019'
         
 steps:
 - script: |

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -97,11 +97,22 @@ stages:
               MSYSTEM: MINGW64
               CHERE_INVOKING: yes
             displayName: 'Create Setup'
+          - task: CopyFiles@2
+            inputs:
+              sourceFolder: './windows-setup/dist'
+              contents: '**'
+              targetFolder: '$(Build.ArtifactStagingDirectory)/portable'
+            displayName: 'Generate portable version'
           - task: PublishPipelineArtifact@0
             inputs:
               artifactName: 'windows'
               targetPath: './windows-setup/xournalpp-setup.exe'
             displayName: 'Publish Windows Setup'
+          - task: PublishPipelineArtifact@1
+            inputs:
+              artifactName: 'windows-portable'
+              targetPath: '$(Build.ArtifactStagingDirectory)/portable'
+            displayName: 'Publish portable version for Windows'
 
       - job: macOS
         pool:

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -81,7 +81,7 @@ stages:
 
       - job: Windows
         pool:
-          vmImage: 'vs2017-win2016'
+          vmImage: 'windows-2019'
         displayName: 'Build for Windows'
         steps:
           - template: steps/build_windows.yml


### PR DESCRIPTION
Partially fixes #3714 (also need to update the deployment steps after this is merged). This PR also updates the Windows CI build to use the `windows-2019` image since the currently used image will be removed next week.