### PR TITLE
3921 show the filepath in the titlebar along with the filename

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -2414,7 +2414,8 @@ void Control::updateWindowTitle() {
             }
 
             if (settings->isFilepathInTitlebarShown()) {
-                title += doc->getPdfFilepath().u8string();
+                title += ("[" + doc->getPdfFilepath().parent_path().u8string() + "] - " +
+                          doc->getPdfFilepath().filename().u8string());
             } else {
                 title += doc->getPdfFilepath().filename().u8string();
             }
@@ -2425,7 +2426,8 @@ void Control::updateWindowTitle() {
         }
 
         if (settings->isFilepathInTitlebarShown()) {
-            title += doc->getFilepath().u8string();
+            title += ("[" + doc->getFilepath().parent_path().u8string() + "] - " +
+                      doc->getFilepath().filename().u8string());
         } else {
             title += doc->getFilepath().filename().u8string();
         }

--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -1961,6 +1961,7 @@ void Control::showSettings() {
     }
 
     win->updateScrollbarSidebarPosition();
+    this->updateWindowTitle();
 
     enableAutosave(settings->isAutosaveEnabled());
 
@@ -2411,14 +2412,23 @@ void Control::updateWindowTitle() {
             if (undoRedo->isChanged()) {
                 title += "*";
             }
-            title += doc->getPdfFilepath().filename().u8string();
+
+            if (settings->isFilepathInTitlebarShown()) {
+                title += doc->getPdfFilepath().u8string();
+            } else {
+                title += doc->getPdfFilepath().filename().u8string();
+            }
         }
     } else {
         if (undoRedo->isChanged()) {
             title += "*";
         }
 
-        title += doc->getFilepath().filename().u8string();
+        if (settings->isFilepathInTitlebarShown()) {
+            title += doc->getFilepath().u8string();
+        } else {
+            title += doc->getFilepath().filename().u8string();
+        }
     }
     this->doc->unlock();
 

--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -1115,9 +1115,7 @@ void Settings::setMenubarVisible(bool visible) {
     save();
 }
 
