### PR TITLE
fix bug for setsquare translation via arrow keys

### DIFF
--- a/src/core/gui/inputdevices/SetsquareInputHandler.cpp
+++ b/src/core/gui/inputdevices/SetsquareInputHandler.cpp
@@ -195,7 +195,7 @@ auto SetsquareInputHandler::handleKeyboard(InputEvent const& event) -> bool {
                 xshift = amount * xdir;
                 yshift = amount * ydir;
             }
-            setsquareView->move(amount * xshift, amount * yshift);
+            setsquareView->move(xshift, yshift);
             view->repaintSetsquare();
             return true;
         }


### PR DESCRIPTION
This is an obvious bug, since `xdir` and `ydir` get multiplied by `amount` twice.