### PR TITLE
Improve cannot find pdflatex error in Flatpak

### DIFF
--- a/po/xournalpp.pot
+++ b/po/xournalpp.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: xournalpp 1.1.0+dev\n"
+"Project-Id-Version: xournalpp 1.1.2~dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-23 18:51+0000\n"
+"POT-Creation-Date: 2022-09-30 03:41-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../src/control/XournalMain.cpp:473
+#: ../src/control/XournalMain.cpp:450
 msgid ""
 "\n"
 "\n"
@@ -28,12 +28,6 @@ msgstr ""
 msgid ""
 "\n"
 " Do you want to continue?"
-msgstr ""
-
-#: ../src/control/XournalMain.cpp:453
-msgid ""
-"\n"
-"Will now attempt to run without this file."
 msgstr ""
 
 #: ../src/gui/toolbarMenubar/ToolPageSpinner.cpp:36
@@ -50,7 +44,7 @@ msgid ""
 "<b>No devices were found. This seems wrong - maybe file a bug report?</b>"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:468
+#: ../src/control/XournalMain.cpp:445
 msgid ""
 "<span foreground='red' size='x-large'>Missing the needed UI file:\n"
 "<b>{1}</b></span>\n"
@@ -64,7 +58,7 @@ msgstr ""
 msgid "Add/Edit Tex"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:690
+#: ../src/control/XournalMain.cpp:670
 msgid "Advanced export options"
 msgstr ""
 
@@ -80,7 +74,7 @@ msgstr ""
 msgid "Apply to current page"
 msgstr ""
 
-#: ../src/control/tools/EditSelection.cpp:351
+#: ../src/control/tools/EditSelection.cpp:352
 msgid "Arrange"
 msgstr ""
 
@@ -156,16 +150,16 @@ msgstr ""
 msgid "Blue"
 msgstr ""
 
-#: ../src/control/tools/EditSelection.cpp:368
+#: ../src/control/tools/EditSelection.cpp:369
 msgid "Bring forward"
 msgstr ""
 
-#: ../src/control/tools/EditSelection.cpp:358
+#: ../src/control/tools/EditSelection.cpp:359
 msgid "Bring to front"
 msgstr ""
 
-#: ../src/control/Control.cpp:2011 ../src/control/Control.cpp:2462
-#: ../src/control/XournalMain.cpp:168
+#: ../src/control/Control.cpp:2015 ../src/control/Control.cpp:2466
+#: ../src/control/XournalMain.cpp:166
 msgid "Cancel"
 msgstr ""
 
@@ -211,7 +205,7 @@ msgstr ""
 msgid "Copy page"
 msgstr ""
 
-#: ../src/util/PathUtil.cpp:249
+#: ../src/util/PathUtil.cpp:257
 msgid ""
 "Could not create folder: {1}\n"
 "Failed with error: {2}"
@@ -229,29 +223,29 @@ msgstr ""
 msgid "Could not load pagetemplates.ini file"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:787
+#: ../src/control/xojfile/LoadHandler.cpp:790
 msgid "Could not open attachment: {1}. Error message: Could not read file"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:796
+#: ../src/control/xojfile/LoadHandler.cpp:800
 msgid "Could not open attachment: {1}. Error message: Could not write file"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:768
-#: ../src/control/xojfile/LoadHandler.cpp:1019
-#: ../src/control/xojfile/LoadHandler.cpp:1037
+#: ../src/control/xojfile/LoadHandler.cpp:770
+#: ../src/control/xojfile/LoadHandler.cpp:1023
+#: ../src/control/xojfile/LoadHandler.cpp:1042
 msgid ""
 "Could not open attachment: {1}. Error message: No valid file size provided"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:759
-#: ../src/control/xojfile/LoadHandler.cpp:775
-#: ../src/control/xojfile/LoadHandler.cpp:1010
-#: ../src/control/xojfile/LoadHandler.cpp:1026
+#: ../src/control/xojfile/LoadHandler.cpp:761
+#: ../src/control/xojfile/LoadHandler.cpp:777
+#: ../src/control/xojfile/LoadHandler.cpp:1014
+#: ../src/control/xojfile/LoadHandler.cpp:1030
 msgid "Could not open attachment: {1}. Error message: {2}"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:159
+#: ../src/control/xojfile/LoadHandler.cpp:161
 msgid "Could not open file: \"{1}\""
 msgstr ""
 
@@ -267,12 +261,12 @@ msgid ""
 "No Toolbars will be available"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:355
-#: ../src/control/xojfile/LoadHandler.cpp:379
+#: ../src/control/xojfile/LoadHandler.cpp:357
+#: ../src/control/xojfile/LoadHandler.cpp:381
 msgid "Could not read image: {1}. Error message: {2}"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:389
+#: ../src/control/xojfile/LoadHandler.cpp:391
 msgid "Could not read page number for cloned background image: {1}."
 msgstr ""
 
@@ -295,10 +289,12 @@ msgid "Could not rename autosave file from \"{1}\" to \"{2}\": {3}"
 msgstr ""
 
 #: ../src/control/latex/LatexGenerator.cpp:70
+#: ../src/core/control/latex/LatexGenerator.cpp:86
 msgid "Could not save .tex file: {1}"
 msgstr ""
 
 #: ../src/control/latex/LatexGenerator.cpp:86
+#: ../src/core/control/latex/LatexGenerator.cpp:101
 msgid "Could not start {1}: {2} (exit code: {3})"
 msgstr ""
 
@@ -324,7 +320,7 @@ msgstr ""
 msgid "Custom"
 msgstr ""
 
-#: ../src/control/jobs/CustomExportJob.cpp:19
+#: ../src/control/jobs/CustomExportJob.cpp:21
 msgid "Custom Export"
 msgstr ""
 
@@ -349,7 +345,7 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:167
+#: ../src/control/XournalMain.cpp:165
 msgid "Delete Logfile"
 msgstr ""
 
@@ -357,7 +353,7 @@ msgstr ""
 msgid "Delete current page"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:209
+#: ../src/control/XournalMain.cpp:207
 msgid "Delete file"
 msgstr ""
 
@@ -373,15 +369,15 @@ msgstr ""
 msgid "Delete this page"
 msgstr ""
 
-#: ../src/control/Control.cpp:2459
+#: ../src/control/Control.cpp:2463
 msgid "Discard"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:691
+#: ../src/control/XournalMain.cpp:671
 msgid "Display advanced export options"
 msgstr ""
 
-#: ../src/control/Control.cpp:1956
+#: ../src/control/Control.cpp:1960
 msgid ""
 "Do not open Autosave files. They may will be overwritten!\n"
 "Copy the files to another folder.\n"
@@ -392,20 +388,20 @@ msgstr ""
 msgid "Do not overwrite the background PDF! This will cause errors!"
 msgstr ""
 
-#: ../src/control/Control.cpp:2453
+#: ../src/control/Control.cpp:2457
 msgid "Document file was removed."
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:241
+#: ../src/control/xojfile/LoadHandler.cpp:243
 msgid "Document is corrupted (no pages found in file)"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:237
+#: ../src/control/xojfile/LoadHandler.cpp:239
 msgid "Document is not complete (maybe the end is cut off?)"
 msgstr ""
 
-#: ../src/model/Document.cpp:285 ../src/model/Document.cpp:294
-#: ../src/model/Document.cpp:297
+#: ../src/model/Document.cpp:291 ../src/model/Document.cpp:300
+#: ../src/model/Document.cpp:303
 msgid "Document not loaded! ({1}), {2}"
 msgstr ""
 
@@ -486,7 +482,7 @@ msgstr ""
 msgid "Eraser"
 msgstr ""
 
-#: ../src/control/Control.cpp:2210
+#: ../src/control/Control.cpp:2214
 msgid ""
 "Error annotate PDF file \"{1}\"\n"
 "{2}"
@@ -496,7 +492,7 @@ msgstr ""
 msgid "Error loading glade file \"{1}\" (try to load \"{2}\")"
 msgstr ""
 
