### PR TITLE
MacOS: fix linker flags when using MacPorts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...${CMAKE_VERSION})
+cmake_minimum_required(VERSION 3.12)
 cmake_policy(VERSION ${CMAKE_VERSION})
 
 ## Project related Variables
@@ -108,6 +108,14 @@ if (#[[${CMAKE_VERSION} VERSION_LESS "3.18" AND]] ${CMAKE_SYSTEM_NAME} MATCHES "
     string(REPLACE "-framework;" "-framework " libs "${libs}")
     message(STATUS "PkgConfig::ExternalModules::INTERFACE_LINK_LIBRARIES fixed: ${libs}")
     set_target_properties(PkgConfig::ExternalModules PROPERTIES INTERFACE_LINK_LIBRARIES "${libs}")
+
+
+    if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.13")
+        # fix broken framework flags from pkgconfig
+        get_target_property(opts PkgConfig::ExternalModules INTERFACE_LINK_OPTIONS)
+        string(REPLACE "-framework;" "SHELL:-framework " opts "${opts}")
+        set_target_properties(PkgConfig::ExternalModules PROPERTIES INTERFACE_LINK_OPTIONS "${opts}")
+    endif ()
 endif ()
 
 find_package(ZLIB REQUIRED)

--- a/src/xoj-preview-extractor/CMakeLists.txt
+++ b/src/xoj-preview-extractor/CMakeLists.txt
@@ -22,20 +22,11 @@ add_executable (xournalpp-thumbnailer
         "${PROJECT_SOURCE_DIR}/src/util/XojPreviewExtractor.cpp"
         )
 
-# MacOS workaround: "-framework ____" flags need to be passed as one string.
-# See https://sourceforge.net/p/plplot/mailman/message/19574644/ for more details
-if (MACOSX)
-  string(REPLACE "-framework;" "-framework " thumbnailer_GTK_LDFLAGS "${GTK_LDFLAGS}")
-else()
-  set(thumbnailer_GTK_LDFLAGS "${GTK_LDFLAGS}")
-endif()
-
 add_dependencies(xournalpp-thumbnailer std::filesystem)
 
 target_link_libraries (xournalpp-thumbnailer
   util
   std::filesystem
-  ${thumbnailer_GTK_LDFLAGS}
   ${ZLIB_LIBRARIES}
   ${librsvg_LDFLAGS}
   ${Glib_LDFLAGS}


### PR DESCRIPTION
The CMake dependencies found with pkgconfig will incorrectly set the external
module LINK_OPTIONS to be of the form `-framework A B C`, which is incorrect.
This commit adds some checks to correct this CMake/pkgconfig error.

Furthermore, some redundant linker flags have been removed from
xournalpp-thumbnailer.