### PR TITLE
fix cairo includes for macos homebrew install

### DIFF
--- a/src/core/control/jobs/RenderJob.h
+++ b/src/core/control/jobs/RenderJob.h
@@ -11,7 +11,7 @@
 
 #pragma once
 
-#include <cairo/cairo.h>  // for cairo_surface_t
+#include <cairo.h>    // for cairo_surface_t
 #include <gtk/gtk.h>  // for GtkWidget
 
 #include "Job.h"  // for Job, JobType

--- a/src/core/pdf/base/XojPdfPage.h
+++ b/src/core/pdf/base/XojPdfPage.h
@@ -16,7 +16,7 @@
 #include <string>     // for string
 #include <vector>     // for vector
 
-#include <cairo/cairo.h>  // for cairo_region_t, cairo_t
+#include <cairo.h>  // for cairo_region_t, cairo_t
 
 /// Determines how text is selected on a user action.
 enum class XojPdfPageSelectionStyle : uint8_t {


### PR DESCRIPTION
Fixes #4220 (and partially  #3949)
The `release-1.1` branch doesn't have includes of the form `#include <cairo/cairo.h>`, so I just apply it on the master branch.

Merging in 24 hours if no objections are raised.