-#: ../src/control/Control.cpp:2033
+#: ../src/control/Control.cpp:2037
 msgid "Error opening file \"{1}\""
 msgstr ""
 
@@ -504,12 +500,12 @@ msgstr ""
 msgid "Error opening file: \"{1}\""
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:443
-#: ../src/control/xojfile/LoadHandler.cpp:463
+#: ../src/control/xojfile/LoadHandler.cpp:445
+#: ../src/control/xojfile/LoadHandler.cpp:465
 msgid "Error reading PDF: {1}"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:520
+#: ../src/control/xojfile/LoadHandler.cpp:522
 msgid "Error reading width of a stroke: {1}"
 msgstr ""
 
@@ -543,17 +539,17 @@ msgstr ""
 msgid "Error: {1}. Please check the contents of {2}"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:187
+#: ../src/control/XournalMain.cpp:185
 msgid ""
 "Errorlog cannot be deleted. You have to do it manually.\n"
 "Logfile: {1}"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:648
+#: ../src/control/XournalMain.cpp:628
 msgid "Export FILE as PDF"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:650
+#: ../src/control/XournalMain.cpp:630
 msgid ""
 "Export FILE as image files (one per page)\n"
 "                                 Guess the output format from the extension "
@@ -565,7 +561,7 @@ msgstr ""
 msgid "Export PDF"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:664
+#: ../src/control/XournalMain.cpp:644
 msgid ""
 "Export layers progressively\n"
 "                                 In PDF export, Render layers progressively "
@@ -577,7 +573,7 @@ msgid ""
 "presentation.\n"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:655
+#: ../src/control/XournalMain.cpp:635
 msgid ""
 "Export without background\n"
 "                                 The exported file has transparent or white "
@@ -585,18 +581,39 @@ msgid ""
 "                                 depending on what its format supports\n"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:660
+#: ../src/control/XournalMain.cpp:640
 msgid ""
 "Export without ruling\n"
 "                                 The exported file has no paper ruling\n"
 msgstr ""
 
 #: ../src/control/latex/LatexGenerator.cpp:61
+#: ../src/core/control/latex/LatexGenerator.cpp:78
 msgid "Failed to find LaTeX generator program in PATH: {1}"
 msgstr ""
 
+#: ../src/core/control/latex/LatexGenerator.cpp:76
+msgid ""
+"Failed to find LaTeX generator program in PATH: {1}\n"
+"\n"
+"Since installation is detected within Flatpak, you need to install the "
+"Flatpak freedesktop Tex Live extension. For example, by running:\n"
+"\n"
+"$ flatpak install flathub org.freedesktop.Sdk.Extension.texlive"
+msgstr ""
+
+#: ../src/pdf/base/XojCairoPdfExport.cpp:154
+#: ../src/pdf/base/XojCairoPdfExport.cpp:199
+msgid "Failed to initialize PDF Cairo surface"
+msgstr ""
+
 #: ../src/control/latex/LatexGenerator.cpp:57
+#: ../src/core/control/latex/LatexGenerator.cpp:71
 msgid "Failed to parse LaTeX generator command: {1}"
+msgstr ""
+
+#: ../src/core/control/latex/LatexGenerator.cpp:60
+msgid "Failed to parse LaTeX generator path: {1}"
 msgstr ""
 
 #: ../src/control/LatexController.cpp:58
@@ -609,7 +626,7 @@ msgid ""
 "{1}"
 msgstr ""
 
-#: ../src/util/PathUtil.cpp:151 ../src/util/PathUtil.cpp:168
+#: ../src/util/PathUtil.cpp:158 ../src/util/PathUtil.cpp:175
 msgid ""
 "File couldn't be opened. You have to do it manually:\n"
 "URL: {1}"
@@ -645,7 +662,7 @@ msgstr ""
 msgid "GNU GPLv2 or later"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:639
+#: ../src/control/XournalMain.cpp:619
 msgid "Get version of xournalpp"
 msgstr ""
 
@@ -719,7 +736,7 @@ msgstr ""
 msgid "Image"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:294
+#: ../src/control/XournalMain.cpp:292
 msgid "Image file successfully created"
 msgstr ""
 
@@ -763,7 +780,7 @@ msgstr ""
 msgid "Isometric Graph"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:635
+#: ../src/control/XournalMain.cpp:615
 msgid "Jump to Page (first Page: 1)"
 msgstr ""
 
@@ -801,8 +818,8 @@ msgstr ""
 msgid "Light Green"
 msgstr ""
 
-#: ../src/gui/PageView.cpp:703
-#: ../src/gui/sidebar/previews/base/SidebarPreviewBaseEntry.cpp:76
+#: ../src/gui/PageView.cpp:699
+#: ../src/gui/sidebar/previews/base/SidebarPreviewBaseEntry.cpp:74
 #: ../src/gui/toolbarMenubar/ToolPageLayer.cpp:20
 msgid "Loading..."
 msgstr ""
@@ -818,14 +835,6 @@ msgstr ""
 
 #: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:489
 msgid "Medium"
-msgstr ""
-
-#: ../src/control/XournalMain.cpp:449
-msgid ""
-"Missing the needed UI file:\n"
-"{1}\n"
-" .app corrupted?\n"
-"Path: {2}"
 msgstr ""
 
 #: ../src/undo/MoveUndoAction.cpp:16
@@ -864,8 +873,8 @@ msgstr ""
 msgid "No device"
 msgstr ""
 
-#: ../src/pdf/base/XojCairoPdfExport.cpp:148
-#: ../src/pdf/base/XojCairoPdfExport.cpp:190
+#: ../src/pdf/base/XojCairoPdfExport.cpp:149
+#: ../src/pdf/base/XojCairoPdfExport.cpp:194
 msgid "No pages to export!"
 msgstr ""
 
@@ -882,7 +891,7 @@ msgstr ""
 msgid "OK"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:671
+#: ../src/control/XournalMain.cpp:651
 msgid ""
 "Only export the pages specified by RANGE (e.g. \"2-3,5,7-\")\n"
 "                                 No effect without -p/--create-pdf or -i/--"
@@ -893,11 +902,11 @@ msgstr ""
 msgid "Open Image"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:165
+#: ../src/control/XournalMain.cpp:163
 msgid "Open Logfile"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:166
+#: ../src/control/XournalMain.cpp:164
 msgid "Open Logfile directory"
 msgstr ""
 
@@ -906,7 +915,7 @@ msgstr ""
 msgid "Open file"
 msgstr ""
 
-#: ../src/control/RecentManager.cpp:185
+#: ../src/control/RecentManager.cpp:188
 msgctxt "{1} is a URI"
 msgid "Open {1}"
 msgstr ""
@@ -928,11 +937,11 @@ msgstr ""
 msgid "PDF background missing"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:348
+#: ../src/control/XournalMain.cpp:346
 msgid "PDF file successfully created"
 msgstr ""
 
-#: ../src/control/jobs/CustomExportJob.cpp:21
+#: ../src/control/jobs/CustomExportJob.cpp:23
 #: ../src/control/jobs/PdfExportJob.cpp:13
 #: ../src/control/stockdlg/XojOpenDlg.cpp:43
 msgid "PDF files"
@@ -942,7 +951,7 @@ msgstr ""
 msgid "PDF {1}"
 msgstr ""
 
-#: ../src/control/jobs/CustomExportJob.cpp:22
+#: ../src/control/jobs/CustomExportJob.cpp:24
 msgid "PNG graphics"
 msgstr ""
 
@@ -1006,7 +1015,7 @@ msgstr ""
 msgid "Presentation mode"
 msgstr ""
 
-#: ../src/gui/dialog/LanguageConfigGui.cpp:68
+#: ../src/gui/dialog/LanguageConfigGui.cpp:56
 msgid "Previously selected language not available anymore!"
 msgstr ""
 
