### PR TITLE
Add RAII wrappers for cairo classes in gui/PageView and jobs/RenderJob

### DIFF
--- a/src/core/control/jobs/RenderJob.h
+++ b/src/core/control/jobs/RenderJob.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <cairo/cairo.h>  // for cairo_surface_t
 #include <gtk/gtk.h>  // for GtkWidget
 
 #include "Job.h"  // for Job, JobType
@@ -42,6 +43,8 @@ private:
     static void repaintWidget(GtkWidget* widget);
 
     void rerenderRectangle(xoj::util::Rectangle<double> const& rect);
+
+    void renderToBuffer(cairo_surface_t* buffer) const;
 
 private:
     XojPageView* view;

--- a/src/core/gui/XournalView.h
+++ b/src/core/gui/XournalView.h
@@ -47,10 +47,6 @@ public:
     ~XournalView() override;
 
 public:
-    bool paint(GtkWidget* widget, GdkEventExpose* event);
-
-    void requestPage(XojPageView* page);
-
     // Recalculate the layout width and height amd layout the pages with the updated layout size
     void layoutPages();
 

--- a/src/core/view/background/PdfBackgroundView.cpp
+++ b/src/core/view/background/PdfBackgroundView.cpp
@@ -18,7 +18,12 @@ void PdfBackgroundView::draw(cairo_t* cr) const {
         cairo_matrix_t matrix = {0};
         cairo_get_matrix(cr, &matrix);
         assert(matrix.xx == matrix.yy && matrix.xy == 0.0 && matrix.yx == 0.0);  // Homothety matrix
-        pdfCache->render(cr, pageNo, matrix.xx, pageWidth, pageHeight);
+        double scaleX;
+        double scaleY;
+        cairo_surface_get_device_scale(cairo_get_target(cr), &scaleX, &scaleY);
+        assert(scaleX == scaleY);
+        double pixelsPerPageUnit = matrix.xx * scaleX;
+        pdfCache->render(cr, pageNo, pixelsPerPageUnit, pageWidth, pageHeight);
     } else {
         g_warning("PdfBackgroundView::draw Missing pdf cache: cannot render the pdf page");
         PdfCache::renderMissingPdfPage(cr, pageWidth, pageHeight);

--- a/src/util/include/util/raii/CLibrariesSPtr.h
+++ b/src/util/include/util/raii/CLibrariesSPtr.h
@@ -1,0 +1,100 @@
+/*
+ * Xournal++
+ *
+ * RAII smart pointers for C library classes
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+#include <utility>
+
+namespace xoj::util {
+/**
+ * @brief Simple template class for RAII smart pointer (aimed at Cairo/GTK/Poppler ref-counting classes)
+ * @param T The wrapper will store a pointer of type T
+ * @param H Handler class containing at least
+ *              static T* ref(T*):
+ *              static void unref(T*);
+ *              static T* adopt(T*);  // What to do to a pointer when we adopt an instance (typically the identity)
+ *          and optionally (for floating refs)
+ *              static T* ref_sink(T*);
+ */
+template <typename T, class H>
+class CLibrariesSPtr {
+public:
+    CLibrariesSPtr() = default;
+
+    using handler_type = H;
+
+private:
+    static auto safeRef(T* ptr) -> T* { return ptr ? H::ref(ptr) : ptr; }
+    static auto safeUnref(T* ptr) -> void {
+        if (ptr) {
+            H::unref(ptr);
+        }
+    }
+    static auto safeSinkRef(T* ptr) -> T* { return ptr ? H::sink_ref(ptr) : ptr; }
+    static auto safeReset(T*& ptr, T* val) -> void { safeUnref(std::exchange(ptr, val)); }
+
+public:
+    ~CLibrariesSPtr() { safeUnref(p); }
+
+    CLibrariesSPtr(const CLibrariesSPtr& other) { p = safeRef(other.p); }
+    CLibrariesSPtr(CLibrariesSPtr&& other) { p = std::exchange(other.p, nullptr); }
+
+    CLibrariesSPtr& operator=(const CLibrariesSPtr& other) {
+        if (this != &other) {
+            safeReset(p, safeRef(other.p));
+        }
+        return *this;
+    }
+    CLibrariesSPtr& operator=(CLibrariesSPtr&& other) {
+        if (this != &other) {
+            safeReset(p, std::exchange(other.p, nullptr));
+        }
+        return *this;
+    }
+
+    constexpr static struct Adopt {
+    } adopt = Adopt();
+    constexpr static struct Ref {
+    } ref = Ref();
+    constexpr static struct RefSink {
+    } refsink = RefSink();
+
+    CLibrariesSPtr(T* p, Adopt = adopt): p(H::adopt(p)) {}
+    CLibrariesSPtr(T* p, Ref): p(safeRef(p)) {}
+    CLibrariesSPtr(T* p, RefSink): p(safeSinkRef(p)) {}
+
+    void reset(T* other = nullptr, Adopt = adopt) { safeReset(p, other); }
+    void reset(T* other, Ref) { safeReset(p, safeRef(other)); }
+    void reset(T* other, RefSink) { safeReset(p, safeRefSink(other)); }
+
+    operator bool() const { return p != nullptr; }
+
+    T* get() { return p; }
+    const T* get() const { return p; }
+
+    T* release() { return std::exchange(p, nullptr); }
+
+    T* operator->() { return p; }
+    const T* operator->() const { return p; }
+
+    void swap(CLibrariesSPtr& other) { std::swap(p, other.p); }
+
+private:
+    T* p = nullptr;
+};
+};  // namespace xoj::util
+
+namespace std {
+template <typename T, class H>
+void swap(xoj::util::CLibrariesSPtr<T, H>& first, xoj::util::CLibrariesSPtr<T, H>& second) {
+    first.swap(second);
+}
+};  // namespace std

