### PR TITLE
Unfocus text boxes after the selected page changes

### DIFF
--- a/src/gui/XournalView.cpp
+++ b/src/gui/XournalView.cpp
@@ -334,6 +334,8 @@ void XournalView::pageSelected(size_t page) {
         this->viewPages[this->lastSelectedPage]->setSelected(false);
     }
 
+    endTextAllPages();
+
     this->currentPage = page;
 
     size_t pdfPage = npos;


### PR DESCRIPTION
Addresses #3765

This pr stops editing of the textbox once you change pages. Before, it would stay selected but you couldn't type until you went back to the page it was on.