-const bool Settings::isFilepathInTitlebarShown() const {
-    return this->filepathShownInTitlebar;
-}
+const bool Settings::isFilepathInTitlebarShown() const { return this->filepathShownInTitlebar; }
 
 void Settings::setFilepathInTitlebarShown(const bool shown) {
     if (this->filepathShownInTitlebar == shown) {
@@ -1125,7 +1123,7 @@ void Settings::setFilepathInTitlebarShown(const bool shown) {
     }
 
     this->filepathShownInTitlebar = shown;
-    
+
     save();
 }
 

--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -1115,6 +1115,20 @@ void Settings::setMenubarVisible(bool visible) {
     save();
 }
 
+const bool Settings::isFilepathInTitlebarShown() const {
+    return this->filepathShownInTitlebar;
+}
+
+void Settings::setFilepathInTitlebarShown(const bool shown) {
+    if (this->filepathShownInTitlebar == shown) {
+        return;
+    }
+
+    this->filepathShownInTitlebar = shown;
+    
+    save();
+}
+
 auto Settings::getAutosaveTimeout() const -> int { return this->autosaveTimeout; }
 
 void Settings::setAutosaveTimeout(int autosave) {

--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -360,6 +360,8 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur) {
         this->maximized = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("showToolbar")) == 0) {
         this->showToolbar = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("filepathShownInTitlebar")) == 0) {
+        this->filepathShownInTitlebar = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("showSidebar")) == 0) {
         this->showSidebar = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("sidebarWidth")) == 0) {
@@ -852,6 +854,7 @@ void Settings::save() {
     SAVE_BOOL_PROP(sidebarOnRight);
     SAVE_BOOL_PROP(scrollbarOnLeft);
     SAVE_BOOL_PROP(menubarVisible);
+    SAVE_BOOL_PROP(filepathShownInTitlebar);
     SAVE_INT_PROP(numColumns);
     SAVE_INT_PROP(numRows);
     SAVE_BOOL_PROP(viewFixedRows);

--- a/src/core/control/settings/Settings.h
+++ b/src/core/control/settings/Settings.h
@@ -215,6 +215,9 @@ public:
     bool isMenubarVisible() const;
     void setMenubarVisible(bool visible);
 
+    const bool isFilepathInTitlebarShown() const;
+    void setFilepathInTitlebarShown(const bool shown);
+
     void setShowPairedPages(bool showPairedPages);
     bool isShowPairedPages() const;
 
@@ -634,6 +637,11 @@ private:
      * If the menu bar is visible on startup
      */
     bool menubarVisible{};
+
+    /**
+     * If the filepath is shown in titlebar
+     */
+    bool filepathShownInTitlebar{};
 
     /**
      *  Hide the scrollbar

--- a/src/core/gui/dialog/SettingsDialog.cpp
+++ b/src/core/gui/dialog/SettingsDialog.cpp
@@ -362,7 +362,6 @@ void SettingsDialog::load() {
     loadCheckbox("cbInputSystemTPCButton", settings->getInputSystemTPCButtonEnabled());
     loadCheckbox("cbInputSystemDrawOutsideWindow", settings->getInputSystemDrawOutsideWindowEnabled());
 
-
     /**
      * Stabilizer related settings
      */
@@ -521,6 +520,7 @@ void SettingsDialog::load() {
     loadCheckbox("cbHidePresentationMenubar", hidePresentationMenubar);
     loadCheckbox("cbHidePresentationSidebar", hidePresentationSidebar);
     loadCheckbox("cbHideMenubarStartup", settings->isMenubarVisible());
+    loadCheckbox("cbShowFilepathInTitlebar", settings->isFilepathInTitlebarShown());
 
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(get("preloadPagesBefore")),
                               static_cast<double>(settings->getPreloadPagesBefore()));
@@ -762,6 +762,7 @@ void SettingsDialog::save() {
                                                            hidePresentationMenubar, hidePresentationSidebar));
 
     settings->setMenubarVisible(getCheckbox("cbHideMenubarStartup"));
+    settings->setFilepathInTitlebarShown(getCheckbox("cbShowFilepathInTitlebar"));
 
     constexpr auto spinAsUint = [&](GtkSpinButton* btn) {
         int v = gtk_spin_button_get_value_as_int(btn);

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -2729,10 +2729,48 @@ This setting can make it easier to draw with touch. </property>
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
                                             <property name="halign">start</property>
+                                            <property name="orientation">vertical</property>
                                             <child>
-                                              <object class="GtkCheckButton" id="cbHideMenubarStartup">
-                                                <property name="label" translatable="yes">Show Menubar on Startup</property>
-                                                <property name="name">cbHideMenubarStartup</property>
+                                              <object class="GtkBox" id="vbox7">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="halign">start</property>
+                                                <child>
+                                                  <object class="GtkCheckButton" id="cbHideMenubarStartup">
+                                                    <property name="label" translatable="yes">Show Menubar on Startup</property>
+                                                    <property name="name">cbHideMenubarStartup</property>
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">True</property>
+                                                    <property name="receives-default">False</property>
+                                                    <property name="xalign">0</property>
+                                                    <property name="draw-indicator">True</property>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="expand">False</property>
+                                                    <property name="fill">True</property>
+                                                    <property name="position">0</property>
+                                                  </packing>
+                                                </child>
+                                                <child>
+                                                  <object class="GtkLabel" id="sid101">
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">False</property>
+                                                    <property name="margin-left">5</property>
+                                                    <property name="label" translatable="yes">&lt;i&gt;Toggle visibility of menubar with F10&lt;/i&gt;</property>
+                                                    <property name="use-markup">True</property>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="expand">False</property>
+                                                    <property name="fill">True</property>
+                                                    <property name="position">1</property>
+                                                  </packing>
+                                                </child>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkCheckButton" id="cbShowFilepathInTitlebar">
+                                                <property name="label" translatable="yes">Show filepath in title bar</property>
+                                                <property name="name">cbShowFilepathInTitlebar</property>
                                                 <property name="visible">True</property>
                                                 <property name="can-focus">True</property>
                                                 <property name="receives-default">False</property>
@@ -2742,21 +2780,7 @@ This setting can make it easier to draw with touch. </property>
                                               <packing>
                                                 <property name="expand">False</property>
                                                 <property name="fill">True</property>
-                                                <property name="position">0</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkLabel" id="sid101">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="margin-left">5</property>
-                                                <property name="label" translatable="yes">&lt;i&gt;Toggle visibility of menubar with F10&lt;/i&gt;</property>
-                                                <property name="use-markup">True</property>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">True</property>
-                                                <property name="position">1</property>
+                                                <property name="position">2</property>
                                               </packing>
                                             </child>
                                           </object>


### PR DESCRIPTION
Made required enhancement per  **Show the filepath in the titlebar along with the filename #3921** issue.
To avoid breaking default behavior added "Show filepath in titlebar" in **view** tab in settings. 
Default behavior remains same i.e. only filename is shown.
Edited behavior when **Show filepath in titlebar** setting changes and settings are saved, change in titlebar is applied immediately.

Translations to other languages were not added.
