### PR TITLE
Fix HiDPI bug when using stroke tools

### DIFF
--- a/src/core/gui/PageView.cpp
+++ b/src/core/gui/PageView.cpp
@@ -1006,7 +1006,7 @@ void XojPageView::elementChanged(Element* elem) {
         this->drawingMutex.lock();
 
         cairo_t* cr = cairo_create(this->crBuffer);
-        double ratio = this->xournal->getZoom();
+        const double ratio = xournal->getZoom() * static_cast<double>(xournal->getDpiScaleFactor());
         cairo_scale(cr, ratio, ratio);
 
         this->inputHandler->draw(cr);


### PR DESCRIPTION
Fix #4011

The issue only affects HiPDI settings, because a DPI scale factor was omitted in `XojPageView::elementChanged()`.
This PR fixes that.