### PR TITLE
Split geometric shape handlers into Controller-View

### DIFF
--- a/src/core/control/tools/ArrowHandler.cpp
+++ b/src/core/control/tools/ArrowHandler.cpp
@@ -4,7 +4,7 @@
 
 #include "control/Control.h"                       // for Control
 #include "control/ToolHandler.h"                   // for ToolHandler
-#include "control/tools/BaseStrokeHandler.h"       // for BaseStrokeHandler
+#include "control/tools/BaseShapeHandler.h"        // for BaseShapeHandler
 #include "control/tools/SnapToGridInputHandler.h"  // for SnapToGridInputHan...
 #include "gui/XournalView.h"                       // for XournalView
 #include "gui/inputdevices/PositionInputData.h"    // for PositionInputData
@@ -14,7 +14,7 @@
 class XojPageView;
 
 ArrowHandler::ArrowHandler(XournalView* xournal, XojPageView* redrawable, const PageRef& page, bool doubleEnded):
-        BaseStrokeHandler(xournal, redrawable, page), doubleEnded(doubleEnded) {}
+        BaseShapeHandler(xournal, redrawable, page), doubleEnded(doubleEnded) {}
 
 ArrowHandler::~ArrowHandler() = default;
 

--- a/src/core/control/tools/ArrowHandler.cpp
+++ b/src/core/control/tools/ArrowHandler.cpp
@@ -1,68 +1,59 @@
 #include "ArrowHandler.h"
 
-#include <cmath>  // for cos, sin, atan2, M_PI
+#include <algorithm>  // for minmax_element
+#include <cmath>      // for cos, sin, atan2, M_PI
 
 #include "control/Control.h"                       // for Control
 #include "control/ToolHandler.h"                   // for ToolHandler
 #include "control/tools/BaseShapeHandler.h"        // for BaseShapeHandler
 #include "control/tools/SnapToGridInputHandler.h"  // for SnapToGridInputHan...
-#include "gui/XournalView.h"                       // for XournalView
 #include "gui/inputdevices/PositionInputData.h"    // for PositionInputData
 #include "model/Point.h"                           // for Point
-#include "model/Stroke.h"                          // for Stroke
+#include "util/Range.h"                            // for Range
 
-class XojPageView;
-
-ArrowHandler::ArrowHandler(XournalView* xournal, XojPageView* redrawable, const PageRef& page, bool doubleEnded):
-        BaseShapeHandler(xournal, redrawable, page), doubleEnded(doubleEnded) {}
+ArrowHandler::ArrowHandler(Control* control, const PageRef& page, bool doubleEnded):
+        BaseShapeHandler(control, page), doubleEnded(doubleEnded) {}
 
 ArrowHandler::~ArrowHandler() = default;
 
