### PR TITLE
Add ruled page template with vertical line on the right

### DIFF
--- a/src/core/control/pagetype/PageTypeHandler.cpp
+++ b/src/core/control/pagetype/PageTypeHandler.cpp
@@ -20,6 +20,7 @@ PageTypeHandler::PageTypeHandler(GladeSearchpath* gladeSearchPath) {
         addPageTypeInfo(_("Plain"), PageTypeFormat::Plain, "");
         addPageTypeInfo(_("Ruled"), PageTypeFormat::Ruled, "");
         addPageTypeInfo(_("Ruled with vertical line"), PageTypeFormat::Lined, "");
+        addPageTypeInfo(_("Ruled with vertical line (right)"), PageTypeFormat::LinedRight, "");
         addPageTypeInfo(_("Staves"), PageTypeFormat::Staves, "");
         addPageTypeInfo(_("Graph"), PageTypeFormat::Graph, "");
         addPageTypeInfo(_("Dotted"), PageTypeFormat::Dotted, "");
@@ -126,6 +127,9 @@ auto PageTypeHandler::getPageTypeFormatForString(const string& format) -> PageTy
     if (format == ":copy") {
         return PageTypeFormat::Copy;
     }
+    if (format == "linedright") {
+        return PageTypeFormat::LinedRight;
+    }
     return PageTypeFormat::Ruled;
 }
 
@@ -153,6 +157,8 @@ auto PageTypeHandler::getStringForPageTypeFormat(const PageTypeFormat& format) -
             return ":image";
         case PageTypeFormat::Copy:
             return ":copy";
+        case PageTypeFormat::LinedRight:
+            return "linedright";
     }
     return "ruled";
 }