@@ -1036,7 +1045,7 @@ msgstr ""
 msgid "Redo: "
 msgstr ""
 
-#: ../src/control/Control.cpp:2010
+#: ../src/control/Control.cpp:2014
 msgid "Remove PDF Background"
 msgstr ""
 
@@ -1056,11 +1065,11 @@ msgstr ""
 msgid "Replace"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:1056
+#: ../src/control/xojfile/LoadHandler.cpp:1061
 msgid "Requested temporary file was not found for attachment {1}"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:210
+#: ../src/control/XournalMain.cpp:208
 msgid "Restore file"
 msgstr ""
 
@@ -1080,7 +1089,7 @@ msgstr ""
 msgid "Ruled with vertical line"
 msgstr ""
 
-#: ../src/control/jobs/CustomExportJob.cpp:23
+#: ../src/control/jobs/CustomExportJob.cpp:25
 msgid "SVG graphics"
 msgstr ""
 
@@ -1088,20 +1097,20 @@ msgstr ""
 msgid "Sample LaTeX file generated successfully."
 msgstr ""
 
-#: ../src/control/Control.cpp:2454 ../src/control/jobs/SaveJob.cpp:15
+#: ../src/control/Control.cpp:2458 ../src/control/jobs/SaveJob.cpp:15
 #: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:335
 msgid "Save"
 msgstr ""
 
-#: ../src/control/Control.cpp:2454
+#: ../src/control/Control.cpp:2458
 msgid "Save As..."
 msgstr ""
 
-#: ../src/control/Control.cpp:2299 ../src/gui/dialog/PageTemplateDialog.cpp:77
+#: ../src/control/Control.cpp:2303 ../src/gui/dialog/PageTemplateDialog.cpp:77
 msgid "Save File"
 msgstr ""
 
-#: ../src/control/jobs/CustomExportJob.cpp:130
+#: ../src/control/jobs/CustomExportJob.cpp:131
 #: ../src/control/jobs/SaveJob.cpp:114
 msgid "Save file error: {1}"
 msgstr ""
@@ -1141,7 +1150,7 @@ msgstr ""
 msgid "Select Region"
 msgstr ""
 
-#: ../src/control/Control.cpp:2009
+#: ../src/control/Control.cpp:2013
 msgid "Select another PDF"
 msgstr ""
 
@@ -1170,15 +1179,15 @@ msgstr ""
 msgid "Selection Combo"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:164
+#: ../src/control/XournalMain.cpp:162
 msgid "Send Bugreport"
 msgstr ""
 
-#: ../src/control/tools/EditSelection.cpp:379
+#: ../src/control/tools/EditSelection.cpp:380
 msgid "Send backward"
 msgstr ""
 
-#: ../src/control/tools/EditSelection.cpp:387
+#: ../src/control/tools/EditSelection.cpp:388
 msgid "Send to back"
 msgstr ""
 
@@ -1186,13 +1195,13 @@ msgstr ""
 msgid "Separator"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:675
+#: ../src/control/XournalMain.cpp:655
 msgid ""
 "Set DPI for PNG exports. Default is 300\n"
 "                                 No effect without -i/--create-img=foo.png"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:685
+#: ../src/control/XournalMain.cpp:665
 msgid ""
 "Set page height for PNG exports\n"
 "                                 No effect without -i/--create-img=foo.png\n"
@@ -1200,7 +1209,7 @@ msgid ""
 "width is used"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:679
+#: ../src/control/XournalMain.cpp:659
 msgid ""
 "Set page width for PNG exports\n"
 "                                 No effect without -i/--create-img=foo.png\n"
@@ -1223,13 +1232,13 @@ msgstr ""
 msgid "Show only not used pages ({1} unused pages)"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:546
+#: ../src/control/XournalMain.cpp:522
 msgid ""
 "Sorry, Xournal++ can only open one file at once.\n"
 "Others are ignored."
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:561
+#: ../src/control/XournalMain.cpp:537
 msgid ""
 "Sorry, Xournal++ cannot open remote files at the moment.\n"
 "You have to copy the file to a local directory."
@@ -1273,7 +1282,7 @@ msgstr ""
 msgid "Swap the current page with the one below"
 msgstr ""
 
-#: ../src/gui/dialog/LanguageConfigGui.cpp:52
+#: ../src/gui/dialog/LanguageConfigGui.cpp:40
 msgid "System Default"
 msgstr ""
 
@@ -1317,14 +1326,14 @@ msgid ""
 "edit?"
 msgstr ""
 
-#: ../src/control/Control.cpp:1998
+#: ../src/control/Control.cpp:2002
 msgid ""
 "The attached background file {1} could not be found. It might have been "
 "moved, renamed or deleted.\n"
 "It was last seen at: {2}"
 msgstr ""
 
-#: ../src/control/Control.cpp:2002
+#: ../src/control/Control.cpp:2006
 msgid ""
 "The background file {1} could not be found. It might have been moved, "
 "renamed or deleted.\n"
@@ -1335,7 +1344,7 @@ msgstr ""
 msgid "The check for overwriting the background failed with:\n"
 msgstr ""
 
-#: ../src/control/Control.cpp:2041
+#: ../src/control/Control.cpp:2045
 msgid ""
 "The file being loaded has a file format version newer than the one currently "
 "supported by this version of Xournal++, so it may not load properly. Open "
@@ -1346,15 +1355,15 @@ msgstr ""
 msgid "The file is no valid .xopp file (Mimetype missing): \"{1}\""
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:126
+#: ../src/control/xojfile/LoadHandler.cpp:127
 msgid "The file is no valid .xopp file (Mimetype wrong): \"{1}\""
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:135
+#: ../src/control/xojfile/LoadHandler.cpp:136
 msgid "The file is no valid .xopp file (Version missing): \"{1}\""
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:147
+#: ../src/control/xojfile/LoadHandler.cpp:149
 msgid "The file is not a valid .xopp file (Version string corrupted): \"{1}\""
 msgstr ""
 
@@ -1362,17 +1371,17 @@ msgstr ""
 msgid "The formula is empty when rendered or invalid."
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:159
+#: ../src/control/XournalMain.cpp:157
 msgid "The most recent log file name: {1}"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:154
+#: ../src/control/XournalMain.cpp:152
 msgid ""
 "There are errorlogfiles from Xournal++. Please send a Bugreport, so the bug "
 "may be fixed."
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:153
+#: ../src/control/XournalMain.cpp:151
 msgid ""
 "There is an errorlogfile from Xournal++. Please send a Bugreport, so the bug "
 "may be fixed."
@@ -1386,7 +1395,7 @@ msgstr ""
 msgid "Thick"
 msgstr ""
 
-#: ../src/control/Control.cpp:2453
+#: ../src/control/Control.cpp:2457
 msgid "This document is not saved yet."
 msgstr ""
 
@@ -1419,7 +1428,7 @@ msgstr ""
 msgid "Unable to open global template file at {1}. Does it exist?"
 msgstr ""
 
-#: ../src/gui/PageView.cpp:350
+#: ../src/gui/PageView.cpp:346
 msgid "Unable to play audio recording {1}"
 msgstr ""
 
@@ -1436,15 +1445,15 @@ msgstr ""
 msgid "Undo: "
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:286
+#: ../src/control/xojfile/LoadHandler.cpp:288
 msgid "Unexpected root tag: {1}"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:307
+#: ../src/control/xojfile/LoadHandler.cpp:309
 msgid "Unexpected tag in document: \"{1}\""
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:496
+#: ../src/control/xojfile/LoadHandler.cpp:498
 msgid "Unknown background type: {1}"
 msgstr ""
 
@@ -1452,23 +1461,23 @@ msgstr ""
 msgid "Unknown color value \"{1}\""
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:450
+#: ../src/control/xojfile/LoadHandler.cpp:452
 msgid "Unknown domain type: {1}"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:226
+#: ../src/control/xojfile/LoadHandler.cpp:228
 msgid "Unknown parser error"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:397
