### PR TITLE
Build: CMake Properly obtain URL of origin

### DIFF
--- a/cmake/include/GitRepo.cmake
+++ b/cmake/include/GitRepo.cmake
@@ -27,7 +27,7 @@ if (EXISTS "${PROJECT_SOURCE_DIR}/.git" AND PATH_GIT)
                    OUTPUT_VARIABLE GIT_BRANCH
                    OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-  execute_process (COMMAND "${PATH_GIT}" config --get remote.origin.url
+  execute_process (COMMAND "${PATH_GIT}" remote get-url origin
                    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
                    OUTPUT_VARIABLE GIT_ORIGIN_URL
                    OUTPUT_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
CMAKE command to get the git remote url doesn't always work. For example, on my machine:

```sh
$ git config --get remote.origin.url
ghhy:xournalpp
```

The build ends up failing:

```txt
CMake Error at cmake/include/GitRepo.cmake:40 (list):
  list index: -1 out of range (-1, 0)
Call Stack (most recent call first):
  CMakeLists.txt:52 (include)
```

Because I have custom `url.<base>.{insteadOf,pushInsteadOf}` declarations in my Git config (see `git-config(1)`)

Better is to do `remote get-url origin`, which is available since Git 2.7, release in 2015. ([source](https://stackoverflow.com/a/32991784))