### PR TITLE
Make version text selectable and print commit number

### DIFF
--- a/src/core/control/XournalMain.cpp
+++ b/src/core/control/XournalMain.cpp
@@ -531,7 +531,11 @@ auto on_handle_local_options(GApplication*, GVariantDict*, XMPtr app_data) -> gi
     initCAndCoutLocales();
 
     auto print_version = [&] {
-        std::cout << PROJECT_NAME << " " << PROJECT_VERSION << std::endl;
+        if(!std::string(GIT_COMMIT_ID).empty()){
+            std::cout << PROJECT_NAME << " " << PROJECT_VERSION << " (" << GIT_COMMIT_ID << ")" << std::endl;
+        } else{
+            std::cout << PROJECT_NAME << " " << PROJECT_VERSION << std::endl;
+        }
         std::cout << "└──libgtk: " << gtk_get_major_version() << "."  //
                   << gtk_get_minor_version() << "."                   //
                   << gtk_get_micro_version() << std::endl;            //

--- a/ui/about.glade
+++ b/ui/about.glade
@@ -85,6 +85,7 @@
                     <property name="can-focus">False</property>
                     <property name="halign">start</property>
                     <property name="label">X.X.X</property>
+                    <property name="selectable">True</property>
                   </object>
                   <packing>
                     <property name="left-attach">1</property>
@@ -127,6 +128,7 @@
                     <property name="can-focus">False</property>
                     <property name="halign">start</property>
                     <property name="label" translatable="yes">RELEASE_IDENTIFIER</property>
+                    <property name="selectable">True</property>
                   </object>
                   <packing>
                     <property name="left-attach">1</property>
@@ -154,6 +156,7 @@
                     <property name="can-focus">False</property>
                     <property name="halign">start</property>
                     <property name="label" translatable="yes">X.X.X</property>
+                    <property name="selectable">True</property>
                   </object>
                   <packing>
                     <property name="left-attach">1</property>


### PR DESCRIPTION
Fix #4113 

* change Xournalpp version, git commit id and GTK version in about window as selectable text

* print commit number along with version number as command output for `xournalpp --version`