### PR TITLE
Do nothing if the page background is 'Copy'

### DIFF
--- a/src/core/control/PageBackgroundChangeController.cpp
+++ b/src/core/control/PageBackgroundChangeController.cpp
@@ -115,7 +115,11 @@ auto PageBackgroundChangeController::commitPageTypeChange(const size_t pageNum, 
     PageType origType = page->getBackgroundType();
 
     // Apply the new background
-    applyPageBackground(page, pageType);
+    if (pageType.format != PageTypeFormat::Copy)
+        applyPageBackground(page, pageType);
+    else
+        g_warning("Found 'Copy' page type. Doing nothing™.");
+
 
     control->firePageChanged(pageNr);
     control->updateBackgroundSizeButton();

--- a/src/core/control/PageBackgroundChangeController.cpp
+++ b/src/core/control/PageBackgroundChangeController.cpp
@@ -115,10 +115,11 @@ auto PageBackgroundChangeController::commitPageTypeChange(const size_t pageNum, 
     PageType origType = page->getBackgroundType();
 
     // Apply the new background
-    if (pageType.format != PageTypeFormat::Copy)
+    if (pageType.format != PageTypeFormat::Copy) {
         applyPageBackground(page, pageType);
-    else
+    } else {
         g_warning("Found 'Copy' page type. Doing nothing™.");
+    }
 
 
     control->firePageChanged(pageNr);

--- a/src/core/control/pagetype/PageTypeMenu.cpp
+++ b/src/core/control/pagetype/PageTypeMenu.cpp
@@ -151,8 +151,9 @@ void PageTypeMenu::entrySelected(PageTypeInfo* t) {
     }
 
     // Disable "Apply to current page" if current format is "Copy."
-    if (this->menuEntryApply)
+    if (this->menuEntryApply) {
         gtk_widget_set_sensitive(this->menuEntryApply, t->page.format != PageTypeFormat::Copy);
+    }
 }
 
 void PageTypeMenu::setSelected(const PageType& selected) {

--- a/src/core/control/pagetype/PageTypeMenu.cpp
+++ b/src/core/control/pagetype/PageTypeMenu.cpp
@@ -198,7 +198,7 @@ void PageTypeMenu::addApplyBackgroundButton(PageTypeApplyListener* pageTypeApply
                          this);
         // Do not initially activate this option if the "Copy" format is selected
         if (getSelected().format == PageTypeFormat::Copy) {
-            gtk_widget_set_sensitive(menuEntryApply, FALSE);
+            gtk_widget_set_sensitive(menuEntryApply, false);
         }
     }
 

--- a/src/core/control/pagetype/PageTypeMenu.cpp
+++ b/src/core/control/pagetype/PageTypeMenu.cpp
@@ -130,11 +130,7 @@ void PageTypeMenu::addMenuEntry(PageTypeInfo* t) {
 
                              if (info.entry == togglebutton) {
                                  // Disable "Apply to current page" if current format is "Copy."
-                                 if (info.info->page.format == PageTypeFormat::Copy) {
-                                     gtk_widget_set_sensitive(self->menuEntryApply, FALSE);
-                                 } else {
-                                     gtk_widget_set_sensitive(self->menuEntryApply, TRUE);
-                                 }
+                                 gtk_widget_set_sensitive(self->menuEntryApply, info.info->page.format != PageTypeFormat::Copy);
                                  self->entrySelected(info.info);
                                  break;
                              }

--- a/src/core/control/pagetype/PageTypeMenu.cpp
+++ b/src/core/control/pagetype/PageTypeMenu.cpp
@@ -127,7 +127,6 @@ void PageTypeMenu::addMenuEntry(PageTypeInfo* t) {
                          }
 
                          for (MenuCallbackInfo& info: self->menuInfos) {
-
                              if (info.entry == togglebutton) {
                                  self->entrySelected(info.info);
                                  break;

--- a/src/core/control/pagetype/PageTypeMenu.cpp
+++ b/src/core/control/pagetype/PageTypeMenu.cpp
@@ -181,6 +181,11 @@ void PageTypeMenu::hideCopyPage() {
  */
 void PageTypeMenu::addApplyBackgroundButton(PageTypeApplyListener* pageTypeApplyListener, bool onlyAllMenu,
                                             ApplyPageTypeSource ptSource) {
+    if (this->menuEntryApply) {
+        g_warning("Button 'Apply to current page' already exists!");
+        return;
+    }
+
     this->pageTypeApplyListener = pageTypeApplyListener;
     this->pageTypeSource = ptSource;
 
@@ -191,7 +196,7 @@ void PageTypeMenu::addApplyBackgroundButton(PageTypeApplyListener* pageTypeApply
     menuY++;
 
     if (!onlyAllMenu) {
-        menuEntryApply = createApplyMenuItem(_("Apply to current page"));
+        this->menuEntryApply = createApplyMenuItem(_("Apply to current page"));
         gtk_menu_attach(GTK_MENU(menu), menuEntryApply, 0, PREVIEW_COLUMNS, menuY, menuY + 1);
         menuY++;
         g_signal_connect(menuEntryApply, "activate", G_CALLBACK(+[](GtkWidget* menu, PageTypeMenu* self) {

--- a/src/core/control/pagetype/PageTypeMenu.cpp
+++ b/src/core/control/pagetype/PageTypeMenu.cpp
@@ -127,7 +127,14 @@ void PageTypeMenu::addMenuEntry(PageTypeInfo* t) {
                          }
 
                          for (MenuCallbackInfo& info: self->menuInfos) {
+
                              if (info.entry == togglebutton) {
+                                 // Disable "Apply to current page" if current format is "Copy."
+                                 if (info.info->page.format == PageTypeFormat::Copy) {
+                                     gtk_widget_set_sensitive(self->menuEntryApply, FALSE);
+                                 } else {
+                                     gtk_widget_set_sensitive(self->menuEntryApply, TRUE);
+                                 }
                                  self->entrySelected(info.info);
                                  break;
                              }
@@ -186,13 +193,17 @@ void PageTypeMenu::addApplyBackgroundButton(PageTypeApplyListener* pageTypeApply
     menuY++;
 
     if (!onlyAllMenu) {
-        GtkWidget* menuEntryApply = createApplyMenuItem(_("Apply to current page"));
+        menuEntryApply = createApplyMenuItem(_("Apply to current page"));
         gtk_menu_attach(GTK_MENU(menu), menuEntryApply, 0, PREVIEW_COLUMNS, menuY, menuY + 1);
         menuY++;
         g_signal_connect(menuEntryApply, "activate", G_CALLBACK(+[](GtkWidget* menu, PageTypeMenu* self) {
                              self->pageTypeApplyListener->applySelectedPageBackground(false, self->pageTypeSource);
                          }),
                          this);
+        // Do not initially activate this option if the "Copy" format is selected
+        if (getSelected().format == PageTypeFormat::Copy) {
+            gtk_widget_set_sensitive(menuEntryApply, FALSE);
+        }
     }
 
     GtkWidget* menuEntryApplyAll = createApplyMenuItem(_("Apply to all pages"));

--- a/src/core/control/pagetype/PageTypeMenu.cpp
+++ b/src/core/control/pagetype/PageTypeMenu.cpp
@@ -129,8 +129,6 @@ void PageTypeMenu::addMenuEntry(PageTypeInfo* t) {
                          for (MenuCallbackInfo& info: self->menuInfos) {
 
                              if (info.entry == togglebutton) {
-                                 // Disable "Apply to current page" if current format is "Copy."
-                                 gtk_widget_set_sensitive(self->menuEntryApply, info.info->page.format != PageTypeFormat::Copy);
                                  self->entrySelected(info.info);
                                  break;
                              }
@@ -152,6 +150,10 @@ void PageTypeMenu::entrySelected(PageTypeInfo* t) {
     if (listener != nullptr) {
         listener->changeCurrentPageBackground(t);
     }
+
+    // Disable "Apply to current page" if current format is "Copy."
+    if (this->menuEntryApply)
+        gtk_widget_set_sensitive(this->menuEntryApply, t->page.format != PageTypeFormat::Copy);
 }
 
 void PageTypeMenu::setSelected(const PageType& selected) {

--- a/src/core/control/pagetype/PageTypeMenu.h
+++ b/src/core/control/pagetype/PageTypeMenu.h
@@ -95,4 +95,5 @@ private:
     bool showPreview;
 
     PageTypeApplyListener* pageTypeApplyListener;
+    GtkWidget* menuEntryApply;
 };

--- a/src/core/control/pagetype/PageTypeMenu.h
+++ b/src/core/control/pagetype/PageTypeMenu.h
@@ -95,5 +95,8 @@ private:
     bool showPreview;
 
     PageTypeApplyListener* pageTypeApplyListener;
+
+    // We need to be able to toggle the activation of the "Apply to Current Page"
+    // entry when the page type changes, so this is a member variable.
     GtkWidget* menuEntryApply;
 };

--- a/src/core/control/pagetype/PageTypeMenu.h
+++ b/src/core/control/pagetype/PageTypeMenu.h
@@ -98,5 +98,5 @@ private:
 
     // We need to be able to toggle the activation of the "Apply to Current Page"
     // entry when the page type changes, so this is a member variable.
-    GtkWidget* menuEntryApply;
+    GtkWidget* menuEntryApply = nullptr;
 };


### PR DESCRIPTION
This is an attempt to fix #4142 by adding a check that straight-up avoids the crash by checking if the background on the current document is the Copy type, and refusing to set the background if that's the case.