### PR TITLE
Fix attach mode issues

### DIFF
--- a/src/core/control/xojfile/LoadHandler.cpp
+++ b/src/core/control/xojfile/LoadHandler.cpp
@@ -465,6 +465,7 @@ void LoadHandler::parseBgPdf() {
                     pdfFilename = xournalFilepath.remove_filename() / pdfFilename;
                 }
             } else if (!strcmp("attach", domain)) {
+                attachToDocument = true;
                 // Handle old format separately
                 if (this->isGzFile) {
                     pdfFilename = (fs::path{xournalFilepath} += ".") += pdfFilename;

--- a/src/core/control/xojfile/SaveHandler.cpp
+++ b/src/core/control/xojfile/SaveHandler.cpp
@@ -2,6 +2,7 @@
 
 #include <cinttypes>  // for PRIx32, uint32_t
 #include <cstdio>     // for sprintf, size_t
+#include <filesystem> // for exists
 
 #include <cairo.h>                  // for cairo_surface_t
 #include <gdk-pixbuf/gdk-pixbuf.h>  // for gdk_pixbuf_save
@@ -235,7 +236,9 @@ void SaveHandler::visitPage(XmlNode* root, PageRef p, Document* doc, int id) {
                 background->setAttrib("filename", "bg.pdf");
 
                 GError* error = nullptr;
-                doc->getPdfDocument().save(filepath, &error);
+                if (!exists(filepath)) {
+                    doc->getPdfDocument().save(filepath, &error);
+                }
 
                 if (error) {
                     if (!this->errorMessage.empty()) {

--- a/src/core/model/Document.cpp
+++ b/src/core/model/Document.cpp
@@ -413,6 +413,7 @@ auto Document::operator=(const Document& doc) -> Document& {
     this->pdfFilepath = doc.pdfFilepath;
     this->filepath = doc.filepath;
     this->pages = doc.pages;
+    this->attachPdf = doc.attachPdf;
 
     indexPdfPages();
     buildContentsModel();


### PR DESCRIPTION
Fixes #3189 and a new bug

**First commit (80e50c53f6801410cd0ad9cd98d6755407c4b629) is quite trivial. It fixes the following issue:**
The attach mode gets lost when loading and copying the Document. 

**Second commit (bf660d496ffec4b4d7212f817fac6a5f53984884) is more controversial:**
When opening a file with attach mode and you save it again then poppler fails to overwrite the pdf file and corrupts it. For this to happen you need the first commit to even be able to save a loaded xournal file in attach mode.

Strangely enough this doesn't happen when you create a new file and annotate a pdf in attach mode. Overwriting the pdf works just fine there. This suggests that something happens with the pdf when loading it.

The way I fixed this is pretty simple. I just don't overwrite the pdf file if it already exists because that's an unnecessary step anyway. 
