### PR TITLE
To make the cursor invisible on eraser motion only (not in erase acti…

### DIFF
--- a/src/core/gui/XournalppCursor.cpp
+++ b/src/core/gui/XournalppCursor.cpp
@@ -273,7 +273,12 @@ void XournalppCursor::updateCursor() {
                 }
             }
         } else if (type == TOOL_ERASER) {
-            cursor = getEraserCursor();
+            if (this->invisible) {
+                setCursor(CRSR_BLANK_CURSOR);
+                cursor = nullptr;
+            } else {
+                cursor = getEraserCursor();
+            }
         }
 
         else if (type == TOOL_TEXT) {

--- a/src/core/gui/inputdevices/StylusInputHandler.cpp
+++ b/src/core/gui/inputdevices/StylusInputHandler.cpp
@@ -71,7 +71,11 @@ auto StylusInputHandler::handleImpl(InputEvent const& event) -> bool {
             this->actionMotion(event);
         }
         XournalppCursor* cursor = xournal->view->getCursor();
-        cursor->setInvisible(false);
+        if (inputContext->getSettings()->getStylusCursorType() == STYLUS_CURSOR_NONE && !this->deviceClassPressed) {
+            cursor->setInvisible(true);
+        } else {
+            cursor->setInvisible(false);
+        }
         cursor->updateCursor();
     }
 


### PR DESCRIPTION
**Context:**
Chances are, The user does not want to see the annoying cursor all the time when the stylus cursor type is set to STYLUS_CURSOR_NONE.
This works fine on pen but eraser. Especially when the stylus is in the proximity of the surface. 
However, the eraser cursor should reappear on in-erase action as it provides the estimation of where the eraser is being applied.

**Solution:**
To implement the logic in the device handler as it is aware of the device status (in motion but in-erase mode).
Since the XournalppCursor is not aware of the device status, then it is not a good candidate to incorporate the logic.