### PR TITLE
Pipeline codesign on MacOS

### DIFF
--- a/azure-pipelines/create-installers.yml
+++ b/azure-pipelines/create-installers.yml
@@ -37,6 +37,8 @@ stages:
             workingDirectory: ./build
             condition: or(eq(variables['Build.Reason'], 'IndividualCI'), ne(variables['runForRelease'], 'False')) # Run for non-scheduled (release)
   - stage: Release
+    variables:
+    - group: code-signing-group
     jobs:
       - template: jobs/release_ubuntu.yml
         parameters:
@@ -109,16 +111,37 @@ stages:
               ./build-app.sh /Users/xournal-dev/gtk
             workingDirectory: ./mac-setup
             displayName: 'Create App'
-          - task: InstallAppleCertificate@2
+          - task: DownloadSecureFile@1
+            name: cert
             inputs:
-              certSecureFile: 'certificate.p12'
-              certPwd: '$(P12password)'
-            displayName: 'Install certificate'
-          - task: Xcode@5
+              secureFile: 'code-signing-certificate-macos.p12'
+            displayName: 'Download code signing certificate'
+          - task: DownloadSecureFile@1
+            name: cert_ca
             inputs:
-              signingOption: 'manual'
-              signingIdentity: '$(APPLE_CERTIFICATE_SIGNING_IDENTITY)'
-            displayName: 'Sign app bundle'
+              secureFile: 'code-signing-certificate-ca-macos.p12'
+            displayName: 'Download code signing certificate authority'
+          - task: DownloadSecureFile@1
+            name: apple_cert
+            inputs:
+              secureFile: 'AppleWWDRCA.cer'
+            displayName: 'Download Apple certificate'
+          - bash: |
+              set -x
+              security create-keychain -p "" build.keychain
+              security default-keychain -s build.keychain
+              security unlock-keychain -p "" build.keychain
+              security set-keychain-settings build.keychain
+              security import '$(cert.secureFilePath)' -k build.keychain -P $(P12password) -T /usr/bin/codesign
+              security import '$(cert_ca.secureFilePath)' -k build.keychain -P $(P12password) -T /usr/bin/codesign
+              security import '$(apple_cert.secureFilePath)' -k build.keychain -T /usr/bin/codesign
+              security list-keychains -s build.keychain
+              security find-identity
+              security set-key-partition-list -S apple-tool:,apple: -s -k "" build.keychain
+              codesign -s Xournal++ -f Xournal++.app
+              codesign -dv Xournal++.app
+            workingDirectory: ./mac-setup
+            displayName: 'Import certificate and sign app bundle'
           - task: PublishPipelineArtifact@0
             inputs:
               artifactName: 'macOS'

--- a/azure-pipelines/create-installers.yml
+++ b/azure-pipelines/create-installers.yml
@@ -109,6 +109,16 @@ stages:
               ./build-app.sh /Users/xournal-dev/gtk
             workingDirectory: ./mac-setup
             displayName: 'Create App'
+          - task: InstallAppleCertificate@2
+            inputs:
+              certSecureFile: 'certificate.p12'
+              certPwd: '$(P12password)'
+            displayName: 'Install certificate'
+          - task: Xcode@5
+            inputs:
+              signingOption: 'manual'
+              signingIdentity: '$(APPLE_CERTIFICATE_SIGNING_IDENTITY)'
+            displayName: 'Sign app bundle'
           - task: PublishPipelineArtifact@0
             inputs:
               artifactName: 'macOS'

--- a/azure-pipelines/create-installers.yml
+++ b/azure-pipelines/create-installers.yml
@@ -111,37 +111,7 @@ stages:
               ./build-app.sh /Users/xournal-dev/gtk
             workingDirectory: ./mac-setup
             displayName: 'Create App'