+#: ../src/control/xojfile/LoadHandler.cpp:399
 msgid "Unknown pixmap::domain type: {1}"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:593
+#: ../src/control/xojfile/LoadHandler.cpp:595
 msgid "Unknown stroke type: \"{1}\", assuming pen"
 msgstr ""
 
-#: ../src/control/Control.cpp:2356
+#: ../src/control/Control.cpp:2360
 msgid "Unsaved Document"
 msgstr ""
 
@@ -1501,19 +1510,19 @@ msgstr ""
 msgid "Write text"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:910
+#: ../src/control/xojfile/LoadHandler.cpp:914
 msgid "Wrong count of points ({1})"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:920
+#: ../src/control/xojfile/LoadHandler.cpp:924
 msgid "Wrong number of points, got {1}, expected {2}"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:223
+#: ../src/control/xojfile/LoadHandler.cpp:225
 msgid "XML Parser error: {1}"
 msgstr ""
 
-#: ../src/control/jobs/CustomExportJob.cpp:24
+#: ../src/control/jobs/CustomExportJob.cpp:26
 msgid "Xournal (Compatibility)"
 msgstr ""
 
@@ -1521,12 +1530,12 @@ msgstr ""
 msgid "Xournal files"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:204
+#: ../src/control/XournalMain.cpp:202
 msgid ""
 "Xournal++ crashed last time. Would you like to restore the last edited file?"
 msgstr ""
 
-#: ../src/control/Control.cpp:2305 ../src/control/stockdlg/XojOpenDlg.cpp:58
+#: ../src/control/Control.cpp:2309 ../src/control/stockdlg/XojOpenDlg.cpp:58
 msgid "Xournal++ files"
 msgstr ""
 
@@ -1547,7 +1556,7 @@ msgid ""
 "Template\"."
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:156
+#: ../src/control/XournalMain.cpp:154
 msgid ""
 "You're using \"{1}/{2}\" branch. Send Bugreport will direct you to this "
 "repo's issue tracker."
@@ -1582,7 +1591,7 @@ msgstr ""
 msgid "Zoom to 100%"
 msgstr ""
 
-#: ../src/control/Control.cpp:2299 ../src/control/jobs/BaseExportJob.cpp:19
+#: ../src/control/Control.cpp:2303 ../src/control/jobs/BaseExportJob.cpp:19
 #: ../src/control/stockdlg/ImageOpenDlg.cpp:12
 #: ../src/control/stockdlg/XojOpenDlg.cpp:12
 #: ../src/gui/dialog/PageTemplateDialog.cpp:78
@@ -1594,7 +1603,7 @@ msgstr ""
 msgid "_Open"
 msgstr ""
 
-#: ../src/control/Control.cpp:2300 ../src/control/jobs/BaseExportJob.cpp:19
+#: ../src/control/Control.cpp:2304 ../src/control/jobs/BaseExportJob.cpp:19
 #: ../src/gui/dialog/PageTemplateDialog.cpp:78
 msgid "_Save"
 msgstr ""
@@ -1635,7 +1644,7 @@ msgstr ""
 msgid "eraser"
 msgstr ""
 
-#: ../src/control/Control.cpp:1970
+#: ../src/control/Control.cpp:1974
 msgid "file: {1}"
 msgstr ""
 
@@ -1696,44 +1705,44 @@ msgstr ""
 msgid "whiteout"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:919
+#: ../src/control/xojfile/LoadHandler.cpp:923
 msgid "xoj-File: {1}"
 msgstr ""
 
-#: ../src/xoj-preview-extractor/xournalpp-thumbnailer.cpp:111
+#: ../src/xoj-preview-extractor/xournalpp-thumbnailer.cpp:112
 msgid "xoj-preview-extractor: call with INPUT.xoj OUTPUT.png"
 msgstr ""
 
-#: ../src/xoj-preview-extractor/xournalpp-thumbnailer.cpp:177
+#: ../src/xoj-preview-extractor/xournalpp-thumbnailer.cpp:176
 msgid "xoj-preview-extractor: could not find icon \"{1}\""
 msgstr ""
 
-#: ../src/xoj-preview-extractor/xournalpp-thumbnailer.cpp:132
+#: ../src/xoj-preview-extractor/xournalpp-thumbnailer.cpp:133
 msgid "xoj-preview-extractor: file \"{1}\" contains no preview"
 msgstr ""
 
-#: ../src/xoj-preview-extractor/xournalpp-thumbnailer.cpp:124
+#: ../src/xoj-preview-extractor/xournalpp-thumbnailer.cpp:125
 msgid "xoj-preview-extractor: file \"{1}\" is not .xoj file"
 msgstr ""
 
-#: ../src/xoj-preview-extractor/xournalpp-thumbnailer.cpp:137
+#: ../src/xoj-preview-extractor/xournalpp-thumbnailer.cpp:138
 msgid ""
 "xoj-preview-extractor: no preview and page found, maybe an invalid file?"
 msgstr ""
 
-#: ../src/xoj-preview-extractor/xournalpp-thumbnailer.cpp:128
+#: ../src/xoj-preview-extractor/xournalpp-thumbnailer.cpp:129
 msgid "xoj-preview-extractor: opening input file \"{1}\" failed"
 msgstr ""
 
-#: ../src/xoj-preview-extractor/xournalpp-thumbnailer.cpp:194
+#: ../src/xoj-preview-extractor/xournalpp-thumbnailer.cpp:193
 msgid "xoj-preview-extractor: opening output file \"{1}\" failed"
 msgstr ""
 
-#: ../src/xoj-preview-extractor/xournalpp-thumbnailer.cpp:201
+#: ../src/xoj-preview-extractor/xournalpp-thumbnailer.cpp:200
 msgid "xoj-preview-extractor: successfully extracted"
 msgstr ""
 
-#: ../src/util/PathUtil.cpp:239
+#: ../src/util/PathUtil.cpp:247
 msgid "xournalpp-{1}"
 msgstr ""
 

--- a/po/xournalpp.pot
+++ b/po/xournalpp.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: xournalpp 1.1.2~dev\n"
+"Project-Id-Version: xournalpp 1.1.0+dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-09-30 03:41-0700\n"
+"POT-Creation-Date: 2021-09-23 18:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../src/control/XournalMain.cpp:450
+#: ../src/control/XournalMain.cpp:473
 msgid ""
 "\n"
 "\n"
@@ -28,6 +28,12 @@ msgstr ""
 msgid ""
 "\n"
 " Do you want to continue?"
+msgstr ""
+
+#: ../src/control/XournalMain.cpp:453
+msgid ""
+"\n"
+"Will now attempt to run without this file."
 msgstr ""
 
 #: ../src/gui/toolbarMenubar/ToolPageSpinner.cpp:36
@@ -44,7 +50,7 @@ msgid ""
 "<b>No devices were found. This seems wrong - maybe file a bug report?</b>"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:445
+#: ../src/control/XournalMain.cpp:468
 msgid ""
 "<span foreground='red' size='x-large'>Missing the needed UI file:\n"
 "<b>{1}</b></span>\n"
@@ -58,7 +64,7 @@ msgstr ""
 msgid "Add/Edit Tex"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:670
+#: ../src/control/XournalMain.cpp:690
 msgid "Advanced export options"
 msgstr ""
 
@@ -74,7 +80,7 @@ msgstr ""
 msgid "Apply to current page"
 msgstr ""
 
-#: ../src/control/tools/EditSelection.cpp:352
+#: ../src/control/tools/EditSelection.cpp:351
 msgid "Arrange"
 msgstr ""
 
@@ -150,16 +156,16 @@ msgstr ""
 msgid "Blue"
 msgstr ""
 
-#: ../src/control/tools/EditSelection.cpp:369
+#: ../src/control/tools/EditSelection.cpp:368
 msgid "Bring forward"
 msgstr ""
 
