### PR TITLE
Fix: move events being processed twice

### DIFF
--- a/src/control/ToolHandler.cpp
+++ b/src/control/ToolHandler.cpp
@@ -532,15 +532,14 @@ auto ToolHandler::isSinglePageTool() -> bool {
     ToolType toolType = this->getToolType();
     DrawingType drawingType = this->getDrawingType();
 
-    return toolType == (TOOL_PEN && (drawingType == DRAWING_TYPE_ARROW || drawingType == DRAWING_TYPE_ELLIPSE ||
-                                     drawingType == DRAWING_TYPE_COORDINATE_SYSTEM ||
-                                     drawingType == DRAWING_TYPE_LINE || drawingType == DRAWING_TYPE_RECTANGLE)) ||
-           drawingType == DRAWING_TYPE_SPLINE || toolType == TOOL_SELECT_REGION || toolType == TOOL_SELECT_RECT ||
-           toolType == TOOL_SELECT_OBJECT || toolType == TOOL_DRAW_RECT || toolType == TOOL_DRAW_ELLIPSE ||
-           toolType == TOOL_DRAW_COORDINATE_SYSTEM || toolType == TOOL_DRAW_ARROW ||
-           toolType == TOOL_FLOATING_TOOLBOX || toolType == TOOL_DRAW_SPLINE;
+    return ((toolType == TOOL_PEN || toolType == TOOL_HIGHLIGHTER) &&
+            (drawingType == DRAWING_TYPE_ARROW || drawingType == DRAWING_TYPE_ELLIPSE ||
+             drawingType == DRAWING_TYPE_COORDINATE_SYSTEM || drawingType == DRAWING_TYPE_LINE ||
+             drawingType == DRAWING_TYPE_RECTANGLE || drawingType == DRAWING_TYPE_SPLINE)) ||
+           toolType == TOOL_SELECT_REGION || toolType == TOOL_SELECT_RECT || toolType == TOOL_SELECT_OBJECT ||
+           toolType == TOOL_DRAW_RECT || toolType == TOOL_DRAW_ELLIPSE || toolType == TOOL_DRAW_COORDINATE_SYSTEM ||
+           toolType == TOOL_DRAW_ARROW || toolType == TOOL_FLOATING_TOOLBOX || toolType == TOOL_DRAW_SPLINE;
 }
-
 
 auto ToolHandler::getSelectedTool(SelectedTool selectedTool) -> Tool* {
     switch (selectedTool) {

--- a/src/gui/inputdevices/PenInputHandler.cpp
+++ b/src/gui/inputdevices/PenInputHandler.cpp
@@ -275,8 +275,6 @@ auto PenInputHandler::actionMotion(InputEvent const& event) -> bool {
         }
     }
 
-    bool result = false;
-
     // Update the cursor
     xournal->view->getCursor()->setInsidePage(currentPage != nullptr);
 
@@ -293,7 +291,10 @@ auto PenInputHandler::actionMotion(InputEvent const& event) -> bool {
 
         pos.pressure = this->filterPressure(pos, sequenceStartPage);
 
-        result = sequenceStartPage->onMotionNotifyEvent(pos);
+        bool result = sequenceStartPage->onMotionNotifyEvent(pos);
+
+        this->updateLastEvent(event);  // Update the last position of the input device
+        return result;
     }
 
     if (currentPage && this->penInWidget) {
@@ -301,13 +302,13 @@ auto PenInputHandler::actionMotion(InputEvent const& event) -> bool {
         PositionInputData pos = getInputDataRelativeToCurrentPage(currentPage, event);
         pos.pressure = this->filterPressure(pos, currentPage);
 
-        result = currentPage->onMotionNotifyEvent(pos);
+        bool result = currentPage->onMotionNotifyEvent(pos);
+
+        this->updateLastEvent(event);  // Update the last position of the input device
+        return result;
     }
 
-    // Update the last position of the input device
-    this->updateLastEvent(event);
-
-    return result;
+    return false;
 }
 
 auto PenInputHandler::actionEnd(InputEvent const& event) -> bool {


### PR DESCRIPTION
Some Motion events were being transfered twice to the same InputHandler, for tools such that isSinglePageTool == true (e.g. rectangle, ellipse, spline tools). This patch fixes this.

It also fixes ToolHandler::isSinglePageTool, were a boolean operation was obviously wrong.

Merging to the release branch in 48 hours, unless an objection is raised.