### PR TITLE
Const-qualify Element::... and fix sign-conversion warnings relative to layer indices

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -2757,7 +2757,7 @@ void Control::clipboardPasteXournal(ObjectInputStream& in) {
 
             pasteAddUndoAction->addElement(layer, element.get(), layer->indexOf(element.get()));
             // Todo: unique_ptr
-            selection->addElement(element.release(), Layer::InvalidElementIndex);
+            selection->addElement(element.release(), Element::InvalidIndex);
         }
         undoRedo->addUndoAction(std::move(pasteAddUndoAction));
 

--- a/src/core/control/SearchControl.cpp
+++ b/src/core/control/SearchControl.cpp
@@ -43,7 +43,7 @@ auto SearchControl::search(std::string text, int* occures, double* top) -> bool 
     }
 
     for (Layer* l: *this->page->getLayers()) {
-        if (!this->page->isLayerVisible(l)) {
+        if (!l->isVisible()) {
             continue;
         }
 

--- a/src/core/control/jobs/PreviewJob.cpp
+++ b/src/core/control/jobs/PreviewJob.cpp
@@ -66,7 +66,7 @@ void PreviewJob::drawPage() {
     PageRef page = this->sidebarPreview->page;
     Document* doc = this->sidebarPreview->sidebar->getControl()->getDocument();
     PreviewRenderType type = this->sidebarPreview->getRenderType();
-    int layer;
+    Layer::Index layer = 0;
 
     doc->lock();
 
@@ -79,7 +79,7 @@ void PreviewJob::drawPage() {
     // switch block can go away and the layer assignment into the remaining switch block.
     switch (type) {
         case RENDER_TYPE_PAGE_LAYER:
-            if (layer != -1) {
+            if (layer != 0) {
                 break;  // out
             }
             [[fallthrough]];
@@ -107,10 +107,10 @@ void PreviewJob::drawPage() {
         case RENDER_TYPE_PAGE_LAYER:
             // render single layer
             view.initDrawing(page, cr2, true);
-            if (layer == -1) {
+            if (layer == 0) {
                 view.drawBackground();
             } else {
-                Layer* drawLayer = (*page->getLayers())[layer];
+                Layer* drawLayer = (*page->getLayers())[layer - 1];
                 xoj::view::LayerView layerView(drawLayer);
                 layerView.draw(context);
             }
@@ -121,7 +121,7 @@ void PreviewJob::drawPage() {
             // render all layers up to layer
             view.initDrawing(page, cr2, true);
             view.drawBackground();
-            for (int i = 0; i <= layer; i++) {
+            for (Layer::Index i = 0; i < layer; i++) {
                 Layer* drawLayer = (*page->getLayers())[i];
                 xoj::view::LayerView layerView(drawLayer);
                 layerView.draw(context);

--- a/src/core/control/layer/LayerController.h
+++ b/src/core/control/layer/LayerController.h
@@ -35,9 +35,8 @@ public:
     void pageSelected(size_t page) override;
 
 public:
-    void insertLayer(PageRef page, Layer* layer, int layerPos);
+    void insertLayer(PageRef page, Layer* layer, Layer::Index layerPos);
     void removeLayer(PageRef page, Layer* layer);
-    void addLayer(PageRef page, Layer* layer);
 
     // Listener handling
 public:
@@ -71,31 +70,31 @@ public:
     void copyCurrentLayer();
     void moveCurrentLayer(bool up);
     void mergeCurrentLayerDown();
-    void switchToLay(int layer, bool hideShow = false);
-    void setLayerVisible(int layerId, bool visible);
+    void switchToLay(Layer::Index layerId, bool hideShow = false);
+    void setLayerVisible(Layer::Index layerId, bool visible);
 
-    PageRef getCurrentPage();
+    PageRef getCurrentPage() const;
     size_t getCurrentPageId() const;
 
     /**
      * @return Layer count of the current page
      */
-    size_t getLayerCount();
+    Layer::Index getLayerCount() const;
 
     /**
      * @return Current layer ID
      */
-    size_t getCurrentLayerId();
+    Layer::Index getCurrentLayerId() const;
 
     /**
      * @return Current layer name
      */
-    std::string getCurrentLayerName();
+    std::string getCurrentLayerName() const;
 
     /**
      * @return Get layer name by layer id
      */
-    std::string getLayerNameById(int id);
+    std::string getLayerNameById(Layer::Index id) const;
 
     /**
      * Sets current layer name

--- a/src/core/control/tools/EditSelection.cpp
+++ b/src/core/control/tools/EditSelection.cpp
@@ -60,7 +60,7 @@ EditSelection::EditSelection(UndoRedoHandler* undo, Selection* selection, XojPag
     construct(undo, view, view->getPage());
 
     // Construct the insert order
-    std::vector<std::pair<Element*, Layer::ElementIndex>> order;
+    std::vector<std::pair<Element*, Element::Index>> order;
     for (Element* e: selection->selectedElements) {
         auto i = std::make_pair(e, this->sourceLayer->indexOf(e));
         order.insert(std::upper_bound(order.begin(), order.end(), i, EditSelectionContents::insertOrderCmp), i);
@@ -316,7 +316,7 @@ void EditSelection::fillUndoItem(DeleteUndoAction* undo) { this->contents->fillU
  * Add an element to this selection
  *
  */
-void EditSelection::addElement(Element* e, Layer::ElementIndex order) {
+void EditSelection::addElement(Element* e, Element::Index order) {
     this->contents->addElement(e, order);
 
     if (e->rescaleOnlyAspectRatio()) {
@@ -341,21 +341,19 @@ auto EditSelection::getElements() const -> const vector<Element*>& { return this
 /**
  * Returns the insert order of this selection
  */
-auto EditSelection::getInsertOrder() const -> std::deque<std::pair<Element*, Layer::ElementIndex>> const& {
+auto EditSelection::getInsertOrder() const -> std::deque<std::pair<Element*, Element::Index>> const& {
     return this->contents->getInsertOrder();
 }
 
 auto EditSelection::rearrangeInsertOrder(const OrderChange change) -> UndoActionPtr {
-    using InsertOrder = std::deque<std::pair<Element*, Layer::ElementIndex>>;
+    using InsertOrder = std::deque<std::pair<Element*, Element::Index>>;
     const InsertOrder oldOrd = this->getInsertOrder();
     InsertOrder newOrd;
     std::string desc = _("Arrange");
     switch (change) {
         case OrderChange::BringToFront:
             // Set to largest positive signed integer
-            for (const auto& [e, _]: oldOrd) {
-                newOrd.emplace_back(e, std::numeric_limits<Layer::ElementIndex>::max());
-            }
+            for (const auto& [e, _]: oldOrd) { newOrd.emplace_back(e, std::numeric_limits<Element::Index>::max()); }
             desc = _("Bring to front");
             break;
         case OrderChange::BringForward:
@@ -363,7 +361,7 @@ auto EditSelection::rearrangeInsertOrder(const OrderChange change) -> UndoAction
             newOrd = oldOrd;
             std::stable_sort(newOrd.begin(), newOrd.end(), EditSelectionContents::insertOrderCmp);
             if (!newOrd.empty()) {
-                Layer::ElementIndex i = newOrd.back().second + 1;
+                Element::Index i = newOrd.back().second + 1;
                 for (auto& it: newOrd) { it.second = i++; }
             }
             desc = _("Bring forward");
@@ -373,14 +371,14 @@ auto EditSelection::rearrangeInsertOrder(const OrderChange change) -> UndoAction
             newOrd = oldOrd;
             std::stable_sort(newOrd.begin(), newOrd.end(), EditSelectionContents::insertOrderCmp);
             if (!newOrd.empty()) {
-                Layer::ElementIndex i = newOrd.front().second;
+                Element::Index i = newOrd.front().second;
                 i = i > 0 ? i - 1 : 0;
                 for (auto& it: newOrd) { it.second = i++; }
             }
             desc = _("Send backward");
             break;
         case OrderChange::SendToBack:
-            Layer::ElementIndex i = 0;
+            Element::Index i = 0;
             for (const auto& [e, _]: oldOrd) {
                 newOrd.emplace_back(e, i);
                 i++;
@@ -671,7 +669,7 @@ void EditSelection::translateToView(XojPageView* v) {
 
 void EditSelection::copySelection() {
     // clone elements in the insert order
-    std::deque<std::pair<Element*, Layer::ElementIndex>> clonedInsertOrder;
+    std::deque<std::pair<Element*, Element::Index>> clonedInsertOrder;
     for (auto [e, index]: getInsertOrder()) { clonedInsertOrder.emplace_back(e->clone(), index); }
 
     // apply transformations and add to layer

--- a/src/core/control/tools/EditSelection.h
+++ b/src/core/control/tools/EditSelection.h
@@ -159,7 +159,7 @@ public:
      * in case we want to replace it back where it came from.
      * 'InvalidLayerIndex' is a special value that says it has no source layer index (e.g, from clipboard)
      */
-    void addElement(Element* e, Layer::ElementIndex order = Layer::InvalidElementIndex);
+    void addElement(Element* e, Element::Index order = Element::InvalidIndex);
 
     /**
      * Returns all containing elements of this selection
@@ -169,7 +169,7 @@ public:
     /**
      * Returns the insert order of this selection
      */
-    std::deque<std::pair<Element*, Layer::ElementIndex>> const& getInsertOrder() const;
+    std::deque<std::pair<Element*, Element::Index>> const& getInsertOrder() const;
 
     enum class OrderChange {
         BringToFront,

--- a/src/core/control/tools/EditSelectionContents.cpp
+++ b/src/core/control/tools/EditSelectionContents.cpp
@@ -56,7 +56,7 @@ EditSelectionContents::~EditSelectionContents() {
 /**
  * Add an element to the this selection
  */
-void EditSelectionContents::addElement(Element* e, Layer::ElementIndex order) {
+void EditSelectionContents::addElement(Element* e, Element::Index order) {
     g_assert(this->selected.size() == this->insertOrder.size());
     this->selected.emplace_back(e);
     auto item = std::make_pair(e, order);
@@ -64,7 +64,7 @@ void EditSelectionContents::addElement(Element* e, Layer::ElementIndex order) {
                              item);
 }
 
-void EditSelectionContents::replaceInsertOrder(std::deque<std::pair<Element*, Layer::ElementIndex>> newInsertOrder) {
+void EditSelectionContents::replaceInsertOrder(std::deque<std::pair<Element*, Element::Index>> newInsertOrder) {
     this->selected.clear();
     this->selected.reserve(newInsertOrder.size());
     std::transform(begin(newInsertOrder), end(newInsertOrder), std::back_inserter(this->selected),
@@ -80,7 +80,7 @@ auto EditSelectionContents::getElements() const -> const vector<Element*>& { ret
 /**
  * Returns the insert order of this selection
  */
-auto EditSelectionContents::getInsertOrder() const -> std::deque<std::pair<Element*, Layer::ElementIndex>> const& {
+auto EditSelectionContents::getInsertOrder() const -> std::deque<std::pair<Element*, Element::Index>> const& {
     return this->insertOrder;
 }
 
@@ -371,7 +371,7 @@ void EditSelectionContents::finalizeSelection(Rectangle<double> bounds, Rectangl
             e->rotate(snappedBounds.x + this->lastSnappedBounds.width / 2,
                       snappedBounds.y + this->lastSnappedBounds.height / 2, this->rotation);
         }
-        if (index == Layer::InvalidElementIndex) {
+        if (index == Element::InvalidIndex) {
             // if the element didn't have a source layer (e.g, clipboard)
             layer->addElement(e);
         } else {

--- a/src/core/control/tools/EditSelectionContents.h
+++ b/src/core/control/tools/EditSelectionContents.h
@@ -83,7 +83,7 @@ public:
      * @param orderInSourceLayer: specifies the index of the element from the source layer,
      * in case we want to replace it back where it came from.
      */
-    void addElement(Element* e, Layer::ElementIndex order);
+    void addElement(Element* e, Element::Index order);
 
     /**
      * Returns all containing elements of this selection
@@ -93,12 +93,12 @@ public:
     /**
      * Returns the insert order of this selection
      */
-    std::deque<std::pair<Element*, Layer::ElementIndex>> const& getInsertOrder() const;
+    std::deque<std::pair<Element*, Element::Index>> const& getInsertOrder() const;
 
     /** replaces all elements by a new vector of elements
      * @param newElements: the elements which should replace the old elements
      * */
-    void replaceInsertOrder(std::deque<std::pair<Element*, Layer::ElementIndex>> newInsertOrder);
+    void replaceInsertOrder(std::deque<std::pair<Element*, Element::Index>> newInsertOrder);
 
 public:
     /**
@@ -149,7 +149,7 @@ public:
     UndoAction* copySelection(PageRef page, XojPageView* view, double x, double y);
 
     const static struct {
-        bool operator()(std::pair<Element*, Layer::ElementIndex> p1, std::pair<Element*, Layer::ElementIndex> p2) {
+        bool operator()(std::pair<Element*, Element::Index> p1, std::pair<Element*, Element::Index> p2) {
             return p1.second < p2.second;
         }
     } insertOrderCmp;
@@ -196,7 +196,7 @@ private:
      *
      * Invariant: the insert order must be sorted by index in ascending order.
      */
-    std::deque<std::pair<Element*, Layer::ElementIndex>> insertOrder;
+    std::deque<std::pair<Element*, Element::Index>> insertOrder;
 
     /**
      * The rendered elements

--- a/src/core/gui/sidebar/previews/layer/SidebarPreviewLayerEntry.cpp
+++ b/src/core/gui/sidebar/previews/layer/SidebarPreviewLayerEntry.cpp
@@ -6,14 +6,15 @@
 #include "SidebarPreviewLayers.h"
 
 
-SidebarPreviewLayerEntry::SidebarPreviewLayerEntry(SidebarPreviewLayers* sidebar, const PageRef& page, int layer,
-                                                   const std::string& layerName, size_t index, bool stacked):
+SidebarPreviewLayerEntry::SidebarPreviewLayerEntry(SidebarPreviewLayers* sidebar, const PageRef& page,
+                                                   Layer::Index layerId, const std::string& layerName, size_t index,
+                                                   bool stacked):
         SidebarPreviewBaseEntry(sidebar, page),
-        index(index),
-        layer(layer),
         sidebar(sidebar),
-        stacked(stacked),
-        box(gtk_box_new(GTK_ORIENTATION_VERTICAL, 2)) {
+        index(index),
+        layerId(layerId),
+        box(gtk_box_new(GTK_ORIENTATION_VERTICAL, 2)),
+        stacked(stacked) {
 
     const auto clickCallback = G_CALLBACK(+[](GtkWidget* widget, GdkEvent* event, SidebarPreviewLayerEntry* self) {
         // Open context menu on right mouse click
@@ -66,7 +67,7 @@ void SidebarPreviewLayerEntry::checkboxToggled() {
     }
 
     bool check = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(cbVisible));
-    (dynamic_cast<SidebarPreviewLayers*>(sidebar))->layerVisibilityChanged(layer + 1, check);
+    (dynamic_cast<SidebarPreviewLayers*>(sidebar))->layerVisibilityChanged(layerId, check);
 }
 
 void SidebarPreviewLayerEntry::mouseButtonPressCallback() {
@@ -79,7 +80,7 @@ auto SidebarPreviewLayerEntry::getRenderType() -> PreviewRenderType {
 
 auto SidebarPreviewLayerEntry::getHeight() -> int { return getWidgetHeight() + toolbarHeight; }
 
-auto SidebarPreviewLayerEntry::getLayer() const -> int { return layer; }
+auto SidebarPreviewLayerEntry::getLayer() const -> Layer::Index { return layerId; }
 
 auto SidebarPreviewLayerEntry::getWidget() -> GtkWidget* { return this->box; }
 

--- a/src/core/gui/sidebar/previews/layer/SidebarPreviewLayerEntry.h
+++ b/src/core/gui/sidebar/previews/layer/SidebarPreviewLayerEntry.h
@@ -20,7 +20,7 @@ class SidebarPreviewBase;
 
 class SidebarPreviewLayerEntry: public SidebarPreviewBaseEntry {
 public:
-    SidebarPreviewLayerEntry(SidebarPreviewLayers* sidebar, const PageRef& page, int layer,
+    SidebarPreviewLayerEntry(SidebarPreviewLayers* sidebar, const PageRef& page, Layer::Index layerId,
                              const std::string& layerName, size_t index, bool stacked);
     ~SidebarPreviewLayerEntry() override;
 
@@ -36,7 +36,7 @@ public:
     /**
      * @return The layer to be rendered
      */
-    int getLayer() const;
+    Layer::Index getLayer() const;
 
     GtkWidget* getWidget() override;
 
@@ -60,7 +60,7 @@ private:
     /**
      * Layer to render
      */
-    int layer;
+    Layer::Index layerId;
 
     /**
      * Toolbar with controls

--- a/src/core/gui/sidebar/previews/layer/SidebarPreviewLayers.h
+++ b/src/core/gui/sidebar/previews/layer/SidebarPreviewLayers.h
@@ -19,6 +19,7 @@
 #include "gui/IconNameHelper.h"
 #include "gui/sidebar/previews/base/SidebarPreviewBase.h"
 #include "gui/sidebar/previews/layer/SidebarLayersContextMenu.h"
+#include "model/Layer.h"
 
 
 class SidebarPreviewLayers: public SidebarPreviewBase, public LayerCtrlListener {
@@ -59,12 +60,12 @@ public:
     /**
      * Select a layer
      */
-    void layerSelected(size_t layerIndex);
+    void layerSelected(Layer::Index layerIndex);
 
     /**
      * A layer was hidden / showed
      */
-    void layerVisibilityChanged(int layerIndex, bool enabled);
+    void layerVisibilityChanged(Layer::Index layerIndex, bool enabled);
 
     /**
      * Opens the layer preview context menu, at the current cursor position, for
@@ -84,7 +85,7 @@ private:
     /**
      * @return things that can reasonably be done to a given layer (e.g. merge down, copy, delete, etc.)
      */
-    [[nodiscard]] static auto getViableActions(size_t layerIndex, size_t layerCount) -> SidebarActions;
+    [[nodiscard]] static auto getViableActions(Layer::Index layerIndex, Layer::Index layerCount) -> SidebarActions;
 
     /**
      * Layer Controller

--- a/src/core/gui/toolbarMenubar/ToolPageLayer.h
+++ b/src/core/gui/toolbarMenubar/ToolPageLayer.h
@@ -15,6 +15,7 @@
 
 #include "control/layer/LayerCtrlListener.h"
 #include "gui/IconNameHelper.h"
+#include "model/Layer.h"
 
 #include "AbstractToolItem.h"
 
@@ -60,12 +61,12 @@ protected:
     GdkPixbuf* getNewToolPixbuf() const override;
 
 private:
-    void createLayerMenuItem(const std::string& text, int layerId);
+    void createLayerMenuItem(const std::string& text, Layer::Index layerId);
     void layerMenuClicked(GtkWidget* menu);
-    void createLayerMenuItemShow(int layerId);
+    void createLayerMenuItemShow(Layer::Index layerId);
     void layerMenuShowClicked(GtkWidget* menu);
 
-    void selectLayer(int layerId);
+    void selectLayer(Layer::Index layerId);
 
 private:
     LayerController* lc = nullptr;
@@ -75,11 +76,12 @@ private:
     GtkWidget* layerButton = nullptr;
     GtkWidget* menu = nullptr;
 
-    std::map<int, GtkWidget*> layerItems;
-    std::map<int, GtkWidget*> showLayerItems;
+    // Widget for the layer menu. Index = 0 is for background.
+    std::vector<GtkWidget*> layerItems;
+    std::vector<GtkWidget*> showLayerItems;
 
     PopupMenuButton* popupMenuButton = nullptr;
-    int menuY = 0;
+    unsigned int menuY = 0;
 
     /**
      * Menu is currently updating - ignore events

--- a/src/core/model/AudioElement.h
+++ b/src/core/model/AudioElement.h
@@ -34,8 +34,8 @@ public:
     void setAudioFilename(fs::path fn);
     auto getAudioFilename() const -> fs::path const&;
 
-    virtual bool intersects(double x, double y, double halfSize) = 0;
-    virtual bool intersects(double x, double y, double halfSize, double* gap) = 0;
+    virtual bool intersects(double x, double y, double halfSize) const = 0;
+    virtual bool intersects(double x, double y, double halfSize, double* gap) const = 0;
 
 protected:
     void serialize(ObjectOutputStream& out) const override;

--- a/src/core/model/Element.cpp
+++ b/src/core/model/Element.cpp
@@ -76,7 +76,7 @@ void Element::setColor(Color color) { this->color = color; }
 
 auto Element::getColor() const -> Color { return this->color; }
 
-auto Element::intersectsArea(const GdkRectangle* src) -> bool {
+auto Element::intersectsArea(const GdkRectangle* src) const -> bool {
     // compute the smallest rectangle with integer coordinates containing the bounding box and having width, height > 0
     auto x = getX();
     auto y = getY();
@@ -89,7 +89,7 @@ auto Element::intersectsArea(const GdkRectangle* src) -> bool {
     return gdk_rectangle_intersect(src, &rect, nullptr);
 }
 
-auto Element::intersectsArea(double x, double y, double width, double height) -> bool {
+auto Element::intersectsArea(double x, double y, double width, double height) const -> bool {
     double dest_x = NAN, dest_y = NAN;
     double dest_w = NAN, dest_h = NAN;
 
@@ -101,7 +101,7 @@ auto Element::intersectsArea(double x, double y, double width, double height) ->
     return (dest_w > 0 && dest_h > 0);
 }
 
-auto Element::isInSelection(ShapeContainer* container) -> bool {
+auto Element::isInSelection(ShapeContainer* container) const -> bool {
     if (!container->contains(getX(), getY())) {
         return false;
     }

--- a/src/core/model/Element.h
+++ b/src/core/model/Element.h
@@ -36,6 +36,9 @@ protected:
 public:
     ~Element() override;
 
+    using Index = std::ptrdiff_t;
+    static constexpr auto InvalidIndex = static_cast<Index>(-1);
+
 public:
     ElementType getType() const;
 

--- a/src/core/model/Element.h
+++ b/src/core/model/Element.h
@@ -58,10 +58,10 @@ public:
 
     xoj::util::Rectangle<double> boundingRect() const;
 
-    virtual bool intersectsArea(const GdkRectangle* src);
-    virtual bool intersectsArea(double x, double y, double width, double height);
+    virtual bool intersectsArea(const GdkRectangle* src) const;
+    virtual bool intersectsArea(double x, double y, double width, double height) const;
 
-    virtual bool isInSelection(ShapeContainer* container);
+    virtual bool isInSelection(ShapeContainer* container) const;
 
     virtual bool rescaleOnlyAspectRatio();
     virtual bool rescaleWithMirror();
@@ -69,7 +69,7 @@ public:
     /**
      * Take 1:1 copy of this element
      */
-    virtual Element* clone() = 0;
+    virtual Element* clone() const = 0;
 
     void serialize(ObjectOutputStream& out) const override;
     void readSerialized(ObjectInputStream& in) override;

--- a/src/core/model/Image.cpp
+++ b/src/core/model/Image.cpp
@@ -24,7 +24,7 @@ Image::~Image() {
     }
 }
 
-auto Image::clone() -> Element* {
+auto Image::clone() const -> Element* {
     auto* img = new Image();
 
     img->x = this->x;

--- a/src/core/model/Image.h
+++ b/src/core/model/Image.h
@@ -51,7 +51,7 @@ public:
     void scale(double x0, double y0, double fx, double fy, double rotation, bool restoreLineWidth) override;
     void rotate(double x0, double y0, double th) override;
 
-    Element* clone() override;
+    Element* clone() const override;
 
     bool hasData() const;
 

--- a/src/core/model/Layer.cpp
+++ b/src/core/model/Layer.cpp
@@ -38,7 +38,7 @@ void Layer::addElement(Element* e) {
     this->elements.push_back(e);
 }
 
-void Layer::insertElement(Element* e, ElementIndex pos) {
+void Layer::insertElement(Element* e, Element::Index pos) {
     if (e == nullptr) {
         g_warning("insertElement(nullptr)!");
         Stacktrace::printStracktrace();
@@ -67,17 +67,17 @@ void Layer::insertElement(Element* e, ElementIndex pos) {
     }
 }
 
-auto Layer::indexOf(Element* e) const -> ElementIndex {
+auto Layer::indexOf(Element* e) const -> Element::Index {
     for (unsigned int i = 0; i < this->elements.size(); i++) {
         if (this->elements[i] == e) {
             return i;
         }
     }
 
-    return InvalidElementIndex;
+    return Element::InvalidIndex;
 }
 
-auto Layer::removeElement(Element* e, bool free) -> ElementIndex {
+auto Layer::removeElement(Element* e, bool free) -> Element::Index {
     for (unsigned int i = 0; i < this->elements.size(); i++) {
         if (e == this->elements[i]) {
             this->elements.erase(this->elements.begin() + i);
@@ -91,7 +91,7 @@ auto Layer::removeElement(Element* e, bool free) -> ElementIndex {
 
     g_warning("Could not remove element from layer, it's not on the layer!");
     Stacktrace::printStracktrace();
-    return InvalidElementIndex;
+    return Element::InvalidIndex;
 }
 
 auto Layer::isAnnotated() const -> bool { return !this->elements.empty(); }

--- a/src/core/model/Layer.h
+++ b/src/core/model/Layer.h
@@ -26,9 +26,6 @@ public:
 
     using Index = size_t;
 
-    using ElementIndex = std::ptrdiff_t;
-    static constexpr auto InvalidElementIndex = static_cast<ElementIndex>(-1);
-
 public:
     /**
      * Appends an Element to this Layer
@@ -42,17 +39,17 @@ public:
      *
      * @note Performs a check to determine whether the element is already contained in the Layer
      */
-    void insertElement(Element* e, ElementIndex pos);
+    void insertElement(Element* e, Element::Index pos);
 
     /**
      * Returns the index of the given Element with respect to the internal list
      */
-    ElementIndex indexOf(Element* e) const;
+    Element::Index indexOf(Element* e) const;
 
     /**
      * Removes an Element from the Layer and optionally deletes it
      */
-    ElementIndex removeElement(Element* e, bool free);
+    Element::Index removeElement(Element* e, bool free);
 
     /**
      * Returns an iterator over the Element%s contained in this Layer

--- a/src/core/model/Layer.h
+++ b/src/core/model/Layer.h
@@ -24,6 +24,8 @@ public:
     Layer();
     virtual ~Layer();
 
+    using Index = size_t;
+
     using ElementIndex = std::ptrdiff_t;
     static constexpr auto InvalidElementIndex = static_cast<ElementIndex>(-1);
 

--- a/src/core/model/Stroke.cpp
+++ b/src/core/model/Stroke.cpp
@@ -87,7 +87,7 @@ auto Stroke::cloneStroke() const -> Stroke* {
     return s;
 }
 
-auto Stroke::clone() -> Element* { return this->cloneStroke(); }
+auto Stroke::clone() const -> Element* { return this->cloneStroke(); }
 
 std::unique_ptr<Stroke> Stroke::cloneSection(const PathParameter& lowerBound, const PathParameter& upperBound) const {
     assert(lowerBound.isValid() && upperBound.isValid());
@@ -209,7 +209,7 @@ auto Stroke::getWidth() const -> double { return this->width; }
 
 auto Stroke::rescaleWithMirror() -> bool { return true; }
 
-auto Stroke::isInSelection(ShapeContainer* container) -> bool {
+auto Stroke::isInSelection(ShapeContainer* container) const -> bool {
     for (auto&& p: this->points) {
         double px = p.x;
         double py = p.y;
@@ -389,14 +389,14 @@ void Stroke::setPressure(const std::vector<double>& pressure) {
 /**
  * checks if the stroke is intersected by the eraser rectangle
  */
-auto Stroke::intersects(double x, double y, double halfEraserSize) -> bool {
+auto Stroke::intersects(double x, double y, double halfEraserSize) const -> bool {
     return intersects(x, y, halfEraserSize, nullptr);
 }
 
 /**
  * checks if the stroke is intersected by the eraser rectangle
  */
-auto Stroke::intersects(double x, double y, double halfEraserSize, double* gap) -> bool {
+auto Stroke::intersects(double x, double y, double halfEraserSize, double* gap) const -> bool {
     if (this->points.empty()) {
         return false;
     }

--- a/src/core/model/Stroke.h
+++ b/src/core/model/Stroke.h
@@ -52,7 +52,7 @@ public:
 
 public:
     Stroke* cloneStroke() const;
-    Element* clone() override;
+    Element* clone() const override;
 
     /**
      * @brief Create a partial clone whose points are those of parameters between lowerBound and upperBound
@@ -114,8 +114,8 @@ public:
     const LineStyle& getLineStyle() const;
     void setLineStyle(const LineStyle& style);
 
-    bool intersects(double x, double y, double halfEraserSize) override;
-    bool intersects(double x, double y, double halfEraserSize, double* gap) override;
+    bool intersects(double x, double y, double halfEraserSize) const override;
+    bool intersects(double x, double y, double halfEraserSize, double* gap) const override;
 
     /**
      * @brief Find the parameters within a certain interval corresponding to the points where the stroke crosses in
@@ -147,7 +147,7 @@ public:
     void scale(double x0, double y0, double fx, double fy, double rotation, bool restoreLineWidth) override;
     void rotate(double x0, double y0, double th) override;
 
-    bool isInSelection(ShapeContainer* container) override;
+    bool isInSelection(ShapeContainer* container) const override;
 
     ErasableStroke* getErasable() const;
     void setErasable(ErasableStroke* erasable);

--- a/src/core/model/TexImage.cpp
+++ b/src/core/model/TexImage.cpp
@@ -24,7 +24,7 @@ void TexImage::freeImageAndPdf() {
     }
 }
 
-auto TexImage::clone() -> Element* {
+auto TexImage::clone() const -> Element* {
     auto* img = new TexImage();
     img->x = this->x;
     img->y = this->y;

--- a/src/core/model/TexImage.h
+++ b/src/core/model/TexImage.h
@@ -57,7 +57,7 @@ public:
     void setText(std::string text);
     std::string getText() const;
 
-    Element* clone() override;
+    Element* clone() const override;
 
     /**
      * @return true if the binary data (PNG or PDF) was loaded successfully.

--- a/src/core/model/Text.cpp
+++ b/src/core/model/Text.cpp
@@ -16,7 +16,7 @@ Text::Text(): AudioElement(ELEMENT_TEXT) {
 
 Text::~Text() = default;
 
-auto Text::clone() -> Element* {
+auto Text::clone() const -> Element* {
     Text* text = new Text();
     text->font = this->font;
     text->text = this->text;
@@ -93,11 +93,11 @@ auto Text::isInEditing() const -> bool { return this->inEditing; }
 
 auto Text::rescaleOnlyAspectRatio() -> bool { return true; }
 
-auto Text::intersects(double x, double y, double halfEraserSize) -> bool {
+auto Text::intersects(double x, double y, double halfEraserSize) const -> bool {
     return intersects(x, y, halfEraserSize, nullptr);
 }
 
-auto Text::intersects(double x, double y, double halfEraserSize, double* gap) -> bool {
+auto Text::intersects(double x, double y, double halfEraserSize, double* gap) const -> bool {
     double x1 = this->x - halfEraserSize;
     double x2 = this->x + this->getElementWidth() + halfEraserSize;
     double y1 = this->y - halfEraserSize;

--- a/src/core/model/Text.h
+++ b/src/core/model/Text.h
@@ -45,10 +45,10 @@ public:
     /**
      * @overwrite
      */
-    Element* clone() override;
+    Element* clone() const override;
 
-    bool intersects(double x, double y, double halfEraserSize) override;
-    bool intersects(double x, double y, double halfEraserSize, double* gap) override;
+    bool intersects(double x, double y, double halfEraserSize) const override;
+    bool intersects(double x, double y, double halfEraserSize, double* gap) const override;
 
 public:
     // Serialize interface

--- a/src/core/model/XojPage.h
+++ b/src/core/model/XojPage.h
@@ -35,9 +35,9 @@ public:
     // So notification can be sent on change
 protected:
     void addLayer(Layer* layer);
-    void insertLayer(Layer* layer, int index);
+    void insertLayer(Layer* layer, Layer::Index index);
     void removeLayer(Layer* layer);
-    void setLayerVisible(int layerId, bool visible);
+    void setLayerVisible(Layer::Index layerId, bool visible);
 
 public:
     // Also set the size over doc->setPageSize!
@@ -56,17 +56,16 @@ public:
 
     size_t getPdfPageNr() const;
 
-    bool isAnnotated();
+    bool isAnnotated() const;
 
     void setBackgroundColor(Color color);
     Color getBackgroundColor() const;
 
     std::vector<Layer*>* getLayers();
-    size_t getLayerCount();
-    int getSelectedLayerId();
-    void setSelectedLayerId(int id);
-    static bool isLayerVisible(Layer* layer);
-    bool isLayerVisible(int layerId);
+    Layer::Index getLayerCount() const;
+    Layer::Index getSelectedLayerId();
+    void setSelectedLayerId(Layer::Index id);
+    bool isLayerVisible(Layer::Index layerId) const;
 
     Layer* getSelectedLayer();
 
@@ -102,7 +101,7 @@ private:
     /**
      * The current selected layer ID
      */
-    size_t currentLayer = npos;
+    Layer::Index currentLayer = npos;
 
     /**
      * The Background Type of the page

--- a/src/core/plugin/luapi_application.h
+++ b/src/core/plugin/luapi_application.h
@@ -8,6 +8,7 @@
  *
  * @license GNU GPLv2 or later
  */
+#pragma once
 
 #include <cstring>
 #include <map>
@@ -941,7 +942,7 @@ static int applib_changeBackgroundPdfPageNr(lua_State* L) {
             luaL_error(L, "Current page has no pdf background, cannot use relative mode!");
         }
     }
-    if (selected >= 0 && selected < static_cast<int>(doc->getPdfPageCount())) {
+    if (selected < doc->getPdfPageCount()) {
         // no need to set a type, if we set the page number the type is also set
         page->setBackgroundPdfPageNr(selected);
 
@@ -1319,7 +1320,7 @@ static int applib_getDocumentStructure(lua_State* L) {
         lua_newtable(L);  // beginning of table for background layer
 
         lua_pushliteral(L, "isVisible");
-        lua_pushboolean(L, page->isLayerVisible(0));
+        lua_pushboolean(L, page->isLayerVisible(0U));
         lua_settable(L, -3);
 
         lua_pushliteral(L, "name");
@@ -1519,7 +1520,7 @@ static int applib_setCurrentLayer(lua_State* L) {
     size_t layerCount = page->getLayerCount();
     size_t layerId = luaL_checkinteger(L, 1);
 
-    if (layerId < 0 || layerId > layerCount) {
+    if (layerId > layerCount) {
         luaL_error(L, "No layer with layer ID %d", layerId);
     }
 
@@ -1548,7 +1549,7 @@ static int applib_setLayerVisibility(lua_State* L) {
         enabled = lua_toboolean(L, 1);
     }
 
-    int layerId = control->getCurrentPage()->getSelectedLayerId();
+    auto layerId = control->getCurrentPage()->getSelectedLayerId();
     control->getLayerController()->setLayerVisible(layerId, enabled);
     return 1;
 }

--- a/src/core/undo/ArrangeUndoAction.h
+++ b/src/core/undo/ArrangeUndoAction.h
@@ -19,7 +19,7 @@
 
 class ArrangeUndoAction: public UndoAction {
 public:
-    using InsertOrder = std::deque<std::pair<Element*, Layer::ElementIndex>>;
+    using InsertOrder = std::deque<std::pair<Element*, Element::Index>>;
 
     ArrangeUndoAction(const PageRef& page, Layer* layer, std::string desc, InsertOrder oldOrder, InsertOrder newOrder);
     ~ArrangeUndoAction() override;

--- a/src/core/undo/DeleteUndoAction.cpp
+++ b/src/core/undo/DeleteUndoAction.cpp
@@ -10,7 +10,7 @@ DeleteUndoAction::DeleteUndoAction(const PageRef& page, bool eraser): UndoAction
     this->page = page;
 }
 
-void DeleteUndoAction::addElement(Layer* layer, Element* e, size_t pos) { elements.emplace(layer, e, pos); }
+void DeleteUndoAction::addElement(Layer* layer, Element* e, Element::Index pos) { elements.emplace(layer, e, pos); }
 
 auto DeleteUndoAction::undo(Control*) -> bool {
     if (elements.empty()) {

--- a/src/core/undo/DeleteUndoAction.h
+++ b/src/core/undo/DeleteUndoAction.h
@@ -17,9 +17,6 @@
 #include "PageLayerPosEntry.h"
 #include "UndoAction.h"
 
-
-class Element;
-
 class DeleteUndoAction: public UndoAction {
 public:
     DeleteUndoAction(const PageRef& page, bool eraser);
@@ -28,7 +25,7 @@ public:
     bool undo(Control*) override;
     bool redo(Control*) override;
 
-    void addElement(Layer* layer, Element* e, size_t pos);  // should be ElementIndex but we don't have that in scope
+    void addElement(Layer* layer, Element* e, Element::Index pos);
 
     std::string getText() override;
 

--- a/src/core/undo/InsertLayerUndoAction.cpp
+++ b/src/core/undo/InsertLayerUndoAction.cpp
@@ -9,10 +9,12 @@
 #include "util/i18n.h"
 
 InsertLayerUndoAction::InsertLayerUndoAction(LayerController* layerController, const PageRef& page, Layer* layer,
-                                             int layerPosition):
-        UndoAction("InsertLayerUndoAction"), layerPosition(layerPosition), layerController(layerController) {
+                                             Layer::Index layerPosition):
+        UndoAction("InsertLayerUndoAction"),
+        layerPosition(layerPosition),
+        layerController(layerController),
+        layer(layer) {
     this->page = page;
-    this->layer = layer;
 }
 
 InsertLayerUndoAction::~InsertLayerUndoAction() {

--- a/src/core/undo/InsertLayerUndoAction.h
+++ b/src/core/undo/InsertLayerUndoAction.h
@@ -14,15 +14,16 @@
 #include <string>
 #include <vector>
 
+#include "model/Layer.h"
+
 #include "UndoAction.h"
 
-
-class Layer;
 class LayerController;
 
 class InsertLayerUndoAction: public UndoAction {
 public:
-    InsertLayerUndoAction(LayerController* layerController, const PageRef& page, Layer* layer, int layerPosition);
+    InsertLayerUndoAction(LayerController* layerController, const PageRef& page, Layer* layer,
+                          Layer::Index layerPosition);
     ~InsertLayerUndoAction() override;
 
 public:
@@ -32,7 +33,7 @@ public:
     std::string getText() override;
 
 private:
-    int layerPosition;
+    Layer::Index layerPosition;
     LayerController* layerController;
     Layer* layer;
 };

--- a/src/core/undo/LayerRenameUndoAction.cpp
+++ b/src/core/undo/LayerRenameUndoAction.cpp
@@ -5,8 +5,8 @@
 LayerRenameUndoAction::LayerRenameUndoAction(LayerController* layerController, Layer* layer, const std::string& newName,
                                              const std::string& oldName):
         UndoAction("LayerUndoAction"),
-        layerController(layerController),
         layer(layer),
+        layerController(layerController),
         newName(newName),
         oldName(oldName) {}
 

--- a/src/core/undo/MergeLayerDownUndoAction.cpp
+++ b/src/core/undo/MergeLayerDownUndoAction.cpp
@@ -9,7 +9,7 @@
 #include "util/i18n.h"
 
 MergeLayerDownUndoAction::MergeLayerDownUndoAction(LayerController* layerController, const PageRef& page,
-                                                   Layer* upperLayer, Layer* lowerLayer, int upperLayerPos,
+                                                   Layer* upperLayer, Layer* lowerLayer, Layer::Index upperLayerPos,
                                                    size_t selectedPage):
         UndoAction("MergeLayerDownUndoAction"),
         upperLayerPos(upperLayerPos),

--- a/src/core/undo/MergeLayerDownUndoAction.h
+++ b/src/core/undo/MergeLayerDownUndoAction.h
@@ -22,7 +22,7 @@ class LayerController;
 class MergeLayerDownUndoAction: public UndoAction {
 public:
     MergeLayerDownUndoAction(LayerController* layerController, const PageRef& page, Layer* upperLayer,
-                             Layer* lowerLayer, int upperLayerPos, size_t selectedPage);
+                             Layer* lowerLayer, Layer::Index upperLayerPos, size_t selectedPage);
 
 public:
     bool undo(Control* control) override;
@@ -33,11 +33,11 @@ public:
 private:
     void triggerUIUpdate(Control* control);
 
-    const int upperLayerPos;
+    const Layer::Index upperLayerPos;
     LayerController* layerController;
     Layer* upperLayer;
     Layer* lowerLayer;
-    const int upperLayerID;
-    const int lowerLayerID;
+    const Layer::Index upperLayerID;
+    const Layer::Index lowerLayerID;
     const size_t selectedPage;
 };

--- a/src/core/undo/MoveLayerUndoAction.cpp
+++ b/src/core/undo/MoveLayerUndoAction.cpp
@@ -9,7 +9,7 @@
 #include "util/i18n.h"
 
 MoveLayerUndoAction::MoveLayerUndoAction(LayerController* layerController, const PageRef& page, Layer* layer,
-                                         int oldLayerPos, int newLayerPos):
+                                         Layer::Index oldLayerPos, Layer::Index newLayerPos):
         UndoAction("MoveLayerUndoAction"),
         oldLayerPos(oldLayerPos),
         newLayerPos(newLayerPos),

--- a/src/core/undo/MoveLayerUndoAction.h
+++ b/src/core/undo/MoveLayerUndoAction.h
@@ -22,8 +22,8 @@ class LayerController;
 
 class MoveLayerUndoAction: public UndoAction {
 public:
-    MoveLayerUndoAction(LayerController* layerController, const PageRef& page, Layer* layer, int oldLayerPos,
-                        int newLayerPos);
+    MoveLayerUndoAction(LayerController* layerController, const PageRef& page, Layer* layer, Layer::Index oldLayerPos,
+                        Layer::Index newLayerPos);
     ~MoveLayerUndoAction() override;
 
 public:
@@ -33,8 +33,8 @@ public:
     std::string getText() override;
 
 private:
-    int oldLayerPos;
-    int newLayerPos;
+    Layer::Index oldLayerPos;
+    Layer::Index newLayerPos;
     LayerController* layerController;
     Layer* layer;
 };

--- a/src/core/undo/PageLayerPosEntry.h
+++ b/src/core/undo/PageLayerPosEntry.h
@@ -18,11 +18,11 @@ class Layer;
 template <class T>
 struct PageLayerPosEntry {
     // TODO: constructor could be removed with C++20
-    PageLayerPosEntry<T>(Layer* layer, T* element, size_t pos): layer(layer), element(element), pos(pos) {}
+    PageLayerPosEntry<T>(Layer* layer, T* element, typename T::Index pos): layer(layer), element(element), pos(pos) {}
 
     Layer* layer;
     T* element;
-    size_t pos;
+    typename T::Index pos;
 };
 
 template <typename T>

--- a/src/core/undo/RemoveLayerUndoAction.cpp
+++ b/src/core/undo/RemoveLayerUndoAction.cpp
@@ -9,11 +9,9 @@
 #include "util/i18n.h"
 
 RemoveLayerUndoAction::RemoveLayerUndoAction(LayerController* layerController, const PageRef& page, Layer* layer,
-                                             int layerPos):
-        UndoAction("RemoveLayerUndoAction"), layerController(layerController) {
+                                             Layer::Index layerPos):
+        UndoAction("RemoveLayerUndoAction"), layerController(layerController), layer(layer), layerPos(layerPos) {
     this->page = page;
-    this->layer = layer;
-    this->layerPos = layerPos;
 }
 
 RemoveLayerUndoAction::~RemoveLayerUndoAction() {

--- a/src/core/undo/RemoveLayerUndoAction.h
+++ b/src/core/undo/RemoveLayerUndoAction.h
@@ -18,7 +18,7 @@ class LayerController;
 
 class RemoveLayerUndoAction: public UndoAction {
 public:
-    RemoveLayerUndoAction(LayerController* layerController, const PageRef& page, Layer* layer, int layerPos);
+    RemoveLayerUndoAction(LayerController* layerController, const PageRef& page, Layer* layer, Layer::Index layerPos);
     ~RemoveLayerUndoAction() override;
 
 public:
@@ -30,5 +30,5 @@ public:
 private:
     LayerController* layerController;
     Layer* layer;
-    int layerPos;
+    Layer::Index layerPos;
 };

--- a/src/core/view/DocumentView.cpp
+++ b/src/core/view/DocumentView.cpp
@@ -128,7 +128,7 @@ void DocumentView::drawPage(PageRef page, cairo_t* cr, bool dontRenderEditingStr
                                (xoj::view::EditionTreatment) !this->dontRenderEditingStroke, xoj::view::NORMAL_COLOR};
     const Rectangle<double> drawArea{this->lX, this->lY, this->lWidth, this->lHeight};
     for (Layer* layer: *page->getLayers()) {
-        if (page->isLayerVisible(layer)) {
+        if (layer->isVisible()) {
             xoj::view::LayerView layerView(layer);
             if (this->lX == -1) {
                 layerView.draw(context);


### PR DESCRIPTION
The code-cleanup PR is two-fold:

- const-qualify getters in Element and derived classes
- Fix sign-conversion warnings relative to layer indices

Most of the changes are trivial, but a couple of points would require a rapid review (all in the second commit, relative to sign-conversions). I'll highlight those points with review comments