### PR TITLE
Remove x and y from GtkXournal struct

### DIFF
--- a/src/core/gui/inputdevices/AbstractInputHandler.cpp
+++ b/src/core/gui/inputdevices/AbstractInputHandler.cpp
@@ -41,13 +41,10 @@ auto AbstractInputHandler::getPageAtCurrentPosition(InputEvent const& event) -> 
         return nullptr;
     }
 
-    gdouble eventX = event.relativeX;
-    gdouble eventY = event.relativeY;
-
     GtkXournal* xournal = this->inputContext->getXournal();
 
-    double x = eventX + xournal->x;
-    double y = eventY + xournal->y;
+    int x = static_cast<int>(std::round(event.relativeX));
+    int y = static_cast<int>(std::round(event.relativeY));
 
     return xournal->layout->getPageViewAt(x, y);
 }
@@ -64,8 +61,8 @@ auto AbstractInputHandler::getInputDataRelativeToCurrentPage(XojPageView* page, 
     gdouble eventY = event.relativeY;
 
     PositionInputData pos = {};
-    pos.x = eventX - page->getX() - xournal->x;
-    pos.y = eventY - page->getY() - xournal->y;
+    pos.x = eventX - static_cast<double>(page->getX());
+    pos.y = eventY - static_cast<double>(page->getY());
     pos.pressure = Point::NO_PRESSURE;
 
     if (this->inputContext->getSettings()->isPressureSensitivity()) {

--- a/src/core/gui/inputdevices/SetsquareInputHandler.cpp
+++ b/src/core/gui/inputdevices/SetsquareInputHandler.cpp
@@ -401,8 +401,8 @@ auto SetsquareInputHandler::getCoords(double xCoord, double yCoord) -> utl::Poin
     const auto zoom = view->getZoom();
     const auto xournal = inputContext->getXournal();
     const auto page = setsquareView->getView();
-    const auto posX = xCoord - static_cast<double>(page->getX() + xournal->x);
-    const auto posY = yCoord - static_cast<double>(page->getY() + xournal->y);
+    const auto posX = xCoord - static_cast<double>(page->getX());
+    const auto posY = yCoord - static_cast<double>(page->getY());
     return utl::Point<double>(posX / zoom, posY / zoom);
 }
 

--- a/src/core/gui/widgets/XournalWidget.cpp
+++ b/src/core/gui/widgets/XournalWidget.cpp
@@ -65,8 +65,6 @@ auto gtk_xournal_new(XournalView* view, InputContext* inputContext) -> GtkWidget
     GtkXournal* xoj = GTK_XOURNAL(g_object_new(gtk_xournal_get_type(), nullptr));
     xoj->view = view;
     xoj->scrollHandling = inputContext->getScrollHandling();
-    xoj->x = 0;
-    xoj->y = 0;
     xoj->layout = new Layout(view, inputContext->getScrollHandling());
     xoj->selection = nullptr;
     xoj->setsquareView = nullptr;
@@ -236,13 +234,6 @@ static void gtk_xournal_draw_shadow(GtkXournal* xournal, cairo_t* cr, int left, 
 void gtk_xournal_repaint_area(GtkWidget* widget, int x1, int y1, int x2, int y2) {
     g_return_if_fail(widget != nullptr);
     g_return_if_fail(GTK_IS_XOURNAL(widget));
-
-    GtkXournal* xournal = GTK_XOURNAL(widget);
-
-    x1 -= xournal->x;
-    x2 -= xournal->x;
-    y1 -= xournal->y;
-    y2 -= xournal->y;
 
     if (x2 < 0 || y2 < 0) {
         return;  // outside visible area

--- a/src/core/gui/widgets/XournalWidget.h
+++ b/src/core/gui/widgets/XournalWidget.h
@@ -48,11 +48,6 @@ struct _GtkXournal {
      */
     ScrollHandling* scrollHandling;
 
-    /**
-     * Visible area
-     */
-    int x;
-    int y;
 
     Layout* layout;
 


### PR DESCRIPTION
Those variables `xournal->x` and `xournal->y` have been `0` all the time (for many years) and made the code look more confusing. They are pointless, so I suggest to remove them via this PR.