### PR TITLE
Minimum size for shape recognizer now customizable

### DIFF
--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -133,6 +133,9 @@ void Settings::loadDefault() {
     this->snapGridTolerance = 0.50;
     this->snapGridSize = DEFAULT_GRID_SIZE;
 
+    this->strokeRecognizerMinX = 30;
+    this->strokeRecognizerMinY = 30;
+
     this->touchDrawing = false;
     this->gtkTouchInertialScrolling = true;
 
@@ -488,6 +491,10 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur) {
         this->snapGridSize = tempg_ascii_strtod(reinterpret_cast<const char*>(value), nullptr);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("snapGridTolerance")) == 0) {
         this->snapGridTolerance = tempg_ascii_strtod(reinterpret_cast<const char*>(value), nullptr);
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("strokeRecognizerMinX")) == 0) {
+        this->strokeRecognizerMinX = tempg_ascii_strtod(reinterpret_cast<const char*>(value), nullptr);
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("strokeRecognizerMinY")) == 0) {
+        this->strokeRecognizerMinY = tempg_ascii_strtod(reinterpret_cast<const char*>(value), nullptr);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("touchDrawing")) == 0) {
         this->touchDrawing = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("gtkTouchInertialScrolling")) == 0) {
@@ -955,6 +962,9 @@ void Settings::save() {
     SAVE_DOUBLE_PROP(snapGridTolerance);
     SAVE_DOUBLE_PROP(snapGridSize);
 
+    SAVE_DOUBLE_PROP(strokeRecognizerMinX);
+    SAVE_DOUBLE_PROP(strokeRecognizerMinY);
+
     SAVE_BOOL_PROP(touchDrawing);
     SAVE_BOOL_PROP(gtkTouchInertialScrolling);
     SAVE_BOOL_PROP(pressureGuessing);
@@ -1049,7 +1059,9 @@ void Settings::save() {
     xmlSetProp(xmlFont, reinterpret_cast<const xmlChar*>("size"), reinterpret_cast<const xmlChar*>(sSize));
 
 
-    for (std::map<string, SElement>::value_type p: data) { saveData(root, p.first, p.second); }
+    for (std::map<string, SElement>::value_type p: data) {
+        saveData(root, p.first, p.second);
+    }
 
     xmlSaveFormatFileEnc(filepath.u8string().c_str(), doc, "UTF-8", 1);
     xmlFreeDoc(doc);
@@ -1111,7 +1123,9 @@ void Settings::saveData(xmlNodePtr root, const string& name, SElement& elem) {
         }
     }
 
-    for (std::map<string, SElement>::value_type p: elem.children()) { saveData(xmlNode, p.first, p.second); }
+    for (std::map<string, SElement>::value_type p: elem.children()) {
+        saveData(xmlNode, p.first, p.second);
+    }
 }
 
 // Getter- / Setter
@@ -1360,6 +1374,25 @@ void Settings::setSnapGridSize(double gridSize) {
     this->snapGridSize = gridSize;
     save();
 }
+
+auto Settings::getStrokeRecognizerMinX() const -> double { return this->strokeRecognizerMinX; };
+void Settings::setStrokeRecognizerMinX(double value) {
+    if (this->strokeRecognizerMinX == value) {
+        return;
+    }
+
+    this->strokeRecognizerMinX = value;
+    save();
+};
+auto Settings::getStrokeRecognizerMinY() const -> double { return this->strokeRecognizerMinY; };
+void Settings::setStrokeRecognizerMinY(double value) {
+    if (this->strokeRecognizerMinY == value) {
+        return;
+    }
+
+    this->strokeRecognizerMinY = value;
+    save();
+};
 
 auto Settings::getTouchDrawingEnabled() const -> bool { return this->touchDrawing; }
 

--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -133,8 +133,7 @@ void Settings::loadDefault() {
     this->snapGridTolerance = 0.50;
     this->snapGridSize = DEFAULT_GRID_SIZE;
 
-    this->strokeRecognizerMinX = 30;
-    this->strokeRecognizerMinY = 30;
+    this->strokeRecognizerMinSize = 40;
 
     this->touchDrawing = false;
     this->gtkTouchInertialScrolling = true;
@@ -491,10 +490,8 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur) {
         this->snapGridSize = tempg_ascii_strtod(reinterpret_cast<const char*>(value), nullptr);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("snapGridTolerance")) == 0) {
         this->snapGridTolerance = tempg_ascii_strtod(reinterpret_cast<const char*>(value), nullptr);
-    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("strokeRecognizerMinX")) == 0) {
-        this->strokeRecognizerMinX = tempg_ascii_strtod(reinterpret_cast<const char*>(value), nullptr);
-    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("strokeRecognizerMinY")) == 0) {
-        this->strokeRecognizerMinY = tempg_ascii_strtod(reinterpret_cast<const char*>(value), nullptr);
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("strokeRecognizerMinSize")) == 0) {
+        this->strokeRecognizerMinSize = tempg_ascii_strtod(reinterpret_cast<const char*>(value), nullptr);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("touchDrawing")) == 0) {
         this->touchDrawing = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("gtkTouchInertialScrolling")) == 0) {
@@ -962,8 +959,7 @@ void Settings::save() {
     SAVE_DOUBLE_PROP(snapGridTolerance);
     SAVE_DOUBLE_PROP(snapGridSize);
 
-    SAVE_DOUBLE_PROP(strokeRecognizerMinX);
-    SAVE_DOUBLE_PROP(strokeRecognizerMinY);
+    SAVE_DOUBLE_PROP(strokeRecognizerMinSize);
 
     SAVE_BOOL_PROP(touchDrawing);
     SAVE_BOOL_PROP(gtkTouchInertialScrolling);
@@ -1375,22 +1371,13 @@ void Settings::setSnapGridSize(double gridSize) {
     save();
 }
 
-auto Settings::getStrokeRecognizerMinX() const -> double { return this->strokeRecognizerMinX; };
-void Settings::setStrokeRecognizerMinX(double value) {
-    if (this->strokeRecognizerMinX == value) {
+auto Settings::getStrokeRecognizerMinSize() const -> double { return this->strokeRecognizerMinSize; };
+void Settings::setStrokeRecognizerMinSize(double value) {
+    if (this->strokeRecognizerMinSize == value) {
         return;
     }
 
-    this->strokeRecognizerMinX = value;
-    save();
-};
-auto Settings::getStrokeRecognizerMinY() const -> double { return this->strokeRecognizerMinY; };
-void Settings::setStrokeRecognizerMinY(double value) {
-    if (this->strokeRecognizerMinY == value) {
-        return;
-    }
-
-    this->strokeRecognizerMinY = value;
+    this->strokeRecognizerMinSize = value;
     save();
 };
 

--- a/src/core/control/settings/Settings.h
+++ b/src/core/control/settings/Settings.h
@@ -298,10 +298,8 @@ public:
     double getSnapGridSize() const;
     void setSnapGridSize(double gridSize);
 
-    double getStrokeRecognizerMinX() const;
-    void setStrokeRecognizerMinX(double value);
-    double getStrokeRecognizerMinY() const;
-    void setStrokeRecognizerMinY(double value);
+    double getStrokeRecognizerMinSize() const;
+    void setStrokeRecognizerMinSize(double value);
 
     StylusCursorType getStylusCursorType() const;
     void setStylusCursorType(StylusCursorType stylusCursorType);
@@ -928,8 +926,10 @@ private:
     /// Grid size for Snapping
     double snapGridSize{};
 
-    double strokeRecognizerMinX{};
-    double strokeRecognizerMinY{};
+    /**
+     * Minimum size of stroke to detect shape
+     */
+    double strokeRecognizerMinSize{};
 
     /// Touchscreens act like multi-touch-aware pens.
     bool touchDrawing{};

--- a/src/core/control/settings/Settings.h
+++ b/src/core/control/settings/Settings.h
@@ -298,6 +298,11 @@ public:
     double getSnapGridSize() const;
     void setSnapGridSize(double gridSize);
 
+    double getStrokeRecognizerMinX() const;
+    void setStrokeRecognizerMinX(double value);
+    double getStrokeRecognizerMinY() const;
+    void setStrokeRecognizerMinY(double value);
+
     StylusCursorType getStylusCursorType() const;
     void setStylusCursorType(StylusCursorType stylusCursorType);
 
@@ -922,6 +927,9 @@ private:
 
     /// Grid size for Snapping
     double snapGridSize{};
+
+    double strokeRecognizerMinX{};
+    double strokeRecognizerMinY{};
 
     /// Touchscreens act like multi-touch-aware pens.
     bool touchDrawing{};

--- a/src/core/control/shaperecognizer/ShapeRecognizer.cpp
+++ b/src/core/control/shaperecognizer/ShapeRecognizer.cpp
@@ -244,26 +244,25 @@ void ShapeRecognizer::optimizePolygonal(const Point* pt, int nsides, int* breaks
     }
 }
 
-auto ShapeRecognizer::isStrokeLargeEnough(Stroke* stroke, double strokeMinX, double strokeMinY) -> bool {
+/**
+ * Determine if a particular stroke is large enough as to make a shape out of it
+ */
+auto ShapeRecognizer::isStrokeLargeEnough(Stroke* stroke, double strokeMinSize) -> bool {
     if (stroke->getPointCount() < 3) {
         return false;
     }
 
     auto rect = stroke->getSnappedBounds();
-    if (rect.width < strokeMinX && rect.height < strokeMinY) {
-        return false;
-    }
-
-    return true;
+    return std::hypot(rect.width, rect.height) >= strokeMinSize;
 }
 
 /**
  * The main pattern recognition function
  */
-auto ShapeRecognizer::recognizePatterns(Stroke* stroke, double strokeMinX, double strokeMinY) -> Stroke* {
+auto ShapeRecognizer::recognizePatterns(Stroke* stroke, double strokeMinSize) -> Stroke* {
     this->stroke = stroke;
 
-    if (!isStrokeLargeEnough(stroke, strokeMinX, strokeMinY)) {
+    if (!isStrokeLargeEnough(stroke, strokeMinSize)) {
         return nullptr;
     }
 

--- a/src/core/control/shaperecognizer/ShapeRecognizer.cpp
+++ b/src/core/control/shaperecognizer/ShapeRecognizer.cpp
@@ -87,7 +87,9 @@ auto ShapeRecognizer::tryRectangle() -> Stroke* {
     auto* s = new Stroke();
     s->applyStyleFrom(this->stroke);
 
-    for (int i = 0; i <= 3; i++) { rs[i].angle = avgAngle + i * M_PI / 2; }
+    for (int i = 0; i <= 3; i++) {
+        rs[i].angle = avgAngle + i * M_PI / 2;
+    }
 
     for (int i = 0; i <= 3; i++) {
         Point p = rs[i].calcEdgeIsect(&rs[(i + 1) % 4]);
@@ -242,13 +244,26 @@ void ShapeRecognizer::optimizePolygonal(const Point* pt, int nsides, int* breaks
     }
 }
 
+auto ShapeRecognizer::isStrokeLargeEnough(Stroke* stroke, double strokeMinX, double strokeMinY) -> bool {
+    if (stroke->getPointCount() < 3) {
+        return false;
+    }
+
+    auto rect = stroke->getSnappedBounds();
+    if (rect.width < strokeMinX && rect.height < strokeMinY) {
+        return false;
+    }
+
+    return true;
+}
+
 /**
  * The main pattern recognition function
  */
-auto ShapeRecognizer::recognizePatterns(Stroke* stroke) -> Stroke* {
+auto ShapeRecognizer::recognizePatterns(Stroke* stroke, double strokeMinX, double strokeMinY) -> Stroke* {
     this->stroke = stroke;
 
-    if (stroke->getPointCount() < 3) {
+    if (!isStrokeLargeEnough(stroke, strokeMinX, strokeMinY)) {
         return nullptr;
     }
 
@@ -271,7 +286,9 @@ auto ShapeRecognizer::recognizePatterns(Stroke* stroke) -> Stroke* {
         while (n + queueLength > MAX_POLYGON_SIDES) {
             // remove oldest polygonal stroke
             int i = 1;
-            while (i < queueLength && queue[i].startpt != 0) { i++; }
+            while (i < queueLength && queue[i].startpt != 0) {
+                i++;
+            }
             queueLength -= i;
             std::move(std::next(begin(queue), i), std::next(begin(queue), i + queueLength), begin(queue));
         }

--- a/src/core/control/shaperecognizer/ShapeRecognizer.h
+++ b/src/core/control/shaperecognizer/ShapeRecognizer.h
@@ -26,7 +26,7 @@ public:
     ShapeRecognizer();
     virtual ~ShapeRecognizer();
 
-    Stroke* recognizePatterns(Stroke* stroke, double strokeMinX, double strokeMinY);
+    Stroke* recognizePatterns(Stroke* stroke, double strokeMinSize);
     void resetRecognizer();
 
 private:
@@ -37,7 +37,7 @@ private:
 
     int findPolygonal(const Point* pt, int start, int end, int nsides, int* breaks, Inertia* ss);
 
-    bool isStrokeLargeEnough(Stroke* stroke, double strokeMinX, double strokeMinY);
+    static bool isStrokeLargeEnough(Stroke* stroke, double strokeMinSize);
 
 private:
     std::array<RecoSegment, MAX_POLYGON_SIDES + 1> queue{};

--- a/src/core/control/shaperecognizer/ShapeRecognizer.h
+++ b/src/core/control/shaperecognizer/ShapeRecognizer.h
@@ -26,7 +26,7 @@ public:
     ShapeRecognizer();
     virtual ~ShapeRecognizer();
 
-    Stroke* recognizePatterns(Stroke* stroke);
+    Stroke* recognizePatterns(Stroke* stroke, double strokeMinX, double strokeMinY);
     void resetRecognizer();
 
 private:
@@ -36,6 +36,8 @@ private:
     static void optimizePolygonal(const Point* pt, int nsides, int* breaks, Inertia* ss);
 
     int findPolygonal(const Point* pt, int start, int end, int nsides, int* breaks, Inertia* ss);
+
+    bool isStrokeLargeEnough(Stroke* stroke, double strokeMinX, double strokeMinY);
 
 private:
     std::array<RecoSegment, MAX_POLYGON_SIDES + 1> queue{};

--- a/src/core/control/tools/StrokeHandler.cpp
+++ b/src/core/control/tools/StrokeHandler.cpp
@@ -274,7 +274,10 @@ void StrokeHandler::onButtonReleaseEvent(const PositionInputData& pos, double zo
     if (h->getDrawingType() == DRAWING_TYPE_STROKE_RECOGNIZER) {
         ShapeRecognizer reco;
 
-        Stroke* recognized = reco.recognizePatterns(stroke.get());
+        auto settings = control->getSettings();
+        auto strokeMinX = settings->getStrokeRecognizerMinX();
+        auto strokeMinY = settings->getStrokeRecognizerMinY();
+        Stroke* recognized = reco.recognizePatterns(stroke.get(), strokeMinX, strokeMinY);
 
         if (recognized) {
             strokeRecognizerDetected(recognized, layer);

--- a/src/core/control/tools/StrokeHandler.cpp
+++ b/src/core/control/tools/StrokeHandler.cpp
@@ -274,10 +274,7 @@ void StrokeHandler::onButtonReleaseEvent(const PositionInputData& pos, double zo
     if (h->getDrawingType() == DRAWING_TYPE_STROKE_RECOGNIZER) {
         ShapeRecognizer reco;
 
-        auto settings = control->getSettings();
-        auto strokeMinX = settings->getStrokeRecognizerMinX();
-        auto strokeMinY = settings->getStrokeRecognizerMinY();
-        Stroke* recognized = reco.recognizePatterns(stroke.get(), strokeMinX, strokeMinY);
+        Stroke* recognized = reco.recognizePatterns(stroke.get(), control->getSettings()->getStrokeRecognizerMinSize());
 
         if (recognized) {
             strokeRecognizerDetected(recognized, layer);

--- a/src/core/gui/dialog/SettingsDialog.cpp
+++ b/src/core/gui/dialog/SettingsDialog.cpp
@@ -435,11 +435,8 @@ void SettingsDialog::load() {
     GtkWidget* spSnapGridSize = get("spSnapGridSize");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spSnapGridSize), settings->getSnapGridSize() / DEFAULT_GRID_SIZE);
 
-    GtkWidget* spStrokeRecognizerX = get("spStrokeRecognizerMinX");
-    gtk_spin_button_set_value(GTK_SPIN_BUTTON(spStrokeRecognizerX), settings->getStrokeRecognizerMinX());
-
-    GtkWidget* spStrokeRecognizerY = get("spStrokeRecognizerMinY");
-    gtk_spin_button_set_value(GTK_SPIN_BUTTON(spStrokeRecognizerY), settings->getStrokeRecognizerMinY());
+    GtkWidget* spStrokeRecognizerMinSize = get("spStrokeRecognizerMinSize");
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(spStrokeRecognizerMinSize), settings->getStrokeRecognizerMinSize());
 
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(get("edgePanSpeed")), settings->getEdgePanSpeed());
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(get("edgePanMaxMult")), settings->getEdgePanMaxMult());
@@ -921,10 +918,8 @@ void SettingsDialog::save() {
     settings->setSnapGridSize(
             static_cast<double>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spSnapGridSize"))) * DEFAULT_GRID_SIZE));
 
-    settings->setStrokeRecognizerMinX(
-            static_cast<double>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spStrokeRecognizerMinX")))));
-    settings->setStrokeRecognizerMinY(
-            static_cast<double>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spStrokeRecognizerMinY")))));
+    settings->setStrokeRecognizerMinSize(
+            static_cast<double>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spStrokeRecognizerMinSize")))));
 
     int selectedInputDeviceIndex = gtk_combo_box_get_active(GTK_COMBO_BOX(get("cbAudioInputDevice"))) - 1;
     if (selectedInputDeviceIndex >= 0 && selectedInputDeviceIndex < static_cast<int>(this->audioInputDevices.size())) {

--- a/src/core/gui/dialog/SettingsDialog.cpp
+++ b/src/core/gui/dialog/SettingsDialog.cpp
@@ -172,10 +172,14 @@ SettingsDialog::SettingsDialog(GladeSearchpath* gladeSearchPath, Settings* setti
 }
 
 SettingsDialog::~SettingsDialog() {
-    for (ButtonConfigGui* bcg: this->buttonConfigs) { delete bcg; }
+    for (ButtonConfigGui* bcg: this->buttonConfigs) {
+        delete bcg;
+    }
     this->buttonConfigs.clear();
 
-    for (DeviceClassConfigGui* dev: this->deviceClassConfigs) { delete dev; }
+    for (DeviceClassConfigGui* dev: this->deviceClassConfigs) {
+        delete dev;
+    }
     this->deviceClassConfigs.clear();
 
     // DO NOT delete settings!
@@ -430,6 +434,12 @@ void SettingsDialog::load() {
 
     GtkWidget* spSnapGridSize = get("spSnapGridSize");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spSnapGridSize), settings->getSnapGridSize() / DEFAULT_GRID_SIZE);
+
+    GtkWidget* spStrokeRecognizerX = get("spStrokeRecognizerMinX");
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(spStrokeRecognizerX), settings->getStrokeRecognizerMinX());
+
+    GtkWidget* spStrokeRecognizerY = get("spStrokeRecognizerMinY");
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(spStrokeRecognizerY), settings->getStrokeRecognizerMinY());
 
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(get("edgePanSpeed")), settings->getEdgePanSpeed());
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(get("edgePanMaxMult")), settings->getEdgePanMaxMult());
@@ -877,7 +887,9 @@ void SettingsDialog::save() {
 
     settings->setDisplayDpi(dpi);
 
-    for (ButtonConfigGui* bcg: this->buttonConfigs) { bcg->saveSettings(); }
+    for (ButtonConfigGui* bcg: this->buttonConfigs) {
+        bcg->saveSettings();
+    }
 
     languageConfig->saveSettings();
 
@@ -908,6 +920,11 @@ void SettingsDialog::save() {
             static_cast<double>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spSnapGridTolerance")))));
     settings->setSnapGridSize(
             static_cast<double>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spSnapGridSize"))) * DEFAULT_GRID_SIZE));
+
+    settings->setStrokeRecognizerMinX(
+            static_cast<double>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spStrokeRecognizerMinX")))));
+    settings->setStrokeRecognizerMinY(
+            static_cast<double>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spStrokeRecognizerMinY")))));
 
     int selectedInputDeviceIndex = gtk_combo_box_get_active(GTK_COMBO_BOX(get("cbAudioInputDevice"))) - 1;
     if (selectedInputDeviceIndex >= 0 && selectedInputDeviceIndex < static_cast<int>(this->audioInputDevices.size())) {
@@ -941,7 +958,9 @@ void SettingsDialog::save() {
     settings->setDefaultSeekTime(
             static_cast<double>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spDefaultSeekTime")))));
 
-    for (DeviceClassConfigGui* deviceClassConfigGui: this->deviceClassConfigs) { deviceClassConfigGui->saveSettings(); }
+    for (DeviceClassConfigGui* deviceClassConfigGui: this->deviceClassConfigs) {
+        deviceClassConfigGui->saveSettings();
+    }
 
     this->latexPanel.save(settings->latexSettings);
 

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.18"/>
   <object class="GtkAdjustment" id="adjustmentAudioGain">
@@ -153,6 +153,18 @@
   <object class="GtkAdjustment" id="adjustmentStrokeIgnoreTime">
     <property name="upper">1000</property>
     <property name="value">150</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustmentStrokeRecognizerMinX">
+    <property name="lower">1</property>
+    <property name="upper">200</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustmentStrokeRecognizerMinY">
+    <property name="lower">1</property>
+    <property name="upper">200</property>
     <property name="step-increment">1</property>
     <property name="page-increment">10</property>
   </object>
@@ -2592,7 +2604,7 @@ This setting can make it easier to draw with touch. </property>
                               <object class="GtkFrame" id="frameTouchScrolling">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
-                                <property name="label-xalign">0.01</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
                                   <object class="GtkAlignment" id="touchScrollingFrameAlignment">
                                     <property name="visible">True</property>
@@ -2974,12 +2986,6 @@ This setting can make it easier to draw with touch. </property>
                                                         <property name="top-attach">3</property>
                                                         <property name="width">2</property>
                                                       </packing>
-                                                    </child>
-                                                    <child>
-                                                      <placeholder/>
-                                                    </child>
-                                                    <child>
-                                                      <placeholder/>
                                                     </child>
                                                     <child>
                                                       <placeholder/>
@@ -4786,6 +4792,115 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                               </packing>
                             </child>
                             <child>
+                              <object class="GtkFrame" id="strokeRecognizerFrrame">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0</property>
+                                <child>
+                                  <object class="GtkAlignment">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="left-padding">12</property>
+                                    <child>
+                                      <object class="GtkBox">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                          <!-- n-columns=3 n-rows=2 -->
+                                          <object class="GtkGrid" id="sid6">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="row-spacing">5</property>
+                                            <property name="column-spacing">5</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="name">lbStrokeRecognizerMinX</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">Minimum X</property>
+                                                <property name="xalign">0</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="name">lbStrokeRecognizerMinY</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">Minimum Y</property>
+                                                <property name="xalign">0</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">1</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSpinButton" id="spStrokeRecognizerMinX">
+                                                <property name="name">spStrokeRecognizerMinX</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="text" translatable="yes">0.20</property>
+                                                <property name="adjustment">adjustmentStrokeRecognizerMinX</property>
+                                                <property name="climb-rate">2</property>
+                                                <property name="value">25</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSpinButton" id="spStrokeRecognizerMinY">
+                                                <property name="name">spStrokeRecognizerMinY</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="text" translatable="yes">0.25</property>
+                                                <property name="adjustment">adjustmentStrokeRecognizerMinY</property>
+                                                <property name="climb-rate">2</property>
+                                                <property name="value">25</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">1</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label">
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">Stroke Recognizer</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">5</property>
+                              </packing>
+                            </child>
+                            <child>
                               <object class="GtkFrame" id="sid154">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
@@ -4977,7 +5092,7 @@ It must be short in time and length and we can't have ignored another stroke rec
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">5</property>
+                                <property name="position">6</property>
                               </packing>
                             </child>
                             <child>
@@ -5106,7 +5221,7 @@ Set this to 0% to always re-render on zoom.</property>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">6</property>
+                                <property name="position">7</property>
                               </packing>
                             </child>
                           </object>

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -156,13 +156,7 @@
     <property name="step-increment">1</property>
     <property name="page-increment">10</property>
   </object>
-  <object class="GtkAdjustment" id="adjustmentStrokeRecognizerMinX">
-    <property name="lower">1</property>
-    <property name="upper">200</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">10</property>
-  </object>
-  <object class="GtkAdjustment" id="adjustmentStrokeRecognizerMinY">
+  <object class="GtkAdjustment" id="adjustmentStrokeRecognizerMinSize">
     <property name="lower">1</property>
     <property name="upper">200</property>
     <property name="step-increment">1</property>
@@ -4807,7 +4801,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                         <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
-                                          <!-- n-columns=3 n-rows=2 -->
+                                          <!-- n-columns=3 n-rows=1 -->
                                           <object class="GtkGrid" id="sid6">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
@@ -4815,10 +4809,10 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                             <property name="column-spacing">5</property>
                                             <child>
                                               <object class="GtkLabel">
-                                                <property name="name">lbStrokeRecognizerMinX</property>
+                                                <property name="name">lbStrokeRecognizerMinSize</property>
                                                 <property name="visible">True</property>
                                                 <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">Minimum X</property>
+                                                <property name="label" translatable="yes">Minimum Stroke Size</property>
                                                 <property name="xalign">0</property>
                                               </object>
                                               <packing>
@@ -4827,25 +4821,12 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                               </packing>
                                             </child>
                                             <child>
-                                              <object class="GtkLabel">
-                                                <property name="name">lbStrokeRecognizerMinY</property>
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">Minimum Y</property>
-                                                <property name="xalign">0</property>
-                                              </object>
-                                              <packing>
-                                                <property name="left-attach">0</property>
-                                                <property name="top-attach">1</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkSpinButton" id="spStrokeRecognizerMinX">
-                                                <property name="name">spStrokeRecognizerMinX</property>
+                                              <object class="GtkSpinButton" id="spStrokeRecognizerMinSize">
+                                                <property name="name">spStrokeRecognizerMinSize</property>
                                                 <property name="visible">True</property>
                                                 <property name="can-focus">True</property>
                                                 <property name="text" translatable="yes">0.20</property>
-                                                <property name="adjustment">adjustmentStrokeRecognizerMinX</property>
+                                                <property name="adjustment">adjustmentStrokeRecognizerMinSize</property>
                                                 <property name="climb-rate">2</property>
                                                 <property name="value">25</property>
                                               </object>
@@ -4853,24 +4834,6 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                                 <property name="left-attach">1</property>
                                                 <property name="top-attach">0</property>
                                               </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkSpinButton" id="spStrokeRecognizerMinY">
-                                                <property name="name">spStrokeRecognizerMinY</property>
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="text" translatable="yes">0.25</property>
-                                                <property name="adjustment">adjustmentStrokeRecognizerMinY</property>
-                                                <property name="climb-rate">2</property>
-                                                <property name="value">25</property>
-                                              </object>
-                                              <packing>
-                                                <property name="left-attach">1</property>
-                                                <property name="top-attach">1</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
                                             </child>
                                             <child>
                                               <placeholder/>


### PR DESCRIPTION
When "shape recognizer" mode is enabled, and when a "pen stroke happens", the new code does the following:
  - take the minimum and maximum values for both the X and Y axis
  - if the bigger X value minus the smaller X value is less than the "minimum size" (and if this holds true for the Y values too), then it does not draw the shape

Note that some of the changes in the diff are due to `clang-format`

Closes #2531

Validation:
- Manual testing
