### PR TITLE
Allow system gtest; add explicit download flag

### DIFF
--- a/azure-pipelines/continuous-integration.yml
+++ b/azure-pipelines/continuous-integration.yml
@@ -22,7 +22,7 @@ stages:
           - template: steps/build_linux.yml
             parameters:
               build_type: 'Debug'
-              cmake_flags: '-DCMAKE_DEBUG_INCLUDES_LDFLAGS=ON -DENABLE_GTEST=ON'
+              cmake_flags: '-DCMAKE_DEBUG_INCLUDES_LDFLAGS=ON -DENABLE_GTEST=ON -DDOWNLOAD_GTEST=on'
           - bash: |
               echo "de_DE.UTF-8 UTF-8" | sudo tee /etc/locale.gen
               sudo locale-gen
@@ -41,7 +41,7 @@ stages:
           - template: steps/build_windows.yml
             parameters:
               build_type: 'Debug'
-              cmake_flags: '-GNinja -DCMAKE_DEBUG_INCLUDES_LDFLAGS=ON -DENABLE_GTEST=ON'
+              cmake_flags: '-GNinja -DCMAKE_DEBUG_INCLUDES_LDFLAGS=ON -DENABLE_GTEST=ON -DDOWNLOAD_GTEST=on'
           - script: |
               set PATH=%PATH%;C:\msys64\usr\bin;C:\msys64\mingw64\bin"
               C:\msys64\usr\bin\bash -lc "cmake --build . --target test-units"
@@ -61,7 +61,7 @@ stages:
           - template: steps/build_mac.yml
             parameters:
               build_type: 'Debug'
-              cmake_flags: '-DCMAKE_DEBUG_INCLUDES_LDFLAGS=ON -DENABLE_GTEST=ON'
+              cmake_flags: '-DCMAKE_DEBUG_INCLUDES_LDFLAGS=ON -DENABLE_GTEST=ON -DDOWNLOAD_GTEST=on'
               generation_path: '/Users/xournal-dev'
           - bash: |
               export PATH="$HOME/.local/bin:/Users/xournal-dev/gtk/inst/bin:$PATH"

--- a/azure-pipelines/jobs/release_ubuntu.yml
+++ b/azure-pipelines/jobs/release_ubuntu.yml
@@ -13,12 +13,20 @@ jobs:
     pool:
       vmImage: 'ubuntu-${{ parameters.ubuntu_version }}'
     displayName: 'Build for Ubuntu ${{ parameters.ubuntu_version }}'
+    variables:
+      # gtest version on Ubuntu 18.04 does not have a pkgconfig file,
+      # so download it instead.
+      ${{ if eq(parameters['ubuntu_version'], '18.04') }}:
+        DOWNLOAD_GTEST_FLAG: '-DDOWNLOAD_GTEST=on'
     steps:
       - template: ../steps/install_deps_ubuntu.yml
       - template: ../steps/build_linux.yml
         parameters:
           build_type: 'RelWithDebInfo'
-          cmake_flags: '-DCMAKE_DEBUG_INCLUDES_LDFLAGS=ON -DENABLE_GTEST=ON -DCMAKE_INSTALL_PREFIX=/usr -DCPACK_GENERATOR="TGZ;DEB"'
+          cmake_flags: >-
+            -DCMAKE_DEBUG_INCLUDES_LDFLAGS=ON
+            -DENABLE_GTEST=ON $(DOWNLOAD_GTEST_FLAG)
+            -DCMAKE_INSTALL_PREFIX=/usr -DCPACK_GENERATOR="TGZ;DEB"
           cmake_commands: '--target package'
       - bash: |
           # Build AppImage

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -64,8 +64,11 @@ stages:
         steps:
           - bash: |
               sudo apt-get update
-              sudo apt-get install -y build-essential gcc-10 g++-10 cmake ninja-build libgtk-3-dev libpoppler-glib-dev libxml2-dev portaudio19-dev libsndfile-dev liblua5.3-dev \
-                                      libzip-dev gettext lsb-release librsvg2-dev help2man
+              sudo apt-get install -y build-essential gcc-10 g++-10 cmake \
+                  ninja-build libgtk-3-dev libpoppler-glib-dev libxml2-dev \
+                  portaudio19-dev libsndfile-dev liblua5.3-dev \
+                  libzip-dev gettext lsb-release librsvg2-dev help2man \
+                  libgtest-dev
             displayName: 'Install dependencies'
           - template: steps/build_linux.yml
             parameters:

--- a/azure-pipelines/steps/build_mac.yml
+++ b/azure-pipelines/steps/build_mac.yml
@@ -44,16 +44,6 @@ steps:
       make install INSTALL_TOP="${{parameters.generation_path}}"/gtk/inst
     displayName: 'Get Lua'
   - bash: |
-      # Cppunit will not be required any longer after the migration to gtest (in version 1.2)
-      cd "${{parameters.generation_path}}"
-      curl -L -o cppunit.tar.gz https://dev-www.libreoffice.org/src/cppunit-1.15.1.tar.gz
-      tar zxf cppunit.tar.gz
-      cd cppunit-1.15.1
-      ./configure --prefix="${{parameters.generation_path}}"/gtk/inst
-      make
-      make install
-    displayName: 'Get Cppunit'
-  - bash: |
       export PKG_CONFIG_PATH="${{parameters.generation_path}}"/gtk/inst/lib/pkgconfig:"${{parameters.generation_path}}"/gtk/inst/share/pkgconfig:/Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.8/lib/pkgconfig
       export PREFIX="${{parameters.generation_path}}"/gtk/inst
       export PATH="$HOME/.local/bin:"${{parameters.generation_path}}"/gtk/inst/bin:$PATH"

