### PR TITLE
Optimize TextEditor calls for rerendering

### DIFF
--- a/src/gui/PageView.cpp
+++ b/src/gui/PageView.cpp
@@ -259,7 +259,7 @@ void XojPageView::startText(double x, double y) {
             this->textEditor->mousePressed(x - text->getX(), y - text->getY());
         }
 
-        this->rerenderPage();
+        this->rerenderElement(text);
     }
 }
 

--- a/src/gui/TextEditor.cpp
+++ b/src/gui/TextEditor.cpp
@@ -22,6 +22,8 @@ TextEditor::TextEditor(XojPageView* gui, GtkWidget* widget, Text* text, bool own
     this->textWidget = gtk_xoj_int_txt_new(this);
     this->lastText = text->getText();
 
+    this->previousBoundingBox = text->boundingRect();
+
     this->buffer = gtk_text_buffer_new(nullptr);
     string txt = this->text->getText();
     gtk_text_buffer_set_text(this->buffer, txt.c_str(), -1);
@@ -168,8 +170,8 @@ void TextEditor::iMCommitCallback(GtkIMContext* context, const gchar* str, TextE
     }
 
     gtk_text_buffer_end_user_action(te->buffer);
-    te->repaintEditor();
     te->contentsChanged();
+    te->repaintEditor();
 }
 
 void TextEditor::iMPreeditChangedCallback(GtkIMContext* context, TextEditor* te) {
@@ -206,8 +208,8 @@ void TextEditor::iMPreeditChangedCallback(GtkIMContext* context, TextEditor* te)
         te->preeditString = "";
     }
     te->preeditCursor = cursor_pos;
-    te->repaintEditor();
     te->contentsChanged();
+    te->repaintEditor();
 
 out:
 
@@ -229,8 +231,8 @@ auto TextEditor::iMRetrieveSurroundingCallback(GtkIMContext* context, TextEditor
     gtk_im_context_set_surrounding(context, text, -1, pos);
     g_free(text);
 
-    te->repaintEditor();
     te->contentsChanged();
+    te->repaintEditor();
     return true;
 }
 
@@ -246,8 +248,8 @@ auto TextEditor::imDeleteSurroundingCallback(GtkIMContext* context, gint offset,
 
     gtk_text_buffer_delete_interactive(te->buffer, &start, &end, true);
 
-    te->repaintEditor();
     te->contentsChanged();
+    te->repaintEditor();
 
     return true;
 }
