### PR TITLE
fixed overriding attach mode when using "proposed pdf" in open dialog

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -2241,7 +2241,7 @@ auto Control::openFile(fs::path filepath, int scrollToPage, bool forceOpen) -> b
         switch (res) {
             case USE_PROPOSED:
                 if (!proposedPdfFilepath.empty()) {
-                    loadHandler.setPdfReplacement(proposedPdfFilepath, true);
+                    loadHandler.setPdfReplacement(proposedPdfFilepath, loadHandler.isAttachedPdfMissing());
                     loadedDocument = loadHandler.loadDocument(filepath);
                 }
                 break;


### PR DESCRIPTION
This pr fixes a issue in  #4165, where in every file attach mode is enabled.

This issue started to appear after #4228 fixed the attach mode. Now the previous mode is kept as is.