### PR TITLE
add optional mode parameter for plugin callback functions

### DIFF
--- a/src/core/plugin/Plugin.cpp
+++ b/src/core/plugin/Plugin.cpp
@@ -100,10 +100,10 @@ void Plugin::registerMenu(GtkWindow* mainWindow, GtkWidget* menu) {
     gtk_window_add_accel_group(GTK_WINDOW(mainWindow), accelGroup);
 }
 
-void Plugin::executeMenuEntry(MenuEntry* entry) { callFunction(entry->callback); }
+void Plugin::executeMenuEntry(MenuEntry* entry) { callFunction(entry->callback, entry->mode); }
 
-auto Plugin::registerMenu(std::string menu, std::string callback, std::string accelerator) -> size_t {
-    menuEntries.emplace_back(this, std::move(menu), std::move(callback), std::move(accelerator));
+auto Plugin::registerMenu(std::string menu, std::string callback, long mode, std::string accelerator) -> size_t {
+    menuEntries.emplace_back(this, std::move(menu), std::move(callback), mode, std::move(accelerator));
     return menuEntries.size() - 1;
 }
 
@@ -235,11 +235,18 @@ void Plugin::loadScript() {
     }
 }
 
-auto Plugin::callFunction(const std::string& fnc) -> bool {
+auto Plugin::callFunction(const std::string& fnc, long mode) -> bool {
     lua_getglobal(lua.get(), fnc.c_str());
 
+    int numArgs = 0;
+
+    if (mode != LONG_MAX) {
+        lua_pushinteger(lua.get(), mode);
+        numArgs = 1;
+    }
+
     // Run the function
-    if (lua_pcall(lua.get(), 0, 0, 0)) {
+    if (lua_pcall(lua.get(), numArgs, 0, 0)) {
         const char* errMsg = lua_tostring(lua.get(), -1);
         std::map<int, std::string> button;
         button.insert(std::pair<int, std::string>(0, _("OK")));

--- a/src/core/plugin/Plugin.h
+++ b/src/core/plugin/Plugin.h
@@ -35,13 +35,18 @@ class Control;
 
 struct MenuEntry final {
     MenuEntry() = default;
-    MenuEntry(Plugin* plugin, std::string menu, std::string callback, std::string accelerator):
-            plugin(plugin), menu(std::move(menu)), callback(std::move(callback)), accelerator(std::move(accelerator)) {}
+    MenuEntry(Plugin* plugin, std::string menu, std::string callback, long mode, std::string accelerator):
+            plugin(plugin),
+            menu(std::move(menu)),
+            callback(std::move(callback)),
+            mode(mode),
+            accelerator(std::move(accelerator)) {}
 
     GtkWidget* widget = nullptr;  ///< Menu item
     Plugin* plugin = nullptr;     ///< The Plugin
     std::string menu{};           ///< Menu display name
     std::string callback{};       ///< Callback function name
+    long mode{LONG_MAX};          ///< mode in which the callback function is run
     std::string accelerator{};
     ///< Accelerator key, see
     ///< https://developer.gnome.org/gtk3/stable/gtk3-Keyboard-Accelerators.html#gtk-accelerator-parse
@@ -100,7 +105,7 @@ public:
 
     /// Register a menu item
     /// @return Internal ID, can e.g. be used to disable the menu
-    auto registerMenu(std::string menu, std::string callback, std::string accelerator) -> size_t;
+    auto registerMenu(std::string menu, std::string callback, long mode, std::string accelerator) -> size_t;
 
     ///@return The main controller
     auto getControl() const -> Control*;
@@ -110,7 +115,7 @@ private:
     void loadIni();
 
     /// Execute lua function
-    auto callFunction(const std::string& fnc) -> bool;
+    auto callFunction(const std::string& fnc, long mode = LONG_MAX) -> bool;
 
     /// Load custom Lua Libraries
     static void registerXournalppLibs(lua_State* luaPtr);


### PR DESCRIPTION
This PR implements an optional `mode` parameter for `app.registerUi`. It allows to have multiple registered entries to share the same callback function executed in a different mode. If the `mode` parameter is specified the callback function should have the form
```lua
def functionname(mode)
  -- code
end
```
For example you may want to register a menu entry for each color in the color palette without defining a separate callback function for each color.