### PR TITLE
scale small arrow heads by line length

### DIFF
--- a/src/core/control/tools/ArrowHandler.cpp
+++ b/src/core/control/tools/ArrowHandler.cpp
@@ -29,7 +29,7 @@ auto ArrowHandler::createShape(bool isAltDown, bool isShiftDown, bool isControlD
     // delta is the angle between each arrow leg and the line
 
     // an appropriate opening angle 2*delta is Pi/3 radians for an arrow shape
-    const double delta = M_PI / 6.0;
+    double delta = M_PI / 6.0;
     // We use different slimness regimes for proper sizing:
     const double THICK1 = 7, THICK3 = 1.6;
     const double LENGTH2 = 0.4, LENGTH4 = (doubleEnded ? 0.5 : 0.8);
@@ -44,9 +44,15 @@ auto ArrowHandler::createShape(bool isAltDown, bool isShiftDown, bool isControlD
     } else if (slimness >= THICK3 / LENGTH4) {
         // arrow head is not too thick compared to the line length (regime 3)
         arrowDist = thickness * THICK3;
+        // help visibility by widening the angle
+        delta = (1 + (slimness - THICK3 / LENGTH2) / (THICK3 / LENGTH4 - THICK3 / LENGTH2)) *  M_PI / 6.0;
+        // which allows to shorten the tips and keep the horizonzal distance
+        arrowDist *= sin(M_PI / 6.0) / sin(delta);
     } else {
         // shrinking down gracefully (regime 4)
         arrowDist = lineLength * LENGTH4;
+        delta = M_PI / 3.0;
+        arrowDist *= sin(M_PI / 6.0) / sin(M_PI / 3.0);
     }
 
     const double angle = atan2(c.y - this->startPoint.y, c.x - this->startPoint.x);

--- a/src/core/control/tools/ArrowHandler.cpp
+++ b/src/core/control/tools/ArrowHandler.cpp
@@ -28,16 +28,27 @@ auto ArrowHandler::createShape(bool isAltDown, bool isShiftDown, bool isControlD
     // arrowDist is the distance between the line's and the arrow's tips
     // delta is the angle between each arrow leg and the line
 
-    // set up the size of the arrow head to be 7x the thickness of the line (regime 1)
-    const double THICK1 = 7, LENGTH2 = 0.4;
-    double arrowDist = thickness * THICK1;
-    // but not too large compared to the line length (regime 2)
-    if (slimness < THICK1 / LENGTH2) {
-        arrowDist = lineLength * LENGTH2;
-    }
-
     // an appropriate opening angle 2*delta is Pi/3 radians for an arrow shape
     const double delta = M_PI / 6.0;
+    // We use different slimness regimes for proper sizing:
+    const double THICK1 = 7, THICK3 = 1.6;
+    const double LENGTH2 = 0.4, LENGTH4 = (doubleEnded ? 0.5 : 0.8);
+    // set up the size of the arrow head to be THICK1 x the thickness of the line
+    double arrowDist = thickness * THICK1;
+    // but not too large compared to the line length
+    if (slimness >= THICK1 / LENGTH2) {
+        // arrow head is not too long compared to the line length (regime 1)
+    } else if (slimness >= THICK3 / LENGTH2) {
+        // arrow head is not too short compared to the thickness (regime 2)
+        arrowDist = lineLength * LENGTH2;
+    } else if (slimness >= THICK3 / LENGTH4) {
+        // arrow head is not too thick compared to the line length (regime 3)
+        arrowDist = thickness * THICK3;
+    } else {
+        // shrinking down gracefully (regime 4)
+        arrowDist = lineLength * LENGTH4;
+    }
+
     const double angle = atan2(c.y - this->startPoint.y, c.x - this->startPoint.x);
 
     std::pair<std::vector<Point>, Range> res; // members initialised below


### PR DESCRIPTION
So far, the size of arrow heads is determined purely by the line width,
which is good for medium sized and long arrows. For very small arrows,
this leads to "interesting effects", especially for double headed
arrows.

To avoid these effects, scale the arrow head by the line length for
short arrows, i.e.: make the heads no larger than 0.4 * line length.
This suites double arrows as well, and besides, 0.4 is roughly
1 - (sqrt(5) - 1) / 2 which is the golden choice.

![nomin](https://user-images.githubusercontent.com/233215/170711635-363ef18c-807c-409d-b2d2-2ce7e5e442ee.png)
![withmin](https://user-images.githubusercontent.com/233215/170711639-7b174ef3-e6f3-41ba-98e6-e36c3d05a2ea.png)