-          - task: DownloadSecureFile@1
-            name: cert
-            inputs:
-              secureFile: 'code-signing-certificate-macos.p12'
-            displayName: 'Download code signing certificate'
-          - task: DownloadSecureFile@1
-            name: cert_ca
-            inputs:
-              secureFile: 'code-signing-certificate-ca-macos.p12'
-            displayName: 'Download code signing certificate authority'
-          - task: DownloadSecureFile@1
-            name: apple_cert
-            inputs:
-              secureFile: 'AppleWWDRCA.cer'
-            displayName: 'Download Apple certificate'
-          - bash: |
-              set -x
-              security create-keychain -p "" build.keychain
-              security default-keychain -s build.keychain
-              security unlock-keychain -p "" build.keychain
-              security set-keychain-settings build.keychain
-              security import '$(cert.secureFilePath)' -k build.keychain -P $(P12password) -T /usr/bin/codesign
-              security import '$(cert_ca.secureFilePath)' -k build.keychain -P $(P12password) -T /usr/bin/codesign
-              security import '$(apple_cert.secureFilePath)' -k build.keychain -T /usr/bin/codesign
-              security list-keychains -s build.keychain
-              security find-identity
-              security set-key-partition-list -S apple-tool:,apple: -s -k "" build.keychain
-              codesign -s Xournal++ -f Xournal++.app
-              codesign -dv Xournal++.app
-            workingDirectory: ./mac-setup
-            displayName: 'Import certificate and sign app bundle'
+          - template: steps/codesigning_mac.yml
           - task: PublishPipelineArtifact@0
             inputs:
               artifactName: 'macOS'

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -45,6 +45,8 @@ stages:
             workingDirectory: ./build
             condition: or(eq(variables['Build.Reason'], 'IndividualCI'), ne(variables['runForRelease'], 'False')) # Run for non-scheduled (release)
   - stage: Release
+    variables:
+    - group: code-signing-group
     jobs:
       - template: jobs/release_ubuntu.yml
         parameters:
@@ -117,16 +119,7 @@ stages:
               ./build-app.sh /Users/xournal-dev/gtk
             workingDirectory: ./mac-setup
             displayName: 'Create App'
-          - task: InstallAppleCertificate@2
-            inputs:
-              certSecureFile: 'certificate.p12'
-              certPwd: '$(P12password)'
-            displayName: 'Install certificate'
-          - task: Xcode@5
-            inputs:
-              signingOption: 'manual'
-              signingIdentity: '$(APPLE_CERTIFICATE_SIGNING_IDENTITY)'
-            displayName: 'Sign app bundle'
+          - template: steps/codesigning_mac.yml
           - task: PublishPipelineArtifact@0
             inputs:
               artifactName: 'macOS'

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -117,6 +117,16 @@ stages:
               ./build-app.sh /Users/xournal-dev/gtk
             workingDirectory: ./mac-setup
             displayName: 'Create App'
+          - task: InstallAppleCertificate@2
+            inputs:
+              certSecureFile: 'certificate.p12'
+              certPwd: '$(P12password)'
+            displayName: 'Install certificate'
+          - task: Xcode@5
+            inputs:
+              signingOption: 'manual'
+              signingIdentity: '$(APPLE_CERTIFICATE_SIGNING_IDENTITY)'
+            displayName: 'Sign app bundle'
           - task: PublishPipelineArtifact@0
             inputs:
               artifactName: 'macOS'

--- a/azure-pipelines/steps/codesigning_mac.yml
+++ b/azure-pipelines/steps/codesigning_mac.yml
@@ -1,0 +1,30 @@
+steps:
+  - task: DownloadSecureFile@1
+    name: cert
+    inputs:
+      secureFile: 'code-signing-certificate-macos.p12'
+      displayName: 'Download code signing certificate'
+  - task: DownloadSecureFile@1
+    name: cert_ca
+    inputs:
+      secureFile: 'code-signing-certificate-ca-macos.p12'
+    displayName: 'Download code signing certificate authority'
+  - bash: |
+      set -x
+      security create-keychain -p "" build.keychain
+      security default-keychain -s build.keychain
+      security unlock-keychain -p "" build.keychain
+      security set-keychain-settings build.keychain
+      curl -L -O https://www.apple.com/certificateauthority/AppleWWDRCA.cer
+      sudo security add-trusted-cert -d -r trustRoot -k build.keychain AppleWWDRCA.cer
+      sudo security add-trusted-cert -d -r trustRoot -k System.keychain AppleWWDRCA.cer
+      security import '$(cert.secureFilePath)' -k build.keychain -P $(P12password) -T /usr/bin/codesign
+      security import '$(cert_ca.secureFilePath)' -k build.keychain -P $(P12password) -T /usr/bin/codesign
+      security list-keychains -s build.keychain
+      security find-identity -p codesigning
+      security find-identity -p sys-kerberos-kdc
+      security set-key-partition-list -S apple-tool:,apple: -s -k "" build.keychain
+      sudo codesign -s Xournal++ -f Xournal++.app
+      codesign -dv Xournal++.app
+    workingDirectory: ./mac-setup
+    displayName: 'Import certificates and sign app bundle'


### PR DESCRIPTION
Testing code signing on MacOS. Fixes  #1757. 

I have created a code signing certificate, exported it as a .p12-file and uploaded it to the secure files library on dev.azure. I also added the password for the exported file to a new variable group on dev.azure. 