### PR TITLE
Split tools/StrokeHandler into View-Controller

### DIFF
--- a/src/core/control/tools/BaseShapeHandler.cpp
+++ b/src/core/control/tools/BaseShapeHandler.cpp
@@ -206,6 +206,10 @@ void BaseShapeHandler::modifyModifiersByDrawDir(double width, double height, dou
 
 auto BaseShapeHandler::getShape() const -> const std::vector<Point>& { return this->shape; }
 
+auto BaseShapeHandler::createView(xoj::view::Repaintable* parent) const -> std::unique_ptr<xoj::view::OverlayView> {
+    return std::make_unique<xoj::view::ShapeToolView>(this, parent);
+}
+
 auto BaseShapeHandler::getViewPool() const
         -> const std::shared_ptr<xoj::util::DispatchPool<xoj::view::ShapeToolView>>& {
     return viewPool;

--- a/src/core/control/tools/BaseShapeHandler.h
+++ b/src/core/control/tools/BaseShapeHandler.h
@@ -34,6 +34,8 @@ class DispatchPool;
 }
 
 namespace xoj::view {
+class OverlayView;
+class Repaintable;
 class ShapeToolView;
 };
 
@@ -55,6 +57,8 @@ public:
     void onButtonPressEvent(const PositionInputData& pos, double zoom) override;
     void onButtonDoublePressEvent(const PositionInputData& pos, double zoom) override;
     bool onKeyEvent(GdkEventKey* event) override;
+
+    std::unique_ptr<xoj::view::OverlayView> createView(xoj::view::Repaintable* parent) const override;
 
     const std::shared_ptr<xoj::util::DispatchPool<xoj::view::ShapeToolView>>& getViewPool() const;
 

--- a/src/core/control/tools/InputHandler.h
+++ b/src/core/control/tools/InputHandler.h
@@ -24,6 +24,11 @@ class Point;
 class Stroke;
 class PositionInputData;
 
+namespace xoj::view {
+class OverlayView;
+class Repaintable;
+};  // namespace xoj::view
+
 /**
  * @brief A base class to handle pointer input
  *
@@ -88,6 +93,8 @@ public:
      * to zoom on a touchscreen device.
      */
     virtual void onSequenceCancelEvent() = 0;
+
+    virtual std::unique_ptr<xoj::view::OverlayView> createView(xoj::view::Repaintable* parent) const = 0;
 
     Stroke* getStroke() const;
 

--- a/src/core/control/tools/SplineHandler.h
+++ b/src/core/control/tools/SplineHandler.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <memory>    // for unique_ptr
 #include <optional>  // for optional
 #include <vector>    // for vector
 
@@ -22,6 +23,7 @@
 #include "model/Point.h"     // for Point
 #include "util/Rectangle.h"  // for Rectangle
 #include "view/StrokeView.h"
+#include "view/overlays/OverlayView.h"
 
 #include "InputHandler.h"            // for InputHandler
 #include "SnapToGridInputHandler.h"  // for SnapToGridInputHandler
@@ -29,6 +31,11 @@
 class PositionInputData;
 class LegacyRedrawable;
 class XournalView;
+
+namespace xoj::view {
+class OverlayView;
+class Repaintable;
+}  // namespace xoj::view
 
 /**
  * @brief A class to handle splines
@@ -50,6 +57,10 @@ public:
     ~SplineHandler() override;
 
     void draw(cairo_t* cr) override;
+
+    std::unique_ptr<xoj::view::OverlayView> createView(xoj::view::Repaintable* parent) const override {
+        return nullptr;
+    }
 
     void onSequenceCancelEvent() override;
     bool onMotionNotifyEvent(const PositionInputData& pos, double zoom) override;

--- a/src/core/control/tools/StrokeHandler.cpp
+++ b/src/core/control/tools/StrokeHandler.cpp
@@ -19,10 +19,6 @@
 #include "control/shaperecognizer/ShapeRecognizer.h"  // for ShapeRecognizer
 #include "control/tools/InputHandler.h"               // for InputHandler::P...
 #include "control/tools/SnapToGridInputHandler.h"     // for SnapToGridInput...
-#include "control/zoom/ZoomControl.h"
-#include "gui/MainWindow.h"
-#include "gui/PageView.h"                        // for XojPageView
-#include "gui/XournalView.h"                     // for XournalView
 #include "gui/inputdevices/PositionInputData.h"  // for PositionInputData
 #include "model/Document.h"                      // for Document
 #include "model/Layer.h"                         // for Layer
@@ -32,11 +28,12 @@
 #include "undo/InsertUndoAction.h"               // for InsertUndoAction
 #include "undo/RecognizerUndoAction.h"           // for RecognizerUndoA...
 #include "undo/UndoRedoHandler.h"                // for UndoRedoHandler
-#include "util/Color.h"                          // for cairo_set_sourc...
+#include "util/DispatchPool.h"                   // for DispatchPool
 #include "util/Range.h"                          // for Range
 #include "util/Rectangle.h"                      // for Rectangle, util
-#include "view/StrokeView.h"                     // for StrokeView, Str...
-#include "view/View.h"                           // for Context
+#include "view/overlays/StrokeToolFilledHighlighterView.h"  // for StrokeToolFilledHighlighterView
+#include "view/overlays/StrokeToolFilledView.h"             // for StrokeToolFilledView
+#include "view/overlays/StrokeToolView.h"                   // for StrokeToolView
 
 #include "StrokeStabilizer.h"  // for Base, get
 
@@ -44,47 +41,15 @@ using namespace xoj::util;
 
 guint32 StrokeHandler::lastStrokeTime;  // persist for next stroke
 
-StrokeHandler::StrokeHandler(Control* control, XojPageView* pageView, const PageRef& page):
+StrokeHandler::StrokeHandler(Control* control, const PageRef& page):
         InputHandler(control, page),
         snappingHandler(control->getSettings()),
         stabilizer(StrokeStabilizer::get(control->getSettings())),
-        pageView(pageView) {}
+        viewPool(std::make_shared<xoj::util::DispatchPool<xoj::view::StrokeToolView>>()) {}
 
-void StrokeHandler::draw(cairo_t* cr) {
-    assert(stroke && stroke->getPointCount() > 0);
-
-    auto setColorAndBlendMode = [stroke = this->stroke.get(), cr]() {
-        if (stroke->getToolType() == StrokeTool::HIGHLIGHTER) {
-            if (auto fill = stroke->getFill(); fill != -1) {
-                Util::cairo_set_source_rgbi(cr, stroke->getColor(), static_cast<double>(fill) / 255.0);
-            } else {
-                Util::cairo_set_source_rgbi(cr, stroke->getColor(), xoj::view::StrokeView::OPACITY_HIGHLIGHTER);
-            }
-            cairo_set_operator(cr, CAIRO_OPERATOR_MULTIPLY);
-        } else {
-            Util::cairo_set_source_rgbi(cr, stroke->getColor());
-            cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
-        }
-    };
-
-    if (this->mask) {
-        setColorAndBlendMode();
-        cairo_mask_surface(cr, mask->surf, 0, 0);
-    } else {
-        if (this->stroke->getPointCount() == 1) {
-            // drawStroke does not handle single dots
-            const Point& pt = this->stroke->getPoint(0);
-            double width = this->stroke->getWidth() * (this->hasPressure ? pt.z : 1.0);
-            setColorAndBlendMode();
-            this->paintDot(cr, pt.x, pt.y, width);
-        } else {
-            strokeView->draw(xoj::view::Context::createDefault(cr));
-        }
-    }
-}
+StrokeHandler::~StrokeHandler() = default;
 
 auto StrokeHandler::onKeyEvent(GdkEventKey* event) -> bool { return false; }
-
 
 auto StrokeHandler::onMotionNotifyEvent(const PositionInputData& pos, double zoom) -> bool {
     if (!stroke) {
@@ -103,9 +68,12 @@ auto StrokeHandler::onMotionNotifyEvent(const PositionInputData& pos, double zoo
     return true;
 }
 
-void StrokeHandler::paintTo(const Point& point) {
+void StrokeHandler::paintTo(Point point) {
+    if (this->hasPressure && point.z > 0.0) {
+        point.z *= this->stroke->getWidth();
+    }
 
-    int pointCount = stroke->getPointCount();
+    auto pointCount = stroke->getPointCount();
 
     if (pointCount > 0) {
         Point endPoint = stroke->getPoint(pointCount - 1);
@@ -113,16 +81,8 @@ void StrokeHandler::paintTo(const Point& point) {
         if (distance < PIXEL_MOTION_THRESHOLD) {  //(!validMotion(point, endPoint)) {
             if (pointCount == 1 && this->hasPressure && endPoint.z < point.z) {
                 // Record the possible increase in pressure for the first point
-                // Nb: at this point, neither point.z nor endPoint.z has been multiplied by this->stroke->getWidth()
                 this->stroke->setLastPressure(point.z);
-                this->firstPointPressureChange = true;
-
-                double width = this->stroke->getWidth() * point.z;
-                if (mask) {
-                    this->paintDot(mask->cr, endPoint.x, endPoint.y, width);
-                }
-                // Trigger a call to `draw`. If mask == nullopt, the `paintDot` is called in `draw`
-                this->pageView->repaintRect(endPoint.x - 0.5 * width, endPoint.y - 0.5 * width, width, width);
+                this->viewPool->dispatch(xoj::view::StrokeToolView::THICKEN_FIRST_POINT_REQUEST, point.z);
             }
             return;
         }
@@ -130,34 +90,25 @@ void StrokeHandler::paintTo(const Point& point) {
             /**
              * Both device and tool are pressure sensitive
              */
-            if (this->firstPointPressureChange) {
-                // Avoid shrinking if we recorded a higher pressure event at the beginning of the stroke
-                this->firstPointPressureChange = false;
-                stroke->setLastPressure(std::max(endPoint.z, point.z) * stroke->getWidth());
-            } else {
-                if (const double widthDelta = (point.z - endPoint.z) * stroke->getWidth();
-                    -widthDelta > MAX_WIDTH_VARIATION || widthDelta > MAX_WIDTH_VARIATION) {
-                    /**
-                     * If the width variation is to big, decompose into shorter segments.
-                     * Those segments can not be shorter than PIXEL_MOTION_THRESHOLD
-                     */
-                    double nbSteps = std::min(std::ceil(std::abs(widthDelta) / MAX_WIDTH_VARIATION),
-                                              std::floor(distance / PIXEL_MOTION_THRESHOLD));
-                    double stepLength = 1.0 / nbSteps;
-                    Point increment((point.x - endPoint.x) * stepLength, (point.y - endPoint.y) * stepLength,
-                                    widthDelta * stepLength);
-                    endPoint.z *= stroke->getWidth();
-                    endPoint.z += increment.z;
-                    stroke->setLastPressure(endPoint.z);
+            if (const double widthDelta = point.z - endPoint.z;
+                - widthDelta > MAX_WIDTH_VARIATION || widthDelta > MAX_WIDTH_VARIATION) {
+                /**
+                 * If the width variation is to big, decompose into shorter segments.
+                 * Those segments can not be shorter than PIXEL_MOTION_THRESHOLD
+                 */
+                double nbSteps = std::min(std::ceil(std::abs(widthDelta) / MAX_WIDTH_VARIATION),
+                                          std::floor(distance / PIXEL_MOTION_THRESHOLD));
+                double stepLength = 1.0 / nbSteps;
+                Point increment((point.x - endPoint.x) * stepLength, (point.y - endPoint.y) * stepLength,
+                                widthDelta * stepLength);
+                endPoint.z += increment.z;
 
-                    for (int i = 1; i < static_cast<int>(nbSteps); i++) {  // The last step is done below
-                        endPoint.x += increment.x;
-                        endPoint.y += increment.y;
-                        endPoint.z += increment.z;
-                        drawSegmentTo(endPoint);
-                    }
+                for (int i = 1; i < static_cast<int>(nbSteps); i++) {  // The last step is done below
+                    endPoint.x += increment.x;
+                    endPoint.y += increment.y;
+                    endPoint.z += increment.z;
+                    drawSegmentTo(endPoint);
                 }
-                stroke->setLastPressure(point.z * stroke->getWidth());
             }
         }
     }
@@ -166,43 +117,18 @@ void StrokeHandler::paintTo(const Point& point) {
 
 void StrokeHandler::drawSegmentTo(const Point& point) {
 
-    stroke->addPoint(this->hasPressure ? point : Point(point.x, point.y));
-
-    double width = stroke->getWidth();
-
-    assert(stroke->getPointCount() >= 2);
-    const Point& prevPoint(stroke->getPoint(stroke->getPointCount() - 2));
-
-    Range rg(prevPoint.x, prevPoint.y);
-    rg.addPoint(point.x, point.y);
-
-    if (stroke->getFill() != -1) {
-        /**
-         * Add the first point to the redraw range, so that the filling is painted.
-         * Note: the actual stroke painting will only happen in this->draw() which is called less often
-         */
-        const Point& firstPoint = stroke->getPointVector().front();
-        rg.addPoint(firstPoint.x, firstPoint.y);
-    } else if (mask) {
-        Stroke lastSegment;
-
-        lastSegment.addPoint(prevPoint);
-        lastSegment.addPoint(point);
-        lastSegment.setWidth(width);
-
-        auto context = xoj::view::Context::createColorBlind(mask->cr);
-        xoj::view::StrokeView sView(&lastSegment);
-        sView.draw(context);
-    }
-
-    width = prevPoint.z != Point::NO_PRESSURE ? prevPoint.z : width;
-
-    // Trigger a call to `draw`. If mask == nullopt, the stroke is drawn in `draw`
-    this->pageView->repaintRect(rg.getX() - 0.5 * width, rg.getY() - 0.5 * width, rg.getWidth() + width,
-                                rg.getHeight() + width);
+    this->stroke->addPoint(this->hasPressure ? point : Point(point.x, point.y));
+    this->viewPool->dispatch(xoj::view::StrokeToolView::ADD_POINT_REQUEST, this->stroke->getPointVector().back());
+    return;
 }
 
-void StrokeHandler::onSequenceCancelEvent() { stroke.reset(); }
+void StrokeHandler::onSequenceCancelEvent() {
+    if (this->stroke) {
+        this->viewPool->dispatchAndClear(xoj::view::StrokeToolView::CANCELLATION_REQUEST,
+                                         Range(this->stroke->boundingRect()));
+        stroke.reset();
+    }
+}
 
 void StrokeHandler::onButtonReleaseEvent(const PositionInputData& pos, double zoom) {
     if (!stroke) {
@@ -235,10 +161,10 @@ void StrokeHandler::onButtonReleaseEvent(const PositionInputData& pos, double zo
             if (pos.timestamp - StrokeHandler::lastStrokeTime > strokeFilterSuccessiveTime) {
                 // stroke not being added to layer... delete here but clear first!
 
-                this->pageView->rerenderRect(stroke->getX(), stroke->getY(), stroke->getElementWidth(),
-                                             stroke->getElementHeight());  // clear onMotionNotifyEvent drawing //!
-
+                this->viewPool->dispatchAndClear(xoj::view::StrokeToolView::CANCELLATION_REQUEST,
+                                                 Range(this->stroke->boundingRect()));
                 stroke.reset();
+
                 this->userTapped = true;
 
                 StrokeHandler::lastStrokeTime = pos.timestamp;
@@ -253,10 +179,12 @@ void StrokeHandler::onButtonReleaseEvent(const PositionInputData& pos, double zo
     // I cannot draw a line with one point, to draw a visible line I need two points,
     // twice the same Point is also OK
     if (auto const& pv = stroke->getPointVector(); pv.size() == 1) {
-        const Point& pt = pv.front();
+        const Point pt = pv.front();  // Make a copy, otherwise stroke->addPoint(pt); in UB
         if (this->hasPressure) {
             // Pressure inference provides a pressure value to the last event. Most devices set this value to 0.
-            this->stroke->setLastPressure(std::max(pt.z, pos.pressure) * this->stroke->getWidth());
+            const double newPressure = std::max(pt.z, pos.pressure * this->stroke->getWidth());
+            this->stroke->setLastPressure(newPressure);
+            this->viewPool->dispatch(xoj::view::StrokeToolView::THICKEN_FIRST_POINT_REQUEST, newPressure);
         }
         stroke->addPoint(pt);
     }
@@ -291,25 +219,23 @@ void StrokeHandler::onButtonReleaseEvent(const PositionInputData& pos, double zo
         Stroke* recognized = reco.recognizePatterns(stroke.get(), control->getSettings()->getStrokeRecognizerMinSize());
 
         if (recognized) {
+            // strokeRecognizerDetected handles the repainting and the deletion of the views.
             strokeRecognizerDetected(recognized, layer);
-
-            // Full repaint is done anyway
-            // So repaint don't need to be done here
-
-            stroke.release();  // The stroke is now owned by the UndoRedoHandler (to undo the recognition)
             return;
         }
     }
 
+    Document* doc = control->getDocument();
+    doc->lock();
+    layer->addElement(stroke.get());
+    doc->unlock();
 
-    Stroke* s = stroke.release();
-    layer->addElement(s);
-    page->fireElementChanged(s);
+    // Blitt the stroke to the page's buffer and delete all views.
+    // Passing the empty Range() as no actual redrawing is necessary at this point
+    this->viewPool->dispatchAndClear(xoj::view::StrokeToolView::FINALIZATION_REQUEST, Range());
 
-    // Manually force the rendering of the stroke, if no motion event occurred between, that would rerender the page.
-    if (s->getPointCount() == 2) {
-        this->pageView->rerenderElement(s);
-    }
+    page->fireElementChanged(stroke.get());
+    stroke.release();
 }
 
 void StrokeHandler::strokeRecognizerDetected(Stroke* recognized, Layer* layer) {
@@ -335,11 +261,13 @@ void StrokeHandler::strokeRecognizerDetected(Stroke* recognized, Layer* layer) {
         recognized->scale(topLeftSnapped.x, topLeftSnapped.y, fx, fy, 0, false);
     }
 
-    auto recognizerUndo = std::make_unique<RecognizerUndoAction>(page, layer, stroke.get(), recognized);
-
     UndoRedoHandler* undo = control->getUndoRedoHandler();
-    undo->addUndoAction(std::move(recognizerUndo));
+    undo->addUndoAction(std::make_unique<RecognizerUndoAction>(page, layer, stroke.get(), recognized));
+
+    Document* doc = control->getDocument();
+    doc->lock();
     layer->addElement(recognized);
+    doc->unlock();
 
     Range range(recognized->getX(), recognized->getY());
     range.addPoint(recognized->getX() + recognized->getElementWidth(),
@@ -348,36 +276,33 @@ void StrokeHandler::strokeRecognizerDetected(Stroke* recognized, Layer* layer) {
     range.addPoint(stroke->getX(), stroke->getY());
     range.addPoint(stroke->getX() + stroke->getElementWidth(), stroke->getY() + stroke->getElementHeight());
 
-    page->fireRangeChanged(range);
+    stroke.release();  // The stroke is now owned by the UndoRedoHandler (to undo the recognition)
+
+    this->viewPool->dispatch(xoj::view::StrokeToolView::STROKE_REPLACEMENT_REQUEST, *recognized);
+
+    // Blitt the new stroke to the page's buffer, delete all the views and refresh the area (so the recognized stroke
+    // gets displayed instead of the old one).
+    this->viewPool->dispatchAndClear(xoj::view::StrokeToolView::FINALIZATION_REQUEST, range);
+
+    stroke.reset(recognized);  // To ensure PageView::elementChanged knows the recognized stroke is handler by *this
+    page->fireElementChanged(recognized);
+    stroke.release();  // The recognized stroke is owned by the layer
 }
 
 void StrokeHandler::onButtonPressEvent(const PositionInputData& pos, double zoom) {
-    if (!stroke) {
-        this->buttonDownPoint.x = pos.x / zoom;
-        this->buttonDownPoint.y = pos.y / zoom;
+    assert(!stroke);
 
-        stroke = createStroke(this->control);
+    this->buttonDownPoint.x = pos.x / zoom;
+    this->buttonDownPoint.y = pos.y / zoom;
 
-        this->hasPressure = this->stroke->getToolType().isPressureSensitive() && pos.pressure != Point::NO_PRESSURE;
+    stroke = createStroke(this->control);
 
-        double p = this->hasPressure ? pos.pressure : Point::NO_PRESSURE;
-        stroke->addPoint(Point(this->buttonDownPoint.x, this->buttonDownPoint.y, p));
+    this->hasPressure = this->stroke->getToolType().isPressureSensitive() && pos.pressure != Point::NO_PRESSURE;
 
-        stabilizer->initialize(this, zoom, pos);
-    }
+    const double width = this->hasPressure ? pos.pressure * stroke->getWidth() : Point::NO_PRESSURE;
+    stroke->addPoint(Point(this->buttonDownPoint.x, this->buttonDownPoint.y, width));
 
-    double width = this->hasPressure ? this->stroke->getWidth() * pos.pressure : this->stroke->getWidth();
-
-    bool needAMask = this->stroke->getFill() == -1 && !stroke->getLineStyle().hasDashes();
-    if (needAMask) {
-        // Strokes that require a full redraw don't use a mask
-        this->createMask();
-        this->paintDot(mask->cr, this->buttonDownPoint.x, this->buttonDownPoint.y, width);
-    } else {
-        strokeView.emplace(stroke.get());
-    }
-    this->pageView->repaintRect(this->buttonDownPoint.x - 0.5 * width, this->buttonDownPoint.y - 0.5 * width, width,
-                                width);
+    stabilizer->initialize(this, zoom, pos);
 
     this->startStrokeTime = pos.timestamp;
 }
@@ -386,41 +311,22 @@ void StrokeHandler::onButtonDoublePressEvent(const PositionInputData&, double) {
     // nothing to do
 }
 
-void StrokeHandler::paintDot(cairo_t* cr, const double x, const double y, const double width) const {
-    cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
-    cairo_set_line_width(cr, width);
-    cairo_move_to(cr, x, y);
-    cairo_line_to(cr, x, y);
-    cairo_stroke(cr);
+auto StrokeHandler::createView(xoj::view::Repaintable* parent) const -> std::unique_ptr<xoj::view::OverlayView> {
+    assert(this->stroke);
+    const Stroke& s = *this->stroke;
+    if (s.getFill() != -1) {
+        if (s.getToolType() == StrokeTool::HIGHLIGHTER) {
+            // Filled highlighter requires to wipe the mask entirely at every iteration
+            // It has a dedicated view class.
+            return std::make_unique<xoj::view::StrokeToolFilledHighlighterView>(this, s, parent);
+        } else {
+            return std::make_unique<xoj::view::StrokeToolFilledView>(this, s, parent);
+        }
+    } else {
+        return std::make_unique<xoj::view::StrokeToolView>(this, s, parent);
+    }
 }
 
-StrokeHandler::Mask::Mask(int width, int height) {
-    surf = cairo_image_surface_create(CAIRO_FORMAT_A8, width, height);
-    cr = cairo_create(surf);
-    cairo_set_source_rgba(cr, 1, 1, 1, 1);
-    cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
-}
-
-StrokeHandler::Mask::~Mask() noexcept {
-    cairo_destroy(cr);
-    cairo_surface_destroy(surf);
-}
-
-void StrokeHandler::createMask() {
-    // todo(bhennion) Make xournal-independent on splitting
-    auto xournal = control->getWindow()->getXournal();
-    const double ratio = control->getZoomControl()->getZoom() * static_cast<double>(xournal->getDpiScaleFactor());
-
-    std::unique_ptr<Rectangle<double>> visibleRect(xournal->getVisibleRect(pageView));
-
-    // We add a padding to limit graphical bugs when scrolling right after completing a stroke
-    const double strokeWidth = this->stroke->getWidth();
-    const int width = static_cast<int>(std::ceil((visibleRect->width + strokeWidth) * ratio));
-    const int height = static_cast<int>(std::ceil((visibleRect->height + strokeWidth) * ratio));
-
-    mask.emplace(width, height);
-
-    cairo_surface_set_device_offset(mask->surf, std::round((0.5 * strokeWidth - visibleRect->x) * ratio),
-                                    std::round((0.5 * strokeWidth - visibleRect->y) * ratio));
-    cairo_surface_set_device_scale(mask->surf, ratio, ratio);
+auto StrokeHandler::getViewPool() const -> const std::shared_ptr<xoj::util::DispatchPool<xoj::view::StrokeToolView>>& {
+    return viewPool;
 }

--- a/src/core/control/tools/StrokeHandler.h
+++ b/src/core/control/tools/StrokeHandler.h
@@ -11,8 +11,7 @@
 
 #pragma once
 
-#include <memory>    // for unique_ptr
-#include <optional>  // for optional
+#include <memory>  // for unique_ptr
 
 #include <cairo.h>    // for cairo_t, cairo_surface_t
 #include <gdk/gdk.h>  // for GdkEventKey
@@ -20,16 +19,25 @@
 
 #include "model/PageRef.h"  // for PageRef
 #include "model/Point.h"    // for Point
-#include "view/StrokeView.h"
 
 #include "InputHandler.h"            // for InputHandler
 #include "SnapToGridInputHandler.h"  // for SnapToGridInputHandler
 
+class Control;
 class Layer;
 class PositionInputData;
 class Stroke;
-class XojPageView;
-class XournalView;
+
+namespace xoj::util {
+template <class T>
+class DispatchPool;
+};
+
+namespace xoj::view {
+class OverlayView;
+class Repaintable;
+class StrokeToolView;
+};  // namespace xoj::view
 
 namespace StrokeStabilizer {
 class Base;
@@ -47,10 +55,10 @@ class Active;
  */
 class StrokeHandler: public InputHandler {
 public:
-    StrokeHandler(Control* control, XojPageView* pageView, const PageRef& page);
-    ~StrokeHandler() override = default;
+    StrokeHandler(Control* control, const PageRef& page);
+    ~StrokeHandler() override;
 
-    void draw(cairo_t* cr) override;
+    void draw(cairo_t*) override {}
 
     void onSequenceCancelEvent() override;
     bool onMotionNotifyEvent(const PositionInputData& pos, double zoom) override;
@@ -64,12 +72,11 @@ public:
      * The line may be subdivided into smaller segments if the pressure variation is too big.
      * @param point The endpoint of the added line
      */
-    void paintTo(const Point& point);
+    void paintTo(Point point);
 
-    /**
-     * @brief paints a single dot
-     */
-    void paintDot(cairo_t* cr, const double x, const double y, const double width) const;
+    auto createView(xoj::view::Repaintable* parent) const -> std::unique_ptr<xoj::view::OverlayView> override;
+
+    const std::shared_ptr<xoj::util::DispatchPool<xoj::view::StrokeToolView>>& getViewPool() const;
 
 protected:
     /**
@@ -86,46 +93,6 @@ protected:
     SnapToGridInputHandler snappingHandler;
 
 private:
-    /**
-     * @brief Create and initialize the mask
-     * The mask is used for strokes that do not require a full redraw at each input event.
-     * For those strokes, whenever a new input event is received, the new segment is simply added to the mask.
-     * The mask is then blitted upon a call to `draw`.
-     *
-     * A stroke requires a full redraw if
-     *      * it has a filling (the filling can not be computed simply from just the last segment)
-     *      * or it has dashes (to get the dash offset right)
-     *
-     * Nb: the dashed exception could be avoided if we recorded the dash offset (= the stroke's length so far)
-     */
-    void createMask();
-
-    // Helper class to safely handle cairo surface and context
-    class Mask {
-    public:
-        Mask() = delete;
-        Mask(const Mask&) = delete;
-        Mask(Mask&&) = delete;
-        Mask& operator=(const Mask&) = delete;
-        Mask& operator=(Mask&&) = delete;
-
-        Mask(int width, int height);
-        ~Mask() noexcept;
-
-        /**
-         * The masking surface
-         */
-        cairo_surface_t* surf = nullptr;
-
-        /**
-         * And the corresponding cairo_t*
-         */
-        cairo_t* cr = nullptr;
-    };
-    std::optional<Mask> mask;
-
-    std::optional<xoj::view::StrokeView> strokeView;
-
     // to filter out short strokes (usually the user tapping on the page to select it)
     guint32 startStrokeTime{};
     static guint32 lastStrokeTime;  // persist across strokes - allow us to not ignore persistent dotting.
@@ -135,12 +102,11 @@ private:
      */
     std::unique_ptr<StrokeStabilizer::Base> stabilizer;
 
+    std::shared_ptr<xoj::util::DispatchPool<xoj::view::StrokeToolView>> viewPool;
+
     bool hasPressure;
-    bool firstPointPressureChange = false;
 
     friend class StrokeStabilizer::Active;
 
     static constexpr double MAX_WIDTH_VARIATION = 0.3;
-
-    XojPageView* pageView;
 };

--- a/src/core/gui/PageView.cpp
+++ b/src/core/gui/PageView.cpp
@@ -589,8 +589,7 @@ auto XojPageView::onMotionNotifyEvent(const PositionInputData& pos) -> bool {
     ToolHandler* h = xournal->getControl()->getToolHandler();
     auto* pdfToolbox = this->xournal->getControl()->getWindow()->getPdfToolbox();
 
-    if (containsPoint(std::lround(x), std::lround(y), true) && this->inputHandler &&
-        this->inputHandler->onMotionNotifyEvent(pos, zoom)) {
+    if (this->inputHandler && this->inputHandler->onMotionNotifyEvent(pos, zoom)) {
         // input handler used this event
     } else if (this->selection) {
         this->selection->currentPos(x, y);

--- a/src/core/gui/inputdevices/PenInputHandler.cpp
+++ b/src/core/gui/inputdevices/PenInputHandler.cpp
@@ -388,7 +388,7 @@ auto PenInputHandler::actionEnd(InputEvent const& event) -> bool {
 
 void PenInputHandler::actionPerform(InputEvent const& event) {
 #ifdef DEBUG_INPUT
-    g_message("Discrete input action; modifier1=%s, modifier2=%2", this->modifier2 ? "true" : "false",
+    g_message("Discrete input action; modifier1=%s, modifier2=%s", this->modifier2 ? "true" : "false",
               this->modifier3 ? "true" : "false");
 #endif
 

--- a/src/core/model/LineStyle.cpp
+++ b/src/core/model/LineStyle.cpp
@@ -29,6 +29,13 @@ void LineStyle::operator=(const LineStyle& other) {
     setDashes(dashes, dashCount);
 }
 
+#ifndef NDEBUG
+bool LineStyle::operator==(const LineStyle& other) const {
+    return (this->dashes == nullptr && other.dashes == nullptr) ||
+           (this->dashes != nullptr && other.dashes != nullptr &&
+            std::equal(this->dashes, this->dashes + this->dashCount, other.dashes, other.dashes + other.dashCount));
+}
+#endif
 
 void LineStyle::serialize(ObjectOutputStream& out) const {
     out.writeObject("LineStyle");

--- a/src/core/model/LineStyle.h
+++ b/src/core/model/LineStyle.h
@@ -24,6 +24,10 @@ public:
     ~LineStyle() override;
 
     void operator=(const LineStyle& other);
+#ifndef NDEBUG
+    // Only use in assert() for now
+    bool operator==(const LineStyle& other) const;
+#endif
 
 public:
     // Serialize interface

--- a/src/core/model/Stroke.cpp
+++ b/src/core/model/Stroke.cpp
@@ -240,24 +240,6 @@ auto Stroke::isInSelection(ShapeContainer* container) const -> bool {
     return true;
 }
 
-void Stroke::setFirstPoint(double x, double y) {
-    if (!this->points.empty()) {
-        Point& p = this->points.front();
-        p.x = x;
-        p.y = y;
-        this->sizeCalculated = false;
-    }
-}
-
-void Stroke::setLastPoint(double x, double y) { setLastPoint({x, y}); }
-
-void Stroke::setLastPoint(const Point& p) {
-    if (!this->points.empty()) {
-        this->points.back() = p;
-        this->sizeCalculated = false;
-    }
-}
-
 void Stroke::addPoint(const Point& p) {
     this->points.emplace_back(p);
     updateBounds(Element::x, Element::y, Element::width, Element::height, Element::snappedBounds, p,
@@ -400,15 +382,15 @@ void Stroke::scalePressure(double factor) {
         return;
     }
     for (auto&& p: this->points) { p.z *= factor; }
-}
-
-void Stroke::clearPressure() {
-    for (auto&& p: points) { p.z = Point::NO_PRESSURE; }
+    this->sizeCalculated = false;
 }
 
 void Stroke::setLastPressure(double pressure) {
     if (!this->points.empty()) {
-        this->points.back().z = pressure;
+        assert(pressure != Point::NO_PRESSURE);
+        Point& back = this->points.back();
+        back.z = pressure;
+        updateBounds(Element::x, Element::y, Element::width, Element::height, snappedBounds, back, 0.5 * pressure);
     }
 }
 

--- a/src/core/model/Stroke.cpp
+++ b/src/core/model/Stroke.cpp
@@ -242,8 +242,10 @@ auto Stroke::isInSelection(ShapeContainer* container) const -> bool {
 
 void Stroke::addPoint(const Point& p) {
     this->points.emplace_back(p);
-    updateBounds(Element::x, Element::y, Element::width, Element::height, Element::snappedBounds, p,
-                 hasPressure() ? p.z / 2.0 : this->width / 2.0);
+    if (sizeCalculated) {
+        updateBounds(Element::x, Element::y, Element::width, Element::height, Element::snappedBounds, p,
+                     hasPressure() ? p.z / 2.0 : this->width / 2.0);
+    }
 }
 
 auto Stroke::getPointCount() const -> int { return this->points.size(); }

--- a/src/core/model/Stroke.h
+++ b/src/core/model/Stroke.h
@@ -108,9 +108,6 @@ public:
     void setFill(int fill);
 
     void addPoint(const Point& p);
-    void setLastPoint(double x, double y);
-    void setFirstPoint(double x, double y);
-    void setLastPoint(const Point& p);
     int getPointCount() const;
     void freeUnusedPointItems();
     std::vector<Point> const& getPointVector() const;

--- a/src/core/view/Mask.cpp
+++ b/src/core/view/Mask.cpp
@@ -93,6 +93,14 @@ void Mask::wipe() {
     });
 }
 
+void Mask::wipeRange(const Range& rg) {
+    assert(isInitialized());
+    xoj::util::CairoSaveGuard saveGuard(cr.get());
+    cairo_rectangle(cr.get(), rg.minX, rg.minY, rg.getWidth(), rg.getHeight());
+    cairo_clip(cr.get());
+    wipe();
+}
+
 void Mask::reset() { cr.reset(); }
 
 #ifdef DEBUG_MASKS

--- a/src/core/view/Mask.cpp
+++ b/src/core/view/Mask.cpp
@@ -2,6 +2,7 @@
 
 #include <cassert>
 #include <cmath>
+#include <iostream>
 
 #include <cairo.h>
 
@@ -23,7 +24,10 @@ std::string getSurfaceTypeName(cairo_surface_t*);
 
 Mask::Mask(cairo_surface_t* target, const Range& extent, double zoom, int dpiScaling, cairo_content_t contentType) {
     assert(target);
-    assert(extent.isValid());
+    assert(extent.isValid() ||
+           ((std::cout << "Invalid range in Mask(): X  " << extent.minX << " -- " << extent.maxX << std::endl
+                       << "                         Y  " << extent.minY << " -- " << extent.maxY << std::endl) &&
+            false));
     assert(zoom > 0.0);
     assert(dpiScaling > 0);
 

--- a/src/core/view/Mask.h
+++ b/src/core/view/Mask.h
@@ -53,6 +53,12 @@ public:
     void wipe();
 
     /**
+     * @brief Erase part the surface's content
+     * @param rg The part to erase, in Page coordinates
+     */
+    void wipeRange(const Range& rg);
+
+    /**
      * @brief Delete the mask
      */
     void reset();

--- a/src/core/view/overlays/BaseStrokeToolView.cpp
+++ b/src/core/view/overlays/BaseStrokeToolView.cpp
@@ -12,16 +12,6 @@
 
 using namespace xoj::view;
 
-static Color strokeColorWithAlpha(const Stroke& s) {
-    Color c = s.getColor();
-    if (s.getToolType() == StrokeTool::HIGHLIGHTER) {
-        c.alpha = s.getFill() == -1 ? 120U : static_cast<uint8_t>(s.getFill());
-    } else {
-        c.alpha = 255U;
-    }
-    return c;
-}
-
 BaseStrokeToolView::BaseStrokeToolView(Repaintable* parent, const Stroke& stroke):
         ToolView(parent),
         cairoOp(stroke.getToolType() == StrokeTool::HIGHLIGHTER ? CAIRO_OPERATOR_MULTIPLY : CAIRO_OPERATOR_OVER),
@@ -31,10 +21,28 @@ BaseStrokeToolView::BaseStrokeToolView(Repaintable* parent, const Stroke& stroke
 
 BaseStrokeToolView::~BaseStrokeToolView() noexcept = default;
 
+Color BaseStrokeToolView::strokeColorWithAlpha(const Stroke& s) {
+    Color c = s.getColor();
+    if (s.getToolType() == StrokeTool::HIGHLIGHTER) {
+        c.alpha = s.getFill() == -1 ? 120U : static_cast<uint8_t>(s.getFill());
+    } else {
+        c.alpha = 255U;
+    }
+    return c;
+}
+
 auto BaseStrokeToolView::createMask(cairo_t* tgtcr) const -> Mask {
     const double zoom = this->parent->getZoom();
     const int dpiScaling = this->parent->getDPIScaling();
     Range visibleRange = this->parent->getVisiblePart();
+
+    if (!visibleRange.isValid()) {
+        /*
+         * The user might be drawing on a page that is not visible at all:
+         * e.g. https://github.com/xournalpp/xournalpp/pull/4158#issuecomment-1385954494
+         */
+        return Mask();
+    }
 
     // Add a small padding, to avoid visual artefacts if scrolling right after finishing a stroke touching the visible
     // area's border

--- a/src/core/view/overlays/BaseStrokeToolView.h
+++ b/src/core/view/overlays/BaseStrokeToolView.h
@@ -36,11 +36,16 @@ protected:
     Mask createMask(cairo_t* targetCr) const;
 
     /**
+     * @brief Helper function to get a color whose alpha value depends on the tool's properties
+     */
+    static Color strokeColorWithAlpha(const Stroke& s);
+
+    /**
      * @brief All that's required to draw a stroke in cairo
      */
-    cairo_operator_t cairoOp;
-    Color strokeColor;
-    LineStyle lineStyle;
+    const cairo_operator_t cairoOp;
+    const Color strokeColor;
+    const LineStyle lineStyle;
     double strokeWidth;
 };
 };  // namespace xoj::view

--- a/src/core/view/overlays/StrokeToolFilledHighlighterView.cpp
+++ b/src/core/view/overlays/StrokeToolFilledHighlighterView.cpp
@@ -1,0 +1,73 @@
+#include "StrokeToolFilledHighlighterView.h"
+
+#include <vector>
+
+#include "model/Point.h"
+#include "util/Color.h"
+#include "util/Range.h"
+#include "util/raii/CairoWrappers.h"
+#include "view/StrokeViewHelper.h"
+
+using namespace xoj::view;
+
+StrokeToolFilledHighlighterView::StrokeToolFilledHighlighterView(const StrokeHandler* strokeHandler,
+                                                                 const Stroke& stroke, Repaintable* parent):
+        StrokeToolFilledView(strokeHandler, stroke, parent) {}
+
+StrokeToolFilledHighlighterView::~StrokeToolFilledHighlighterView() noexcept = default;
+
+void StrokeToolFilledHighlighterView::draw(cairo_t* cr) const {
+
+    std::vector<Point> pts = this->flushBuffer();
+    if (pts.empty()) {
+        // The input sequence has probably been cancelled. This view should soon be deleted
+        return;
+    }
+
+    this->filling.appendSegments(pts);
+
+    if (!this->mask.isInitialized()) {
+        // Initialize mask on first call
+        this->mask = this->createMask(cr);
+        if (!mask.isInitialized()) {
+            /*
+             * The user might be drawing on a page that is not visible at all:
+             * e.g. https://github.com/xournalpp/xournalpp/pull/4158#issuecomment-1385954494
+             */
+            return;
+        }
+    }
+
+    if (this->singleDot) {
+        this->drawDot(this->mask.get(), pts.back());
+    } else {
+        /*
+         * Upon adding a segment, the filling can actually shrink.
+         * We wipe the portion of the mask that can change: the convex hull of the added points + the first point
+         */
+        Range wipe(filling.firstPoint.x, filling.firstPoint.y);
+
+        for (auto& p: pts) {
+            wipe.addPoint(p.x, p.y);
+        }
+
+        if (wipe.isValid()) {
+            this->mask.wipeRange(wipe);
+        }
+
+
+        /*
+         * Draw both the filling and the stroke alike on the mask
+         */
+        cairo_set_line_width(this->mask.get(), this->strokeWidth);
+        StrokeViewHelper::pathToCairo(this->mask.get(), this->filling.contour);
+        cairo_fill_preserve(this->mask.get());
+        cairo_stroke(this->mask.get());
+    }
+
+    xoj::util::CairoSaveGuard saveGuard(cr);
+    Util::cairo_set_source_argb(cr, this->strokeColor);
+    cairo_set_operator(cr, this->cairoOp);
+
+    cairo_mask_surface(cr, cairo_get_target(this->mask.get()), 0, 0);
+}

--- a/src/core/view/overlays/StrokeToolFilledHighlighterView.h
+++ b/src/core/view/overlays/StrokeToolFilledHighlighterView.h
@@ -1,0 +1,25 @@
+/*
+ * Xournal++
+ *
+ * View active stroke tool -- for filled highlighter only
+ *      In this case, the mask needs to be wiped at every iteration, and repainted to avoid artefacts like in
+ *          https://github.com/xournalpp/xournalpp/issues/3709
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+#pragma once
+
+#include "StrokeToolFilledView.h"
+
+namespace xoj::view {
+class StrokeToolFilledHighlighterView: public StrokeToolFilledView {
+public:
+    StrokeToolFilledHighlighterView(const StrokeHandler* strokeHandler, const Stroke& stroke, Repaintable* parent);
+    virtual ~StrokeToolFilledHighlighterView() noexcept;
+
+    void draw(cairo_t* cr) const override;
+};
+};  // namespace xoj::view

--- a/src/core/view/overlays/StrokeToolFilledView.cpp
+++ b/src/core/view/overlays/StrokeToolFilledView.cpp
@@ -1,0 +1,62 @@
+#include "StrokeToolFilledView.h"
+
+#include <algorithm>
+#include <cassert>
+
+#include "model/Stroke.h"
+#include "util/Color.h"
+#include "util/Range.h"
+#include "view/Repaintable.h"
+#include "view/StrokeViewHelper.h"
+
+using namespace xoj::view;
+
+static const Point& setupFirstPoint(const Stroke& s) {
+    const auto& pts = s.getPointVector();
+    assert(!pts.empty());
+    return pts.front();
+}
+
+StrokeToolFilledView::StrokeToolFilledView(const StrokeHandler* strokeHandler, const Stroke& stroke,
+                                           Repaintable* parent):
+        StrokeToolView(strokeHandler, stroke, parent), filling(stroke.getFill() / 255.0, setupFirstPoint(stroke)) {}
+
+StrokeToolFilledView::~StrokeToolFilledView() noexcept = default;
+
+void StrokeToolFilledView::drawFilling(cairo_t* cr, const std::vector<Point>& pts) const {
+    this->filling.appendSegments(pts);
+    /*
+     * Draw the filling directly (not through the mask)
+     *   Upon adding a segment, the filling can actually shrink, making it easier to redraw the filling every time.
+     */
+    StrokeViewHelper::pathToCairo(cr, this->filling.contour);
+    Util::cairo_set_source_rgbi(cr, strokeColor, this->filling.alpha);
+    cairo_fill(cr);
+}
+
+void StrokeToolFilledView::on(StrokeToolView::AddPointRequest, const Point& p) {
+    this->singleDot = false;
+    assert(!this->pointBuffer.empty());
+    Point lastPoint = this->pointBuffer.back();
+    this->pointBuffer.emplace_back(p);
+    auto rg = this->getRepaintRange(lastPoint, p);
+    // Add the first point, so that the range covers all the filling changes
+    rg.addPoint(this->filling.firstPoint.x, this->filling.firstPoint.y);
+    this->parent->flagDirtyRegion(rg);
+}
+
+void StrokeToolFilledView::on(StrokeToolView::StrokeReplacementRequest, const Stroke& newStroke) {
+    StrokeToolView::on(STROKE_REPLACEMENT_REQUEST, newStroke);
+    this->filling.contour = this->pointBuffer;
+    if (!this->pointBuffer.empty()) {
+        const Point& fp = this->pointBuffer.front();
+        this->filling.firstPoint = utl::Point<double>(fp.x, fp.y);
+    }
+}
+
+void StrokeToolFilledView::FillingData::appendSegments(const std::vector<Point>& pts) {
+    assert(!pts.empty());
+    // Add new points to the contour
+    // contour.back() == pts.front(), so we skip it.
+    std::copy(std::next(pts.begin()), pts.end(), std::back_inserter(contour));
+}

--- a/src/core/view/overlays/StrokeToolFilledView.h
+++ b/src/core/view/overlays/StrokeToolFilledView.h
@@ -1,0 +1,59 @@
+/*
+ * Xournal++
+ *
+ * View active stroke tool -- filled strokes, but not filled highlighter.
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+#pragma once
+
+#include <vector>
+
+#include <cairo.h>
+
+#include "model/Point.h"
+#include "util/Point.h"
+
+#include "StrokeToolView.h"
+
+namespace xoj::view {
+class StrokeToolFilledHighlighterView;
+
+/**
+ * @brief View active stroke tool -- with a filling
+ *
+ * In draw, the filling is painted directly, while the stroke itself is blitted from the mask
+ */
+class StrokeToolFilledView: public StrokeToolView {
+public:
+    StrokeToolFilledView(const StrokeHandler* strokeHandler, const Stroke& stroke, Repaintable* parent);
+    virtual ~StrokeToolFilledView() noexcept;
+
+    void drawFilling(cairo_t* cr, const std::vector<Point>& pts) const override;
+
+    void on(AddPointRequest, const Point& p) override;
+    void on(StrokeReplacementRequest, const Stroke& newStroke) override;
+
+protected:
+    class FillingData {
+    public:
+        FillingData(double alpha, const Point& p): alpha(alpha), firstPoint(p.x, p.y), contour{p} {}
+
+        const double alpha;
+        utl::Point<double> firstPoint;  // Store a copy for safe concurrent access
+
+
+        void appendSegments(const std::vector<Point>& pts);
+
+        /**
+         * @brief Filling contour (i.e. the stroke's entire path)
+         */
+        std::vector<Point> contour;
+    };
+
+    mutable FillingData filling;
+};
+};  // namespace xoj::view

--- a/src/core/view/overlays/StrokeToolView.cpp
+++ b/src/core/view/overlays/StrokeToolView.cpp
@@ -1,0 +1,144 @@
+#include "StrokeToolView.h"
+
+#include <cassert>
+#include <functional>
+#include <memory>
+#include <numeric>
+
+#include "control/tools/StrokeHandler.h"
+#include "model/LineStyle.h"
+#include "model/Stroke.h"
+#include "util/Color.h"
+#include "util/PairView.h"
+#include "util/Range.h"
+#include "util/raii/CairoWrappers.h"  // for CairoSaveGuard
+#include "view/Repaintable.h"
+#include "view/StrokeViewHelper.h"
+
+using namespace xoj::view;
+
+StrokeToolView::StrokeToolView(const StrokeHandler* strokeHandler, const Stroke& stroke, Repaintable* parent):
+        BaseStrokeToolView(parent, stroke), strokeHandler(strokeHandler), pointBuffer(stroke.getPointVector()) {
+    this->registerToPool(strokeHandler->getViewPool());
+    parent->flagDirtyRegion(Range(stroke.boundingRect()));
+}
+
+StrokeToolView::~StrokeToolView() noexcept { this->unregisterFromPool(); }
+
+bool StrokeToolView::isViewOf(const OverlayBase* overlay) const { return overlay == this->strokeHandler; }
+
+void StrokeToolView::draw(cairo_t* cr) const {
+
+    std::vector<Point> pts = this->flushBuffer();
+    if (pts.empty()) {
+        // The input sequence has probably been cancelled. This view should soon be deleted
+        return;
+    }
+    // pts.front() is the last point we painted on the mask during the last iteration (see flushBuffer())
+
+    if (!mask.isInitialized()) {
+        // Initialize the mask on first call
+        mask = createMask(cr);
+        if (!mask.isInitialized()) {
+            /*
+             * The user might be drawing on a page that is not visible at all:
+             * e.g. https://github.com/xournalpp/xournalpp/pull/4158#issuecomment-1385954494
+             */
+            return;
+        }
+    }
+
+    xoj::util::CairoSaveGuard saveGuard(cr);
+    cairo_set_operator(cr, this->cairoOp);
+
+    this->drawFilling(cr, pts);  // Noop in the base class.
+
+    Util::cairo_set_source_argb(cr, strokeColor);
+
+    if (pts.size() > 1) {
+        // Draw the new segments on the mask
+        if (pts.front().z == Point::NO_PRESSURE) {
+            StrokeViewHelper::drawNoPressure(this->mask.get(), pts, this->strokeWidth, this->lineStyle,
+                                             this->dashOffset);
+            if (this->lineStyle.hasDashes()) {
+                // Keep the offset up to date, so we do not have to redraw the entire stroke every time.
+                PairView segments(pts);
+                this->dashOffset =
+                        std::transform_reduce(segments.begin(), segments.end(), this->dashOffset, std::plus<>(),
+                                              [](auto& seg) { return seg.front().lineLengthTo(seg.back()); });
+            }
+        } else {
+            this->dashOffset =
+                    StrokeViewHelper::drawWithPressure(this->mask.get(), pts, this->lineStyle, this->dashOffset);
+        }
+    } else if (this->singleDot) {
+        this->drawDot(this->mask.get(), pts.back());
+    }
+
+    cairo_mask_surface(cr, cairo_get_target(this->mask.get()), 0, 0);
+}
+
+void StrokeToolView::on(StrokeToolView::AddPointRequest, const Point& p) {
+    this->singleDot = false;
+    assert(!this->pointBuffer.empty());  // front() is the last point we painted on the mask (see flushBuffer())
+    Point lastPoint = this->pointBuffer.back();
+    this->pointBuffer.emplace_back(p);
+    this->parent->flagDirtyRegion(this->getRepaintRange(lastPoint, p));
+}
+
+void StrokeToolView::on(StrokeToolView::ThickenFirstPointRequest, double newWidth) {
+    assert(newWidth > 0.0);
+    assert(this->pointBuffer.size() == 1);
+    Point& p = this->pointBuffer.back();
+    assert(p.z <= newWidth);  // Thicken means thicken
+    p.z = newWidth;
+    Range rg = Range(p.x, p.y);
+    rg.addPadding(0.5 * newWidth);
+    this->parent->flagDirtyRegion(rg);
+}
+
+void StrokeToolView::deleteOn(StrokeToolView::CancellationRequest, const Range& rg) {
+    this->pointBuffer.clear();
+    this->parent->drawAndDeleteToolView(this, rg);
+}
+
+void StrokeToolView::on(StrokeToolView::StrokeReplacementRequest, const Stroke& newStroke) {
+    this->mask.wipe();
+    this->pointBuffer = newStroke.getPointVector();
+    this->dashOffset = 0;
+    this->strokeWidth = newStroke.getWidth();
+    assert(this->strokeColor == strokeColorWithAlpha(newStroke));
+    assert(this->lineStyle == newStroke.getLineStyle());
+    assert(this->cairoOp ==
+           (newStroke.getToolType() == StrokeTool::HIGHLIGHTER ? CAIRO_OPERATOR_MULTIPLY : CAIRO_OPERATOR_OVER));
+}
+
+void StrokeToolView::deleteOn(StrokeToolView::FinalizationRequest, const Range& rg) {
+    this->parent->drawAndDeleteToolView(this, rg);
+}
+
+auto StrokeToolView::getRepaintRange(const Point& lastPoint, const Point& addedPoint) const -> Range {
+    const double width = lastPoint.z == Point::NO_PRESSURE ? this->strokeWidth : lastPoint.z;
+    Range rg(lastPoint.x, lastPoint.y);
+    rg.addPoint(addedPoint.x, addedPoint.y);
+    rg.addPadding(0.5 * width);
+    return rg;
+}
+
+void StrokeToolView::drawDot(cairo_t* cr, const Point& p) const {
+    cairo_set_line_width(cr, p.z == Point::NO_PRESSURE ? this->strokeWidth : p.z);
+    cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+    cairo_move_to(cr, p.x, p.y);
+    cairo_line_to(cr, p.x, p.y);
+    cairo_stroke(cr);
+}
+
+std::vector<Point> StrokeToolView::flushBuffer() const {
+    std::vector<Point> pts;
+    std::swap(this->pointBuffer, pts);
+    if (!pts.empty()) {
+        // Keep the last point in the buffer - to be used in the next iteration
+        this->pointBuffer.emplace_back(pts.back());
+    }
+    return pts;
+}

--- a/src/core/view/overlays/StrokeToolView.h
+++ b/src/core/view/overlays/StrokeToolView.h
@@ -1,0 +1,108 @@
+/*
+ * Xournal++
+ *
+ * View active stroke tool - abstract base class
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+#pragma once
+
+#include <vector>
+
+#include <cairo.h>
+
+#include "util/DispatchPool.h"
+#include "view/Mask.h"
+
+#include "BaseStrokeToolView.h"
+
+class StrokeHandler;
+class Point;
+class Range;
+class Stroke;
+class OverlayBase;
+
+namespace xoj::view {
+class Repaintable;
+
+class StrokeToolView: public BaseStrokeToolView, public xoj::util::Listener<StrokeToolView> {
+public:
+    StrokeToolView(const StrokeHandler* strokeHandler, const Stroke& stroke, Repaintable* parent);
+    virtual ~StrokeToolView() noexcept;
+
+    bool isViewOf(const OverlayBase* overlay) const override;
+
+    void draw(cairo_t* cr) const override;
+
+    /**
+     * Listener interface
+     */
+    static constexpr struct AddPointRequest {
+    } ADD_POINT_REQUEST = {};
+    virtual void on(AddPointRequest, const Point& p);
+
+    static constexpr struct ThickenFirstPointRequest {
+    } THICKEN_FIRST_POINT_REQUEST = {};
+    void on(ThickenFirstPointRequest, double newPressure);
+
+    static constexpr struct StrokeReplacementRequest {
+    } STROKE_REPLACEMENT_REQUEST = {};
+    virtual void on(StrokeReplacementRequest, const Stroke& newStroke);
+
+    static constexpr struct CancellationRequest {
+    } CANCELLATION_REQUEST = {};
+    void deleteOn(CancellationRequest, const Range& rg);
+
+    /**
+     * @brief Called before the corresponding StrokeHandler's destruction
+     */
+    static constexpr struct FinalizationRequest {
+    } FINALIZATION_REQUEST = {};
+    void deleteOn(FinalizationRequest, const Range& rg);
+
+protected:
+    /**
+     * @brief Compute the bounding box of the given segment, taking stroke width into account.
+     */
+    auto getRepaintRange(const Point& lastPoint, const Point& addedPoint) const -> Range;
+
+    void drawDot(cairo_t* cr, const Point& p) const;
+
+    /**
+     * @brief (Thread-safe) Flush the communication buffer and returns its content.
+     */
+    std::vector<Point> flushBuffer() const;
+
+    // Nothing in the base class
+    virtual void drawFilling(cairo_t*, const std::vector<Point>&) const {}
+
+protected:
+    const StrokeHandler* strokeHandler;
+
+protected:
+    bool singleDot = true;
+
+    /**
+     * @brief offset for drawing dashes (if any)
+     *      In effect, this stores the length of the path already drawn to the mask.
+     */
+    mutable double dashOffset = 0;
+
+    /**
+     * @brief Controller/View communication buffer
+     *      Those are in the same thread. Add mutex protection if this changes
+     */
+    mutable std::vector<Point> pointBuffer;  // Todo: implement a lock-free fifo?
+
+    /**
+     * @brief Drawing mask.
+     *
+     * The stroke is drawn to the mask and the mask is then blitted wherever needed.
+     * Upon calls to draw(), the buffer is flushed and the corresponding part of stroke is added to the mask.
+     */
+    mutable Mask mask;
+};
+};  // namespace xoj::view

--- a/src/util/Range.cpp
+++ b/src/util/Range.cpp
@@ -54,3 +54,7 @@ auto Range::empty() const -> bool {
 bool Range::isValid() const { return minX <= maxX && minY <= maxY; }
 
 bool Range::contains(double x, double y) const { return x >= minX && x <= maxX && y >= minY && y <= maxY; }
+
+bool Range::contains(const xoj::util::Rectangle<double>& r) const {
+    return this->minX <= r.x && this->maxX >= r.x + r.width && this->minY <= r.y && this->maxY >= r.y + r.height;
+}

--- a/src/util/include/util/Range.h
+++ b/src/util/include/util/Range.h
@@ -41,6 +41,7 @@ public:
     [[nodiscard]] bool empty() const;
     [[nodiscard]] bool isValid() const;
     [[nodiscard]] bool contains(double x, double y) const;
+    [[nodiscard]] bool contains(const xoj::util::Rectangle<double>& r) const;
 
     double minX = std::numeric_limits<double>::max();
     double minY = std::numeric_limits<double>::max();


### PR DESCRIPTION
Follows #4137.

This PR splits tools/StrokeHandler into a View and a Controller. It also optimizes the rendering costs ~~and protects the data with a mutex (see #3579)~~.


- [x] Merge #4137 and rebase

~~**Edit:** the CI failing is due to GCC 8 not handling `std::transform_reduce`. Will be fixed with #4160~~   done