### PR TITLE
Added the "Fill Opacity" feature to the available toolbar items

### DIFF
--- a/src/core/gui/toolbarMenubar/ToolMenuHandler.cpp
+++ b/src/core/gui/toolbarMenubar/ToolMenuHandler.cpp
@@ -532,7 +532,7 @@ void ToolMenuHandler::initToolItems() {
     addToolItem(toolPageLayer);
 
     addCustomItemTgl("TOOL_FILL", ACTION_TOOL_FILL, GROUP_FILL, false, "fill", _("Fill"));
-
+    addCustomItem("PEN_FILL_OPACITY", ACTION_TOOL_PEN_FILL_OPACITY, "pen-fill-opacity", _("Fill Opacity"));
 
     /*
      * Non-menu items

--- a/ui/iconsColor-dark/hicolor/scalable/actions/xopp-pen-fill-opacity.svg
+++ b/ui/iconsColor-dark/hicolor/scalable/actions/xopp-pen-fill-opacity.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 12 12" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;">
+    <g transform="matrix(-1.16326,-0.196413,-0.196399,-1.23673,22.6456,22.8712)">
+        <path d="M12,14L10.338,11.998" style="fill:none;stroke:rgb(177,102,230);stroke-width:0.51px;"/>
+    </g>
+    <g transform="matrix(-1.16926,-0.203643,-0.203628,-1.24543,20.2053,25.5202)">
+        <path d="M12,14L10.338,11.998" style="fill:none;stroke:rgb(177,102,230);stroke-width:0.51px;"/>
+    </g>
+    <g transform="matrix(-1.29817,-0.358943,-0.358944,-1.43256,25.1021,28.477)">
+        <path d="M12,14L10.338,11.998" style="fill:none;stroke:rgb(177,102,230);stroke-width:0.39px;"/>
+    </g>
+    <g transform="matrix(-1.16688,0,0,-1.16688,20.8069,20.7838)">
+        <g>
+            <g transform="matrix(1.17962,0,0,1.17962,-1.18817,-1.21141)">
+                <circle cx="11" cy="11" r="3" style="fill:none;stroke:rgb(177,102,230);stroke-width:0.69px;"/>
+            </g>
+            <g transform="matrix(1.17962,0,0,1.17962,0.912203,0.892474)">
+                <circle cx="11" cy="11" r="3" style="fill:none;stroke:rgb(177,102,230);stroke-width:0.69px;"/>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/ui/iconsLucide-dark/hicolor/scalable/actions/xopp-pen-fill-opacity.svg
+++ b/ui/iconsLucide-dark/hicolor/scalable/actions/xopp-pen-fill-opacity.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 12 12" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;">
+    <g transform="matrix(-0.120504,0,0,-0.120504,12.3154,12.2981)">
+        <g transform="matrix(9.68333,0,0,9.68333,-70.4667,-70.4188)">
+            <g transform="matrix(1.17962,0,0,1.17962,-1.18817,-1.21141)">
+                <circle cx="11" cy="11" r="3" style="fill:none;stroke:rgb(189,189,189);stroke-width:0.69px;"/>
+            </g>
+            <g transform="matrix(1.17962,0,0,1.17962,0.912203,0.892474)">
+                <circle cx="11" cy="11" r="3" style="fill:none;stroke:rgb(189,189,189);stroke-width:0.69px;"/>
+            </g>
+        </g>
+        <g transform="matrix(9.6533,1.62993,1.62981,10.263,-85.7251,-87.7404)">
+            <path d="M12,14L10.338,11.998" style="fill:none;stroke:rgb(189,189,189);stroke-width:0.51px;"/>
+        </g>
+        <g transform="matrix(9.70311,1.68993,1.6898,10.3352,-65.4742,-109.723)">
+            <path d="M12,14L10.338,11.998" style="fill:none;stroke:rgb(189,189,189);stroke-width:0.51px;"/>
+        </g>
+        <g transform="matrix(10.7728,2.97868,2.97869,11.8881,-106.11,-134.26)">
+            <path d="M12,14L10.338,11.998" style="fill:none;stroke:rgb(189,189,189);stroke-width:0.39px;"/>
+        </g>
+    </g>
+</svg>

--- a/ui/iconsLucide-light/hicolor/scalable/actions/xopp-pen-fill-opacity.svg
+++ b/ui/iconsLucide-light/hicolor/scalable/actions/xopp-pen-fill-opacity.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 12 12" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;">
+    <g transform="matrix(-0.120504,0,0,-0.120504,12.3154,12.2981)">
+        <g transform="matrix(9.68333,0,0,9.68333,-70.4667,-70.4188)">
+            <g transform="matrix(1.17962,0,0,1.17962,-1.18817,-1.21141)">
+                <circle cx="11" cy="11" r="3" style="fill:none;stroke:rgb(77,110,135);stroke-width:0.69px;"/>
+            </g>
+            <g transform="matrix(1.17962,0,0,1.17962,0.912203,0.892474)">
+                <circle cx="11" cy="11" r="3" style="fill:none;stroke:rgb(77,110,135);stroke-width:0.69px;"/>
+            </g>
+        </g>
+        <g transform="matrix(9.6533,1.62993,1.62981,10.263,-85.7251,-87.7404)">
+            <path d="M12,14L10.338,11.998" style="fill:none;stroke:rgb(77,110,135);stroke-width:0.51px;"/>
+        </g>
+        <g transform="matrix(9.70311,1.68993,1.6898,10.3352,-65.4742,-109.723)">
+            <path d="M12,14L10.338,11.998" style="fill:none;stroke:rgb(77,110,135);stroke-width:0.51px;"/>
+        </g>
+        <g transform="matrix(10.7728,2.97868,2.97869,11.8881,-106.11,-134.26)">
+            <path d="M12,14L10.338,11.998" style="fill:none;stroke:rgb(77,110,135);stroke-width:0.39px;"/>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
Until now, if you wanted to change the **fill opacity**, you had to go to _tools -> pen/textmarker-> fill-opacity_. But this PR adds the functionality to reach the **fill opacity** option more easily by providing a new toolbar item, as requested in #4123. 

I also created a new icon. The color scheme was fitted to the already existing **fill** icon. If you don't like the icon or its colors and have any suggestions on how to improve it, just let me now and I will fix it.