-#: ../src/control/tools/EditSelection.cpp:359
+#: ../src/control/tools/EditSelection.cpp:358
 msgid "Bring to front"
 msgstr ""
 
-#: ../src/control/Control.cpp:2015 ../src/control/Control.cpp:2466
-#: ../src/control/XournalMain.cpp:166
+#: ../src/control/Control.cpp:2011 ../src/control/Control.cpp:2462
+#: ../src/control/XournalMain.cpp:168
 msgid "Cancel"
 msgstr ""
 
@@ -205,7 +211,7 @@ msgstr ""
 msgid "Copy page"
 msgstr ""
 
-#: ../src/util/PathUtil.cpp:257
+#: ../src/util/PathUtil.cpp:249
 msgid ""
 "Could not create folder: {1}\n"
 "Failed with error: {2}"
@@ -223,29 +229,29 @@ msgstr ""
 msgid "Could not load pagetemplates.ini file"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:790
+#: ../src/control/xojfile/LoadHandler.cpp:787
 msgid "Could not open attachment: {1}. Error message: Could not read file"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:800
+#: ../src/control/xojfile/LoadHandler.cpp:796
 msgid "Could not open attachment: {1}. Error message: Could not write file"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:770
-#: ../src/control/xojfile/LoadHandler.cpp:1023
-#: ../src/control/xojfile/LoadHandler.cpp:1042
+#: ../src/control/xojfile/LoadHandler.cpp:768
+#: ../src/control/xojfile/LoadHandler.cpp:1019
+#: ../src/control/xojfile/LoadHandler.cpp:1037
 msgid ""
 "Could not open attachment: {1}. Error message: No valid file size provided"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:761
-#: ../src/control/xojfile/LoadHandler.cpp:777
-#: ../src/control/xojfile/LoadHandler.cpp:1014
-#: ../src/control/xojfile/LoadHandler.cpp:1030
+#: ../src/control/xojfile/LoadHandler.cpp:759
+#: ../src/control/xojfile/LoadHandler.cpp:775
+#: ../src/control/xojfile/LoadHandler.cpp:1010
+#: ../src/control/xojfile/LoadHandler.cpp:1026
 msgid "Could not open attachment: {1}. Error message: {2}"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:161
+#: ../src/control/xojfile/LoadHandler.cpp:159
 msgid "Could not open file: \"{1}\""
 msgstr ""
 
@@ -261,12 +267,12 @@ msgid ""
 "No Toolbars will be available"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:357
-#: ../src/control/xojfile/LoadHandler.cpp:381
+#: ../src/control/xojfile/LoadHandler.cpp:355
+#: ../src/control/xojfile/LoadHandler.cpp:379
 msgid "Could not read image: {1}. Error message: {2}"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:391
+#: ../src/control/xojfile/LoadHandler.cpp:389
 msgid "Could not read page number for cloned background image: {1}."
 msgstr ""
 
@@ -289,12 +295,10 @@ msgid "Could not rename autosave file from \"{1}\" to \"{2}\": {3}"
 msgstr ""
 
 #: ../src/control/latex/LatexGenerator.cpp:70
-#: ../src/core/control/latex/LatexGenerator.cpp:86
 msgid "Could not save .tex file: {1}"
 msgstr ""
 
 #: ../src/control/latex/LatexGenerator.cpp:86
-#: ../src/core/control/latex/LatexGenerator.cpp:101
 msgid "Could not start {1}: {2} (exit code: {3})"
 msgstr ""
 
@@ -320,7 +324,7 @@ msgstr ""
 msgid "Custom"
 msgstr ""
 
-#: ../src/control/jobs/CustomExportJob.cpp:21
+#: ../src/control/jobs/CustomExportJob.cpp:19
 msgid "Custom Export"
 msgstr ""
 
@@ -345,7 +349,7 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:165
+#: ../src/control/XournalMain.cpp:167
 msgid "Delete Logfile"
 msgstr ""
 
@@ -353,7 +357,7 @@ msgstr ""
 msgid "Delete current page"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:207
+#: ../src/control/XournalMain.cpp:209
 msgid "Delete file"
 msgstr ""
 
@@ -369,15 +373,15 @@ msgstr ""
 msgid "Delete this page"
 msgstr ""
 
-#: ../src/control/Control.cpp:2463
+#: ../src/control/Control.cpp:2459
 msgid "Discard"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:671
+#: ../src/control/XournalMain.cpp:691
 msgid "Display advanced export options"
 msgstr ""
 
-#: ../src/control/Control.cpp:1960
+#: ../src/control/Control.cpp:1956
 msgid ""
 "Do not open Autosave files. They may will be overwritten!\n"
 "Copy the files to another folder.\n"
@@ -388,20 +392,20 @@ msgstr ""
 msgid "Do not overwrite the background PDF! This will cause errors!"
 msgstr ""
 
-#: ../src/control/Control.cpp:2457
+#: ../src/control/Control.cpp:2453
 msgid "Document file was removed."
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:243
+#: ../src/control/xojfile/LoadHandler.cpp:241
 msgid "Document is corrupted (no pages found in file)"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:239
+#: ../src/control/xojfile/LoadHandler.cpp:237
 msgid "Document is not complete (maybe the end is cut off?)"
 msgstr ""
 
-#: ../src/model/Document.cpp:291 ../src/model/Document.cpp:300
-#: ../src/model/Document.cpp:303
+#: ../src/model/Document.cpp:285 ../src/model/Document.cpp:294
+#: ../src/model/Document.cpp:297
 msgid "Document not loaded! ({1}), {2}"
 msgstr ""
 
@@ -482,7 +486,7 @@ msgstr ""
 msgid "Eraser"
 msgstr ""
 
-#: ../src/control/Control.cpp:2214
+#: ../src/control/Control.cpp:2210
 msgid ""
 "Error annotate PDF file \"{1}\"\n"
 "{2}"
@@ -492,7 +496,7 @@ msgstr ""
 msgid "Error loading glade file \"{1}\" (try to load \"{2}\")"
 msgstr ""
 
-#: ../src/control/Control.cpp:2037
+#: ../src/control/Control.cpp:2033
 msgid "Error opening file \"{1}\""
 msgstr ""
 
@@ -500,12 +504,12 @@ msgstr ""
 msgid "Error opening file: \"{1}\""
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:445
-#: ../src/control/xojfile/LoadHandler.cpp:465
+#: ../src/control/xojfile/LoadHandler.cpp:443
+#: ../src/control/xojfile/LoadHandler.cpp:463
 msgid "Error reading PDF: {1}"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:522
+#: ../src/control/xojfile/LoadHandler.cpp:520
 msgid "Error reading width of a stroke: {1}"
 msgstr ""
 
@@ -539,17 +543,17 @@ msgstr ""
 msgid "Error: {1}. Please check the contents of {2}"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:185
+#: ../src/control/XournalMain.cpp:187
 msgid ""
 "Errorlog cannot be deleted. You have to do it manually.\n"
 "Logfile: {1}"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:628
+#: ../src/control/XournalMain.cpp:648
 msgid "Export FILE as PDF"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:630
+#: ../src/control/XournalMain.cpp:650
 msgid ""
 "Export FILE as image files (one per page)\n"
 "                                 Guess the output format from the extension "
@@ -561,7 +565,7 @@ msgstr ""
 msgid "Export PDF"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:644
+#: ../src/control/XournalMain.cpp:664
 msgid ""
 "Export layers progressively\n"
 "                                 In PDF export, Render layers progressively "
@@ -573,7 +577,7 @@ msgid ""
 "presentation.\n"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:635
+#: ../src/control/XournalMain.cpp:655
 msgid ""
 "Export without background\n"
 "                                 The exported file has transparent or white "
@@ -581,39 +585,18 @@ msgid ""
 "                                 depending on what its format supports\n"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:640
+#: ../src/control/XournalMain.cpp:660
 msgid ""
 "Export without ruling\n"
 "                                 The exported file has no paper ruling\n"
 msgstr ""
 
 #: ../src/control/latex/LatexGenerator.cpp:61