--- a/src/util/include/util/raii/CairoWrappers.h
+++ b/src/util/include/util/raii/CairoWrappers.h
@@ -1,0 +1,65 @@
+/*
+ * Xournal++
+ *
+ * RAII wrappers for C library classes
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+#include <utility>
+
+#include <cairo.h>
+
+#include "CLibrariesSPtr.h"
+
+namespace xoj::util {
+
+inline namespace raii {
+namespace specialization {
+
+template <typename T>  // Todo(cpp20): replace with std:identity()
+constexpr auto identity = [](T* p) { return p; };
+
+class CairoHandler {
+public:
+    constexpr static auto ref = cairo_reference;
+    constexpr static auto unref = cairo_destroy;
+    constexpr static auto adopt = identity<cairo_t>;
+};
+
+class CairoSurfaceHandler {
+public:
+    constexpr static auto ref = cairo_surface_reference;
+    constexpr static auto unref = cairo_surface_destroy;
+    constexpr static auto adopt = identity<cairo_surface_t>;
+};
+};  // namespace specialization
+
+using CairoSPtr = CLibrariesSPtr<cairo_t, raii::specialization::CairoHandler>;
+using CairoSurfaceSPtr = CLibrariesSPtr<cairo_surface_t, raii::specialization::CairoSurfaceHandler>;
+
+/**
+ * @brief cairo_save(cr)/cairo_restore(cr) RAII implementation
+ */
+class CairoSaveGuard {
+public:
+    CairoSaveGuard() = delete;
+    CairoSaveGuard(cairo_t* cr): cr(cr) { cairo_save(cr); }
+    ~CairoSaveGuard() { cairo_restore(cr); }
+
+    CairoSaveGuard(const CairoSaveGuard&) = delete;
+    CairoSaveGuard(CairoSaveGuard&&) = delete;
+    CairoSaveGuard& operator=(const CairoSaveGuard&) = delete;
+    CairoSaveGuard& operator=(CairoSaveGuard&&) = delete;
+
+private:
+    cairo_t* cr;
+};
+
+};  // namespace raii
+};  // namespace xoj::util

