### PR TITLE
Added a workaround for a reference issue.

### DIFF
--- a/src/core/gui/XournalView.cpp
+++ b/src/core/gui/XournalView.cpp
@@ -44,8 +44,7 @@ XournalView::XournalView(GtkWidget* parent, Control* control, ScrollHandling* sc
 
     InputContext* inputContext = new InputContext(this, scrollHandling);
     this->widget = gtk_xournal_new(this, inputContext);
-    // we need to refer widget here, because we unref it somewhere twice!?
-    g_object_ref(this->widget);
+    g_object_ref_sink(this->widget);  // take ownership without increasing the ref count
 
     gtk_container_add(GTK_CONTAINER(parent), this->widget);
     gtk_widget_show(this->widget);

--- a/src/core/gui/inputdevices/InputContext.cpp
+++ b/src/core/gui/inputdevices/InputContext.cpp
@@ -26,6 +26,9 @@ InputContext::InputContext(XournalView* view, ScrollHandling* scrollHandling) {
 }
 
 InputContext::~InputContext() {
+    // Destructor is called in xournal_widget_dispose, so it can still accept events
+    g_signal_handler_disconnect(this->widget, signal_id);
+
     delete this->stylusHandler;
     this->stylusHandler = nullptr;
 
@@ -43,6 +46,7 @@ InputContext::~InputContext() {
 }
 
 void InputContext::connect(GtkWidget* pWidget) {
+    assert(!this->widget);
     this->widget = pWidget;
     gtk_widget_set_support_multidevice(widget, true);
 
@@ -60,7 +64,7 @@ void InputContext::connect(GtkWidget* pWidget) {
 
     gtk_widget_add_events(pWidget, mask);
 
-    g_signal_connect(pWidget, "event", G_CALLBACK(eventCallback), this);
+    signal_id = g_signal_connect(pWidget, "event", G_CALLBACK(eventCallback), this);
 }
 
 auto InputContext::eventCallback(GtkWidget* widget, GdkEvent* event, InputContext* self) -> bool {

--- a/src/core/gui/inputdevices/InputContext.h
+++ b/src/core/gui/inputdevices/InputContext.h
@@ -40,6 +40,7 @@ class SetsquareInputHandler;
 class InputContext {
 
 private:
+    gulong signal_id{0};
     std::unique_ptr<SetsquareInputHandler> setsquareHandler;
     StylusInputHandler* stylusHandler;
     MouseInputHandler* mouseHandler;


### PR DESCRIPTION
- since the xournal widget is in disposing state,
 the event handlers can still be called

fixes #3997