### PR TITLE
Properly handle blocking of devices for setsquare

### DIFF
--- a/src/core/gui/inputdevices/InputContext.cpp
+++ b/src/core/gui/inputdevices/InputContext.cpp
@@ -7,6 +7,7 @@
 #include "control/DeviceListHelper.h"
 
 #include "InputEvents.h"
+#include "SetsquareInputHandler.h"
 
 InputContext::InputContext(XournalView* view, ScrollHandling* scrollHandling) {
     this->view = view;
@@ -170,7 +171,7 @@ void InputContext::focusWidget() {
 }
 
 void InputContext::blockDevice(InputContext::DeviceType deviceType) {
-    this->setsquareHandler->block(true);
+    this->setsquareHandler->blockDevice(deviceType);
     switch (deviceType) {
         case MOUSE:
             this->mouseHandler->block(true);
@@ -186,7 +187,7 @@ void InputContext::blockDevice(InputContext::DeviceType deviceType) {
 }
 
 void InputContext::unblockDevice(InputContext::DeviceType deviceType) {
-    this->setsquareHandler->block(false);
+    this->setsquareHandler->unblockDevice(deviceType);
     switch (deviceType) {
         case MOUSE:
             this->mouseHandler->block(false);

--- a/src/core/gui/inputdevices/InputContext.h
+++ b/src/core/gui/inputdevices/InputContext.h
@@ -30,11 +30,13 @@
 #include "HandRecognition.h"
 #include "KeyboardInputHandler.h"
 #include "MouseInputHandler.h"
-#include "SetsquareInputHandler.h"
 #include "StylusInputHandler.h"
 #include "TouchDrawingInputHandler.h"
 #include "TouchInputHandler.h"
 #include "config-debug.h"
+
+class SetsquareInputHandler;
+
 class InputContext {
 
 private:

--- a/src/core/gui/inputdevices/SetsquareInputHandler.h
+++ b/src/core/gui/inputdevices/SetsquareInputHandler.h
@@ -17,7 +17,7 @@
 
 #include "util/Point.h"
 
-#include "AbstractInputHandler.h"
+#include "InputContext.h"
 
 class InputContext;
 
@@ -29,8 +29,20 @@ class InputContext;
  *
  * The touch handling part is adopted from the TouchInputHandler class
  */
-class SetsquareInputHandler: public AbstractInputHandler {
+class SetsquareInputHandler {
+
 private:
+    /**
+     * @brief the input context attached to this handler
+     */
+    InputContext* inputContext;
+
+    /**
+     * @brief saves which devices are blocked, so they don't need to be handled
+     *        This is currently used for the automatic hand recognition, that can be turned on in the settings
+     */
+    std::map<InputContext::DeviceType, bool> isBlocked{};
+
     /**
      * @brief the touch event sequence corresponding to the first finger touching the screen
      */
@@ -139,8 +151,9 @@ private:
 
 public:
     explicit SetsquareInputHandler(InputContext* inputContext);
-    ~SetsquareInputHandler() override = default;
+    ~SetsquareInputHandler() = default;
 
-    bool handleImpl(InputEvent const& event) override;
-    void onUnblock() override;
+    bool handle(InputEvent const& event);
+    void blockDevice(InputContext::DeviceType deviceType);
+    void unblockDevice(InputContext::DeviceType deviceType);
 };


### PR DESCRIPTION
This PR make the setsquare handle blocking of devices properly, which is currently used for the automatic hand recognition (an option that can be turned on in the preferences, Touchscreen panel). It fixes an issue reported by @lxdb in #3082, where using the stylus resulted in input events temporarily not getting processed at all (since everything was blocked by the setsquare input handler). 

@lxdb Please test the PR on your device (with automatic hand recognition turned on).