### PR TITLE
Remove unecessary mask in StrokeHandler

### DIFF
--- a/src/core/control/SearchControl.cpp
+++ b/src/core/control/SearchControl.cpp
@@ -17,7 +17,7 @@ SearchControl::~SearchControl() { freeSearchResults(); }
 
 void SearchControl::freeSearchResults() { this->results.clear(); }
 
-void SearchControl::paint(cairo_t* cr, GdkRectangle* rect, double zoom, const GdkRGBA& color) {
+void SearchControl::paint(cairo_t* cr, double zoom, const GdkRGBA& color) {
     // set the line always the same size on display
     cairo_set_line_width(cr, 1 / zoom);
 

--- a/src/core/control/SearchControl.h
+++ b/src/core/control/SearchControl.h
@@ -20,7 +20,7 @@ public:
     virtual ~SearchControl();
 
     bool search(std::string text, int* occures, double* top);
-    void paint(cairo_t* cr, GdkRectangle* rect, double zoom, const GdkRGBA& color);
+    void paint(cairo_t* cr, double zoom, const GdkRGBA& color);
 
 private:
     void freeSearchResults();

--- a/src/core/control/tools/BaseStrokeHandler.cpp
+++ b/src/core/control/tools/BaseStrokeHandler.cpp
@@ -29,11 +29,6 @@ void BaseStrokeHandler::draw(cairo_t* cr) {
         return;
     }
 
-    double zoom = xournal->getZoom();
-    int dpiScaleFactor = xournal->getDpiScaleFactor();
-
-    cairo_scale(cr, zoom * dpiScaleFactor, zoom * dpiScaleFactor);
-
     auto context = xoj::view::Context::createDefault(cr);
     strokeView->draw(context);
 }

--- a/src/core/control/tools/PdfElemSelection.cpp
+++ b/src/core/control/tools/PdfElemSelection.cpp
@@ -56,7 +56,7 @@ bool PdfElemSelection::finalizeSelection(XojPdfPageSelectionStyle style) {
     return !this->selectedTextRects.empty();
 }
 
-void PdfElemSelection::paint(cairo_t* cr, GdkRectangle* rect, double zoom, XojPdfPageSelectionStyle style) {
+void PdfElemSelection::paint(cairo_t* cr, XojPdfPageSelectionStyle style) {
     if (!this->pdf)
         return;
 

--- a/src/core/control/tools/PdfElemSelection.h
+++ b/src/core/control/tools/PdfElemSelection.h
@@ -39,7 +39,7 @@ public:
     bool finalizeSelection(XojPdfPageSelectionStyle style);
 
     /// Render the selection visuals with the given style
-    void paint(cairo_t* cr, GdkRectangle* rect, double zoom, XojPdfPageSelectionStyle style);
+    void paint(cairo_t* cr, XojPdfPageSelectionStyle style);
 
     /// Update the (unfinalized) selection bounds with the given
     /// style.

--- a/src/core/control/tools/Selection.cpp
+++ b/src/core/control/tools/Selection.cpp
@@ -89,7 +89,7 @@ void RectSelection::currentPos(double x, double y) {
 
 auto RectSelection::userTapped(double zoom) -> bool { return this->maxDist < 10 / zoom; }
 
-void RectSelection::paint(cairo_t* cr, GdkRectangle* rect, double zoom) {
+void RectSelection::paint(cairo_t* cr, double zoom) {
     GdkRGBA selectionColor = view->getSelectionColor();
 
     // set the line always the same size on display
@@ -129,7 +129,7 @@ public:
 
 RegionSelect::RegionSelect(double x, double y, Redrawable* view): Selection(view) { currentPos(x, y); }
 
-void RegionSelect::paint(cairo_t* cr, GdkRectangle* rect, double zoom) {
+void RegionSelect::paint(cairo_t* cr, double zoom) {
     // at least three points needed
     if (points.size() >= 3) {
         GdkRGBA selectionColor = view->getSelectionColor();

--- a/src/core/control/tools/Selection.h
+++ b/src/core/control/tools/Selection.h
@@ -27,7 +27,7 @@ public:
 
 public:
     virtual bool finalize(PageRef page) = 0;
-    virtual void paint(cairo_t* cr, GdkRectangle* rect, double zoom) = 0;
+    virtual void paint(cairo_t* cr, double zoom) = 0;
     virtual void currentPos(double x, double y) = 0;
     virtual bool userTapped(double zoom) = 0;
 
@@ -52,7 +52,7 @@ public:
 
 public:
     bool finalize(PageRef page) override;
-    void paint(cairo_t* cr, GdkRectangle* rect, double zoom) override;
+    void paint(cairo_t* cr, double zoom) override;
     void currentPos(double x, double y) override;
     bool contains(double x, double y) override;
     bool userTapped(double zoom) override;
@@ -81,7 +81,7 @@ public:
 
 public:
     bool finalize(PageRef page) override;
-    void paint(cairo_t* cr, GdkRectangle* rect, double zoom) override;
+    void paint(cairo_t* cr, double zoom) override;
     void currentPos(double x, double y) override;
     bool contains(double x, double y) override;
     bool userTapped(double zoom) override;

--- a/src/core/control/tools/SplineHandler.cpp
+++ b/src/core/control/tools/SplineHandler.cpp
@@ -28,8 +28,6 @@ void SplineHandler::draw(cairo_t* cr) {
         return;
     }
 
-    double zoom = xournal->getZoom();
-    double radius = RADIUS_WITHOUT_ZOOM / zoom;
     if (xournal->getControl()->getToolHandler()->getDrawingType() != DRAWING_TYPE_SPLINE) {
         g_warning("Drawing type is not spline any longer");
         this->finalizeSpline();
@@ -38,10 +36,10 @@ void SplineHandler::draw(cairo_t* cr) {
         return;
     }
 
-    int dpiScaleFactor = xournal->getDpiScaleFactor();
-    cairo_scale(cr, zoom * dpiScaleFactor, zoom * dpiScaleFactor);
-
+    double zoom = xournal->getZoom();
+    double radius = RADIUS_WITHOUT_ZOOM / zoom;
     double lineWidth = LINE_WIDTH_WITHOUT_ZOOM / zoom;
+
     cairo_set_line_width(cr, lineWidth);
     const Point& firstKnot = this->knots.front();
     const Point& lastKnot = this->knots.back();

--- a/src/core/control/tools/StrokeHandler.cpp
+++ b/src/core/control/tools/StrokeHandler.cpp
@@ -360,10 +360,10 @@ void StrokeHandler::onButtonPressEvent(const PositionInputData& pos) {
 
         cairo_surface_set_device_offset(surfMask, (0.5 * strokeWidth - visibleRect->x) * ratio,
                                         (0.5 * strokeWidth - visibleRect->y) * ratio);
+        cairo_surface_set_device_scale(surfMask, ratio, ratio);
 
         crMask = cairo_create(surfMask);
 
-        cairo_scale(crMask, ratio, ratio);
 
         // Paint the starting point
         this->paintDot(this->buttonDownPoint.x, this->buttonDownPoint.y,

--- a/src/core/control/tools/VerticalToolHandler.h
+++ b/src/core/control/tools/VerticalToolHandler.h
@@ -43,7 +43,7 @@ public:
     VerticalToolHandler(VerticalToolHandler&&) = delete;
     VerticalToolHandler&& operator=(VerticalToolHandler&&) = delete;
 
-    void paint(cairo_t* cr, GdkRectangle* rect, double zoom);
+    void paint(cairo_t* cr);
 
     /** Update the tool state with the new spacing position */
     void currentPos(double x, double y);

--- a/src/core/gui/TextEditor.cpp
+++ b/src/core/gui/TextEditor.cpp
@@ -951,7 +951,7 @@ void TextEditor::drawCursor(cairo_t* cr, double x, double y, double height, doub
     Util::cairo_set_source_rgbi(cr, this->text->getColor());
 }
 
-void TextEditor::paint(cairo_t* cr, GdkRectangle* repaintRect, double zoom) {
+void TextEditor::paint(cairo_t* cr, double zoom) {
     GdkRGBA selectionColor = this->gui->getSelectionColor();
 
     cairo_save(cr);

--- a/src/core/gui/TextEditor.h
+++ b/src/core/gui/TextEditor.h
@@ -29,7 +29,7 @@ public:
     /** Represents the different kinds of text selection */
     enum class SelectType { word, paragraph, all };
 
-    void paint(cairo_t* cr, GdkRectangle* rect, double zoom);
+    void paint(cairo_t* cr, double zoom);
 
     bool onKeyPressEvent(GdkEventKey* event);
     bool onKeyReleaseEvent(GdkEventKey* event);


### PR DESCRIPTION
This PR improves performance and mem usage in StrokeHandler for strokes that require a full redraw at each event, by removing an unecessary mask.

It also fixes the display of single-point strokes that require a full redraw, and removes the corresponding warnings.

This is ready for a review.