### PR TITLE
explicitly focus out im context

### DIFF
--- a/src/core/gui/TextEditor.cpp
+++ b/src/core/gui/TextEditor.cpp
@@ -68,6 +68,8 @@ TextEditor::TextEditor(XojPageView* gui, GtkWidget* widget, Text* text, bool own
 }
 
 TextEditor::~TextEditor() {
+    gtk_im_context_focus_out(this->imContext);
+
     this->text->setInEditing(false);
     this->widget = nullptr;
 


### PR DESCRIPTION
This fixes a crash on wayland on rocky8  (and likely other RHEL8-ish distros) when opening a save dialog after using the text tool. Fixes issue #4279.