--- a/azure-pipelines/steps/install_deps_ubuntu.yml
+++ b/azure-pipelines/steps/install_deps_ubuntu.yml
@@ -7,6 +7,8 @@ parameters:
 steps:
   - bash: |
       sudo apt-get update
-      sudo apt-get install -y librsvg2-dev gcc-8 g++-8 cmake ninja-build libgtk-3-dev libpoppler-glib-dev portaudio19-dev libsndfile-dev liblua5.3-dev libzip-dev gettext help2man
+      sudo apt-get install -y librsvg2-dev gcc-8 g++-8 cmake ninja-build \
+        libgtk-3-dev libpoppler-glib-dev portaudio19-dev libsndfile-dev \
+        liblua5.3-dev libzip-dev gettext help2man libgtest-dev
       g++ --version
     displayName: 'Install dependencies'

--- a/readme/LinuxBuild.md
+++ b/readme/LinuxBuild.md
@@ -182,3 +182,19 @@ cmake .. -DCMAKE_INSTALL_PREFIX=/usr
 sudo cmake --build . --target install
 ./cmake/postinst configure
 ```
+
+## Running tests
+
+The unit tests can be enabled by setting `-DENABLE_GTEST=on` when running the
+CMake command. This requires having `googletest` available, either through your
+system's package manager or by setting `-DDOWNLOAD_GTEST=on` to automatically
+download and build `googletest`.
+
+The tests can be run as follows:
+```
+# build unit test executables
+cmake --build . --target test-units
+
+# run unit tests
+cmake --build . --target test
+```

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,14 +18,6 @@ if(MACOSX)
     set(CMAKE_BUILD_WITH_INSTALL_RPATH ON)
 endif()
 
-# Download and Build GoogleTest
-include(FetchContent)
-FetchContent_Declare(
-    googletest
-    URL https://github.com/google/googletest/archive/refs/tags/release-1.11.0.zip
-)
-# Prevent reloading if already downloaed
-set(FETCHCONTENT_UPDATES_DISCONNECTED ON)
 # For Windows: Prevent overriding the parent project's compiler/linker settings
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
@@ -33,7 +25,34 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 # This is not strictly necessary as add_subdirectory is called on ./test with
 # EXCLUDE_FROM_ALL, but better safe than sorry
 option(INSTALL_GTEST "Enable installation of googletest." OFF)
-FetchContent_MakeAvailable(googletest)
+
+# Explicit flag to enable gtest download
+option(DOWNLOAD_GTEST "Force download of googletest." OFF)
+
+if (${DOWNLOAD_GTEST})
+  message(STATUS "Downloading gtest...")
+  # Download and build GoogleTest
+  include(FetchContent)
+  FetchContent_Declare(
+      googletest
+      URL https://github.com/google/googletest/archive/refs/tags/release-1.11.0.zip
+  )
+  # Prevent reloading if already downloaed
+  set(FETCHCONTENT_UPDATES_DISCONNECTED ON)
+  FetchContent_MakeAvailable(googletest)
+else ()
+  # Use system GoogleTest
+  find_package(GTest)
+  if (NOT ${GTEST_FOUND})
+    message(FATAL_ERROR
+      "googletest not found. If you would like to download it automatically, add\n"
+      "    -DDOWNLOAD_GTEST=on\n"
+      "to the cmake command."
+    )
+  endif ()
+
+  add_library(gtest_main ALIAS GTest::Main)
+endif ()
 
 # Load configure file including constants and helper Macros
 configure_file (

--- a/test/unit_tests/control/ToolEnumsTest.cpp
+++ b/test/unit_tests/control/ToolEnumsTest.cpp
@@ -25,8 +25,8 @@ TEST(ToolEnumsTest, testToolSizeSerialization) {
     for (unsigned int i = 0; i <= TOOL_SIZE_NONE; i++) {
         auto toolSize = static_cast<ToolSize>(i);
         std::string s = toolSizeToString(toolSize);
-        GTEST_ASSERT_FALSE(s.empty());
-        GTEST_ASSERT_EQ(toolSize, toolSizeFromString(s));
+        EXPECT_FALSE(s.empty());
+        EXPECT_EQ(toolSize, toolSizeFromString(s));
     }
 }
 
@@ -39,7 +39,7 @@ TEST(ToolEnumsTest, testToolTypeSerialization) {
     for (unsigned int i = 0; i < TOOL_END_ENTRY; i++) {
         auto toolType = static_cast<ToolType>(i);
         std::string s = toolTypeToString(toolType);
-        GTEST_ASSERT_FALSE(s.empty());
-        GTEST_ASSERT_EQ(toolType, toolTypeFromString(s));
+        EXPECT_FALSE(s.empty());
+        EXPECT_EQ(toolType, toolTypeFromString(s));
     }
 }


### PR DESCRIPTION
This PR changes the test build config so that the system gtest is preferred. Optionally, `-DDOWNLOAD_GTEST=on` may be set to explicitly download gtest from the internet (system gtest is ignored when using this flag). Rationale: sandboxed build environments may not have internet (e.g., Debian CI), but we still want to be able to run tests.

Edit: TODO:
* [x] update the readme.