--- a/src/core/control/xojfile/XojExportHandler.cpp
+++ b/src/core/control/xojfile/XojExportHandler.cpp
@@ -47,7 +47,7 @@ void XojExportHandler::writeSolidBackground(XmlNode* background, PageRef p) {
 
     format = PageTypeHandler::getStringForPageTypeFormat(bgFormat);
     if (bgFormat != PageTypeFormat::Plain && bgFormat != PageTypeFormat::Ruled && bgFormat != PageTypeFormat::Lined &&
-        bgFormat != PageTypeFormat::Graph) {
+        bgFormat != PageTypeFormat::Graph && bgFormat != PageTypeFormat::LinedRight) {
         format = "plain";
     }
 

--- a/src/core/model/PageType.h
+++ b/src/core/model/PageType.h
@@ -15,7 +15,7 @@
 #include <vector>
 
 
-enum class PageTypeFormat { Plain, Ruled, Lined, Staves, Graph, Dotted, IsoDotted, IsoGraph, Pdf, Image, Copy };
+enum class PageTypeFormat { Plain, Ruled, Lined, Staves, Graph, Dotted, IsoDotted, IsoGraph, Pdf, Image, Copy, LinedRight };
 
 class PageType {
 public:

--- a/src/core/model/PageType.h
+++ b/src/core/model/PageType.h
@@ -15,7 +15,20 @@
 #include <vector>
 
 
-enum class PageTypeFormat { Plain, Ruled, Lined, Staves, Graph, Dotted, IsoDotted, IsoGraph, Pdf, Image, Copy, LinedRight };
+enum class PageTypeFormat {
+    Plain,
+    Ruled,
+    Lined,
+    Staves,
+    Graph,
+    Dotted,
+    IsoDotted,
+    IsoGraph,
+    Pdf,
+    Image,
+    Copy,
+    LinedRight
+};
 
 class PageType {
 public:

--- a/src/core/view/oldbackground/LineBackgroundPainter.cpp
+++ b/src/core/view/oldbackground/LineBackgroundPainter.cpp
@@ -2,7 +2,7 @@
 
 #include "util/Util.h"
 
-LineBackgroundPainter::LineBackgroundPainter(bool verticalLine): verticalLine(verticalLine) {}
+LineBackgroundPainter::LineBackgroundPainter(const PageTypeFormat format): format(format) {}
 
 LineBackgroundPainter::~LineBackgroundPainter() = default;
 
@@ -19,7 +19,7 @@ void LineBackgroundPainter::paint() {
 
     paintBackgroundRuled();
 
-    if (verticalLine) {
+    if (format == PageTypeFormat::Lined || format == PageTypeFormat::LinedRight) {
         paintBackgroundVerticalLine();
     }
 }
@@ -50,7 +50,9 @@ void LineBackgroundPainter::paintBackgroundVerticalLine() {
     Util::cairo_set_source_rgbi(cr, this->foregroundColor2);
     cairo_set_line_width(cr, lineWidth * lineWidthFactor);
 
-    cairo_move_to(cr, 72, 0);
-    cairo_line_to(cr, 72, height);
+    double x = format == PageTypeFormat::LinedRight ? width - 72 : 72;
+
+    cairo_move_to(cr, x, 0);
+    cairo_line_to(cr, x, height);
     cairo_stroke(cr);
 }

--- a/src/core/view/oldbackground/LineBackgroundPainter.h
+++ b/src/core/view/oldbackground/LineBackgroundPainter.h
@@ -15,11 +15,12 @@
 #include <vector>
 
 #include "BaseBackgroundPainter.h"
+#include "model/PageType.h"
 
 
 class LineBackgroundPainter: public BaseBackgroundPainter {
 public:
-    LineBackgroundPainter(bool verticalLine);
+    LineBackgroundPainter(const PageTypeFormat format);
     ~LineBackgroundPainter() override;
 
 public:
@@ -35,5 +36,5 @@ public:
     void paintBackgroundVerticalLine();
 
 private:
-    bool verticalLine;
+    PageTypeFormat format;
 };

--- a/src/core/view/oldbackground/LineBackgroundPainter.h
+++ b/src/core/view/oldbackground/LineBackgroundPainter.h
@@ -14,8 +14,9 @@
 #include <string>
 #include <vector>
 
-#include "BaseBackgroundPainter.h"
 #include "model/PageType.h"
+
+#include "BaseBackgroundPainter.h"
 
 
 class LineBackgroundPainter: public BaseBackgroundPainter {

--- a/src/core/view/oldbackground/MainBackgroundPainter.cpp
+++ b/src/core/view/oldbackground/MainBackgroundPainter.cpp
@@ -12,8 +12,9 @@
 MainBackgroundPainter::MainBackgroundPainter() {
     defaultPainter = new BaseBackgroundPainter();
 
-    painter[PageTypeFormat::Ruled] = new LineBackgroundPainter(false);
-    painter[PageTypeFormat::Lined] = new LineBackgroundPainter(true);
+    painter[PageTypeFormat::Ruled] = new LineBackgroundPainter(PageTypeFormat::Ruled);
+    painter[PageTypeFormat::Lined] = new LineBackgroundPainter(PageTypeFormat::Lined);
+    painter[PageTypeFormat::LinedRight] = new LineBackgroundPainter(PageTypeFormat::LinedRight);
     painter[PageTypeFormat::Staves] = new StavesBackgroundPainter();
     painter[PageTypeFormat::Graph] = new GraphBackgroundPainter();
     painter[PageTypeFormat::Dotted] = new DottedBackgroundPainter();

--- a/ui/pagetemplates.ini
+++ b/ui/pagetemplates.ini
@@ -15,6 +15,11 @@ name=Ruled with vertical line
 name[de]=Liniert mit Randlinie
 format=lined
 
+[predefinedLinedRight]
+name=Ruled with vertical line on the right
+name[de]=Liniert mit rechter Randlinie
+format=linedright
+
 [predefinedStaves]
 name=Staves
 name[de]=Notenlinien


### PR DESCRIPTION
This adds a variant of the lined page template that features a vertical bar on the right hand side. I find it more convenient to use on devices that feature a physical touch screen when using the page's full width, as my hand doesn't have to go as much over the screen's edge.