### PR TITLE
Code cleanup before handlers splitting

### DIFF
--- a/src/core/gui/PageView.cpp
+++ b/src/core/gui/PageView.cpp
@@ -699,9 +699,9 @@ void XojPageView::rerenderPage() {
     this->xournal->getControl()->getScheduler()->addRerenderPage(this);
 }
 
-void XojPageView::repaintPage() { xournal->getRepaintHandler()->repaintPage(this); }
+void XojPageView::repaintPage() const { xournal->getRepaintHandler()->repaintPage(this); }
 
-void XojPageView::repaintArea(double x1, double y1, double x2, double y2) {
+void XojPageView::repaintArea(double x1, double y1, double x2, double y2) const {
     double zoom = xournal->getZoom();
     xournal->getRepaintHandler()->repaintPageArea(this, std::lround(x1 * zoom) - 10, std::lround(y1 * zoom) - 10,
                                                   std::lround(x2 * zoom) + 20, std::lround(y2 * zoom) + 20);
@@ -917,9 +917,9 @@ auto XojPageView::getMappedRow() const -> int { return this->mappedRow; }
 auto XojPageView::getMappedCol() const -> int { return this->mappedCol; }
 
 
-auto XojPageView::getPage() -> const PageRef { return page; }
+auto XojPageView::getPage() const -> const PageRef { return page; }
 
-auto XojPageView::getXournal() -> XournalView* { return this->xournal; }
+auto XojPageView::getXournal() const -> XournalView* { return this->xournal; }
 
 auto XojPageView::getHeight() const -> double { return this->page->getHeight(); }
 

--- a/src/core/gui/PageView.h
+++ b/src/core/gui/PageView.h
@@ -49,8 +49,8 @@ public:
     void rerenderPage() override;
     void rerenderRect(double x, double y, double width, double height) override;
 
-    void repaintPage() override;
-    void repaintArea(double x1, double y1, double x2, double y2) override;
+    void repaintPage() const override;
+    void repaintArea(double x1, double y1, double x2, double y2) const override;
 
     void setSelected(bool selected);
 
@@ -104,9 +104,9 @@ public:
      * Returns a reference to the XojPage belonging to
      * this PageView
      */
-    const PageRef getPage();
+    const PageRef getPage() const;
 
-    XournalView* getXournal();
+    XournalView* getXournal() const;
 
     /**
      * Returns the width of this PageView

--- a/src/core/gui/Redrawable.cpp
+++ b/src/core/gui/Redrawable.cpp
@@ -3,11 +3,11 @@
 #include "model/Element.h"  // for Element
 #include "util/Range.h"     // for Range
 
-void Redrawable::repaintElement(Element* e) {
+void Redrawable::repaintElement(Element* e) const {
     repaintArea(e->getX(), e->getY(), e->getElementWidth() + e->getX(), e->getElementHeight() + e->getY());
 }
 
-void Redrawable::repaintRect(double x, double y, double width, double height) {
+void Redrawable::repaintRect(double x, double y, double width, double height) const {
     repaintArea(x, y, x + width, y + height);
 }
 

--- a/src/core/gui/Redrawable.h
+++ b/src/core/gui/Redrawable.h
@@ -33,9 +33,9 @@ public:
      *
      * for refreshing the view buffer (if you have changed the document) call rerender.
      */
-    virtual void repaintArea(double x1, double y1, double x2, double y2) = 0;
-    void repaintRect(double x, double y, double width, double height);
-    [[maybe_unused]] void repaintElement(Element* e);
+    virtual void repaintArea(double x1, double y1, double x2, double y2) const = 0;
+    void repaintRect(double x, double y, double width, double height) const;
+    [[maybe_unused]] void repaintElement(Element* e) const;
 
     /**
      * Call this if you only need to readraw the view, this means the buffer will be painted again,
@@ -43,7 +43,7 @@ public:
      *
      * for refreshing the view buffer (if you have changed the document) call repaint.
      */
-    virtual void repaintPage() = 0;
+    virtual void repaintPage() const = 0;
 
     /**
      * Repaint our buffer, then redraw the widget

--- a/src/core/gui/RepaintHandler.cpp
+++ b/src/core/gui/RepaintHandler.cpp
@@ -11,7 +11,7 @@ RepaintHandler::RepaintHandler(XournalView* xournal): xournal(xournal) {}
 
 RepaintHandler::~RepaintHandler() { this->xournal = nullptr; }
 
-void RepaintHandler::repaintPage(XojPageView* view) {
+void RepaintHandler::repaintPage(const XojPageView* view) {
     int x1 = view->getX();
     int y1 = view->getY();
     int x2 = x1 + view->getDisplayWidth();
@@ -20,10 +20,10 @@ void RepaintHandler::repaintPage(XojPageView* view) {
     gtk_xournal_repaint_area(this->xournal->getWidget(), x1, y1, x2, y2);
 }
 
-void RepaintHandler::repaintPageArea(XojPageView* view, int x1, int y1, int x2, int y2) {
+void RepaintHandler::repaintPageArea(const XojPageView* view, int x1, int y1, int x2, int y2) {
     int x = view->getX();
     int y = view->getY();
     gtk_xournal_repaint_area(this->xournal->getWidget(), x + x1, y + y1, x + x2, y + y2);
 }
 
-void RepaintHandler::repaintPageBorder(XojPageView* view) { gtk_widget_queue_draw(this->xournal->getWidget()); }
+void RepaintHandler::repaintPageBorder(const XojPageView* view) { gtk_widget_queue_draw(this->xournal->getWidget()); }

--- a/src/core/gui/RepaintHandler.h
+++ b/src/core/gui/RepaintHandler.h
@@ -23,17 +23,17 @@ public:
     /**
      * Repaint a page
      */
-    void repaintPage(XojPageView* view);
+    void repaintPage(const XojPageView* view);
 
     /**
      * Repaint a page area, coordinates are in view coordinates
      */
-    void repaintPageArea(XojPageView* view, int x1, int y1, int x2, int y2);
+    void repaintPageArea(const XojPageView* view, int x1, int y1, int x2, int y2);
 
     /**
      * Repaints the page border (at least)
      */
-    void repaintPageBorder(XojPageView* view);
+    void repaintPageBorder(const XojPageView* view);
 
 private:
     XournalView* xournal;

--- a/src/core/gui/XournalView.cpp
+++ b/src/core/gui/XournalView.cpp
@@ -290,7 +290,7 @@ auto XournalView::onKeyPressEvent(GdkEventKey* event) -> bool {
     return false;
 }
 
-auto XournalView::getRepaintHandler() -> RepaintHandler* { return this->repaintHandler; }
+auto XournalView::getRepaintHandler() const -> RepaintHandler* { return this->repaintHandler; }
 
 auto XournalView::onKeyReleaseEvent(GdkEventKey* event) -> bool {
     size_t p = getCurrentPage();
@@ -338,7 +338,7 @@ void XournalView::forceUpdatePagenumbers() {
     control->firePageSelected(p);
 }
 
-auto XournalView::getViewFor(size_t pageNr) -> XojPageView* {
+auto XournalView::getViewFor(size_t pageNr) const -> XojPageView* {
     if (pageNr == npos || pageNr >= this->viewPages.size()) {
         return nullptr;
     }
@@ -394,7 +394,7 @@ void XournalView::pageSelected(size_t page) {
     }
 }
 
-auto XournalView::getControl() -> Control* { return control; }
+auto XournalView::getControl() const -> Control* { return control; }
 
 void XournalView::scrollTo(size_t pageNo, double yDocument) {
     if (pageNo >= this->viewPages.size()) {
@@ -447,7 +447,7 @@ void XournalView::layerChanged(size_t page) {
     }
 }
 
-void XournalView::getPasteTarget(double& x, double& y) {
+void XournalView::getPasteTarget(double& x, double& y) const {
     size_t pageNo = getCurrentPage();
     if (pageNo == npos) {
         return;
@@ -467,7 +467,7 @@ void XournalView::getPasteTarget(double& x, double& y) {
  *
  * Or nullptr if the page is not visible
  */
-auto XournalView::getVisibleRect(size_t page) -> Rectangle<double>* {
+auto XournalView::getVisibleRect(size_t page) const -> Rectangle<double>* {
     if (page == npos || page >= this->viewPages.size()) {
         return nullptr;
     }
@@ -476,21 +476,21 @@ auto XournalView::getVisibleRect(size_t page) -> Rectangle<double>* {
     return getVisibleRect(p);
 }
 
-auto XournalView::getVisibleRect(XojPageView* redrawable) -> Rectangle<double>* {
+auto XournalView::getVisibleRect(const XojPageView* redrawable) const -> Rectangle<double>* {
     return gtk_xournal_get_visible_area(this->widget, redrawable);
 }
 
 /**
  * @return Helper class for Touch specific fixes
  */
-auto XournalView::getHandRecognition() -> HandRecognition* { return handRecognition; }
+auto XournalView::getHandRecognition() const -> HandRecognition* { return handRecognition; }
 
 /**
  * @return Scrollbars
  */
-auto XournalView::getScrollHandling() -> ScrollHandling* { return scrollHandling; }
+auto XournalView::getScrollHandling() const -> ScrollHandling* { return scrollHandling; }
 
-auto XournalView::getWidget() -> GtkWidget* { return widget; }
+auto XournalView::getWidget() const -> GtkWidget* { return widget; }
 
 void XournalView::ensureRectIsVisible(int x, int y, int width, int height) {
     Layout* layout = gtk_xournal_get_layout(this->widget);
@@ -560,7 +560,7 @@ void XournalView::pageDeleted(size_t page) {
     control->getScrollHandler()->scrollToPage(currentPage);
 }
 
-auto XournalView::getTextEditor() -> TextEditor* {
+auto XournalView::getTextEditor() const -> TextEditor* {
     for (auto&& page: viewPages) {
         if (page->getTextEditor()) {
             return page->getTextEditor();
@@ -570,7 +570,7 @@ auto XournalView::getTextEditor() -> TextEditor* {
     return nullptr;
 }
 
-auto XournalView::getCache() -> PdfCache* { return this->cache.get(); }
+auto XournalView::getCache() const -> PdfCache* { return this->cache.get(); }
 
 void XournalView::pageInserted(size_t page) {
     Document* doc = control->getDocument();
@@ -586,9 +586,9 @@ void XournalView::pageInserted(size_t page) {
     layout->updateVisibility();
 }
 
-auto XournalView::getZoom() -> double { return control->getZoomControl()->getZoom(); }
+auto XournalView::getZoom() const -> double { return control->getZoomControl()->getZoom(); }
 
-auto XournalView::getDpiScaleFactor() -> int { return gtk_widget_get_scale_factor(widget); }
+auto XournalView::getDpiScaleFactor() const -> int { return gtk_widget_get_scale_factor(widget); }
 
 void XournalView::clearSelection() {
     EditSelection* sel = GTK_XOURNAL(widget)->selection;
@@ -675,7 +675,7 @@ void XournalView::resetSetsquareView() {
     this->control->fireActionSelected(GROUP_SETSQUARE, ACTION_NONE);
 }
 
-auto XournalView::getSetsquareView() -> SetsquareView* {
+auto XournalView::getSetsquareView() const -> SetsquareView* {
     g_return_val_if_fail(this->widget != nullptr, nullptr);
     g_return_val_if_fail(GTK_IS_XOURNAL(this->widget), nullptr);
 
@@ -713,7 +713,7 @@ auto XournalView::getDisplayWidth() const -> int {
     return allocation.width;
 }
 
-auto XournalView::isPageVisible(size_t page, int* visibleHeight) -> bool {
+auto XournalView::isPageVisible(size_t page, int* visibleHeight) const -> bool {
     Rectangle<double>* rect = getVisibleRect(page);
     if (rect) {
         if (visibleHeight) {
@@ -804,13 +804,13 @@ auto XournalView::actionDelete() -> bool {
     return page->actionDelete();
 }
 
-auto XournalView::getDocument() -> Document* { return control->getDocument(); }
+auto XournalView::getDocument() const -> Document* { return control->getDocument(); }
 
 auto XournalView::getViewPages() const -> std::vector<XojPageView*> const& { return viewPages; }
 
-auto XournalView::getCursor() -> XournalppCursor* { return control->getCursor(); }
+auto XournalView::getCursor() const -> XournalppCursor* { return control->getCursor(); }
 
-auto XournalView::getSelection() -> EditSelection* {
+auto XournalView::getSelection() const -> EditSelection* {
     g_return_val_if_fail(this->widget != nullptr, nullptr);
     g_return_val_if_fail(GTK_IS_XOURNAL(this->widget), nullptr);
 

--- a/src/core/gui/XournalView.h
+++ b/src/core/gui/XournalView.h
@@ -24,6 +24,7 @@
 #include "control/zoom/ZoomListener.h"  // for ZoomListener
 #include "model/DocumentChangeType.h"   // for DocumentChangeType
 #include "model/DocumentListener.h"     // for DocumentListener
+#include "util/Util.h"                  // for npos
 
 class Control;
 class XournalppCursor;
@@ -65,7 +66,7 @@ public:
 
     void forceUpdatePagenumbers();
 
-    XojPageView* getViewFor(size_t pageNr);
+    XojPageView* getViewFor(size_t pageNr) const;
 
     bool searchTextOnPage(std::string text, size_t p, int* occures, double* top);
 
@@ -73,7 +74,7 @@ public:
     bool copy();
     bool paste();
 
-    void getPasteTarget(double& x, double& y);
+    void getPasteTarget(double& x, double& y) const;
 
     bool actionDelete();
 
@@ -82,34 +83,34 @@ public:
     int getDisplayWidth() const;
     int getDisplayHeight() const;
 
-    bool isPageVisible(size_t page, int* visibleHeight);
+    bool isPageVisible(size_t page, int* visibleHeight) const;
 
     void ensureRectIsVisible(int x, int y, int width, int height);
 
     void setSelection(EditSelection* selection);
-    EditSelection* getSelection();
+    EditSelection* getSelection() const;
     void deleteSelection(EditSelection* sel = nullptr);
     void repaintSelection(bool evenWithoutSelection = false);
 
     void setSetsquareView(std::unique_ptr<SetsquareView> setsquareView);
     void resetSetsquareView();
-    SetsquareView* getSetsquareView();
+    SetsquareView* getSetsquareView() const;
     void repaintSetsquare(bool evenWithoutSetsquare = false);
 
-    TextEditor* getTextEditor();
+    TextEditor* getTextEditor() const;
     std::vector<XojPageView*> const& getViewPages() const;
 
-    Control* getControl();
-    double getZoom();
-    int getDpiScaleFactor();
-    Document* getDocument();
-    PdfCache* getCache();
-    RepaintHandler* getRepaintHandler();
-    GtkWidget* getWidget();
-    XournalppCursor* getCursor();
+    Control* getControl() const;
+    double getZoom() const;
+    int getDpiScaleFactor() const;
+    Document* getDocument() const;
+    PdfCache* getCache() const;
+    RepaintHandler* getRepaintHandler() const;
+    GtkWidget* getWidget() const;
+    XournalppCursor* getCursor() const;
 
-    xoj::util::Rectangle<double>* getVisibleRect(int page);
-    xoj::util::Rectangle<double>* getVisibleRect(XojPageView* redrawable);
+    xoj::util::Rectangle<double>* getVisibleRect(size_t page) const;
+    xoj::util::Rectangle<double>* getVisibleRect(const XojPageView* redrawable) const;
 
     /**
      * A pen action was detected now, therefore ignore touch events
@@ -120,12 +121,12 @@ public:
     /**
      * @return Helper class for Touch specific fixes
      */
-    HandRecognition* getHandRecognition();
+    HandRecognition* getHandRecognition() const;
 
     /**
      * @return Scrollbars
      */
-    ScrollHandling* getScrollHandling();
+    ScrollHandling* getScrollHandling() const;
 
 public:
     // ZoomListener interface
@@ -153,8 +154,6 @@ private:
 
     std::pair<size_t, size_t> preloadPageBounds(size_t page, size_t maxPage);
 
-    xoj::util::Rectangle<double>* getVisibleRect(size_t page);
-
     static gboolean clearMemoryTimer(XournalView* widget);
 
     void cleanupBufferCache();
@@ -175,7 +174,7 @@ private:
     Control* control = nullptr;
 
     size_t currentPage = 0;
-    size_t lastSelectedPage = -1;
+    size_t lastSelectedPage = npos;
 
     std::unique_ptr<PdfCache> cache;
 

--- a/src/core/gui/widgets/XournalWidget.cpp
+++ b/src/core/gui/widgets/XournalWidget.cpp
@@ -93,7 +93,7 @@ static void gtk_xournal_class_init(GtkXournalClass* cptr) {
     reinterpret_cast<GObjectClass*>(widget_class)->dispose = gtk_xournal_dispose;
 }
 
-auto gtk_xournal_get_visible_area(GtkWidget* widget, XojPageView* p) -> Rectangle<double>* {
+auto gtk_xournal_get_visible_area(GtkWidget* widget, const XojPageView* p) -> Rectangle<double>* {
     g_return_val_if_fail(widget != nullptr, nullptr);
     g_return_val_if_fail(GTK_IS_XOURNAL(widget), nullptr);
 

--- a/src/core/gui/widgets/XournalWidget.h
+++ b/src/core/gui/widgets/XournalWidget.h
@@ -91,6 +91,6 @@ void gtk_xournal_scroll_relative(GtkWidget* widget, double x, double y);
 
 void gtk_xournal_repaint_area(GtkWidget* widget, int x1, int y1, int x2, int y2);
 
-xoj::util::Rectangle<double>* gtk_xournal_get_visible_area(GtkWidget* widget, XojPageView* p);
+xoj::util::Rectangle<double>* gtk_xournal_get_visible_area(GtkWidget* widget, const XojPageView* p);
 
 G_END_DECLS

--- a/src/util/include/util/PairView.h
+++ b/src/util/include/util/PairView.h
@@ -10,6 +10,7 @@
  */
 #pragma once
 
+#include <array>
 #include <iterator>
 
 #include "TypeIfThenElse.h"
@@ -108,13 +109,20 @@ private:
 
 public:
     const_iterator begin() const { return const_iterator(container.begin()); }
-    iterator begin() { return iterator(container.begin()); }
+
+    template <class T = contiguous_container_type, std::enable_if_t<!std::is_const<T>::value, int> = 0>
+    iterator begin() {
+        return iterator(container.begin());
+    }
+
     const_iterator end() const {
         if (container.empty()) {
             return begin();
         }
         return const_iterator(std::prev(container.end()));
     }
+
+    template <class T = contiguous_container_type, std::enable_if_t<!std::is_const<T>::value, int> = 0>
     iterator end() {
         if (container.empty()) {
             return begin();


### PR DESCRIPTION
This is a code cleanup PR coming from #4137, #4158 and #4159, to simplify the reviewing.

Two things in here:
1. Some const-correctness in various classes in gui/
2. Fix util/PairView to work on const qualified containers

Since nothing is really happening in this PR, I'll be merging it in 48 hours unless someone objects.