### PR TITLE
Select correct tool when selecting default tool

### DIFF
--- a/src/control/Control.cpp
+++ b/src/control/Control.cpp
@@ -1660,6 +1660,10 @@ void Control::selectTool(ToolType type) {
 void Control::selectDefaultTool() {
     ButtonConfig* cfg = settings->getButtonConfig(Button::BUTTON_DEFAULT);
     cfg->applyConfigToToolbarTool(toolHandler);
+
+    if (toolHandler->getToolType() != TOOL_NONE) {
+        selectTool(toolHandler->getToolType());
+    }
 }
 
 void Control::toolChanged() {


### PR DESCRIPTION
Bug fix attempt for selecting correct tool when Tools->Default Tools is selected.