-#: ../src/core/control/latex/LatexGenerator.cpp:78
 msgid "Failed to find LaTeX generator program in PATH: {1}"
 msgstr ""
 
-#: ../src/core/control/latex/LatexGenerator.cpp:76
-msgid ""
-"Failed to find LaTeX generator program in PATH: {1}\n"
-"\n"
-"Since installation is detected within Flatpak, you need to install the "
-"Flatpak freedesktop Tex Live extension. For example, by running:\n"
-"\n"
-"$ flatpak install flathub org.freedesktop.Sdk.Extension.texlive"
-msgstr ""
-
-#: ../src/pdf/base/XojCairoPdfExport.cpp:154
-#: ../src/pdf/base/XojCairoPdfExport.cpp:199
-msgid "Failed to initialize PDF Cairo surface"
-msgstr ""
-
 #: ../src/control/latex/LatexGenerator.cpp:57
-#: ../src/core/control/latex/LatexGenerator.cpp:71
 msgid "Failed to parse LaTeX generator command: {1}"
-msgstr ""
-
-#: ../src/core/control/latex/LatexGenerator.cpp:60
-msgid "Failed to parse LaTeX generator path: {1}"
 msgstr ""
 
 #: ../src/control/LatexController.cpp:58
@@ -626,7 +609,7 @@ msgid ""
 "{1}"
 msgstr ""
 
-#: ../src/util/PathUtil.cpp:158 ../src/util/PathUtil.cpp:175
+#: ../src/util/PathUtil.cpp:151 ../src/util/PathUtil.cpp:168
 msgid ""
 "File couldn't be opened. You have to do it manually:\n"
 "URL: {1}"
@@ -662,7 +645,7 @@ msgstr ""
 msgid "GNU GPLv2 or later"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:619
+#: ../src/control/XournalMain.cpp:639
 msgid "Get version of xournalpp"
 msgstr ""
 
@@ -736,7 +719,7 @@ msgstr ""
 msgid "Image"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:292
+#: ../src/control/XournalMain.cpp:294
 msgid "Image file successfully created"
 msgstr ""
 
@@ -780,7 +763,7 @@ msgstr ""
 msgid "Isometric Graph"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:615
+#: ../src/control/XournalMain.cpp:635
 msgid "Jump to Page (first Page: 1)"
 msgstr ""
 
@@ -818,8 +801,8 @@ msgstr ""
 msgid "Light Green"
 msgstr ""
 
-#: ../src/gui/PageView.cpp:699
-#: ../src/gui/sidebar/previews/base/SidebarPreviewBaseEntry.cpp:74
+#: ../src/gui/PageView.cpp:703
+#: ../src/gui/sidebar/previews/base/SidebarPreviewBaseEntry.cpp:76
 #: ../src/gui/toolbarMenubar/ToolPageLayer.cpp:20
 msgid "Loading..."
 msgstr ""
@@ -835,6 +818,14 @@ msgstr ""
 
 #: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:489
 msgid "Medium"
+msgstr ""
+
+#: ../src/control/XournalMain.cpp:449
+msgid ""
+"Missing the needed UI file:\n"
+"{1}\n"
+" .app corrupted?\n"
+"Path: {2}"
 msgstr ""
 
 #: ../src/undo/MoveUndoAction.cpp:16
@@ -873,8 +864,8 @@ msgstr ""
 msgid "No device"
 msgstr ""
 
-#: ../src/pdf/base/XojCairoPdfExport.cpp:149
-#: ../src/pdf/base/XojCairoPdfExport.cpp:194
+#: ../src/pdf/base/XojCairoPdfExport.cpp:148
+#: ../src/pdf/base/XojCairoPdfExport.cpp:190
 msgid "No pages to export!"
 msgstr ""
 
@@ -891,7 +882,7 @@ msgstr ""
 msgid "OK"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:651
+#: ../src/control/XournalMain.cpp:671
 msgid ""
 "Only export the pages specified by RANGE (e.g. \"2-3,5,7-\")\n"
 "                                 No effect without -p/--create-pdf or -i/--"
@@ -902,11 +893,11 @@ msgstr ""
 msgid "Open Image"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:163
+#: ../src/control/XournalMain.cpp:165
 msgid "Open Logfile"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:164
+#: ../src/control/XournalMain.cpp:166
 msgid "Open Logfile directory"
 msgstr ""
 
@@ -915,7 +906,7 @@ msgstr ""
 msgid "Open file"
 msgstr ""
 
-#: ../src/control/RecentManager.cpp:188
+#: ../src/control/RecentManager.cpp:185
 msgctxt "{1} is a URI"
 msgid "Open {1}"
 msgstr ""
@@ -937,11 +928,11 @@ msgstr ""
 msgid "PDF background missing"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:346
+#: ../src/control/XournalMain.cpp:348
 msgid "PDF file successfully created"
 msgstr ""
 
-#: ../src/control/jobs/CustomExportJob.cpp:23
+#: ../src/control/jobs/CustomExportJob.cpp:21
 #: ../src/control/jobs/PdfExportJob.cpp:13
 #: ../src/control/stockdlg/XojOpenDlg.cpp:43
 msgid "PDF files"
@@ -951,7 +942,7 @@ msgstr ""
 msgid "PDF {1}"
 msgstr ""
 
-#: ../src/control/jobs/CustomExportJob.cpp:24
+#: ../src/control/jobs/CustomExportJob.cpp:22
 msgid "PNG graphics"
 msgstr ""
 
@@ -1015,7 +1006,7 @@ msgstr ""
 msgid "Presentation mode"
 msgstr ""
 
-#: ../src/gui/dialog/LanguageConfigGui.cpp:56
+#: ../src/gui/dialog/LanguageConfigGui.cpp:68
 msgid "Previously selected language not available anymore!"
 msgstr ""
 
@@ -1045,7 +1036,7 @@ msgstr ""
 msgid "Redo: "
 msgstr ""
 
-#: ../src/control/Control.cpp:2014
+#: ../src/control/Control.cpp:2010
 msgid "Remove PDF Background"
 msgstr ""
 
@@ -1065,11 +1056,11 @@ msgstr ""
 msgid "Replace"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:1061
+#: ../src/control/xojfile/LoadHandler.cpp:1056
 msgid "Requested temporary file was not found for attachment {1}"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:208
+#: ../src/control/XournalMain.cpp:210
 msgid "Restore file"
 msgstr ""
 
@@ -1089,7 +1080,7 @@ msgstr ""
 msgid "Ruled with vertical line"
 msgstr ""
 
-#: ../src/control/jobs/CustomExportJob.cpp:25
+#: ../src/control/jobs/CustomExportJob.cpp:23
 msgid "SVG graphics"
 msgstr ""
 
@@ -1097,20 +1088,20 @@ msgstr ""
 msgid "Sample LaTeX file generated successfully."
 msgstr ""
 
-#: ../src/control/Control.cpp:2458 ../src/control/jobs/SaveJob.cpp:15
+#: ../src/control/Control.cpp:2454 ../src/control/jobs/SaveJob.cpp:15
 #: ../src/gui/toolbarMenubar/ToolMenuHandler.cpp:335
 msgid "Save"
 msgstr ""
 
-#: ../src/control/Control.cpp:2458
+#: ../src/control/Control.cpp:2454
 msgid "Save As..."
 msgstr ""
 
-#: ../src/control/Control.cpp:2303 ../src/gui/dialog/PageTemplateDialog.cpp:77
+#: ../src/control/Control.cpp:2299 ../src/gui/dialog/PageTemplateDialog.cpp:77
 msgid "Save File"
 msgstr ""
 
-#: ../src/control/jobs/CustomExportJob.cpp:131
+#: ../src/control/jobs/CustomExportJob.cpp:130
 #: ../src/control/jobs/SaveJob.cpp:114
 msgid "Save file error: {1}"
 msgstr ""
