### PR TITLE
Support AppImage Update in build script

### DIFF
--- a/azure-pipelines/jobs/release_ubuntu.yml
+++ b/azure-pipelines/jobs/release_ubuntu.yml
@@ -33,8 +33,9 @@ jobs:
           export VERSION=$(cat VERSION | sed '1q;d')
           export ARCH=$(cat VERSION | sed '4q;d')
           ../azure-pipelines/util/build_appimage.sh
-          # Move and rename the generated AppImage file
+          # Move and rename the generated AppImage file (and zsync file for AppImageUpdate)
           find . -name '*.AppImage' -not -name 'linuxdeploy.AppImage' -exec mv {} packages/xournalpp-$VERSION-$ARCH.AppImage \;
+          find . -name '*.AppImage.zsync' -not -name 'linuxdeploy.AppImage.zsync' -exec mv {} packages/xournalpp-$VERSION-$ARCH.AppImage.zsync \;
         workingDirectory: ./build
         displayName: 'Create AppImage'
         condition: eq('${{ parameters.build_appimage }}', true)

--- a/azure-pipelines/util/build_appimage.sh
+++ b/azure-pipelines/util/build_appimage.sh
@@ -44,5 +44,9 @@ ICON_FILE="$APPDIR"/usr/share/icons/hicolor/scalable/apps/com.github.xournalpp.x
 DESKTOP_FILE="$APPDIR"/usr/share/applications/com.github.xournalpp.xournalpp.desktop
 echo "Use the icon file $ICON_FILE and the desktop file $DESKTOP_FILE"
 
+appimage_name='appimage'
+
+export UPD_INFO="gh-releases-zsync|xournalpp|xournalpp|latest|$appimage_name.zsync"
+
 # call through linuxdeploy
-./"$LINUXDEPLOY" --appdir="$APPDIR" --plugin gtk --plugin gettext --output appimage --icon-file="$ICON_FILE" --desktop-file="$DESKTOP_FILE"
+./"$LINUXDEPLOY" --appdir="$APPDIR" --plugin gtk --plugin gettext --output "$appimage_name" --icon-file="$ICON_FILE" --desktop-file="$DESKTOP_FILE"


### PR DESCRIPTION
This modifies the build script such that now a `.zsync` file is written in `./build`, for AppImage Update. Closes #1915

Documentation used (for future reference):

- [Usage of `UPD_INFO`](https://github.com/AppImageCommunity/AppImageUpdate/blob/af298b7aebfab4bcee7490a86f0471cc22db248b/ci/build-appimages.sh#L100)
- [Documentation](https://github.com/AppImage/AppImageSpec/blob/ce1910e6443357e3406a40d458f78ba3f34293b8/draft.md#github-releases) for `gh-releases-zsync`

The original issue states that:

> create a .zsync file, which you, by default, just need to put next to the AppImage (e.g., on GitHub, just upload both together)

I couldn't find the script that uploads the built artifacts to GitHub. Is that script located here or is the publishing step a manual one and this can just be merged?