### PR TITLE
Rpkg

### DIFF
--- a/rpm/fedora/xournalpp.spec
+++ b/rpm/fedora/xournalpp.spec
@@ -127,7 +127,7 @@ appstream-util validate-relax --nonet %{buildroot}%{_metainfodir}/com.github.%{n
 * Sun Mar 6 2022 Luya Tshimbalanga <luya@fedoraproject.org>
 - Port enhanced spec file from Michael J Gruber version
 
-* Thu Oct 20 2021 Ulrich Huber <ulrich@huberulrich.de>
+* Thu Oct 21 2021 Ulrich Huber <ulrich@huberulrich.de>
 - See https://github.com/%{name}/%{name}/CHANGELOG.md
 
 * Sat Feb 20 2021 Luya Tshimbalanga <luya@fedoraproject.org>

--- a/rpm/fedora/xournalpp.spec
+++ b/rpm/fedora/xournalpp.spec
@@ -1,25 +1,21 @@
 # Force out of source build
-%global         __cmake_in_source_build 0
+%global __cmake_in_source_build 0
 
 #This spec file is intended for daily development snapshot release
-%global	build_repo https://github.com/xournalpp/xournalpp/
-%global	build_branch master
-%global	version_string 1.1.1+dev
-%define	build_commit %(git ls-remote %{build_repo} | grep "refs/heads/%{build_branch}" | cut -c1-41)
-%define	build_shortcommit %(c=%{build_commit}; echo ${c:0:7})
-%global	build_timestamp %(date +"%Y%m%d")
-%global	rel_build %{build_timestamp}git%{build_shortcommit}
+%global build_shortcommit {{{ git rev-parse --short HEAD }}}
+%global version_string {{{ git describe --tags --match 'v[0-9]*' | sed -e 's/^v\(.*\)-\([0-9]*\)-g\(.*\)$/\1^\2.g\3/' }}}
 %global _gtest 1
 
 Name:           xournalpp
 # See https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_examples
-Version:        %{version_string}^%{rel_build}
+Version:        %{version_string}
 Release:        1%{dist}
 Summary:        Handwriting note-taking software with PDF annotation support
 
 License:        GPLv2+
-URL:            %{build_repo}
-Source:         %{url}/archive/%{build_branch}.tar.gz
+URL:            https://xournalpp.github.io
+VCS:            {{{ git_cwd_vcs }}}
+Source:         {{{ git_cwd_pack }}}
 
 BuildRequires:  cmake >= 3.10
 BuildRequires:  desktop-file-utils
@@ -70,7 +66,7 @@ The %{name}-ui package contains a graphical user interface for  %{name}.
 
 
 %prep
-%autosetup -n %{name}-%{build_branch}
+%autosetup -n %{name}
 
 %build
 %cmake \
@@ -124,6 +120,9 @@ appstream-util validate-relax --nonet %{buildroot}%{_metainfodir}/com.github.%{n
 %{_datadir}/%{name}/ui
 
 %changelog
+* Fri Apr 1 2022 Michael J Gruber <mjg@fedoraproject.org>
+- Switch spec file to rpkg format
+
 * Sun Mar 6 2022 Luya Tshimbalanga <luya@fedoraproject.org>
 - Port enhanced spec file from Michael J Gruber version
 


### PR DESCRIPTION
So here is the rebased rpkg branch related to #3694. The spec is almost completely due to @luyatshimbalanga , with adaptions to use rpkg instead of lua for computing the version etc. Note:

- This gives a valid spec file only after processing with `rpkg` (which is the intended use case for automatic builds on copr).
- The computed versions sort earlier than the ones created so far - users of the copr repo need to "downgrade" to the new versions. So, either decide that this is acceptable for "devel users" (it should be) or hold this merge back until the next release.