### PR TITLE
#3921 Show filepath in titlebar along with the filename

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -2398,7 +2398,7 @@ auto Control::showSaveDialog() -> bool {
 }
 
 void Control::updateWindowTitle() {
-    string title{};
+string title{};
 
     this->doc->lock();
     if (doc->getFilepath().empty()) {
@@ -2408,25 +2408,14 @@ void Control::updateWindowTitle() {
             if (undoRedo->isChanged()) {
                 title += "*";
             }
-
-            if (settings->isFilepathInTitlebarShown()) {
-                title += ("[" + doc->getPdfFilepath().parent_path().u8string() + "] - " +
-                          doc->getPdfFilepath().filename().u8string());
-            } else {
-                title += doc->getPdfFilepath().filename().u8string();
-            }
+            title += doc->getPdfFilepath().u8string();
         }
     } else {
         if (undoRedo->isChanged()) {
             title += "*";
         }
 
-        if (settings->isFilepathInTitlebarShown()) {
-            title += ("[" + doc->getFilepath().parent_path().u8string() + "] - " +
-                      doc->getFilepath().filename().u8string());
-        } else {
-            title += doc->getFilepath().filename().u8string();
-        }
+        title += doc->getFilepath().u8string();
     }
     this->doc->unlock();
 


### PR DESCRIPTION
Addressing issue [#3921](https://github.com/xournalpp/xournalpp/issues/3921), changed code to show the full file path in the window's title bar so that if the user has multiple windows, each editing files of the same name in different directories, it is easier for the user to differentiate between them.