### PR TITLE
merge release 1.1

### DIFF
--- a/src/core/control/XournalMain.cpp
+++ b/src/core/control/XournalMain.cpp
@@ -56,6 +56,16 @@ auto exportImg(const char* input, const char* output, const char* range, int png
 
 void initResourcePath(GladeSearchpath* gladePath, const gchar* relativePathAndFile, bool failIfNotFound = true);
 
+void initCAndCoutLocales() {
+    /**
+     * Force numbers to be printed out and parsed by C libraries (cairo) in the "classic" locale.
+     * This avoids issue with tags when exporting to PDF, see #3551
+     */
+    setlocale(LC_NUMERIC, "C");
+
+    std::cout.imbue(std::locale());
+}
+
 void initLocalisation() {
 #ifdef ENABLE_NLS
     fs::path localeDir = Util::getGettextFilepath(Util::getLocalePath().u8string().c_str());
@@ -77,13 +87,8 @@ void initLocalisation() {
                   "xournalpp with msvc",
                   e.what());
     }
-    /**
-     * Force numbers to be printed out and parsed by C libraries (cairo) in the "classic" locale.
-     * This avoids issue with tags when exporting to PDF, see #3551
-     */
-    setlocale(LC_NUMERIC, "C");
 
-    std::cout.imbue(std::locale());
+    initCAndCoutLocales();
 }
 
 auto migrateSettings() -> MigrateResult {
@@ -482,6 +487,7 @@ void on_startup(GApplication* application, XMPtr app_data) {
 }
 
 auto on_handle_local_options(GApplication*, GVariantDict*, XMPtr app_data) -> gint {
+    initCAndCoutLocales();
     if (app_data->showVersion) {
         std::cout << PROJECT_NAME << " " << PROJECT_VERSION << std::endl;
         std::cout << "└──libgtk: " << gtk_get_major_version() << "."  //

--- a/src/core/gui/TextEditor.cpp
+++ b/src/core/gui/TextEditor.cpp
@@ -906,7 +906,10 @@ auto TextEditor::blinkCallback(TextEditor* te) -> gint {
     return false;
 }
 
-void TextEditor::repaintEditor() { this->gui->repaintPage(); }
+void TextEditor::repaintEditor() {
+    auto rect = text->boundingRect();
+    this->gui->repaintRect(rect.x, rect.y, rect.width, rect.height);
+}
 
 /**
  * Calculate the UTF-8 Char offset into a byte offset.

--- a/src/core/view/TextView.cpp
+++ b/src/core/view/TextView.cpp
@@ -113,6 +113,6 @@ void TextView::calcSize(const Text* t, double& width, double& height) {
     height = (static_cast<double>(h)) / PANGO_SCALE;
     g_object_unref(layout);
 
-    cairo_surface_destroy(surface);
     cairo_destroy(cr);
+    cairo_surface_destroy(surface);
 }

--- a/ui/xournalpp.css
+++ b/ui/xournalpp.css
@@ -165,3 +165,6 @@ window.darkMode #sidebarContents {
 	background-color: #222;
 }
 
+menubar, toolbar {
+    -GtkWidget-window-dragging: false
+}


### PR DESCRIPTION
This is a merge of the bugfixes from the release branch to the master branch, for #3503 could interfere with https://github.com/xournalpp/xournalpp/commit/38258a498f9edfc8cea0e842da745dcaa0fa7505.

Note that two commits from the release branch were dropped:

- e409fb6 : Automated version bump to 1.1.2~dev
- 034deb5 : Fix backtrace linker flags

@Technius, could you confirm that 034deb5 is not needed on the master branch?