### PR TITLE
Fix text edition display bug when an IM is used

### DIFF
--- a/src/gui/TextEditor.h
+++ b/src/gui/TextEditor.h
@@ -19,6 +19,8 @@
 #include "undo/UndoAction.h"
 
 class XojPageView;
+template <class T>
+class Rectangle;
 
 class TextEditor {
 public:
@@ -60,6 +62,7 @@ public:
     UndoAction* setColor(Color color);
 
 private:
+    Rectangle<double> computeBoundingRect();
     void repaintEditor();
     void drawCursor(cairo_t* cr, double x, double y, double height, double zoom);
     void repaintCursor();


### PR DESCRIPTION
Fix #4135.

The issue was the following: when computing the area to repaint, the TextEditor was relying on Text::calcSize. The problem is that the Text element does not contain the current pre-edition string of the Input Method, leading to the repainting of to small a box.

The fix is thus to properly compute the bounding box of the text.