--- a/src/util/include/util/raii/GObjectSPtr.h
+++ b/src/util/include/util/raii/GObjectSPtr.h
@@ -1,0 +1,44 @@
+/*
+ * Xournal++
+ *
+ * RAII wrappers for C library classes
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+#include <utility>
+
+#include <glib-object.h>
+#include <gtk/gtk.h>
+
+#include "CLibrariesSPtr.h"
+
+namespace xoj::util {
+
+inline namespace raii {
+namespace specialization {
+
+template <class object_type>
+class GObjectHandler {
+public:
+    static object_type* ref(object_type* p) { return static_cast<object_type*>(g_object_ref(p)); }
+    constexpr static auto unref = g_object_unref;
+    static object_type* ref_sink(object_type* p) { return static_cast<object_type*>(g_object_ref_sink(p)); }
+    static object_type* adopt(object_type* p) {
+#if (GLIB_MAJOR_VERSION > 2 || (GLIB_MAJOR_VERSION == 2 && GLIB_MINOR_VERSION >= 70))
+        return static_cast<object_type*>(g_object_take_ref(p));
+#else
+        return g_object_is_floating(p) ? static_cast<object_type*>(g_object_ref_sink(p)) : p;
+#endif
+    }
+};
+};  // namespace specialization
+
+using WidgetSPtr = CLibrariesSPtr<GtkWidget, raii::specialization::GObjectHandler<GtkWidget>>;
+};  // namespace raii
+};  // namespace xoj::util

--- a/test/unit_tests/util/RAIIWrappersTest.cpp
+++ b/test/unit_tests/util/RAIIWrappersTest.cpp
@@ -1,0 +1,288 @@
+#include <gtest/gtest.h>
+
+#include "util/raii/CairoWrappers.h"
+#include "util/raii/GObjectSPtr.h"
+
+namespace {
+class TestData {
+public:
+    TestData() { nbData++; };
+    ~TestData() { nbData--; };
+
+    int value = 2;
+
+    int ref_count = 1;
+
+    static int nbData;
+};
+int TestData::nbData = 0;
+
+class TestDataHandler {
+public:
+    static TestData* ref(TestData* p) {
+        p->ref_count++;
+        return p;
+    }
+    static void unref(TestData* p) {
+        p->ref_count--;
+        if (p->ref_count == 0) {
+            delete (p);
+        }
+    }
+    constexpr static auto adopt = [](TestData* p) { return p; };
+};
+
+};  // namespace
+
+using TestRAII = xoj::util::CLibrariesSPtr<TestData, TestDataHandler>;
+
+TEST(UtilsRAII, testCLibbrairiesSPtr_Constructors) {
+    {
+        TestRAII t;  // Default constructor
+        EXPECT_EQ(t.get(), nullptr);
+        EXPECT_FALSE(t);
+        EXPECT_EQ(TestData::nbData, 0);
+
+        TestData* p = nullptr;
+        TestRAII t1(p = new TestData());  // Adoption
+        EXPECT_EQ(t1.get(), p);
+        EXPECT_EQ(TestData::nbData, 1);
+        EXPECT_EQ(p->ref_count, 1);
+
+        TestRAII t2(std::move(t1));  // move constructor
+        EXPECT_EQ(t1.get(), nullptr);
+        EXPECT_EQ(t2.get(), p);
+        EXPECT_EQ(p->ref_count, 1);
+        EXPECT_EQ(TestData::nbData, 1);
+
+        TestRAII t3(t2);  // copy constructor
+        EXPECT_EQ(t2.get(), p);
+        EXPECT_EQ(t3.get(), p);
+        EXPECT_EQ(p->ref_count, 2);
+        EXPECT_EQ(TestData::nbData, 1);
+
+        TestRAII t4(t2.get(), TestRAII::ref);  // ref
+        EXPECT_EQ(t4.get(), p);
+        EXPECT_EQ(p->ref_count, 3);
+        EXPECT_EQ(TestData::nbData, 1);
+    }
+    EXPECT_EQ(TestData::nbData, 0);
+}
+
+TEST(UtilsRAII, testCLibbrairiesSPtr_MoveAssignments) {
+    {
+        TestData* p = nullptr;
+        TestData* q = nullptr;
+        TestRAII t1(p = new TestData());
+        TestRAII t2(q = new TestData());
+        EXPECT_EQ(TestData::nbData, 2);
+        EXPECT_EQ(t1.get(), p);
+        EXPECT_EQ(t2.get(), q);
+        EXPECT_EQ(p->ref_count, 1);
+        EXPECT_EQ(q->ref_count, 1);
+        t1->value = 4;
+        t2->value = 14;
+
+        std::swap(t1, t2);
+        EXPECT_EQ(t1->value, 14);
+        EXPECT_EQ(t2->value, 4);
+        EXPECT_EQ(TestData::nbData, 2);
+        EXPECT_EQ(t1.get(), q);
+        EXPECT_EQ(t2.get(), p);
+        EXPECT_EQ(p->ref_count, 1);
+        EXPECT_EQ(q->ref_count, 1);
+
+        t1 = std::move(t2);  // move assignment - non empty to non empty - different data
+        q = nullptr;
+        EXPECT_EQ(TestData::nbData, 1);
+        EXPECT_EQ(p->ref_count, 1);
+        EXPECT_EQ(t1.get(), p);
+        EXPECT_EQ(t1->value, 4);
+        EXPECT_EQ(t2.get(), nullptr);
+        EXPECT_TRUE(t1);
+        EXPECT_FALSE(t2);
+
+        TestRAII t3(p, TestRAII::ref);
+        EXPECT_EQ(p->ref_count, 2);
+        t1 = std::move(t3);  // move assignment - non empty to non empty - same data
+        EXPECT_EQ(TestData::nbData, 1);
+        EXPECT_EQ(p->ref_count, 1);
+        EXPECT_EQ(t1.get(), p);
+        EXPECT_EQ(t1->value, 4);
+        EXPECT_EQ(t2.get(), nullptr);
+        EXPECT_TRUE(t1);
+        EXPECT_FALSE(t2);
+
+        t2 = std::move(t1);  // move assignment - non empty to empty
+        EXPECT_EQ(TestData::nbData, 1);
+        EXPECT_EQ(p->ref_count, 1);
+        EXPECT_EQ(t1.get(), nullptr);
+        EXPECT_EQ(t2->value, 4);
+        EXPECT_EQ(t2.get(), p);
+
+        t2 = std::move(t1);  // move assignment - empty to non-empty
+        p = nullptr;
+        EXPECT_EQ(TestData::nbData, 0);
+        EXPECT_EQ(t1.get(), nullptr);
+        EXPECT_EQ(t2.get(), nullptr);
+
+        t2 = std::move(t1);  // move assignment - empty to empty
+        EXPECT_EQ(TestData::nbData, 0);
+        EXPECT_EQ(t1.get(), nullptr);
+        EXPECT_EQ(t2.get(), nullptr);
+    }
+    EXPECT_EQ(TestData::nbData, 0);
+}
+
+TEST(UtilsRAII, testCLibbrairiesSPtr_CopyAssignments) {
+    {
+        TestData* p = nullptr;
+        TestData* q = nullptr;
+        TestRAII t1(p = new TestData());
+        TestRAII t2(q = new TestData());
+        EXPECT_EQ(TestData::nbData, 2);
+        EXPECT_EQ(t1.get(), p);
+        EXPECT_EQ(t2.get(), q);
+        EXPECT_EQ(p->ref_count, 1);
+        EXPECT_EQ(q->ref_count, 1);
+        t1->value = 4;
+        t2->value = 14;
+
+        t2 = t1;  // copy assignment - non empty to non empty - different data
+        q = nullptr;
+        EXPECT_EQ(TestData::nbData, 1);
+        EXPECT_EQ(p->ref_count, 2);
+        EXPECT_EQ(t1.get(), p);
+        EXPECT_EQ(t2.get(), p);
+        EXPECT_EQ(t2->value, 4);
+
+        t2 = t1;  // copy assignment - non empty to non empty - same data
+        EXPECT_EQ(TestData::nbData, 1);
+        EXPECT_EQ(p->ref_count, 2);
+        EXPECT_EQ(t1.get(), p);
+        EXPECT_EQ(t2.get(), p);
+        EXPECT_EQ(t2->value, 4);
+
+        TestRAII t3;
+        t2 = t3;  // copy assignment - empty to non-empty
+        EXPECT_EQ(TestData::nbData, 1);
+        EXPECT_EQ(p->ref_count, 1);  // t1
+        EXPECT_EQ(t2.get(), nullptr);
+        EXPECT_EQ(t3.get(), nullptr);
+
+        t3 = t1;  // copy assignment - non empty to empty
+        EXPECT_EQ(TestData::nbData, 1);
+        EXPECT_EQ(p->ref_count, 2);  // t{1,3}
+        EXPECT_EQ(t1.get(), p);
+        EXPECT_EQ(t3->value, 4);
+        EXPECT_EQ(t3.get(), p);
+
+        TestRAII t4;
+        t2 = t4;  // copy assignment - empty to empty
+        EXPECT_EQ(TestData::nbData, 1);
+        EXPECT_EQ(t2.get(), nullptr);
+        EXPECT_EQ(t4.get(), nullptr);
+    }
+    EXPECT_EQ(TestData::nbData, 0);
+}
+
+TEST(UtilsRAII, testCLibbrairiesSPtr_Reset) {
+    {
+        TestData* p = nullptr;
+        TestData* q = nullptr;
+        TestRAII t1(p = new TestData());
+        TestRAII t2;
+        EXPECT_EQ(TestData::nbData, 1);
+        EXPECT_EQ(t1.get(), p);
+        EXPECT_EQ(t2.get(), nullptr);
+        EXPECT_EQ(p->ref_count, 1);
+        t1->value = 4;
+
+        t2.reset(q = new TestData());  // Reset - non-nullptr to empty
+        EXPECT_EQ(TestData::nbData, 2);
+        EXPECT_EQ(t2.get(), q);
+        EXPECT_TRUE(t2);
+        EXPECT_EQ(q->ref_count, 1);
+
+        t2.reset(q = new TestData());  // Reset - non-nullptr to non-empty
+        EXPECT_EQ(t2.get(), q);
+        EXPECT_EQ(TestData::nbData, 2);
+
+        t1.reset();  // Reset - nullptr to non-empty
+        p = nullptr;
+        EXPECT_EQ(TestData::nbData, 1);
+        EXPECT_EQ(t1.get(), nullptr);
+
+        t1.reset();  // Reset - nullptr to empty
+        EXPECT_EQ(TestData::nbData, 1);
+        EXPECT_EQ(t1.get(), nullptr);
+    }
+    EXPECT_EQ(TestData::nbData, 0);
+}
+
+/**
+ * Test GObject smart pointer
+ */
+namespace {
+G_BEGIN_DECLS
+
+#define TEST_OBJECT_TYPE test_object_get_type()
+G_DECLARE_FINAL_TYPE(TestObject, test_object, TEST, OBJECT, GObject)
+
+TestObject* test_object_new(void);
+
+struct _TestObject {
+    GObject parent_instance;
+};
+int TestObjectCount = 0;
+
+G_DEFINE_TYPE(TestObject, test_object, G_TYPE_OBJECT)
+
+static void test_object_init(TestObject* self) { TestObjectCount++; }
+
+static void test_object_dispose(GObject* gobject) {
+    TestObjectCount--;
+    G_OBJECT_CLASS(test_object_parent_class)->dispose(gobject);
+}
+
+static void test_object_finalize(GObject* gobject) { G_OBJECT_CLASS(test_object_parent_class)->finalize(gobject); }
+
+static void test_object_class_init(TestObjectClass* klass) {
+    GObjectClass* object_class = G_OBJECT_CLASS(klass);
+
+    object_class->dispose = test_object_dispose;
+    object_class->finalize = test_object_finalize;
+}
+
+G_END_DECLS
+};  // namespace
+
+TEST(UtilsRAII, testGObjectSPtr) {
+    using TestPtr = xoj::util::CLibrariesSPtr<TestObject, xoj::util::specialization::GObjectHandler<TestObject>>;
+    EXPECT_EQ(TestObjectCount, 0);
+    {
+        TestPtr t(TEST_OBJECT(g_object_new(TEST_OBJECT_TYPE, nullptr)));
+        EXPECT_FALSE(g_object_is_floating(t.get()));
+        EXPECT_EQ(TestObjectCount, 1);
+    }
+    EXPECT_EQ(TestObjectCount, 0);
+    {
+        TestObject* t = TEST_OBJECT(g_object_new(TEST_OBJECT_TYPE, nullptr));
+        EXPECT_FALSE(g_object_is_floating(t));
+        g_object_force_floating(G_OBJECT(t));
+        EXPECT_TRUE(g_object_is_floating(t));
+        EXPECT_EQ(TestObjectCount, 1);
+        TestPtr t1(t);  // Adopt a floating ref
+        EXPECT_EQ(t1.get(), t);
+        EXPECT_FALSE(g_object_is_floating(t1.get()));
+    }
+    EXPECT_EQ(TestObjectCount, 0);
+    {
+        TestObject* t = TEST_OBJECT(g_object_new(TEST_OBJECT_TYPE, nullptr));
+        EXPECT_EQ(TestObjectCount, 1);
+        TestPtr t1(t, TestPtr::ref);
+        g_object_unref(t);
+        EXPECT_EQ(TestObjectCount, 1);
+    }
+    EXPECT_EQ(TestObjectCount, 0);
+}

--- a/test/unit_tests/util/TinySmallVectorTest.cpp
+++ b/test/unit_tests/util/TinySmallVectorTest.cpp
@@ -6,6 +6,7 @@
 #include "util/SmallVector.h"
 #include "util/TinyVector.h"
 
+namespace {
 class TestData {
 public:
     TestData() { nbData++; };
@@ -36,6 +37,7 @@ public:
     static int nbData;
 };
 int TestData::nbData = 0;
+};  // namespace
 
 TEST(UtilsVectors, testTinyVector) {
     TestData::nbData = 0;


### PR DESCRIPTION
This PR creates RAII wrappers for cairo_t and cairo_surface_t (as well as a template for further applications -- e.g. GObject...).

Those wrappers are then used in gui/PageView and to refactor jobs/RenderJob.

One major change with this PR concerns HiDPI settings: jobs/RenderJob is now able to rerender only a portion of the page (it was only the case for GDK_SCALE=1 before this PR).
This should drastically improve performances on HiDPI displays and fix #3903 and may help with other performance related issues as well.

**Note:** ~~This PR is based on #4081. Only the last 2 commits actually belong to this PR.~~

- [x] Merge #4081 and rebase