@@ -817,16 +819,16 @@ void TextEditor::backspace() {
 
     // Backspace deletes the selection, if one exists
     if (gtk_text_buffer_delete_selection(this->buffer, true, true)) {
-        this->repaintEditor();
         this->contentsChanged();
+        this->repaintEditor();
         return;
     }
 
     gtk_text_buffer_get_iter_at_mark(this->buffer, &insert, gtk_text_buffer_get_insert(this->buffer));
 
     if (gtk_text_buffer_backspace(this->buffer, &insert, true, true)) {
-        this->repaintEditor();
         this->contentsChanged();
+        this->repaintEditor();
     } else {
         gtk_widget_error_bell(this->widget);
     }
@@ -854,8 +856,8 @@ void TextEditor::cutToClipboard() {
     GtkClipboard* clipboard = gtk_widget_get_clipboard(this->widget, GDK_SELECTION_CLIPBOARD);
     gtk_text_buffer_cut_clipboard(this->buffer, clipboard, true);
 
-    this->repaintEditor();
     this->contentsChanged(true);
+    this->repaintEditor();
 }
 
 void TextEditor::pasteFromClipboard() {
@@ -864,8 +866,8 @@ void TextEditor::pasteFromClipboard() {
 }
 
 void TextEditor::bufferPasteDoneCallback(GtkTextBuffer* buffer, GtkClipboard* clipboard, TextEditor* te) {
-    te->repaintEditor();
     te->contentsChanged(true);
+    te->repaintEditor();
 }
 
 void TextEditor::resetImContext() {
@@ -875,11 +877,7 @@ void TextEditor::resetImContext() {
     }
 }
 
-void TextEditor::repaintCursor() {
-    double x = this->text->getX();
-    double y = this->text->getY();
-    this->gui->repaintArea(x, y, x + this->text->getElementWidth(), y + this->text->getElementHeight());
-}
+void TextEditor::repaintCursor() { this->gui->repaintElement(this->text); }
 
 #define CURSOR_ON_MULTIPLIER 2
 #define CURSOR_OFF_MULTIPLIER 1
@@ -907,8 +905,14 @@ auto TextEditor::blinkCallback(TextEditor* te) -> gint {
 }
 
 void TextEditor::repaintEditor() {
-    auto rect = text->boundingRect();
-    this->gui->rerenderRect(rect.x, rect.y, rect.width, rect.height);
+    auto rect = this->text->boundingRect();
+    this->previousBoundingBox.unite(rect);
+    const double zoom = this->gui->getXournal()->getZoom();
+    const double padding = (BORDER_WIDTH_IN_PIXELS + PADDING_IN_PIXELS) / zoom;
+    this->gui->repaintRect(this->previousBoundingBox.x - padding, this->previousBoundingBox.y - padding,
+                           this->previousBoundingBox.width + 2.0 * padding,
+                           this->previousBoundingBox.height + 2.0 * padding);
+    this->previousBoundingBox = rect;
 }
 
 /**
@@ -1045,10 +1049,11 @@ void TextEditor::paint(cairo_t* cr, GdkRectangle* repaintRect, double zoom) {
     cairo_restore(cr);
 
     // set the line always the same size on display
-    cairo_set_line_width(cr, 1 / zoom);
+    cairo_set_line_width(cr, BORDER_WIDTH_IN_PIXELS / zoom);
     gdk_cairo_set_source_rgba(cr, &selectionColor);
 
-    cairo_rectangle(cr, x0 - 5 / zoom, y0 - 5 / zoom, width + 10 / zoom, height + 10 / zoom);
+    cairo_rectangle(cr, x0 - PADDING_IN_PIXELS / zoom, y0 - PADDING_IN_PIXELS / zoom,
+                    width + 2 * PADDING_IN_PIXELS / zoom, height + 2 * PADDING_IN_PIXELS / zoom);
     cairo_stroke(cr);
 
     // Notify the IM of the app's window and cursor position.

--- a/src/gui/TextEditor.h
+++ b/src/gui/TextEditor.h
@@ -107,6 +107,8 @@ private:
     double markPosX = 0;
     double markPosY = 0;
 
+    Rectangle<double> previousBoundingBox;
+
     bool cursorBlink = true;
     int cursorBlinkTime = 0;
     int cursorBlinkTimeout = 0;
@@ -119,4 +121,7 @@ private:
     bool mouseDown = false;
     bool cursorOverwrite = false;
     bool cursorVisible = false;
+
+    static constexpr int PADDING_IN_PIXELS = 5;
+    static constexpr int BORDER_WIDTH_IN_PIXELS = 1;
 };

--- a/src/gui/TextEditor.h
+++ b/src/gui/TextEditor.h
@@ -107,6 +107,12 @@ private:
     double markPosX = 0;
     double markPosY = 0;
 
+    /**
+     * Tracks the bounding box of the editor from the last render.
+     *
+     * Because adding or deleting lines may cause the size of the bounding box to change,
+     * we need to rerender the union of the current and previous bboxes.
+     */
     Rectangle<double> previousBoundingBox;
 
     bool cursorBlink = true;
@@ -122,6 +128,8 @@ private:
     bool cursorOverwrite = false;
     bool cursorVisible = false;
 
+    // Padding between the text logical box and the frame
     static constexpr int PADDING_IN_PIXELS = 5;
+    // Width of the lines making the frame
     static constexpr int BORDER_WIDTH_IN_PIXELS = 1;
 };


### PR DESCRIPTION
The PR offers a better fix to #3977, reverting #4000 which had a performance cost.

Indeed, #4000 triggered unecessary rerenderings (i.e. recomputation of the page buffer), while repaint (i.e. reblitting the buffer and the TextEditor) was enough.

The issue #3977 came from the fact that the rectangle in `rect` in 
https://github.com/xournalpp/xournalpp/blob/a394f85395f3c70d43a880a4de4354b2d9378fb1/src/gui/TextEditor.cpp#L909-L912
was computed without the string in `this->text` having been updated. This resulted in a to small repaint operation.

This PR ensures the string is updated before `repaintEditor` is called when adding characters, and after when removing characters.

NB: the reason why #4000 actually fixed the issue was that each rerendering trigger a repaint of the entire widget. Again, an overkill.