### PR TITLE
Fix compilation when plugins are not being build

### DIFF
--- a/src/core/plugin/PluginController.cpp
+++ b/src/core/plugin/PluginController.cpp
@@ -5,14 +5,14 @@
 #include <tuple>
 #include <utility>
 
+#include "control/Control.h"
+#include "gui/MainWindow.h"
 
 #ifdef ENABLE_PLUGINS
 #include <algorithm>
 
-#include "control/Control.h"
 #include "control/settings/Settings.h"
 #include "gui/GladeSearchpath.h"
-#include "gui/MainWindow.h"
 #include "gui/dialog/PluginDialog.h"
 #include "util/PathUtil.h"
 #include "util/StringUtils.h"

--- a/src/core/plugin/PluginController.cpp
+++ b/src/core/plugin/PluginController.cpp
@@ -2,13 +2,13 @@
 
 #include <cassert>
 #include <memory>
-#include <tuple>
-#include <utility>
 
 #include "control/Control.h"
 #include "gui/MainWindow.h"
 
 #ifdef ENABLE_PLUGINS
+#include <tuple>
+#include <utility>
 #include <algorithm>
 
 #include "control/settings/Settings.h"


### PR DESCRIPTION
While the includes are wrapped in the preprocessor checks, we use the classes in the cases where plugins are not enabled too.

```log
/home/user/projects/xournalpp/src/core/plugin/PluginController.cpp:164:5: error: unknown type name 'GtkWidget'
    GtkWidget* menuitemPlugin = control->getWindow()->get("menuitemPlugin");
    ^
/home/user/projects/xournalpp/src/core/plugin/PluginController.cpp:164:40: error: member access into incomplete type 'Control'
    GtkWidget* menuitemPlugin = control->getWindow()->get("menuitemPlugin");
                                       ^
/home/user/projects/xournalpp/src/core/plugin/PluginController.h:21:7: note: forward declaration of 'Control'
class Control;
      ^
```