### PR TITLE
Refactor setsquare to use MVC pattern

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -345,7 +345,7 @@ void Control::initWindow(MainWindow* win) {
 
     fireActionSelected(GROUP_SNAPPING, settings->isSnapRotation() ? ACTION_ROTATION_SNAPPING : ACTION_NONE);
     fireActionSelected(GROUP_GRID_SNAPPING, settings->isSnapGrid() ? ACTION_GRID_SNAPPING : ACTION_NONE);
-    fireActionSelected(GROUP_SETSQUARE, ACTION_NONE);
+    fireActionSelected(GROUP_GEOMETRY_TOOL, ACTION_NONE);
 }
 
 auto Control::autosaveCallback(Control* control) -> bool {
@@ -647,12 +647,14 @@ void Control::actionPerformed(ActionType type, ActionGroup group, GtkToolButton*
             }
             break;
         case ACTION_SETSQUARE:
-            if (auto xournal = this->win->getXournal(); !xournal->getSetsquareController()) {
-                xournal->resetSetsquare();
-                xournal->makeSetsquare();
+            if (auto xournal = this->win->getXournal();
+                !xournal->getGeometryToolController() ||
+                xournal->getGeometryToolController()->getType() != "setsquare") {
+                xournal->resetGeometryTool();
+                xournal->makeGeometryTool("setsquare");
                 xournal->getViewFor(getCurrentPageNo())->rerenderPage();
             } else {
-                xournal->resetSetsquare();
+                xournal->resetGeometryTool();
                 xournal->getViewFor(getCurrentPageNo())->rerenderPage();
             }
             break;
@@ -1357,11 +1359,11 @@ void Control::updateDeletePageButton() {
 void Control::deletePage() {
     clearSelectionEndText();
 
-    // if the current page contains the Setsquare, reset it
+    // if the current page contains the geometry tool, reset it
     size_t pNr = getCurrentPageNo();
-    auto setsquareController = win->getXournal()->getSetsquareController();
-    if (setsquareController && doc->indexOf(setsquareController->getPage()) == pNr) {
-        win->getXournal()->resetSetsquare();
+    auto geometryToolController = win->getXournal()->getGeometryToolController();
+    if (geometryToolController && doc->indexOf(geometryToolController->getPage()) == pNr) {
+        win->getXournal()->resetGeometryTool();
     }
     // don't allow delete pages if we have less than 2 pages,
     // so we can be (more or less) sure there is at least one page.
@@ -2779,7 +2781,7 @@ auto Control::close(const bool allowDestroy, const bool allowCancel) -> bool {
     if (allowDestroy && discard) {
         this->closeDocument();
     }
-    win->getXournal()->resetSetsquare();
+    win->getXournal()->resetGeometryTool();
     return true;
 }
 

--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -1069,23 +1069,23 @@ void Control::makeGeometryTool(GeometryToolType tool) {
     if (tool == GeometryToolType::SETSQUARE) {
         auto setsquare = new Setsquare();
         view->addOverlayView(std::make_unique<xoj::view::SetsquareView>(setsquare, view, zoom));
-        std::unique_ptr<GeometryTool> geometryTool = std::unique_ptr<GeometryTool>(setsquare);
+        this->geometryTool = std::unique_ptr<GeometryTool>(setsquare);
         this->geometryToolController = std::make_unique<SetsquareController>(view, setsquare);
         std::unique_ptr<GeometryToolInputHandler> geometryToolInputHandler =
                 std::make_unique<SetsquareInputHandler>(this->win->getXournal(), geometryToolController.get());
         geometryToolInputHandler->registerToPool(setsquare->getHandlerPool());
-        fireActionSelected(GROUP_GEOMETRY_TOOL, ACTION_SETSQUARE);
-        this->win->getXournal()->setGeometryTool(std::move(geometryTool));
         auto xournal = GTK_XOURNAL(this->win->getXournal()->getWidget());
         xournal->input->setGeometryToolInputHandler(std::move(geometryToolInputHandler));
+        fireActionSelected(GROUP_GEOMETRY_TOOL, ACTION_SETSQUARE);
     }
 }
 
 void Control::resetGeometryTool() {
     this->geometryToolController.reset();
-    this->win->getXournal()->resetGeometryTool();
+    this->geometryTool.reset();
     auto xournal = GTK_XOURNAL(this->win->getXournal()->getWidget());
     xournal->input->resetGeometryToolInputHandler();
+    fireActionSelected(GROUP_GEOMETRY_TOOL, ACTION_NONE);
 }
 
 auto Control::copy() -> bool {

--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -649,9 +649,9 @@ void Control::actionPerformed(ActionType type, ActionGroup group, GtkToolButton*
         case ACTION_SETSQUARE:
             if (auto xournal = this->win->getXournal();
                 !xournal->getGeometryToolController() ||
-                xournal->getGeometryToolController()->getType() != "setsquare") {
+                xournal->getGeometryToolController()->getType() != GeometryToolType::SETSQUARE) {
                 xournal->resetGeometryTool();
-                xournal->makeGeometryTool("setsquare");
+                xournal->makeGeometryTool(GeometryToolType::SETSQUARE);
                 xournal->getViewFor(getCurrentPageNo())->rerenderPage();
             } else {
                 xournal->resetGeometryTool();
@@ -1362,9 +1362,11 @@ void Control::deletePage() {
     // if the current page contains the geometry tool, reset it
     size_t pNr = getCurrentPageNo();
     auto geometryToolController = win->getXournal()->getGeometryToolController();
+    doc->lock();
     if (geometryToolController && doc->indexOf(geometryToolController->getPage()) == pNr) {
         win->getXournal()->resetGeometryTool();
     }
+    doc->unlock();
     // don't allow delete pages if we have less than 2 pages,
     // so we can be (more or less) sure there is at least one page.
     if (this->doc->getPageCount() < 2) {

--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -1075,13 +1075,17 @@ void Control::makeGeometryTool(GeometryToolType tool) {
                 std::make_unique<SetsquareInputHandler>(this->win->getXournal(), geometryToolController.get());
         geometryToolInputHandler->registerToPool(setsquare->getHandlerPool());
         fireActionSelected(GROUP_GEOMETRY_TOOL, ACTION_SETSQUARE);
-        this->win->getXournal()->setGeometryTool(std::move(geometryTool), std::move(geometryToolInputHandler));
+        this->win->getXournal()->setGeometryTool(std::move(geometryTool));
+        auto xournal = GTK_XOURNAL(this->win->getXournal()->getWidget());
+        xournal->input->setGeometryToolInputHandler(std::move(geometryToolInputHandler));
     }
 }
 
 void Control::resetGeometryTool() {
     this->geometryToolController.reset();
     this->win->getXournal()->resetGeometryTool();
+    auto xournal = GTK_XOURNAL(this->win->getXournal()->getWidget());
+    xournal->input->resetGeometryToolInputHandler();
 }
 
 auto Control::copy() -> bool {

--- a/src/core/control/Control.h
+++ b/src/core/control/Control.h
@@ -26,6 +26,7 @@
 #include "enums/ActionGroup.enum.h"         // for ActionGroup
 #include "enums/ActionType.enum.h"          // for ActionType
 #include "model/DocumentHandler.h"          // for DocumentHandler
+#include "model/GeometryTool.h"             // for GeometryTool
 #include "model/PageRef.h"                  // for PageRef
 #include "undo/UndoRedoHandler.h"           // for UndoRedoHandler (ptr only)
 
@@ -35,6 +36,7 @@
 #include "ToolHandler.h"       // for ToolListener
 #include "filesystem.h"        // for path
 
+class GeometryToolController;
 class AudioController;
 class FullscreenHandler;
 class Sidebar;
@@ -349,6 +351,9 @@ protected:
     bool loadPdf(fs::path const& filepath, int scrollToPage);
 
 private:
+    void makeGeometryTool(GeometryToolType tool);
+    void resetGeometryTool();
+
     /**
      * "Closes" the document, preparing the editor for a new document.
      */
@@ -440,6 +445,8 @@ private:
     PageBackgroundChangeController* pageBackgroundChangeController;
 
     LayerController* layerController;
+
+    std::unique_ptr<GeometryToolController> geometryToolController;
 
     /**
      * Manage all Xournal++ plugins

--- a/src/core/control/Control.h
+++ b/src/core/control/Control.h
@@ -446,6 +446,7 @@ private:
 
     LayerController* layerController;
 
+    std::unique_ptr<GeometryTool> geometryTool;
     std::unique_ptr<GeometryToolController> geometryToolController;
 
     /**

--- a/src/core/control/GeometryToolController.cpp
+++ b/src/core/control/GeometryToolController.cpp
@@ -79,21 +79,20 @@ void GeometryToolController::addStrokeToLayer() {
     const auto layer = page->getSelectedLayer();
 
     const auto undo = control->getUndoRedoHandler();
-    undo->addUndoAction(std::make_unique<InsertUndoAction>(page, layer, stroke));
-
-    layer->addElement(stroke);
+    undo->addUndoAction(std::make_unique<InsertUndoAction>(page, layer, stroke.get()));
+    layer->addElement(stroke.get());
 
     const Rectangle<double> rect{stroke->getX(), stroke->getY(), stroke->getElementWidth(), stroke->getElementHeight()};
     view->rerenderRect(rect.x, rect.y, rect.width, rect.height);
-    stroke = nullptr;
+    stroke.release();
     geometryTool->setStroke(nullptr);
     xournal->getCursor()->updateCursor();
 }
 
 void GeometryToolController::initializeStroke() {
     const auto h = view->getXournal()->getControl()->getToolHandler();
-    stroke = new Stroke();
-    geometryTool->setStroke(stroke);
+    stroke = std::make_unique<Stroke>();
+    geometryTool->setStroke(stroke.get());
     stroke->setWidth(h->getThickness());
     stroke->setColor(h->getColor());
     stroke->setFill(h->getFill());

--- a/src/core/control/GeometryToolController.cpp
+++ b/src/core/control/GeometryToolController.cpp
@@ -10,36 +10,37 @@
 #include "undo/InsertUndoAction.h"
 
 using xoj::util::Rectangle;
-GeometryToolController::GeometryToolController(XojPageView* view, GeometryTool* s): view(view), s(s) {}
+GeometryToolController::GeometryToolController(XojPageView* view, GeometryTool* geometryTool):
+        view(view), geometryTool(geometryTool) {}
 
 GeometryToolController::~GeometryToolController() = default;
 
 void GeometryToolController::move(double x, double y) {
-    s->setTranslationX(s->getTranslationX() + x);
-    s->setTranslationY(s->getTranslationY() + y);
-    s->notify();
+    geometryTool->setTranslationX(geometryTool->getTranslationX() + x);
+    geometryTool->setTranslationY(geometryTool->getTranslationY() + y);
+    geometryTool->notify();
 }
 
 void GeometryToolController::rotate(double da, double cx, double cy) {
-    s->setRotation(s->getRotation() + da);
-    const auto offsetX = s->getTranslationX() - cx;
-    const auto offsetY = s->getTranslationY() - cy;
+    geometryTool->setRotation(geometryTool->getRotation() + da);
+    const auto offsetX = geometryTool->getTranslationX() - cx;
+    const auto offsetY = geometryTool->getTranslationY() - cy;
     const auto mx = offsetX * cos(da) - offsetY * sin(da);
     const auto my = offsetX * sin(da) + offsetY * cos(da);
-    s->setTranslationX(cx + mx);
-    s->setTranslationY(cy + my);
-    s->notify();
+    geometryTool->setTranslationX(cx + mx);
+    geometryTool->setTranslationY(cy + my);
+    geometryTool->notify();
 }
 
 void GeometryToolController::scale(double f, double cx, double cy) {
-    s->setHeight(s->getHeight() * f);
-    const auto offsetX = s->getTranslationX() - cx;
-    const auto offsetY = s->getTranslationY() - cy;
+    geometryTool->setHeight(geometryTool->getHeight() * f);
+    const auto offsetX = geometryTool->getTranslationX() - cx;
+    const auto offsetY = geometryTool->getTranslationY() - cy;
     const auto mx = offsetX * f;
     const auto my = offsetY * f;
-    s->setTranslationX(cx + mx);
-    s->setTranslationY(cy + my);
-    s->notify();
+    geometryTool->setTranslationX(cx + mx);
+    geometryTool->setTranslationY(cy + my);
+    geometryTool->notify();
 }
 
 
@@ -58,14 +59,14 @@ void GeometryToolController::addStrokeToLayer() {
     const Rectangle<double> rect{stroke->getX(), stroke->getY(), stroke->getElementWidth(), stroke->getElementHeight()};
     view->rerenderRect(rect.x, rect.y, rect.width, rect.height);
     stroke = nullptr;
-    s->setStroke(nullptr);
+    geometryTool->setStroke(nullptr);
     xournal->getCursor()->updateCursor();
 }
 
 void GeometryToolController::initializeStroke() {
     const auto h = view->getXournal()->getControl()->getToolHandler();
     stroke = new Stroke();
-    s->setStroke(stroke);
+    geometryTool->setStroke(stroke);
     stroke->setWidth(h->getThickness());
     stroke->setColor(h->getColor());
     stroke->setFill(h->getFill());

--- a/src/core/control/GeometryToolController.cpp
+++ b/src/core/control/GeometryToolController.cpp
@@ -4,6 +4,7 @@
 #include "control/layer/LayerController.h"
 #include "gui/XournalView.h"
 #include "gui/XournalppCursor.h"
+#include "model/Document.h"
 #include "model/GeometryTool.h"
 #include "model/Stroke.h"
 #include "model/XojPage.h"
@@ -74,14 +75,16 @@ void GeometryToolController::markPoint(double x, double y) {
 void GeometryToolController::addStrokeToLayer() {
     const auto xournal = view->getXournal();
     const auto control = xournal->getControl();
+    const auto doc = control->getDocument();
     const auto page = view->getPage();
+
+    doc->lock();
     control->getLayerController()->ensureLayerExists(page);
     const auto layer = page->getSelectedLayer();
-
+    layer->addElement(stroke.get());
+    doc->unlock();
     const auto undo = control->getUndoRedoHandler();
     undo->addUndoAction(std::make_unique<InsertUndoAction>(page, layer, stroke.get()));
-    layer->addElement(stroke.get());
-
     const Rectangle<double> rect{stroke->getX(), stroke->getY(), stroke->getElementWidth(), stroke->getElementHeight()};
     view->rerenderRect(rect.x, rect.y, rect.width, rect.height);
     stroke.release();

--- a/src/core/control/GeometryToolController.cpp
+++ b/src/core/control/GeometryToolController.cpp
@@ -22,10 +22,8 @@ void GeometryToolController::move(double x, double y) {
 
 void GeometryToolController::rotate(double da, double cx, double cy) {
     s->setRotation(s->getRotation() + da);
-    const auto tx = s->getTranslationX();
-    const auto ty = s->getTranslationY();
-    const auto offsetX = tx - cx;
-    const auto offsetY = ty - cy;
+    const auto offsetX = s->getTranslationX() - cx;
+    const auto offsetY = s->getTranslationY() - cy;
     const auto mx = offsetX * cos(da) - offsetY * sin(da);
     const auto my = offsetX * sin(da) + offsetY * cos(da);
     s->setTranslationX(cx + mx);
@@ -35,10 +33,8 @@ void GeometryToolController::rotate(double da, double cx, double cy) {
 
 void GeometryToolController::scale(double f, double cx, double cy) {
     s->setHeight(s->getHeight() * f);
-    const auto tx = s->getTranslationX();
-    const auto ty = s->getTranslationY();
-    const auto offsetX = tx - cx;
-    const auto offsetY = ty - cy;
+    const auto offsetX = s->getTranslationX() - cx;
+    const auto offsetY = s->getTranslationY() - cy;
     const auto mx = offsetX * f;
     const auto my = offsetY * f;
     s->setTranslationX(cx + mx);

--- a/src/core/control/GeometryToolController.cpp
+++ b/src/core/control/GeometryToolController.cpp
@@ -40,7 +40,7 @@ void GeometryToolController::scale(double f, double cx, double cy) {
     const auto my = offsetY * f;
     geometryTool->setTranslationX(cx + mx);
     geometryTool->setTranslationY(cy + my);
-    geometryTool->notify();
+    geometryTool->notify(true);
 }
 
 

--- a/src/core/control/GeometryToolController.cpp
+++ b/src/core/control/GeometryToolController.cpp
@@ -19,7 +19,7 @@ GeometryToolController::GeometryToolController(XojPageView* view, GeometryTool* 
 
 GeometryToolController::~GeometryToolController() = default;
 
-void GeometryToolController::move(double x, double y) {
+void GeometryToolController::translate(double x, double y) {
     geometryTool->setTranslationX(geometryTool->getTranslationX() + x);
     geometryTool->setTranslationY(geometryTool->getTranslationY() + y);
     geometryTool->notify();
@@ -59,14 +59,16 @@ void GeometryToolController::markPoint(double x, double y) {
     cross->addPoint(Point(x + MARK_SIZE, y - MARK_SIZE));
     cross->addPoint(Point(x - MARK_SIZE, y + MARK_SIZE));
 
+    const auto doc = control->getDocument();
     const auto page = view->getPage();
+    doc->lock();
     control->getLayerController()->ensureLayerExists(page);
     const auto layer = page->getSelectedLayer();
+    layer->addElement(cross);
+    doc->unlock();
 
     const auto undo = control->getUndoRedoHandler();
     undo->addUndoAction(std::make_unique<InsertUndoAction>(page, layer, cross));
-
-    layer->addElement(cross);
 
     const Rectangle<double> rect{cross->getX(), cross->getY(), cross->getElementWidth(), cross->getElementHeight()};
     view->rerenderRect(rect.x, rect.y, rect.width, rect.height);
@@ -116,6 +118,6 @@ void GeometryToolController::initializeStroke() {
     }
 }
 
-auto GeometryToolController::getPage() const -> PageRef { return view->getPage(); }
+auto GeometryToolController::getPage() const -> const PageRef { return view->getPage(); }
 
 auto GeometryToolController::getView() const -> XojPageView* { return view; }

--- a/src/core/control/GeometryToolController.cpp
+++ b/src/core/control/GeometryToolController.cpp
@@ -70,6 +70,20 @@ void GeometryToolController::initializeStroke() {
     stroke->setColor(h->getColor());
     stroke->setFill(h->getFill());
     stroke->setLineStyle(h->getLineStyle());
+    switch (h->getToolType()) {
+        case TOOL_PEN:
+            stroke->setToolType(StrokeTool::PEN);
+            break;
+        case TOOL_HIGHLIGHTER:
+            stroke->setToolType(StrokeTool::HIGHLIGHTER);
+            break;
+        case TOOL_ERASER:
+            stroke->setToolType(StrokeTool::ERASER);
+            break;
+        default:
+            g_warning("Unhandled tool when initializing stroke in geometry tool controller");
+            break;
+    }
 }
 
 auto GeometryToolController::getPage() const -> PageRef { return view->getPage(); }

--- a/src/core/control/GeometryToolController.cpp
+++ b/src/core/control/GeometryToolController.cpp
@@ -1,0 +1,81 @@
+#include "GeometryToolController.h"
+
+#include "control/Control.h"
+#include "control/layer/LayerController.h"
+#include "gui/XournalView.h"
+#include "gui/XournalppCursor.h"
+#include "model/GeometryTool.h"
+#include "model/Stroke.h"
+#include "model/XojPage.h"
+#include "undo/InsertUndoAction.h"
+
+using xoj::util::Rectangle;
+GeometryToolController::GeometryToolController(XojPageView* view, GeometryTool* s): view(view), s(s) {}
+
+GeometryToolController::~GeometryToolController() = default;
+
+void GeometryToolController::move(double x, double y) {
+    s->setTranslationX(s->getTranslationX() + x);
+    s->setTranslationY(s->getTranslationY() + y);
+    s->notify();
+}
+
+void GeometryToolController::rotate(double da, double cx, double cy) {
+    s->setRotation(s->getRotation() + da);
+    const auto tx = s->getTranslationX();
+    const auto ty = s->getTranslationY();
+    const auto offsetX = tx - cx;
+    const auto offsetY = ty - cy;
+    const auto mx = offsetX * cos(da) - offsetY * sin(da);
+    const auto my = offsetX * sin(da) + offsetY * cos(da);
+    s->setTranslationX(cx + mx);
+    s->setTranslationY(cy + my);
+    s->notify();
+}
+
+void GeometryToolController::scale(double f, double cx, double cy) {
+    s->setHeight(s->getHeight() * f);
+    const auto tx = s->getTranslationX();
+    const auto ty = s->getTranslationY();
+    const auto offsetX = tx - cx;
+    const auto offsetY = ty - cy;
+    const auto mx = offsetX * f;
+    const auto my = offsetY * f;
+    s->setTranslationX(cx + mx);
+    s->setTranslationY(cy + my);
+    s->notify();
+}
+
+
+void GeometryToolController::addStrokeToLayer() {
+    const auto xournal = view->getXournal();
+    const auto control = xournal->getControl();
+    const auto page = view->getPage();
+    control->getLayerController()->ensureLayerExists(page);
+    const auto layer = page->getSelectedLayer();
+
+    const auto undo = control->getUndoRedoHandler();
+    undo->addUndoAction(std::make_unique<InsertUndoAction>(page, layer, stroke));
+
+    layer->addElement(stroke);
+
+    const Rectangle<double> rect{stroke->getX(), stroke->getY(), stroke->getElementWidth(), stroke->getElementHeight()};
+    view->rerenderRect(rect.x, rect.y, rect.width, rect.height);
+    stroke = nullptr;
+    s->setStroke(nullptr);
+    xournal->getCursor()->updateCursor();
+}
+
+void GeometryToolController::initializeStroke() {
+    const auto h = view->getXournal()->getControl()->getToolHandler();
+    stroke = new Stroke();
+    s->setStroke(stroke);
+    stroke->setWidth(h->getThickness());
+    stroke->setColor(h->getColor());
+    stroke->setFill(h->getFill());
+    stroke->setLineStyle(h->getLineStyle());
+}
+
+auto GeometryToolController::getPage() const -> PageRef { return view->getPage(); }
+
+auto GeometryToolController::getView() const -> XojPageView* { return view; }

--- a/src/core/control/GeometryToolController.h
+++ b/src/core/control/GeometryToolController.h
@@ -14,9 +14,9 @@
 #include <gtk/gtk.h>
 
 #include "gui/PageView.h"
+#include "model/GeometryTool.h"
 #include "util/Point.h"
 
-class GeometryTool;
 class Stroke;
 
 /**
@@ -85,7 +85,7 @@ public:
 
     virtual bool isInsideGeometryTool(double x, double y, double border = 0.0) const = 0;
 
-    virtual std::string getType() const = 0;
+    virtual GeometryToolType getType() const = 0;
 
 public:
     XojPageView* view;
@@ -98,5 +98,5 @@ public:
     /**
      * @brief The stroke drawn
      */
-    Stroke* stroke = nullptr;
+    std::unique_ptr<Stroke> stroke;
 };

--- a/src/core/control/GeometryToolController.h
+++ b/src/core/control/GeometryToolController.h
@@ -34,11 +34,11 @@ public:
 
 public:
     /**
-     * @brief moves the geometry tool in x- and y-direction
+     * @brief translates the geometry tool in x- and y-direction
      * @param x the translation in x-direction (in document coordinates)
      * @param y the translation in y-direction (in document coordinates)
      */
-    void move(double x, double y);
+    void translate(double x, double y);
 
     /**
      * @brief rotates the geometry tool around its rotation center
@@ -57,7 +57,7 @@ public:
     void scale(double f, double cx, double cy);
 
     /**
-     * @brief marks a point with a "x"
+     * @brief marks a point with a "x" and puts the mark onto the current layer
      * @param x the x-coordinate of the point (in document coordinates)
      * @param y the y-coordinate of the point (in document coordinates)
      */
@@ -81,7 +81,7 @@ public:
     /**
      * @brief the page with respect to which the setsquare is initialized
      */
-    PageRef getPage() const;
+    const PageRef getPage() const;
 
     virtual bool isInsideGeometryTool(double x, double y, double border = 0.0) const = 0;
 

--- a/src/core/control/GeometryToolController.h
+++ b/src/core/control/GeometryToolController.h
@@ -1,0 +1,95 @@
+/*
+ * Xournal++
+ *
+ * A geometry tool controller
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+#include <gtk/gtk.h>
+
+#include "gui/PageView.h"
+#include "util/Point.h"
+
+class GeometryTool;
+class Stroke;
+
+/**
+ * @brief A class that controls a geometry tool
+
+ * The geometry tool can be moved, rotated and scaled
+ * There are methods for translating coordinates
+ * and methods to deal with the temporary stroke
+ */
+
+class GeometryToolController {
+public:
+    GeometryToolController(XojPageView* view, GeometryTool* s);
+    ~GeometryToolController();
+
+public:
+    /**
+     * @brief moves the geometry tool in x- and y-direction
+     * @param x the translation in x-direction (in document coordinates)
+     * @param y the translation in y-direction (in document coordinates)
+     */
+    void move(double x, double y);
+
+    /**
+     * @brief rotates the geometry tool around its rotation center
+     * @param da the rotation angle
+     * @param cx the x-coordinate of the rotation center (in document coordinates)
+     * @param cy the y-coordinate of the rotation center (in document coordinates)
+     */
+    void rotate(double da, double cx, double cy);
+
+    /**
+     * @brief resizes the geometry tool by the factor f with respect to a given scaling center
+     * @param f the scaling factor
+     * @param cx the x-coordinate of the scaling center (in document coordinates)
+     * @param cy the y-coordinate of the scaling center (in document coordiantes)
+     */
+    void scale(double f, double cx, double cy);
+
+    /**
+     * @brief adds the stroke to the layer and rerenders the stroke area
+     */
+    void addStrokeToLayer();
+
+    /**
+     * @brief initializes the stroke by using the properties from the tool handler
+     */
+    void initializeStroke();
+
+    /**
+     * @brief the page view of the page with respect to which the geometry tool is initialized
+     */
+    XojPageView* getView() const;
+
+    /**
+     * @brief the page with respect to which the setsquare is initialized
+     */
+    PageRef getPage() const;
+
+    virtual bool isInsideGeometryTool(double x, double y, double border = 0.0) const = 0;
+
+    virtual std::string getType() const = 0;
+
+public:
+    XojPageView* view;
+
+    /**
+     * @brief the underlying geometry tool
+     */
+    GeometryTool* s;
+
+    /**
+     * @brief The stroke drawn
+     */
+    Stroke* stroke = nullptr;
+};

--- a/src/core/control/GeometryToolController.h
+++ b/src/core/control/GeometryToolController.h
@@ -29,7 +29,7 @@ class Stroke;
 
 class GeometryToolController {
 public:
-    GeometryToolController(XojPageView* view, GeometryTool* s);
+    GeometryToolController(XojPageView* view, GeometryTool* geometryTool);
     ~GeometryToolController();
 
 public:
@@ -86,7 +86,7 @@ public:
     /**
      * @brief the underlying geometry tool
      */
-    GeometryTool* s;
+    GeometryTool* geometryTool;
 
     /**
      * @brief The stroke drawn

--- a/src/core/control/GeometryToolController.h
+++ b/src/core/control/GeometryToolController.h
@@ -57,6 +57,13 @@ public:
     void scale(double f, double cx, double cy);
 
     /**
+     * @brief marks a point with a "x"
+     * @param x the x-coordinate of the point (in document coordinates)
+     * @param y the y-coordinate of the point (in document coordinates)
+     */
+    void markPoint(double x, double y);
+
+    /**
      * @brief adds the stroke to the layer and rerenders the stroke area
      */
     void addStrokeToLayer();

--- a/src/core/control/SetsquareController.cpp
+++ b/src/core/control/SetsquareController.cpp
@@ -89,7 +89,7 @@ void SetsquareController::updateRadius(double x, double y) {
     const auto p = posRelToSide(HYPOTENUSE, x, y);
     const auto rad = std::hypot(p.x, p.y);
 
-    if (rad >= geometryTool->getHeight() / std::sqrt(2.) - 1.15) {  // TODO
+    if (rad >= geometryTool->getHeight() / std::sqrt(2.) - 1.15 || p.y > 0) {  // TODO
         this->strokeAngle = std::atan2(p.y, p.x);
         stroke->addPoint(Point(x, y));
     } else {

--- a/src/core/control/SetsquareController.cpp
+++ b/src/core/control/SetsquareController.cpp
@@ -47,7 +47,7 @@ auto SetsquareController::getPointForPos(double xCoord) const -> utl::Point<doub
     return utl::Point<double>(x, y);
 }
 
-void SetsquareController::createStroke(double x) {
+void SetsquareController::createEdgeStroke(double x) {
     if (!std::isnan(x)) {
         hypotenuseMax = x;
         hypotenuseMin = x;
@@ -62,14 +62,14 @@ void SetsquareController::createStroke(double x) {
     }
 }
 
-void SetsquareController::createRadius(double x, double y) {
+void SetsquareController::createRadialStroke(double x, double y) {
     const auto p = posRelToSide(HYPOTENUSE, x, y);
     this->strokeAngle = std::atan2(p.y, p.x);
     initializeStroke();
-    updateRadius(x, y);
+    updateRadialStroke(x, y);
 }
 
-void SetsquareController::updateStroke(double x) {
+void SetsquareController::updateEdgeStroke(double x) {
     hypotenuseMax = std::max(this->hypotenuseMax, x);
     hypotenuseMin = std::min(this->hypotenuseMin, x);
     stroke->deletePointsFrom(0);
@@ -81,7 +81,7 @@ void SetsquareController::updateStroke(double x) {
     geometryTool->notify();
 }
 
-void SetsquareController::updateRadius(double x, double y) {
+void SetsquareController::updateRadialStroke(double x, double y) {
     stroke->deletePointsFrom(0);
     const auto c = getPointForPos(0);
     stroke->addPoint(Point(c.x, c.y));
@@ -103,17 +103,17 @@ void SetsquareController::updateRadius(double x, double y) {
     geometryTool->notify();
 }
 
-void SetsquareController::finalizeStroke() {
+void SetsquareController::finalizeEdgeStroke() {
     hypotenuseMax = std::numeric_limits<double>::min();
     hypotenuseMin = std::numeric_limits<double>::max();
     addStrokeToLayer();
 }
 
-void SetsquareController::finalizeRadius() {
+void SetsquareController::finalizeRadialStroke() {
     strokeAngle = NAN;
     addStrokeToLayer();
 }
 
-auto SetsquareController::existsStroke() -> bool { return !(hypotenuseMax == std::numeric_limits<double>::min()); }
+auto SetsquareController::existsEdgeStroke() -> bool { return !(hypotenuseMax == std::numeric_limits<double>::min()); }
 
-auto SetsquareController::existsRadius() -> bool { return !std::isnan(strokeAngle); }
+auto SetsquareController::existsRadialStroke() -> bool { return !std::isnan(strokeAngle); }

--- a/src/core/control/SetsquareController.cpp
+++ b/src/core/control/SetsquareController.cpp
@@ -15,7 +15,7 @@ SetsquareController::SetsquareController(XojPageView* view, Setsquare* setsquare
 
 SetsquareController::~SetsquareController() = default;
 
-auto SetsquareController::getType() const -> std::string { return "setsquare"; }
+auto SetsquareController::getType() const -> GeometryToolType { return GeometryToolType::SETSQUARE; }
 
 auto SetsquareController::posRelToSide(Leg leg, double x, double y) const -> utl::Point<double> {
     cairo_matrix_t matrix = geometryTool->getMatrix();
@@ -25,9 +25,9 @@ auto SetsquareController::posRelToSide(Leg leg, double x, double y) const -> utl
         case HYPOTENUSE:
             return utl::Point<double>(x, -y);
         case LEFT_LEG:
-            return utl::Point<double>((y + x) / sqrt(2.), (y - x - geometryTool->getHeight()) / sqrt(2.));
+            return utl::Point<double>((y + x) / std::sqrt(2.), (y - x - geometryTool->getHeight()) / std::sqrt(2.));
         case RIGHT_LEG:
-            return utl::Point<double>((y - x) / sqrt(2.), (y + x - geometryTool->getHeight()) / sqrt(2.));
+            return utl::Point<double>((y - x) / std::sqrt(2.), (y + x - geometryTool->getHeight()) / std::sqrt(2.));
         default:
             g_error("Invalid enum value: %d", leg);
     }
@@ -104,8 +104,8 @@ void SetsquareController::updateRadius(double x, double y) {
 }
 
 void SetsquareController::finalizeStroke() {
-    hypotenuseMax = NAN;
-    hypotenuseMin = NAN;
+    hypotenuseMax = std::numeric_limits<double>::min();
+    hypotenuseMin = std::numeric_limits<double>::max();
     addStrokeToLayer();
 }
 
@@ -114,6 +114,6 @@ void SetsquareController::finalizeRadius() {
     addStrokeToLayer();
 }
 
-auto SetsquareController::existsStroke() -> bool { return !std::isnan(hypotenuseMax) && !std::isnan(hypotenuseMin); }
+auto SetsquareController::existsStroke() -> bool { return !(hypotenuseMax == std::numeric_limits<double>::min()); }
 
 auto SetsquareController::existsRadius() -> bool { return !std::isnan(strokeAngle); }

--- a/src/core/control/SetsquareController.cpp
+++ b/src/core/control/SetsquareController.cpp
@@ -1,0 +1,185 @@
+#include "SetsquareController.h"
+
+#include "control/Control.h"
+#include "control/layer/LayerController.h"
+#include "gui/XournalView.h"
+#include "gui/XournalppCursor.h"
+#include "model/Setsquare.h"
+#include "model/Stroke.h"
+#include "model/XojPage.h"
+#include "undo/InsertUndoAction.h"  // for InsertUndoAction
+
+using xoj::util::Rectangle;
+SetsquareController::SetsquareController(XojPageView* view, Setsquare* s): view(view), s(s) {}
+
+SetsquareController::~SetsquareController() = default;
+
+void SetsquareController::move(double x, double y) {
+    s->setTranslationX(s->getTranslationX() + x);
+    s->setTranslationY(s->getTranslationY() + y);
+    s->notify();
+}
+
+void SetsquareController::rotate(double da, double cx, double cy) {
+    s->setRotation(s->getRotation() + da);
+    const auto tx = s->getTranslationX();
+    const auto ty = s->getTranslationY();
+    const auto offsetX = tx - cx;
+    const auto offsetY = ty - cy;
+    const auto mx = offsetX * cos(da) - offsetY * sin(da);
+    const auto my = offsetX * sin(da) + offsetY * cos(da);
+    s->setTranslationX(cx + mx);
+    s->setTranslationY(cy + my);
+    s->notify();
+}
+
+void SetsquareController::scale(double f, double cx, double cy) {
+    s->setHeight(s->getHeight() * f);
+    const auto tx = s->getTranslationX();
+    const auto ty = s->getTranslationY();
+    const auto offsetX = tx - cx;
+    const auto offsetY = ty - cy;
+    const auto mx = offsetX * f;
+    const auto my = offsetY * f;
+    s->setTranslationX(cx + mx);
+    s->setTranslationY(cy + my);
+    s->notify();
+}
+
+
+void SetsquareController::addStrokeToLayer() {
+    const auto xournal = view->getXournal();
+    const auto control = xournal->getControl();
+    const auto page = view->getPage();
+    control->getLayerController()->ensureLayerExists(page);
+    const auto layer = page->getSelectedLayer();
+
+    const auto undo = control->getUndoRedoHandler();
+    undo->addUndoAction(std::make_unique<InsertUndoAction>(page, layer, stroke));
+
+    layer->addElement(stroke);
+
+    const Rectangle<double> rect{stroke->getX(), stroke->getY(), stroke->getElementWidth(), stroke->getElementHeight()};
+    view->rerenderRect(rect.x, rect.y, rect.width, rect.height);
+    stroke = nullptr;
+    s->setStroke(nullptr);
+    xournal->getCursor()->updateCursor();
+}
+
+void SetsquareController::initializeStroke() {
+    const auto h = view->getXournal()->getControl()->getToolHandler();
+    stroke = new Stroke();
+    s->setStroke(stroke);
+    stroke->setWidth(h->getThickness());
+    stroke->setColor(h->getColor());
+    stroke->setFill(h->getFill());
+    stroke->setLineStyle(h->getLineStyle());
+}
+
+auto SetsquareController::getPage() const -> PageRef { return view->getPage(); }
+
+auto SetsquareController::getView() const -> XojPageView* { return view; }
+
+auto SetsquareController::posRelToSide(Leg leg, double x, double y) const -> utl::Point<double> {
+    cairo_matrix_t matrix{};
+    s->getMatrix(matrix);
+    cairo_matrix_invert(&matrix);
+    cairo_matrix_transform_point(&matrix, &x, &y);
+    switch (leg) {
+        case HYPOTENUSE:
+            return utl::Point<double>(x, -y);
+        case LEFT_LEG:
+            return utl::Point<double>((y + x) / sqrt(2.), (y - x - s->getHeight()) / sqrt(2.));
+        case RIGHT_LEG:
+            return utl::Point<double>((y - x) / sqrt(2.), (y + x - s->getHeight()) / sqrt(2.));
+        default:
+            g_error("Invalid enum value: %d", leg);
+    }
+}
+
+auto SetsquareController::isInsideSetsquare(double x, double y, double border) const -> bool {
+    return posRelToSide(HYPOTENUSE, x, y).y < border && posRelToSide(LEFT_LEG, x, y).y < border &&
+           posRelToSide(RIGHT_LEG, x, y).y < border;
+}
+
+auto SetsquareController::getPointForPos(double xCoord) const -> utl::Point<double> {
+    cairo_matrix_t matrix{};
+    double x = xCoord;
+    double y = 0.0;
+    s->getMatrix(matrix);
+    cairo_matrix_transform_point(&matrix, &x, &y);
+
+    return utl::Point<double>(x, y);
+}
+
+void SetsquareController::createStroke(double x) {
+    if (!std::isnan(x)) {
+        hypotenuseMax = x;
+        hypotenuseMin = x;
+
+        const auto p = this->getPointForPos(x);
+        initializeStroke();
+        stroke->addPoint(Point(p.x, p.y));
+        stroke->addPoint(Point(p.x, p.y));  // doubled point
+        s->notify();
+    } else {
+        g_warning("No valid stroke from setsquare!");
+    }
+}
+
+void SetsquareController::createRadius(double x, double y) {
+    const auto p = posRelToSide(HYPOTENUSE, x, y);
+    this->strokeAngle = std::atan2(p.y, p.x);
+    initializeStroke();
+    updateRadius(x, y);
+}
+
+void SetsquareController::updateStroke(double x) {
+    hypotenuseMax = std::max(this->hypotenuseMax, x);
+    hypotenuseMin = std::min(this->hypotenuseMin, x);
+    stroke->deletePointsFrom(0);
+    const auto p1 = getPointForPos(hypotenuseMin);
+    const auto p2 = getPointForPos(hypotenuseMax);
+
+    stroke->addPoint(Point(p1.x, p1.y));
+    stroke->addPoint(Point(p2.x, p2.y));
+    s->notify();
+}
+
+void SetsquareController::updateRadius(double x, double y) {
+    stroke->deletePointsFrom(0);
+    const auto c = getPointForPos(0);
+    stroke->addPoint(Point(c.x, c.y));
+
+    const auto p = posRelToSide(HYPOTENUSE, x, y);
+    const auto rad = std::hypot(p.x, p.y);
+
+    if (rad >= s->getHeight() / std::sqrt(2.) - 1.15) {  // TODO
+        this->strokeAngle = std::atan2(p.y, p.x);
+        stroke->addPoint(Point(x, y));
+    } else {
+        cairo_matrix_t matrix{};
+        auto qx = rad * std::cos(this->strokeAngle);
+        auto qy = -rad * std::sin(this->strokeAngle);
+        s->getMatrix(matrix);
+        cairo_matrix_transform_point(&matrix, &qx, &qy);
+
+        stroke->addPoint(Point(qx, qy));
+    }
+    s->notify();
+}
+
+void SetsquareController::finalizeStroke() {
+    hypotenuseMax = NAN;
+    hypotenuseMin = NAN;
+    addStrokeToLayer();
+}
+
+void SetsquareController::finalizeRadius() {
+    strokeAngle = NAN;
+    addStrokeToLayer();
+}
+
+auto SetsquareController::existsStroke() -> bool { return !std::isnan(hypotenuseMax) && !std::isnan(hypotenuseMin); }
+
+auto SetsquareController::existsRadius() -> bool { return !std::isnan(strokeAngle); }

--- a/src/core/control/SetsquareController.cpp
+++ b/src/core/control/SetsquareController.cpp
@@ -17,8 +17,7 @@ SetsquareController::~SetsquareController() = default;
 auto SetsquareController::getType() const -> std::string { return "setsquare"; }
 
 auto SetsquareController::posRelToSide(Leg leg, double x, double y) const -> utl::Point<double> {
-    cairo_matrix_t matrix{};
-    s->getMatrix(matrix);
+    cairo_matrix_t matrix = s->getMatrix();
     cairo_matrix_invert(&matrix);
     cairo_matrix_transform_point(&matrix, &x, &y);
     switch (leg) {
@@ -39,10 +38,9 @@ auto SetsquareController::isInsideGeometryTool(double x, double y, double border
 }
 
 auto SetsquareController::getPointForPos(double xCoord) const -> utl::Point<double> {
-    cairo_matrix_t matrix{};
     double x = xCoord;
     double y = 0.0;
-    s->getMatrix(matrix);
+    cairo_matrix_t matrix = s->getMatrix();
     cairo_matrix_transform_point(&matrix, &x, &y);
 
     return utl::Point<double>(x, y);
@@ -94,10 +92,9 @@ void SetsquareController::updateRadius(double x, double y) {
         this->strokeAngle = std::atan2(p.y, p.x);
         stroke->addPoint(Point(x, y));
     } else {
-        cairo_matrix_t matrix{};
+        cairo_matrix_t matrix = s->getMatrix();
         auto qx = rad * std::cos(this->strokeAngle);
         auto qy = -rad * std::sin(this->strokeAngle);
-        s->getMatrix(matrix);
         cairo_matrix_transform_point(&matrix, &qx, &qy);
 
         stroke->addPoint(Point(qx, qy));

--- a/src/core/control/SetsquareController.cpp
+++ b/src/core/control/SetsquareController.cpp
@@ -7,7 +7,6 @@
 #include "model/Setsquare.h"
 #include "model/Stroke.h"
 #include "model/XojPage.h"
-#include "undo/InsertUndoAction.h"  // for InsertUndoAction
 
 using xoj::util::Rectangle;
 SetsquareController::SetsquareController(XojPageView* view, Setsquare* setsquare):
@@ -89,7 +88,7 @@ void SetsquareController::updateRadialStroke(double x, double y) {
     const auto p = posRelToSide(HYPOTENUSE, x, y);
     const auto rad = std::hypot(p.x, p.y);
 
-    if (rad >= geometryTool->getHeight() / std::sqrt(2.) - 1.15 || p.y > 0) {  // TODO
+    if (rad >= Setsquare::radiusFromHeight(geometryTool->getHeight()) || p.y > 0) {
         this->strokeAngle = std::atan2(p.y, p.x);
         stroke->addPoint(Point(x, y));
     } else {
@@ -104,7 +103,7 @@ void SetsquareController::updateRadialStroke(double x, double y) {
 }
 
 void SetsquareController::finalizeEdgeStroke() {
-    hypotenuseMax = std::numeric_limits<double>::min();
+    hypotenuseMax = std::numeric_limits<double>::lowest();
     hypotenuseMin = std::numeric_limits<double>::max();
     addStrokeToLayer();
 }
@@ -114,6 +113,6 @@ void SetsquareController::finalizeRadialStroke() {
     addStrokeToLayer();
 }
 
-auto SetsquareController::existsEdgeStroke() -> bool { return !(hypotenuseMax == std::numeric_limits<double>::min()); }
+auto SetsquareController::existsEdgeStroke() -> bool { return hypotenuseMax != std::numeric_limits<double>::lowest(); }
 
 auto SetsquareController::existsRadialStroke() -> bool { return !std::isnan(strokeAngle); }

--- a/src/core/control/SetsquareController.h
+++ b/src/core/control/SetsquareController.h
@@ -16,6 +16,8 @@
 #include "gui/PageView.h"
 #include "util/Point.h"
 
+#include "GeometryToolController.h"
+
 class Setsquare;
 class Stroke;
 
@@ -31,54 +33,13 @@ enum Leg { HYPOTENUSE, LEFT_LEG, RIGHT_LEG };
  * the midpoint to the longest side of the setsquare.
  */
 
-class SetsquareController {
+class SetsquareController: public GeometryToolController {
 public:
     SetsquareController(XojPageView* view, Setsquare* s);
     ~SetsquareController();
 
 public:
-    /**
-     * @brief moves the setsquare in x- and y-direction
-     * @param x the translation in x-direction (in document coordinates)
-     * @param y the translation in y-direction (in document coordinates)
-     */
-    void move(double x, double y);
-
-    /**
-     * @brief rotates the setsquare around its rotation center
-     * @param da the rotation angle
-     * @param cx the x-coordinate of the rotation center (in document coordinates)
-     * @param cy the y-coordinate of the rotation center (in document coordinates)
-     */
-    void rotate(double da, double cx, double cy);
-
-    /**
-     * @brief resizes the setsquare by the factor f with respect to a given scaling center
-     * @param f the scaling factor
-     * @param cx the x-coordinate of the scaling center (in document coordinates)
-     * @param cy the y-coordinate of the scaling center (in document coordiantes)
-     */
-    void scale(double f, double cx, double cy);
-
-    /**
-     * @brief adds the stroke to the layer and rerenders the stroke area
-     */
-    void addStrokeToLayer();
-
-    /**
-     * @brief initializes the stroke by using the properties from the tool handler
-     */
-    void initializeStroke();
-
-    /**
-     * @brief the page view of the page with respect to which the setsquare is initialized
-     */
-    XojPageView* getView() const;
-
-    /**
-     * @brief the page with respect to which the setsquare is initialized
-     */
-    PageRef getPage() const;
+    std::string getType() const override;
 
     /**
      * @brief returns the position of a point relative to a coordinate system, in which the given setsquare leg lies on
@@ -96,7 +57,7 @@ public:
      * @param y the y-coordinate of the given point (in document coordinates)
      * @param border the size of the border (if negative, the setsquare is shrinked via the border)
      */
-    bool isInsideSetsquare(double x, double y, double border = 0.0) const;
+    bool isInsideGeometryTool(double x, double y, double border = 0.0) const override;
 
     /**
      * @brief the point (in document coordinates) for a given position on the longest side of the setsquare
@@ -165,17 +126,4 @@ private:
      * @brief the current angle at which the temporary radius is drawn
      */
     double strokeAngle = NAN;
-
-public:
-    XojPageView* view;
-
-    /**
-     * @brief the underlying setsquare
-     */
-    Setsquare* s;
-
-    /**
-     * @brief The stroke drawn
-     */
-    Stroke* stroke = nullptr;
 };

--- a/src/core/control/SetsquareController.h
+++ b/src/core/control/SetsquareController.h
@@ -35,7 +35,7 @@ enum Leg { HYPOTENUSE, LEFT_LEG, RIGHT_LEG };
 
 class SetsquareController: public GeometryToolController {
 public:
-    SetsquareController(XojPageView* view, Setsquare* s);
+    SetsquareController(XojPageView* view, Setsquare* setsquare);
     ~SetsquareController();
 
 public:

--- a/src/core/control/SetsquareController.h
+++ b/src/core/control/SetsquareController.h
@@ -1,0 +1,181 @@
+/*
+ * Xournal++
+ *
+ * A setsquare controller
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+#include <gtk/gtk.h>
+
+#include "gui/PageView.h"
+#include "util/Point.h"
+
+class Setsquare;
+class Stroke;
+
+enum Leg { HYPOTENUSE, LEFT_LEG, RIGHT_LEG };
+
+/**
+ * @brief A class that controls a setsquare
+
+ * The setsquare can be moved, rotated and scaled
+ * There are methods for translating coordinates
+ * and methods to deal with the temporary stroke
+ * that is displayed near the longest side or
+ * the midpoint to the longest side of the setsquare.
+ */
+
+class SetsquareController {
+public:
+    SetsquareController(XojPageView* view, Setsquare* s);
+    ~SetsquareController();
+
+public:
+    /**
+     * @brief moves the setsquare in x- and y-direction
+     * @param x the translation in x-direction (in document coordinates)
+     * @param y the translation in y-direction (in document coordinates)
+     */
+    void move(double x, double y);
+
+    /**
+     * @brief rotates the setsquare around its rotation center
+     * @param da the rotation angle
+     * @param cx the x-coordinate of the rotation center (in document coordinates)
+     * @param cy the y-coordinate of the rotation center (in document coordinates)
+     */
+    void rotate(double da, double cx, double cy);
+
+    /**
+     * @brief resizes the setsquare by the factor f with respect to a given scaling center
+     * @param f the scaling factor
+     * @param cx the x-coordinate of the scaling center (in document coordinates)
+     * @param cy the y-coordinate of the scaling center (in document coordiantes)
+     */
+    void scale(double f, double cx, double cy);
+
+    /**
+     * @brief adds the stroke to the layer and rerenders the stroke area
+     */
+    void addStrokeToLayer();
+
+    /**
+     * @brief initializes the stroke by using the properties from the tool handler
+     */
+    void initializeStroke();
+
+    /**
+     * @brief the page view of the page with respect to which the setsquare is initialized
+     */
+    XojPageView* getView() const;
+
+    /**
+     * @brief the page with respect to which the setsquare is initialized
+     */
+    PageRef getPage() const;
+
+    /**
+     * @brief returns the position of a point relative to a coordinate system, in which the given setsquare leg lies on
+     * the x-axis with the origin in its center (where the unit is 1 cm)
+     * @param leg the leg of the setsquare
+     * @param x the x-coordinate of the point (in document coordinates)
+     * @param y the y-coordinate of the point (in document coordinates)
+     */
+    utl::Point<double> posRelToSide(Leg leg, double x, double y) const;
+
+    /**
+     * @brief checks whether a point with given coordinates lies in the setsquare with an additional border enlarging
+     * (or shrinked) it
+     * @param x the x-coordinate of the given point (in document coordinates)
+     * @param y the y-coordinate of the given point (in document coordinates)
+     * @param border the size of the border (if negative, the setsquare is shrinked via the border)
+     */
+    bool isInsideSetsquare(double x, double y, double border = 0.0) const;
+
+    /**
+     * @brief the point (in document coordinates) for a given position on the longest side of the setsquare
+     * @param x the x-coordinate of the point on the longest side of the setsquare (when unrotated and untranslated)
+     */
+    utl::Point<double> getPointForPos(double x) const;
+
+    /**
+     * @brief creates a stroke starting at the given position of the longest side of the setsquare
+     * @param x the x-coordinate of the point on the longest side of the setsquare (when unrotated and untranslated)
+     */
+    void createStroke(double x);
+
+    /**
+     * @brief updates the stroke aligned to the longest side of the setsquare
+     * @param x the x-coordinate of the point on the longest side of the setsquare (when unrotated and untranslated)
+     * updating the stroke
+     */
+    void updateStroke(double x);
+
+    /**
+     * @brief finishes the stroke aligned to the longest side of the setsquare
+     */
+    void finalizeStroke();
+
+    /**
+     * @brief creates a radius starting at the given position to the origin of the setsquare
+     * @param x the x-coordinate of the current point
+     * @param y the y-coordinate of the current point
+     */
+    void createRadius(double x, double y);
+
+    /**
+     * @brief updates the radius to the origin of the setsquare
+     * @param x the x-coordinate of the current point
+     * @param y the y-coordinate of the current point
+     * updating the stroke
+     */
+    void updateRadius(double x, double y);
+
+    /**
+     * @brief finishes the radius to the origin of the setsquare
+     */
+    void finalizeRadius();
+
+    /**
+     * checks whether a stroke already exists
+     */
+    bool existsStroke();
+
+    /**
+     * checks whether a radius already exists
+     */
+    bool existsRadius();
+
+private:
+    /**
+     * @brief when a stroke aligned to the longest side (hypotenuse) of the setsquare is drawn, the minimal and maximal
+     * x-coordinates of the point to be drawn (with respect to an unrotated, and untranslated coordinate system) are
+     * saved in the variables hypotenuseMin and hypotenuseMax
+     */
+    double hypotenuseMax = NAN;
+    double hypotenuseMin = NAN;
+
+    /**
+     * @brief the current angle at which the temporary radius is drawn
+     */
+    double strokeAngle = NAN;
+
+public:
+    XojPageView* view;
+
+    /**
+     * @brief the underlying setsquare
+     */
+    Setsquare* s;
+
+    /**
+     * @brief The stroke drawn
+     */
+    Stroke* stroke = nullptr;
+};

--- a/src/core/control/SetsquareController.h
+++ b/src/core/control/SetsquareController.h
@@ -14,6 +14,7 @@
 #include <gtk/gtk.h>
 
 #include "gui/PageView.h"
+#include "model/GeometryTool.h"
 #include "util/Point.h"
 
 #include "GeometryToolController.h"
@@ -39,7 +40,7 @@ public:
     ~SetsquareController();
 
 public:
-    std::string getType() const override;
+    GeometryToolType getType() const override;
 
     /**
      * @brief returns the position of a point relative to a coordinate system, in which the given setsquare leg lies on
@@ -119,8 +120,8 @@ private:
      * x-coordinates of the point to be drawn (with respect to an unrotated, and untranslated coordinate system) are
      * saved in the variables hypotenuseMin and hypotenuseMax
      */
-    double hypotenuseMax = NAN;
-    double hypotenuseMin = NAN;
+    double hypotenuseMax = std::numeric_limits<double>::min();
+    double hypotenuseMin = std::numeric_limits<double>::max();
 
     /**
      * @brief the current angle at which the temporary radius is drawn

--- a/src/core/control/SetsquareController.h
+++ b/src/core/control/SetsquareController.h
@@ -70,26 +70,26 @@ public:
      * @brief creates a stroke starting at the given position of the longest side of the setsquare
      * @param x the x-coordinate of the point on the longest side of the setsquare (when unrotated and untranslated)
      */
-    void createStroke(double x);
+    void createEdgeStroke(double x);
 
     /**
      * @brief updates the stroke aligned to the longest side of the setsquare
      * @param x the x-coordinate of the point on the longest side of the setsquare (when unrotated and untranslated)
      * updating the stroke
      */
-    void updateStroke(double x);
+    void updateEdgeStroke(double x);
 
     /**
      * @brief finishes the stroke aligned to the longest side of the setsquare
      */
-    void finalizeStroke();
+    void finalizeEdgeStroke();
 
     /**
      * @brief creates a radius starting at the given position to the origin of the setsquare
      * @param x the x-coordinate of the current point
      * @param y the y-coordinate of the current point
      */
-    void createRadius(double x, double y);
+    void createRadialStroke(double x, double y);
 
     /**
      * @brief updates the radius to the origin of the setsquare
@@ -97,22 +97,22 @@ public:
      * @param y the y-coordinate of the current point
      * updating the stroke
      */
-    void updateRadius(double x, double y);
+    void updateRadialStroke(double x, double y);
 
     /**
      * @brief finishes the radius to the origin of the setsquare
      */
-    void finalizeRadius();
+    void finalizeRadialStroke();
 
     /**
      * checks whether a stroke already exists
      */
-    bool existsStroke();
+    bool existsEdgeStroke();
 
     /**
      * checks whether a radius already exists
      */
-    bool existsRadius();
+    bool existsRadialStroke();
 
 private:
     /**

--- a/src/core/control/SetsquareController.h
+++ b/src/core/control/SetsquareController.h
@@ -120,7 +120,7 @@ private:
      * x-coordinates of the point to be drawn (with respect to an unrotated, and untranslated coordinate system) are
      * saved in the variables hypotenuseMin and hypotenuseMax
      */
-    double hypotenuseMax = std::numeric_limits<double>::min();
+    double hypotenuseMax = std::numeric_limits<double>::lowest();
     double hypotenuseMin = std::numeric_limits<double>::max();
 
     /**

--- a/src/core/enums/ActionGroup.enum.h
+++ b/src/core/enums/ActionGroup.enum.h
@@ -56,7 +56,7 @@ enum ActionGroup {
 
     GROUP_HIGHLIGHT_POSITION,
 
-    GROUP_SETSQUARE,
+    GROUP_GEOMETRY_TOOL,
 
     GROUP_FILL,
 

--- a/src/core/enums/generated/ActionGroup.generated.cpp
+++ b/src/core/enums/generated/ActionGroup.generated.cpp
@@ -96,8 +96,8 @@ auto ActionGroup_fromString(const string& value) -> ActionGroup {
         return GROUP_HIGHLIGHT_POSITION;
     }
 
-    if (value == "GROUP_SETSQUARE") {
-        return GROUP_SETSQUARE;
+    if (value == "GROUP_GEOMETRY_TOOL") {
+        return GROUP_GEOMETRY_TOOL;
     }
 
     if (value == "GROUP_FILL") {
@@ -210,8 +210,8 @@ auto ActionGroup_toString(ActionGroup value) -> string {
         return "GROUP_HIGHLIGHT_POSITION";
     }
 
-    if (value == GROUP_SETSQUARE) {
-        return "GROUP_SETSQUARE";
+    if (value == GROUP_GEOMETRY_TOOL) {
+        return "GROUP_GEOMETRY_TOOL";
     }
 
     if (value == GROUP_FILL) {

--- a/src/core/gui/PageView.cpp
+++ b/src/core/gui/PageView.cpp
@@ -102,6 +102,10 @@ XojPageView::~XojPageView() {
     deleteViewBuffer();  // Ensures the mutex is locked during the buffer's destruction
 }
 
+void XojPageView::addOverlayView(std::unique_ptr<xoj::view::OverlayView> overlay) {
+    this->overlayViews.emplace_back(std::move(overlay));
+}
+
 void XojPageView::setIsVisible(bool visible) {
     if (visible) {
         this->lastVisibleTime = 0;

--- a/src/core/gui/PageView.h
+++ b/src/core/gui/PageView.h
@@ -53,6 +53,7 @@ public:
     ~XojPageView() override;
 
 public:
+    void addOverlayView(std::unique_ptr<xoj::view::OverlayView>);
     void rerenderPage() override;
     void rerenderRect(double x, double y, double width, double height) override;
 

--- a/src/core/gui/XournalView.cpp
+++ b/src/core/gui/XournalView.cpp
@@ -11,6 +11,7 @@
 #include <glib-object.h>     // for g_object_ref_sink
 
 #include "control/Control.h"                         // for Control
+#include "control/GeometryToolController.h"          // for GeometryToolController
 #include "control/PdfCache.h"                        // for PdfCache
 #include "control/ScrollHandler.h"                   // for ScrollHandler
 #include "control/SetsquareController.h"             // for SetsquareController
@@ -699,26 +700,13 @@ void XournalView::repaintSelection(bool evenWithoutSelection) {
 
 auto XournalView::getGeometryToolInputHandler() -> GeometryToolInputHandler* { return geometryToolInputHandler.get(); }
 
-auto XournalView::getGeometryToolController() -> GeometryToolController* { return geometryToolController.get(); }
-
-void XournalView::makeGeometryTool(GeometryToolType tool) {
-    auto view = getViewFor(control->getCurrentPageNo());
-    auto* zoomControl = this->getControl()->getZoomControl();
-
-    if (tool == GeometryToolType::SETSQUARE) {
-        auto setsquare = new Setsquare();
-        view->addOverlayView(std::make_unique<xoj::view::SetsquareView>(setsquare, view, zoomControl));
-        this->geometryTool = std::unique_ptr<GeometryTool>(setsquare);
-        this->geometryToolController = std::make_unique<SetsquareController>(view, setsquare);
-        this->geometryToolInputHandler =
-                std::make_unique<SetsquareInputHandler>(this, this->geometryToolController.get());
-        geometryToolInputHandler->registerToPool(setsquare->getHandlerPool());
-        control->fireActionSelected(GROUP_GEOMETRY_TOOL, ACTION_SETSQUARE);
-    }
+void XournalView::setGeometryTool(std::unique_ptr<GeometryTool> tool,
+                                  std::unique_ptr<GeometryToolInputHandler> handler) {
+    this->geometryTool = std::move(tool);
+    this->geometryToolInputHandler = std::move(handler);
 }
 
 void XournalView::resetGeometryTool() {
-    geometryToolController.reset();
     geometryToolInputHandler.reset();
     geometryTool.reset();
     this->control->fireActionSelected(GROUP_GEOMETRY_TOOL, ACTION_NONE);

--- a/src/core/gui/XournalView.cpp
+++ b/src/core/gui/XournalView.cpp
@@ -698,16 +698,9 @@ void XournalView::repaintSelection(bool evenWithoutSelection) {
     gtk_widget_queue_draw(this->widget);
 }
 
-auto XournalView::getGeometryToolInputHandler() -> GeometryToolInputHandler* { return geometryToolInputHandler.get(); }
-
-void XournalView::setGeometryTool(std::unique_ptr<GeometryTool> tool,
-                                  std::unique_ptr<GeometryToolInputHandler> handler) {
-    this->geometryTool = std::move(tool);
-    this->geometryToolInputHandler = std::move(handler);
-}
+void XournalView::setGeometryTool(std::unique_ptr<GeometryTool> tool) { this->geometryTool = std::move(tool); }
 
 void XournalView::resetGeometryTool() {
-    geometryToolInputHandler.reset();
     geometryTool.reset();
     this->control->fireActionSelected(GROUP_GEOMETRY_TOOL, ACTION_NONE);
 }

--- a/src/core/gui/XournalView.cpp
+++ b/src/core/gui/XournalView.cpp
@@ -10,39 +10,35 @@
 #include <gdk/gdkkeysyms.h>  // for GDK_KEY_Page_Down
 #include <glib-object.h>     // for g_object_ref_sink
 
-#include "control/Control.h"                         // for Control
-#include "control/GeometryToolController.h"          // for GeometryToolController
-#include "control/PdfCache.h"                        // for PdfCache
-#include "control/ScrollHandler.h"                   // for ScrollHandler
-#include "control/SetsquareController.h"             // for SetsquareController
-#include "control/ToolHandler.h"                     // for ToolHandler
-#include "control/jobs/XournalScheduler.h"           // for XournalScheduler
-#include "control/settings/MetadataManager.h"        // for MetadataManager
-#include "control/settings/Settings.h"               // for Settings
-#include "control/tools/CursorSelectionType.h"       // for CURSOR_SELECTION_NONE
-#include "control/tools/EditSelection.h"             // for EditSelection
-#include "control/zoom/ZoomControl.h"                // for ZoomControl
-#include "enums/ActionGroup.enum.h"                  // for GROUP_GEOMETRY_TOOL
-#include "enums/ActionType.enum.h"                   // for ACTION_NONE
-#include "gui/MainWindow.h"                          // for MainWindow
-#include "gui/PdfFloatingToolbox.h"                  // for PdfFloatingToolbox
-#include "gui/inputdevices/HandRecognition.h"        // for HandRecognition
-#include "gui/inputdevices/InputContext.h"           // for InputContext
-#include "gui/inputdevices/SetsquareInputHandler.h"  // for SetsquareInputHandler
-#include "gui/toolbarMenubar/ColorToolItem.h"        // for ColorToolItem
-#include "gui/toolbarMenubar/ToolMenuHandler.h"      // for ToolMenuHandler
-#include "gui/widgets/XournalWidget.h"               // for gtk_xournal_get_layout
-#include "model/Document.h"                          // for Document
-#include "model/Element.h"                           // for Element, ELEMENT_STROKE
-#include "model/PageRef.h"                           // for PageRef
-#include "model/Stroke.h"                            // for Stroke, StrokeTool::E...
-#include "model/XojPage.h"                           // for XojPage
-#include "undo/DeleteUndoAction.h"                   // for DeleteUndoAction
-#include "undo/UndoRedoHandler.h"                    // for UndoRedoHandler
-#include "util/Point.h"                              // for Point
-#include "util/Rectangle.h"                          // for Rectangle
-#include "util/Util.h"                               // for npos
-#include "view/SetsquareView.h"                      // for SetsquareView
+#include "control/Control.h"                     // for Control
+#include "control/PdfCache.h"                    // for PdfCache
+#include "control/ScrollHandler.h"               // for ScrollHandler
+#include "control/ToolHandler.h"                 // for ToolHandler
+#include "control/jobs/XournalScheduler.h"       // for XournalScheduler
+#include "control/settings/MetadataManager.h"    // for MetadataManager
+#include "control/settings/Settings.h"           // for Settings
+#include "control/tools/CursorSelectionType.h"   // for CURSOR_SELECTION_NONE
+#include "control/tools/EditSelection.h"         // for EditSelection
+#include "control/zoom/ZoomControl.h"            // for ZoomControl
+#include "enums/ActionGroup.enum.h"              // for GROUP_GEOMETRY_TOOL
+#include "enums/ActionType.enum.h"               // for ACTION_NONE
+#include "gui/MainWindow.h"                      // for MainWindow
+#include "gui/PdfFloatingToolbox.h"              // for PdfFloatingToolbox
+#include "gui/inputdevices/HandRecognition.h"    // for HandRecognition
+#include "gui/inputdevices/InputContext.h"       // for InputContext
+#include "gui/toolbarMenubar/ColorToolItem.h"    // for ColorToolItem
+#include "gui/toolbarMenubar/ToolMenuHandler.h"  // for ToolMenuHandler
+#include "gui/widgets/XournalWidget.h"           // for gtk_xournal_get_layout
+#include "model/Document.h"                      // for Document
+#include "model/Element.h"                       // for Element, ELEMENT_STROKE
+#include "model/PageRef.h"                       // for PageRef
+#include "model/Stroke.h"                        // for Stroke, StrokeTool::E...
+#include "model/XojPage.h"                       // for XojPage
+#include "undo/DeleteUndoAction.h"               // for DeleteUndoAction
+#include "undo/UndoRedoHandler.h"                // for UndoRedoHandler
+#include "util/Point.h"                          // for Point
+#include "util/Rectangle.h"                      // for Rectangle
+#include "util/Util.h"                           // for npos
 
 #include "Layout.h"           // for Layout
 #include "PageView.h"         // for XojPageView
@@ -696,13 +692,6 @@ void XournalView::repaintSelection(bool evenWithoutSelection) {
 
     // repaint always the whole widget
     gtk_widget_queue_draw(this->widget);
-}
-
-void XournalView::setGeometryTool(std::unique_ptr<GeometryTool> tool) { this->geometryTool = std::move(tool); }
-
-void XournalView::resetGeometryTool() {
-    geometryTool.reset();
-    this->control->fireActionSelected(GROUP_GEOMETRY_TOOL, ACTION_NONE);
 }
 
 void XournalView::layoutPages() {

--- a/src/core/gui/XournalView.cpp
+++ b/src/core/gui/XournalView.cpp
@@ -701,11 +701,11 @@ auto XournalView::getGeometryToolHandler() -> GeometryToolHandler* { return geom
 
 auto XournalView::getGeometryToolController() -> GeometryToolController* { return geometryToolController; }
 
-void XournalView::makeGeometryTool(std::string tool) {
+void XournalView::makeGeometryTool(GeometryToolType tool) {
     auto view = getViewFor(control->getCurrentPageNo());
     auto* zoomControl = this->getControl()->getZoomControl();
 
-    if (tool == "setsquare") {
+    if (tool == GeometryToolType::SETSQUARE) {
         auto setsquare = new Setsquare();
         view->addOverlayView(std::make_unique<xoj::view::SetsquareView>(setsquare, view, zoomControl));
         this->geometryTool = setsquare;

--- a/src/core/gui/XournalView.cpp
+++ b/src/core/gui/XournalView.cpp
@@ -703,9 +703,11 @@ auto XournalView::getGeometryToolController() -> GeometryToolController* { retur
 
 void XournalView::makeGeometryTool(std::string tool) {
     auto view = getViewFor(control->getCurrentPageNo());
+    auto* zoomControl = this->getControl()->getZoomControl();
+
     if (tool == "setsquare") {
         auto setsquare = new Setsquare();
-        view->addOverlayView(std::make_unique<xoj::view::SetsquareView>(setsquare, view));
+        view->addOverlayView(std::make_unique<xoj::view::SetsquareView>(setsquare, view, zoomControl));
         this->geometryTool = setsquare;
         this->geometryToolController = new SetsquareController(view, setsquare);
         this->geometryToolHandler = new SetsquareInputHandler(this, this->geometryToolController);

--- a/src/core/gui/XournalView.cpp
+++ b/src/core/gui/XournalView.cpp
@@ -697,7 +697,7 @@ void XournalView::repaintSelection(bool evenWithoutSelection) {
     gtk_widget_queue_draw(this->widget);
 }
 
-auto XournalView::getGeometryToolHandler() -> GeometryToolHandler* { return geometryToolHandler; }
+auto XournalView::getGeometryToolInputHandler() -> GeometryToolInputHandler* { return geometryToolInputHandler; }
 
 auto XournalView::getGeometryToolController() -> GeometryToolController* { return geometryToolController; }
 
@@ -710,8 +710,8 @@ void XournalView::makeGeometryTool(GeometryToolType tool) {
         view->addOverlayView(std::make_unique<xoj::view::SetsquareView>(setsquare, view, zoomControl));
         this->geometryTool = setsquare;
         this->geometryToolController = new SetsquareController(view, setsquare);
-        this->geometryToolHandler = new SetsquareInputHandler(this, this->geometryToolController);
-        geometryToolHandler->registerToPool(setsquare->getHandlerPool());
+        this->geometryToolInputHandler = new SetsquareInputHandler(this, this->geometryToolController);
+        geometryToolInputHandler->registerToPool(setsquare->getHandlerPool());
         control->fireActionSelected(GROUP_GEOMETRY_TOOL, ACTION_SETSQUARE);
     }
 }
@@ -719,8 +719,8 @@ void XournalView::makeGeometryTool(GeometryToolType tool) {
 void XournalView::resetGeometryTool() {
     delete geometryToolController;
     geometryToolController = nullptr;
-    delete geometryToolHandler;
-    geometryToolHandler = nullptr;
+    delete geometryToolInputHandler;
+    geometryToolInputHandler = nullptr;
     delete geometryTool;
     geometryTool = nullptr;
     this->control->fireActionSelected(GROUP_GEOMETRY_TOOL, ACTION_NONE);

--- a/src/core/gui/XournalView.h
+++ b/src/core/gui/XournalView.h
@@ -96,7 +96,7 @@ public:
 
     GeometryToolHandler* getGeometryToolHandler();
     GeometryToolController* getGeometryToolController();
-    void makeGeometryTool(std::string tool);
+    void makeGeometryTool(GeometryToolType);
     void resetGeometryTool();
 
     TextEditor* getTextEditor() const;

--- a/src/core/gui/XournalView.h
+++ b/src/core/gui/XournalView.h
@@ -21,13 +21,13 @@
 #include <glib.h>     // for gboolean
 #include <gtk/gtk.h>  // for GtkWidget, GtkAllocation
 
-#include "control/GeometryToolController.h"        // for GeometryToolController
-#include "control/zoom/ZoomListener.h"             // for ZoomListener
+#include "control/GeometryToolController.h"             // for GeometryToolController
+#include "control/zoom/ZoomListener.h"                  // for ZoomListener
 #include "gui/inputdevices/GeometryToolInputHandler.h"  // for GeometryToolInputHandler
-#include "model/DocumentChangeType.h"              // for DocumentChangeType
-#include "model/DocumentListener.h"                // for DocumentListener
-#include "model/GeometryTool.h"                    // for GeometryTool
-#include "util/Util.h"                             // for npos
+#include "model/DocumentChangeType.h"                   // for DocumentChangeType
+#include "model/DocumentListener.h"                     // for DocumentListener
+#include "model/GeometryTool.h"                         // for GeometryTool
+#include "util/Util.h"                                  // for npos
 
 class Control;
 class XournalppCursor;
@@ -188,9 +188,9 @@ private:
     /**
      * Geometry tool, if active
      */
-    GeometryTool* geometryTool = nullptr;
-    GeometryToolController* geometryToolController = nullptr;
-    GeometryToolInputHandler* geometryToolInputHandler = nullptr;
+    std::unique_ptr<GeometryTool> geometryTool;
+    std::unique_ptr<GeometryToolController> geometryToolController;
+    std::unique_ptr<GeometryToolInputHandler> geometryToolInputHandler;
 
     /**
      * Memory cleanup timeout

--- a/src/core/gui/XournalView.h
+++ b/src/core/gui/XournalView.h
@@ -21,13 +21,13 @@
 #include <glib.h>     // for gboolean
 #include <gtk/gtk.h>  // for GtkWidget, GtkAllocation
 
-#include "control/SetsquareController.h"             // for SetsquareController
-#include "control/zoom/ZoomListener.h"               // for ZoomListener
-#include "gui/inputdevices/SetsquareInputHandler.h"  // for SetsquareInputHandler
-#include "model/DocumentChangeType.h"                // for DocumentChangeType
-#include "model/DocumentListener.h"                  // for DocumentListener
-#include "model/Setsquare.h"                         // for Setsquare
-#include "util/Util.h"                               // for npos
+#include "control/GeometryToolController.h"        // for GeometryToolController
+#include "control/zoom/ZoomListener.h"             // for ZoomListener
+#include "gui/inputdevices/GeometryToolHandler.h"  // for GeometryToolHandler
+#include "model/DocumentChangeType.h"              // for DocumentChangeType
+#include "model/DocumentListener.h"                // for DocumentListener
+#include "model/GeometryTool.h"                    // for GeometryTool
+#include "util/Util.h"                             // for npos
 
 class Control;
 class XournalppCursor;
@@ -94,10 +94,10 @@ public:
     void deleteSelection(EditSelection* sel = nullptr);
     void repaintSelection(bool evenWithoutSelection = false);
 
-    SetsquareInputHandler* getSetsquareHandler();
-    SetsquareController* getSetsquareController();
-    void makeSetsquare();
-    void resetSetsquare();
+    GeometryToolHandler* getGeometryToolHandler();
+    GeometryToolController* getGeometryToolController();
+    void makeGeometryTool(std::string tool);
+    void resetGeometryTool();
 
     TextEditor* getTextEditor() const;
     std::vector<XojPageView*> const& getViewPages() const;
@@ -186,11 +186,11 @@ private:
     RepaintHandler* repaintHandler = nullptr;
 
     /**
-     * Setsquare, if active
+     * Geometry tool, if active
      */
-    Setsquare* setsquare = nullptr;
-    SetsquareController* setsquareController = nullptr;
-    SetsquareInputHandler* setsquareHandler = nullptr;
+    GeometryTool* geometryTool = nullptr;
+    GeometryToolController* geometryToolController = nullptr;
+    GeometryToolHandler* geometryToolHandler = nullptr;
 
     /**
      * Memory cleanup timeout

--- a/src/core/gui/XournalView.h
+++ b/src/core/gui/XournalView.h
@@ -24,7 +24,6 @@
 #include "control/zoom/ZoomListener.h"  // for ZoomListener
 #include "model/DocumentChangeType.h"   // for DocumentChangeType
 #include "model/DocumentListener.h"     // for DocumentListener
-#include "model/GeometryTool.h"         // for GeometryTool
 #include "util/Util.h"                  // for npos
 
 class Control;
@@ -91,9 +90,6 @@ public:
     EditSelection* getSelection() const;
     void deleteSelection(EditSelection* sel = nullptr);
     void repaintSelection(bool evenWithoutSelection = false);
-
-    void setGeometryTool(std::unique_ptr<GeometryTool> tool);
-    void resetGeometryTool();
 
     TextEditor* getTextEditor() const;
     std::vector<XojPageView*> const& getViewPages() const;
@@ -180,11 +176,6 @@ private:
      * Handler for rerendering pages / repainting pages
      */
     RepaintHandler* repaintHandler = nullptr;
-
-    /**
-     * Geometry tool, if active
-     */
-    std::unique_ptr<GeometryTool> geometryTool;
 
     /**
      * Memory cleanup timeout

--- a/src/core/gui/XournalView.h
+++ b/src/core/gui/XournalView.h
@@ -22,12 +22,12 @@
 #include <gtk/gtk.h>  // for GtkWidget, GtkAllocation
 
 #include "control/SetsquareController.h"             // for SetsquareController
-#include "control/zoom/ZoomListener.h"  // for ZoomListener
+#include "control/zoom/ZoomListener.h"               // for ZoomListener
 #include "gui/inputdevices/SetsquareInputHandler.h"  // for SetsquareInputHandler
-#include "model/DocumentChangeType.h"   // for DocumentChangeType
-#include "model/DocumentListener.h"     // for DocumentListener
-#include "model/Setsquare.h"            // for Setsquare
-#include "util/Util.h"                  // for npos
+#include "model/DocumentChangeType.h"                // for DocumentChangeType
+#include "model/DocumentListener.h"                  // for DocumentListener
+#include "model/Setsquare.h"                         // for Setsquare
+#include "util/Util.h"                               // for npos
 
 class Control;
 class XournalppCursor;

--- a/src/core/gui/XournalView.h
+++ b/src/core/gui/XournalView.h
@@ -23,7 +23,7 @@
 
 #include "control/GeometryToolController.h"        // for GeometryToolController
 #include "control/zoom/ZoomListener.h"             // for ZoomListener
-#include "gui/inputdevices/GeometryToolHandler.h"  // for GeometryToolHandler
+#include "gui/inputdevices/GeometryToolInputHandler.h"  // for GeometryToolInputHandler
 #include "model/DocumentChangeType.h"              // for DocumentChangeType
 #include "model/DocumentListener.h"                // for DocumentListener
 #include "model/GeometryTool.h"                    // for GeometryTool
@@ -94,7 +94,7 @@ public:
     void deleteSelection(EditSelection* sel = nullptr);
     void repaintSelection(bool evenWithoutSelection = false);
 
-    GeometryToolHandler* getGeometryToolHandler();
+    GeometryToolInputHandler* getGeometryToolInputHandler();
     GeometryToolController* getGeometryToolController();
     void makeGeometryTool(GeometryToolType);
     void resetGeometryTool();
@@ -190,7 +190,7 @@ private:
      */
     GeometryTool* geometryTool = nullptr;
     GeometryToolController* geometryToolController = nullptr;
-    GeometryToolHandler* geometryToolHandler = nullptr;
+    GeometryToolInputHandler* geometryToolInputHandler = nullptr;
 
     /**
      * Memory cleanup timeout

--- a/src/core/gui/XournalView.h
+++ b/src/core/gui/XournalView.h
@@ -92,8 +92,7 @@ public:
     void deleteSelection(EditSelection* sel = nullptr);
     void repaintSelection(bool evenWithoutSelection = false);
 
-    GeometryToolInputHandler* getGeometryToolInputHandler();
-    void setGeometryTool(std::unique_ptr<GeometryTool> tool, std::unique_ptr<GeometryToolInputHandler> handler);
+    void setGeometryTool(std::unique_ptr<GeometryTool> tool);
     void resetGeometryTool();
 
     TextEditor* getTextEditor() const;
@@ -186,7 +185,6 @@ private:
      * Geometry tool, if active
      */
     std::unique_ptr<GeometryTool> geometryTool;
-    std::unique_ptr<GeometryToolInputHandler> geometryToolInputHandler;
 
     /**
      * Memory cleanup timeout

--- a/src/core/gui/XournalView.h
+++ b/src/core/gui/XournalView.h
@@ -21,9 +21,12 @@
 #include <glib.h>     // for gboolean
 #include <gtk/gtk.h>  // for GtkWidget, GtkAllocation
 
+#include "control/SetsquareController.h"             // for SetsquareController
 #include "control/zoom/ZoomListener.h"  // for ZoomListener
+#include "gui/inputdevices/SetsquareInputHandler.h"  // for SetsquareInputHandler
 #include "model/DocumentChangeType.h"   // for DocumentChangeType
 #include "model/DocumentListener.h"     // for DocumentListener
+#include "model/Setsquare.h"            // for Setsquare
 #include "util/Util.h"                  // for npos
 
 class Control;
@@ -36,7 +39,6 @@ class RepaintHandler;
 class ScrollHandling;
 class TextEditor;
 class HandRecognition;
-class SetsquareView;
 namespace xoj::util {
 template <class T>
 class Rectangle;
@@ -92,10 +94,10 @@ public:
     void deleteSelection(EditSelection* sel = nullptr);
     void repaintSelection(bool evenWithoutSelection = false);
 
-    void setSetsquareView(std::unique_ptr<SetsquareView> setsquareView);
-    void resetSetsquareView();
-    SetsquareView* getSetsquareView() const;
-    void repaintSetsquare(bool evenWithoutSetsquare = false);
+    SetsquareInputHandler* getSetsquareHandler();
+    SetsquareController* getSetsquareController();
+    void makeSetsquare();
+    void resetSetsquare();
 
     TextEditor* getTextEditor() const;
     std::vector<XojPageView*> const& getViewPages() const;
@@ -182,6 +184,13 @@ private:
      * Handler for rerendering pages / repainting pages
      */
     RepaintHandler* repaintHandler = nullptr;
+
+    /**
+     * Setsquare, if active
+     */
+    Setsquare* setsquare = nullptr;
+    SetsquareController* setsquareController = nullptr;
+    SetsquareInputHandler* setsquareHandler = nullptr;
 
     /**
      * Memory cleanup timeout

--- a/src/core/gui/XournalView.h
+++ b/src/core/gui/XournalView.h
@@ -21,13 +21,11 @@
 #include <glib.h>     // for gboolean
 #include <gtk/gtk.h>  // for GtkWidget, GtkAllocation
 
-#include "control/GeometryToolController.h"             // for GeometryToolController
-#include "control/zoom/ZoomListener.h"                  // for ZoomListener
-#include "gui/inputdevices/GeometryToolInputHandler.h"  // for GeometryToolInputHandler
-#include "model/DocumentChangeType.h"                   // for DocumentChangeType
-#include "model/DocumentListener.h"                     // for DocumentListener
-#include "model/GeometryTool.h"                         // for GeometryTool
-#include "util/Util.h"                                  // for npos
+#include "control/zoom/ZoomListener.h"  // for ZoomListener
+#include "model/DocumentChangeType.h"   // for DocumentChangeType
+#include "model/DocumentListener.h"     // for DocumentListener
+#include "model/GeometryTool.h"         // for GeometryTool
+#include "util/Util.h"                  // for npos
 
 class Control;
 class XournalppCursor;
@@ -95,8 +93,7 @@ public:
     void repaintSelection(bool evenWithoutSelection = false);
 
     GeometryToolInputHandler* getGeometryToolInputHandler();
-    GeometryToolController* getGeometryToolController();
-    void makeGeometryTool(GeometryToolType);
+    void setGeometryTool(std::unique_ptr<GeometryTool> tool, std::unique_ptr<GeometryToolInputHandler> handler);
     void resetGeometryTool();
 
     TextEditor* getTextEditor() const;
@@ -189,7 +186,6 @@ private:
      * Geometry tool, if active
      */
     std::unique_ptr<GeometryTool> geometryTool;
-    std::unique_ptr<GeometryToolController> geometryToolController;
     std::unique_ptr<GeometryToolInputHandler> geometryToolInputHandler;
 
     /**

--- a/src/core/gui/inputdevices/GeometryToolHandler.cpp
+++ b/src/core/gui/inputdevices/GeometryToolHandler.cpp
@@ -1,0 +1,348 @@
+#include "GeometryToolHandler.h"
+
+#include <algorithm>  // for max
+#include <cmath>      // for atan2, abs, cos, remainder
+#include <memory>     // for __shared_ptr_access, shar...
+
+#include <gdk/gdkkeysyms.h>  // for GDK_KEY_Down, GDK_KEY_Left
+#include <glib.h>            // for g_warning
+
+#include "control/Control.h"                 // for Control
+#include "control/GeometryToolController.h"  // for GeometryToolController
+#include "control/ToolEnums.h"               // for TOOL_HAND, TOOL_HIGHLIGHTER
+#include "control/ToolHandler.h"             // for ToolHandler
+#include "control/settings/Settings.h"       // for Settings
+#include "gui/XournalView.h"                 // for XournalView
+#include "gui/inputdevices/InputContext.h"   // for InputContext::DeviceType
+#include "gui/inputdevices/InputEvents.h"    // for InputEvent, BUTTON_PRESS_...
+#include "model/Element.h"                   // for Element, ELEMENT_STROKE
+#include "model/GeometryTool.h"              // for HALF_CM
+#include "model/Layer.h"                     // for Layer
+#include "model/Snapping.h"                  // for distanceLine
+#include "model/Stroke.h"                    // for Stroke
+#include "model/XojPage.h"                   // for XojPage
+
+constexpr double MOVE_AMOUNT = HALF_CM / 2.0;
+constexpr double MOVE_AMOUNT_SMALL = HALF_CM / 20.0;
+constexpr double ROTATE_AMOUNT = M_PI * 5.0 / 180.0;
+constexpr double ROTATE_AMOUNT_SMALL = M_PI * 0.2 / 180.0;
+constexpr double SCALE_AMOUNT = 1.1;
+constexpr double SCALE_AMOUNT_SMALL = 1.01;
+constexpr double SNAPPING_DISTANCE_TOLERANCE = 5.0;                 // pt
+constexpr double SNAPPING_ROTATION_TOLERANCE = 3.0 * M_PI / 180.0;  // rad
+constexpr double ZOOM_DISTANCE_MIN = 0.01;
+
+GeometryToolHandler::GeometryToolHandler(XournalView* xournal, GeometryToolController* controller, double h, double tx,
+                                         double ty):
+        xournal(xournal), controller(controller), height(h), translationX(tx), translationY(ty) {}
+
+GeometryToolHandler::~GeometryToolHandler() = default;
+
+auto GeometryToolHandler::handle(InputEvent const& event) -> bool {
+    if (xournal->getSelection() || xournal->getControl()->getTextEditor()) {
+        return false;
+    }
+    const auto device = event.deviceClass;
+    if ((device == INPUT_DEVICE_MOUSE && isBlocked[InputContext::DeviceType::MOUSE]) ||
+        (device == INPUT_DEVICE_PEN && isBlocked[InputContext::DeviceType::STYLUS]) ||
+        (device == INPUT_DEVICE_TOUCHSCREEN && isBlocked[InputContext::DeviceType::TOUCHSCREEN])) {
+        return false;  // don't intervene
+    }
+
+    switch (device) {
+        case INPUT_DEVICE_KEYBOARD:
+            return this->handleKeyboard(event);
+        case INPUT_DEVICE_TOUCHSCREEN:
+            return this->handleTouchscreen(event);
+        case INPUT_DEVICE_PEN:
+        case INPUT_DEVICE_MOUSE:
+            return this->handlePointer(event);
+        case INPUT_DEVICE_MOUSE_KEYBOARD_COMBO:
+            return this->handlePointer(event) || this->handleKeyboard(event);
+        default:
+            g_warning("Device class %d not handled by geometry tool", event.deviceClass);
+            return false;
+    }
+}
+
+void GeometryToolHandler::on(UpdateValuesRequest, double h, double rot, double tx, double ty) {
+    height = h;
+    rotation = rot;
+    translationX = tx;
+    translationY = ty;
+}
+
+auto GeometryToolHandler::handleTouchscreen(InputEvent const& event) -> bool {
+    const auto zoomGesturesEnabled = xournal->getControl()->getSettings()->isZoomGesturesEnabled();
+    // Don't handle more then 2 inputs
+    if (this->primarySequence && this->primarySequence != event.sequence && this->secondarySequence &&
+        this->secondarySequence != event.sequence) {
+        return false;
+    }
+    if (event.type == BUTTON_PRESS_EVENT) {
+        // Start scrolling when a sequence starts and we currently have none other
+        if (this->primarySequence == nullptr && this->secondarySequence == nullptr) {
+            auto coords = getCoords(event);
+
+            if (controller->isInsideGeometryTool(coords.x, coords.y, 0)) {
+                // Set sequence data
+                this->primarySequence = event.sequence;
+                sequenceStart(event);
+                return true;
+            } else {
+                return false;
+            }
+
+        }
+        // Start zooming as soon as we have two sequences.
+        else if (this->primarySequence && this->primarySequence != event.sequence &&
+                 this->secondarySequence == nullptr) {
+            this->secondarySequence = event.sequence;
+
+            // Set sequence data
+            sequenceStart(event);
+
+            // Even if zoom gestures are disabled,
+            // this is still the start of a sequence. Just
+            // don't start zooming.
+            if (zoomGesturesEnabled) {
+                zoomStart();
+                return true;
+            }
+        }
+    }
+
+    if (event.type == MOTION_EVENT && this->primarySequence) {
+        if (this->primarySequence && this->secondarySequence && zoomGesturesEnabled) {
+            zoomMotion(event);
+            return true;
+        } else if (event.sequence == this->primarySequence) {
+            scrollMotion(event);
+            return true;
+        } else if (this->primarySequence && this->secondarySequence) {
+            sequenceStart(event);
+            return true;
+        }
+    }
+
+    if (event.type == BUTTON_RELEASE_EVENT) {
+        if (event.sequence == this->primarySequence) {
+            // If secondarySequence is nullptr, this sets primarySequence
+            // to nullptr. If it isn't, then it is now the primary sequence!
+            this->primarySequence = this->secondarySequence;
+            this->secondarySequence = nullptr;
+
+            this->priLastAbs = this->secLastAbs;
+            this->priLastRel = this->secLastRel;
+        } else {
+            this->secondarySequence = nullptr;
+        }
+    }
+    return false;
+}
+
+auto GeometryToolHandler::handleKeyboard(InputEvent const& event) -> bool {
+    GdkEvent* gdkEvent = event.sourceEvent;
+    if (gdkEvent->type == GDK_KEY_PRESS) {
+        auto keyEvent = reinterpret_cast<GdkEventKey*>(gdkEvent);
+
+        double xdir = 0;
+        double ydir = 0;
+        double angle = 0.0;
+        double scale = 1.0;
+
+        switch (keyEvent->keyval) {
+            case GDK_KEY_Left:
+                xdir = -1;
+                break;
+            case GDK_KEY_Up:
+                ydir = -1;
+                break;
+            case GDK_KEY_Right:
+                xdir = 1;
+                break;
+            case GDK_KEY_Down:
+                ydir = 1;
+                break;
+            case GDK_KEY_r:
+            case GDK_KEY_R: {  // r like "rotate"
+                angle = (event.state & GDK_MOD1_MASK) ? ROTATE_AMOUNT_SMALL : ROTATE_AMOUNT;
+                angle = (event.state & GDK_SHIFT_MASK) ? angle : -angle;
+                break;
+            }
+            case GDK_KEY_s:
+            case GDK_KEY_S: {
+                scale = (event.state & GDK_MOD1_MASK) ? SCALE_AMOUNT_SMALL : SCALE_AMOUNT;
+                scale = (event.state & GDK_SHIFT_MASK) ? 1.0 / scale : scale;
+                const auto h = height * scale;
+                if (h > getMaxHeight() || h < getMinHeight()) {
+                    scale = 1.0;
+                }
+                break;
+            }
+        }
+
+        if (xdir != 0 || ydir != 0) {
+            const auto c = std::cos(rotation);
+            const auto s = std::sin(rotation);
+            double xshift{0.0};
+            double yshift{0.0};
+            const auto amount = (event.state & GDK_MOD1_MASK) ? MOVE_AMOUNT_SMALL : MOVE_AMOUNT;
+            if (event.state & GDK_SHIFT_MASK) {
+                xshift = amount * (c * xdir - s * ydir);
+                yshift = amount * (s * xdir + c * ydir);
+            } else {
+                xshift = amount * xdir;
+                yshift = amount * ydir;
+            }
+            controller->move(xshift, yshift);
+            return true;
+        }
+
+        auto p = utl::Point(translationX, translationY);
+        if (angle != 0) {
+            controller->rotate(angle, p.x, p.y);
+            return true;
+        }
+        if (scale != 1.0) {
+            controller->scale(scale, p.x, p.y);
+            return true;
+        }
+    }
+    return false;
+}
+
+void GeometryToolHandler::sequenceStart(InputEvent const& event) {
+    if (event.sequence == this->primarySequence) {
+        this->priLastAbs = {event.absoluteX, event.absoluteY};
+        this->priLastRel = {event.relativeX, event.relativeY};
+    } else {
+        this->secLastAbs = {event.absoluteX, event.absoluteY};
+        this->secLastRel = {event.relativeX, event.relativeY};
+    }
+    const auto page = controller->getPage();
+
+    const auto l = page->getSelectedLayer();
+    this->lines.clear();
+    for (const auto& e: l->getElements()) {
+        if (e->getType() == ELEMENT_STROKE) {
+            auto s = dynamic_cast<Stroke*>(e);
+            if (s->getPointCount() == 2) {
+                lines.push_back(s);
+            }
+        }
+    }
+}
+
+void GeometryToolHandler::scrollMotion(InputEvent const& event) {
+    // Will only be called if there is a single sequence (zooming handles two sequences)
+    auto offset = [&]() {
+        auto absolutePoint = utl::Point{event.absoluteX, event.absoluteY};
+        if (event.sequence == this->primarySequence) {
+            const auto offset = absolutePoint - this->priLastAbs;
+            this->priLastAbs = absolutePoint;
+            return offset;
+        } else {
+            const auto offset = absolutePoint - this->secLastAbs;
+            this->secLastAbs = absolutePoint;
+            return offset;
+        }
+    }();
+    const auto zoom = xournal->getZoom();
+    auto p = utl::Point(translationX, translationY);
+    p.x += offset.x / zoom;
+    p.y += offset.y / zoom;
+    const auto pos = Point(p.x, p.y);
+    double minDist = SNAPPING_DISTANCE_TOLERANCE;
+    const auto angleSetsquare = rotation;
+    double diffAngle{NAN};
+    for (const auto& l: lines) {
+        auto first = l->getPoint(0);
+        auto second = l->getPoint(1);
+        auto dist = Snapping::distanceLine(pos, first, second);
+        auto angleLine = std::atan2(second.y - first.y, second.x - first.x);
+        auto diff = std::remainder(angleLine - angleSetsquare, M_PI_2);
+        if (dist < minDist && std::abs(diff) <= SNAPPING_ROTATION_TOLERANCE) {
+            minDist = dist;
+            diffAngle = diff;
+        }
+    }
+    if (!std::isnan(diffAngle)) {
+        controller->rotate(diffAngle, p.x, p.y);
+    }
+    controller->move(offset.x / zoom, offset.y / zoom);
+}
+
+void GeometryToolHandler::zoomStart() {
+    this->startZoomDistance = std::max(this->priLastAbs.distance(this->secLastAbs), ZOOM_DISTANCE_MIN);
+
+    // Whether we can ignore the zoom portion of the gesture (e.g. distance between touch points
+    // hasn't changed enough).
+    this->canBlockZoom = true;
+
+    this->lastZoomScrollCenter = (this->priLastAbs + this->secLastAbs) / 2.0;
+    const auto shift = this->secLastAbs - this->priLastAbs;
+    this->lastAngle = atan2(shift.y, shift.x);
+    this->lastDist = this->startZoomDistance;
+}
+
+void GeometryToolHandler::zoomMotion(InputEvent const& event) {
+    if (event.sequence == this->primarySequence) {
+        this->priLastAbs = {event.absoluteX, event.absoluteY};
+        this->priLastRel = {event.relativeX, event.relativeY};
+    } else {
+        this->secLastAbs = {event.absoluteX, event.absoluteY};
+        this->secLastRel = {event.relativeX, event.relativeY};
+    }
+
+    const double dist = std::max(this->priLastAbs.distance(this->secLastAbs), ZOOM_DISTANCE_MIN);
+
+    const auto zoomTriggerThreshold = xournal->getControl()->getSettings()->getTouchZoomStartThreshold();
+    const double zoomChangePercentage = std::abs(dist - startZoomDistance) / startZoomDistance * 100;
+
+    // Has the touch points moved far enough to trigger a zoom?
+    if (zoomChangePercentage >= zoomTriggerThreshold) {
+        this->canBlockZoom = false;
+    }
+
+    const auto center = (this->priLastAbs + this->secLastAbs) / 2;
+    const auto shift = this->secLastAbs - priLastAbs;
+    const auto angle = atan2(shift.y, shift.x);
+
+    const auto offset = center - lastZoomScrollCenter;
+    const auto zoom = xournal->getZoom();
+    controller->move(offset.x / zoom, offset.y / zoom);
+    const auto angleIncrease = angle - lastAngle;
+    const auto centerRel = (this->priLastRel + this->secLastRel) / 2.0;
+    const auto coords = getCoords(centerRel.x, centerRel.y);
+    const auto secondary = getCoords(this->secLastRel.x, this->secLastRel.y);
+    if (controller->isInsideGeometryTool(secondary.x, secondary.y, 0.0)) {
+        controller->rotate(angleIncrease, coords.x, coords.y);
+    }  // allow moving without accidental rotation
+    const auto scaleFactor = dist / lastDist;
+    const auto h = height * scaleFactor;
+
+    if (!canBlockZoom && h <= getMaxHeight() && h >= getMinHeight()) {
+        controller->scale(scaleFactor, coords.x, coords.y);
+    }
+
+    this->lastZoomScrollCenter = center;
+    this->lastAngle = angle;
+    this->lastDist = dist;
+}
+
+auto GeometryToolHandler::getCoords(double xCoord, double yCoord) -> utl::Point<double> {
+    const auto zoom = xournal->getZoom();
+    const auto view = controller->getView();
+    const auto posX = xCoord - static_cast<double>(view->getX());
+    const auto posY = yCoord - static_cast<double>(view->getY());
+    return utl::Point<double>(posX / zoom, posY / zoom);
+}
+
+auto GeometryToolHandler::getCoords(InputEvent const& event) -> utl::Point<double> {
+    return getCoords(event.relativeX, event.relativeY);
+}
+
+void GeometryToolHandler::blockDevice(InputContext::DeviceType deviceType) { isBlocked[deviceType] = true; }
+
+void GeometryToolHandler::unblockDevice(InputContext::DeviceType deviceType) { isBlocked[deviceType] = false; }

--- a/src/core/gui/inputdevices/GeometryToolHandler.cpp
+++ b/src/core/gui/inputdevices/GeometryToolHandler.cpp
@@ -178,6 +178,10 @@ auto GeometryToolHandler::handleKeyboard(InputEvent const& event) -> bool {
                 }
                 break;
             }
+            case GDK_KEY_m: {
+                controller->markPoint(translationX, translationY);
+                return true;
+            }
         }
 
         if (xdir != 0 || ydir != 0) {

--- a/src/core/gui/inputdevices/GeometryToolHandler.h
+++ b/src/core/gui/inputdevices/GeometryToolHandler.h
@@ -1,0 +1,186 @@
+/*
+ * Xournal++
+ *
+ * Input handler for the geometry tool.
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+#include <map>     // for map
+#include <vector>  // for vector
+
+#include <gdk/gdk.h>  // for GdkEventSequence
+
+#include "util/DispatchPool.h"  // for xoj::util::Listener
+#include "util/Point.h"         // for Point
+
+#include "InputContext.h"  // for InputContext::DeviceType, InputContext
+
+class Stroke;
+class GeometryToolController;
+struct InputEvent;
+
+/**
+ * @brief Input handler for the geometry tool
+ *
+ * The geometry tool is designed to be used with touch/keyboard with one hand and mouse/stylus with the other hand
+ * Keyboard and Touch are used to move the geometry tool (and the page), to rotate it and change its size, whereas
+ * Stylus/Mouse are used to draw/annotate.
+ *
+ * The touch handling part is adopted from the TouchInputHandler class
+ */
+class GeometryToolHandler: public xoj::util::Listener<GeometryToolHandler> {
+
+protected:
+    /**
+     * @brief the XournalView attached to this handler
+     */
+    XournalView* xournal;
+
+    /**
+     * @brief the geometry tool controller
+     *
+     */
+    GeometryToolController* controller;
+
+    double height;
+    double rotation = 0.;
+    double translationX;
+    double translationY;
+
+    /**
+     * @brief saves which devices are blocked, so they don't need to be handled
+     *        This is currently used for the automatic hand recognition, that can be turned on in the settings
+     */
+    std::map<InputContext::DeviceType, bool> isBlocked{};
+
+    /**
+     * @brief the touch event sequence corresponding to the first finger touching the screen
+     */
+    GdkEventSequence* primarySequence{};
+    /**
+     * @brief the touch event sequence corresponding to the second finger touching the screen
+     */
+    GdkEventSequence* secondarySequence{};
+
+    /**
+     * @brief the distance between the two fingers touching the screen at the start of a zoom sequence
+     */
+    double startZoomDistance{0.0};
+
+    /**
+     * @brief the previous mid point between the two fingers in a zoom sequence
+     */
+    utl::Point<double> lastZoomScrollCenter{};
+
+    /**
+     * @brief The current absolute and relative positions of the first (primary) finger and second (secondary) finger
+     */
+    utl::Point<double> priLastAbs{-1.0, -1.0};
+    utl::Point<double> secLastAbs{-1.0, -1.0};
+    utl::Point<double> priLastRel{-1.0, -1.0};
+    utl::Point<double> secLastRel{-1.0, -1.0};
+
+    /**
+     * @brief The previous angle between the line through the positions of the two fingers and the x-axis
+     */
+    double lastAngle{0.0};
+
+    /**
+     * @brief The previous distance between the two fingers touching the screen
+     */
+    double lastDist{1.0};
+
+    /**
+     * @brief whether resizing the geometry tool can be blocked, because the distance between the fingers hasn't changed
+     * enough
+     */
+    bool canBlockZoom{false};
+
+    /**
+     * @brief whether a scrolling for the hand tool takes place (after touching the geometry tool with the hand tool)
+     */
+    bool handScrolling{false};
+
+    /**
+     * @brief the line segments (strokes with two points) of the current layer, that are used for rotation snapping the
+     * geometry tool
+     */
+    std::vector<Stroke*> lines;
+
+protected:
+    /**
+     * @brief initializes an input sequence (right after the first or second finger is put onto the screen)
+     * @param event the input event initializing the sequence
+     */
+    void sequenceStart(InputEvent const& event);
+
+    /**
+     * @brief scrolling method
+     * @param event the current input event
+     */
+    void scrollMotion(InputEvent const& event);
+
+    /**
+     * @brief start zooming (after the second finger is put onto the screen)
+     */
+    void zoomStart();
+
+    /**
+     * @brief zoooming method
+     * @param event the current input event
+     */
+    void zoomMotion(InputEvent const& event);
+
+    /**
+     * @brief handles input from the touchscreen for the geometry tool
+     */
+    bool handleTouchscreen(InputEvent const& event);
+
+    /**
+     * @brief handles input from the keyboard for the geometry tool
+     */
+    bool handleKeyboard(InputEvent const& event);
+
+    /**
+     * @brief handles input from mouse and stylus for the geometry tool
+     */
+    virtual bool handlePointer(InputEvent const& event) = 0;
+
+    /**
+     * @brief the document coordinates derived from an input event
+     * @param event an input event
+     */
+    utl::Point<double> getCoords(InputEvent const& event);
+
+    /**
+     * @brief the document coordinates derived from relative view coordinates
+     * @param relative x coordinate
+     * @param relative y coordinate
+     */
+    utl::Point<double> getCoords(double x, double y);
+
+    virtual double getMinHeight() const = 0;
+    virtual double getMaxHeight() const = 0;
+
+public:
+    explicit GeometryToolHandler(XournalView* xournalView, GeometryToolController* controller, double h, double tx,
+                                 double ty);
+    virtual ~GeometryToolHandler();
+
+    bool handle(InputEvent const& event);
+    void blockDevice(InputContext::DeviceType deviceType);
+    void unblockDevice(InputContext::DeviceType deviceType);
+
+    /**
+     * Listener interface
+     */
+    static constexpr struct UpdateValuesRequest {
+    } UPDATE_VALUES = {};
+    void on(UpdateValuesRequest, double h, double rot, double tx, double ty);
+};

--- a/src/core/gui/inputdevices/GeometryToolHandler.h
+++ b/src/core/gui/inputdevices/GeometryToolHandler.h
@@ -79,12 +79,10 @@ protected:
     utl::Point<double> lastZoomScrollCenter{};
 
     /**
-     * @brief The current absolute and relative positions of the first (primary) finger and second (secondary) finger
+     * @brief The current positions of the first (primary) finger and second (secondary) finger in page coordinates
      */
-    utl::Point<double> priLastAbs{-1.0, -1.0};
-    utl::Point<double> secLastAbs{-1.0, -1.0};
-    utl::Point<double> priLastRel{-1.0, -1.0};
-    utl::Point<double> secLastRel{-1.0, -1.0};
+    utl::Point<double> priLastPageRel{-1.0, -1.0};
+    utl::Point<double> secLastPageRel{-1.0, -1.0};
 
     /**
      * @brief The previous angle between the line through the positions of the two fingers and the x-axis
@@ -157,13 +155,6 @@ protected:
      * @param event an input event
      */
     utl::Point<double> getCoords(InputEvent const& event);
-
-    /**
-     * @brief the document coordinates derived from relative view coordinates
-     * @param relative x coordinate
-     * @param relative y coordinate
-     */
-    utl::Point<double> getCoords(double x, double y);
 
     virtual double getMinHeight() const = 0;
     virtual double getMaxHeight() const = 0;

--- a/src/core/gui/inputdevices/GeometryToolInputHandler.h
+++ b/src/core/gui/inputdevices/GeometryToolInputHandler.h
@@ -34,7 +34,7 @@ struct InputEvent;
  *
  * The touch handling part is adopted from the TouchInputHandler class
  */
-class GeometryToolHandler: public xoj::util::Listener<GeometryToolHandler> {
+class GeometryToolInputHandler: public xoj::util::Listener<GeometryToolInputHandler> {
 
 protected:
     /**
@@ -160,9 +160,9 @@ protected:
     virtual double getMaxHeight() const = 0;
 
 public:
-    explicit GeometryToolHandler(XournalView* xournalView, GeometryToolController* controller, double h, double tx,
-                                 double ty);
-    virtual ~GeometryToolHandler();
+    explicit GeometryToolInputHandler(XournalView* xournalView, GeometryToolController* controller, double h, double tx,
+                                      double ty);
+    virtual ~GeometryToolInputHandler();
 
     bool handle(InputEvent const& event);
     void blockDevice(InputContext::DeviceType deviceType);

--- a/src/core/gui/inputdevices/GeometryToolInputHandler.h
+++ b/src/core/gui/inputdevices/GeometryToolInputHandler.h
@@ -125,15 +125,16 @@ protected:
     void scrollMotion(InputEvent const& event);
 
     /**
-     * @brief start zooming (after the second finger is put onto the screen)
+     * @brief start rotating and zooming (after the second finger is put onto the screen)
+     * only zooms, when zoom gestures are enabled
      */
-    void zoomStart();
+    void rotateAndZoomStart();
 
     /**
-     * @brief zoooming method
+     * @brief rotation and zooming method, only zooms when zoom gestures are enabled
      * @param event the current input event
      */
-    void zoomMotion(InputEvent const& event);
+    void rotateAndZoomMotion(InputEvent const& event);
 
     /**
      * @brief handles input from the touchscreen for the geometry tool

--- a/src/core/gui/inputdevices/InputContext.cpp
+++ b/src/core/gui/inputdevices/InputContext.cpp
@@ -125,7 +125,7 @@ auto InputContext::handle(GdkEvent* sourceEvent) -> bool {
 
     // separate events to appropriate handlers
     // handle geometry tool
-    if (auto handler = view->getGeometryToolHandler(); handler && handler->handle(event)) {
+    if (auto handler = view->getGeometryToolInputHandler(); handler && handler->handle(event)) {
         return true;
     }
 
@@ -192,7 +192,7 @@ void InputContext::focusWidget() {
 }
 
 void InputContext::blockDevice(InputContext::DeviceType deviceType) {
-    if (auto handler = view->getGeometryToolHandler()) {
+    if (auto handler = view->getGeometryToolInputHandler()) {
         handler->blockDevice(deviceType);
     }
     switch (deviceType) {
@@ -210,7 +210,7 @@ void InputContext::blockDevice(InputContext::DeviceType deviceType) {
 }
 
 void InputContext::unblockDevice(InputContext::DeviceType deviceType) {
-    if (auto handler = view->getGeometryToolHandler()) {
+    if (auto handler = view->getGeometryToolInputHandler()) {
         handler->unblockDevice(deviceType);
     }
     switch (deviceType) {

--- a/src/core/gui/inputdevices/InputContext.cpp
+++ b/src/core/gui/inputdevices/InputContext.cpp
@@ -124,8 +124,8 @@ auto InputContext::handle(GdkEvent* sourceEvent) -> bool {
     this->modifierState = event.state;
 
     // separate events to appropriate handlers
-    // handle setsquare
-    if (auto handler = view->getSetsquareHandler(); handler && handler->handle(event)) {
+    // handle geometry tool
+    if (auto handler = view->getGeometryToolHandler(); handler && handler->handle(event)) {
         return true;
     }
 
@@ -192,7 +192,7 @@ void InputContext::focusWidget() {
 }
 
 void InputContext::blockDevice(InputContext::DeviceType deviceType) {
-    if (auto handler = view->getSetsquareHandler()) {
+    if (auto handler = view->getGeometryToolHandler()) {
         handler->blockDevice(deviceType);
     }
     switch (deviceType) {
@@ -210,7 +210,7 @@ void InputContext::blockDevice(InputContext::DeviceType deviceType) {
 }
 
 void InputContext::unblockDevice(InputContext::DeviceType deviceType) {
-    if (auto handler = view->getSetsquareHandler()) {
+    if (auto handler = view->getGeometryToolHandler()) {
         handler->unblockDevice(deviceType);
     }
     switch (deviceType) {

--- a/src/core/gui/inputdevices/InputContext.cpp
+++ b/src/core/gui/inputdevices/InputContext.cpp
@@ -126,7 +126,7 @@ auto InputContext::handle(GdkEvent* sourceEvent) -> bool {
 
     // separate events to appropriate handlers
     // handle geometry tool
-    if (auto handler = view->getGeometryToolInputHandler(); handler && handler->handle(event)) {
+    if (geometryToolInputHandler && geometryToolInputHandler->handle(event)) {
         return true;
     }
 
@@ -181,6 +181,12 @@ auto InputContext::getToolHandler() -> ToolHandler* { return view->getControl()-
 
 auto InputContext::getScrollHandling() -> ScrollHandling* { return this->scrollHandling; }
 
+void InputContext::setGeometryToolInputHandler(std::unique_ptr<GeometryToolInputHandler> handler) {
+    this->geometryToolInputHandler = std::move(handler);
+}
+
+void InputContext::resetGeometryToolInputHandler() { this->geometryToolInputHandler.reset(); }
+
 auto InputContext::getModifierState() -> GdkModifierType { return this->modifierState; }
 
 /**
@@ -193,8 +199,8 @@ void InputContext::focusWidget() {
 }
 
 void InputContext::blockDevice(InputContext::DeviceType deviceType) {
-    if (auto handler = view->getGeometryToolInputHandler()) {
-        handler->blockDevice(deviceType);
+    if (geometryToolInputHandler) {
+        geometryToolInputHandler->blockDevice(deviceType);
     }
     switch (deviceType) {
         case MOUSE:
@@ -211,8 +217,8 @@ void InputContext::blockDevice(InputContext::DeviceType deviceType) {
 }
 
 void InputContext::unblockDevice(InputContext::DeviceType deviceType) {
-    if (auto handler = view->getGeometryToolInputHandler()) {
-        handler->unblockDevice(deviceType);
+    if (geometryToolInputHandler) {
+        geometryToolInputHandler->unblockDevice(deviceType);
     }
     switch (deviceType) {
         case MOUSE:

--- a/src/core/gui/inputdevices/InputContext.cpp
+++ b/src/core/gui/inputdevices/InputContext.cpp
@@ -21,9 +21,8 @@
 #include "gui/inputdevices/TouchDrawingInputHandler.h"  // for TouchDrawingI...
 #include "gui/inputdevices/TouchInputHandler.h"         // for TouchInputHan...
 
-#include "InputEvents.h"            // for InputEvent
-#include "SetsquareInputHandler.h"  // for SetsquareInpu...
-#include "config-debug.h"           // for DEBUG_INPUT
+#include "InputEvents.h"   // for InputEvent
+#include "config-debug.h"  // for DEBUG_INPUT
 
 class ScrollHandling;
 class ToolHandler;
@@ -37,7 +36,6 @@ InputContext::InputContext(XournalView* view, ScrollHandling* scrollHandling) {
     this->touchDrawingHandler = new TouchDrawingInputHandler(this);
     this->mouseHandler = new MouseInputHandler(this);
     this->keyboardHandler = new KeyboardInputHandler(this);
-    this->setsquareHandler = std::make_unique<SetsquareInputHandler>(this);
 
     for (const InputDevice& savedDevices: this->view->getControl()->getSettings()->getKnownInputDevices()) {
         this->knownDevices.insert(savedDevices.getName());
@@ -127,7 +125,7 @@ auto InputContext::handle(GdkEvent* sourceEvent) -> bool {
 
     // separate events to appropriate handlers
     // handle setsquare
-    if (this->setsquareHandler->handle(event)) {
+    if (auto handler = view->getSetsquareHandler(); handler && handler->handle(event)) {
         return true;
     }
 
@@ -194,7 +192,9 @@ void InputContext::focusWidget() {
 }
 
 void InputContext::blockDevice(InputContext::DeviceType deviceType) {
-    this->setsquareHandler->blockDevice(deviceType);
+    if (auto handler = view->getSetsquareHandler()) {
+        handler->blockDevice(deviceType);
+    }
     switch (deviceType) {
         case MOUSE:
             this->mouseHandler->block(true);
@@ -210,7 +210,9 @@ void InputContext::blockDevice(InputContext::DeviceType deviceType) {
 }
 
 void InputContext::unblockDevice(InputContext::DeviceType deviceType) {
-    this->setsquareHandler->unblockDevice(deviceType);
+    if (auto handler = view->getSetsquareHandler()) {
+        handler->unblockDevice(deviceType);
+    }
     switch (deviceType) {
         case MOUSE:
             this->mouseHandler->block(false);

--- a/src/core/gui/inputdevices/InputContext.cpp
+++ b/src/core/gui/inputdevices/InputContext.cpp
@@ -14,6 +14,7 @@
 #include "control/DeviceListHelper.h"                   // for InputDevice
 #include "control/settings/Settings.h"                  // for Settings
 #include "gui/XournalView.h"                            // for XournalView
+#include "gui/inputdevices/GeometryToolInputHandler.h"  // for GeometryToolInputHandler
 #include "gui/inputdevices/HandRecognition.h"           // for HandRecognition
 #include "gui/inputdevices/KeyboardInputHandler.h"      // for KeyboardInput...
 #include "gui/inputdevices/MouseInputHandler.h"         // for MouseInputHan...

--- a/src/core/gui/inputdevices/InputContext.h
+++ b/src/core/gui/inputdevices/InputContext.h
@@ -22,6 +22,7 @@
 
 #include "gui/widgets/XournalWidget.h"  // for GtkXournal
 
+class GeometryToolInputHandler;
 class KeyboardInputHandler;
 class MouseInputHandler;
 class ScrollHandling;
@@ -41,6 +42,7 @@ private:
     TouchDrawingInputHandler* touchDrawingHandler;
     KeyboardInputHandler* keyboardHandler;
     TouchInputHandler* touchHandler;
+    std::unique_ptr<GeometryToolInputHandler> geometryToolInputHandler;
 
     GtkWidget* widget = nullptr;
     XournalView* view;
@@ -94,6 +96,8 @@ public:
     ToolHandler* getToolHandler();
     Settings* getSettings();
     ScrollHandling* getScrollHandling();
+    void setGeometryToolInputHandler(std::unique_ptr<GeometryToolInputHandler> handler);
+    void resetGeometryToolInputHandler();
 
     GdkModifierType getModifierState();
     void focusWidget();

--- a/src/core/gui/inputdevices/InputContext.h
+++ b/src/core/gui/inputdevices/InputContext.h
@@ -22,7 +22,6 @@
 
 #include "gui/widgets/XournalWidget.h"  // for GtkXournal
 
-class SetsquareInputHandler;
 class KeyboardInputHandler;
 class MouseInputHandler;
 class ScrollHandling;
@@ -37,7 +36,6 @@ class InputContext {
 
 private:
     gulong signal_id{0};
-    std::unique_ptr<SetsquareInputHandler> setsquareHandler;
     StylusInputHandler* stylusHandler;
     MouseInputHandler* mouseHandler;
     TouchDrawingInputHandler* touchDrawingHandler;

--- a/src/core/gui/inputdevices/SetsquareInputHandler.cpp
+++ b/src/core/gui/inputdevices/SetsquareInputHandler.cpp
@@ -6,208 +6,18 @@
 #include "control/SetsquareController.h"   // for SetsquareController, HYPOTENUSE
 #include "control/ToolEnums.h"             // for TOOL_HAND, TOOL_HIGHLIGHTER
 #include "control/ToolHandler.h"           // for ToolHandler
-#include "control/settings/Settings.h"     // for Settings
-#include "gui/PageView.h"                  // for XojPageView
 #include "gui/XournalView.h"               // for XournalView
 #include "gui/inputdevices/InputEvents.h"  // for InputEvent
 #include "model/Setsquare.h"               // for Setsquare::INITIAL_HEIGHT,...
-#include "model/Snapping.h"                // for distanceLine
-#include "model/XojPage.h"                 // for XojPage
 
-constexpr double MOVE_AMOUNT = HALF_CM / 2.0;
-constexpr double MOVE_AMOUNT_SMALL = HALF_CM / 20.0;
-constexpr double ROTATE_AMOUNT = M_PI * 5.0 / 180.0;
-constexpr double ROTATE_AMOUNT_SMALL = M_PI * 0.2 / 180.0;
-constexpr double SCALE_AMOUNT = 1.1;
-constexpr double SCALE_AMOUNT_SMALL = 1.01;
 constexpr double MIN_HEIGHT = 4.5;
 constexpr double MAX_HEIGHT = 15.0;
-constexpr double SNAPPING_DISTANCE_TOLERANCE = 5.0;                 // pt
-constexpr double SNAPPING_ROTATION_TOLERANCE = 3.0 * M_PI / 180.0;  // rad
-constexpr double ZOOM_DISTANCE_MIN = 0.01;
 
-SetsquareInputHandler::SetsquareInputHandler(XournalView* xournal, SetsquareController* controller):
-        xournal(xournal),
-        controller(controller),
-        height(Setsquare::INITIAL_HEIGHT),
-        translationX(Setsquare::INITIAL_X),
-        translationY(Setsquare::INITIAL_Y) {}
+SetsquareInputHandler::SetsquareInputHandler(XournalView* xournal, GeometryToolController* controller):
+        GeometryToolHandler(xournal, controller, Setsquare::INITIAL_HEIGHT, Setsquare::INITIAL_X,
+                            Setsquare::INITIAL_Y) {}
 
 SetsquareInputHandler::~SetsquareInputHandler() noexcept { this->unregisterFromPool(); }
-
-auto SetsquareInputHandler::handle(InputEvent const& event) -> bool {
-    if (xournal->getSelection() || xournal->getControl()->getTextEditor()) {
-        return false;
-    }
-    const auto device = event.deviceClass;
-    if ((device == INPUT_DEVICE_MOUSE && isBlocked[InputContext::DeviceType::MOUSE]) ||
-        (device == INPUT_DEVICE_PEN && isBlocked[InputContext::DeviceType::STYLUS]) ||
-        (device == INPUT_DEVICE_TOUCHSCREEN && isBlocked[InputContext::DeviceType::TOUCHSCREEN])) {
-        return false;  // don't intervene
-    }
-
-    switch (device) {
-        case INPUT_DEVICE_KEYBOARD:
-            return this->handleKeyboard(event);
-        case INPUT_DEVICE_TOUCHSCREEN:
-            return this->handleTouchscreen(event);
-        case INPUT_DEVICE_PEN:
-        case INPUT_DEVICE_MOUSE:
-            return this->handlePointer(event);
-        case INPUT_DEVICE_MOUSE_KEYBOARD_COMBO:
-            return this->handlePointer(event) || this->handleKeyboard(event);
-        default:
-            g_warning("Device class %d not handled by setsquare", event.deviceClass);
-            return false;
-    }
-}
-
-void SetsquareInputHandler::on(UpdateValuesRequest, double h, double rot, double tx, double ty) {
-    height = h;
-    rotation = rot;
-    translationX = tx;
-    translationY = ty;
-}
-
-auto SetsquareInputHandler::handleTouchscreen(InputEvent const& event) -> bool {
-    const auto zoomGesturesEnabled = xournal->getControl()->getSettings()->isZoomGesturesEnabled();
-    // Don't handle more then 2 inputs
-    if (this->primarySequence && this->primarySequence != event.sequence && this->secondarySequence &&
-        this->secondarySequence != event.sequence) {
-        return false;
-    }
-    if (event.type == BUTTON_PRESS_EVENT) {
-        // Start scrolling when a sequence starts and we currently have none other
-        if (this->primarySequence == nullptr && this->secondarySequence == nullptr) {
-            auto coords = getCoords(event);
-
-            if (controller->isInsideSetsquare(coords.x, coords.y, 0)) {
-                // Set sequence data
-                this->primarySequence = event.sequence;
-                sequenceStart(event);
-                return true;
-            } else {
-                return false;
-            }
-
-        }
-        // Start zooming as soon as we have two sequences.
-        else if (this->primarySequence && this->primarySequence != event.sequence &&
-                 this->secondarySequence == nullptr) {
-            this->secondarySequence = event.sequence;
-
-            // Set sequence data
-            sequenceStart(event);
-
-            // Even if zoom gestures are disabled,
-            // this is still the start of a sequence. Just
-            // don't start zooming.
-            if (zoomGesturesEnabled) {
-                zoomStart();
-                return true;
-            }
-        }
-    }
-
-    if (event.type == MOTION_EVENT && this->primarySequence) {
-        if (this->primarySequence && this->secondarySequence && zoomGesturesEnabled) {
-            zoomMotion(event);
-            return true;
-        } else if (event.sequence == this->primarySequence) {
-            scrollMotion(event);
-            return true;
-        } else if (this->primarySequence && this->secondarySequence) {
-            sequenceStart(event);
-            return true;
-        }
-    }
-
-    if (event.type == BUTTON_RELEASE_EVENT) {
-        if (event.sequence == this->primarySequence) {
-            // If secondarySequence is nullptr, this sets primarySequence
-            // to nullptr. If it isn't, then it is now the primary sequence!
-            this->primarySequence = this->secondarySequence;
-            this->secondarySequence = nullptr;
-
-            this->priLastAbs = this->secLastAbs;
-            this->priLastRel = this->secLastRel;
-        } else {
-            this->secondarySequence = nullptr;
-        }
-    }
-    return false;
-}
-
-auto SetsquareInputHandler::handleKeyboard(InputEvent const& event) -> bool {
-    GdkEvent* gdkEvent = event.sourceEvent;
-    if (gdkEvent->type == GDK_KEY_PRESS) {
-        auto keyEvent = reinterpret_cast<GdkEventKey*>(gdkEvent);
-
-        double xdir = 0;
-        double ydir = 0;
-        double angle = 0.0;
-        double scale = 1.0;
-
-        switch (keyEvent->keyval) {
-            case GDK_KEY_Left:
-                xdir = -1;
-                break;
-            case GDK_KEY_Up:
-                ydir = -1;
-                break;
-            case GDK_KEY_Right:
-                xdir = 1;
-                break;
-            case GDK_KEY_Down:
-                ydir = 1;
-                break;
-            case GDK_KEY_r:
-            case GDK_KEY_R: {  // r like "rotate"
-                angle = (event.state & GDK_MOD1_MASK) ? ROTATE_AMOUNT_SMALL : ROTATE_AMOUNT;
-                angle = (event.state & GDK_SHIFT_MASK) ? angle : -angle;
-                break;
-            }
-            case GDK_KEY_s:
-            case GDK_KEY_S: {
-                scale = (event.state & GDK_MOD1_MASK) ? SCALE_AMOUNT_SMALL : SCALE_AMOUNT;
-                scale = (event.state & GDK_SHIFT_MASK) ? 1.0 / scale : scale;
-                const auto h = height * scale;
-                if (h > getMaxHeight() || h < getMinHeight()) {
-                    scale = 1.0;
-                }
-                break;
-            }
-        }
-
-        if (xdir != 0 || ydir != 0) {
-            const auto c = std::cos(rotation);
-            const auto s = std::sin(rotation);
-            double xshift{0.0};
-            double yshift{0.0};
-            const auto amount = (event.state & GDK_MOD1_MASK) ? MOVE_AMOUNT_SMALL : MOVE_AMOUNT;
-            if (event.state & GDK_SHIFT_MASK) {
-                xshift = amount * (c * xdir - s * ydir);
-                yshift = amount * (s * xdir + c * ydir);
-            } else {
-                xshift = amount * xdir;
-                yshift = amount * ydir;
-            }
-            controller->move(xshift, yshift);
-            return true;
-        }
-
-        auto p = utl::Point(translationX, translationY);
-        if (angle != 0) {
-            controller->rotate(angle, p.x, p.y);
-            return true;
-        }
-        if (scale != 1.0) {
-            controller->scale(scale, p.x, p.y);
-            return true;
-        }
-    }
-    return false;
-}
 
 auto SetsquareInputHandler::handlePointer(InputEvent const& event) -> bool {
     const auto coords = getCoords(event);
@@ -218,13 +28,13 @@ auto SetsquareInputHandler::handlePointer(InputEvent const& event) -> bool {
         case TOOL_HIGHLIGHTER:
         case TOOL_PEN:
             if (event.type == BUTTON_PRESS_EVENT) {
-                if (controller->isInsideSetsquare(coords.x, coords.y, 0) &&
+                if (controller->isInsideGeometryTool(coords.x, coords.y, 0) &&
                     setsquareController->posRelToSide(HYPOTENUSE, coords.x, coords.y).y >= -0.5) {
                     // initialize range
                     const auto proj = setsquareController->posRelToSide(HYPOTENUSE, coords.x, coords.y).x;
                     setsquareController->createStroke(proj);
                     return true;
-                } else if (controller->isInsideSetsquare(coords.x, coords.y, 0) &&
+                } else if (controller->isInsideGeometryTool(coords.x, coords.y, 0) &&
                            (setsquareController->posRelToSide(LEFT_LEG, coords.x, coords.y).y >= -0.5 ||
                             setsquareController->posRelToSide(RIGHT_LEG, coords.x, coords.y).y >= -0.5)) {
 
@@ -259,7 +69,7 @@ auto SetsquareInputHandler::handlePointer(InputEvent const& event) -> bool {
             return false;
         case TOOL_HAND:
             if (event.type == BUTTON_PRESS_EVENT) {
-                if (!controller->isInsideSetsquare(coords.x, coords.y, 0)) {
+                if (!controller->isInsideGeometryTool(coords.x, coords.y, 0)) {
                     return false;
                 } else {
                     sequenceStart(event);
@@ -277,139 +87,5 @@ auto SetsquareInputHandler::handlePointer(InputEvent const& event) -> bool {
     }
 }
 
-void SetsquareInputHandler::sequenceStart(InputEvent const& event) {
-    if (event.sequence == this->primarySequence) {
-        this->priLastAbs = {event.absoluteX, event.absoluteY};
-        this->priLastRel = {event.relativeX, event.relativeY};
-    } else {
-        this->secLastAbs = {event.absoluteX, event.absoluteY};
-        this->secLastRel = {event.relativeX, event.relativeY};
-    }
-    const auto page = controller->getPage();
-
-    const auto l = page->getSelectedLayer();
-    this->lines.clear();
-    for (const auto& e: l->getElements()) {
-        if (e->getType() == ELEMENT_STROKE) {
-            auto s = dynamic_cast<Stroke*>(e);
-            if (s->getPointCount() == 2) {
-                lines.push_back(s);
-            }
-        }
-    }
-}
-
-void SetsquareInputHandler::scrollMotion(InputEvent const& event) {
-    // Will only be called if there is a single sequence (zooming handles two sequences)
-    auto offset = [&]() {
-        auto absolutePoint = utl::Point{event.absoluteX, event.absoluteY};
-        if (event.sequence == this->primarySequence) {
-            const auto offset = absolutePoint - this->priLastAbs;
-            this->priLastAbs = absolutePoint;
-            return offset;
-        } else {
-            const auto offset = absolutePoint - this->secLastAbs;
-            this->secLastAbs = absolutePoint;
-            return offset;
-        }
-    }();
-    const auto zoom = xournal->getZoom();
-    auto p = utl::Point(translationX, translationY);
-    p.x += offset.x / zoom;
-    p.y += offset.y / zoom;
-    const auto pos = Point(p.x, p.y);
-    double minDist = SNAPPING_DISTANCE_TOLERANCE;
-    const auto angleSetsquare = rotation;
-    double diffAngle{NAN};
-    for (const auto& l: lines) {
-        auto first = l->getPoint(0);
-        auto second = l->getPoint(1);
-        auto dist = Snapping::distanceLine(pos, first, second);
-        auto angleLine = std::atan2(second.y - first.y, second.x - first.x);
-        auto diff = std::remainder(angleLine - angleSetsquare, M_PI_2);
-        if (dist < minDist && std::abs(diff) <= SNAPPING_ROTATION_TOLERANCE) {
-            minDist = dist;
-            diffAngle = diff;
-        }
-    }
-    if (!std::isnan(diffAngle)) {
-        controller->rotate(diffAngle, p.x, p.y);
-    }
-    controller->move(offset.x / zoom, offset.y / zoom);
-}
-
-void SetsquareInputHandler::zoomStart() {
-    this->startZoomDistance = std::max(this->priLastAbs.distance(this->secLastAbs), ZOOM_DISTANCE_MIN);
-
-    // Whether we can ignore the zoom portion of the gesture (e.g. distance between touch points
-    // hasn't changed enough).
-    this->canBlockZoom = true;
-
-    this->lastZoomScrollCenter = (this->priLastAbs + this->secLastAbs) / 2.0;
-    const auto shift = this->secLastAbs - this->priLastAbs;
-    this->lastAngle = atan2(shift.y, shift.x);
-    this->lastDist = this->startZoomDistance;
-}
-
-void SetsquareInputHandler::zoomMotion(InputEvent const& event) {
-    if (event.sequence == this->primarySequence) {
-        this->priLastAbs = {event.absoluteX, event.absoluteY};
-        this->priLastRel = {event.relativeX, event.relativeY};
-    } else {
-        this->secLastAbs = {event.absoluteX, event.absoluteY};
-        this->secLastRel = {event.relativeX, event.relativeY};
-    }
-
-    const double dist = std::max(this->priLastAbs.distance(this->secLastAbs), ZOOM_DISTANCE_MIN);
-
-    const auto zoomTriggerThreshold = xournal->getControl()->getSettings()->getTouchZoomStartThreshold();
-    const double zoomChangePercentage = std::abs(dist - startZoomDistance) / startZoomDistance * 100;
-
-    // Has the touch points moved far enough to trigger a zoom?
-    if (zoomChangePercentage >= zoomTriggerThreshold) {
-        this->canBlockZoom = false;
-    }
-
-    const auto center = (this->priLastAbs + this->secLastAbs) / 2;
-    const auto shift = this->secLastAbs - priLastAbs;
-    const auto angle = atan2(shift.y, shift.x);
-
-    const auto offset = center - lastZoomScrollCenter;
-    const auto zoom = xournal->getZoom();
-    controller->move(offset.x / zoom, offset.y / zoom);
-    const auto angleIncrease = angle - lastAngle;
-    const auto centerRel = (this->priLastRel + this->secLastRel) / 2.0;
-    const auto coords = getCoords(centerRel.x, centerRel.y);
-    const auto secondary = getCoords(this->secLastRel.x, this->secLastRel.y);
-    if (controller->isInsideSetsquare(secondary.x, secondary.y, 0.0)) {
-        controller->rotate(angleIncrease, coords.x, coords.y);
-    }  // allow moving without accidental rotation
-    const auto scaleFactor = dist / lastDist;
-    const auto h = height * scaleFactor;
-
-    if (!canBlockZoom && h <= getMaxHeight() && h >= getMinHeight()) {
-        controller->scale(scaleFactor, coords.x, coords.y);
-    }
-
-    this->lastZoomScrollCenter = center;
-    this->lastAngle = angle;
-    this->lastDist = dist;
-}
-
-auto SetsquareInputHandler::getCoords(double xCoord, double yCoord) -> utl::Point<double> {
-    const auto zoom = xournal->getZoom();
-    const auto view = controller->getView();
-    const auto posX = xCoord - static_cast<double>(view->getX());
-    const auto posY = yCoord - static_cast<double>(view->getY());
-    return utl::Point<double>(posX / zoom, posY / zoom);
-}
-
-auto SetsquareInputHandler::getCoords(InputEvent const& event) -> utl::Point<double> {
-    return getCoords(event.relativeX, event.relativeY);
-}
-
-void SetsquareInputHandler::blockDevice(InputContext::DeviceType deviceType) { isBlocked[deviceType] = true; }
-
-void SetsquareInputHandler::unblockDevice(InputContext::DeviceType deviceType) { isBlocked[deviceType] = false; }
 auto SetsquareInputHandler::getMinHeight() const -> double { return MIN_HEIGHT; }
 auto SetsquareInputHandler::getMaxHeight() const -> double { return MAX_HEIGHT; }

--- a/src/core/gui/inputdevices/SetsquareInputHandler.cpp
+++ b/src/core/gui/inputdevices/SetsquareInputHandler.cpp
@@ -32,14 +32,14 @@ auto SetsquareInputHandler::handlePointer(InputEvent const& event) -> bool {
                     setsquareController->posRelToSide(HYPOTENUSE, coords.x, coords.y).y >= -0.5) {
                     // initialize range
                     const auto proj = setsquareController->posRelToSide(HYPOTENUSE, coords.x, coords.y).x;
-                    setsquareController->createStroke(proj);
+                    setsquareController->createEdgeStroke(proj);
                     return true;
                 } else if (controller->isInsideGeometryTool(coords.x, coords.y, 0) &&
                            (setsquareController->posRelToSide(LEFT_LEG, coords.x, coords.y).y >= -0.5 ||
                             setsquareController->posRelToSide(RIGHT_LEG, coords.x, coords.y).y >= -0.5)) {
 
                     // initialize point
-                    setsquareController->createRadius(coords.x, coords.y);
+                    setsquareController->createRadialStroke(coords.x, coords.y);
                     return true;
                 } else {
                     return false;
@@ -47,22 +47,22 @@ auto SetsquareInputHandler::handlePointer(InputEvent const& event) -> bool {
 
             } else if (event.type == MOTION_EVENT) {
                 // update range and paint
-                if (setsquareController->existsStroke()) {
+                if (setsquareController->existsEdgeStroke()) {
                     const auto proj = setsquareController->posRelToSide(HYPOTENUSE, coords.x, coords.y).x;
-                    setsquareController->updateStroke(proj);
+                    setsquareController->updateEdgeStroke(proj);
                     return true;
-                } else if (setsquareController->existsRadius()) {
-                    setsquareController->updateRadius(coords.x, coords.y);
+                } else if (setsquareController->existsRadialStroke()) {
+                    setsquareController->updateRadialStroke(coords.x, coords.y);
                     return true;
                 }
                 return false;
             } else if (event.type == BUTTON_RELEASE_EVENT) {
                 // add stroke to layer and reset
-                if (setsquareController->existsStroke()) {
-                    setsquareController->finalizeStroke();
+                if (setsquareController->existsEdgeStroke()) {
+                    setsquareController->finalizeEdgeStroke();
                     return true;
-                } else if (setsquareController->existsRadius()) {
-                    setsquareController->finalizeRadius();
+                } else if (setsquareController->existsRadialStroke()) {
+                    setsquareController->finalizeRadialStroke();
                     return true;
                 }
             }

--- a/src/core/gui/inputdevices/SetsquareInputHandler.cpp
+++ b/src/core/gui/inputdevices/SetsquareInputHandler.cpp
@@ -14,8 +14,8 @@ constexpr double MIN_HEIGHT = 4.5;
 constexpr double MAX_HEIGHT = 15.0;
 
 SetsquareInputHandler::SetsquareInputHandler(XournalView* xournal, GeometryToolController* controller):
-        GeometryToolHandler(xournal, controller, Setsquare::INITIAL_HEIGHT, Setsquare::INITIAL_X,
-                            Setsquare::INITIAL_Y) {}
+        GeometryToolInputHandler(xournal, controller, Setsquare::INITIAL_HEIGHT, Setsquare::INITIAL_X,
+                                 Setsquare::INITIAL_Y) {}
 
 SetsquareInputHandler::~SetsquareInputHandler() noexcept { this->unregisterFromPool(); }
 

--- a/src/core/gui/inputdevices/SetsquareInputHandler.h
+++ b/src/core/gui/inputdevices/SetsquareInputHandler.h
@@ -11,7 +11,7 @@
 
 #pragma once
 
-#include "GeometryToolHandler.h"
+#include "GeometryToolInputHandler.h"
 
 class Stroke;
 class GeometryToolController;
@@ -21,9 +21,9 @@ struct InputEvent;
  * @brief Input handler for the setsquare
  *
  * Only the pointer handling (mouse / stylus) is defined in this class.
- * The rest comes from the GeometryToolHandler
+ * The rest comes from the GeometryToolInputHandler
  * */
-class SetsquareInputHandler: public GeometryToolHandler {
+class SetsquareInputHandler: public GeometryToolInputHandler {
 
 public:
     explicit SetsquareInputHandler(XournalView* xournalView, GeometryToolController* controller);

--- a/src/core/gui/inputdevices/SetsquareInputHandler.h
+++ b/src/core/gui/inputdevices/SetsquareInputHandler.h
@@ -11,177 +11,30 @@
 
 #pragma once
 
-#include <map>     // for map
-#include <vector>  // for vector
-
-#include <gdk/gdk.h>  // for GdkEventSequence
-
-#include "util/DispatchPool.h"  // for xoj::util::Listener
-#include "util/Point.h"         // for Point
-
-#include "InputContext.h"  // for InputContext::DeviceType, InputContext
-
+#include "GeometryToolHandler.h"
 
 class Stroke;
-class SetsquareController;
+class GeometryToolController;
 struct InputEvent;
 
 /**
  * @brief Input handler for the setsquare
- * The setsquare is designed to be used with touch/keyboard with one hand and mouse/stylus with the other hand
- * Keyboard and Touch are used to move the setsquare (and the page), to rotate it and change its size, whereas
- * Stylus/Mouse are used to draw/annotate and in particular to draw lines at the longest side of the setsquare.
  *
- * The touch handling part is adopted from the TouchInputHandler class
- */
-
-class SetsquareInputHandler: public xoj::util::Listener<SetsquareInputHandler> {
+ * Only the pointer handling (mouse / stylus) is defined in this class.
+ * The rest comes from the GeometryToolHandler
+ * */
+class SetsquareInputHandler: public GeometryToolHandler {
 
 public:
-    explicit SetsquareInputHandler(XournalView* xournalView, SetsquareController* controller);
-    ~SetsquareInputHandler();
+    explicit SetsquareInputHandler(XournalView* xournalView, GeometryToolController* controller);
+    ~SetsquareInputHandler() noexcept override;
 
 private:
-    /**
-     * @brief the XournalView attached to this handler
-     */
-    XournalView* xournal;
-
-    /**
-     * @brief the setsquare controller
-     *
-     */
-    SetsquareController* controller;
-
-    double height;
-    double rotation = 0.;
-    double translationX;
-    double translationY;
-
-    /**
-     * @brief saves which devices are blocked, so they don't need to be handled
-     *        This is currently used for the automatic hand recognition, that can be turned on in the settings
-     */
-    std::map<InputContext::DeviceType, bool> isBlocked{};
-
-    /**
-     * @brief the touch event sequence corresponding to the first finger touching the screen
-     */
-    GdkEventSequence* primarySequence{};
-    /**
-     * @brief the touch event sequence corresponding to the second finger touching the screen
-     */
-    GdkEventSequence* secondarySequence{};
-
-    /**
-     * @brief the distance between the two fingers touching the screen at the start of a zoom sequence
-     */
-    double startZoomDistance{0.0};
-
-    /**
-     * @brief the previous mid point between the two fingers in a zoom sequence
-     */
-    utl::Point<double> lastZoomScrollCenter{};
-
-    /**
-     * @brief The current absolute and relative positions of the first (primary) finger and second (secondary) finger
-     */
-    utl::Point<double> priLastAbs{-1.0, -1.0};
-    utl::Point<double> secLastAbs{-1.0, -1.0};
-    utl::Point<double> priLastRel{-1.0, -1.0};
-    utl::Point<double> secLastRel{-1.0, -1.0};
-
-    /**
-     * @brief The previous angle between the line through the positions of the two fingers and the x-axis
-     */
-    double lastAngle{0.0};
-
-    /**
-     * @brief The previous distance between the two fingers touching the screen
-     */
-    double lastDist{1.0};
-
-    /**
-     * @brief whether resizing the setsquare can be blocked, because the distance between the fingers hasn't changed
-     * enough
-     */
-    bool canBlockZoom{false};
-
-    /**
-     * @brief whether a scrolling for the hand tool takes place (after touching the setsquare with the hand tool)
-     */
-    bool handScrolling{false};
-
-    /**
-     * @brief the line segments (strokes with two points) of the current layer, that are used for rotation snapping the
-     * setsquare
-     */
-    std::vector<Stroke*> lines;
-
-    /**
-     * @brief initializes an input sequence (right after the first or second finger is put onto the screen)
-     * @param event the input event initializing the sequence
-     */
-    void sequenceStart(InputEvent const& event);
-
-    /**
-     * @brief scrolling method
-     * @param event the current input event
-     */
-    void scrollMotion(InputEvent const& event);
-
-    /**
-     * @brief start zooming (after the second finger is put onto the screen)
-     */
-    void zoomStart();
-
-    /**
-     * @brief zoooming method
-     * @param event the current input event
-     */
-    void zoomMotion(InputEvent const& event);
-
-    /**
-     * @brief handles input from the touchscreen for the setsquare
-     */
-    bool handleTouchscreen(InputEvent const& event);
-
-    /**
-     * @brief handles input from the keyboard for the setsquare
-     */
-    bool handleKeyboard(InputEvent const& event);
-
     /**
      * @brief handles input from mouse and stylus for the setsquare
      */
-    bool handlePointer(InputEvent const& event);
+    bool handlePointer(InputEvent const& event) override;
 
-private:
-    /**
-     * @brief the document coordinates derived from an input event
-     * @param event an input event
-     */
-    utl::Point<double> getCoords(InputEvent const& event);
-
-    /**
-     * @brief the document coordinates derived from relative view coordinates
-     * @param relative x coordinate
-     * @param relative y coordinate
-     */
-    utl::Point<double> getCoords(double x, double y);
-
-    double getMinHeight() const;
-    double getMaxHeight() const;
-
-public:
-    bool handle(InputEvent const& event);
-    void blockDevice(InputContext::DeviceType deviceType);
-    void unblockDevice(InputContext::DeviceType deviceType);
-
-    /**
-     * Listener interface
-     */
-    static constexpr struct UpdateValuesRequest {
-    } UPDATE_VALUES = {};
-    void on(UpdateValuesRequest, double h, double rot, double tx, double ty);
+    double getMinHeight() const override;
+    double getMaxHeight() const override;
 };

--- a/src/core/gui/inputdevices/SetsquareInputHandler.h
+++ b/src/core/gui/inputdevices/SetsquareInputHandler.h
@@ -16,11 +16,14 @@
 
 #include <gdk/gdk.h>  // for GdkEventSequence
 
-#include "util/Point.h"  // for Point
+#include "util/DispatchPool.h"  // for xoj::util::Listener
+#include "util/Point.h"         // for Point
 
 #include "InputContext.h"  // for InputContext::DeviceType, InputContext
 
+
 class Stroke;
+class SetsquareController;
 struct InputEvent;
 
 /**
@@ -31,13 +34,29 @@ struct InputEvent;
  *
  * The touch handling part is adopted from the TouchInputHandler class
  */
-class SetsquareInputHandler {
+
+class SetsquareInputHandler: public xoj::util::Listener<SetsquareInputHandler> {
+
+public:
+    explicit SetsquareInputHandler(XournalView* xournalView, SetsquareController* controller);
+    ~SetsquareInputHandler();
 
 private:
     /**
-     * @brief the input context attached to this handler
+     * @brief the XournalView attached to this handler
      */
-    InputContext* inputContext;
+    XournalView* xournal;
+
+    /**
+     * @brief the setsquare controller
+     *
+     */
+    SetsquareController* controller;
+
+    double height;
+    double rotation = 0.;
+    double translationX;
+    double translationY;
 
     /**
      * @brief saves which devices are blocked, so they don't need to be handled
@@ -99,7 +118,6 @@ private:
      */
     std::vector<Stroke*> lines;
 
-private:
     /**
      * @brief initializes an input sequence (right after the first or second finger is put onto the screen)
      * @param event the input event initializing the sequence
@@ -138,6 +156,7 @@ private:
      */
     bool handlePointer(InputEvent const& event);
 
+private:
     /**
      * @brief the document coordinates derived from an input event
      * @param event an input event
@@ -151,11 +170,18 @@ private:
      */
     utl::Point<double> getCoords(double x, double y);
 
-public:
-    explicit SetsquareInputHandler(InputContext* inputContext);
-    ~SetsquareInputHandler() = default;
+    double getMinHeight() const;
+    double getMaxHeight() const;
 
+public:
     bool handle(InputEvent const& event);
     void blockDevice(InputContext::DeviceType deviceType);
     void unblockDevice(InputContext::DeviceType deviceType);
+
+    /**
+     * Listener interface
+     */
+    static constexpr struct UpdateValuesRequest {
+    } UPDATE_VALUES = {};
+    void on(UpdateValuesRequest, double h, double rot, double tx, double ty);
 };

--- a/src/core/gui/toolbarMenubar/ToolMenuHandler.cpp
+++ b/src/core/gui/toolbarMenubar/ToolMenuHandler.cpp
@@ -408,7 +408,7 @@ void ToolMenuHandler::initToolItems() {
                      _("Rotation Snapping"));
     addCustomItemTgl("GRID_SNAPPING", ACTION_GRID_SNAPPING, GROUP_GRID_SNAPPING, false, "snapping-grid",
                      _("Grid Snapping"));
-    addCustomItemTgl("SETSQUARE", ACTION_SETSQUARE, GROUP_SETSQUARE, false, "setsquare", _("Setsquare"));
+    addCustomItemTgl("SETSQUARE", ACTION_SETSQUARE, GROUP_GEOMETRY_TOOL, false, "setsquare", _("Setsquare"));
 
     /*
      * Menu View

--- a/src/core/gui/widgets/XournalWidget.cpp
+++ b/src/core/gui/widgets/XournalWidget.cpp
@@ -20,7 +20,6 @@
 #include "gui/scroll/ScrollHandling.h"      // for ScrollHandling
 #include "util/Color.h"                     // for cairo_set_source_rgbi
 #include "util/Rectangle.h"                 // for Rectangle
-#include "view/SetsquareView.h"             // for SetsquareView
 
 
 using xoj::util::Rectangle;
@@ -71,8 +70,6 @@ auto gtk_xournal_new(XournalView* view, InputContext* inputContext) -> GtkWidget
     xoj->scrollHandling = inputContext->getScrollHandling();
     xoj->layout = new Layout(view, inputContext->getScrollHandling());
     xoj->selection = nullptr;
-    xoj->setsquareView = nullptr;
-
     xoj->input = inputContext;
 
     xoj->input->connect(GTK_WIDGET(xoj));
@@ -293,19 +290,6 @@ static auto gtk_xournal_draw(GtkWidget* widget, cairo_t* cr) -> gboolean {
         cairo_restore(cr);
     }
 
-    if (xournal->setsquareView) {
-        auto&& pv = xournal->setsquareView->getView();
-        int px = pv->getX();
-        int py = pv->getY();
-
-        if (clippingRect.intersects(pv->getRect())) {
-            cairo_save(cr);
-            cairo_translate(cr, px, py);
-            xournal->setsquareView->paint(cr);
-            cairo_restore(cr);
-        }
-    }
-
     return true;
 }
 
@@ -316,8 +300,6 @@ static void gtk_xournal_dispose(GObject* object) {
 
     delete xournal->selection;
     xournal->selection = nullptr;
-
-    xournal->setsquareView = nullptr;
 
     delete xournal->layout;
     xournal->layout = nullptr;

--- a/src/core/gui/widgets/XournalWidget.h
+++ b/src/core/gui/widgets/XournalWidget.h
@@ -17,8 +17,6 @@
 #include <glib.h>         // for G_BEGIN_DECLS, G_END_DECLS
 #include <gtk/gtk.h>      // for GtkWidget, GtkWidgetClass
 
-#include "view/SetsquareView.h"  // for SetsquareView
-
 namespace xoj::util {
 template <class T>
 class Rectangle;
@@ -33,7 +31,6 @@ G_BEGIN_DECLS
 #define GTK_IS_XOURNAL(obj) G_TYPE_CHECK_INSTANCE_TYPE(obj, gtk_xournal_get_type())
 
 class EditSelection;
-class SetsquareView;
 class Layout;
 class XojPageView;
 class ScrollHandling;
@@ -65,11 +62,6 @@ struct _GtkXournal {
      * Selected content, if any
      */
     EditSelection* selection;
-
-    /**
-     * Setsquare, if active
-     */
-    std::unique_ptr<SetsquareView> setsquareView;
 
     /**
      * Input handling

--- a/src/core/model/GeometryTool.cpp
+++ b/src/core/model/GeometryTool.cpp
@@ -8,7 +8,7 @@ GeometryTool::GeometryTool(double h, double r, double tx, double ty):
         translationX(tx),
         translationY(ty),
         viewPool(std::make_shared<xoj::util::DispatchPool<xoj::view::GeometryToolView>>()),
-        handlerPool(std::make_shared<xoj::util::DispatchPool<GeometryToolHandler>>()) {}
+        handlerPool(std::make_shared<xoj::util::DispatchPool<GeometryToolInputHandler>>()) {}
 
 GeometryTool::~GeometryTool() {}
 
@@ -36,7 +36,7 @@ auto GeometryTool::getMatrix() const -> cairo_matrix_t {
 auto GeometryTool::getViewPool() const -> const std::shared_ptr<xoj::util::DispatchPool<xoj::view::GeometryToolView>>& {
     return viewPool;
 }
-auto GeometryTool::getHandlerPool() const -> const std::shared_ptr<xoj::util::DispatchPool<GeometryToolHandler>>& {
+auto GeometryTool::getHandlerPool() const -> const std::shared_ptr<xoj::util::DispatchPool<GeometryToolInputHandler>>& {
     return handlerPool;
 }
 

--- a/src/core/model/GeometryTool.cpp
+++ b/src/core/model/GeometryTool.cpp
@@ -1,0 +1,43 @@
+#include "GeometryTool.h"
+
+#include <initializer_list>  // for initializer_list
+
+GeometryTool::GeometryTool(double h, double r, double tx, double ty):
+        height(h),
+        rotation(r),
+        translationX(tx),
+        translationY(ty),
+        viewPool(std::make_shared<xoj::util::DispatchPool<xoj::view::GeometryToolView>>()),
+        handlerPool(std::make_shared<xoj::util::DispatchPool<GeometryToolHandler>>()) {}
+
+GeometryTool::~GeometryTool() {}
+
+void GeometryTool::setHeight(double height) { this->height = height; }
+auto GeometryTool::getHeight() const -> double { return this->height; }
+
+void GeometryTool::setRotation(double rotation) { this->rotation = rotation; }
+auto GeometryTool::getRotation() const -> double { return this->rotation; }
+
+void GeometryTool::setTranslationX(double x) { this->translationX = x; }
+auto GeometryTool::getTranslationX() const -> double { return this->translationX; }
+
+void GeometryTool::setTranslationY(double y) { this->translationY = y; }
+auto GeometryTool::getTranslationY() const -> double { return this->translationY; }
+
+void GeometryTool::getMatrix(cairo_matrix_t& matrix) const {
+    cairo_matrix_init_identity(&matrix);
+    cairo_matrix_translate(&matrix, this->translationX, this->translationY);
+    cairo_matrix_rotate(&matrix, this->rotation);
+    cairo_matrix_scale(&matrix, CM, CM);
+}
+
+auto GeometryTool::getViewPool() const -> const std::shared_ptr<xoj::util::DispatchPool<xoj::view::GeometryToolView>>& {
+    return viewPool;
+}
+auto GeometryTool::getHandlerPool() const -> const std::shared_ptr<xoj::util::DispatchPool<GeometryToolHandler>>& {
+    return handlerPool;
+}
+
+auto GeometryTool::getStroke() const -> Stroke* { return this->stroke; }
+
+void GeometryTool::setStroke(Stroke* s) { this->stroke = s; }

--- a/src/core/model/GeometryTool.cpp
+++ b/src/core/model/GeometryTool.cpp
@@ -2,13 +2,14 @@
 
 #include <initializer_list>  // for initializer_list
 
-GeometryTool::GeometryTool(double h, double r, double tx, double ty):
+GeometryTool::GeometryTool(double h, double r, double tx, double ty, Range toolRange):
         height(h),
         rotation(r),
         translationX(tx),
         translationY(ty),
         viewPool(std::make_shared<xoj::util::DispatchPool<xoj::view::GeometryToolView>>()),
-        handlerPool(std::make_shared<xoj::util::DispatchPool<GeometryToolInputHandler>>()) {}
+        handlerPool(std::make_shared<xoj::util::DispatchPool<GeometryToolInputHandler>>()),
+        lastRepaintRange(toolRange) {}
 
 GeometryTool::~GeometryTool() {}
 

--- a/src/core/model/GeometryTool.cpp
+++ b/src/core/model/GeometryTool.cpp
@@ -43,3 +43,14 @@ auto GeometryTool::getHandlerPool() const -> const std::shared_ptr<xoj::util::Di
 auto GeometryTool::getStroke() const -> Stroke* { return this->stroke; }
 
 void GeometryTool::setStroke(Stroke* s) { this->stroke = s; }
+
+auto GeometryTool::computeRepaintRange(Range rg) const -> Range {
+    Range lastRange = this->lastRepaintRange;
+    if (this->stroke) {
+        rg.addPoint(this->stroke->getX(), this->stroke->getY());
+        rg.addPoint(this->stroke->getX() + this->stroke->getElementWidth(),
+                    this->stroke->getY() + this->stroke->getElementHeight());
+    }
+    this->lastRepaintRange = rg;
+    return rg.unite(lastRange);
+}

--- a/src/core/model/GeometryTool.cpp
+++ b/src/core/model/GeometryTool.cpp
@@ -24,11 +24,13 @@ auto GeometryTool::getTranslationX() const -> double { return this->translationX
 void GeometryTool::setTranslationY(double y) { this->translationY = y; }
 auto GeometryTool::getTranslationY() const -> double { return this->translationY; }
 
-void GeometryTool::getMatrix(cairo_matrix_t& matrix) const {
+auto GeometryTool::getMatrix() const -> cairo_matrix_t {
+    cairo_matrix_t matrix;
     cairo_matrix_init_identity(&matrix);
     cairo_matrix_translate(&matrix, this->translationX, this->translationY);
     cairo_matrix_rotate(&matrix, this->rotation);
     cairo_matrix_scale(&matrix, CM, CM);
+    return matrix;
 }
 
 auto GeometryTool::getViewPool() const -> const std::shared_ptr<xoj::util::DispatchPool<xoj::view::GeometryToolView>>& {

--- a/src/core/model/GeometryTool.h
+++ b/src/core/model/GeometryTool.h
@@ -60,7 +60,7 @@ public:
     void setTranslationY(double y);
     double getTranslationY() const;
 
-    void getMatrix(cairo_matrix_t& matrix) const;
+    cairo_matrix_t getMatrix() const;
 
     Stroke* getStroke() const;
     void setStroke(Stroke* s);

--- a/src/core/model/GeometryTool.h
+++ b/src/core/model/GeometryTool.h
@@ -38,7 +38,7 @@ namespace xoj::view {
 class GeometryToolView;
 };
 
-class GeometryToolHandler;
+class GeometryToolInputHandler;
 
 class GeometryTool: public OverlayBase {
 public:
@@ -68,7 +68,7 @@ public:
     void setStroke(Stroke* s);
 
     const std::shared_ptr<xoj::util::DispatchPool<xoj::view::GeometryToolView>>& getViewPool() const;
-    const std::shared_ptr<xoj::util::DispatchPool<GeometryToolHandler>>& getHandlerPool() const;
+    const std::shared_ptr<xoj::util::DispatchPool<GeometryToolInputHandler>>& getHandlerPool() const;
 
     virtual void notify(bool resetMask = false) const = 0;  // calls the update method of all observers
     /**
@@ -103,7 +103,7 @@ protected:
     Stroke* stroke = nullptr;
 
     std::shared_ptr<xoj::util::DispatchPool<xoj::view::GeometryToolView>> viewPool;
-    std::shared_ptr<xoj::util::DispatchPool<GeometryToolHandler>> handlerPool;
+    std::shared_ptr<xoj::util::DispatchPool<GeometryToolInputHandler>> handlerPool;
 
     /**
      * @brief Bounding box of the geometry tool and stroke after its last update

--- a/src/core/model/GeometryTool.h
+++ b/src/core/model/GeometryTool.h
@@ -95,4 +95,16 @@ protected:
 
     std::shared_ptr<xoj::util::DispatchPool<xoj::view::GeometryToolView>> viewPool;
     std::shared_ptr<xoj::util::DispatchPool<GeometryToolHandler>> handlerPool;
+
+    /**
+     * @brief Bounding box of the geometry tool and stroke after its last update
+     */
+    mutable Range lastRepaintRange;
+
+protected:
+    /**
+     * @brief computes the repaint range by uniting the stroke's repaint range with the geometry tool repaint range
+     * @param rg the geometry tool repaint range
+     */
+    Range computeRepaintRange(Range rg) const;
 };

--- a/src/core/model/GeometryTool.h
+++ b/src/core/model/GeometryTool.h
@@ -20,6 +20,8 @@
 constexpr static double HALF_CM = 14.17;
 constexpr static double CM = 2. * HALF_CM;
 
+enum GeometryToolType { SETSQUARE };
+
 /**
  * @brief A class that models a geometry tool
  *

--- a/src/core/model/GeometryTool.h
+++ b/src/core/model/GeometryTool.h
@@ -68,7 +68,14 @@ public:
     const std::shared_ptr<xoj::util::DispatchPool<xoj::view::GeometryToolView>>& getViewPool() const;
     const std::shared_ptr<xoj::util::DispatchPool<GeometryToolHandler>>& getHandlerPool() const;
 
-    virtual void notify() const = 0;  // calls the update method of all observers
+    virtual void notify(bool resetMask = false) const = 0;  // calls the update method of all observers
+    /**
+     * @brief Returns the range for the tool alone (without stroke)
+     *
+     * @param transformed whether the range should be rotated and translated
+     */
+    virtual Range getToolRange(bool transformed) const = 0;
+
 
 protected:
     /**

--- a/src/core/model/GeometryTool.h
+++ b/src/core/model/GeometryTool.h
@@ -49,7 +49,7 @@ public:
      * @param x the x-coordinate (in pt) of the rotation center
      * @param y the y-coordinate (in pt) of the rotation center
      */
-    GeometryTool(double height, double rotation, double x, double y);
+    GeometryTool(double height, double rotation, double x, double y, Range toolRange);
 
     virtual ~GeometryTool();
 

--- a/src/core/model/GeometryTool.h
+++ b/src/core/model/GeometryTool.h
@@ -1,0 +1,98 @@
+/*
+ * Xournal++
+ *
+ * A geometry tool
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+#include <cairo.h>  // for cairo_matrix_t
+
+#include "model/OverlayBase.h"
+#include "model/Stroke.h"
+#include "util/DispatchPool.h"
+
+constexpr static double HALF_CM = 14.17;
+constexpr static double CM = 2. * HALF_CM;
+
+/**
+ * @brief A class that models a geometry tool
+ *
+ * The geometry tool has a certain height/size, may be rotated and
+ * translated. User coordinates are specified in cm.
+ */
+
+namespace xoj::util {
+template <class T>
+class DispatchPool;
+}
+
+namespace xoj::view {
+class GeometryToolView;
+};
+
+class GeometryToolHandler;
+
+class GeometryTool: public OverlayBase {
+public:
+    /**
+     * @brief A geometry tool specified by its height, rotation angle and translations in x- and y-directions
+     * @param height the height (size parameter) of the geometry tool
+     * @param rotation the angle (in radian) around which the geometry tool is rotated with respect to the x-axis
+     * @param x the x-coordinate (in pt) of the rotation center
+     * @param y the y-coordinate (in pt) of the rotation center
+     */
+    GeometryTool(double height, double rotation, double x, double y);
+
+    virtual ~GeometryTool();
+
+    void setHeight(double height);
+    double getHeight() const;
+    void setRotation(double rotation);
+    double getRotation() const;
+    void setTranslationX(double x);
+    double getTranslationX() const;
+    void setTranslationY(double y);
+    double getTranslationY() const;
+
+    void getMatrix(cairo_matrix_t& matrix) const;
+
+    Stroke* getStroke() const;
+    void setStroke(Stroke* s);
+
+    const std::shared_ptr<xoj::util::DispatchPool<xoj::view::GeometryToolView>>& getViewPool() const;
+    const std::shared_ptr<xoj::util::DispatchPool<GeometryToolHandler>>& getHandlerPool() const;
+
+    virtual void notify() const = 0;  // calls the update method of all observers
+
+protected:
+    /**
+     * @brief the height of the geometry tool
+     */
+    double height;
+
+    /**
+     * @brief the angle (in radian) around which the geometry tool is rotated with respect to the x-axis
+     */
+    double rotation;
+
+    /**
+     * @brief the x-coordinate (in pt) of the rotation center
+     */
+    double translationX;
+
+    /**
+     * @brief the y-coordinate (in pt) of the rotation center
+     */
+    double translationY;
+
+    Stroke* stroke = nullptr;
+
+    std::shared_ptr<xoj::util::DispatchPool<xoj::view::GeometryToolView>> viewPool;
+    std::shared_ptr<xoj::util::DispatchPool<GeometryToolHandler>> handlerPool;
+};

--- a/src/core/model/Setsquare.cpp
+++ b/src/core/model/Setsquare.cpp
@@ -8,13 +8,7 @@
 
 Setsquare::Setsquare(): Setsquare(INITIAL_HEIGHT, .0, INITIAL_X, INITIAL_Y) {}
 
-Setsquare::Setsquare(double height, double rotation, double x, double y):
-        height(height),
-        rotation(rotation),
-        translationX(x),
-        translationY(y),
-        viewPool(std::make_shared<xoj::util::DispatchPool<xoj::view::SetsquareView>>()),
-        handlerPool(std::make_shared<xoj::util::DispatchPool<SetsquareInputHandler>>()) {}
+Setsquare::Setsquare(double height, double rotation, double x, double y): GeometryTool(height, rotation, x, y) {}
 
 Setsquare::~Setsquare() { viewPool->dispatchAndClear(xoj::view::SetsquareView::FINALIZATION_REQUEST, Range()); }
 
@@ -42,33 +36,3 @@ void Setsquare::notify() const {
     handlerPool->dispatch(SetsquareInputHandler::UPDATE_VALUES, this->getHeight(), this->getRotation(),
                           this->getTranslationX(), this->getTranslationY());
 }
-
-void Setsquare::setHeight(double height) { this->height = height; }
-auto Setsquare::getHeight() const -> double { return this->height; }
-
-void Setsquare::setRotation(double rotation) { this->rotation = rotation; }
-auto Setsquare::getRotation() const -> double { return this->rotation; }
-
-void Setsquare::setTranslationX(double x) { this->translationX = x; }
-auto Setsquare::getTranslationX() const -> double { return this->translationX; }
-
-void Setsquare::setTranslationY(double y) { this->translationY = y; }
-auto Setsquare::getTranslationY() const -> double { return this->translationY; }
-
-void Setsquare::getMatrix(cairo_matrix_t& matrix) const {
-    cairo_matrix_init_identity(&matrix);
-    cairo_matrix_translate(&matrix, this->translationX, this->translationY);
-    cairo_matrix_rotate(&matrix, this->rotation);
-    cairo_matrix_scale(&matrix, CM, CM);
-}
-
-auto Setsquare::getViewPool() const -> const std::shared_ptr<xoj::util::DispatchPool<xoj::view::SetsquareView>>& {
-    return viewPool;
-}
-auto Setsquare::getHandlerPool() const -> const std::shared_ptr<xoj::util::DispatchPool<SetsquareInputHandler>>& {
-    return handlerPool;
-}
-
-auto Setsquare::getStroke() const -> Stroke* { return this->stroke; }
-
-void Setsquare::setStroke(Stroke* s) { this->stroke = s; }

--- a/src/core/model/Setsquare.cpp
+++ b/src/core/model/Setsquare.cpp
@@ -20,17 +20,10 @@ void Setsquare::notify() const {
     rg.addPoint(translationX + cs * h, translationY - si * h);
     rg.addPoint(translationX - cs * h, translationY + si * h);
     rg.addPoint(translationX - si * h, translationY + cs * h);
-    if (this->stroke) {
-        rg.addPoint(this->stroke->getX(), this->stroke->getY());
-        rg.addPoint(this->stroke->getX() + this->stroke->getElementWidth(),
-                    this->stroke->getY() + this->stroke->getElementHeight());
-    }
-    Range repaintRange = rg.unite(this->lastRepaintRange);
-    this->lastRepaintRange = rg;
 
     viewPool->dispatch(xoj::view::SetsquareView::UPDATE_VALUES, this->getHeight(), this->getRotation(),
                        this->getMatrix());
-    viewPool->dispatch(xoj::view::SetsquareView::FLAG_DIRTY_REGION, repaintRange);
+    viewPool->dispatch(xoj::view::SetsquareView::FLAG_DIRTY_REGION, this->computeRepaintRange(rg));
     handlerPool->dispatch(SetsquareInputHandler::UPDATE_VALUES, this->getHeight(), this->getRotation(),
                           this->getTranslationX(), this->getTranslationY());
 }

--- a/src/core/model/Setsquare.cpp
+++ b/src/core/model/Setsquare.cpp
@@ -26,6 +26,7 @@ auto Setsquare::getToolRange(bool transformed) const -> Range {
         rg.addPoint(-h, 0);
         rg.addPoint(0, h);
     }
+    rg.addPadding(.5 * xoj::view::SetsquareView::LINE_WIDTH);  // account for line width
     return rg;
 }
 

--- a/src/core/model/Setsquare.cpp
+++ b/src/core/model/Setsquare.cpp
@@ -29,9 +29,8 @@ void Setsquare::notify() const {
     Range repaintRange = rg.unite(this->lastRepaintRange);
     this->lastRepaintRange = rg;
 
-    cairo_matrix_t matrix{};
-    this->getMatrix(matrix);
-    viewPool->dispatch(xoj::view::SetsquareView::UPDATE_VALUES, this->getHeight(), this->getRotation(), matrix);
+    viewPool->dispatch(xoj::view::SetsquareView::UPDATE_VALUES, this->getHeight(), this->getRotation(),
+                       this->getMatrix());
     viewPool->dispatch(xoj::view::SetsquareView::FLAG_DIRTY_REGION, repaintRange);
     handlerPool->dispatch(SetsquareInputHandler::UPDATE_VALUES, this->getHeight(), this->getRotation(),
                           this->getTranslationX(), this->getTranslationY());

--- a/src/core/model/Setsquare.cpp
+++ b/src/core/model/Setsquare.cpp
@@ -1,63 +1,46 @@
 #include "Setsquare.h"
 
-#include <algorithm>         // for max, min
-#include <cmath>             // for sin, sqrt, abs, pow, cos, floor, remainder
-#include <cstdlib>           // for abs
+#include <cmath>             // for sin, cos
 #include <initializer_list>  // for initializer_list
-#include <iomanip>           // for operator<<, setprecision
-#include <sstream>           // for stringstream, basic_ostream, fixed, basi...
 
-constexpr double LINE_WIDTH = .02;
-constexpr double FONT_SIZE = .2;
-constexpr double CIRCLE_RAD = .3;
-constexpr double TICK_SMALL = .1;
-constexpr double TICK_LARGE = .2;
-constexpr double DISTANCE_SEMICIRCLE_FROM_LEGS = 1.15;
-constexpr double MAX_HOR_POS_VMARKS = 2.5;
-constexpr int MIN_OFFSET_ANG_MARKS = 2;
-constexpr double RELATIVE_CIRCLE_POS = .75;
-constexpr double RELATIVE_MAX_HOR_POS_VMARKS = .6;
-constexpr double HMARK_POS = 2.;
-constexpr double MIN_DIST_FROM_HMARK = .2;
-constexpr int MIN_VMARK_SMALL = 3;
-constexpr int MIN_VMARK_LARGE = 5;
-constexpr int OFFSET_FROM_SEMICIRCLE = 2.;
-constexpr double ZERO_MARK_TICK = .5;
-constexpr int SKIPPED_HMARKS = 8;
+#include "gui/inputdevices/SetsquareInputHandler.h"
+#include "view/SetsquareView.h"
 
-// parameters used when initially displaying setsquare on a page
-constexpr double INITIAL_HEIGHT = 8.0;
-constexpr double INITIAL_X = 21. * HALF_CM;
-constexpr double INITIAL_Y = 15. * HALF_CM;
-
-constexpr double rad(double n) { return n * M_PI / 180.; }
-constexpr double rad(int n) { return rad(static_cast<double>(n)); }
-constexpr double deg(double a) { return a * 180.0 / M_PI; }
-inline double cathete(double h, double o) { return std::sqrt(std::pow(h, 2) - std::pow(o, 2)); }
-
-Setsquare::Setsquare(): height(INITIAL_HEIGHT), rotation(.0), translationX(INITIAL_X), translationY(INITIAL_Y) {}
+Setsquare::Setsquare(): Setsquare(INITIAL_HEIGHT, .0, INITIAL_X, INITIAL_Y) {}
 
 Setsquare::Setsquare(double height, double rotation, double x, double y):
-        height(height), rotation(rotation), translationX(x), translationY(y) {}
+        height(height),
+        rotation(rotation),
+        translationX(x),
+        translationY(y),
+        viewPool(std::make_shared<xoj::util::DispatchPool<xoj::view::SetsquareView>>()),
+        handlerPool(std::make_shared<xoj::util::DispatchPool<SetsquareInputHandler>>()) {}
 
-Setsquare::~Setsquare() {}
+Setsquare::~Setsquare() { viewPool->dispatchAndClear(xoj::view::SetsquareView::FINALIZATION_REQUEST, Range()); }
 
-void Setsquare::updateValues() {
-    radius = height / std::sqrt(2.) - DISTANCE_SEMICIRCLE_FROM_LEGS;
-    circlePos = height * RELATIVE_CIRCLE_POS;
-    horPosVmarks = std::min(MAX_HOR_POS_VMARKS, radius * RELATIVE_MAX_HOR_POS_VMARKS);
-    minVmark = (std::abs(horPosVmarks - HMARK_POS - TICK_SMALL / 2.) < MIN_DIST_FROM_HMARK - TICK_SMALL / 2.) ?
-                       MIN_VMARK_LARGE :
-                       MIN_VMARK_SMALL;
-    maxVmark = static_cast<int>(std::floor(cathete(radius, horPosVmarks) * 10.0)) - OFFSET_FROM_SEMICIRCLE;
-
-    // The following computation of the angular marks offset is based on experimentation.
-    offset = std::max(MIN_OFFSET_ANG_MARKS,
-                      static_cast<int>(256.0 / std::pow(height, 2)));  // larger offset for small height
-    if (std ::abs(radius - std::round(radius)) < .2) {  // larger offset when semicircle comes close to big hmarks
-        offset = std::max(offset, static_cast<int>(24.0 / radius));
+void Setsquare::notify() const {
+    double cs = std::cos(rotation);
+    double si = std::sin(rotation);
+    double h = height * CM;
+    Range rg;
+    rg.addPoint(translationX + cs * h, translationY - si * h);
+    rg.addPoint(translationX - cs * h, translationY + si * h);
+    rg.addPoint(translationX - si * h, translationY + cs * h);
+    if (this->stroke) {
+        rg.addPoint(this->stroke->getX(), this->stroke->getY());
+        rg.addPoint(this->stroke->getX() + this->stroke->getElementWidth(),
+                    this->stroke->getY() + this->stroke->getElementHeight());
+        rg.addPadding(0.5 * this->stroke->getWidth());
     }
-    maxHmark = static_cast<int>(std::floor(height * 10.0)) - SKIPPED_HMARKS;
+    Range repaintRange = rg.unite(this->lastRepaintRange);
+    this->lastRepaintRange = rg;
+
+    cairo_matrix_t matrix{};
+    this->getMatrix(matrix);
+    viewPool->dispatch(xoj::view::SetsquareView::UPDATE_VALUES, this->getHeight(), this->getRotation(), matrix);
+    viewPool->dispatch(xoj::view::SetsquareView::FLAG_DIRTY_REGION, repaintRange);
+    handlerPool->dispatch(SetsquareInputHandler::UPDATE_VALUES, this->getHeight(), this->getRotation(),
+                          this->getTranslationX(), this->getTranslationY());
 }
 
 void Setsquare::setHeight(double height) { this->height = height; }
@@ -72,17 +55,6 @@ auto Setsquare::getTranslationX() const -> double { return this->translationX; }
 void Setsquare::setTranslationY(double y) { this->translationY = y; }
 auto Setsquare::getTranslationY() const -> double { return this->translationY; }
 
-auto Setsquare::getRadius() const -> double { return this->radius; }
-
-void Setsquare::move(double x, double y) {
-    this->translationX += x;
-    this->translationY += y;
-}
-
-void Setsquare::rotate(double da) { this->rotation += da; }
-
-void Setsquare::scale(double f) { this->height *= f; }
-
 void Setsquare::getMatrix(cairo_matrix_t& matrix) const {
     cairo_matrix_init_identity(&matrix);
     cairo_matrix_translate(&matrix, this->translationX, this->translationY);
@@ -90,248 +62,13 @@ void Setsquare::getMatrix(cairo_matrix_t& matrix) const {
     cairo_matrix_scale(&matrix, CM, CM);
 }
 
-void Setsquare::paint(cairo_t* cr) {
-    cairo_save(cr);
-
-    cairo_matrix_t matrix{};
-    getMatrix(matrix);
-    cairo_transform(cr, &matrix);
-    cairo_set_line_width(cr, LINE_WIDTH);
-    cairo_set_fill_rule(cr, CAIRO_FILL_RULE_EVEN_ODD);
-    cairo_select_font_face(cr, "Arial", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_NORMAL);
-    cairo_set_font_size(cr, FONT_SIZE);
-
-    updateValues();
-
-    // clip to slightly enlarged setsquare for performance reasons
-    const double enlargedHeight = this->height + LINE_WIDTH;
-    cairo_move_to(cr, enlargedHeight, -LINE_WIDTH);
-    cairo_line_to(cr, -enlargedHeight, -LINE_WIDTH);
-    cairo_line_to(cr, .0, enlargedHeight);
-    cairo_close_path(cr);
-    cairo_clip(cr);
-
-    cairo_set_source_rgb(cr, 1., .0, .0);  // red
-    drawOutline(cr);
-
-    cairo_set_source_rgb(cr, .0, .0, 1.);  // blue
-    drawHorizontalMarks(cr);
-
-    cairo_set_source_rgb(cr, .0, .5, .0);  // green
-    drawVerticalMarks(cr);
-
-    cairo_set_source_rgb(cr, .5, .0, .5);  // violet
-    drawAngularMarks(cr);
-
-    cairo_set_source_rgb(cr, .0, .5, .5);  // turquoise
-    drawRotation(cr);
-
-    cairo_restore(cr);
+auto Setsquare::getViewPool() const -> const std::shared_ptr<xoj::util::DispatchPool<xoj::view::SetsquareView>>& {
+    return viewPool;
+}
+auto Setsquare::getHandlerPool() const -> const std::shared_ptr<xoj::util::DispatchPool<SetsquareInputHandler>>& {
+    return handlerPool;
 }
 
-void Setsquare::drawOutline(cairo_t* cr) const {
-    cairo_save(cr);
+auto Setsquare::getStroke() const -> Stroke* { return this->stroke; }
 
-    cairo_move_to(cr, this->height, .0);
-    cairo_line_to(cr, -this->height, .0);
-    cairo_line_to(cr, .0, this->height);
-    cairo_close_path(cr);
-    cairo_stroke_preserve(cr);
-
-    cairo_set_source_rgba(cr, .2, .2, .2, .1);  // transparent gray
-    cairo_fill(cr);
-
-    cairo_restore(cr);
-}
-
-void Setsquare::drawRotation(cairo_t* cr) const {
-    cairo_save(cr);
-
-    // write the angle between hypotenuse and horizontal axis within a small circle
-    std::stringstream ss;
-    ss << std::fixed << std::setprecision(1) << std::abs(std::remainder(deg(this->rotation), 180.));
-    cairo_move_to(cr, .0, this->circlePos);
-    showTextCenteredAndRotated(cr, ss.str(), -deg(this->rotation));
-
-    cairo_move_to(cr, .0, this->circlePos);
-    cairo_new_sub_path(cr);
-    cairo_arc(cr, .0, this->circlePos, CIRCLE_RAD, .0, 2. * M_PI);
-    cairo_stroke(cr);
-
-    cairo_restore(cr);
-}
-
-void Setsquare::drawAngularMarks(cairo_t* cr) const {
-    cairo_save(cr);
-
-    // BEGIN: 45 degree marks
-    clipHorizontalStripes(cr);
-    clipVerticalStripes(cr);
-
-    for (int i: {45, 135}) {
-        const double cs = std::cos(rad(i));
-        const double si = std::sin(rad(i));
-
-        // inside semicircle
-        const double radInsideUpper = this->radius - .3;  // 4.2
-        cairo_move_to(cr, cs, si);
-        cairo_line_to(cr, radInsideUpper * cs, radInsideUpper * si);
-
-        // outside semicircle
-        const double radOutsideLower = this->radius + .3;                  // 4.8
-        const double radOutsideUpper = this->height / std::sqrt(2.) - .3;  // 5.4
-        cairo_move_to(cr, radOutsideLower * cs, radOutsideLower * si);
-        cairo_line_to(cr, radOutsideUpper * cs, radOutsideUpper * si);
-    }
-    cairo_stroke(cr);
-    cairo_reset_clip(cr);
-    // END: 45 degree marks
-
-    // BEGIN: marks and numbers around semicircle
-    for (int i = 1; i < 180; i++) {
-        // the radius corresponding to the point with angle i on one of the short sides of the setsquare
-        // it is computed using the law of sines
-        const double radCath = this->height * std::sin(rad(45)) / std::sin(rad(i > 90 ? i - 45 : 135 - i));
-        const double cs = std::cos(rad(i));
-        const double si = std::sin(rad(i));
-        const double tick = (i % 5 == 0) ? TICK_LARGE : TICK_SMALL;
-        cairo_move_to(cr, radCath * cs, radCath * si);  // move to one of the short sides of the set square
-        if (i % 10 == 0 && i > this->offset && i < 180 - this->offset) {
-            // large tick near short side of set square
-            const double radTickEnd = (i == 90) ? (this->circlePos + .5) : (this->radius + .8);
-            cairo_line_to(cr, radTickEnd * cs, radTickEnd * si);
-
-            // show increasing numbers near semi-circle
-            const double radInc = this->radius + 0.3;
-            cairo_move_to(cr, radInc * cs, radInc * si);
-            showTextCenteredAndRotated(cr, std::to_string(i), i + 270);
-
-            // show decreasing numbers a bit further from semi-circle
-            if (i != 90) {
-                const double radDec = this->radius + 0.6;
-                cairo_move_to(cr, radDec * cs, radDec * si);
-                showTextCenteredAndRotated(cr, std::to_string(180 - i), i + 270);
-            }
-        } else {
-            cairo_rel_line_to(cr, -tick * cs, -tick * si);  // just a tick near short side of set square
-        }
-
-        if (i > this->offset && i < 180 - this->offset) {
-            // tick near semi-circle
-            cairo_move_to(cr, this->radius * cs, this->radius * si);
-            cairo_rel_line_to(cr, tick * cs, tick * si);
-        }
-    }
-    cairo_stroke(cr);
-    // END: marks and numbers around semicircle
-
-    cairo_restore(cr);
-}
-
-void Setsquare::drawVerticalMarks(cairo_t* cr) const {
-    cairo_save(cr);
-
-    const auto max = this->maxVmark / 10;  // number of full centimeters
-
-    // BEGIN: VERTICAL marks within semicircle
-    clipVerticalStripes(cr);
-
-    // draw vertical marks
-    for (double i = .5; i <= max; i += .5) {
-        const double x = cathete(this->radius - .25, i);
-        cairo_move_to(cr, -x, i);
-        cairo_line_to(cr, x, i);
-        cairo_stroke(cr);
-    }
-    cairo_reset_clip(cr);
-    // END: VERTICAL marks within circle
-
-
-    // BEGIN: vertical measuring marks with numbers
-    for (int i = this->minVmark; i <= this->maxVmark; i++) {
-        const double y = static_cast<double>(i) / 10.;
-        const double tick = (i % 5 == 0) ? TICK_LARGE : TICK_SMALL;
-
-        // marks and numbers (left and right)
-        for (const double sign: {-1., 1.}) {
-            cairo_move_to(cr, sign * this->horPosVmarks, y);
-            cairo_rel_line_to(cr, -sign * tick, .0);
-            if (i % 10 == 0) {
-                const auto text = std::to_string(i / 10);
-                cairo_rel_move_to(cr, -sign * TICK_SMALL, .0);
-                showTextCenteredAndRotated(cr, text, .0);
-            };
-        }
-    }
-    cairo_stroke(cr);
-    // END: vertical measuring marks with numbers
-
-    cairo_restore(cr);
-}
-
-void Setsquare::drawHorizontalMarks(cairo_t* cr) const {
-    cairo_save(cr);
-
-    const auto max = this->maxVmark / 10;  // number of full centimeters
-
-    // BEGIN: line indicating horizontal 0
-    for (auto i = 1; i <= max; i++) {
-        cairo_move_to(cr, .0, static_cast<double>(i) - ZERO_MARK_TICK / 2.);
-        cairo_rel_line_to(cr, .0, ZERO_MARK_TICK);
-    }
-    cairo_stroke(cr);
-    // END: line indicating horizontal 0
-
-    // BEGIN: measuring marks on top
-    for (int i = -this->maxHmark; i <= this->maxHmark; i++) {
-        const double tick = (i % 5 == 0) ? TICK_LARGE : TICK_SMALL;
-        // draw marks
-        cairo_move_to(cr, static_cast<double>(i) / 10., .0);
-        cairo_rel_line_to(cr, .0, tick);
-        if (i % 10 == 0) {
-            // draw numbers
-            cairo_rel_move_to(cr, .0, FONT_SIZE / 2.);
-            const auto text = std::to_string(std::abs(i / 10));
-            showTextCenteredAndRotated(cr, text.c_str(), .0);
-        }
-    }
-    cairo_stroke(cr);
-    // END: measuring marks on top
-
-    cairo_restore(cr);
-}
-
-void Setsquare::showTextCenteredAndRotated(cairo_t* cr, std::string text, double angle) const {
-    cairo_save(cr);
-
-    cairo_text_extents_t te;
-    cairo_text_extents(cr, text.c_str(), &te);
-    const double dx = te.x_bearing + te.width / 2.0;
-    const double dy = te.y_bearing + te.height / 2.0;
-
-    cairo_rotate(cr, rad(angle));
-    cairo_rel_move_to(cr, -dx, -dy);
-    cairo_text_path(cr, text.c_str());
-
-    cairo_restore(cr);
-}
-
-void Setsquare::clipVerticalStripes(cairo_t* cr) const {
-    // y-coordinate of the highest vertical mark
-    const auto y = static_cast<double>(this->maxVmark) / 10.;
-
-    cairo_rectangle(cr, -this->horPosVmarks - .25, .0, .75, y + .5);          // left stripe
-    cairo_rectangle(cr, this->horPosVmarks - .5, .0, .75, y + .5);            // right stripe
-    cairo_rectangle(cr, -.25, .0, .5, y + .5);                                // middle stripe
-    cairo_rectangle(cr, -this->height, .0, 2. * this->height, this->height);  // clip to the outside
-    cairo_clip(cr);
-}
-
-void Setsquare::clipHorizontalStripes(cairo_t* cr) const {
-    for (auto i = .5; i <= static_cast<double>(this->maxVmark) / 10.0; i += .5) {
-        double x = cathete(this->radius - .25, i);
-        cairo_rectangle(cr, -x, i - .15, 2. * x, .3);
-    }
-    cairo_rectangle(cr, -this->height, .0, 2. * this->height, this->height);  // clip to the outside
-    cairo_clip(cr);
-}
+void Setsquare::setStroke(Stroke* s) { this->stroke = s; }

--- a/src/core/model/Setsquare.cpp
+++ b/src/core/model/Setsquare.cpp
@@ -24,7 +24,6 @@ void Setsquare::notify() const {
         rg.addPoint(this->stroke->getX(), this->stroke->getY());
         rg.addPoint(this->stroke->getX() + this->stroke->getElementWidth(),
                     this->stroke->getY() + this->stroke->getElementHeight());
-        rg.addPadding(0.5 * this->stroke->getWidth());
     }
     Range repaintRange = rg.unite(this->lastRepaintRange);
     this->lastRepaintRange = rg;

--- a/src/core/model/Setsquare.cpp
+++ b/src/core/model/Setsquare.cpp
@@ -8,7 +8,8 @@
 
 Setsquare::Setsquare(): Setsquare(INITIAL_HEIGHT, .0, INITIAL_X, INITIAL_Y) {}
 
-Setsquare::Setsquare(double height, double rotation, double x, double y): GeometryTool(height, rotation, x, y) {}
+Setsquare::Setsquare(double height, double rotation, double x, double y):
+        GeometryTool(height, rotation, x, y, getToolRange(true)) {}
 
 Setsquare::~Setsquare() { viewPool->dispatchAndClear(xoj::view::SetsquareView::FINALIZATION_REQUEST, Range()); }
 

--- a/src/core/model/Setsquare.h
+++ b/src/core/model/Setsquare.h
@@ -42,7 +42,8 @@ public:
 
     virtual ~Setsquare();
 
-    void notify() const override;  // calls the update method of all observers
+    void notify(bool resetMask) const override;  // calls the update method of all observers
+    Range getToolRange(bool transformed) const override;
 
     // parameters used when initially displaying setsquare on a page
     static constexpr double INITIAL_HEIGHT = 8.0;

--- a/src/core/model/Setsquare.h
+++ b/src/core/model/Setsquare.h
@@ -11,14 +11,7 @@
 
 #pragma once
 
-#include <cairo.h>  // for cairo_matrix_t
-
-#include "model/OverlayBase.h"
-#include "model/Stroke.h"
-#include "util/DispatchPool.h"
-
-constexpr static double HALF_CM = 14.17;
-constexpr static double CM = 2. * HALF_CM;
+#include "model/GeometryTool.h"
 
 /**
  * @brief A class that models a setsquare
@@ -27,16 +20,6 @@ constexpr static double CM = 2. * HALF_CM;
  * translated. User coordinates are specified in cm.
  */
 
-
-namespace xoj::util {
-template <class T>
-class DispatchPool;
-}
-
-namespace xoj::view {
-class SetsquareView;
-};
-
 class SetsquareInputHandler;
 
 namespace xoj::view {
@@ -44,7 +27,7 @@ class SetsquareView;
 };
 
 
-class Setsquare: public OverlayBase {
+class Setsquare: public GeometryTool {
 public:
     Setsquare();
 
@@ -52,63 +35,21 @@ public:
      * @brief A setsquare specified by its height, rotation angle and translations in x- and y-directions
      * @param height the height of the setsquare
      * @param rotation the angle (in radian) around which the setsquare is rotated with respect to the x-axis
-     * @param x the x-coordinate (in pt) of the mid point of the longest side of the setsquare
+     * @param x the x-coordinate o(in pt) f the mid point of the longest side of the setsquare
      * @param y the y-coordinate (in pt) of the mid point of the longest side of the setsquare
      */
     Setsquare(double height, double rotation, double x, double y);
 
-    ~Setsquare();
+    virtual ~Setsquare();
 
-    void notify() const;  // calls the update method of all observers
+    void notify() const override;  // calls the update method of all observers
 
     // parameters used when initially displaying setsquare on a page
     static constexpr double INITIAL_HEIGHT = 8.0;
     static constexpr double INITIAL_X = 21. * HALF_CM;
     static constexpr double INITIAL_Y = 15. * HALF_CM;
 
-    void setHeight(double height);
-    double getHeight() const;
-    void setRotation(double rotation);
-    double getRotation() const;
-    void setTranslationX(double x);
-    double getTranslationX() const;
-    void setTranslationY(double y);
-    double getTranslationY() const;
-
-    void getMatrix(cairo_matrix_t& matrix) const;
-
-    Stroke* getStroke() const;
-    void setStroke(Stroke* s);
-
-    const std::shared_ptr<xoj::util::DispatchPool<xoj::view::SetsquareView>>& getViewPool() const;
-    const std::shared_ptr<xoj::util::DispatchPool<SetsquareInputHandler>>& getHandlerPool() const;
-
 private:
-    /**
-     * @brief the height of the setsquare
-     */
-    double height;
-
-    /**
-     * @brief the angle (in radian) around which the setsquare is rotated with respect to the x-axis
-     */
-    double rotation;
-
-    /**
-     * @brief the x-coordinate (in pt) of the rotation center
-     */
-    double translationX;
-
-    /**
-     * @brief the y-coordinate (in pt) of the rotation center
-     */
-    double translationY;
-
-    Stroke* stroke = nullptr;
-
-    std::shared_ptr<xoj::util::DispatchPool<xoj::view::SetsquareView>> viewPool;
-    std::shared_ptr<xoj::util::DispatchPool<SetsquareInputHandler>> handlerPool;
-
     /**
      * @brief Bounding box of the setsquare and stroke after its last update
      */

--- a/src/core/model/Setsquare.h
+++ b/src/core/model/Setsquare.h
@@ -11,6 +11,8 @@
 
 #pragma once
 
+#include <cmath>
+
 #include "model/GeometryTool.h"
 
 /**
@@ -49,4 +51,9 @@ public:
     static constexpr double INITIAL_HEIGHT = 8.0;
     static constexpr double INITIAL_X = 21. * HALF_CM;
     static constexpr double INITIAL_Y = 15. * HALF_CM;
+    // relation between setsquare height and radius
+    static constexpr double DISTANCE_SEMICIRCLE_FROM_LEGS = 1.15;
+    static inline double radiusFromHeight(double height) {
+        return height / std::sqrt(2.) - DISTANCE_SEMICIRCLE_FROM_LEGS;
+    }
 };

--- a/src/core/model/Setsquare.h
+++ b/src/core/model/Setsquare.h
@@ -48,10 +48,4 @@ public:
     static constexpr double INITIAL_HEIGHT = 8.0;
     static constexpr double INITIAL_X = 21. * HALF_CM;
     static constexpr double INITIAL_Y = 15. * HALF_CM;
-
-private:
-    /**
-     * @brief Bounding box of the setsquare and stroke after its last update
-     */
-    mutable Range lastRepaintRange;
 };

--- a/src/core/model/Setsquare.h
+++ b/src/core/model/Setsquare.h
@@ -1,7 +1,7 @@
 /*
  * Xournal++
  *
- * A setsquare, model and paiting to a cairo context
+ * A setsquare model
  *
  * @author Xournal++ Team
  * https://github.com/xournalpp/xournalpp
@@ -11,22 +11,40 @@
 
 #pragma once
 
-#include <string>  // for string
+#include <cairo.h>  // for cairo_matrix_t
 
-#include <cairo.h>  // for cairo_t, cairo_matrix_t
+#include "model/OverlayBase.h"
+#include "model/Stroke.h"
+#include "util/DispatchPool.h"
 
 constexpr static double HALF_CM = 14.17;
 constexpr static double CM = 2. * HALF_CM;
 
 /**
- * @brief A class that models a setsquare, including method to paint the setsquare to a cairo context
+ * @brief A class that models a setsquare
  *
  * The setsquare has the shape of a right-angled isosceles triangle and has a certain height, may be rotated and
- * translated. User coordinates are specified in cm. The setsquare has vertical, horizontal and angular marks.
- * The intersection angle with the x-axis is displayed as well
+ * translated. User coordinates are specified in cm.
  */
 
-class Setsquare {
+
+namespace xoj::util {
+template <class T>
+class DispatchPool;
+}
+
+namespace xoj::view {
+class SetsquareView;
+};
+
+class SetsquareInputHandler;
+
+namespace xoj::view {
+class SetsquareView;
+};
+
+
+class Setsquare: public OverlayBase {
 public:
     Setsquare();
 
@@ -34,18 +52,19 @@ public:
      * @brief A setsquare specified by its height, rotation angle and translations in x- and y-directions
      * @param height the height of the setsquare
      * @param rotation the angle (in radian) around which the setsquare is rotated with respect to the x-axis
-     * @param x the x-coordinate o(in pt) f the mid point of the longest side of the setsquare
+     * @param x the x-coordinate (in pt) of the mid point of the longest side of the setsquare
      * @param y the y-coordinate (in pt) of the mid point of the longest side of the setsquare
      */
     Setsquare(double height, double rotation, double x, double y);
 
-    virtual ~Setsquare();
+    ~Setsquare();
 
-    /**
-     * @brief paints the setsquare to a cairo context
-     * @param cr the cairo context
-     */
-    void paint(cairo_t* cr);
+    void notify() const;  // calls the update method of all observers
+
+    // parameters used when initially displaying setsquare on a page
+    static constexpr double INITIAL_HEIGHT = 8.0;
+    static constexpr double INITIAL_X = 21. * HALF_CM;
+    static constexpr double INITIAL_Y = 15. * HALF_CM;
 
     void setHeight(double height);
     double getHeight() const;
@@ -55,111 +74,43 @@ public:
     double getTranslationX() const;
     void setTranslationY(double y);
     double getTranslationY() const;
-    double getRadius() const;
 
-    /**
-     * @brief translates the setsquare
-     * @param x the amount of translation in x-direction
-     * @param y the amount of translation in y-direction
-     */
-    void move(double x, double y);
-
-    /**
-     * @brief rotates the setsquare around the mid point of its longest side
-     * @param da the angle increase (in radian)
-     */
-    void rotate(double da);
-
-    /**
-     * @brief central scaling of the setsquare with center equal to the mid point of its longest side
-     * @param f the scaling factor
-     */
-    void scale(double f);
-
-    /**
-     * @brief returns the matrix which translates from user coordinates (in which the setsquare
-     * has its longest side on the x-axis with its mid point equal to the origin) to document coordinates
-     * @param matrix the matrix into which the result gets stored
-     */
     void getMatrix(cairo_matrix_t& matrix) const;
+
+    Stroke* getStroke() const;
+    void setStroke(Stroke* s);
+
+    const std::shared_ptr<xoj::util::DispatchPool<xoj::view::SetsquareView>>& getViewPool() const;
+    const std::shared_ptr<xoj::util::DispatchPool<SetsquareInputHandler>>& getHandlerPool() const;
 
 private:
     /**
-     * @brief the height of the setsquare (regarded as an isoceles triangle)
+     * @brief the height of the setsquare
      */
-    double height = 8.0;
+    double height;
 
     /**
      * @brief the angle (in radian) around which the setsquare is rotated with respect to the x-axis
      */
-    double rotation = 0.0;
+    double rotation;
 
     /**
-     * @brief the x-coordinate (in pt) of the mid point of the longest side of the setsquare (by default 10.5 cm)
+     * @brief the x-coordinate (in pt) of the rotation center
      */
-    double translationX = 21. * HALF_CM;
+    double translationX;
 
     /**
-     * @brief the y-coordinate (in pt) of the mid point of the longest side of the setsquare (by default 7.5 cm)
+     * @brief the y-coordinate (in pt) of the rotation center
      */
-    double translationY = 15 * HALF_CM;
+    double translationY;
+
+    Stroke* stroke = nullptr;
+
+    std::shared_ptr<xoj::util::DispatchPool<xoj::view::SetsquareView>> viewPool;
+    std::shared_ptr<xoj::util::DispatchPool<SetsquareInputHandler>> handlerPool;
 
     /**
-     * @brief the radius of the semi-circle for the angular marks
+     * @brief Bounding box of the setsquare and stroke after its last update
      */
-    double radius = 4.5;
-
-    /**
-     * @brief the distance of the circle containing the rotation angle display from the mid point of the longest side of
-     * the setsquare
-     */
-    double circlePos = 6.0;
-
-    /**
-     * @brief the distance (in cm) of the vertical marks from the symmetry axis of the setsquare
-     */
-    double horPosVmarks = 2.5;
-
-    /**
-     * @brief the index of the first vertical mark which should be drawn (which should not overlap with the measuring
-     * marks)
-     */
-    int minVmark = 3;
-
-    /**
-     * @brief the index of the last vertical mark to be drawn
-     */
-    int maxVmark = 35;
-
-    /**
-     * @brief the number of angular marks that are left away on both ends (in order not to overlap with the measuring
-     * marks)
-     */
-    int offset = 4;
-
-    /**
-     * @brief the index of the last horizontal mark to be drawn
-     */
-    int maxHmark = 70;
-
-    void drawVerticalMarks(cairo_t* cr) const;
-    void drawHorizontalMarks(cairo_t* cr) const;
-    void drawAngularMarks(cairo_t* cr) const;
-    void drawOutline(cairo_t* cr) const;
-    void drawRotation(cairo_t* cr) const;
-    void clipVerticalStripes(cairo_t* cr) const;
-    void clipHorizontalStripes(cairo_t* cr) const;
-
-    /**
-     * @brief updates the values radius, horPosVmarks, minVmark, maxVmark computed from the height of the setsquare
-     */
-    void updateValues();
-
-    /**
-     * @brief renders text centered and possibly rotated at the current position on a cairo context
-     * @param cr the cairo context
-     * @param text the text string
-     * @param angle the rotation angle
-     */
-    void showTextCenteredAndRotated(cairo_t* cr, std::string text, double angle) const;
+    mutable Range lastRepaintRange;
 };

--- a/src/core/view/GeometryToolView.cpp
+++ b/src/core/view/GeometryToolView.cpp
@@ -1,0 +1,46 @@
+#include "GeometryToolView.h"
+
+#include "model/GeometryTool.h"  // for GeometryTool
+#include "model/Stroke.h"        // for Stroke
+#include "view/Repaintable.h"    // for Repaintable
+#include "view/View.h"           // for Context
+
+#include "StrokeView.h"  // for StrokeView
+
+using namespace xoj::view;
+
+GeometryToolView::GeometryToolView(const GeometryTool* s, Repaintable* parent): ToolView(parent), s(s) {}
+
+GeometryToolView::~GeometryToolView() = default;
+
+void GeometryToolView::draw(cairo_t* cr) const {
+    cairo_save(cr);
+    this->drawGeometryTool(cr);
+    this->drawTemporaryStroke(cr);
+    cairo_restore(cr);
+}
+
+bool GeometryToolView::isViewOf(const OverlayBase* overlay) const { return overlay == this->s; }
+
+void GeometryToolView::drawTemporaryStroke(cairo_t* cr) const {
+    if (s->getStroke()) {
+        auto context = xoj::view::Context::createDefault(cr);
+        xoj::view::StrokeView strokeView(s->getStroke());
+        strokeView.draw(context);
+    }
+}
+
+void GeometryToolView::showTextCenteredAndRotated(cairo_t* cr, std::string text, double angle) const {
+    cairo_save(cr);
+
+    cairo_text_extents_t te;
+    cairo_text_extents(cr, text.c_str(), &te);
+    const double dx = te.x_bearing + te.width / 2.0;
+    const double dy = te.y_bearing + te.height / 2.0;
+
+    cairo_rotate(cr, rad(angle));
+    cairo_rel_move_to(cr, -dx, -dy);
+    cairo_text_path(cr, text.c_str());
+
+    cairo_restore(cr);
+}

--- a/src/core/view/GeometryToolView.cpp
+++ b/src/core/view/GeometryToolView.cpp
@@ -10,7 +10,8 @@
 
 using namespace xoj::view;
 
-GeometryToolView::GeometryToolView(const GeometryTool* s, Repaintable* parent): ToolView(parent), s(s) {}
+GeometryToolView::GeometryToolView(const GeometryTool* geometryTool, Repaintable* parent):
+        ToolView(parent), geometryTool(geometryTool) {}
 
 GeometryToolView::~GeometryToolView() = default;
 
@@ -20,17 +21,17 @@ void GeometryToolView::draw(cairo_t* cr) const {
     this->drawTemporaryStroke(cr);
 }
 
-bool GeometryToolView::isViewOf(const OverlayBase* overlay) const { return overlay == this->s; }
+bool GeometryToolView::isViewOf(const OverlayBase* overlay) const { return overlay == this->geometryTool; }
 
 void GeometryToolView::drawTemporaryStroke(cairo_t* cr) const {
-    if (s->getStroke()) {
+    if (geometryTool->getStroke()) {
         auto context = xoj::view::Context::createDefault(cr);
-        xoj::view::StrokeView strokeView(s->getStroke());
+        xoj::view::StrokeView strokeView(geometryTool->getStroke());
         strokeView.draw(context);
     }
 }
 
-void GeometryToolView::showTextCenteredAndRotated(cairo_t* cr, std::string text, double angle) const {
+void GeometryToolView::showTextCenteredAndRotated(cairo_t* cr, const std::string& text, double angle) const {
     xoj::util::CairoSaveGuard saveGuard(cr);
     cairo_text_extents_t te;
     cairo_text_extents(cr, text.c_str(), &te);

--- a/src/core/view/GeometryToolView.cpp
+++ b/src/core/view/GeometryToolView.cpp
@@ -1,9 +1,10 @@
 #include "GeometryToolView.h"
 
-#include "model/GeometryTool.h"  // for GeometryTool
-#include "model/Stroke.h"        // for Stroke
-#include "view/Repaintable.h"    // for Repaintable
-#include "view/View.h"           // for Context
+#include "model/GeometryTool.h"       // for GeometryTool
+#include "model/Stroke.h"             // for Stroke
+#include "util/raii/CairoWrappers.h"  // for CairoSaveGuard
+#include "view/Repaintable.h"         // for Repaintable
+#include "view/View.h"                // for Context
 
 #include "StrokeView.h"  // for StrokeView
 
@@ -14,10 +15,9 @@ GeometryToolView::GeometryToolView(const GeometryTool* s, Repaintable* parent): 
 GeometryToolView::~GeometryToolView() = default;
 
 void GeometryToolView::draw(cairo_t* cr) const {
-    cairo_save(cr);
+    xoj::util::CairoSaveGuard saveGuard(cr);
     this->drawGeometryTool(cr);
     this->drawTemporaryStroke(cr);
-    cairo_restore(cr);
 }
 
 bool GeometryToolView::isViewOf(const OverlayBase* overlay) const { return overlay == this->s; }
@@ -31,8 +31,7 @@ void GeometryToolView::drawTemporaryStroke(cairo_t* cr) const {
 }
 
 void GeometryToolView::showTextCenteredAndRotated(cairo_t* cr, std::string text, double angle) const {
-    cairo_save(cr);
-
+    xoj::util::CairoSaveGuard saveGuard(cr);
     cairo_text_extents_t te;
     cairo_text_extents(cr, text.c_str(), &te);
     const double dx = te.x_bearing + te.width / 2.0;
@@ -41,6 +40,4 @@ void GeometryToolView::showTextCenteredAndRotated(cairo_t* cr, std::string text,
     cairo_rotate(cr, rad(angle));
     cairo_rel_move_to(cr, -dx, -dy);
     cairo_text_path(cr, text.c_str());
-
-    cairo_restore(cr);
 }

--- a/src/core/view/GeometryToolView.h
+++ b/src/core/view/GeometryToolView.h
@@ -1,0 +1,103 @@
+/*
+ * Xournal++
+ *
+ * A GeometryTool view
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+#include <cmath>
+
+#include <cairo.h>  // for cairo_t
+
+#include "model/GeometryTool.h"  // for GeometryTool
+#include "view/overlays/BaseStrokeToolView.h"
+
+class Stroke;
+class XojPageView;
+class OverlayBase;
+
+/**
+ * @brief A class that renders a geometry tool
+ */
+
+namespace xoj::view {
+class Repaintable;
+
+constexpr double rad(double n) { return n * M_PI / 180.; }
+constexpr double rad(int n) { return rad(static_cast<double>(n)); }
+constexpr double deg(double a) { return a * 180.0 / M_PI; }
+inline double cathete(double h, double o) { return std::sqrt(std::pow(h, 2) - std::pow(o, 2)); }
+
+class GeometryToolView: public ToolView, public xoj::util::Listener<GeometryToolView> {
+
+public:
+    GeometryToolView(const GeometryTool* s, Repaintable* parent);
+    virtual ~GeometryToolView();
+
+    /**
+     * Listener interface
+     */
+    static constexpr struct FlagDirtyRegionRequest {
+    } FLAG_DIRTY_REGION = {};
+    virtual void on(FlagDirtyRegionRequest, const Range& rg) = 0;
+
+    static constexpr struct UpdateValuesRequest {
+    } UPDATE_VALUES = {};
+    virtual void on(UpdateValuesRequest, double h, double rot, cairo_matrix_t m) = 0;
+
+    static constexpr struct FinalizationRequest {
+    } FINALIZATION_REQUEST = {};
+    /**
+     * @brief Called before the corresponding GeometryTool's destruction
+     * @param rg The bounding box of the entire geometry tool
+     */
+    virtual void deleteOn(FinalizationRequest, const Range& rg) = 0;
+
+    /**
+     * @brief draws the geometry tool and temporary stroke to a cairo context
+     * @param cr the cairo context
+     */
+    void draw(cairo_t* cr) const override;
+
+    bool isViewOf(const OverlayBase* overlay) const override;
+
+private:
+    /**
+     * @brief draws the GeometryTool to a cairo context
+     * @param cr the cairo context drawn to
+     */
+    virtual void drawGeometryTool(cairo_t* cr) const = 0;
+
+    /**
+     * @brief draws the temporary stroke to a cairo context
+     * @param cr the cairo context drawn to
+     */
+    void drawTemporaryStroke(cairo_t* cr) const;
+
+protected:
+    /**
+     * @brief the underlying GeometryTool
+     */
+    const GeometryTool* s;
+
+    /**
+     * @brief The stroke drawn aligned to the longest side of the GeometryTool or ending at the midpoint of the longest
+     * side of the GeometryTool
+     */
+    Stroke* stroke = nullptr;
+
+    /**
+     * @brief renders text centered and possibly rotated at the current position on a cairo context
+     * @param cr the cairo context
+     * @param text the text string
+     * @param angle the rotation angle
+     */
+    void showTextCenteredAndRotated(cairo_t* cr, std::string text, double angle) const;
+};
+};  // namespace xoj::view

--- a/src/core/view/GeometryToolView.h
+++ b/src/core/view/GeometryToolView.h
@@ -19,7 +19,6 @@
 #include "view/overlays/BaseStrokeToolView.h"
 
 class Stroke;
-class XojPageView;
 class OverlayBase;
 
 /**
@@ -37,7 +36,7 @@ inline double cathete(double h, double o) { return std::sqrt(std::pow(h, 2) - st
 class GeometryToolView: public ToolView, public xoj::util::Listener<GeometryToolView> {
 
 public:
-    GeometryToolView(const GeometryTool* s, Repaintable* parent);
+    GeometryToolView(const GeometryTool* geometryTool, Repaintable* parent);
     virtual ~GeometryToolView();
 
     /**
@@ -84,7 +83,7 @@ protected:
     /**
      * @brief the underlying GeometryTool
      */
-    const GeometryTool* s;
+    const GeometryTool* geometryTool;
 
     /**
      * @brief The stroke drawn aligned to the longest side of the GeometryTool or ending at the midpoint of the longest
@@ -98,6 +97,6 @@ protected:
      * @param text the text string
      * @param angle the rotation angle
      */
-    void showTextCenteredAndRotated(cairo_t* cr, std::string text, double angle) const;
+    void showTextCenteredAndRotated(cairo_t* cr, const std::string& text, double angle) const;
 };
 };  // namespace xoj::view

--- a/src/core/view/SetsquareView.cpp
+++ b/src/core/view/SetsquareView.cpp
@@ -36,7 +36,7 @@ constexpr int OFFSET_FROM_SEMICIRCLE = 2.;
 constexpr double ZERO_MARK_TICK = .5;
 constexpr int SKIPPED_HMARKS = 8;
 
-SetsquareView::SetsquareView(const Setsquare* s, Repaintable* parent): ToolView(parent), s(s) {
+SetsquareView::SetsquareView(const Setsquare* s, Repaintable* parent): GeometryToolView(s, parent) {
     this->registerToPool(s->getViewPool());
 }
 
@@ -69,39 +69,7 @@ void SetsquareView::deleteOn(SetsquareView::FinalizationRequest, const Range& rg
     this->parent->drawAndDeleteToolView(this, rg);
 }
 
-void SetsquareView::draw(cairo_t* cr) const {
-    cairo_save(cr);
-    this->drawSetsquare(cr);
-    this->drawTemporaryStroke(cr);
-    cairo_restore(cr);
-}
-
-bool SetsquareView::isViewOf(const OverlayBase* overlay) const { return overlay == this->s; }
-
-void SetsquareView::drawTemporaryStroke(cairo_t* cr) const {
-    if (s->getStroke()) {
-        auto context = xoj::view::Context::createDefault(cr);
-        xoj::view::StrokeView strokeView(s->getStroke());
-        strokeView.draw(context);
-    }
-}
-
-void SetsquareView::showTextCenteredAndRotated(cairo_t* cr, std::string text, double angle) const {
-    cairo_save(cr);
-
-    cairo_text_extents_t te;
-    cairo_text_extents(cr, text.c_str(), &te);
-    const double dx = te.x_bearing + te.width / 2.0;
-    const double dy = te.y_bearing + te.height / 2.0;
-
-    cairo_rotate(cr, rad(angle));
-    cairo_rel_move_to(cr, -dx, -dy);
-    cairo_text_path(cr, text.c_str());
-
-    cairo_restore(cr);
-}
-
-void SetsquareView::drawSetsquare(cairo_t* cr) const {
+void SetsquareView::drawGeometryTool(cairo_t* cr) const {
     cairo_save(cr);
 
     cairo_transform(cr, &matrix);

--- a/src/core/view/SetsquareView.cpp
+++ b/src/core/view/SetsquareView.cpp
@@ -2,216 +2,328 @@
 
 #include <algorithm>  // for max, min
 #include <cmath>      // for isnan, sqrt, cos, sin, atan2
-#include <utility>    // for move
+#include <iomanip>
+#include <sstream>
+#include <utility>  // for move
 
 #include <glib.h>  // for g_error, g_warning
 
-#include "control/Control.h"                // for Control
-#include "control/ToolHandler.h"            // for ToolHandler
-#include "control/layer/LayerController.h"  // for LayerController
-#include "gui/PageView.h"                   // for XojPageView
-#include "gui/XournalView.h"                // for XournalView
-#include "gui/XournalppCursor.h"            // for XournalppCursor
-#include "model/Layer.h"                    // for Layer
-#include "model/Point.h"                    // for Point
-#include "model/Setsquare.h"                // for Setsquare
-#include "model/Stroke.h"                   // for Stroke
-#include "model/XojPage.h"                  // for XojPage
-#include "undo/InsertUndoAction.h"          // for InsertUndoAction
-#include "undo/UndoRedoHandler.h"           // for UndoRedoHandler
-#include "util/Rectangle.h"                 // for Rectangle
-#include "view/View.h"                      // for Context
+#include "gui/XournalView.h"  // for XournalView
+#include "model/Setsquare.h"  // for Setsquare
+#include "model/Stroke.h"     // for Stroke
+#include "view/View.h"        // for Context
 
 #include "StrokeView.h"  // for StrokeView
 
-using xoj::util::Rectangle;
+using namespace xoj::view;
 
-SetsquareView::SetsquareView(XojPageView* view, std::unique_ptr<Setsquare>& s): view(view), s(std::move(s)) {}
 
-void SetsquareView::paint(cairo_t* cr) {
-    const auto zoom = view->getXournal()->getZoom();
+constexpr double LINE_WIDTH = .02;
+constexpr double FONT_SIZE = .2;
+constexpr double CIRCLE_RAD = .3;
+constexpr double TICK_SMALL = .1;
+constexpr double TICK_LARGE = .2;
+constexpr double DISTANCE_SEMICIRCLE_FROM_LEGS = 1.15;
+constexpr double MAX_HOR_POS_VMARKS = 2.5;
+constexpr int MIN_OFFSET_ANG_MARKS = 2;
+constexpr double RELATIVE_CIRCLE_POS = .75;
+constexpr double RELATIVE_MAX_HOR_POS_VMARKS = .6;
+constexpr double HMARK_POS = 2.;
+constexpr double MIN_DIST_FROM_HMARK = .2;
+constexpr int MIN_VMARK_SMALL = 3;
+constexpr int MIN_VMARK_LARGE = 5;
+constexpr int OFFSET_FROM_SEMICIRCLE = 2.;
+constexpr double ZERO_MARK_TICK = .5;
+constexpr int SKIPPED_HMARKS = 8;
+
+SetsquareView::SetsquareView(const Setsquare* s, Repaintable* parent): ToolView(parent), s(s) {
+    this->registerToPool(s->getViewPool());
+}
+
+SetsquareView::~SetsquareView() noexcept { this->unregisterFromPool(); };
+
+void SetsquareView::on(FlagDirtyRegionRequest, const Range& rg) { this->parent->flagDirtyRegion(rg); }
+
+void SetsquareView::on(UpdateValuesRequest, double h, double rot, cairo_matrix_t m) {
+    height = h;
+    rotation = rot;
+    matrix = m;
+    radius = height / std::sqrt(2.) - DISTANCE_SEMICIRCLE_FROM_LEGS;
+    circlePos = height * RELATIVE_CIRCLE_POS;
+    horPosVmarks = std::min(MAX_HOR_POS_VMARKS, radius * RELATIVE_MAX_HOR_POS_VMARKS);
+    minVmark = (std::abs(horPosVmarks - HMARK_POS - TICK_SMALL / 2.) < MIN_DIST_FROM_HMARK - TICK_SMALL / 2.) ?
+                       MIN_VMARK_LARGE :
+                       MIN_VMARK_SMALL;
+    maxVmark = static_cast<int>(std::floor(cathete(radius, horPosVmarks) * 10.0)) - OFFSET_FROM_SEMICIRCLE;
+
+    // The following computation of the angular marks offset is based on experimentation.
+    offset = std::max(MIN_OFFSET_ANG_MARKS,
+                      static_cast<int>(256.0 / std::pow(height, 2)));  // larger offset for small height
+    if (std ::abs(radius - std::round(radius)) < .2) {  // larger offset when semicircle comes close to big hmarks
+        offset = std::max(offset, static_cast<int>(24.0 / radius));
+    }
+    maxHmark = static_cast<int>(std::floor(height * 10.0)) - SKIPPED_HMARKS;
+}
+
+void SetsquareView::deleteOn(SetsquareView::FinalizationRequest, const Range& rg) {
+    this->parent->drawAndDeleteToolView(this, rg);
+}
+
+void SetsquareView::draw(cairo_t* cr) const {
     cairo_save(cr);
-    cairo_scale(cr, zoom, zoom);
-    this->s->paint(cr);
+    this->drawSetsquare(cr);
     this->drawTemporaryStroke(cr);
     cairo_restore(cr);
 }
 
-void SetsquareView::drawTemporaryStroke(cairo_t* cr) {
-    if (stroke) {
+bool SetsquareView::isViewOf(const OverlayBase* overlay) const { return overlay == this->s; }
+
+void SetsquareView::drawTemporaryStroke(cairo_t* cr) const {
+    if (s->getStroke()) {
         auto context = xoj::view::Context::createDefault(cr);
-        xoj::view::StrokeView strokeView(stroke);
+        xoj::view::StrokeView strokeView(s->getStroke());
         strokeView.draw(context);
     }
 }
 
-void SetsquareView::move(double x, double y) { s->move(x, y); }
+void SetsquareView::showTextCenteredAndRotated(cairo_t* cr, std::string text, double angle) const {
+    cairo_save(cr);
 
-void SetsquareView::rotate(double da, double cx, double cy) {
-    s->rotate(da);
-    const auto tx = getTranslationX();
-    const auto ty = getTranslationY();
-    const auto offsetX = tx - cx;
-    const auto offsetY = ty - cy;
-    const auto mx = offsetX * cos(da) - offsetY * sin(da);
-    const auto my = offsetX * sin(da) + offsetY * cos(da);
-    s->move(cx + mx - tx, cy + my - ty);
+    cairo_text_extents_t te;
+    cairo_text_extents(cr, text.c_str(), &te);
+    const double dx = te.x_bearing + te.width / 2.0;
+    const double dy = te.y_bearing + te.height / 2.0;
+
+    cairo_rotate(cr, rad(angle));
+    cairo_rel_move_to(cr, -dx, -dy);
+    cairo_text_path(cr, text.c_str());
+
+    cairo_restore(cr);
 }
 
-void SetsquareView::scale(double f, double cx, double cy) {
-    s->scale(f);
-    const auto tx = getTranslationX();
-    const auto ty = getTranslationY();
-    const auto offsetX = tx - cx;
-    const auto offsetY = ty - cy;
-    const auto mx = offsetX * f;
-    const auto my = offsetY * f;
-    s->move(cx + mx - tx, cy + my - ty);
+void SetsquareView::drawSetsquare(cairo_t* cr) const {
+    cairo_save(cr);
+
+    cairo_transform(cr, &matrix);
+    cairo_set_line_width(cr, LINE_WIDTH);
+    cairo_set_fill_rule(cr, CAIRO_FILL_RULE_EVEN_ODD);
+    cairo_select_font_face(cr, "Arial", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_NORMAL);
+    cairo_set_font_size(cr, FONT_SIZE);
+
+    // clip to slightly enlarged setsquare for performance reasons
+    const double enlargedHeight = this->height + LINE_WIDTH;
+    cairo_move_to(cr, enlargedHeight, -LINE_WIDTH);
+    cairo_line_to(cr, -enlargedHeight, -LINE_WIDTH);
+    cairo_line_to(cr, .0, enlargedHeight);
+    cairo_close_path(cr);
+    cairo_clip(cr);
+
+    cairo_set_source_rgb(cr, 1., .0, .0);  // red
+    drawOutline(cr);
+
+    cairo_set_source_rgb(cr, .0, .0, 1.);  // blue
+    drawHorizontalMarks(cr);
+
+    cairo_set_source_rgb(cr, .0, .5, .0);  // green
+    drawVerticalMarks(cr);
+
+    cairo_set_source_rgb(cr, .5, .0, .5);  // violet
+    drawAngularMarks(cr);
+
+    cairo_set_source_rgb(cr, .0, .5, .5);  // turquoise
+    drawRotation(cr);
+
+    cairo_restore(cr);
 }
 
-auto SetsquareView::getHeight() const -> double { return s->getHeight(); }
+void SetsquareView::drawOutline(cairo_t* cr) const {
+    cairo_save(cr);
 
-auto SetsquareView::getRotation() const -> double { return s->getRotation(); }
+    cairo_move_to(cr, this->height, .0);
+    cairo_line_to(cr, -this->height, .0);
+    cairo_line_to(cr, .0, this->height);
+    cairo_close_path(cr);
+    cairo_stroke_preserve(cr);
 
-auto SetsquareView::getTranslationX() const -> double { return s->getTranslationX(); }
+    cairo_set_source_rgba(cr, .2, .2, .2, .1);  // transparent gray
+    cairo_fill(cr);
 
-auto SetsquareView::getTranslationY() const -> double { return s->getTranslationY(); }
+    cairo_restore(cr);
+}
 
-auto SetsquareView::getView() const -> XojPageView* { return view; }
+void SetsquareView::drawRotation(cairo_t* cr) const {
+    cairo_save(cr);
 
-auto SetsquareView::getPage() const -> PageRef { return view->getPage(); }
+    // write the angle between hypotenuse and horizontal axis within a small circle
+    std::stringstream ss;
+    ss << std::fixed << std::setprecision(1) << std::abs(std::remainder(deg(this->rotation), 180.));
+    cairo_move_to(cr, .0, this->circlePos);
+    showTextCenteredAndRotated(cr, ss.str(), -deg(this->rotation));
 
-auto SetsquareView::posRelToSide(Leg leg, double x, double y) const -> utl::Point<double> {
-    cairo_matrix_t matrix{};
-    s->getMatrix(matrix);
-    cairo_matrix_invert(&matrix);
-    cairo_matrix_transform_point(&matrix, &x, &y);
-    switch (leg) {
-        case HYPOTENUSE:
-            return utl::Point<double>(x, -y);
-        case LEFT_LEG:
-            return utl::Point<double>((y + x) / sqrt(2.), (y - x - getHeight()) / sqrt(2.));
-        case RIGHT_LEG:
-            return utl::Point<double>((y - x) / sqrt(2.), (y + x - getHeight()) / sqrt(2.));
-        default:
-            g_error("Invalid enum value: %d", leg);
+    cairo_move_to(cr, .0, this->circlePos);
+    cairo_new_sub_path(cr);
+    cairo_arc(cr, .0, this->circlePos, CIRCLE_RAD, .0, 2. * M_PI);
+    cairo_stroke(cr);
+
+    cairo_restore(cr);
+}
+
+void SetsquareView::drawAngularMarks(cairo_t* cr) const {
+    cairo_save(cr);
+
+    // BEGIN: 45 degree marks
+    clipHorizontalStripes(cr);
+    clipVerticalStripes(cr);
+
+    for (int i: {45, 135}) {
+        const double cs = std::cos(rad(i));
+        const double si = std::sin(rad(i));
+
+        // inside semicircle
+        const double radInsideUpper = this->radius - .3;  // 4.2
+        cairo_move_to(cr, cs, si);
+        cairo_line_to(cr, radInsideUpper * cs, radInsideUpper * si);
+
+        // outside semicircle
+        const double radOutsideLower = this->radius + .3;                  // 4.8
+        const double radOutsideUpper = this->height / std::sqrt(2.) - .3;  // 5.4
+        cairo_move_to(cr, radOutsideLower * cs, radOutsideLower * si);
+        cairo_line_to(cr, radOutsideUpper * cs, radOutsideUpper * si);
     }
-}
+    cairo_stroke(cr);
+    cairo_reset_clip(cr);
+    // END: 45 degree marks
 
-auto SetsquareView::isInsideSetsquare(double x, double y, double border) const -> bool {
-    return posRelToSide(HYPOTENUSE, x, y).y < border && posRelToSide(LEFT_LEG, x, y).y < border &&
-           posRelToSide(RIGHT_LEG, x, y).y < border;
-}
+    // BEGIN: marks and numbers around semicircle
+    for (int i = 1; i < 180; i++) {
+        // the radius corresponding to the point with angle i on one of the short sides of the setsquare
+        // it is computed using the law of sines
+        const double radCath = this->height * std::sin(rad(45)) / std::sin(rad(i > 90 ? i - 45 : 135 - i));
+        const double cs = std::cos(rad(i));
+        const double si = std::sin(rad(i));
+        const double tick = (i % 5 == 0) ? TICK_LARGE : TICK_SMALL;
+        cairo_move_to(cr, radCath * cs, radCath * si);  // move to one of the short sides of the set square
+        if (i % 10 == 0 && i > this->offset && i < 180 - this->offset) {
+            // large tick near short side of set square
+            const double radTickEnd = (i == 90) ? (this->circlePos + .5) : (this->radius + .8);
+            cairo_line_to(cr, radTickEnd * cs, radTickEnd * si);
 
-auto SetsquareView::getPointForPos(double xCoord) const -> utl::Point<double> {
-    cairo_matrix_t matrix{};
-    double x = xCoord;
-    double y = 0.0;
-    s->getMatrix(matrix);
-    cairo_matrix_transform_point(&matrix, &x, &y);
+            // show increasing numbers near semi-circle
+            const double radInc = this->radius + 0.3;
+            cairo_move_to(cr, radInc * cs, radInc * si);
+            showTextCenteredAndRotated(cr, std::to_string(i), i + 270);
 
-    return utl::Point<double>(x, y);
-}
+            // show decreasing numbers a bit further from semi-circle
+            if (i != 90) {
+                const double radDec = this->radius + 0.6;
+                cairo_move_to(cr, radDec * cs, radDec * si);
+                showTextCenteredAndRotated(cr, std::to_string(180 - i), i + 270);
+            }
+        } else {
+            cairo_rel_line_to(cr, -tick * cs, -tick * si);  // just a tick near short side of set square
+        }
 
-void SetsquareView::createStroke(double x) {
-    if (!std::isnan(x)) {
-        hypotenuseMax = x;
-        hypotenuseMin = x;
-
-        const auto p = this->getPointForPos(x);
-        initializeStroke();
-        stroke->addPoint(Point(p.x, p.y));
-        stroke->addPoint(Point(p.x, p.y));  // doubled point
-
-    } else {
-        g_warning("No valid stroke from setsquare!");
+        if (i > this->offset && i < 180 - this->offset) {
+            // tick near semi-circle
+            cairo_move_to(cr, this->radius * cs, this->radius * si);
+            cairo_rel_line_to(cr, tick * cs, tick * si);
+        }
     }
+    cairo_stroke(cr);
+    // END: marks and numbers around semicircle
+
+    cairo_restore(cr);
 }
 
-void SetsquareView::createRadius(double x, double y) {
-    const auto p = posRelToSide(HYPOTENUSE, x, y);
-    this->strokeAngle = std::atan2(p.y, p.x);
-    initializeStroke();
-    updateRadius(x, y);
-}
+void SetsquareView::drawVerticalMarks(cairo_t* cr) const {
+    cairo_save(cr);
 
-void SetsquareView::updateStroke(double x) {
-    hypotenuseMax = std::max(this->hypotenuseMax, x);
-    hypotenuseMin = std::min(this->hypotenuseMin, x);
-    stroke->deletePointsFrom(0);
-    const auto p1 = getPointForPos(hypotenuseMin);
-    const auto p2 = getPointForPos(hypotenuseMax);
+    const auto max = this->maxVmark / 10;  // number of full centimeters
 
-    stroke->addPoint(Point(p1.x, p1.y));
-    stroke->addPoint(Point(p2.x, p2.y));
-    const Rectangle<double> rect{stroke->getX(), stroke->getY(), stroke->getElementWidth(), stroke->getElementHeight()};
-    this->getView()->rerenderRect(rect.x, rect.y, rect.width, rect.height);
-}
+    // BEGIN: VERTICAL marks within semicircle
+    clipVerticalStripes(cr);
 
-void SetsquareView::updateRadius(double x, double y) {
-    stroke->deletePointsFrom(0);
-    const auto c = getPointForPos(0);
-    stroke->addPoint(Point(c.x, c.y));
-
-    const auto p = posRelToSide(HYPOTENUSE, x, y);
-    const auto rad = std::hypot(p.x, p.y);
-
-    if (rad >= s->getRadius()) {
-        this->strokeAngle = std::atan2(p.y, p.x);
-        stroke->addPoint(Point(x, y));
-    } else {
-        cairo_matrix_t matrix{};
-        auto qx = rad * std::cos(this->strokeAngle);
-        auto qy = -rad * std::sin(this->strokeAngle);
-        s->getMatrix(matrix);
-        cairo_matrix_transform_point(&matrix, &qx, &qy);
-
-        stroke->addPoint(Point(qx, qy));
+    // draw vertical marks
+    for (double i = .5; i <= max; i += .5) {
+        const double x = cathete(this->radius - .25, i);
+        cairo_move_to(cr, -x, i);
+        cairo_line_to(cr, x, i);
+        cairo_stroke(cr);
     }
+    cairo_reset_clip(cr);
+    // END: VERTICAL marks within circle
 
-    const Rectangle<double> rect{stroke->getX(), stroke->getY(), stroke->getElementWidth(), stroke->getElementHeight()};
-    this->getView()->rerenderRect(rect.x, rect.y, rect.width, rect.height);
+
+    // BEGIN: vertical measuring marks with numbers
+    for (int i = this->minVmark; i <= this->maxVmark; i++) {
+        const double y = static_cast<double>(i) / 10.;
+        const double tick = (i % 5 == 0) ? TICK_LARGE : TICK_SMALL;
+
+        // marks and numbers (left and right)
+        for (const double sign: {-1., 1.}) {
+            cairo_move_to(cr, sign * this->horPosVmarks, y);
+            cairo_rel_line_to(cr, -sign * tick, .0);
+            if (i % 10 == 0) {
+                const auto text = std::to_string(i / 10);
+                cairo_rel_move_to(cr, -sign * TICK_SMALL, .0);
+                showTextCenteredAndRotated(cr, text, .0);
+            };
+        }
+    }
+    cairo_stroke(cr);
+    // END: vertical measuring marks with numbers
+
+    cairo_restore(cr);
 }
 
-void SetsquareView::finalizeStroke() {
-    hypotenuseMax = NAN;
-    hypotenuseMin = NAN;
-    addStrokeToLayer();
+void SetsquareView::drawHorizontalMarks(cairo_t* cr) const {
+    cairo_save(cr);
+
+    const auto max = this->maxVmark / 10;  // number of full centimeters
+
+    // BEGIN: line indicating horizontal 0
+    for (auto i = 1; i <= max; i++) {
+        cairo_move_to(cr, .0, static_cast<double>(i) - ZERO_MARK_TICK / 2.);
+        cairo_rel_line_to(cr, .0, ZERO_MARK_TICK);
+    }
+    cairo_stroke(cr);
+    // END: line indicating horizontal 0
+
+    // BEGIN: measuring marks on top
+    for (int i = -this->maxHmark; i <= this->maxHmark; i++) {
+        const double tick = (i % 5 == 0) ? TICK_LARGE : TICK_SMALL;
+        // draw marks
+        cairo_move_to(cr, static_cast<double>(i) / 10., .0);
+        cairo_rel_line_to(cr, .0, tick);
+        if (i % 10 == 0) {
+            // draw numbers
+            cairo_rel_move_to(cr, .0, FONT_SIZE / 2.);
+            const auto text = std::to_string(std::abs(i / 10));
+            showTextCenteredAndRotated(cr, text.c_str(), .0);
+        }
+    }
+    cairo_stroke(cr);
+    // END: measuring marks on top
+
+    cairo_restore(cr);
 }
 
-void SetsquareView::finalizeRadius() {
-    strokeAngle = NAN;
-    addStrokeToLayer();
+void SetsquareView::clipVerticalStripes(cairo_t* cr) const {
+    // y-coordinate of the highest vertical mark
+    const auto y = static_cast<double>(this->maxVmark) / 10.;
+
+    cairo_rectangle(cr, -this->horPosVmarks - .25, .0, .75, y + .5);          // left stripe
+    cairo_rectangle(cr, this->horPosVmarks - .5, .0, .75, y + .5);            // right stripe
+    cairo_rectangle(cr, -.25, .0, .5, y + .5);                                // middle stripe
+    cairo_rectangle(cr, -this->height, .0, 2. * this->height, this->height);  // clip to the outside
+    cairo_clip(cr);
 }
 
-auto SetsquareView::existsStroke() -> bool { return !std::isnan(hypotenuseMax) && !std::isnan(hypotenuseMin); }
-
-auto SetsquareView::existsRadius() -> bool { return !std::isnan(strokeAngle); }
-
-void SetsquareView::addStrokeToLayer() {
-    const auto xournal = this->getView()->getXournal();
-    const auto control = xournal->getControl();
-    const auto page = getPage();
-    control->getLayerController()->ensureLayerExists(page);
-    const auto layer = page->getSelectedLayer();
-
-    const auto undo = control->getUndoRedoHandler();
-    undo->addUndoAction(std::make_unique<InsertUndoAction>(page, layer, stroke));
-
-    layer->addElement(stroke);
-
-    const Rectangle<double> rect{stroke->getX(), stroke->getY(), stroke->getElementWidth(), stroke->getElementHeight()};
-    this->getView()->rerenderRect(rect.x, rect.y, rect.width, rect.height);
-    stroke = nullptr;
-    xournal->getCursor()->updateCursor();
-}
-
-void SetsquareView::initializeStroke() {
-    const auto control = this->getView()->getXournal()->getControl();
-    const auto h = control->getToolHandler();
-    stroke = new Stroke();
-    stroke->setWidth(h->getThickness());
-    stroke->setColor(h->getColor());
-    stroke->setFill(h->getFill());
-    stroke->setLineStyle(h->getLineStyle());
+void SetsquareView::clipHorizontalStripes(cairo_t* cr) const {
+    for (auto i = .5; i <= static_cast<double>(this->maxVmark) / 10.0; i += .5) {
+        double x = cathete(this->radius - .25, i);
+        cairo_rectangle(cr, -x, i - .15, 2. * x, .3);
+    }
+    cairo_rectangle(cr, -this->height, .0, 2. * this->height, this->height);  // clip to the outside
+    cairo_clip(cr);
 }

--- a/src/core/view/SetsquareView.cpp
+++ b/src/core/view/SetsquareView.cpp
@@ -23,7 +23,6 @@ constexpr double FONT_SIZE = .2;
 constexpr double CIRCLE_RAD = .3;
 constexpr double TICK_SMALL = .1;
 constexpr double TICK_LARGE = .2;
-constexpr double DISTANCE_SEMICIRCLE_FROM_LEGS = 1.15;
 constexpr double MAX_HOR_POS_VMARKS = 2.5;
 constexpr int MIN_OFFSET_ANG_MARKS = 2;
 constexpr double RELATIVE_CIRCLE_POS = .75;
@@ -49,7 +48,7 @@ void SetsquareView::on(UpdateValuesRequest, double h, double rot, cairo_matrix_t
     height = h;
     rotation = rot;
     matrix = m;
-    radius = height / std::sqrt(2.) - DISTANCE_SEMICIRCLE_FROM_LEGS;
+    radius = Setsquare::radiusFromHeight(height);
     circlePos = height * RELATIVE_CIRCLE_POS;
     horPosVmarks = std::min(MAX_HOR_POS_VMARKS, radius * RELATIVE_MAX_HOR_POS_VMARKS);
     minVmark = (std::abs(horPosVmarks - HMARK_POS - TICK_SMALL / 2.) < MIN_DIST_FROM_HMARK - TICK_SMALL / 2.) ?

--- a/src/core/view/SetsquareView.cpp
+++ b/src/core/view/SetsquareView.cpp
@@ -37,7 +37,8 @@ constexpr int OFFSET_FROM_SEMICIRCLE = 2.;
 constexpr double ZERO_MARK_TICK = .5;
 constexpr int SKIPPED_HMARKS = 8;
 
-SetsquareView::SetsquareView(const Setsquare* setsquare, Repaintable* parent): GeometryToolView(setsquare, parent) {
+SetsquareView::SetsquareView(const Setsquare* setsquare, Repaintable* parent, ZoomControl* zoomControl):
+        GeometryToolView(setsquare, parent, zoomControl) {
     this->registerToPool(setsquare->getViewPool());
 }
 
@@ -72,7 +73,8 @@ void SetsquareView::deleteOn(SetsquareView::FinalizationRequest, const Range& rg
 
 void SetsquareView::drawGeometryTool(cairo_t* cr) const {
     xoj::util::CairoSaveGuard saveGuard(cr);
-    cairo_transform(cr, &matrix);
+    cairo_scale(cr, CM, CM);
+
     cairo_set_line_width(cr, LINE_WIDTH);
     cairo_set_fill_rule(cr, CAIRO_FILL_RULE_EVEN_ODD);
     cairo_select_font_face(cr, "Arial", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_NORMAL);
@@ -97,6 +99,14 @@ void SetsquareView::drawGeometryTool(cairo_t* cr) const {
 
     cairo_set_source_rgb(cr, .5, .0, .5);  // violet
     drawAngularMarks(cr);
+}
+
+void SetsquareView::drawDisplays(cairo_t* cr) const {
+    xoj::util::CairoSaveGuard saveGuard(cr);
+    cairo_transform(cr, &matrix);
+    cairo_set_line_width(cr, LINE_WIDTH);
+    cairo_select_font_face(cr, "Arial", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_NORMAL);
+    cairo_set_font_size(cr, FONT_SIZE);
 
     cairo_set_source_rgb(cr, .0, .5, .5);  // turquoise
     drawRotation(cr);

--- a/src/core/view/SetsquareView.cpp
+++ b/src/core/view/SetsquareView.cpp
@@ -19,7 +19,6 @@
 using namespace xoj::view;
 
 
-constexpr double LINE_WIDTH = .02;
 constexpr double FONT_SIZE = .2;
 constexpr double CIRCLE_RAD = .3;
 constexpr double TICK_SMALL = .1;

--- a/src/core/view/SetsquareView.cpp
+++ b/src/core/view/SetsquareView.cpp
@@ -8,10 +8,11 @@
 
 #include <glib.h>  // for g_error, g_warning
 
-#include "gui/XournalView.h"  // for XournalView
-#include "model/Setsquare.h"  // for Setsquare
-#include "model/Stroke.h"     // for Stroke
-#include "view/View.h"        // for Context
+#include "gui/XournalView.h"          // for XournalView
+#include "model/Setsquare.h"          // for Setsquare
+#include "model/Stroke.h"             // for Stroke
+#include "util/raii/CairoWrappers.h"  // for CairoSaveGuard
+#include "view/View.h"                // for Context
 
 #include "StrokeView.h"  // for StrokeView
 
@@ -70,8 +71,7 @@ void SetsquareView::deleteOn(SetsquareView::FinalizationRequest, const Range& rg
 }
 
 void SetsquareView::drawGeometryTool(cairo_t* cr) const {
-    cairo_save(cr);
-
+    xoj::util::CairoSaveGuard saveGuard(cr);
     cairo_transform(cr, &matrix);
     cairo_set_line_width(cr, LINE_WIDTH);
     cairo_set_fill_rule(cr, CAIRO_FILL_RULE_EVEN_ODD);
@@ -100,13 +100,10 @@ void SetsquareView::drawGeometryTool(cairo_t* cr) const {
 
     cairo_set_source_rgb(cr, .0, .5, .5);  // turquoise
     drawRotation(cr);
-
-    cairo_restore(cr);
 }
 
 void SetsquareView::drawOutline(cairo_t* cr) const {
-    cairo_save(cr);
-
+    xoj::util::CairoSaveGuard saveGuard(cr);
     cairo_move_to(cr, this->height, .0);
     cairo_line_to(cr, -this->height, .0);
     cairo_line_to(cr, .0, this->height);
@@ -115,12 +112,10 @@ void SetsquareView::drawOutline(cairo_t* cr) const {
 
     cairo_set_source_rgba(cr, .2, .2, .2, .1);  // transparent gray
     cairo_fill(cr);
-
-    cairo_restore(cr);
 }
 
 void SetsquareView::drawRotation(cairo_t* cr) const {
-    cairo_save(cr);
+    xoj::util::CairoSaveGuard saveGuard(cr);
 
     // write the angle between hypotenuse and horizontal axis within a small circle
     std::stringstream ss;
@@ -132,13 +127,10 @@ void SetsquareView::drawRotation(cairo_t* cr) const {
     cairo_new_sub_path(cr);
     cairo_arc(cr, .0, this->circlePos, CIRCLE_RAD, .0, 2. * M_PI);
     cairo_stroke(cr);
-
-    cairo_restore(cr);
 }
 
 void SetsquareView::drawAngularMarks(cairo_t* cr) const {
-    cairo_save(cr);
-
+    xoj::util::CairoSaveGuard saveGuard(cr);
     // BEGIN: 45 degree marks
     clipHorizontalStripes(cr);
     clipVerticalStripes(cr);
@@ -199,13 +191,10 @@ void SetsquareView::drawAngularMarks(cairo_t* cr) const {
     }
     cairo_stroke(cr);
     // END: marks and numbers around semicircle
-
-    cairo_restore(cr);
 }
 
 void SetsquareView::drawVerticalMarks(cairo_t* cr) const {
-    cairo_save(cr);
-
+    xoj::util::CairoSaveGuard saveGuard(cr);
     const auto max = this->maxVmark / 10;  // number of full centimeters
 
     // BEGIN: VERTICAL marks within semicircle
@@ -240,13 +229,10 @@ void SetsquareView::drawVerticalMarks(cairo_t* cr) const {
     }
     cairo_stroke(cr);
     // END: vertical measuring marks with numbers
-
-    cairo_restore(cr);
 }
 
 void SetsquareView::drawHorizontalMarks(cairo_t* cr) const {
-    cairo_save(cr);
-
+    xoj::util::CairoSaveGuard saveGuard(cr);
     const auto max = this->maxVmark / 10;  // number of full centimeters
 
     // BEGIN: line indicating horizontal 0
@@ -272,8 +258,6 @@ void SetsquareView::drawHorizontalMarks(cairo_t* cr) const {
     }
     cairo_stroke(cr);
     // END: measuring marks on top
-
-    cairo_restore(cr);
 }
 
 void SetsquareView::clipVerticalStripes(cairo_t* cr) const {

--- a/src/core/view/SetsquareView.cpp
+++ b/src/core/view/SetsquareView.cpp
@@ -8,10 +8,10 @@
 
 #include <glib.h>  // for g_error, g_warning
 
-#include "gui/XournalView.h"          // for XournalView
 #include "model/Setsquare.h"          // for Setsquare
 #include "model/Stroke.h"             // for Stroke
 #include "util/raii/CairoWrappers.h"  // for CairoSaveGuard
+#include "view/Repaintable.h"         // for Repaintable
 #include "view/View.h"                // for Context
 
 #include "StrokeView.h"  // for StrokeView
@@ -37,8 +37,8 @@ constexpr int OFFSET_FROM_SEMICIRCLE = 2.;
 constexpr double ZERO_MARK_TICK = .5;
 constexpr int SKIPPED_HMARKS = 8;
 
-SetsquareView::SetsquareView(const Setsquare* s, Repaintable* parent): GeometryToolView(s, parent) {
-    this->registerToPool(s->getViewPool());
+SetsquareView::SetsquareView(const Setsquare* setsquare, Repaintable* parent): GeometryToolView(setsquare, parent) {
+    this->registerToPool(setsquare->getViewPool());
 }
 
 SetsquareView::~SetsquareView() noexcept { this->unregisterFromPool(); };

--- a/src/core/view/SetsquareView.h
+++ b/src/core/view/SetsquareView.h
@@ -106,5 +106,8 @@ private:
     void drawRotation(cairo_t* cr) const;
     void clipVerticalStripes(cairo_t* cr) const;
     void clipHorizontalStripes(cairo_t* cr) const;
+
+public:
+    static constexpr double LINE_WIDTH = .02;
 };
 };  // namespace xoj::view

--- a/src/core/view/SetsquareView.h
+++ b/src/core/view/SetsquareView.h
@@ -46,7 +46,7 @@ class SetsquareView: public GeometryToolView {
 
 public:
     SetsquareView(const Setsquare* s, Repaintable* parent, ZoomControl* zoomControl);
-    ~SetsquareView() override;
+    ~SetsquareView() noexcept override;
 
     void on(FlagDirtyRegionRequest, const Range& rg) override;
     void on(UpdateValuesRequest, double h, double rot, cairo_matrix_t m) override;

--- a/src/core/view/SetsquareView.h
+++ b/src/core/view/SetsquareView.h
@@ -23,6 +23,7 @@
 
 class Stroke;
 class OverlayBase;
+class ZoomControl;
 
 /**
  * @brief A class that renders a setsquare
@@ -44,7 +45,7 @@ class Repaintable;
 class SetsquareView: public GeometryToolView {
 
 public:
-    SetsquareView(const Setsquare* s, Repaintable* parent);
+    SetsquareView(const Setsquare* s, Repaintable* parent, ZoomControl* zoomControl);
     ~SetsquareView() override;
 
     void on(FlagDirtyRegionRequest, const Range& rg) override;
@@ -53,6 +54,7 @@ public:
 
 private:
     void drawGeometryTool(cairo_t* cr) const override;
+    void drawDisplays(cairo_t* cr) const override;
 
     double height = Setsquare::INITIAL_HEIGHT;
     double rotation = 0.;

--- a/src/core/view/SetsquareView.h
+++ b/src/core/view/SetsquareView.h
@@ -106,10 +106,5 @@ private:
     void drawRotation(cairo_t* cr) const;
     void clipVerticalStripes(cairo_t* cr) const;
     void clipHorizontalStripes(cairo_t* cr) const;
-
-    /**
-     * @brief updates the values radius, horPosVmarks, minVmark, maxVmark computed from the height of the setsquare
-     */
-    void updateValues(double h, double rot, cairo_matrix_t m);
 };
 };  // namespace xoj::view

--- a/src/core/view/SetsquareView.h
+++ b/src/core/view/SetsquareView.h
@@ -19,6 +19,8 @@
 #include "util/DispatchPool.h"
 #include "view/overlays/BaseStrokeToolView.h"
 
+#include "GeometryToolView.h"
+
 class Stroke;
 class XojPageView;
 class OverlayBase;
@@ -40,75 +42,18 @@ class OverlayBase;
 namespace xoj::view {
 class Repaintable;
 
-constexpr double rad(double n) { return n * M_PI / 180.; }
-constexpr double rad(int n) { return rad(static_cast<double>(n)); }
-constexpr double deg(double a) { return a * 180.0 / M_PI; }
-inline double cathete(double h, double o) { return std::sqrt(std::pow(h, 2) - std::pow(o, 2)); }
-
-class SetsquareView: public ToolView, public xoj::util::Listener<SetsquareView> {
+class SetsquareView: public GeometryToolView {
 
 public:
     SetsquareView(const Setsquare* s, Repaintable* parent);
     ~SetsquareView() override;
 
-    /**
-     * Listener interface
-     */
-    static constexpr struct FlagDirtyRegionRequest {
-    } FLAG_DIRTY_REGION = {};
-    void on(FlagDirtyRegionRequest, const Range& rg);
-
-    static constexpr struct UpdateValuesRequest {
-    } UPDATE_VALUES = {};
-    void on(UpdateValuesRequest, double h, double rot, cairo_matrix_t m);
-
-    static constexpr struct FinalizationRequest {
-    } FINALIZATION_REQUEST = {};
-    /**
-     * @brief Called before the setsquare's destruction
-     * @param rg The bounding box of the entire setsquare
-     */
-    void deleteOn(FinalizationRequest, const Range& rg);
-
-    /**
-     * @brief draws the setsquare and temporary stroke to a cairo context
-     * @param cr the cairo context
-     */
-    void draw(cairo_t* cr) const override;
-
-    bool isViewOf(const OverlayBase* overlay) const override;
+    void on(FlagDirtyRegionRequest, const Range& rg) override;
+    void on(UpdateValuesRequest, double h, double rot, cairo_matrix_t m) override;
+    void deleteOn(FinalizationRequest, const Range& rg) override;
 
 private:
-    /**
-     * @brief draws the setsquare to a cairo context
-     * @param cr the cairo context drawn to
-     */
-    void drawSetsquare(cairo_t* cr) const;
-
-    /**
-     * @brief draws the temporary stroke to a cairo context
-     * @param cr the cairo context drawn to
-     */
-    void drawTemporaryStroke(cairo_t* cr) const;
-
-    /**
-     * @brief the underlying setsquare
-     */
-    const Setsquare* s;
-
-    /**
-     * @brief The stroke drawn aligned to the longest side of the setsquare or ending at the midpoint of the longest
-     * side of the setsquare
-     */
-    Stroke* stroke = nullptr;
-
-    /**
-     * @brief renders text centered and possibly rotated at the current position on a cairo context
-     * @param cr the cairo context
-     * @param text the text string
-     * @param angle the rotation angle
-     */
-    void showTextCenteredAndRotated(cairo_t* cr, std::string text, double angle) const;
+    void drawGeometryTool(cairo_t* cr) const override;
 
     double height = Setsquare::INITIAL_HEIGHT;
     double rotation = 0.;

--- a/src/core/view/SetsquareView.h
+++ b/src/core/view/SetsquareView.h
@@ -22,7 +22,6 @@
 #include "GeometryToolView.h"
 
 class Stroke;
-class XojPageView;
 class OverlayBase;
 
 /**


### PR DESCRIPTION
~This is a continuation of #3962 and is based on #4137, #4158 and #4159 from @bhennion.~
This PR refactors the setsquare. ~Currently it contains adding a compass, but that will later be moved into another PR.~
Previously it contained a compass, but that was moved into PR #4443.
I tried to follow the MVC pattern (push variant) explained by @LittleHuba in https://github.com/xournalpp/xournalpp/pull/3962#discussion_r858021356. ~Only the last two commits are relevant.~
I will explain the most relevant commits: 

1) MVC pattern
In 6efc15adb79f885b221fa7e9b353914d7c2571c2 the MVC pattern is applied:

The class `Setsquare` is the model.
The class `SetsquareView` is the view.
The class `SetsquareController` is the controller.
The class `SetsquareInputHandler` is somewhere between a view and a controller.

- The model has a `viewPool` and a `handlerPool` for pushing updates to the `SetsquareView`(s) and `SetsquareInputHandler`(s).
It stores the data for the setsquare and the stroke (near the longest side of the setsquare or from a point close to a shorter side of the setsquare to the midpoint of the longest side) and has getters and setters.

- The view only uses the model for querying the `viewPool`. It doesn't update the model and contains only drawing methods except of the methods to update itself when pushed from the model. 

- The input handler just handles input and uses the controller to manipulate the model. It also updates itself when pushed from the model.

- The controller manipulates the model (moves, rotates and scales the setsquare, creates and updates strokes) and contains more methods, which didn't fit in one of the other classes.

For pushing updates to the view and input handler, I use the `xoj::util::Listener` class; for rendering the setsquare I use the `OverlayBase` and `ToolView` classes, all by @bhennion .

There ~are still two issues~ is still one issue with the rendering:
~1) When activating the setsquare, it is not rendered immediately. It is only rendered after it has been moved/scaled or rotated. I'm not sure why that happens. I tried to notify the setsquare after constructing instances of all classes (in `Control.cpp`), but that crashes.~

~2)~ Since the rendering uses an overlay of one of the page views and the pages are drawn one after the other, when moving the setsquare towards the next page, the fraction that lands on the next page appears to be cut, as if the setsquare was gliding under the next page. It's not like that when moving the setsquare to the page before.
![SetsquareCutFromNextPage](https://user-images.githubusercontent.com/40485433/186721832-ea18453f-3677-4f53-b8d0-3c3c7c622e29.png)

2) Derive Setsquare classes from GeometryTool classes

In order to prepare for other geometry tools (like a compass or a ruler) to be added, in 714e479e1c04e618e1aed20f74701e07b206e8a8 the Setsquare classes are derived from more generic GeometryTool classes. Those classes basically contain the functionality of the Setsquare that all geometry tools will most likely share. This makes it easier to implement new geometry tools.

- `Setsquare` is derived from `GeometryTool`
- `SetsquareView` is derived from `GeometryToolView`
- `SetsquareController` is derived from `GeometryToolController`
- `SetsquareInputHandler` is derived from `GeometryToolHandler`

This strategy is demonstrated in ~commit bb512582867027fd5bb1aba64af264946e34b80f~ PR #4443  where the Compass is added. ~Although that commit won't be part of this PR, it is included so that the strategy can be checked to work.~

Any feedback is welcome. As I had no previous exposure to the MVC pattern, I find it quite tough to find the proper way for this refactoring.

~Only the two last commits are relevant:
ff9058228d7f4e27933c0b567bcb621d9360d19f is the combination of the commits in #3962 rebased on #4159. The setsquare is functionally equivalent to the version in master. 
The real work is in adfc317dcbc3e3e8f8218b77610ba504ab7229b4~

**Edit:** Updated description, described derivation from GeometryTool classes (Oct 15)
**Edit:** Updated description after moving the compass into another PR.