@@ -1150,7 +1141,7 @@ msgstr ""
 msgid "Select Region"
 msgstr ""
 
-#: ../src/control/Control.cpp:2013
+#: ../src/control/Control.cpp:2009
 msgid "Select another PDF"
 msgstr ""
 
@@ -1179,15 +1170,15 @@ msgstr ""
 msgid "Selection Combo"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:162
+#: ../src/control/XournalMain.cpp:164
 msgid "Send Bugreport"
 msgstr ""
 
-#: ../src/control/tools/EditSelection.cpp:380
+#: ../src/control/tools/EditSelection.cpp:379
 msgid "Send backward"
 msgstr ""
 
-#: ../src/control/tools/EditSelection.cpp:388
+#: ../src/control/tools/EditSelection.cpp:387
 msgid "Send to back"
 msgstr ""
 
@@ -1195,13 +1186,13 @@ msgstr ""
 msgid "Separator"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:655
+#: ../src/control/XournalMain.cpp:675
 msgid ""
 "Set DPI for PNG exports. Default is 300\n"
 "                                 No effect without -i/--create-img=foo.png"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:665
+#: ../src/control/XournalMain.cpp:685
 msgid ""
 "Set page height for PNG exports\n"
 "                                 No effect without -i/--create-img=foo.png\n"
@@ -1209,7 +1200,7 @@ msgid ""
 "width is used"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:659
+#: ../src/control/XournalMain.cpp:679
 msgid ""
 "Set page width for PNG exports\n"
 "                                 No effect without -i/--create-img=foo.png\n"
@@ -1232,13 +1223,13 @@ msgstr ""
 msgid "Show only not used pages ({1} unused pages)"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:522
+#: ../src/control/XournalMain.cpp:546
 msgid ""
 "Sorry, Xournal++ can only open one file at once.\n"
 "Others are ignored."
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:537
+#: ../src/control/XournalMain.cpp:561
 msgid ""
 "Sorry, Xournal++ cannot open remote files at the moment.\n"
 "You have to copy the file to a local directory."
@@ -1282,7 +1273,7 @@ msgstr ""
 msgid "Swap the current page with the one below"
 msgstr ""
 
-#: ../src/gui/dialog/LanguageConfigGui.cpp:40
+#: ../src/gui/dialog/LanguageConfigGui.cpp:52
 msgid "System Default"
 msgstr ""
 
@@ -1326,14 +1317,14 @@ msgid ""
 "edit?"
 msgstr ""
 
-#: ../src/control/Control.cpp:2002
+#: ../src/control/Control.cpp:1998
 msgid ""
 "The attached background file {1} could not be found. It might have been "
 "moved, renamed or deleted.\n"
 "It was last seen at: {2}"
 msgstr ""
 
-#: ../src/control/Control.cpp:2006
+#: ../src/control/Control.cpp:2002
 msgid ""
 "The background file {1} could not be found. It might have been moved, "
 "renamed or deleted.\n"
@@ -1344,7 +1335,7 @@ msgstr ""
 msgid "The check for overwriting the background failed with:\n"
 msgstr ""
 
-#: ../src/control/Control.cpp:2045
+#: ../src/control/Control.cpp:2041
 msgid ""
 "The file being loaded has a file format version newer than the one currently "
 "supported by this version of Xournal++, so it may not load properly. Open "
@@ -1355,15 +1346,15 @@ msgstr ""
 msgid "The file is no valid .xopp file (Mimetype missing): \"{1}\""
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:127
+#: ../src/control/xojfile/LoadHandler.cpp:126
 msgid "The file is no valid .xopp file (Mimetype wrong): \"{1}\""
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:136
+#: ../src/control/xojfile/LoadHandler.cpp:135
 msgid "The file is no valid .xopp file (Version missing): \"{1}\""
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:149
+#: ../src/control/xojfile/LoadHandler.cpp:147
 msgid "The file is not a valid .xopp file (Version string corrupted): \"{1}\""
 msgstr ""
 
@@ -1371,17 +1362,17 @@ msgstr ""
 msgid "The formula is empty when rendered or invalid."
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:157
+#: ../src/control/XournalMain.cpp:159
 msgid "The most recent log file name: {1}"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:152
+#: ../src/control/XournalMain.cpp:154
 msgid ""
 "There are errorlogfiles from Xournal++. Please send a Bugreport, so the bug "
 "may be fixed."
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:151
+#: ../src/control/XournalMain.cpp:153
 msgid ""
 "There is an errorlogfile from Xournal++. Please send a Bugreport, so the bug "
 "may be fixed."
@@ -1395,7 +1386,7 @@ msgstr ""
 msgid "Thick"
 msgstr ""
 
-#: ../src/control/Control.cpp:2457
+#: ../src/control/Control.cpp:2453
 msgid "This document is not saved yet."
 msgstr ""
 
@@ -1428,7 +1419,7 @@ msgstr ""
 msgid "Unable to open global template file at {1}. Does it exist?"
 msgstr ""
 
-#: ../src/gui/PageView.cpp:346
+#: ../src/gui/PageView.cpp:350
 msgid "Unable to play audio recording {1}"
 msgstr ""
 
@@ -1445,15 +1436,15 @@ msgstr ""
 msgid "Undo: "
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:288
+#: ../src/control/xojfile/LoadHandler.cpp:286
 msgid "Unexpected root tag: {1}"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:309
+#: ../src/control/xojfile/LoadHandler.cpp:307
 msgid "Unexpected tag in document: \"{1}\""
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:498
+#: ../src/control/xojfile/LoadHandler.cpp:496
 msgid "Unknown background type: {1}"
 msgstr ""
 
@@ -1461,23 +1452,23 @@ msgstr ""
 msgid "Unknown color value \"{1}\""
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:452
+#: ../src/control/xojfile/LoadHandler.cpp:450
 msgid "Unknown domain type: {1}"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:228
+#: ../src/control/xojfile/LoadHandler.cpp:226
 msgid "Unknown parser error"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:399
+#: ../src/control/xojfile/LoadHandler.cpp:397
 msgid "Unknown pixmap::domain type: {1}"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:595
+#: ../src/control/xojfile/LoadHandler.cpp:593
 msgid "Unknown stroke type: \"{1}\", assuming pen"
 msgstr ""
 
-#: ../src/control/Control.cpp:2360
+#: ../src/control/Control.cpp:2356
 msgid "Unsaved Document"
 msgstr ""
 
@@ -1510,19 +1501,19 @@ msgstr ""
 msgid "Write text"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:914
+#: ../src/control/xojfile/LoadHandler.cpp:910
 msgid "Wrong count of points ({1})"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:924
+#: ../src/control/xojfile/LoadHandler.cpp:920
 msgid "Wrong number of points, got {1}, expected {2}"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:225
+#: ../src/control/xojfile/LoadHandler.cpp:223
 msgid "XML Parser error: {1}"
 msgstr ""
 
-#: ../src/control/jobs/CustomExportJob.cpp:26
+#: ../src/control/jobs/CustomExportJob.cpp:24
 msgid "Xournal (Compatibility)"
 msgstr ""
 
@@ -1530,12 +1521,12 @@ msgstr ""
 msgid "Xournal files"
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:202
+#: ../src/control/XournalMain.cpp:204
 msgid ""
 "Xournal++ crashed last time. Would you like to restore the last edited file?"
 msgstr ""
 
-#: ../src/control/Control.cpp:2309 ../src/control/stockdlg/XojOpenDlg.cpp:58
+#: ../src/control/Control.cpp:2305 ../src/control/stockdlg/XojOpenDlg.cpp:58
 msgid "Xournal++ files"
 msgstr ""
 
@@ -1556,7 +1547,7 @@ msgid ""
 "Template\"."
 msgstr ""
 
-#: ../src/control/XournalMain.cpp:154
+#: ../src/control/XournalMain.cpp:156
 msgid ""
 "You're using \"{1}/{2}\" branch. Send Bugreport will direct you to this "
 "repo's issue tracker."
