### PR TITLE
Fetch PopplerPage from PdfCache instead of recreating it

### DIFF
--- a/src/core/control/PdfCache.cpp
+++ b/src/core/control/PdfCache.cpp
@@ -5,6 +5,10 @@
 #include <cstdio>
 #include <utility>
 
+#include "control/settings/Settings.h"
+#include "pdf/base/XojPdfDocument.h"
+#include "util/i18n.h"
+
 class PdfCacheEntry {
 public:
     /**
@@ -35,27 +39,38 @@ public:
     cairo_surface_t* rendered;
 };
 
-PdfCache::PdfCache(size_t size) { this->size = size; }
+PdfCache::PdfCache(const XojPdfDocument& doc, Settings* settings): pdfDocument(doc) { updateSettings(settings); }
 
 PdfCache::~PdfCache() {
     clearCache();
     this->size = 0;
 }
 
-void PdfCache::setZoom(double zoom) { this->zoom = zoom; }
-
 void PdfCache::setRefreshThreshold(double threshold) { this->zoomRefreshThreshold = threshold; }
 
-void PdfCache::setAnyZoomChangeCausesRecache(bool b) { this->zoomClearsCache = b; }
+void PdfCache::setMaxSize(size_t newSize) {
+    this->size = newSize;
+    while (this->data.size() > this->size) {
+        delete this->data.back();
+        this->data.pop_back();
+    }
+}
+
+void PdfCache::updateSettings(Settings* settings) {
+    if (settings) {
+        setMaxSize(settings->getPdfPageCacheSize());
+        setRefreshThreshold(settings->getPDFPageRerenderThreshold());
+    }
+}
 
 void PdfCache::clearCache() {
     for (PdfCacheEntry* e: this->data) { delete e; }
     this->data.clear();
 }
 
-auto PdfCache::lookup(const XojPdfPageSPtr& popplerPage) -> PdfCacheEntry* {
+auto PdfCache::lookup(size_t pdfPageNo) const -> PdfCacheEntry* {
     for (PdfCacheEntry* e: this->data) {
-        if (e->popplerPage->getPageId() == popplerPage->getPageId()) {
+        if (static_cast<size_t>(e->popplerPage->getPageId()) == pdfPageNo) {
             return e;
         }
     }
@@ -75,53 +90,59 @@ PdfCacheEntry* PdfCache::cache(XojPdfPageSPtr popplerPage, cairo_surface_t* img,
     return ne;
 }
 
-void PdfCache::render(cairo_t* cr, const XojPdfPageSPtr& popplerPage, double zoom) {
-    this->renderMutex.lock();
+void PdfCache::render(cairo_t* cr, size_t pdfPageNo, double zoom, double pageWidth, double pageHeight) {
+    std::lock_guard<std::mutex> lock(this->renderMutex);
 
-    this->setZoom(zoom);
+    PdfCacheEntry* cacheResult = lookup(pdfPageNo);
 
-    PdfCacheEntry* cacheResult = lookup(popplerPage);
-    bool needsRefresh{cacheResult == nullptr};
+    bool needsRefresh = cacheResult == nullptr;
 
-    if (cacheResult != nullptr) {
-        double averagedZoom = (this->zoom + cacheResult->zoom) / 2.0;
-        double percentZoomChange = std::abs(cacheResult->zoom - this->zoom) * 100.0 / averagedZoom;
+    if (!needsRefresh) {
+        double averagedZoom = (zoom + cacheResult->zoom) / 2.0;
+        double percentZoomChange = std::abs(cacheResult->zoom - zoom) * 100.0 / averagedZoom;
 
         // If we do have a cached result, is its rendering quality
         // acceptable for our current zoom?
-        needsRefresh = (this->zoom > 1.0 && percentZoomChange > this->zoomRefreshThreshold)
-
-                       // Has the user requested that we **always** clear the cache on zoom?
-                       || (this->zoomClearsCache && this->zoom != cacheResult->zoom);
+        needsRefresh = (zoom > 1.0 && percentZoomChange > this->zoomRefreshThreshold);
     }
 
     if (needsRefresh) {
         double renderZoom = std::max(zoom, 1.0);
 
+        auto popplerPage = cacheResult ? cacheResult->popplerPage : pdfDocument.getPage(pdfPageNo);
+
+        if (!popplerPage) {
+            g_warning("PdfCache::render Could not get the pdf page %zu from the document", pdfPageNo);
+            renderMissingPdfPage(cr, pageWidth, pageHeight);
+            return;
+        }
+
         auto* img = cairo_image_surface_create(CAIRO_FORMAT_ARGB32,
                                                static_cast<int>(std::ceil(popplerPage->getWidth() * renderZoom)),
                                                static_cast<int>(std::ceil(popplerPage->getHeight() * renderZoom)));
-        cairo_t* cr2 = cairo_create(img);
+        cairo_surface_set_device_scale(img, renderZoom, renderZoom);
 
-        cairo_scale(cr2, renderZoom, renderZoom);
+        cairo_t* cr2 = cairo_create(img);
         popplerPage->render(cr2);
         cairo_destroy(cr2);
 
         cacheResult = cache(popplerPage, img, renderZoom);
     }
 
-    cairo_matrix_t mOriginal;
-    cairo_matrix_t mScaled;
-    cairo_get_matrix(cr, &mOriginal);
-    cairo_get_matrix(cr, &mScaled);
-    mScaled.xx = this->zoom / cacheResult->zoom;
-    mScaled.yy = this->zoom / cacheResult->zoom;
-    mScaled.xy = 0;
-    mScaled.yx = 0;
-    cairo_set_matrix(cr, &mScaled);
     cairo_set_source_surface(cr, cacheResult->rendered, 0, 0);
     cairo_paint(cr);
-    cairo_set_matrix(cr, &mOriginal);
+}
 
-    this->renderMutex.unlock();
+void PdfCache::renderMissingPdfPage(cairo_t* cr, double pageWidth, double pageHeight) {
+    cairo_select_font_face(cr, "Sans", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_BOLD);
+    cairo_set_font_size(cr, 26);
+
+    cairo_set_source_rgb(cr, 0.8, 0.8, 0.8);
+
+    cairo_text_extents_t extents = {0};
+    std::string strMissing = _("PDF background missing");
+
+    cairo_text_extents(cr, strMissing.c_str(), &extents);
+    cairo_move_to(cr, pageWidth / 2 - extents.width / 2, pageHeight / 2 - extents.height / 2);
+    cairo_show_text(cr, strMissing.c_str());
 }

--- a/src/core/control/jobs/PreviewJob.cpp
+++ b/src/core/control/jobs/PreviewJob.cpp
@@ -56,9 +56,8 @@ void PreviewJob::finishPaint() {
 
 void PreviewJob::drawBackgroundPdf(Document* doc) {
     auto pgNo = this->sidebarPreview->page->getPdfPageNr();
-    XojPdfPageSPtr popplerPage = doc->getPdfPage(pgNo);
 
-    PdfView::drawPage(this->sidebarPreview->sidebar->getCache(), popplerPage, cr2, zoom,
+    PdfView::drawPage(this->sidebarPreview->sidebar->getCache(), pgNo, cr2, zoom,
                       this->sidebarPreview->page->getWidth(), this->sidebarPreview->page->getHeight());
 }
 

--- a/src/core/control/jobs/RenderJob.cpp
+++ b/src/core/control/jobs/RenderJob.cpp
@@ -49,9 +49,8 @@ void RenderJob::rerenderRectangle(Rectangle<double> const& rect) {
     bool backgroundVisible = view->page->isLayerVisible(0);
     if (backgroundVisible && view->page->getBackgroundType().isPdfPage()) {
         auto pgNo = view->page->getPdfPageNr();
-        XojPdfPageSPtr popplerPage = doc->getPdfPage(pgNo);
         PdfCache* cache = view->xournal->getCache();
-        PdfView::drawPage(cache, popplerPage, crRect, zoom, pageWidth, pageHeight);
+        PdfView::drawPage(cache, pgNo, crRect, zoom, pageWidth, pageHeight);
     }
 
     doc->lock();
@@ -108,11 +107,6 @@ void RenderJob::run() {
 
         doc->lock();
 
-        if (this->view->page->getBackgroundType().isPdfPage()) {
-            auto pgNo = this->view->page->getPdfPageNr();
-            popplerPage = doc->getPdfPage(pgNo);
-        }
-
         Control* control = view->getXournal()->getControl();
         DocumentView localView;
         localView.setMarkAudioStroke(control->getToolHandler()->getToolType() == TOOL_PLAY_OBJECT);
@@ -121,7 +115,8 @@ void RenderJob::run() {
 
         bool backgroundVisible = this->view->page->isLayerVisible(0);
         if (backgroundVisible && this->view->page->getBackgroundType().isPdfPage()) {
-            PdfView::drawPage(this->view->xournal->getCache(), popplerPage, cr2, zoom, width, height);
+            auto pgNo = this->view->page->getPdfPageNr();
+            PdfView::drawPage(this->view->xournal->getCache(), pgNo, cr2, zoom, width, height);
         }
         localView.drawPage(this->view->page, cr2, false);
 

--- a/src/core/gui/XournalView.h
+++ b/src/core/gui/XournalView.h
@@ -140,6 +140,8 @@ public:
 
     static void onRealized(GtkWidget* widget, XournalView* view);
 
+    void onSettingsChanged();
+
 private:
     void fireZoomChanged();
 
@@ -169,7 +171,7 @@ private:
     size_t currentPage = 0;
     size_t lastSelectedPage = -1;
 
-    PdfCache* cache = nullptr;
+    std::unique_ptr<PdfCache> cache;
 
     /**
      * Handler for rerendering pages / repainting pages

--- a/src/core/gui/dialog/SettingsDialog.cpp
+++ b/src/core/gui/dialog/SettingsDialog.cpp
@@ -7,6 +7,7 @@
 
 #include "control/DeviceListHelper.h"
 #include "control/tools/StrokeStabilizerEnum.h"
+#include "gui/XournalView.h"
 #include "gui/widgets/ZoomCallib.h"
 #include "util/PathUtil.h"
 #include "util/StringUtils.h"
@@ -914,4 +915,5 @@ void SettingsDialog::save() {
 
     this->control->getWindow()->setGtkTouchscreenScrollingForDeviceMapping();
     this->control->initButtonTool();
+    this->control->getWindow()->getXournal()->onSettingsChanged();
 }

--- a/src/core/gui/sidebar/previews/base/SidebarPreviewBase.h
+++ b/src/core/gui/sidebar/previews/base/SidebarPreviewBase.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -101,7 +102,7 @@ private:
     /**
      * For preview rendering
      */
-    PdfCache* cache = nullptr;
+    std::unique_ptr<PdfCache> cache;
 
     /**
      * The layouting class for the prviews

--- a/src/core/pdf/base/XojPdfDocument.cpp
+++ b/src/core/pdf/base/XojPdfDocument.cpp
@@ -8,7 +8,9 @@
 
 XojPdfDocument::XojPdfDocument(): doc(new PopplerGlibDocument()) {}
 
-XojPdfDocument::XojPdfDocument(const XojPdfDocument& doc): doc(new PopplerGlibDocument()) {}
+XojPdfDocument::XojPdfDocument(const XojPdfDocument& doc): doc(new PopplerGlibDocument()) {
+    this->doc->assign(doc.doc);
+}
 
 XojPdfDocument::~XojPdfDocument() {
     delete doc;

--- a/src/core/view/PdfView.cpp
+++ b/src/core/view/PdfView.cpp
@@ -8,28 +8,12 @@ PdfView::PdfView() = default;
 
 PdfView::~PdfView() = default;
 
-void PdfView::drawPage(PdfCache* cache, const XojPdfPageSPtr& popplerPage, cairo_t* cr, double zoom, double width,
-                       double height) {
-    if (popplerPage) {
+void PdfView::drawPage(PdfCache* cache, size_t pageNo, cairo_t* cr, double zoom, double width, double height) {
+    if (cache) {
         cairo_set_source_rgb(cr, 1., 1., 1.);
         cairo_paint(cr);
-
-        if (cache) {
-            cache->render(cr, popplerPage, zoom);
-        } else {
-            popplerPage->render(cr);
-        }
+        cache->render(cr, pageNo, zoom, width, height);
     } else {
-        cairo_select_font_face(cr, "Sans", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_BOLD);
-        cairo_set_font_size(cr, 26);
-
-        cairo_set_source_rgb(cr, 0.8, 0.8, 0.8);
-
-        cairo_text_extents_t extents = {0};
-        std::string strMissing = _("PDF background missing");
-
-        cairo_text_extents(cr, strMissing.c_str(), &extents);
-        cairo_move_to(cr, width / 2 - extents.width / 2, height / 2 - extents.height / 2);
-        cairo_show_text(cr, strMissing.c_str());
+        PdfCache::renderMissingPdfPage(cr, width, height);
     }
 }

--- a/src/core/view/PdfView.h
+++ b/src/core/view/PdfView.h
@@ -22,6 +22,5 @@ private:
     virtual ~PdfView();
 
 public:
-    static void drawPage(PdfCache* cache, const XojPdfPageSPtr& popplerPage, cairo_t* cr, double zoom, double width,
-                         double height);
+    static void drawPage(PdfCache* cache, size_t pageNo, cairo_t* cr, double zoom, double width, double height);
 };


### PR DESCRIPTION
This PR improves the behaviour of PdfCache (and callers).

Before this PR, whenever a pdf background was to be rendered:

- a PopplerPage was extracted from the PDF document (using the page number, through a call to `poppler_document_get_page(document, number)`).
- the PopplerPage was passed on to PdfCache, which tested if the cache contained another page with the same number

The PR removes the unnecessary creation of a new PopplerPage (meaning the extraction from the PDF document), and simply searches the cache for a PopplerPage with the same number.

I am not sure how expensive a call to `poppler_document_get_page(document, number)` is, but this should slightly improve the performance of the process.

I tested the following behaviours:

- Open a file without a pdf background
- Open a file with a pdf background
- Change a single page's background (to ruled background, or to another page of the pdf)
- Change file (in both directions, and from pdf to pdf)
- Export a file with pdf background, in all possible formats (pdf, png, svg)
- Zoom in and out (and check the cache is used, through some debug `cout`'s)
- Open a large pdf file (500 pages), scroll and check it's fluid
- Check the previews

Tell me if I forgot something obvious...

Otherwise, this PR is ready for review :-)
