### PR TITLE
[1.1.x] ci: update Windows VM image to windows-2019

### DIFF
--- a/azure-pipelines/continuous-integration.yml
+++ b/azure-pipelines/continuous-integration.yml
@@ -35,7 +35,7 @@ stages:
 
       - job: 'Windows'
         pool:
-          vmImage: 'vs2017-win2016'
+          vmImage: 'windows-2019'
         displayName: 'Test Xournal++ on Windows'
         steps:
           - template: steps/build_windows.yml

--- a/azure-pipelines/create-installers.yml
+++ b/azure-pipelines/create-installers.yml
@@ -73,7 +73,7 @@ stages:
           
       - job: Windows
         pool:
-          vmImage: 'vs2017-win2016'
+          vmImage: 'windows-2019'
         displayName: 'Build for Windows'
         steps:
           - template: steps/build_windows.yml

--- a/azure-pipelines/dependencies/msys2-blob.yml
+++ b/azure-pipelines/dependencies/msys2-blob.yml
@@ -8,7 +8,7 @@ trigger:
 pr: none
 
 pool:
-  vmImage: 'vs2017-win2016'
+  vmImage: 'windows-2019'
         
 steps:
 - script: |

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -81,7 +81,7 @@ stages:
           
       - job: Windows
         pool:
-          vmImage: 'vs2017-win2016'
+          vmImage: 'windows-2019'
         displayName: 'Build for Windows'
         steps:
           - template: steps/build_windows.yml


### PR DESCRIPTION
Switch away from deprecated vs2017-win2016 image on 1.1.x branch. We already
switched to windows-2019 on master branch.