### PR TITLE
 Added functionality to the missing PDF background dialog to propose a replacement file

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -2148,7 +2148,7 @@ auto Control::openFile(fs::path filepath, int scrollToPage, bool forceOpen) -> b
         }
 
         // try to find file in current directory
-        auto proposedPdfFilepath = filepath.parent_path() /= missingFilePath.filename();
+        auto proposedPdfFilepath = filepath.parent_path() / missingFilePath.filename();
         bool proposedPdfFileExits = fs::exists(proposedPdfFilepath);
         if (proposedPdfFileExits) {
             msg += FS(_F("\nProposed replacement file: \"{1}\"") % proposedPdfFilepath.string());

--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -2140,10 +2140,10 @@ auto Control::openFile(fs::path filepath, int scrollToPage, bool forceOpen) -> b
         GMatchInfo* matchInfo = nullptr;
         GRegex* regex = g_regex_new(R"([A-Z]:\\.*\\(.*))", static_cast<GRegexCompileFlags>(0),
                                     static_cast<GRegexMatchFlags>(0), nullptr);
-        g_regex_match(regex, missingFilePath.filename().c_str(), static_cast<GRegexMatchFlags>(0), &matchInfo);
+        g_regex_match(regex, (gchar*) missingFilePath.filename().c_str(), static_cast<GRegexMatchFlags>(0), &matchInfo);
 
         if (g_match_info_matches(matchInfo)) {
-            parentFolderPath = missingFilePath.filename();
+            parentFolderPath = missingFilePath.filename().string();
             filename = g_match_info_fetch(matchInfo, 1);
         } else {
             parentFolderPath = missingFilePath.parent_path().string();

--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -2132,9 +2132,12 @@ auto Control::openFile(fs::path filepath, int scrollToPage, bool forceOpen) -> b
         // give the user a second chance to select a new PDF filepath, or to discard the PDF
         const fs::path missingFilePath = fs::path(loadHandler.getMissingPdfFilename());
 
-        string parentFolderPath;
-        string filename;
-
+        std::string parentFolderPath;
+        std::string filename;
+#if defined(WIN32)
+        parentFolderPath = missingFilePath.parent_path().string();
+        filename = missingFilePath.filename().string();
+#else
         // since POSIX systems detect the whole Windows path as a filename, this checks whether missingFilePath contains
         // a Windows path
         GMatchInfo* matchInfo = nullptr;
@@ -2149,7 +2152,7 @@ auto Control::openFile(fs::path filepath, int scrollToPage, bool forceOpen) -> b
             parentFolderPath = missingFilePath.parent_path().string();
             filename = missingFilePath.filename().string();
         }
-
+#endif
         std::string msg;
         if (loadHandler.isAttachedPdfMissing()) {
             msg = FS(_F("The attached background file \"{1}\" could not be found. It might have been moved, "


### PR DESCRIPTION
If there is a PDF file with the same name as the missing PDF in the directory where the journal file is saved, the dialog now proposes that file to the user. If not the dialog stays as before.

This is especially useful when moving the journal file and the background to a new location. Or in my case where I switch between Linux and Windows a lot, the background can be automatically found even tho Linux and Windows are using a different path structure