### PR TITLE
Forward-declare XojPage in PageRef and protect headers

### DIFF
--- a/src/core/audio/AudioQueue.h
+++ b/src/core/audio/AudioQueue.h
@@ -17,7 +17,6 @@
 #include <deque>
 #include <limits>
 #include <mutex>
-#include <vector>
 
 template <typename T>
 class AudioQueue {

--- a/src/core/control/CrashHandlerWindows.h
+++ b/src/core/control/CrashHandlerWindows.h
@@ -8,6 +8,7 @@
  *
  * @license GNU GPLv2 or later
  */
+#pragma once
 
 void installCrashHandlers() {
     // Todo: Implement SE-Exception Handler for Windows

--- a/src/core/gui/ToolbarDefinitions.h
+++ b/src/core/gui/ToolbarDefinitions.h
@@ -8,6 +8,7 @@
  *
  * @license GNU GPLv2 or later
  */
+#pragma once
 
 typedef struct {
     /**

--- a/src/core/gui/widgets/ZoomCallib.h
+++ b/src/core/gui/widgets/ZoomCallib.h
@@ -8,9 +8,7 @@
  *
  * @license GPL
  */
-
-#ifndef __ZOOMCALLIB_H__
-#define __ZOOMCALLIB_H__
+#pragma once
 
 #include <glib-object.h>  // for G_TYPE_CHECK_INSTANCE_TYPE, G_TYPE_CHECK_IN...
 #include <glib.h>         // for gint, G_BEGIN_DECLS, G_END_DECLS
@@ -43,6 +41,3 @@ void zoomcallib_set_val(ZoomCallib* callib, gint val);
 GtkWidget* zoomcallib_new();
 
 G_END_DECLS
-
-
-#endif /* __ZOOMCALLIB_H__ */

--- a/src/core/gui/widgets/gtkmenutooltogglebutton.h
+++ b/src/core/gui/widgets/gtkmenutooltogglebutton.h
@@ -18,6 +18,7 @@
  * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
  * Boston, MA 02111-1307, USA.
  */
+#pragma once
 
 /**
  * Adapted MenuToolButton to a MenuToolTooggleButton

--- a/src/core/model/ElementContainer.h
+++ b/src/core/model/ElementContainer.h
@@ -11,6 +11,8 @@
 
 #pragma once
 
+#include <vector>
+
 class Element;
 
 class ElementContainer {

--- a/src/core/model/PageRef.h
+++ b/src/core/model/PageRef.h
@@ -8,10 +8,10 @@
  *
  * @license GNU GPLv2 or later
  */
-
 #pragma once
+
 #include <memory>
 
-#include "XojPage.h"
+class XojPage;
 
 using PageRef = std::shared_ptr<XojPage>;

--- a/src/core/plugin/PluginController.cpp
+++ b/src/core/plugin/PluginController.cpp
@@ -1,5 +1,6 @@
 #include "PluginController.h"
 
+#include <cassert>
 #include <memory>
 #include <tuple>
 #include <utility>

--- a/src/core/plugin/luapi_application.h
+++ b/src/core/plugin/luapi_application.h
@@ -36,6 +36,7 @@
 #include "model/Stroke.h"
 #include "model/StrokeStyle.h"
 #include "model/Text.h"
+#include "model/XojPage.h"
 #include "undo/InsertUndoAction.h"
 #include "util/StringUtils.h"
 #include "util/XojMsgBox.h"

--- a/src/util/include/util/CircularBuffer.h
+++ b/src/util/include/util/CircularBuffer.h
@@ -8,6 +8,10 @@
  *
  * @license GNU GPLv2 or later
  */
+#pragma once
+
+#include <vector>
+
 template <class T>
 class CircularBuffer: private std::vector<T> {
 public:

--- a/test/unit_tests/control/LoadHandlerTest.cpp
+++ b/test/unit_tests/control/LoadHandlerTest.cpp
@@ -21,6 +21,7 @@
 #include "model/Image.h"
 #include "model/Stroke.h"
 #include "model/Text.h"
+#include "model/XojPage.h"
 #include "util/PathUtil.h"
 
 #include "filesystem.h"


### PR DESCRIPTION
This PR is a followup of #4098: it cleans up a couple of includes in a couple of header files that do not have a .cpp counterpart.

As the changes are completely harmless, I'll be merging this in 24 hours unless someone objects.