@@ -1591,7 +1582,7 @@ msgstr ""
 msgid "Zoom to 100%"
 msgstr ""
 
-#: ../src/control/Control.cpp:2303 ../src/control/jobs/BaseExportJob.cpp:19
+#: ../src/control/Control.cpp:2299 ../src/control/jobs/BaseExportJob.cpp:19
 #: ../src/control/stockdlg/ImageOpenDlg.cpp:12
 #: ../src/control/stockdlg/XojOpenDlg.cpp:12
 #: ../src/gui/dialog/PageTemplateDialog.cpp:78
@@ -1603,7 +1594,7 @@ msgstr ""
 msgid "_Open"
 msgstr ""
 
-#: ../src/control/Control.cpp:2304 ../src/control/jobs/BaseExportJob.cpp:19
+#: ../src/control/Control.cpp:2300 ../src/control/jobs/BaseExportJob.cpp:19
 #: ../src/gui/dialog/PageTemplateDialog.cpp:78
 msgid "_Save"
 msgstr ""
@@ -1644,7 +1635,7 @@ msgstr ""
 msgid "eraser"
 msgstr ""
 
-#: ../src/control/Control.cpp:1974
+#: ../src/control/Control.cpp:1970
 msgid "file: {1}"
 msgstr ""
 
@@ -1705,44 +1696,44 @@ msgstr ""
 msgid "whiteout"
 msgstr ""
 
-#: ../src/control/xojfile/LoadHandler.cpp:923
+#: ../src/control/xojfile/LoadHandler.cpp:919
 msgid "xoj-File: {1}"
 msgstr ""
 
-#: ../src/xoj-preview-extractor/xournalpp-thumbnailer.cpp:112
+#: ../src/xoj-preview-extractor/xournalpp-thumbnailer.cpp:111
 msgid "xoj-preview-extractor: call with INPUT.xoj OUTPUT.png"
 msgstr ""
 
-#: ../src/xoj-preview-extractor/xournalpp-thumbnailer.cpp:176
+#: ../src/xoj-preview-extractor/xournalpp-thumbnailer.cpp:177
 msgid "xoj-preview-extractor: could not find icon \"{1}\""
 msgstr ""
 
-#: ../src/xoj-preview-extractor/xournalpp-thumbnailer.cpp:133
+#: ../src/xoj-preview-extractor/xournalpp-thumbnailer.cpp:132
 msgid "xoj-preview-extractor: file \"{1}\" contains no preview"
 msgstr ""
 
-#: ../src/xoj-preview-extractor/xournalpp-thumbnailer.cpp:125
+#: ../src/xoj-preview-extractor/xournalpp-thumbnailer.cpp:124
 msgid "xoj-preview-extractor: file \"{1}\" is not .xoj file"
 msgstr ""
 
-#: ../src/xoj-preview-extractor/xournalpp-thumbnailer.cpp:138
+#: ../src/xoj-preview-extractor/xournalpp-thumbnailer.cpp:137
 msgid ""
 "xoj-preview-extractor: no preview and page found, maybe an invalid file?"
 msgstr ""
 
-#: ../src/xoj-preview-extractor/xournalpp-thumbnailer.cpp:129
+#: ../src/xoj-preview-extractor/xournalpp-thumbnailer.cpp:128
 msgid "xoj-preview-extractor: opening input file \"{1}\" failed"
 msgstr ""
 
-#: ../src/xoj-preview-extractor/xournalpp-thumbnailer.cpp:193
+#: ../src/xoj-preview-extractor/xournalpp-thumbnailer.cpp:194
 msgid "xoj-preview-extractor: opening output file \"{1}\" failed"
 msgstr ""
 
-#: ../src/xoj-preview-extractor/xournalpp-thumbnailer.cpp:200
+#: ../src/xoj-preview-extractor/xournalpp-thumbnailer.cpp:201
 msgid "xoj-preview-extractor: successfully extracted"
 msgstr ""
 
-#: ../src/util/PathUtil.cpp:247
+#: ../src/util/PathUtil.cpp:239
 msgid "xournalpp-{1}"
 msgstr ""
 

--- a/src/control/latex/LatexGenerator.cpp
+++ b/src/control/latex/LatexGenerator.cpp
@@ -58,10 +58,15 @@ auto LatexGenerator::asyncRun(const fs::path& texDir, const std::string& texFile
     }
     gchar* prog = argv[0];
     if (!prog || !(prog = g_find_program_in_path(prog))) {
-        GenError res{FS(_F("Failed to find LaTeX generator program in PATH: {1}") % argv[0])};
-        g_strfreev(argv);
-        g_error_free(err);
-        return res;
+        if (Util::isFlatpakInstallation()) {
+            return GenError{
+                    FS(_F("Failed to find LaTeX generator program in PATH: {1}\n\nSince installation is detected "
+                          "within Flatpak, you need to install the Flatpak freedesktop Tex Live extension. For "
+                          "example, by running:\n\n$ flatpak install flathub org.freedesktop.Sdk.Extension.texlive") %
+                       prog)};
+        } else {
+            return GenError{FS(_F("Failed to find LaTeX generator program in PATH: {1}") % prog)};
+        }
     }
     g_free(argv[0]);
     argv[0] = prog;

--- a/src/control/latex/LatexGenerator.cpp
+++ b/src/control/latex/LatexGenerator.cpp
@@ -6,6 +6,7 @@
 #include <sstream>
 
 #include <glib.h>
+#include <util/Util.h>
 #include <util/PathUtil.h>
 
 #include "i18n.h"

--- a/src/control/latex/LatexGenerator.cpp
+++ b/src/control/latex/LatexGenerator.cpp
@@ -58,15 +58,20 @@ auto LatexGenerator::asyncRun(const fs::path& texDir, const std::string& texFile
     }
     gchar* prog = argv[0];
     if (!prog || !(prog = g_find_program_in_path(prog))) {
+        GenError res{};
         if (Util::isFlatpakInstallation()) {
-            return GenError{
+            res = GenError{
                     FS(_F("Failed to find LaTeX generator program in PATH: {1}\n\nSince installation is detected "
                           "within Flatpak, you need to install the Flatpak freedesktop Tex Live extension. For "
                           "example, by running:\n\n$ flatpak install flathub org.freedesktop.Sdk.Extension.texlive") %
                        prog)};
         } else {
-            return GenError{FS(_F("Failed to find LaTeX generator program in PATH: {1}") % prog)};
+            res = GenError{FS(_F("Failed to find LaTeX generator program in PATH: {1}") % prog)};
         }
+
+        g_strfreev(argv);
+        g_error_free(err);
+        return res;
     }
     g_free(argv[0]);
     argv[0] = prog;

--- a/src/control/latex/LatexGenerator.cpp
+++ b/src/control/latex/LatexGenerator.cpp
@@ -6,8 +6,8 @@
 #include <sstream>
 
 #include <glib.h>
-#include <util/Util.h>
 #include <util/PathUtil.h>
+#include <util/Util.h>
 
 #include "i18n.h"
 

--- a/src/util/Util.cpp
+++ b/src/util/Util.cpp
@@ -77,3 +77,5 @@ void Util::systemWithMessage(const char* command) {
         XojMsgBox::showErrorToUser(nullptr, msg);
     }
 }
+
+bool Util::isFlatpakInstallation() { return fs::exists("/.flatpak-info"); }

--- a/src/util/Util.h
+++ b/src/util/Util.h
@@ -31,6 +31,11 @@ pid_t getPid();
 void systemWithMessage(const char* command);
 
 /**
+ * Check if currently running in a Flatpak sandbox
+ */
+bool isFlatpakInstallation();
+
+/**
  * Execute the callback in the UI Thread.
  *
  * Make sure the container class is not deleted before the UI stuff is finished!


### PR DESCRIPTION
This improves the error message for Flatpak users when pdflatex cannot be found. This makes the experience much more clear for the end user.

Closes #3996