### PR TITLE
fix launchpad build recipe

### DIFF
--- a/xournalpp-ubuntu-ppa.recipe
+++ b/xournalpp-ubuntu-ppa.recipe
@@ -1,3 +1,3 @@
-# git-build-recipe format 0.4 deb-version 1:{debupstream}-{revtime}-1
+# git-build-recipe format 0.4 deb-version 2:{debupstream}-{revtime}
 lp:xournalpp master
 


### PR DESCRIPTION
The previous recipe had the issue, that the +dev versions were considered to be lower than the released versions (without +dev). Leaving out the patch version fixes that problem. The epoch has to be increased (from 1 to 2) so that all newly released versions are higher than the previously released ones.

Sanity checks (using `dpkg --compare-versions`), all of which echo `true`: as you may check by pasting these lines into a console.
```shell
# ~dev before 'no suffix' before +dev
dpkg --compare-versions "2:1.1.1~dev-202201011200" lt "2:1.1.1-202201011200" && echo true
dpkg --compare-versions "2:1.1.1-202201011200" lt "2:1.1.1+dev-202201011200" && echo true
# increase of revision time
dpkg --compare-versions "2:1.1.1~dev-202201011200" lt "2:1.1.1~dev-202201011201" && echo true
dpkg --compare-versions "2:1.1.1-202201011200" lt "2:1.1.1-202201011201" && echo true
dpkg --compare-versions "2:1.1.1+dev-202201011200" lt "2:1.1.1+dev-202201011201" && echo true
# increase of version number
dpkg --compare-versions "2:1.1.1~dev-202201011200" lt "2:1.1.2~dev-202201011200" && echo true
dpkg --compare-versions "2:1.1.1-202201011200" lt "2:1.1.2-202201011200" && echo true
dpkg --compare-versions "2:1.1.1+dev-202201011200" lt "2:1.1.2+dev-202201011200" && echo true
# increase of version number is more important than suffix and time
dpkg --compare-versions "2:1.1.1+dev-202201011200" lt "2:1.1.2~dev-202201011200" && echo true
dpkg --compare-versions "2:1.1.1+dev-202201011201" lt "2:1.1.2+dev-202201011200" && echo true
# increase of epoch is more important than version, suffix and time
dpkg --compare-versions "1:1.1.2+dev-202201011201" lt "2:1.1.1~dev-202201011200" && echo true
```
Once the PR is merged I will write to @andreasb242 for updating the build recipe on Launchpad.