-void ArrowHandler::drawShape(Point& c, const PositionInputData& pos) {
-    this->currPoint = c;  // in case redrawn by keypress event in base class.
+auto ArrowHandler::createShape(bool isAltDown, bool isShiftDown, bool isControlDown)
+        -> std::pair<std::vector<Point>, Range> {
+    Point c = snappingHandler.snap(this->currPoint, this->startPoint, isAltDown);
 
-    /**
-     * Snap first point to grid (if enabled)
-     */
-    bool altDown = pos.isAltDown();
+    // We've now computed the line points for the arrow
+    // so we just have to build the head
 
-    Point firstPoint = snappingHandler.snapToGrid(stroke->getPoint(0), altDown);
-    stroke->setFirstPoint(firstPoint.x, firstPoint.y);
+    // set up the size of the arrowhead to be 7x the thickness of the line
+    double arrowDist = control->getToolHandler()->getThickness() * 7.0;
 
+    // an appropriate delta is Pi/3 radians for an arrow shape
+    double delta = M_PI / 6.0;
+    double angle = atan2(c.y - this->startPoint.y, c.x - this->startPoint.x);
 
-    int count = stroke->getPointCount();
-    if (count < 1) {
-        stroke->addPoint(c);
-    } else {
-        // disable this to see such a cool "serrate brush" effect
-        if (count > 4) {
-            stroke->deletePointsFrom(1);
-        }
+    std::pair<std::vector<Point>, Range> res;
+    std::vector<Point>& shape = res.first;
 
-        c = snappingHandler.snap(c, firstPoint, altDown);
+    shape.reserve(doubleEnded ? 9 : 5);
 
-        // We've now computed the line points for the arrow
-        // so we just have to build the head
+    shape.emplace_back(this->startPoint);
 
-        // set up the size of the arrowhead to be 7x the thickness of the line
-        double arrowDist = xournal->getControl()->getToolHandler()->getThickness() * 7.0;
-
-        // an appropriate delta is Pi/3 radians for an arrow shape
-        double delta = M_PI / 6.0;
-        double angle = atan2(c.y - firstPoint.y, c.x - firstPoint.x);
-
-        if (doubleEnded) {
-            stroke->addPoint(Point(firstPoint.x + arrowDist * cos(angle + delta),
-                                   firstPoint.y + arrowDist * sin(angle + delta)));
-            stroke->addPoint(firstPoint);
-            stroke->addPoint(Point(firstPoint.x + arrowDist * cos(angle - delta),
-                                   firstPoint.y + arrowDist * sin(angle - delta)));
-            stroke->addPoint(firstPoint);
-        }
-
-        stroke->addPoint(c);
-        stroke->addPoint(Point(c.x - arrowDist * cos(angle + delta), c.y - arrowDist * sin(angle + delta)));
-        stroke->addPoint(c);
-        stroke->addPoint(Point(c.x - arrowDist * cos(angle - delta), c.y - arrowDist * sin(angle - delta)));
+    if (doubleEnded) {
+        shape.emplace_back(startPoint.x + arrowDist * cos(angle + delta),
+                           startPoint.y + arrowDist * sin(angle + delta));
+        shape.emplace_back(startPoint);
+        shape.emplace_back(startPoint.x + arrowDist * cos(angle - delta),
+                           startPoint.y + arrowDist * sin(angle - delta));
+        shape.emplace_back(startPoint);
     }
+
+    shape.emplace_back(c);
+    shape.emplace_back(c.x - arrowDist * cos(angle + delta), c.y - arrowDist * sin(angle + delta));
+    shape.emplace_back(c);
+    shape.emplace_back(c.x - arrowDist * cos(angle - delta), c.y - arrowDist * sin(angle - delta));
+
+    auto [minX, maxX] = std::minmax_element(shape.begin(), shape.end(), [](auto& p, auto& q) { return p.x < q.x; });
+    auto [minY, maxY] = std::minmax_element(shape.begin(), shape.end(), [](auto& p, auto& q) { return p.y < q.y; });
+    res.second = Range(minX->x, minY->y, maxX->x, maxY->y);
+
+    return res;
 }

--- a/src/core/control/tools/ArrowHandler.h
+++ b/src/core/control/tools/ArrowHandler.h
@@ -13,14 +13,14 @@
 
 #include "model/PageRef.h"  // for PageRef
 
-#include "BaseStrokeHandler.h"  // for BaseStrokeHandler
+#include "BaseShapeHandler.h"  // for BaseShapeHandler
 
 class Point;
 class PositionInputData;
 class XojPageView;
 class XournalView;
 
-class ArrowHandler: public BaseStrokeHandler {
+class ArrowHandler: public BaseShapeHandler {
 public:
     ArrowHandler(XournalView* xournal, XojPageView* redrawable, const PageRef& page, bool doubleEnded);
     ~ArrowHandler() override;

--- a/src/core/control/tools/ArrowHandler.h
+++ b/src/core/control/tools/ArrowHandler.h
@@ -11,23 +11,22 @@
 
 #pragma once
 
+#include <vector>  // for vector
+
 #include "model/PageRef.h"  // for PageRef
 
 #include "BaseShapeHandler.h"  // for BaseShapeHandler
 
 class Point;
-class PositionInputData;
-class XojPageView;
-class XournalView;
+class Control;
 
 class ArrowHandler: public BaseShapeHandler {
 public:
-    ArrowHandler(XournalView* xournal, XojPageView* redrawable, const PageRef& page, bool doubleEnded);
+    ArrowHandler(Control* control, const PageRef& page, bool doubleEnded);
     ~ArrowHandler() override;
 
 private:
-    void drawShape(Point& currentPoint, const PositionInputData& pos) override;
+    auto createShape(bool isAltDown, bool isShiftDown, bool isControlDown)
+            -> std::pair<std::vector<Point>, Range> override;
     bool doubleEnded = false;
-
-private:
 };

--- a/src/core/control/tools/BaseShapeHandler.cpp
+++ b/src/core/control/tools/BaseShapeHandler.cpp
@@ -1,4 +1,4 @@
-#include "BaseStrokeHandler.h"
+#include "BaseShapeHandler.h"
 
 #include <cmath>     // for pow, NAN
 #include <memory>    // for make_unique, __share...
@@ -25,19 +25,19 @@
 
 using xoj::util::Rectangle;
 
-guint32 BaseStrokeHandler::lastStrokeTime;  // persist for next stroke
+guint32 BaseShapeHandler::lastStrokeTime;  // persist for next stroke
 
 
-BaseStrokeHandler::BaseStrokeHandler(XournalView* xournal, XojPageView* redrawable, const PageRef& page, bool flipShift,
-                                     bool flipControl):
+BaseShapeHandler::BaseShapeHandler(XournalView* xournal, XojPageView* redrawable, const PageRef& page, bool flipShift,
+                                   bool flipControl):
         InputHandler(xournal, redrawable, page),
         flipShift(flipShift),
         flipControl(flipControl),
         snappingHandler(xournal->getControl()->getSettings()) {}
 
-BaseStrokeHandler::~BaseStrokeHandler() = default;
+BaseShapeHandler::~BaseShapeHandler() = default;
 
-void BaseStrokeHandler::draw(cairo_t* cr) {
+void BaseShapeHandler::draw(cairo_t* cr) {
     if (!stroke) {
         return;
     }
@@ -46,7 +46,7 @@ void BaseStrokeHandler::draw(cairo_t* cr) {
     strokeView->draw(context);
 }
 
-auto BaseStrokeHandler::onKeyEvent(GdkEventKey* event) -> bool {
+auto BaseShapeHandler::onKeyEvent(GdkEventKey* event) -> bool {
     if (event->is_modifier) {
         Rectangle<double> rect = stroke->boundingRect();
 
@@ -82,7 +82,7 @@ auto BaseStrokeHandler::onKeyEvent(GdkEventKey* event) -> bool {
     return false;
 }
 
-auto BaseStrokeHandler::onMotionNotifyEvent(const PositionInputData& pos) -> bool {
+auto BaseShapeHandler::onMotionNotifyEvent(const PositionInputData& pos) -> bool {
     if (!stroke) {
         return false;
     }
@@ -114,12 +114,12 @@ auto BaseStrokeHandler::onMotionNotifyEvent(const PositionInputData& pos) -> boo
     return true;
 }
 
-void BaseStrokeHandler::onMotionCancelEvent() {
+void BaseShapeHandler::onMotionCancelEvent() {
     delete stroke;
     stroke = nullptr;
 }
 
-void BaseStrokeHandler::onButtonReleaseEvent(const PositionInputData& pos) {
+void BaseShapeHandler::onButtonReleaseEvent(const PositionInputData& pos) {
     xournal->getCursor()->activateDrawDirCursor(false);  // in case released within  fixate_Dir_Mods_Dist
 
     if (stroke == nullptr) {
@@ -146,20 +146,20 @@ void BaseStrokeHandler::onButtonReleaseEvent(const PositionInputData& pos) {
 
         if (lengthSqrd < pow((strokeFilterIgnoreLength * dpmm), 2) &&
             pos.timestamp - this->startStrokeTime < strokeFilterIgnoreTime) {
-            if (pos.timestamp - BaseStrokeHandler::lastStrokeTime > strokeFilterSuccessiveTime) {
+            if (pos.timestamp - BaseShapeHandler::lastStrokeTime > strokeFilterSuccessiveTime) {
                 // stroke not being added to layer... delete here.
                 delete stroke;
                 stroke = nullptr;
                 this->userTapped = true;
 
-                BaseStrokeHandler::lastStrokeTime = pos.timestamp;
+                BaseShapeHandler::lastStrokeTime = pos.timestamp;
 
                 xournal->getCursor()->updateCursor();
 
                 return;
             }
         }
-        BaseStrokeHandler::lastStrokeTime = pos.timestamp;
+        BaseShapeHandler::lastStrokeTime = pos.timestamp;
     }
 
 
@@ -190,7 +190,7 @@ void BaseStrokeHandler::onButtonReleaseEvent(const PositionInputData& pos) {
     xournal->getCursor()->updateCursor();
 }
 
-void BaseStrokeHandler::onButtonPressEvent(const PositionInputData& pos) {
+void BaseShapeHandler::onButtonPressEvent(const PositionInputData& pos) {
     double zoom = xournal->getZoom();
     this->buttonDownPoint.x = pos.x / zoom;
     this->buttonDownPoint.y = pos.y / zoom;
@@ -203,11 +203,11 @@ void BaseStrokeHandler::onButtonPressEvent(const PositionInputData& pos) {
     this->startStrokeTime = pos.timestamp;
 }
 
-void BaseStrokeHandler::onButtonDoublePressEvent(const PositionInputData& pos) {
+void BaseShapeHandler::onButtonDoublePressEvent(const PositionInputData& pos) {
     // nothing to do
 }
 
-void BaseStrokeHandler::modifyModifiersByDrawDir(double width, double height, bool changeCursor) {
+void BaseShapeHandler::modifyModifiersByDrawDir(double width, double height, bool changeCursor) {
     bool gestureShift = this->flipShift;
     bool gestureControl = this->flipControl;
 

--- a/src/core/control/tools/BaseShapeHandler.h
+++ b/src/core/control/tools/BaseShapeHandler.h
@@ -28,12 +28,12 @@ class XournalView;
 enum DIRSET_MODIFIERS { NONE = 0, SET = 1, SHIFT = 1 << 1, CONTROL = 1 << 2 };
 
 
-class BaseStrokeHandler: public InputHandler {
+class BaseShapeHandler: public InputHandler {
 public:
-    BaseStrokeHandler(XournalView* xournal, XojPageView* redrawable, const PageRef& page, bool flipShift = false,
-                      bool flipControl = false);
+    BaseShapeHandler(XournalView* xournal, XojPageView* redrawable, const PageRef& page, bool flipShift = false,
+                     bool flipControl = false);
 
-    ~BaseStrokeHandler() override;
+    ~BaseShapeHandler() override;
 
     void draw(cairo_t* cr) override;
 

--- a/src/core/control/tools/BaseShapeHandler.h
+++ b/src/core/control/tools/BaseShapeHandler.h
@@ -94,8 +94,9 @@ protected:
 
     /**
      * @brief Bounding box of the stroke after its last update
+     *      WARNING: The stroke width is not taken into account (i.e. this is the snapping box)
      */
-    Range lastDrawingRange;
+    Range lastSnappingRange;
 
     DIRSET_MODIFIERS drawModifierFixed = NONE;
     bool flipShift =

--- a/src/core/control/tools/BaseShapeHandler.h
+++ b/src/core/control/tools/BaseShapeHandler.h
@@ -11,8 +11,7 @@
 
 #pragma once
 
-#include <memory>   // for shared_ptr
-#include <mutex>    // for mutex
+#include <memory>  // for shared_ptr
 #include <utility>  // for pair
 #include <vector>   // for vector
 
@@ -60,9 +59,9 @@ public:
     const std::shared_ptr<xoj::util::DispatchPool<xoj::view::ShapeToolView>>& getViewPool() const;
 
     /**
-     * @brief (Thread-safe) Get a clone of the shape's points.
+     * @brief Get the shape's points.
      */
-    std::vector<Point> getShapeClone() const;
+    const std::vector<Point>& getShape() const;
 
 private:
     /**
@@ -73,13 +72,13 @@ private:
     virtual std::pair<std::vector<Point>, Range> createShape(bool isAltDown, bool isShiftDown, bool isControlDown) = 0;
 
     /**
-     * @brief (Thread-safe) Update the current shape with the latest event info.
+     * @brief Update the current shape with the latest event info.
      *      Also warns the listeners about the change, usually triggering a redraw during the next screen update.
      */
     void updateShape(bool isAltDown, bool isShiftDown, bool isControlDown);
 
     /**
-     * @brief (Thread-safe) Cancel the current shape creation: clears all data and wipes any drawing made
+     * @brief Cancel the current shape creation: clears all data and wipes any drawing made
      */
     void cancelStroke();
 
@@ -92,7 +91,6 @@ protected:
 
 protected:
     std::vector<Point> shape;
-    mutable std::mutex shapeMutex;
 
     /**
      * @brief Bounding box of the stroke after its last update

--- a/src/core/control/tools/CoordinateSystemHandler.cpp
+++ b/src/core/control/tools/CoordinateSystemHandler.cpp
@@ -4,7 +4,7 @@
 
 #include "control/Control.h"                       // for Control
 #include "control/settings/Settings.h"             // for Settings
-#include "control/tools/BaseStrokeHandler.h"       // for BaseStrokeHandler
+#include "control/tools/BaseShapeHandler.h"        // for BaseShapeHandler
 #include "control/tools/SnapToGridInputHandler.h"  // for SnapToGridInputHan...
 #include "gui/XournalView.h"                       // for XournalView
 #include "gui/inputdevices/PositionInputData.h"    // for PositionInputData
@@ -14,7 +14,7 @@ class XojPageView;
 
 CoordinateSystemHandler::CoordinateSystemHandler(XournalView* xournal, XojPageView* redrawable, const PageRef& page,
                                                  bool flipShift, bool flipControl):
-        BaseStrokeHandler(xournal, redrawable, page, flipShift, flipControl) {}
+        BaseShapeHandler(xournal, redrawable, page, flipShift, flipControl) {}
 
 CoordinateSystemHandler::~CoordinateSystemHandler() = default;
 

--- a/src/core/control/tools/CoordinateSystemHandler.cpp
+++ b/src/core/control/tools/CoordinateSystemHandler.cpp
@@ -8,13 +8,11 @@
 #include "control/tools/SnapToGridInputHandler.h"  // for SnapToGridInputHan...
 #include "gui/XournalView.h"                       // for XournalView
 #include "gui/inputdevices/PositionInputData.h"    // for PositionInputData
-#include "model/Stroke.h"                          // for Stroke
+#include "model/Point.h"                           // for Point
 
-class XojPageView;
-
-CoordinateSystemHandler::CoordinateSystemHandler(XournalView* xournal, XojPageView* redrawable, const PageRef& page,
-                                                 bool flipShift, bool flipControl):
-        BaseShapeHandler(xournal, redrawable, page, flipShift, flipControl) {}
+CoordinateSystemHandler::CoordinateSystemHandler(Control* control, const PageRef& page, bool flipShift,
+                                                 bool flipControl):
+        BaseShapeHandler(control, page, flipShift, flipControl) {}
 
 CoordinateSystemHandler::~CoordinateSystemHandler() = default;
 
@@ -25,54 +23,43 @@ CoordinateSystemHandler::~CoordinateSystemHandler() = default;
  * @param shiftDown Boolean to indicate if "shift" is currently pressed.
  *                  It is currently not used.
  */
-void CoordinateSystemHandler::drawShape(Point& c, const PositionInputData& pos) {
+auto CoordinateSystemHandler::createShape(bool isAltDown, bool isShiftDown, bool isControlDown)
+        -> std::pair<std::vector<Point>, Range> {
     /**
      * Snap point to grid (if enabled)
      */
-    c = snappingHandler.snapToGrid(c, pos.isAltDown());
+    Point c = snappingHandler.snapToGrid(this->currPoint, isAltDown);
 
-    if (!this->started)  // initialize first point
-    {
-        this->startPoint = c;
-        this->started = true;
-        stroke->addPoint(c);  // avoid complaints about <2 points.
+    double width = c.x - this->startPoint.x;
+    double height = c.y - this->startPoint.y;
+
+    this->modShift = isShiftDown;
+    this->modControl = isControlDown;
+
+    Settings* settings = control->getSettings();
+    if (settings->getDrawDirModsEnabled()) {
+        // change modifiers based on draw dir
+        this->modifyModifiersByDrawDir(width, height, true);
+    }
+
+    if (this->modShift) {
+        // make square
+        int signW = width > 0 ? 1 : -1;
+        int signH = height > 0 ? 1 : -1;
+        width = std::max(width * signW, height * signH) * signW;
+        height = (width * signW) * signH;
+    }
+
+    const Point& p1 = this->startPoint;
+
+    Range rg(p1.x, p1.y);
+    rg.addPoint(p1.x + width, p1.y + height);
+
+    if (!this->modControl) {
+        // draw out from starting point
+        return {{p1, Point(p1.x, p1.y + height), Point(p1.x + width, p1.y + height)}, rg};
     } else {
-        double width = c.x - this->startPoint.x;
-        double height = c.y - this->startPoint.y;
-
-        this->currPoint = c;
-
-        this->modShift = pos.isShiftDown();
-        this->modControl = pos.isControlDown();
-
-        Settings* settings = xournal->getControl()->getSettings();
-        if (settings->getDrawDirModsEnabled())  // change modifiers based on draw dir
-        {
-            this->modifyModifiersByDrawDir(width, height, true);
-        }
-
-        if (this->modShift)  // make square
-        {
-            int signW = width > 0 ? 1 : -1;
-            int signH = height > 0 ? 1 : -1;
-            width = std::max(width * signW, height * signH) * signW;
-            height = (width * signW) * signH;
-        }
-
-        Point p1 = this->startPoint;
-
-        stroke->deletePointsFrom(0);  // delete previous points
-
-        if (!this->modControl)  // draw out from starting point
-        {
-            stroke->addPoint(p1);
-            stroke->addPoint(Point(p1.x, p1.y + height));
-            stroke->addPoint(Point(p1.x + width, p1.y + height));
-        } else  // Control is down
-        {
-            stroke->addPoint(Point(p1.x, p1.y + height));
-            stroke->addPoint(p1);
-            stroke->addPoint(Point(p1.x + width, p1.y));
-        }
+        // Control is down
+        return {{Point(p1.x, p1.y + height), p1, Point(p1.x + width, p1.y)}, rg};
     }
 }

--- a/src/core/control/tools/CoordinateSystemHandler.h
+++ b/src/core/control/tools/CoordinateSystemHandler.h
@@ -14,13 +14,13 @@
 #include "model/PageRef.h"  // for PageRef
 #include "model/Point.h"    // for Point
 
-#include "BaseStrokeHandler.h"  // for BaseStrokeHandler
+#include "BaseShapeHandler.h"  // for BaseShapeHandler
 
 class PositionInputData;
 class XojPageView;
 class XournalView;
 
-class CoordinateSystemHandler: public BaseStrokeHandler {
+class CoordinateSystemHandler: public BaseShapeHandler {
 public:
     CoordinateSystemHandler(XournalView* xournal, XojPageView* redrawable, const PageRef& page, bool flipShift = false,
                             bool flipControl = false);

--- a/src/core/control/tools/CoordinateSystemHandler.h
+++ b/src/core/control/tools/CoordinateSystemHandler.h
@@ -11,25 +11,20 @@
 
 #pragma once
 
+#include <vector>  // for vector
+
 #include "model/PageRef.h"  // for PageRef
-#include "model/Point.h"    // for Point
 
 #include "BaseShapeHandler.h"  // for BaseShapeHandler
 
-class PositionInputData;
-class XojPageView;
 class XournalView;
 
 class CoordinateSystemHandler: public BaseShapeHandler {
 public:
-    CoordinateSystemHandler(XournalView* xournal, XojPageView* redrawable, const PageRef& page, bool flipShift = false,
-                            bool flipControl = false);
+    CoordinateSystemHandler(Control* control, const PageRef& page, bool flipShift = false, bool flipControl = false);
     ~CoordinateSystemHandler() override;
 
 private:
-    void drawShape(Point& currentPoint, const PositionInputData& pos) override;
-
-private:
-    Point startPoint;
-    bool started = false;
+    auto createShape(bool isAltDown, bool isShiftDown, bool isControlDown)
+            -> std::pair<std::vector<Point>, Range> override;
 };

--- a/src/core/control/tools/EllipseHandler.cpp
+++ b/src/core/control/tools/EllipseHandler.cpp
@@ -5,7 +5,7 @@
 
 #include "control/Control.h"                       // for Control
 #include "control/settings/Settings.h"             // for Settings
-#include "control/tools/BaseStrokeHandler.h"       // for BaseStrokeHandler
+#include "control/tools/BaseShapeHandler.h"        // for BaseShapeHandler
 #include "control/tools/SnapToGridInputHandler.h"  // for SnapToGridInputHan...
 #include "gui/XournalView.h"                       // for XournalView
 #include "gui/inputdevices/PositionInputData.h"    // for PositionInputData
@@ -16,7 +16,7 @@ class XojPageView;
 
 EllipseHandler::EllipseHandler(XournalView* xournal, XojPageView* redrawable, const PageRef& page, bool flipShift,
                                bool flipControl):
-        BaseStrokeHandler(xournal, redrawable, page, flipShift, flipControl) {}
+        BaseShapeHandler(xournal, redrawable, page, flipShift, flipControl) {}
 
 EllipseHandler::~EllipseHandler() = default;
 

--- a/src/core/control/tools/EllipseHandler.h
+++ b/src/core/control/tools/EllipseHandler.h
@@ -14,13 +14,13 @@
 #include "model/PageRef.h"  // for PageRef
 #include "model/Point.h"    // for Point
 
-#include "BaseStrokeHandler.h"  // for BaseStrokeHandler
+#include "BaseShapeHandler.h"  // for BaseShapeHandler
 
 class PositionInputData;
 class XojPageView;
 class XournalView;
 
-class EllipseHandler: public BaseStrokeHandler {
+class EllipseHandler: public BaseShapeHandler {
 public:
     EllipseHandler(XournalView* xournal, XojPageView* redrawable, const PageRef& page, bool flipShift = false,
                    bool flipControl = false);

--- a/src/core/control/tools/EllipseHandler.h
+++ b/src/core/control/tools/EllipseHandler.h
@@ -11,25 +11,21 @@
 
 #pragma once
 
+#include <vector>  // for vector
+
 #include "model/PageRef.h"  // for PageRef
-#include "model/Point.h"    // for Point
 
 #include "BaseShapeHandler.h"  // for BaseShapeHandler
 
-class PositionInputData;
-class XojPageView;
-class XournalView;
+class Point;
+class Control;
 
 class EllipseHandler: public BaseShapeHandler {
 public:
-    EllipseHandler(XournalView* xournal, XojPageView* redrawable, const PageRef& page, bool flipShift = false,
-                   bool flipControl = false);
+    EllipseHandler(Control* control, const PageRef& page, bool flipShift = false, bool flipControl = false);
     ~EllipseHandler() override;
 
 private:
-    void drawShape(Point& currentPoint, const PositionInputData& pos) override;
-
-private:
-    Point startPoint;
-    bool started = false;
+    auto createShape(bool isAltDown, bool isShiftDown, bool isControlDown)
+            -> std::pair<std::vector<Point>, Range> override;
 };

--- a/src/core/control/tools/EraseHandler.cpp
+++ b/src/core/control/tools/EraseHandler.cpp
@@ -9,7 +9,7 @@
 
 #include "control/ToolEnums.h"            // for ERASER_TYPE_DELETE_STROKE
 #include "control/ToolHandler.h"          // for ToolHandler
-#include "gui/Redrawable.h"               // for Redrawable
+#include "gui/LegacyRedrawable.h"         // for Redrawable
 #include "model/Document.h"               // for Document
 #include "model/Element.h"                // for Element, ELEMENT_STROKE
 #include "model/Layer.h"                  // for Layer
@@ -24,7 +24,7 @@
 #include "util/SmallVector.h"             // for SmallVector
 
 EraseHandler::EraseHandler(UndoRedoHandler* undo, Document* doc, const PageRef& page, ToolHandler* handler,
-                           Redrawable* view):
+                           LegacyRedrawable* view):
         page(page),
         handler(handler),
         view(view),

--- a/src/core/control/tools/EraseHandler.h
+++ b/src/core/control/tools/EraseHandler.h
@@ -18,14 +18,15 @@ class Document;
 class EraseUndoAction;
 class Layer;
 class Range;
-class Redrawable;
+class LegacyRedrawable;
 class Stroke;
 class ToolHandler;
 class UndoRedoHandler;
 
 class EraseHandler {
 public:
-    EraseHandler(UndoRedoHandler* undo, Document* doc, const PageRef& page, ToolHandler* handler, Redrawable* view);
+    EraseHandler(UndoRedoHandler* undo, Document* doc, const PageRef& page, ToolHandler* handler,
+                 LegacyRedrawable* view);
     virtual ~EraseHandler();
 
 public:
@@ -38,7 +39,7 @@ private:
 private:
     PageRef page;
     ToolHandler* handler;
-    Redrawable* view;
+    LegacyRedrawable* view;
     Document* doc;
     UndoRedoHandler* undo;
 

--- a/src/core/control/tools/InputHandler.cpp
+++ b/src/core/control/tools/InputHandler.cpp
@@ -9,54 +9,47 @@
 #include "control/Control.h"          // for Control
 #include "control/ToolEnums.h"        // for TOOL_ERASER, TOOL_HIGHLIGHTER
 #include "control/ToolHandler.h"      // for ToolHandler
-#include "gui/XournalView.h"          // for XournalView
 #include "model/Point.h"              // for Point, Point::NO_PRESSURE
 #include "model/Stroke.h"             // for Stroke, STROKE_TOOL_ERASER, STR...
 #include "util/Color.h"               // for Color
 
 #include "filesystem.h"  // for path
 
-InputHandler::InputHandler(XournalView* xournal, XojPageView* redrawable, const PageRef& page):
-        xournal(xournal), redrawable(redrawable), page(page), stroke(nullptr) {}
+InputHandler::InputHandler(Control* control, const PageRef& page): control(control), page(page) {}
 
 InputHandler::~InputHandler() = default;
 
-/**
- * @return Current editing stroke
- */
-auto InputHandler::getStroke() -> Stroke* { return stroke; }
+auto InputHandler::getStroke() const -> Stroke* { return stroke.get(); }
 
-void InputHandler::createStroke(Point p) {
-    ToolHandler* h = xournal->getControl()->getToolHandler();
+auto InputHandler::createStroke(Control* control) -> std::unique_ptr<Stroke> {
+    ToolHandler* h = control->getToolHandler();
 
-    stroke = new Stroke();
-    stroke->setWidth(h->getThickness());
-    stroke->setColor(h->getColor());
-    stroke->setFill(h->getFill());
-    stroke->setLineStyle(h->getLineStyle());
+    auto s = std::make_unique<Stroke>();
+    s->setWidth(h->getThickness());
+    s->setColor(h->getColor());
+    s->setFill(h->getFill());
+    s->setLineStyle(h->getLineStyle());
 
     if (h->getToolType() == TOOL_PEN) {
-        stroke->setToolType(STROKE_TOOL_PEN);
+        s->setToolType(STROKE_TOOL_PEN);
 
-        if (xournal->getControl()->getAudioController()->isRecording()) {
-            fs::path audioFilename = xournal->getControl()->getAudioController()->getAudioFilename();
-            size_t sttime = xournal->getControl()->getAudioController()->getStartTime();
+        if (control->getAudioController()->isRecording()) {
+            fs::path audioFilename = control->getAudioController()->getAudioFilename();
+            size_t sttime = control->getAudioController()->getStartTime();
             size_t milliseconds = ((g_get_monotonic_time() / 1000) - sttime);
-            stroke->setTimestamp(milliseconds);
-            stroke->setAudioFilename(audioFilename);
+            s->setTimestamp(milliseconds);
+            s->setAudioFilename(audioFilename);
         }
     } else if (h->getToolType() == TOOL_HIGHLIGHTER) {
-        stroke->setToolType(STROKE_TOOL_HIGHLIGHTER);
-        p.z = Point::NO_PRESSURE;
+        s->setToolType(STROKE_TOOL_HIGHLIGHTER);
     } else if (h->getToolType() == TOOL_ERASER) {
-        stroke->setToolType(STROKE_TOOL_ERASER);
-        stroke->setColor(Color(0xffffffU));
-        p.z = Point::NO_PRESSURE;
+        s->setToolType(STROKE_TOOL_ERASER);
+        s->setColor(Color(0xffffffU));
     }
 
-    stroke->addPoint(p);
+    return s;
 }
 
 auto InputHandler::validMotion(Point p, Point q) -> bool {
-    return hypot(p.x - q.x, p.y - q.y) >= PIXEL_MOTION_THRESHOLD;
+    return std::hypot(p.x - q.x, p.y - q.y) >= PIXEL_MOTION_THRESHOLD;
 }

--- a/src/core/control/tools/InputHandler.h
+++ b/src/core/control/tools/InputHandler.h
@@ -12,7 +12,6 @@
 #pragma once
 
 #include <memory>  // for unique_ptr
-#include <mutex>   // for mutex
 
 #include <cairo.h>    // for cairo_t
 #include <gdk/gdk.h>  // for GdkEventKey

--- a/src/core/control/tools/InputHandler.h
+++ b/src/core/control/tools/InputHandler.h
@@ -11,18 +11,18 @@
 
 #pragma once
 
-#include <optional>  // for optional
+#include <memory>  // for unique_ptr
+#include <mutex>   // for mutex
 
 #include <cairo.h>    // for cairo_t
 #include <gdk/gdk.h>  // for GdkEventKey
 
-#include "model/PageRef.h"    // for PageRef
-#include "view/StrokeView.h"  // for StrokeView
+#include "model/OverlayBase.h"
+#include "model/PageRef.h"  // for PageRef
 
+class Control;
 class Point;
 class Stroke;
-class XournalView;
-class XojPageView;
 class PositionInputData;
 
 /**
@@ -32,9 +32,9 @@ class PositionInputData;
  * and updates the XojPageView to display strokes being
  * drawn
  */
-class InputHandler {
+class InputHandler: public OverlayBase {
 public:
-    InputHandler(XournalView* xournal, XojPageView* redrawable, const PageRef& page);
+    InputHandler(Control* control, const PageRef& page);
     virtual ~InputHandler();
 
 public:
@@ -55,7 +55,7 @@ public:
      * structures and queue repaints of the XojPageView
      * if necessary
      */
-    virtual bool onMotionNotifyEvent(const PositionInputData& pos) = 0;
+    virtual bool onMotionNotifyEvent(const PositionInputData& pos, double zoom) = 0;
 
     /**
      * This method is called from the XojPageView when a keypress is detected.
@@ -69,31 +69,28 @@ public:
      * This method is called from the XojPageView as soon
      * as the pointer is released.
      */
-    virtual void onButtonReleaseEvent(const PositionInputData& pos) = 0;
+    virtual void onButtonReleaseEvent(const PositionInputData& pos, double zoom) = 0;
 
     /**
      * This method is called from the XojPageView as soon
      * as the pointer is pressed.
      */
-    virtual void onButtonPressEvent(const PositionInputData& pos) = 0;
+    virtual void onButtonPressEvent(const PositionInputData& pos, double zoom) = 0;
 
     /**
      * This method is called from the XojPageView as soon
      * as the pointer is pressed a second time.
      */
-    virtual void onButtonDoublePressEvent(const PositionInputData& pos) = 0;
+    virtual void onButtonDoublePressEvent(const PositionInputData& pos, double zoom) = 0;
 
     /**
      * This method is called when an action taken by the pointer is canceled.
      * It is used, for instance, to cancel a stroke drawn when a user starts
      * to zoom on a touchscreen device.
      */
-    virtual void onMotionCancelEvent() = 0;
+    virtual void onSequenceCancelEvent() = 0;
 
-    /**
-     * @return Current editing stroke
-     */
-    Stroke* getStroke();
+    Stroke* getStroke() const;
 
     /**
      * userTapped - experimental feature to take action on filtered draw. See cbDoActionOnStrokeFilter
@@ -101,16 +98,19 @@ public:
     bool userTapped = false;
 
 protected:
+    [[nodiscard]] static std::unique_ptr<Stroke> createStroke(Control* control);
+
     static bool validMotion(Point p, Point q);
 
-    void createStroke(Point p);
-
+    /**
+     * Smaller movements will be ignored.
+     * Expressed in page coordinates
+     */
     static constexpr double PIXEL_MOTION_THRESHOLD = 0.3;
 
 protected:
-    XournalView* xournal;
-    XojPageView* redrawable;
+    Control* control;
     PageRef page;
-    Stroke* stroke;
-    std::optional<xoj::view::StrokeView> strokeView;
+
+    std::unique_ptr<Stroke> stroke;
 };

--- a/src/core/control/tools/RectangleHandler.cpp
+++ b/src/core/control/tools/RectangleHandler.cpp
@@ -4,7 +4,7 @@
 
 #include "control/Control.h"                       // for Control
 #include "control/settings/Settings.h"             // for Settings
-#include "control/tools/BaseStrokeHandler.h"       // for BaseStrokeHandler
+#include "control/tools/BaseShapeHandler.h"        // for BaseShapeHandler
 #include "control/tools/SnapToGridInputHandler.h"  // for SnapToGridInputHan...
 #include "gui/XournalView.h"                       // for XournalView
 #include "gui/inputdevices/PositionInputData.h"    // for PositionInputData
@@ -14,7 +14,7 @@ class XojPageView;
 
 RectangleHandler::RectangleHandler(XournalView* xournal, XojPageView* redrawable, const PageRef& page, bool flipShift,
                                    bool flipControl):
-        BaseStrokeHandler(xournal, redrawable, page, flipShift, flipControl) {}
+        BaseShapeHandler(xournal, redrawable, page, flipShift, flipControl) {}
 
 RectangleHandler::~RectangleHandler() = default;
 

--- a/src/core/control/tools/RectangleHandler.cpp
+++ b/src/core/control/tools/RectangleHandler.cpp
@@ -6,70 +6,54 @@
 #include "control/settings/Settings.h"             // for Settings
 #include "control/tools/BaseShapeHandler.h"        // for BaseShapeHandler
 #include "control/tools/SnapToGridInputHandler.h"  // for SnapToGridInputHan...
-#include "gui/XournalView.h"                       // for XournalView
-#include "gui/inputdevices/PositionInputData.h"    // for PositionInputData
-#include "model/Stroke.h"                          // for Stroke
+#include "model/Point.h"                           // for Point
 
-class XojPageView;
 
-RectangleHandler::RectangleHandler(XournalView* xournal, XojPageView* redrawable, const PageRef& page, bool flipShift,
-                                   bool flipControl):
-        BaseShapeHandler(xournal, redrawable, page, flipShift, flipControl) {}
+RectangleHandler::RectangleHandler(Control* control, const PageRef& page, bool flipShift, bool flipControl):
+        BaseShapeHandler(control, page, flipShift, flipControl) {}
 
 RectangleHandler::~RectangleHandler() = default;
 
-void RectangleHandler::drawShape(Point& c, const PositionInputData& pos) {
-    this->currPoint = c;
-
+auto RectangleHandler::createShape(bool isAltDown, bool isShiftDown, bool isControlDown)
+        -> std::pair<std::vector<Point>, Range> {
     /**
      * Snap point to grid (if enabled)
      */
-    c = snappingHandler.snapToGrid(c, pos.isAltDown());
+    Point c = snappingHandler.snapToGrid(this->currPoint, isAltDown);
 
-    if (!this->started)  // initialize first point
-    {
-        this->startPoint = c;
-        this->started = true;
-        stroke->addPoint(c);  // avoid complaints about <2 points.
-    } else {
-        double width = c.x - this->startPoint.x;
-        double height = c.y - this->startPoint.y;
+    double width = c.x - this->startPoint.x;
+    double height = c.y - this->startPoint.y;
 
 
-        this->modShift = pos.isShiftDown();
-        this->modControl = pos.isControlDown();
+    this->modShift = isShiftDown;
+    this->modControl = isControlDown;
 
-        Settings* settings = xournal->getControl()->getSettings();
-        if (settings->getDrawDirModsEnabled())  // change modifiers based on draw dir
-        {
-            this->modifyModifiersByDrawDir(width, height, true);
-        }
-
-        if (this->modShift)  // make square
-        {
-            int signW = width > 0 ? 1 : -1;
-            int signH = height > 0 ? 1 : -1;
-            width = std::max(width * signW, height * signH) * signW;
-            height = (width * signW) * signH;
-        }
-
-        Point p1;
-        if (!this->modControl) {
-            p1 = this->startPoint;
-
-        } else  // Control is down - drawing from center
-        {
-            p1 = Point(this->startPoint.x - width, this->startPoint.y - height);
-        }
-
-        Point p2 = Point(this->startPoint.x + width, this->startPoint.y + height);
-
-        stroke->deletePointsFrom(0);  // delete previous points
-
-        stroke->addPoint(p1);
-        stroke->addPoint(Point(p1.x, p2.y));
-        stroke->addPoint(p2);
-        stroke->addPoint(Point(p2.x, p1.y));
-        stroke->addPoint(p1);
+    Settings* settings = control->getSettings();
+    if (settings->getDrawDirModsEnabled()) {
+        // change modifiers based on draw dir
+        this->modifyModifiersByDrawDir(width, height, true);
     }
+
+    if (this->modShift) {
+        // make square
+        int signW = width > 0 ? 1 : -1;
+        int signH = height > 0 ? 1 : -1;
+        width = std::max(width * signW, height * signH) * signW;
+        height = (width * signW) * signH;
+    }
+
+    Point p1;
+    if (!this->modControl) {
+        p1 = this->startPoint;
+    } else {
+        // Control is down - drawing from center
+        p1 = Point(this->startPoint.x - width, this->startPoint.y - height);
+    }
+
+    Point p2 = Point(this->startPoint.x + width, this->startPoint.y + height);
+
+    Range rg(p1.x, p1.y);
+    rg.addPoint(p2.x, p2.y);
+
+    return {{p1, {p1.x, p2.y}, p2, {p2.x, p1.y}, p1}, rg};
 }

--- a/src/core/control/tools/RectangleHandler.h
+++ b/src/core/control/tools/RectangleHandler.h
@@ -14,13 +14,13 @@
 #include "model/PageRef.h"  // for PageRef
 #include "model/Point.h"    // for Point
 
-#include "BaseStrokeHandler.h"  // for BaseStrokeHandler
+#include "BaseShapeHandler.h"  // for BaseShapeHandler
 
 class PositionInputData;
 class XojPageView;
 class XournalView;
 
-class RectangleHandler: public BaseStrokeHandler {
+class RectangleHandler: public BaseShapeHandler {
 public:
     RectangleHandler(XournalView* xournal, XojPageView* redrawable, const PageRef& page, bool flipShift = false,
                      bool flipControl = false);

--- a/src/core/control/tools/RectangleHandler.h
+++ b/src/core/control/tools/RectangleHandler.h
@@ -11,25 +11,21 @@
 
 #pragma once
 
+#include <vector>  // for vector
+
 #include "model/PageRef.h"  // for PageRef
-#include "model/Point.h"    // for Point
 
 #include "BaseShapeHandler.h"  // for BaseShapeHandler
 
-class PositionInputData;
-class XojPageView;
-class XournalView;
+class Point;
+class Control;
 
 class RectangleHandler: public BaseShapeHandler {
 public:
-    RectangleHandler(XournalView* xournal, XojPageView* redrawable, const PageRef& page, bool flipShift = false,
-                     bool flipControl = false);
+    RectangleHandler(Control* control, const PageRef& page, bool flipShift = false, bool flipControl = false);
     ~RectangleHandler() override;
 
 private:
-    void drawShape(Point& currentPoint, const PositionInputData& pos) override;
-
-private:
-    Point startPoint;
-    bool started = false;
+    auto createShape(bool isAltDown, bool isShiftDown, bool isControlDown)
+            -> std::pair<std::vector<Point>, Range> override;
 };

--- a/src/core/control/tools/RulerHandler.cpp
+++ b/src/core/control/tools/RulerHandler.cpp
@@ -1,6 +1,6 @@
 #include "RulerHandler.h"
 
-#include "control/tools/BaseStrokeHandler.h"       // for BaseStrokeHandler
+#include "control/tools/BaseShapeHandler.h"        // for BaseShapeHandler
 #include "control/tools/SnapToGridInputHandler.h"  // for SnapToGridInputHan...
 #include "gui/inputdevices/PositionInputData.h"    // for PositionInputData
 #include "model/Point.h"                           // for Point
@@ -10,7 +10,7 @@ class XojPageView;
 class XournalView;
 
 RulerHandler::RulerHandler(XournalView* xournal, XojPageView* redrawable, const PageRef& page):
-        BaseStrokeHandler(xournal, redrawable, page) {}
+        BaseShapeHandler(xournal, redrawable, page) {}
 
 RulerHandler::~RulerHandler() = default;
 

--- a/src/core/control/tools/RulerHandler.cpp
+++ b/src/core/control/tools/RulerHandler.cpp
@@ -2,33 +2,18 @@
 
 #include "control/tools/BaseShapeHandler.h"        // for BaseShapeHandler
 #include "control/tools/SnapToGridInputHandler.h"  // for SnapToGridInputHan...
-#include "gui/inputdevices/PositionInputData.h"    // for PositionInputData
 #include "model/Point.h"                           // for Point
-#include "model/Stroke.h"                          // for Stroke
 
-class XojPageView;
 class XournalView;
 
-RulerHandler::RulerHandler(XournalView* xournal, XojPageView* redrawable, const PageRef& page):
-        BaseShapeHandler(xournal, redrawable, page) {}
+RulerHandler::RulerHandler(Control* control, const PageRef& page): BaseShapeHandler(control, page) {}
 
 RulerHandler::~RulerHandler() = default;
 
-void RulerHandler::drawShape(Point& currentPoint, const PositionInputData& pos) {
-    this->currPoint = currentPoint;  // in case redrawn by keypress event in base class.
-
-    /**
-     * Snap first point to grid (if enabled)
-     */
-    bool altDown = pos.isAltDown();
-
-    Point firstPoint = snappingHandler.snapToGrid(stroke->getPoint(0), altDown);
-    stroke->setFirstPoint(firstPoint.x, firstPoint.y);
-
-    if (stroke->getPointCount() < 2) {
-        stroke->addPoint(currentPoint);
-    } else {
-        Point secondPoint = snappingHandler.snap(currentPoint, firstPoint, altDown);
-        stroke->setLastPoint(secondPoint.x, secondPoint.y);
-    }
+auto RulerHandler::createShape(bool isAltDown, bool isShiftDown, bool isControlDown)
+        -> std::pair<std::vector<Point>, Range> {
+    Point secondPoint = snappingHandler.snap(this->currPoint, this->startPoint, isAltDown);
+    Range rg(this->startPoint.x, this->startPoint.y);
+    rg.addPoint(secondPoint.x, secondPoint.y);
+    return {{this->startPoint, secondPoint}, rg};
 }

--- a/src/core/control/tools/RulerHandler.h
+++ b/src/core/control/tools/RulerHandler.h
@@ -13,14 +13,14 @@
 
 #include "model/PageRef.h"  // for PageRef
 
-#include "BaseStrokeHandler.h"  // for BaseStrokeHandler
+#include "BaseShapeHandler.h"  // for BaseShapeHandler
 
 class Point;
 class PositionInputData;
 class XojPageView;
 class XournalView;
 
-class RulerHandler: public BaseStrokeHandler {
+class RulerHandler: public BaseShapeHandler {
 public:
     RulerHandler(XournalView* xournal, XojPageView* redrawable, const PageRef& page);
     ~RulerHandler() override;

--- a/src/core/control/tools/RulerHandler.h
+++ b/src/core/control/tools/RulerHandler.h
@@ -11,22 +11,21 @@
 
 #pragma once
 
+#include <vector>
+
 #include "model/PageRef.h"  // for PageRef
 
 #include "BaseShapeHandler.h"  // for BaseShapeHandler
 
 class Point;
-class PositionInputData;
-class XojPageView;
-class XournalView;
+class Control;
 
 class RulerHandler: public BaseShapeHandler {
 public:
-    RulerHandler(XournalView* xournal, XojPageView* redrawable, const PageRef& page);
+    RulerHandler(Control* control, const PageRef& page);
     ~RulerHandler() override;
 
 private:
-    void drawShape(Point& currentPoint, const PositionInputData& pos) override;
-
-private:
+    auto createShape(bool isAltDown, bool isShiftDown, bool isControlDown)
+            -> std::pair<std::vector<Point>, Range> override;
 };

--- a/src/core/control/tools/Selection.cpp
+++ b/src/core/control/tools/Selection.cpp
@@ -7,11 +7,11 @@
 
 #include <gdk/gdk.h>  // for GdkRGBA, gdk_cairo_set_source_rgba
 
-#include "gui/Redrawable.h"  // for Redrawable
+#include "gui/LegacyRedrawable.h"  // for Redrawable
 #include "model/Layer.h"     // for Layer
 #include "model/XojPage.h"   // for XojPage
 
-Selection::Selection(Redrawable* view) {
+Selection::Selection(LegacyRedrawable* view) {
     this->view = view;
     this->page = nullptr;
 
@@ -28,7 +28,7 @@ Selection::~Selection() {
 
 //////////////////////////////////////////////////////////
 
-RectSelection::RectSelection(double x, double y, Redrawable* view): Selection(view) {
+RectSelection::RectSelection(double x, double y, LegacyRedrawable* view): Selection(view) {
     this->sx = x;
     this->sy = y;
     this->ex = x;
@@ -134,7 +134,7 @@ public:
     double y;
 };
 
-RegionSelect::RegionSelect(double x, double y, Redrawable* view): Selection(view) { currentPos(x, y); }
+RegionSelect::RegionSelect(double x, double y, LegacyRedrawable* view): Selection(view) { currentPos(x, y); }
 
 void RegionSelect::paint(cairo_t* cr, double zoom) {
     // at least three points needed

--- a/src/core/control/tools/Selection.h
+++ b/src/core/control/tools/Selection.h
@@ -18,12 +18,12 @@
 #include "model/Element.h"  // for Element (ptr only), ShapeContainer
 #include "model/PageRef.h"  // for PageRef
 
-class Redrawable;
+class LegacyRedrawable;
 
 
 class Selection: public ShapeContainer {
 public:
-    Selection(Redrawable* view);
+    Selection(LegacyRedrawable* view);
     ~Selection() override;
 
 public:
@@ -36,7 +36,7 @@ private:
 protected:
     std::vector<Element*> selectedElements;
     PageRef page;
-    Redrawable* view;
+    LegacyRedrawable* view;
 
     double x1Box;
     double x2Box;
@@ -48,7 +48,7 @@ protected:
 
 class RectSelection: public Selection {
 public:
-    RectSelection(double x, double y, Redrawable* view);
+    RectSelection(double x, double y, LegacyRedrawable* view);
     ~RectSelection() override;
 
 public:
@@ -78,7 +78,7 @@ class RegionPoint;
 
 class RegionSelect: public Selection {
 public:
-    RegionSelect(double x, double y, Redrawable* view);
+    RegionSelect(double x, double y, LegacyRedrawable* view);
 
 public:
     bool finalize(PageRef page) override;

--- a/src/core/control/tools/SplineHandler.h
+++ b/src/core/control/tools/SplineHandler.h
@@ -11,7 +11,8 @@
 
 #pragma once
 
-#include <vector>  // for vector
+#include <optional>  // for optional
+#include <vector>    // for vector
 
 #include <cairo.h>    // for cairo_t
 #include <gdk/gdk.h>  // for GdkEventKey
@@ -20,12 +21,13 @@
 #include "model/PageRef.h"   // for PageRef
 #include "model/Point.h"     // for Point
 #include "util/Rectangle.h"  // for Rectangle
+#include "view/StrokeView.h"
 
 #include "InputHandler.h"            // for InputHandler
 #include "SnapToGridInputHandler.h"  // for SnapToGridInputHandler
 
 class PositionInputData;
-class XojPageView;
+class LegacyRedrawable;
 class XournalView;
 
 /**
@@ -44,16 +46,16 @@ class XournalView;
 
 class SplineHandler: public InputHandler {
 public:
-    SplineHandler(XournalView* xournal, XojPageView* redrawable, const PageRef& page);
+    SplineHandler(Control* control, LegacyRedrawable* redrawable, const PageRef& page);
     ~SplineHandler() override;
 
     void draw(cairo_t* cr) override;
 
-    void onMotionCancelEvent() override;
-    bool onMotionNotifyEvent(const PositionInputData& pos) override;
-    void onButtonReleaseEvent(const PositionInputData& pos) override;
-    void onButtonPressEvent(const PositionInputData& pos) override;
-    void onButtonDoublePressEvent(const PositionInputData& pos) override;
+    void onSequenceCancelEvent() override;
+    bool onMotionNotifyEvent(const PositionInputData& pos, double zoom) override;
+    void onButtonReleaseEvent(const PositionInputData& pos, double zoom) override;
+    void onButtonPressEvent(const PositionInputData& pos, double zoom) override;
+    void onButtonDoublePressEvent(const PositionInputData& pos, double zoom) override;
     bool onKeyEvent(GdkEventKey* event) override;
 
 private:
@@ -70,15 +72,19 @@ private:
 private:
     std::vector<Point> knots{};
     std::vector<Point> tangents{};
+    std::optional<xoj::view::StrokeView> strokeView;
+
     bool isButtonPressed = false;
     SnapToGridInputHandler snappingHandler;
+
+    LegacyRedrawable* redrawable;
 
 public:
     void addKnot(const Point& p);
     void addKnotWithTangent(const Point& p, const Point& t);
     void modifyLastTangent(const Point& t);
     void deleteLastKnotWithTangent();
-    int getKnotCount() const;
+    size_t getKnotCount() const;
 
 protected:
     Point currPoint;

--- a/src/core/control/tools/StrokeHandler.h
+++ b/src/core/control/tools/StrokeHandler.h
@@ -20,6 +20,7 @@
 
 #include "model/PageRef.h"  // for PageRef
 #include "model/Point.h"    // for Point
+#include "view/StrokeView.h"
 
 #include "InputHandler.h"            // for InputHandler
 #include "SnapToGridInputHandler.h"  // for SnapToGridInputHandler
@@ -46,16 +47,16 @@ class Active;
  */
 class StrokeHandler: public InputHandler {
 public:
-    StrokeHandler(XournalView* xournal, XojPageView* redrawable, const PageRef& page);
+    StrokeHandler(Control* control, XojPageView* pageView, const PageRef& page);
     ~StrokeHandler() override = default;
 
     void draw(cairo_t* cr) override;
 
-    void onMotionCancelEvent() override;
-    bool onMotionNotifyEvent(const PositionInputData& pos) override;
-    void onButtonReleaseEvent(const PositionInputData& pos) override;
-    void onButtonPressEvent(const PositionInputData& pos) override;
-    void onButtonDoublePressEvent(const PositionInputData& pos) override;
+    void onSequenceCancelEvent() override;
+    bool onMotionNotifyEvent(const PositionInputData& pos, double zoom) override;
+    void onButtonReleaseEvent(const PositionInputData& pos, double zoom) override;
+    void onButtonPressEvent(const PositionInputData& pos, double zoom) override;
+    void onButtonDoublePressEvent(const PositionInputData& pos, double zoom) override;
     bool onKeyEvent(GdkEventKey* event) override;
 
     /**
@@ -123,6 +124,8 @@ private:
     };
     std::optional<Mask> mask;
 
+    std::optional<xoj::view::StrokeView> strokeView;
+
     // to filter out short strokes (usually the user tapping on the page to select it)
     guint32 startStrokeTime{};
     static guint32 lastStrokeTime;  // persist across strokes - allow us to not ignore persistent dotting.
@@ -138,4 +141,6 @@ private:
     friend class StrokeStabilizer::Active;
 
     static constexpr double MAX_WIDTH_VARIATION = 0.3;
+
+    XojPageView* pageView;
 };

--- a/src/core/control/tools/VerticalToolHandler.cpp
+++ b/src/core/control/tools/VerticalToolHandler.cpp
@@ -11,7 +11,7 @@
 
 #include "control/tools/SnapToGridInputHandler.h"  // for SnapToGridInputHan...
 #include "control/zoom/ZoomControl.h"              // for ZoomControl
-#include "gui/Redrawable.h"                        // for Redrawable
+#include "gui/LegacyRedrawable.h"                  // for Redrawable
 #include "model/Element.h"                         // for Element
 #include "model/Layer.h"                           // for Layer
 #include "model/XojPage.h"                         // for XojPage
@@ -24,7 +24,7 @@
 
 class Settings;
 
-VerticalToolHandler::VerticalToolHandler(Redrawable* view, const PageRef& page, Settings* settings, double y,
+VerticalToolHandler::VerticalToolHandler(LegacyRedrawable* view, const PageRef& page, Settings* settings, double y,
                                          bool initiallyReverse, ZoomControl* zoomControl, GdkWindow* window):
         window(window),
         view(view),

--- a/src/core/control/tools/VerticalToolHandler.h
+++ b/src/core/control/tools/VerticalToolHandler.h
@@ -28,7 +28,7 @@ class ZoomControl;
 class Element;
 class Layer;
 class MoveUndoAction;
-class Redrawable;
+class LegacyRedrawable;
 class Settings;
 namespace xoj::util {
 template <class T>
@@ -44,8 +44,8 @@ public:
      * @param initiallyReverse Set this to true if the user has the reverse mode
      * button (e.g., Ctrl) held down when a vertical selection is started.
      */
-    VerticalToolHandler(Redrawable* view, const PageRef& page, Settings* settings, double y, bool initiallyReverse,
-                        ZoomControl* zoomControl, GdkWindow* window);
+    VerticalToolHandler(LegacyRedrawable* view, const PageRef& page, Settings* settings, double y,
+                        bool initiallyReverse, ZoomControl* zoomControl, GdkWindow* window);
     ~VerticalToolHandler() override;
     VerticalToolHandler(VerticalToolHandler&) = delete;
     VerticalToolHandler& operator=(VerticalToolHandler&) = delete;
@@ -98,7 +98,7 @@ private:
     std::optional<xoj::util::Rectangle<double>> getElementsBoundingRect() const;
 
     GdkWindow* window;
-    Redrawable* view;
+    LegacyRedrawable* view;
     PageRef page;
     Layer* layer;
     std::vector<Element*> elements;

--- a/src/core/gui/LegacyRedrawable.cpp
+++ b/src/core/gui/LegacyRedrawable.cpp
@@ -1,18 +1,18 @@
-#include "Redrawable.h"
+#include "LegacyRedrawable.h"
 
 #include "model/Element.h"  // for Element
 #include "util/Range.h"     // for Range
 
-void Redrawable::repaintElement(Element* e) const {
+void LegacyRedrawable::repaintElement(Element* e) const {
     repaintArea(e->getX(), e->getY(), e->getElementWidth() + e->getX(), e->getElementHeight() + e->getY());
 }
 
-void Redrawable::repaintRect(double x, double y, double width, double height) const {
+void LegacyRedrawable::repaintRect(double x, double y, double width, double height) const {
     repaintArea(x, y, x + width, y + height);
 }
 
-void Redrawable::rerenderRange(Range& r) { rerenderRect(r.getX(), r.getY(), r.getWidth(), r.getHeight()); }
+void LegacyRedrawable::rerenderRange(Range& r) { rerenderRect(r.getX(), r.getY(), r.getWidth(), r.getHeight()); }
 
-void Redrawable::rerenderElement(Element* e) {
+void LegacyRedrawable::rerenderElement(Element* e) {
     rerenderRect(e->getX() - 1, e->getY() - 1, e->getElementWidth() + 2, e->getElementHeight() + 2);
 }

--- a/src/core/gui/LegacyRedrawable.h
+++ b/src/core/gui/LegacyRedrawable.h
@@ -16,16 +16,28 @@
 class Element;
 class Range;
 
-class Redrawable {
+/*
+ * The (base) class Redrawable (now LegacyRedrawable) is deprecated. Use xoj::view::Repaintable instead.
+ *
+ * Reasons for the deprecation:
+ *
+ *  * It is basically used synonymously to XojPageView.
+ *  * More importantly, the coexistence of Redrawable::repaint... and Redrawable::rerender... is bothersome.
+ *    it is not clear (without diving in the code) what the difference should be.
+ *    (repaint = ask gtk to call us back to blitt the buffer, rerender = change the buffer's content)
+ *    The rerender... methods should not exist. The derived class should be told what happened (something changed),
+ *    and decide by itself if the buffer should be updated or not (if there is a buffer to begin with).
+ */
+class [[deprecated]] LegacyRedrawable {
 protected:
-    Redrawable() = default;
+    LegacyRedrawable() = default;
 
 public:
-    Redrawable(Redrawable&&) = default;
-    Redrawable(Redrawable const&) = default;
-    virtual ~Redrawable() = default;
-    Redrawable& operator=(Redrawable&&) = default;
-    Redrawable& operator=(Redrawable const&) = default;
+    LegacyRedrawable(LegacyRedrawable&&) = default;
+    LegacyRedrawable(LegacyRedrawable const&) = default;
+    virtual ~LegacyRedrawable() = default;
+    LegacyRedrawable& operator=(LegacyRedrawable&&) = default;
+    LegacyRedrawable& operator=(LegacyRedrawable const&) = default;
 
     /**
      * Call this if you only need to repaint the view, this means the buffer will be painted again,

--- a/src/core/gui/PageView.h
+++ b/src/core/gui/PageView.h
@@ -41,10 +41,10 @@ class Element;
 class PositionInputData;
 class Range;
 class TexImage;
-class OverlayBase;
 
 namespace xoj::view {
 class OverlayView;
+class ToolView;
 }
 
 class XojPageView: public LegacyRedrawable, public PageListener, public xoj::view::Repaintable {
@@ -61,12 +61,19 @@ public:
 
     // Repaintable interface
     void flagDirtyRegion(const Range& rg) const override;
+    /**
+     * @brief This draws the ToolView directly onto the buffer, deletes the view and repaints the given range
+     *      Used to avoid blinking when a tool finished editing an element
+     */
+    void drawAndDeleteToolView(xoj::view::ToolView* v, const Range& rg) override;
+
     int getDPIScaling() const override;
     double getZoom() const override;
     Range getVisiblePart() const override;
 
     double getWidth() const override;
     double getHeight() const override;
+    // End of Repaintable interface
 
 
     void setSelected(bool selected);
@@ -203,8 +210,7 @@ private:
      */
     void showPdfToolbox(const PositionInputData& pos);
 
-    auto getViewOf(OverlayBase* overlay) const -> xoj::view::OverlayView*;
-    void deleteViewOf(OverlayBase* overlay);
+    void deleteView(xoj::view::OverlayView* v);
 
 private:
     PageRef page;

--- a/src/core/gui/inputdevices/TouchDrawingInputHandler.cpp
+++ b/src/core/gui/inputdevices/TouchDrawingInputHandler.cpp
@@ -71,7 +71,7 @@ auto TouchDrawingInputHandler::handleImpl(InputEvent const& event) -> bool {
             XojPageView* currentPage = this->getPageAtCurrentPosition(event);
 
             if (currentPage) {
-                currentPage->onMotionCancelEvent();
+                currentPage->onSequenceCancelEvent();
             }
         }
 

--- a/src/core/gui/widgets/XournalWidget.cpp
+++ b/src/core/gui/widgets/XournalWidget.cpp
@@ -12,8 +12,8 @@
 #include "control/settings/Settings.h"      // for Settings
 #include "control/tools/EditSelection.h"    // for EditSelection
 #include "gui/Layout.h"                     // for Layout
+#include "gui/LegacyRedrawable.h"           // for Redrawable
 #include "gui/PageView.h"                   // for XojPageView
-#include "gui/Redrawable.h"                 // for Redrawable
 #include "gui/Shadow.h"                     // for Shadow
 #include "gui/XournalView.h"                // for XournalView
 #include "gui/inputdevices/InputContext.h"  // for InputContext
@@ -286,7 +286,7 @@ static auto gtk_xournal_draw(GtkWidget* widget, cairo_t* cr) -> gboolean {
         cairo_save(cr);
         double zoom = xournal->view->getZoom();
 
-        Redrawable* red = xournal->selection->getView();
+        LegacyRedrawable* red = xournal->selection->getView();
         cairo_translate(cr, red->getX(), red->getY());
 
         xournal->selection->paint(cr, zoom);

--- a/src/core/model/OverlayBase.h
+++ b/src/core/model/OverlayBase.h
@@ -1,0 +1,23 @@
+/*
+ * Xournal++
+ *
+ *
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+/**
+ * Empty base class for overlays: anything that is drawn over a document, but not in the document
+ *  (e.g. active tools, selections, search results highlighting...).
+ *
+ * This class is only used for pointer comparison.
+ */
+class OverlayBase {
+public:
+    virtual ~OverlayBase() = default;
+};

--- a/src/core/model/Stroke.cpp
+++ b/src/core/model/Stroke.cpp
@@ -302,6 +302,22 @@ Point Stroke::getPoint(PathParameter parameter) const {
 
 auto Stroke::getPoints() const -> const Point* { return this->points.data(); }
 
+void Stroke::setPointVector(const std::vector<Point>& other, const Range* const snappingBox) {
+    this->points = other;
+    if (!snappingBox || this->points.empty() || this->points.front().z != Point::NO_PRESSURE) {
+        // We cannot deduce the bounding box from the snapping box if the stroke has pressure values
+        this->sizeCalculated = false;
+    } else {
+        assert(snappingBox->isValid());
+        this->snappedBounds = xoj::util::Rectangle<double>(*snappingBox);
+        Element::x = snappingBox->minX - 0.5 * this->width;
+        Element::y = snappingBox->minY - 0.5 * this->width;
+        Element::width = snappingBox->getWidth() + this->width;
+        Element::height = snappingBox->getHeight() + this->width;
+        this->sizeCalculated = true;
+    }
+}
+
 void Stroke::freeUnusedPointItems() { this->points = {begin(this->points), end(this->points)}; }
 
 void Stroke::setToolType(StrokeTool type) { this->toolType = type; }

--- a/src/core/model/Stroke.h
+++ b/src/core/model/Stroke.h
@@ -105,6 +105,15 @@ public:
     Point getPoint(PathParameter parameter) const;
     const Point* getPoints() const;
 
+    /**
+     * @brief Replace the stroke's points by the ones in the provided vector (they will be copied).
+     * @param other New vector of points for the stroke
+     * @param snappingBox (optional) Precomputed snapping box of the new points (i.e. the smallest Range containing all
+     * the points, stroke width or pressure values not being considered). The snappingBox parameter avoids a
+     * recomputation of the bounding boxes if the new points have no pressure values.
+     */
+    void setPointVector(const std::vector<Point>& other, const Range* const snappingBox = nullptr);
+
     void deletePoint(int index);
     void deletePointsFrom(int index);
 

--- a/src/core/view/Mask.cpp
+++ b/src/core/view/Mask.cpp
@@ -1,0 +1,147 @@
+#include "Mask.h"
+
+#include <cassert>
+#include <cmath>
+
+#include <cairo.h>
+
+#include "util/Range.h"
+
+using namespace xoj::view;
+
+
+#ifdef DEBUG_MASKS
+#include <iostream>
+#include <string>
+namespace {  // cairo helper functions, for handling various surface types
+std::string getSurfaceTypeName(cairo_surface_t*);
+};
+#define IF_DBG_MASKS(f) f
+#else
+#define IF_DBG_MASKS(f)
+#endif
+
+Mask::Mask(cairo_surface_t* target, const Range& extent, double zoom, int dpiScaling, cairo_content_t contentType) {
+    assert(target);
+    assert(extent.isValid());
+    assert(zoom > 0.0);
+    assert(dpiScaling > 0);
+
+    const int xOffset = -static_cast<int>(std::floor(extent.minX * zoom));
+    const int yOffset = -static_cast<int>(std::floor(extent.minY * zoom));
+    const int width = static_cast<int>(std::ceil(extent.maxX * zoom)) + xOffset;
+    const int height = static_cast<int>(std::ceil(extent.maxY * zoom)) + yOffset;
+
+    /*
+     * Create the most suitable kind of surface.
+     *
+     * Note that width and height are in device space coordinates (i.e. before DPI scaling).
+     * If `target` has a device scaling, then the number of pixels in the resulting surface will be multiplied
+     * accordingly, and a similar scaling is applied to the new surface.
+     */
+    cairo_surface_t* surf = cairo_surface_create_similar(target, contentType, width, height);
+    IF_DBG_MASKS({
+        std::cout << "Creating mask of type: " << getSurfaceTypeName(surf) << std::endl;
+        std::cout << "  Its size: " << width << " x " << height << " (in device space)" << std::endl;
+        double x;
+        double y;
+        cairo_surface_get_device_scale(surf, &x, &y);
+        std::cout << "  Its scaling: " << x << " x " << y << std::endl;
+    });
+    cairo_surface_set_device_offset(surf, xOffset * dpiScaling, yOffset * dpiScaling);
+    cairo_surface_set_device_scale(surf, zoom * dpiScaling, zoom * dpiScaling);
+
+    this->cr.reset(cairo_create(surf));
+    cairo_surface_destroy(surf);  // surf is now owned by this->cr
+
+    IF_DBG_MASKS({
+        xoj::util::CairoSaveGuard saveGuard(cr.get());
+        cairo_set_operator(cr.get(), CAIRO_OPERATOR_OVER);
+        cairo_set_source_rgba(cr.get(), 1.0, 0.0, 0.0, 0.3);
+        cairo_paint(cr.get());
+    });
+}
+
+auto Mask::get() -> cairo_t* { return cr.get(); }
+
+bool Mask::isInitialized() const { return cr; }
+
+void Mask::blitTo(cairo_t* targetCr) const {
+    assert(isInitialized());
+    cairo_mask_surface(targetCr, cairo_get_target(const_cast<cairo_t*>(cr.get())), 0.0, 0.0);
+}
+
+void Mask::wipe() {
+    assert(isInitialized());
+    xoj::util::CairoSaveGuard saveGuard(cr.get());
+    cairo_set_operator(cr.get(), CAIRO_OPERATOR_CLEAR);
+    cairo_paint(cr.get());
+    IF_DBG_MASKS({
+        cairo_set_operator(cr.get(), CAIRO_OPERATOR_OVER);
+        cairo_set_source_rgba(cr.get(), 1.0, 0.0, 0.0, 0.3);
+        cairo_paint(cr.get());
+    });
+}
+
+#ifdef DEBUG_MASKS
+namespace {
+auto getSurfaceTypeName(cairo_surface_t* surf) -> std::string {
+    auto surftype = cairo_surface_get_type(surf);
+    switch (surftype) {
+        // Strings from https://cairographics.org/manual/cairo-cairo-surface-t.html#cairo-surface-type-t
+        case CAIRO_SURFACE_TYPE_IMAGE:
+            return "image";
+        case CAIRO_SURFACE_TYPE_PDF:
+            return "pdf";
+        case CAIRO_SURFACE_TYPE_PS:
+            return "ps";
+        case CAIRO_SURFACE_TYPE_XLIB:
+            return "xlib";
+        case CAIRO_SURFACE_TYPE_XCB:
+            return "xcb";
+        case CAIRO_SURFACE_TYPE_GLITZ:
+            return "glitz";
+        case CAIRO_SURFACE_TYPE_QUARTZ:
+            return "quartz";
+        case CAIRO_SURFACE_TYPE_WIN32:
+            return "win32";
+        case CAIRO_SURFACE_TYPE_BEOS:
+            return "beos";
+        case CAIRO_SURFACE_TYPE_DIRECTFB:
+            return "directfb";
+        case CAIRO_SURFACE_TYPE_SVG:
+            return "svg";
+        case CAIRO_SURFACE_TYPE_OS2:
+            return "os2";
+        case CAIRO_SURFACE_TYPE_WIN32_PRINTING:
+            return "win32 printing surface";
+        case CAIRO_SURFACE_TYPE_QUARTZ_IMAGE:
+            return "quartz_image";
+        case CAIRO_SURFACE_TYPE_SCRIPT:
+            return "script";
+        case CAIRO_SURFACE_TYPE_QT:
+            return "Qt";
+        case CAIRO_SURFACE_TYPE_RECORDING:
+            return "recording";
+        case CAIRO_SURFACE_TYPE_VG:
+            return "OpenVG surface";
+        case CAIRO_SURFACE_TYPE_GL:
+            return "OpenGL";
+        case CAIRO_SURFACE_TYPE_DRM:
+            return "Direct Render Manager";
+        case CAIRO_SURFACE_TYPE_TEE:
+            return "'tee' (a multiplexing surface)";
+        case CAIRO_SURFACE_TYPE_XML:
+            return "XML (for debugging)";
+        case CAIRO_SURFACE_TYPE_SKIA:
+            return "CAIRO_SURFACE_TYPE_SKIA";
+        case CAIRO_SURFACE_TYPE_SUBSURFACE:
+            return "subsurface created with cairo_surface_create_for_rectangle()";
+        case CAIRO_SURFACE_TYPE_COGL:
+            return "Cogl";
+        default:
+            return "Unknown surface type";
+    }
+}
+};  // namespace
+#endif

--- a/src/core/view/Mask.h
+++ b/src/core/view/Mask.h
@@ -1,0 +1,48 @@
+/*
+ * Xournal++
+ *
+ * Virtual class for showing overlays (e.g. active tools, selections and so on)
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+#include <cairo.h>
+
+#include "util/raii/CairoWrappers.h"
+
+class Range;
+
+namespace xoj::view {
+
+/**
+ * @brief Mask class: a cairo surface and its context to draw on, with the later purpose of blitting or using as a
+ * buffer.
+ */
+class Mask {
+public:
+    Mask() = default;
+    /**
+     * @brief Create a mask tailored for the specified target
+     * @param target A cairo surface similar to that on which the mask will be used
+     * @param extent The extent of the mask, in local coordinates (i.e. in the coordinates of the cairo context(s) on
+     * which the mask will be used).
+     * @param zoom The local zoom ratio (zoom ratio of the cairo context(s) on which the mask will be used).
+     * @param DPIScaling The targeted screen DPI scaling
+     * @param contentType The intended content of the mask
+     */
+    Mask(cairo_surface_t* target, const Range& extent, double zoom, int DPIScaling,
+         cairo_content_t contentType = CAIRO_CONTENT_ALPHA);
+    cairo_t* get();
+    bool isInitialized() const;
+    void blitTo(cairo_t* targetCr) const;
+    void wipe();
+
+private:
+    xoj::util::CairoSPtr cr;
+};
+};  // namespace xoj::view

--- a/src/core/view/Repaintable.h
+++ b/src/core/view/Repaintable.h
@@ -13,6 +13,7 @@
 class Range;
 
 namespace xoj::view {
+class ToolView;
 
 class Repaintable {
 public:
@@ -41,5 +42,11 @@ public:
      * @brief Flag a region as dirty. Dirty regions will get redrawn at the next screen refresh.
      */
     virtual void flagDirtyRegion(const Range& rg) const = 0;
+
+    /**
+     * @brief Remove a tool view and repaint the given range
+     *      Called just before the tool sequence ends and the handler is deleted.
+     */
+    virtual void drawAndDeleteToolView(ToolView* v, const Range& rg) = 0;
 };
 };  // namespace xoj::view

--- a/src/core/view/Repaintable.h
+++ b/src/core/view/Repaintable.h
@@ -1,0 +1,45 @@
+/*
+ * Xournal++
+ *
+ *
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+#pragma once
+
+class Range;
+
+namespace xoj::view {
+
+class Repaintable {
+public:
+    Repaintable() = default;
+    virtual ~Repaintable() = default;
+
+    Repaintable(const Repaintable&) = delete;
+    Repaintable(Repaintable&&) = delete;
+
+    /**
+     * @brief Get the Repaintable's visible part, in local coordinates
+     * @return A range. It could be empty.
+     */
+    virtual Range getVisiblePart() const = 0;
+
+    virtual int getDPIScaling() const = 0;
+
+    // Get the current zoom.
+    virtual double getZoom() const = 0;
+
+    // Width and height, in local coordinates
+    virtual double getWidth() const = 0;
+    virtual double getHeight() const = 0;
+
+    /**
+     * @brief Flag a region as dirty. Dirty regions will get redrawn at the next screen refresh.
+     */
+    virtual void flagDirtyRegion(const Range& rg) const = 0;
+};
+};  // namespace xoj::view

--- a/src/core/view/StrokeView.h
+++ b/src/core/view/StrokeView.h
@@ -33,20 +33,6 @@ public:
     void draw(const Context& ctx) const override;
 
 private:
-    inline void pathToCairo(cairo_t* cr) const;
-
-    /**
-     * No pressure sensitivity, one line is drawn
-     */
-    void drawNoPressure(cairo_t* cr) const;
-
-    /**
-     * Draw a stroke with pressure, for this multiple
-     * lines with different widths needs to be drawn
-     */
-    void drawWithPressure(cairo_t* cr) const;
-
-private:
     const Stroke* s;
 
 public:

--- a/src/core/view/StrokeViewHelper.cpp
+++ b/src/core/view/StrokeViewHelper.cpp
@@ -1,0 +1,65 @@
+#include "StrokeViewHelper.h"
+
+#include <cassert>
+
+#include "model/LineStyle.h"
+#include "model/Point.h"
+#include "util/LoopUtil.h"
+#include "util/PairView.h"
+
+void xoj::view::StrokeViewHelper::pathToCairo(cairo_t* cr, const std::vector<Point>& pts) {
+    for_first_then_each(
+            pts, [cr](auto const& first) { cairo_move_to(cr, first.x, first.y); },
+            [cr](auto const& other) { cairo_line_to(cr, other.x, other.y); });
+}
+
+/**
+ * No pressure sensitivity, one line is drawn
+ */
+void xoj::view::StrokeViewHelper::drawNoPressure(cairo_t* cr, const std::vector<Point>& pts, const double strokeWidth,
+                                                 const LineStyle& lineStyle, double dashOffset) {
+    cairo_set_line_width(cr, strokeWidth);
+
+    const double* dashes = nullptr;
+    int dashCount = 0;
+    lineStyle.getDashes(dashes, dashCount);
+    cairo_set_dash(cr, dashes, dashCount, dashOffset);
+
+    pathToCairo(cr, pts);
+    cairo_stroke(cr);
+}
+
+/**
+ * Draw a stroke with pressure, for this multiple lines with different widths needs to be drawn
+ */
+double xoj::view::StrokeViewHelper::drawWithPressure(cairo_t* cr, const std::vector<Point>& pts,
+                                                     const LineStyle& lineStyle, double dashOffset) {
+    const double* dashes = nullptr;
+    int dashCount = 0;
+    lineStyle.getDashes(dashes, dashCount);
+
+    /*
+     * Because the width varies, we need to call cairo_stroke() once per segment
+     */
+    auto drawSegment = [cr](const Point& p, const Point& q) {
+        assert(p.z > 0.0);
+        cairo_set_line_width(cr, p.z);
+        cairo_move_to(cr, p.x, p.y);
+        cairo_line_to(cr, q.x, q.y);
+        cairo_stroke(cr);
+    };
+
+    if (dashes) {
+        for (const auto& [p, q]: PairView(pts)) {
+            cairo_set_dash(cr, dashes, dashCount, dashOffset);
+            dashOffset += p.lineLengthTo(q);
+            drawSegment(p, q);
+        }
+    } else {
+        cairo_set_dash(cr, nullptr, 0, 0.0);
+        for (const auto& [p, q]: PairView(pts)) {
+            drawSegment(p, q);
+        }
+    }
+    return dashOffset;
+}

--- a/src/core/view/StrokeViewHelper.h
+++ b/src/core/view/StrokeViewHelper.h
@@ -1,0 +1,40 @@
+/*
+ * Xournal++
+ *
+ * Draw stroke
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+#include <vector>
+
+#include <cairo.h>
+
+class LineStyle;
+class Point;
+
+namespace xoj::view::StrokeViewHelper {
+
+/**
+ * @brief Simply adds the points to a cairo context, as a single path
+ */
+void pathToCairo(cairo_t* cr, const std::vector<Point>& pts);
+
+/**
+ * @brief No pressure sensitivity, one line is drawn, with given width and line style (dashes)
+ */
+void drawNoPressure(cairo_t* cr, const std::vector<Point>& pts, const double strokeWidth, const LineStyle& lineStyle,
+                    double dashOffset = 0);
+
+/**
+ * @brief Draw a stroke with pressure, for this multiple lines with different widths needs to be drawn.
+ * @return New dash offset, if one wants to keep on drawing the same stroke.
+ *      Effectively, the return value equals dashOffset + length of the path.
+ */
+double drawWithPressure(cairo_t* cr, const std::vector<Point>& pts, const LineStyle& lineStyle, double dashOffset = 0);
+};  // namespace xoj::view::StrokeViewHelper

--- a/src/core/view/overlays/BaseShapeOrSplineToolView.cpp
+++ b/src/core/view/overlays/BaseShapeOrSplineToolView.cpp
@@ -20,7 +20,7 @@ static double getFillingAlpha(const InputHandler* h) {
     return f == -1 ? 0.0 : f / 255.0;
 }
 
-BaseShapeOrSplineToolView::BaseShapeOrSplineToolView(const InputHandler* toolHandler, const Repaintable* parent):
+BaseShapeOrSplineToolView::BaseShapeOrSplineToolView(const InputHandler* toolHandler, Repaintable* parent):
         BaseStrokeToolView(parent, safeGetStroke(toolHandler)),
         fillingAlpha(getFillingAlpha(toolHandler)),
         needMask(this->fillingAlpha != 0.0 && safeGetStroke(toolHandler).getToolType() == STROKE_TOOL_HIGHLIGHTER) {}

--- a/src/core/view/overlays/BaseShapeOrSplineToolView.cpp
+++ b/src/core/view/overlays/BaseShapeOrSplineToolView.cpp
@@ -1,0 +1,82 @@
+#include "BaseShapeOrSplineToolView.h"
+
+#include <cassert>
+
+#include "control/tools/InputHandler.h"
+#include "model/LineStyle.h"
+#include "model/Stroke.h"
+#include "util/Color.h"
+
+using namespace xoj::view;
+
+static const Stroke& safeGetStroke(const InputHandler* h) {
+    assert(h);
+    assert(h->getStroke());
+    return *h->getStroke();
+}
+
+static double getFillingAlpha(const InputHandler* h) {
+    auto f = safeGetStroke(h).getFill();
+    return f == -1 ? 0.0 : f / 255.0;
+}
+
+BaseShapeOrSplineToolView::BaseShapeOrSplineToolView(const InputHandler* toolHandler, const Repaintable* parent):
+        BaseStrokeToolView(parent, safeGetStroke(toolHandler)),
+        fillingAlpha(getFillingAlpha(toolHandler)),
+        needMask(this->fillingAlpha != 0.0 && safeGetStroke(toolHandler).getToolType() == STROKE_TOOL_HIGHLIGHTER) {}
+
+BaseShapeOrSplineToolView::~BaseShapeOrSplineToolView() noexcept = default;
+
+cairo_t* BaseShapeOrSplineToolView::prepareContext(cairo_t* cr) const {
+    cairo_set_operator(cr, this->cairoOp);
+
+    if (needMask) {
+        // The mask is only for filled highlighter strokes, to avoid artefacts as in
+        // https://github.com/xournalpp/xournalpp/issues/3709
+        if (!mask.isInitialized()) {
+            mask = createMask(cr);
+            const double* dashes = nullptr;
+            int dashCount = 0;
+            this->lineStyle.getDashes(dashes, dashCount);
+            cairo_set_dash(mask.get(), dashes, dashCount, 0.0);
+            cairo_set_line_width(mask.get(), this->strokeWidth);
+            // operator is already set by createMask().
+        } else {
+            // Clear the mask
+            mask.wipe();
+        }
+        return mask.get();
+    } else {
+        cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+        cairo_set_line_join(cr, CAIRO_LINE_JOIN_ROUND);
+        cairo_set_line_width(cr, this->strokeWidth);
+
+        const double* dashes = nullptr;
+        int dashCount = 0;
+        this->lineStyle.getDashes(dashes, dashCount);
+        assert((dashCount == 0 && dashes == nullptr) || (dashCount != 0 && dashes != nullptr));
+        cairo_set_dash(cr, dashes, dashCount, 0.0);
+        return cr;
+    }
+}
+
+void BaseShapeOrSplineToolView::commitDrawing(cairo_t* cr) const {
+    if (fillingAlpha != 0.0) {
+        if (mask.isInitialized()) {
+            cairo_fill_preserve(mask.get());
+        } else {
+            // Not need when using a mask: transparency will be applied upon blitting.
+            Util::cairo_set_source_rgbi(cr, strokeColor, fillingAlpha);
+            cairo_fill_preserve(cr);
+        }
+    }
+
+    Util::cairo_set_source_argb(cr, this->strokeColor);
+
+    if (mask.isInitialized()) {
+        cairo_stroke(mask.get());
+        mask.blitTo(cr);
+    } else {
+        cairo_stroke(cr);
+    }
+}

--- a/src/core/view/overlays/BaseShapeOrSplineToolView.h
+++ b/src/core/view/overlays/BaseShapeOrSplineToolView.h
@@ -1,0 +1,42 @@
+/*
+ * Xournal++
+ *
+ * Base view for shapes or spline tools
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+#pragma once
+
+#include <cairo.h>
+
+#include "view/Mask.h"
+
+#include "BaseStrokeToolView.h"
+
+class InputHandler;
+
+namespace xoj::view {
+class Repaintable;
+
+class BaseShapeOrSplineToolView: public BaseStrokeToolView {
+
+public:
+    BaseShapeOrSplineToolView(const InputHandler* handler, const Repaintable* parent);
+    ~BaseShapeOrSplineToolView() noexcept override;
+
+protected:
+    cairo_t* prepareContext(cairo_t* cr) const;
+
+    void commitDrawing(cairo_t* cr) const;
+
+    const double fillingAlpha;
+
+    // The mask is only for filled highlighter strokes, to avoid artefacts as in
+    // https://github.com/xournalpp/xournalpp/issues/3709
+    mutable Mask mask;
+    bool needMask;
+};
+};  // namespace xoj::view

--- a/src/core/view/overlays/BaseShapeOrSplineToolView.h
+++ b/src/core/view/overlays/BaseShapeOrSplineToolView.h
@@ -24,7 +24,7 @@ class Repaintable;
 class BaseShapeOrSplineToolView: public BaseStrokeToolView {
 
 public:
-    BaseShapeOrSplineToolView(const InputHandler* handler, const Repaintable* parent);
+    BaseShapeOrSplineToolView(const InputHandler* handler, Repaintable* parent);
     ~BaseShapeOrSplineToolView() noexcept override;
 
 protected:

--- a/src/core/view/overlays/BaseStrokeToolView.cpp
+++ b/src/core/view/overlays/BaseStrokeToolView.cpp
@@ -1,0 +1,51 @@
+#include "BaseStrokeToolView.h"
+
+#include <cmath>
+
+#include <cairo.h>
+
+#include "model/Stroke.h"
+#include "util/Range.h"
+#include "view/Mask.h"
+#include "view/Repaintable.h"
+#include "view/overlays/OverlayView.h"
+
+using namespace xoj::view;
+
+static Color strokeColorWithAlpha(const Stroke& s) {
+    Color c = s.getColor();
+    if (s.getToolType() == STROKE_TOOL_HIGHLIGHTER) {
+        c.alpha = s.getFill() == -1 ? 120U : static_cast<uint8_t>(s.getFill());
+    } else {
+        c.alpha = 255U;
+    }
+    return c;
+}
+
+BaseStrokeToolView::BaseStrokeToolView(const Repaintable* parent, const Stroke& stroke):
+        OverlayView(parent),
+        cairoOp(stroke.getToolType() == STROKE_TOOL_HIGHLIGHTER ? CAIRO_OPERATOR_MULTIPLY : CAIRO_OPERATOR_OVER),
+        strokeColor(strokeColorWithAlpha(stroke)),
+        lineStyle(stroke.getLineStyle()),
+        strokeWidth(stroke.getWidth()) {}
+
+BaseStrokeToolView::~BaseStrokeToolView() noexcept = default;
+
+auto BaseStrokeToolView::createMask(cairo_t* tgtcr) const -> Mask {
+    const double zoom = this->parent->getZoom();
+    const int dpiScaling = this->parent->getDPIScaling();
+    Range visibleRange = this->parent->getVisiblePart();
+
+    // Add a small padding, to avoid visual artefacts if scrolling right after finishing a stroke touching the visible
+    // area's border
+    visibleRange.addPadding(0.5 * this->strokeWidth);
+
+    Mask mask(cairo_get_target(tgtcr), visibleRange, zoom, dpiScaling);
+    cairo_t* cr = mask.get();
+
+    cairo_set_source_rgba(cr, 1, 1, 1, 1);
+    cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
+    cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+    cairo_set_line_join(cr, CAIRO_LINE_JOIN_ROUND);
+    return mask;
+}

--- a/src/core/view/overlays/BaseStrokeToolView.cpp
+++ b/src/core/view/overlays/BaseStrokeToolView.cpp
@@ -22,8 +22,8 @@ static Color strokeColorWithAlpha(const Stroke& s) {
     return c;
 }
 
-BaseStrokeToolView::BaseStrokeToolView(const Repaintable* parent, const Stroke& stroke):
-        OverlayView(parent),
+BaseStrokeToolView::BaseStrokeToolView(Repaintable* parent, const Stroke& stroke):
+        ToolView(parent),
         cairoOp(stroke.getToolType() == STROKE_TOOL_HIGHLIGHTER ? CAIRO_OPERATOR_MULTIPLY : CAIRO_OPERATOR_OVER),
         strokeColor(strokeColorWithAlpha(stroke)),
         lineStyle(stroke.getLineStyle()),

--- a/src/core/view/overlays/BaseStrokeToolView.h
+++ b/src/core/view/overlays/BaseStrokeToolView.h
@@ -23,9 +23,9 @@ namespace xoj::view {
 class Mask;
 class Repaintable;
 
-class BaseStrokeToolView: public OverlayView {
+class BaseStrokeToolView: public ToolView {
 protected:
-    BaseStrokeToolView(const Repaintable* parent, const Stroke& stroke);
+    BaseStrokeToolView(Repaintable* parent, const Stroke& stroke);
     ~BaseStrokeToolView() noexcept override;
 
     /**

--- a/src/core/view/overlays/BaseStrokeToolView.h
+++ b/src/core/view/overlays/BaseStrokeToolView.h
@@ -1,0 +1,46 @@
+/*
+ * Xournal++
+ *
+ * Virtual class for showing overlays (e.g. active tools, selections and so on)
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+#include <cairo.h>
+
+#include "model/LineStyle.h"
+#include "util/Color.h"
+#include "view/overlays/OverlayView.h"
+
+class Stroke;
+
+namespace xoj::view {
+class Mask;
+class Repaintable;
+
+class BaseStrokeToolView: public OverlayView {
+protected:
+    BaseStrokeToolView(const Repaintable* parent, const Stroke& stroke);
+    ~BaseStrokeToolView() noexcept override;
+
+    /**
+     * @brief Creates a mask corresponding to the parent's visible area.
+     * The mask is optimized (?) to be blitted to a surface of the same type as cairo_get_target(targetCr).
+     * If targetCr == nullptr, the surface is of CAIRO_SURFACE_TYPE_IMAGE.
+     */
+    Mask createMask(cairo_t* targetCr) const;
+
+    /**
+     * @brief All that's required to draw a stroke in cairo
+     */
+    cairo_operator_t cairoOp;
+    Color strokeColor;
+    LineStyle lineStyle;
+    double strokeWidth;
+};
+};  // namespace xoj::view

--- a/src/core/view/overlays/OverlayView.h
+++ b/src/core/view/overlays/OverlayView.h
@@ -1,0 +1,35 @@
+/*
+ * Xournal++
+ *
+ * Virtual class for showing overlays (e.g. active tools, selections and so on)
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+#include <cairo.h>
+
+class OverlayBase;
+
+namespace xoj::view {
+class Repaintable;
+class OverlayView {
+public:
+    OverlayView(const Repaintable* parent): parent(parent) {}
+    virtual ~OverlayView() = default;
+
+    /**
+     * @brief Draws the overlay to the given context
+     */
+    virtual void draw(cairo_t* cr) const = 0;
+
+    virtual bool isViewOf(const OverlayBase* overlay) const = 0;
+
+protected:
+    const Repaintable* parent;
+};
+};  // namespace xoj::view

--- a/src/core/view/overlays/OverlayView.h
+++ b/src/core/view/overlays/OverlayView.h
@@ -19,7 +19,7 @@ namespace xoj::view {
 class Repaintable;
 class OverlayView {
 public:
-    OverlayView(const Repaintable* parent): parent(parent) {}
+    OverlayView(Repaintable* parent): parent(parent) {}
     virtual ~OverlayView() = default;
 
     /**
@@ -30,6 +30,16 @@ public:
     virtual bool isViewOf(const OverlayBase* overlay) const = 0;
 
 protected:
-    const Repaintable* parent;
+    Repaintable* parent;
+};
+
+class ToolView: public OverlayView {
+public:
+    ToolView(Repaintable* parent): OverlayView(parent) {}
+
+    /**
+     * @brief Draws without putative drawing aids (e.g. spline knots and tangents, text frame)
+     */
+    virtual void drawWithoutDrawingAids(cairo_t* cr) const { this->draw(cr); }
 };
 };  // namespace xoj::view

--- a/src/core/view/overlays/ShapeToolView.cpp
+++ b/src/core/view/overlays/ShapeToolView.cpp
@@ -17,7 +17,7 @@ ShapeToolView::ShapeToolView(const BaseShapeHandler* toolHandler, const Repainta
 ShapeToolView::~ShapeToolView() noexcept { this->unregisterFromPool(); }
 
 void ShapeToolView::draw(cairo_t* cr) const {
-    auto pts = this->toolHandler->getShapeClone();
+    const auto& pts = this->toolHandler->getShape();
 
     if (pts.empty()) {
         // The input sequence has been cancelled. This view should soon be deleted

--- a/src/core/view/overlays/ShapeToolView.cpp
+++ b/src/core/view/overlays/ShapeToolView.cpp
@@ -1,0 +1,38 @@
+#include "ShapeToolView.h"
+
+#include <vector>
+
+#include "control/tools/BaseShapeHandler.h"
+#include "util/raii/CairoWrappers.h"
+#include "view/Repaintable.h"
+#include "view/StrokeViewHelper.h"
+
+using namespace xoj::view;
+
+ShapeToolView::ShapeToolView(const BaseShapeHandler* toolHandler, const Repaintable* parent):
+        BaseShapeOrSplineToolView(toolHandler, parent), toolHandler(toolHandler) {
+    this->registerToPool(toolHandler->getViewPool());
+}
+
+ShapeToolView::~ShapeToolView() noexcept { this->unregisterFromPool(); }
+
+void ShapeToolView::draw(cairo_t* cr) const {
+    auto pts = this->toolHandler->getShapeClone();
+
+    if (pts.empty()) {
+        // The input sequence has been cancelled. This view should soon be deleted
+        return;
+    }
+
+    xoj::util::CairoSaveGuard saveGuard(cr);  // cairo_save
+
+    cairo_t* effCr = this->prepareContext(cr);
+
+    StrokeViewHelper::pathToCairo(effCr, pts);
+
+    this->commitDrawing(cr);
+}
+
+bool ShapeToolView::isViewOf(const OverlayBase* overlay) const { return overlay == this->toolHandler; }
+
+void ShapeToolView::on(ShapeToolView::FlagDirtyRegionRequest, const Range& rg) { this->parent->flagDirtyRegion(rg); }

--- a/src/core/view/overlays/ShapeToolView.cpp
+++ b/src/core/view/overlays/ShapeToolView.cpp
@@ -9,7 +9,7 @@
 
 using namespace xoj::view;
 
-ShapeToolView::ShapeToolView(const BaseShapeHandler* toolHandler, const Repaintable* parent):
+ShapeToolView::ShapeToolView(const BaseShapeHandler* toolHandler, Repaintable* parent):
         BaseShapeOrSplineToolView(toolHandler, parent), toolHandler(toolHandler) {
     this->registerToPool(toolHandler->getViewPool());
 }
@@ -36,3 +36,7 @@ void ShapeToolView::draw(cairo_t* cr) const {
 bool ShapeToolView::isViewOf(const OverlayBase* overlay) const { return overlay == this->toolHandler; }
 
 void ShapeToolView::on(ShapeToolView::FlagDirtyRegionRequest, const Range& rg) { this->parent->flagDirtyRegion(rg); }
+
+void ShapeToolView::deleteOn(ShapeToolView::FinalizationRequest, const Range& rg) {
+    this->parent->drawAndDeleteToolView(this, rg);
+}

--- a/src/core/view/overlays/ShapeToolView.h
+++ b/src/core/view/overlays/ShapeToolView.h
@@ -1,0 +1,49 @@
+/*
+ * Xournal++
+ *
+ * View active shape tools (rectangle, ellipse and so on)
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+#pragma once
+
+#include <cairo.h>  // for cairo_t
+
+#include "util/DispatchPool.h"  // for Listener
+
+#include "BaseShapeOrSplineToolView.h"
+
+class BaseShapeHandler;
+class OverlayBase;
+class Range;
+
+namespace xoj::view {
+class Repaintable;
+
+class ShapeToolView final: public BaseShapeOrSplineToolView, public xoj::util::Listener<ShapeToolView> {
+
+public:
+    ShapeToolView(const BaseShapeHandler* handler, const Repaintable* parent);
+    ~ShapeToolView() noexcept override;
+
+    /**
+     * @brief Draws the overlay to the given context
+     */
+    void draw(cairo_t* cr) const override;
+
+    bool isViewOf(const OverlayBase* overlay) const override;
+
+    /**
+     * Listener interface
+     */
+    static constexpr struct FlagDirtyRegionRequest {
+    } FLAG_DIRTY_REGION = {};
+    void on(FlagDirtyRegionRequest, const Range& rg);
+
+private:
+    const BaseShapeHandler* toolHandler;
+};
+};  // namespace xoj::view

--- a/src/core/view/overlays/ShapeToolView.h
+++ b/src/core/view/overlays/ShapeToolView.h
@@ -26,7 +26,7 @@ class Repaintable;
 class ShapeToolView final: public BaseShapeOrSplineToolView, public xoj::util::Listener<ShapeToolView> {
 
 public:
-    ShapeToolView(const BaseShapeHandler* handler, const Repaintable* parent);
+    ShapeToolView(const BaseShapeHandler* handler, Repaintable* parent);
     ~ShapeToolView() noexcept override;
 
     /**
@@ -42,6 +42,15 @@ public:
     static constexpr struct FlagDirtyRegionRequest {
     } FLAG_DIRTY_REGION = {};
     void on(FlagDirtyRegionRequest, const Range& rg);
+
+
+    static constexpr struct FinalizationRequest {
+    } FINALIZATION_REQUEST = {};
+    /**
+     * @brief Called before the corresponding BaseShapeHandler's destruction
+     * @param rg The bounding box of the entire stroke
+     */
+    void deleteOn(FinalizationRequest, const Range& rg);
 
 private:
     const BaseShapeHandler* toolHandler;

--- a/src/util/Color.cpp
+++ b/src/util/Color.cpp
@@ -23,8 +23,7 @@ auto Util::rgb_to_hex_string(Color rgb) -> std::string {
     char resultHex[7];
 
     // 06: Pad with zeroes to a length of 6.
-    int status = std::snprintf(resultHex, 7, "%06x", uint32_t(rgb));
-    assert(status > 0);
+    assert(std::snprintf(resultHex, 7, "%06x", uint32_t(rgb)) > 0);
 
     std::stringstream result;
     result << "#" << resultHex;

--- a/src/util/Range.cpp
+++ b/src/util/Range.cpp
@@ -2,32 +2,46 @@
 
 #include <algorithm>  // for max, min
 
-Range::Range(double x, double y) {
-    this->x1 = x;
-    this->x2 = x;
+#include "util/Rectangle.h"
 
-    this->y1 = y;
-    this->y2 = y;
-}
 
-Range::~Range() = default;
+Range::Range(const xoj::util::Rectangle<double>& r): minX(r.x), minY(r.y), maxX(r.x + r.width), maxY(r.y + r.height) {}
 
 void Range::addPoint(double x, double y) {
-    this->x1 = std::min(this->x1, x);
-    this->x2 = std::max(this->x2, x);
+    this->minX = std::min(this->minX, x);
+    this->maxX = std::max(this->maxX, x);
 
-    this->y1 = std::min(this->y1, y);
-    this->y2 = std::max(this->y2, y);
+    this->minY = std::min(this->minY, y);
+    this->maxY = std::max(this->maxY, y);
 }
 
-auto Range::getX() const -> double { return this->x1; }
+Range Range::unite(const Range& o) const {
+    return Range(std::min(minX, o.minX), std::min(minY, o.minY), std::max(maxX, o.maxX), std::max(maxY, o.maxY));
+}
 
-auto Range::getY() const -> double { return this->y1; }
+Range Range::intersect(const Range& o) const {
+    Range rg(std::max(minX, o.minX), std::max(minY, o.minY), std::min(maxX, o.maxX), std::min(maxY, o.maxY));
+    return rg.isValid() ? rg : Range();
+}
 
-auto Range::getWidth() const -> double { return this->x2 - this->x1; }
+auto Range::getX() const -> double { return this->minX; }
 
-auto Range::getHeight() const -> double { return this->y2 - this->y1; }
+auto Range::getY() const -> double { return this->minY; }
 
-auto Range::getX2() const -> double { return this->x2; }
+auto Range::getWidth() const -> double { return this->maxX - this->minX; }
 
-auto Range::getY2() const -> double { return this->y2; }
+auto Range::getHeight() const -> double { return this->maxY - this->minY; }
+
+void Range::addPadding(double padding) {
+    this->minX -= padding;
+    this->maxX += padding;
+    this->minY -= padding;
+    this->maxY += padding;
+}
+
+auto Range::empty() const -> bool {
+    Range empty;
+    return this->minX == empty.minX && this->minY == empty.minY && this->maxX == empty.maxX && this->maxY == empty.maxY;
+}
+
+bool Range::isValid() const { return minX <= maxX && minY <= maxY; }

--- a/src/util/Util.cpp
+++ b/src/util/Util.cpp
@@ -42,13 +42,13 @@ void Util::execInUiThread(std::function<void()>&& callback, gint priority) {
                               new CallbackUiData(std::move(callback)), nullptr);
 }
 
-void Util::cairo_set_source_rgbi(cairo_t* cr, Color color) {
-    auto rgba = rgb_to_GdkRGBA(color);
+void Util::cairo_set_source_rgbi(cairo_t* cr, Color color, double alpha) {
+    auto rgba = argb_to_GdkRGBA(color, alpha);
     gdk_cairo_set_source_rgba(cr, &rgba);
 }
 
-void Util::cairo_set_source_rgbi(cairo_t* cr, Color color, double alpha) {
-    auto rgba = argb_to_GdkRGBA(color, alpha);
+void Util::cairo_set_source_argb(cairo_t* cr, Color color) {
+    auto rgba = argb_to_GdkRGBA(color);
     gdk_cairo_set_source_rgba(cr, &rgba);
 }
 

--- a/src/util/include/util/Color.h
+++ b/src/util/include/util/Color.h
@@ -104,9 +104,11 @@ constexpr auto ColorU16_to_argb(const ColorU16& color) -> Color;
 constexpr auto argb_to_ColorU16(const Color& color) -> ColorU16;
 constexpr auto GdkRGBA_to_ColorU16(const GdkRGBA& color) -> ColorU16;
 
+/// Set the color of a cairo context -- uses alpha as alpha value
+void cairo_set_source_rgbi(cairo_t* cr, Color color, double alpha = 1.0);
 
-void cairo_set_source_rgbi(cairo_t* cr, Color color);
-void cairo_set_source_rgbi(cairo_t* cr, Color color, double alpha);
+/// Set the color of a cairo context -- uses color.alpha as alpha value
+void cairo_set_source_argb(cairo_t* cr, Color color);  // Use color.alpha
 
 constexpr auto floatToUIntColor(double color) -> uint8_t;
 

--- a/src/util/include/util/DispatchPool.h
+++ b/src/util/include/util/DispatchPool.h
@@ -1,0 +1,118 @@
+/*
+ * Xournal++
+ *
+ * Template class for a dispatch pool and listeners
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cassert>
+#include <memory>
+#include <vector>
+
+namespace xoj::util {
+
+/**
+ * @brief Utility class for dispatching a method call to multiple "listeners".
+ *
+ * The listeners must implement functions
+ *      void on(Arg&&...);
+ * that the dispatcher will call through dispatch().
+ */
+template <class ListenerT>
+class DispatchPool final {
+public:
+    using listener_type = ListenerT;
+
+    /**
+     * @brief Invokes the `on()` method of all registered `ListenerT`s.
+     */
+    template <typename... Args>
+    void dispatch(Args&&... args) const {
+        for (auto* v: this->pool) {
+            v->on(std::forward<Args>(args)...);
+        }
+    }
+
+    /**
+     * @brief Adds a new listener to the pool.
+     * The listener must not already be registered.
+     */
+    void add(listener_type* v) {
+        assert(v != nullptr && "Adding nullptr listener");
+        assert(std::find(this->pool.begin(), this->pool.end(), v) == this->pool.end() && "Listener is already listed");
+        this->pool.emplace_back(v);
+    }
+
+    void remove(listener_type* v) {
+        assert(v != nullptr && "Removing nullptr listener");
+        auto it = std::find(this->pool.begin(), this->pool.end(), v);
+        if (it != this->pool.end()) {
+            this->pool.erase(it);
+        }
+    }
+
+    [[nodiscard]] bool empty() const { return pool.empty(); }
+
+private:
+    std::vector<listener_type*> pool;
+};
+
+/**
+ * @brief CRTP-style class for listener
+ * Usage:
+ *  class A: Listener<A> {
+ *      (virtual) ~A() { unregisterFromPool(); }
+ *      void on(...);  // Signal receiver
+ *  };
+ *
+ * WARNING: Always unregisterFromPool() in derived class destructor.
+ *
+ * For listening to several type of dispatchers do:
+ *     class A : public Listener<A> {...};  // virtual void on(...); in here
+ *     class B : public Listener<B> {...};  // virtual void on(...); in here - types must differ from the ones in A
+ *     class C : public A, public B {...};  // overload everything here
+ */
+template <class T>
+class Listener {
+private:
+    // Keep the constructor private: only T can inherit Listener<T> (for the static_cast<T*>(this) below).
+    Listener() = default;
+    friend T;
+
+    using pool_type = xoj::util::DispatchPool<T>;
+
+public:
+    /**
+     * @brief Register to a new dispatch pool. Unregisters from any pool the listener was previously registered to.
+     */
+    void registerToPool(const std::shared_ptr<pool_type>& newpool) {
+        if (auto p = this->pool.lock()) {
+            p->remove(static_cast<T*>(this));
+        }
+        newpool->add(static_cast<T*>(this));
+        this->pool = newpool;
+    }
+
+    /**
+     * @brief Unregisters from the current pool (if any).
+     */
+    void unregisterFromPool() {
+        if (auto p = this->pool.lock()) {
+            p->remove(static_cast<T*>(this));
+        }
+        this->pool.reset();
+    }
+
+    [[nodiscard]] auto getPool() const -> std::shared_ptr<pool_type> { return this->pool.lock(); }
+
+private:
+    std::weak_ptr<pool_type> pool;
+};
+};  // namespace xoj::util

--- a/src/util/include/util/Range.h
+++ b/src/util/include/util/Range.h
@@ -11,25 +11,37 @@
 
 #pragma once
 
+#include <limits>
 
-class Range {
+namespace xoj::util {
+template <typename Float>
+class Rectangle;
+};
+
+class Range final {
 public:
-    Range(double x, double y);
-    virtual ~Range();
+    Range() = default;  // Empty range
+    Range(double x, double y): minX(x), minY(y), maxX(x), maxY(y) {}
+    Range(double minX, double minY, double maxX, double maxY): minX(minX), minY(minY), maxX(maxX), maxY(maxY) {}
+    explicit Range(const xoj::util::Rectangle<double>& r);
 
     void addPoint(double x, double y);
 
-    double getX() const;
-    double getY() const;
-    double getWidth() const;
-    double getHeight() const;
+    [[nodiscard]] Range unite(const Range& other) const;
+    [[nodiscard]] Range intersect(const Range& other) const;
 
-    double getX2() const;
-    double getY2() const;
+    [[nodiscard]] double getX() const;
+    [[nodiscard]] double getY() const;
+    [[nodiscard]] double getWidth() const;
+    [[nodiscard]] double getHeight() const;
 
-private:
-    double x1;
-    double y1;
-    double y2;
-    double x2;
+    void addPadding(double padding);
+
+    [[nodiscard]] bool empty() const;
+    [[nodiscard]] bool isValid() const;
+
+    double minX = std::numeric_limits<double>::max();
+    double minY = std::numeric_limits<double>::max();
+    double maxX = std::numeric_limits<double>::lowest();
+    double maxY = std::numeric_limits<double>::lowest();
 };

--- a/test/unit_tests/model/ErasableStrokeTest.cpp
+++ b/test/unit_tests/model/ErasableStrokeTest.cpp
@@ -13,10 +13,10 @@
 using xoj::util::Rectangle;
 
 void assertRangesEq(const Range& r1, const Range& r2) {
-    ASSERT_EQ(r1.getX(), r2.getX());
-    ASSERT_EQ(r1.getY(), r2.getY());
-    ASSERT_EQ(r1.getX2(), r2.getX2());
-    ASSERT_EQ(r1.getY2(), r2.getY2());
+    ASSERT_EQ(r1.minX, r2.minX);
+    ASSERT_EQ(r1.minY, r2.minY);
+    ASSERT_EQ(r1.maxX, r2.maxX);
+    ASSERT_EQ(r1.maxY, r2.maxY);
 }
 
 TEST(ErasableStroke, testOverlapTree) {
@@ -66,7 +66,7 @@ TEST(ErasableStroke, testOverlapTree) {
     // clang format on
 
     auto singlePointRangeAtCenter = [](Range range) {
-        return Range(0.5 * (range.getX() + range.getX2()), 0.5 * (range.getY() + range.getY2()));
+        return Range(0.5 * (range.minX + range.maxX), 0.5 * (range.minY + range.maxY));
     };
 
     for (size_t i = 0; i < 2; i++) {

--- a/test/unit_tests/util/RangeTest.cpp
+++ b/test/unit_tests/util/RangeTest.cpp
@@ -1,0 +1,62 @@
+#include <array>
+
+#include <gtest/gtest.h>
+
+#include "util/Range.h"
+
+namespace {
+struct TestData {
+    TestData(const Range& rg, bool isEmpty, bool isValid): rg(rg), isEmpty(isEmpty), isValid(isValid) {}
+    Range rg;
+    bool isEmpty;
+    bool isValid;
+};
+
+std::array<TestData, 5> testData = {
+        //
+        TestData(Range(), true, false),                      //
+        TestData(Range(1.0, 0.0), false, true),              //
+        TestData(Range(0.0, 0.0, 1.0, 1.0), false, true),    //
+        TestData(Range(0.0, 0.0, -1.0, 1.0), false, false),  //
+        TestData(Range(0.0, 0.0, 1.0, 0.0), false, true)     //
+};
+
+bool equal(const Range& r1, const Range& r2) {
+    return r1.minX == r2.minX && r1.minY == r2.minY && r1.maxX == r2.maxX && r1.maxY == r2.maxY;
+}
+};  // namespace
+
+TEST(UtilRange, testEmptyValid) {
+    for (auto& d: testData) {
+        EXPECT_EQ(d.rg.empty(), d.isEmpty);
+        EXPECT_EQ(d.rg.isValid(), d.isValid);
+    }
+}
+
+TEST(UtilRange, testUnite) {
+    Range emptyRange;
+    for (auto& d: testData) {
+        EXPECT_TRUE(equal(d.rg.unite(emptyRange), d.rg));
+    }
+
+    // intersecting ranges
+    EXPECT_TRUE(equal(Range(0.0, -1.0, 1.0, 2.0).unite(Range(0.5, 1.0, 0.6, 3.0)), Range(0.0, -1.0, 1.0, 3.0)));
+    // subrange
+    EXPECT_TRUE(equal(Range(0.0, -1.0, 1.0, 2.0).unite(Range(0.5, 1.0, 0.6, 1.5)), Range(0.0, -1.0, 1.0, 2.0)));
+    // disjoint ranges
+    EXPECT_TRUE(equal(Range(0.0, -1.0, 1.0, 2.0).unite(Range(1.5, 3.0, 2.0, 4.0)), Range(0.0, -1.0, 2.0, 4.0)));
+}
+
+TEST(UtilRange, testIntersect) {
+    Range emptyRange;
+    for (auto& d: testData) {
+        EXPECT_TRUE(d.rg.intersect(emptyRange).empty());
+    }
+
+    // intersecting ranges
+    EXPECT_TRUE(equal(Range(0.0, -1.0, 1.0, 2.0).intersect(Range(0.5, 1.0, 0.6, 3.0)), Range(0.5, 1.0, 0.6, 2.0)));
+    // subrange
+    EXPECT_TRUE(equal(Range(0.0, -1.0, 1.0, 2.0).intersect(Range(0.5, 1.0, 0.6, 1.5)), Range(0.5, 1.0, 0.6, 1.5)));
+    // disjoint ranges
+    EXPECT_TRUE(Range(0.0, -1.0, 1.0, 2.0).intersect(Range(1.5, 3.0, 2.0, 4.0)).empty());
+}


### PR DESCRIPTION
This PR is a proposed first step towards splitting gui/PageView into a view and a controller.
Before this split could be possible, we need to split every tool handler: gui/PageView owns tool handlers which will need to be split into a view, owned by a future view/PageView, and a handler, owned by a future control/PageController.

In this PR, we split the derived classes of BaseStrokeHandler (i.e. the handlers for all geometric shapes -- Rectangle, ellipse, arrow and so on -- but not StrokeHandler). A lot of planning has gone into this PR. I'll try my best to describe the plan, stop me if you object to any parts of it.

- The gui/PageView has a pool of `OverlayView`'s, which should, in time, contain what I call overlays: everything that needs to be painted but is not actually in the page model (e.g. current tools, selections, search results highlighting). For now, this pool contains at most 1 element, corresponding, if there is one, to the active BaseStrokeHandler.
- In order to be able, in a distant future, to have several views of the current document (e.g. to implement #1638 or #2020), each BaseStrokeHandler now has a pool of views, and dispatches repaint requests to the entire pool. Similar things should be implemented for other tools (and other overlays) in the future.
- The OverlayView's inherit from a base class Repaintable, which should, in due time, take over gui/Redrawable. ~~The class Repaintable includes a possible change of coordinates, so that repaint request are always expressed in local coordinates, and transfered up to a parent Repaintable after changing from child coordinates to parent coordinates (think of selections, pages in a layout, or maybe one day, subpages #3684).~~ Edit: This was removed in an iteration of the PR.
- Once this strategy is applied to all other tool handlers (at least StrokeHandler, SplineHandler, SetsquareHandler, Selection, EditSelection, PdfElemSelection, VerticalToolHandler, SearchControl), then we can actually split gui/PageView into a view and a controller. The view view/PageView would inherit from Repaintable, and control/PageController would have a pool of view/PageView's to send repaint/rerender/change requests to.

More specific implementation comments:
- To accomodate the various dispatch needs, a very generic DispatchPool class is implemented. (I'd love feedback on the implementation here)
- ~~The data of the BaseStrokeHandler's is also now protected by a mutex, to address #3579, at least for those tools.~~
    **Edit:** this is actually not necessary, see #3579.
- The class BaseStrokeHandler is renamed to BaseShapeHandler in order to fix its confusing name.