### PR TITLE
Update open-jpeg and poppler version in MacOS build script

### DIFF
--- a/mac-setup/build-poppler.sh
+++ b/mac-setup/build-poppler.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -x
 export PATH="$HOME/.new_local/bin:$PATH"
 
-curl -L https://github.com/uclouvain/openjpeg/archive/v2.4.0.tar.gz -o openjpeg.tar.gz
+curl -L https://github.com/uclouvain/openjpeg/archive/v2.5.0.tar.gz -o openjpeg.tar.gz
 tar xf openjpeg.tar.gz
 cd openjpeg-* || exit
 mkdir build
@@ -19,7 +19,7 @@ export LIBRARY_PATH="$HOME/gtk/inst/lib:$LIBRARY_PATH"
 jhbuild build freetype fontconfig
 jhbuild buildone -acf cairo
 
-curl https://poppler.freedesktop.org/poppler-22.03.0.tar.xz -o poppler.tar.xz
+curl https://poppler.freedesktop.org/poppler-22.06.0.tar.xz -o poppler.tar.xz
 tar xf poppler.tar.xz
 cd poppler-* || exit
 mkdir build

--- a/readme/MacBuild.md
+++ b/readme/MacBuild.md
@@ -91,6 +91,11 @@ Steps are from this [source](https://stackoverflow.com/questions/17980759/xcode-
 jhbuild build adwaita-icon-theme
 ````
 
+### 8. Build GtkSourceView
+````bash
+jhbuild build gtksourceview3
+````
+
 ## Build Xournal++ and package it as .app
 
 ### Automated step


### PR DESCRIPTION
The current Gtk blob for MacOS already contains the updated versions of open-jpeg and poplar.