### PR TITLE
fix "suggest parantheses around && within ||"

### DIFF
--- a/src/core/control/tools/SplineHandler.cpp
+++ b/src/core/control/tools/SplineHandler.cpp
@@ -105,8 +105,8 @@ constexpr double MIN_TANGENT_LENGTH = 1.0;
 
 auto SplineHandler::onKeyEvent(GdkEventKey* event) -> bool {
     if (!stroke ||
-        event->type != GDK_KEY_PRESS && event->keyval != GDK_KEY_Escape) {  // except for escape key only act on key
-                                                                            // press event, not on key release event
+        (event->type != GDK_KEY_PRESS && event->keyval != GDK_KEY_Escape)) {  // except for escape key only act on key
+                                                                              // press event, not on key release event
         return false;
     }
 

--- a/src/core/gui/MainWindow.cpp
+++ b/src/core/gui/MainWindow.cpp
@@ -562,7 +562,7 @@ void MainWindow::setToolbarVisible(bool visible) {
     settings->setToolbarVisible(visible);
     for (int i = 0; i < TOOLBAR_DEFINITIONS_LEN; i++) {
         auto widget = this->toolbarWidgets[i];
-        if (!visible || GTK_IS_CONTAINER(widget) && gtk_container_get_children(GTK_CONTAINER(widget))) {
+        if (!visible || (GTK_IS_CONTAINER(widget) && gtk_container_get_children(GTK_CONTAINER(widget)))) {
             gtk_widget_set_visible(widget, visible);
         }
     }

--- a/src/core/gui/PageView.cpp
+++ b/src/core/gui/PageView.cpp
@@ -286,8 +286,8 @@ auto XojPageView::onButtonPressEvent(const PositionInputData& pos) -> bool {
     XournalppCursor* cursor = xournal->getCursor();
     cursor->setMouseDown(true);
 
-    if ((h->getToolType() == TOOL_PEN || h->getToolType() == TOOL_HIGHLIGHTER) &&
-                h->getDrawingType() != DRAWING_TYPE_SPLINE ||
+    if (((h->getToolType() == TOOL_PEN || h->getToolType() == TOOL_HIGHLIGHTER) &&
+         h->getDrawingType() != DRAWING_TYPE_SPLINE) ||
         (h->getToolType() == TOOL_ERASER && h->getEraserType() == ERASER_TYPE_WHITEOUT)) {
         delete this->inputHandler;
         this->inputHandler = nullptr;

--- a/src/core/gui/inputdevices/TouchDrawingInputHandler.cpp
+++ b/src/core/gui/inputdevices/TouchDrawingInputHandler.cpp
@@ -32,7 +32,7 @@ auto TouchDrawingInputHandler::handleImpl(InputEvent const& event) -> bool {
 
     // Do we need to end the touch sequence?
     bool mustEnd = event.type == BUTTON_RELEASE_EVENT;
-    mustEnd = mustEnd || event.type == GRAB_BROKEN_EVENT && this->deviceClassPressed;
+    mustEnd = mustEnd || (event.type == GRAB_BROKEN_EVENT && this->deviceClassPressed);
 
     // Notify if finger enters/leaves widget
     // Note: Drawing outside window doesn't seem to work


### PR DESCRIPTION
Fixes some compiler warnings related to "suggest parantheses around && within ||"