### PR TITLE
View refactor 1.5: SelectionView & PdfPage::render

### DIFF
--- a/src/core/control/ClipboardHandler.cpp
+++ b/src/core/control/ClipboardHandler.cpp
@@ -6,12 +6,13 @@
 #include <cairo-svg.h>
 #include <config.h>
 
+#include "model/Text.h"
 #include "util/Util.h"
 #include "util/pixbuf-utils.h"
 #include "util/serializing/BinObjectEncoding.h"
 #include "util/serializing/ObjectInputStream.h"
 #include "util/serializing/ObjectOutputStream.h"
-#include "view/DocumentView.h"
+#include "view/SelectionView.h"
 
 #include "Control.h"
 
@@ -160,8 +161,6 @@ auto ClipboardHandler::copy() -> bool {
     // prepare image contents: PNG
     /////////////////////////////////////////////////////////////////
 
-    DocumentView view;
-
     double dpiFactor = 1.0 / Util::DPI_NORMALIZATION_FACTOR * 300.0;
 
     int width = static_cast<int>(selection->getWidth() * dpiFactor);
@@ -171,7 +170,9 @@ auto ClipboardHandler::copy() -> bool {
     cairo_scale(crPng, dpiFactor, dpiFactor);
 
     cairo_translate(crPng, -selection->getXOnView(), -selection->getYOnView());
-    view.drawSelection(crPng, this->selection);
+
+    xoj::view::SelectionView view(this->selection);
+    view.draw(xoj::view::Context::createDefault(crPng));
 
     cairo_destroy(crPng);
 
@@ -190,7 +191,7 @@ auto ClipboardHandler::copy() -> bool {
                                                 selection->getWidth(), selection->getHeight());
     cairo_t* crSVG = cairo_create(surfaceSVG);
 
-    view.drawSelection(crSVG, this->selection);
+    view.draw(xoj::view::Context::createDefault(crSVG));
 
     cairo_surface_destroy(surfaceSVG);
     cairo_destroy(crSVG);

--- a/src/core/control/PdfCache.cpp
+++ b/src/core/control/PdfCache.cpp
@@ -104,7 +104,7 @@ void PdfCache::render(cairo_t* cr, const XojPdfPageSPtr& popplerPage, double zoo
         cairo_t* cr2 = cairo_create(img);
 
         cairo_scale(cr2, renderZoom, renderZoom);
-        popplerPage->render(cr2, false);
+        popplerPage->render(cr2);
         cairo_destroy(cr2);
 
         cacheResult = cache(popplerPage, img, renderZoom);

--- a/src/core/control/PrintHandler.cpp
+++ b/src/core/control/PrintHandler.cpp
@@ -31,12 +31,12 @@ void drawPage(GtkPrintOperation* /*operation*/, GtkPrintContext* context, int pa
     if (page->getBackgroundType().isPdfPage()) {
         XojPdfPageSPtr popplerPage = doc->getPdfPage(page->getPdfPageNr());
         if (popplerPage) {
-            popplerPage->render(cr, true);
+            popplerPage->renderForPrinting(cr);
         }
     }
 
     DocumentView view;
-    view.drawPage(page, cr, true /* dont render eraseable */);
+    view.drawPage(page, cr, true /* dont render eraseable */, true /* dont show pdf background*/);
 }
 
 void requestPageSetup(GtkPrintOperation* /*op*/, GtkPrintContext* /*ctx*/, int pageNr, GtkPageSetup* setup,

--- a/src/core/control/jobs/CustomExportJob.cpp
+++ b/src/core/control/jobs/CustomExportJob.cpp
@@ -12,7 +12,6 @@
 #include "util/PathUtil.h"
 #include "util/XojMsgBox.h"
 #include "util/i18n.h"
-#include "view/PdfView.h"
 
 #include "ImageExport.h"
 #include "SaveJob.h"

--- a/src/core/control/jobs/SaveJob.cpp
+++ b/src/core/control/jobs/SaveJob.cpp
@@ -55,7 +55,8 @@ void SaveJob::updatePreview(Control* control) {
         width *= zoom;
         height *= zoom;
 
-        cairo_surface_t* crBuffer = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
+        cairo_surface_t* crBuffer = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, static_cast<int>(std::ceil(width)),
+                                                               static_cast<int>(std::ceil(height)));
 
         cairo_t* cr = cairo_create(crBuffer);
         cairo_scale(cr, zoom, zoom);
@@ -64,7 +65,7 @@ void SaveJob::updatePreview(Control* control) {
             auto pgNo = page->getPdfPageNr();
             XojPdfPageSPtr popplerPage = doc->getPdfPage(pgNo);
             if (popplerPage) {
-                popplerPage->render(cr, false);
+                popplerPage->render(cr);
             }
         }
 

--- a/src/core/control/tools/EditSelectionContents.cpp
+++ b/src/core/control/tools/EditSelectionContents.cpp
@@ -24,7 +24,7 @@
 #include "undo/UndoRedoHandler.h"
 #include "util/serializing/ObjectInputStream.h"
 #include "util/serializing/ObjectOutputStream.h"
-#include "view/DocumentView.h"
+#include "view/SelectionView.h"
 
 #include "Selection.h"
 
@@ -497,8 +497,9 @@ void EditSelectionContents::paint(cairo_t* cr, double x, double y, double rotati
         cairo_scale(cr2, fx, fy);
         cairo_translate(cr2, -dx, -dy);
         cairo_scale(cr2, zoom, zoom);
-        DocumentView view;
-        view.drawSelection(cr2, this);
+
+        xoj::view::SelectionView view(this);
+        view.draw(xoj::view::Context::createDefault(cr2));
 
         cairo_destroy(cr2);
     }

--- a/src/core/control/tools/VerticalToolHandler.cpp
+++ b/src/core/control/tools/VerticalToolHandler.cpp
@@ -8,7 +8,7 @@
 #include "control/zoom/ZoomControl.h"
 #include "model/Layer.h"
 #include "undo/UndoRedoHandler.h"
-#include "view/DocumentView.h"
+#include "view/SelectionView.h"
 
 VerticalToolHandler::VerticalToolHandler(Redrawable* view, const PageRef& page, Settings* settings, double y,
                                          bool initiallyReverse, ZoomControl* zoomControl, GdkWindow* window):
@@ -80,8 +80,8 @@ void VerticalToolHandler::redrawBuffer() {
     } else {
         g_assert(this->spacingSide == Side::Above);
     }
-    DocumentView v;
-    v.drawSelection(cr, this);
+    xoj::view::SelectionView v(this);
+    v.draw(xoj::view::Context::createDefault(cr));
 
     cairo_destroy(cr);
 }

--- a/src/core/pdf/base/XojCairoPdfExport.cpp
+++ b/src/core/pdf/base/XojCairoPdfExport.cpp
@@ -110,14 +110,15 @@ void XojCairoPdfExport::exportPage(size_t page) {
     DocumentView view;
 
     cairo_save(this->cr);
-    if (p->getBackgroundType().isPdfPage() && (exportBackground >= EXPORT_BACKGROUND_UNRULED)) {
+
+    if (p->getBackgroundType().isPdfPage() && (exportBackground != EXPORT_BACKGROUND_NONE)) {
         auto pgNo = p->getPdfPageNr();
         XojPdfPageSPtr popplerPage = doc->getPdfPage(pgNo);
 
-        popplerPage->render(cr, true);
+        popplerPage->renderForPrinting(cr);
     }
 
-    view.drawPage(p, this->cr, true /* dont render eraseable */, exportBackground == EXPORT_BACKGROUND_NONE,
+    view.drawPage(p, this->cr, true /* dont render eraseable */, true /* don't rerender the pdf background */,
                   exportBackground == EXPORT_BACKGROUND_NONE, exportBackground <= EXPORT_BACKGROUND_UNRULED);
 
     // next page

--- a/src/core/pdf/base/XojPdfPage.h
+++ b/src/core/pdf/base/XojPdfPage.h
@@ -51,7 +51,16 @@ public:
     virtual double getWidth() const = 0;
     virtual double getHeight() const = 0;
 
-    virtual void render(cairo_t* cr, bool forPrinting = false) = 0;
+    /**
+     * Renders the page to the given cairo context.
+     * Use render() for rendering to a screen (or a raster image format),
+     * Use renderForPrinting() for exports to vector formats (not sure it will be vectorial, but the quality is better)
+     *
+     * See https://poppler.freedesktop.org/api/glib/poppler-Poppler-Page.html#poppler-page-render-for-printing
+     * for actual differences between the two functions in the poppler based implementation.
+     */
+    virtual void render(cairo_t* cr) const = 0;
+    virtual void renderForPrinting(cairo_t* cr) const = 0;
 
     virtual std::vector<XojPdfRectangle> findText(std::string& text) = 0;
 

--- a/src/core/pdf/popplerapi/PopplerGlibPage.cpp
+++ b/src/core/pdf/popplerapi/PopplerGlibPage.cpp
@@ -60,14 +60,9 @@ auto PopplerGlibPage::getHeight() const -> double {
     return height;
 }
 
-void PopplerGlibPage::render(cairo_t* cr, bool forPrinting)  // NOLINT(google-default-arguments)
-{
-    if (forPrinting) {
-        poppler_page_render_for_printing(page, cr);
-    } else {
-        poppler_page_render(page, cr);
-    }
-}
+void PopplerGlibPage::render(cairo_t* cr) const { poppler_page_render(page, cr); }
+
+void PopplerGlibPage::renderForPrinting(cairo_t* cr) const { poppler_page_render_for_printing(page, cr); }
 
 auto PopplerGlibPage::getPageId() const -> int { return poppler_page_get_index(page); }
 

--- a/src/core/pdf/popplerapi/PopplerGlibPage.h
+++ b/src/core/pdf/popplerapi/PopplerGlibPage.h
@@ -27,7 +27,8 @@ public:
     double getWidth() const override;
     double getHeight() const override;
 
-    void render(cairo_t* cr, bool forPrinting = false) override;  // NOLINT(google-default-arguments)
+    void render(cairo_t* cr) const override;
+    void renderForPrinting(cairo_t* cr) const override;
 
     std::vector<XojPdfRectangle> findText(std::string& text) override;
 

--- a/src/core/view/DocumentView.cpp
+++ b/src/core/view/DocumentView.cpp
@@ -1,7 +1,5 @@
 #include "DocumentView.h"
 
-#include "control/tools/EditSelection.h"
-#include "control/tools/Selection.h"
 #include "model/Layer.h"
 #include "model/eraser/ErasableStroke.h"
 #include "view/background/MainBackgroundPainter.h"
@@ -23,15 +21,6 @@ DocumentView::~DocumentView() {
  * Mark stroke with Audio
  */
 void DocumentView::setMarkAudioStroke(bool markAudioStroke) { this->markAudioStroke = markAudioStroke; }
-
-void DocumentView::drawSelection(cairo_t* cr, ElementContainer* container) {
-    xoj::view::Context context{cr, (xoj::view::NonAudioTreatment)this->markAudioStroke,
-                               (xoj::view::EditionTreatment) !this->dontRenderEditingStroke, xoj::view::NORMAL_COLOR};
-    for (Element* e: container->getElements()) {
-        auto elementView = xoj::view::ElementView::createFromElement(e);
-        elementView->draw(context);
-    }
-}
 
 void DocumentView::limitArea(double x, double y, double width, double height) {
     this->lX = x;

--- a/src/core/view/DocumentView.h
+++ b/src/core/view/DocumentView.h
@@ -24,8 +24,6 @@
 #include "model/TexImage.h"
 #include "model/Text.h"
 
-
-class EditSelection;
 class MainBackgroundPainter;
 
 class DocumentView {
@@ -47,8 +45,6 @@ public:
                   bool hideImageBackground = false, bool hideRulingBackground = false);
 
     void limitArea(double x, double y, double width, double height);
-
-    void drawSelection(cairo_t* cr, ElementContainer* container);
 
     /**
      * Mark stroke with Audio

--- a/src/core/view/PdfView.cpp
+++ b/src/core/view/PdfView.cpp
@@ -9,17 +9,15 @@ PdfView::PdfView() = default;
 PdfView::~PdfView() = default;
 
 void PdfView::drawPage(PdfCache* cache, const XojPdfPageSPtr& popplerPage, cairo_t* cr, double zoom, double width,
-                       double height, bool forPrinting) {
+                       double height) {
     if (popplerPage) {
-        if (!forPrinting) {
-            cairo_set_source_rgb(cr, 1., 1., 1.);
-            cairo_paint(cr);
-        }
+        cairo_set_source_rgb(cr, 1., 1., 1.);
+        cairo_paint(cr);
 
-        if (cache && !forPrinting) {
+        if (cache) {
             cache->render(cr, popplerPage, zoom);
         } else {
-            popplerPage->render(cr, forPrinting);
+            popplerPage->render(cr);
         }
     } else {
         cairo_select_font_face(cr, "Sans", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_BOLD);

--- a/src/core/view/PdfView.h
+++ b/src/core/view/PdfView.h
@@ -23,5 +23,5 @@ private:
 
 public:
     static void drawPage(PdfCache* cache, const XojPdfPageSPtr& popplerPage, cairo_t* cr, double zoom, double width,
-                         double height, bool forPrinting = false);
+                         double height);
 };

--- a/src/core/view/SelectionView.cpp
+++ b/src/core/view/SelectionView.cpp
@@ -1,0 +1,15 @@
+#include "SelectionView.h"
+
+#include "model/Element.h"
+#include "model/ElementContainer.h"
+
+using namespace xoj::view;
+
+SelectionView::SelectionView(const ElementContainer* container): container(container) {}
+
+void SelectionView::draw(const Context& ctx) const {
+    for (Element* e: container->getElements()) {
+        auto elementView = ElementView::createFromElement(e);
+        elementView->draw(ctx);
+    }
+}

--- a/src/core/view/SelectionView.h
+++ b/src/core/view/SelectionView.h
@@ -1,0 +1,29 @@
+/*
+ * Xournal++
+ *
+ * Displays the content of a selection
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+#include "View.h"
+
+class ElementContainer;
+
+class xoj::view::SelectionView {
+public:
+    SelectionView(const ElementContainer* container);
+
+    /**
+     * @brief Draws the container to the given context
+     */
+    void draw(const Context& ctx) const;
+
+private:
+    const ElementContainer* container;
+};

--- a/src/core/view/View.h
+++ b/src/core/view/View.h
@@ -47,6 +47,7 @@ class StrokeView;
 class TextView;
 
 class LayerView;
+class SelectionView;
 class BackgroundView;
 class ImageBackgroundView;
 


### PR DESCRIPTION
This PR is a segment of #3969 (for easier review). It does two independent bits:

1. Create a SelectionView class to handle drawing the content of a selection (or any other ElementContainer)
2. Split XojPdfPage::render into two (render and renderForPrinting), simplifying the code.

This is ready for a review.