### PR TITLE
Fix many diagnostic warnings

### DIFF
--- a/src/core/audio/AudioRecorder.cpp
+++ b/src/core/audio/AudioRecorder.cpp
@@ -6,7 +6,6 @@
 #include "audio/VorbisConsumer.h"     // for VorbisConsumer
 
 AudioRecorder::AudioRecorder(Settings& settings):
-        settings(settings),
         audioQueue(std::make_unique<AudioQueue<float>>()),
         portAudioProducer(std::make_unique<PortAudioProducer>(settings, *audioQueue)),
         vorbisConsumer(std::make_unique<VorbisConsumer>(settings, *audioQueue)) {}

--- a/src/core/audio/AudioRecorder.h
+++ b/src/core/audio/AudioRecorder.h
@@ -23,7 +23,8 @@ class PortAudioProducer;
 class Settings;
 class VorbisConsumer;
 
-struct AudioRecorder final {
+class AudioRecorder final {
+public:
     explicit AudioRecorder(Settings& settings);
     AudioRecorder(AudioRecorder const&) = delete;
     AudioRecorder(AudioRecorder&&) = delete;

--- a/src/core/audio/AudioRecorder.h
+++ b/src/core/audio/AudioRecorder.h
@@ -34,12 +34,10 @@ public:
 
     bool start(fs::path const& file);
     void stop();
-    bool isRecording() const;
+    [[nodiscard]] bool isRecording() const;
     std::vector<DeviceInfo> getInputDevices() const;
 
 private:
-    Settings& settings;
-
     std::unique_ptr<AudioQueue<float>> audioQueue;
     std::unique_ptr<PortAudioProducer> portAudioProducer;
     std::unique_ptr<VorbisConsumer> vorbisConsumer;

--- a/src/core/audio/VorbisProducer.h
+++ b/src/core/audio/VorbisProducer.h
@@ -19,7 +19,8 @@
 template <typename T>
 class AudioQueue;
 
-struct VorbisProducer final {
+class VorbisProducer final {
+public:
     explicit VorbisProducer(AudioQueue<float>& audioQueue): audioQueue(audioQueue) {}
 
     bool start(fs::path const& file, unsigned int timestamp);

--- a/src/core/control/Tool.cpp
+++ b/src/core/control/Tool.cpp
@@ -5,11 +5,11 @@
 
 Tool::Tool(std::string name, ToolType type, Color color, unsigned int capabilities,
            std::optional<std::array<double, toolSizes>> thickness):
-        name{std::move(name)}, type{type}, capabilities{capabilities}, thickness{std::move(thickness)} {
+        name{std::move(name)}, type{type}, thickness{std::move(thickness)}, capabilities{capabilities} {
     setColor(color);
 }
 
-Tool::Tool(const Tool& t): name{t.name}, type{t.type}, capabilities{t.capabilities}, thickness{t.thickness} {
+Tool::Tool(const Tool& t): name{t.name}, type{t.type}, thickness{t.thickness}, capabilities{t.capabilities} {
     setColor(t.getColor());
 }
 

--- a/src/core/control/XournalMain.cpp
+++ b/src/core/control/XournalMain.cpp
@@ -68,11 +68,6 @@ auto migrateSettings() -> MigrateResult;
 void checkForErrorlog();
 void checkForEmergencySave(Control* control);
 
-auto exportPdf(const char* input, const char* output, const char* range, ExportBackgroundType exportBackground,
-               bool progressiveMode) -> int;
-auto exportImg(const char* input, const char* output, const char* range, int pngDpi, int pngWidth, int pngHeight,
-               ExportBackgroundType exportBackground) -> int;
-
 void initResourcePath(GladeSearchpath* gladePath, const gchar* relativePathAndFile, bool failIfNotFound = true);
 
 void initCAndCoutLocales() {

--- a/src/core/control/XournalMain.cpp
+++ b/src/core/control/XournalMain.cpp
@@ -454,7 +454,9 @@ void on_startup(GApplication* application, XMPtr app_data) {
             }
         }
 
-        for (auto& p: iconLoadOrder) { gtk_icon_theme_prepend_search_path(gtk_icon_theme_get_default(), p.c_str()); }
+        for (auto& p: iconLoadOrder) {
+            gtk_icon_theme_prepend_search_path(gtk_icon_theme_get_default(), p.c_str());
+        }
     }
 
     auto& globalLatexTemplatePath = app_data->control->getSettings()->latexSettings.globalTemplatePath;
@@ -526,9 +528,9 @@ auto on_handle_local_options(GApplication*, GVariantDict*, XMPtr app_data) -> gi
     initCAndCoutLocales();
 
     auto print_version = [&] {
-        if(!std::string(GIT_COMMIT_ID).empty()){
+        if (!std::string(GIT_COMMIT_ID).empty()) {
             std::cout << PROJECT_NAME << " " << PROJECT_VERSION << " (" << GIT_COMMIT_ID << ")" << std::endl;
-        } else{
+        } else {
             std::cout << PROJECT_NAME << " " << PROJECT_VERSION << std::endl;
         }
         std::cout << "└──libgtk: " << gtk_get_major_version() << "."  //

--- a/src/core/control/tools/EditSelection.cpp
+++ b/src/core/control/tools/EditSelection.cpp
@@ -52,13 +52,13 @@ constexpr int ROTATE_PADDING = 8;
 constexpr unsigned int PAN_TIMER_RATE = 30;
 
 EditSelection::EditSelection(UndoRedoHandler* undo, const PageRef& page, XojPageView* view):
-        snappingHandler(view->getXournal()->getControl()->getSettings()),
         x(0),
         y(0),
         rotation(0),
         width(0),
         height(0),
-        snappedBounds(Rectangle<double>{}) {
+        snappedBounds(Rectangle<double>{}),
+        snappingHandler(view->getXournal()->getControl()->getSettings()) {
     construct(undo, view, page);
 }
 

--- a/src/core/control/tools/EditSelectionContents.cpp
+++ b/src/core/control/tools/EditSelectionContents.cpp
@@ -41,8 +41,8 @@ using xoj::util::Rectangle;
 
 EditSelectionContents::EditSelectionContents(Rectangle<double> bounds, Rectangle<double> snappedBounds,
                                              const PageRef& sourcePage, Layer* sourceLayer, XojPageView* sourceView):
-        lastBounds(bounds),
         originalBounds(bounds),
+        lastBounds(bounds),
         lastSnappedBounds(snappedBounds),
         sourcePage(sourcePage),
         sourceLayer(sourceLayer),

--- a/src/core/gui/FloatingToolbox.h
+++ b/src/core/gui/FloatingToolbox.h
@@ -92,5 +92,4 @@ private:
     int floatingToolboxX = 0;
     int floatingToolboxY = 0;
     FloatingToolBoxState floatingToolboxState = recalcSize;
-    int numWidgets = 0;
 };

--- a/src/core/gui/dialog/LatexSettingsPanel.cpp
+++ b/src/core/gui/dialog/LatexSettingsPanel.cpp
@@ -28,8 +28,8 @@ class GladeSearchpath;
 LatexSettingsPanel::LatexSettingsPanel(GladeSearchpath* gladeSearchPath):
         GladeGui(gladeSearchPath, "latexSettings.glade", "latexSettingsPanel"),
         cbAutoDepCheck(GTK_TOGGLE_BUTTON(this->get("latexSettingsRunCheck"))),
-        cbUseSystemFont(GTK_TOGGLE_BUTTON(this->get("cbUseSystemFont"))),
-        globalTemplateChooser(GTK_FILE_CHOOSER(this->get("latexSettingsTemplateFile"))) {
+        globalTemplateChooser(GTK_FILE_CHOOSER(this->get("latexSettingsTemplateFile"))),
+        cbUseSystemFont(GTK_TOGGLE_BUTTON(this->get("cbUseSystemFont"))) {
     g_object_ref(this->cbAutoDepCheck);
     g_object_ref(this->cbUseSystemFont);
     g_object_ref(this->globalTemplateChooser);

--- a/src/core/gui/dialog/RenameLayerDialog.cpp
+++ b/src/core/gui/dialog/RenameLayerDialog.cpp
@@ -14,7 +14,7 @@ class Layer;
 
 RenameLayerDialog::RenameLayerDialog(GladeSearchpath* gladeSearchPath, UndoRedoHandler* undo, LayerController* lc,
                                      Layer* l):
-        GladeGui(gladeSearchPath, "renameLayerDialog.glade", "renameLayerDialog"), undo(undo), lc(lc), l(l) {
+        GladeGui(gladeSearchPath, "renameLayerDialog.glade", "renameLayerDialog"), lc(lc), undo(undo), l(l) {
     gtk_entry_set_text(GTK_ENTRY(get("layerNameEntry")), lc->getCurrentLayerName().c_str());
 
     g_signal_connect(get("renameButton"), "clicked", G_CALLBACK(renameSuccessful), this);

--- a/src/core/gui/dialog/toolbarCustomize/ToolbarAdapter.h
+++ b/src/core/gui/dialog/toolbarCustomize/ToolbarAdapter.h
@@ -77,6 +77,5 @@ private:
     std::string toolbarName;
     MainWindow* window;
 
-    GtkToolItem* spacerItem{};
     ToolMenuHandler* toolHandler;
 };

--- a/src/core/gui/inputdevices/AbstractInputHandler.cpp
+++ b/src/core/gui/inputdevices/AbstractInputHandler.cpp
@@ -70,7 +70,6 @@ auto AbstractInputHandler::getPageAtCurrentPosition(InputEvent const& event) -> 
 auto AbstractInputHandler::getInputDataRelativeToCurrentPage(XojPageView* page, InputEvent const& event)
         -> PositionInputData {
     g_assert(page != nullptr);
-    GtkXournal* xournal = inputContext->getXournal();
 
     gdouble eventX = event.relativeX;
     gdouble eventY = event.relativeY;

--- a/src/core/gui/inputdevices/HandRecognition.cpp
+++ b/src/core/gui/inputdevices/HandRecognition.cpp
@@ -15,7 +15,7 @@
 using std::string;
 
 HandRecognition::HandRecognition(GtkWidget* widget, InputContext* inputContext, Settings* settings):
-        widget(widget), inputContext(inputContext), settings(settings) {
+        inputContext(inputContext), settings(settings) {
 #ifdef X11_ENABLED
     const char* sessionType = g_getenv("XDG_SESSION_TYPE");
     if (sessionType != nullptr && strcmp(sessionType, "x11") == 0) {

--- a/src/core/gui/inputdevices/HandRecognition.h
+++ b/src/core/gui/inputdevices/HandRecognition.h
@@ -102,11 +102,6 @@ private:
     TouchDisableInterface* touchImpl = nullptr;
 
     /**
-     * XournalView
-     */
-    GtkWidget* widget;
-
-    /**
      * InputContext
      */
     InputContext* inputContext;

--- a/src/core/gui/inputdevices/PenInputHandler.h
+++ b/src/core/gui/inputdevices/PenInputHandler.h
@@ -20,9 +20,6 @@ class PositionInputData;
 class XojPageView;
 
 class PenInputHandler: public AbstractInputHandler {
-private:
-    XojPageView* lastActivePage = nullptr;
-
 protected:
     /**
      * Whether the current device class has a device with button 1 in pressed state

--- a/src/core/gui/inputdevices/SetsquareInputHandler.cpp
+++ b/src/core/gui/inputdevices/SetsquareInputHandler.cpp
@@ -419,7 +419,6 @@ auto SetsquareInputHandler::getCoords(double xCoord, double yCoord) -> utl::Poin
     const auto view = inputContext->getView();
     const auto setsquareView = view->getSetsquareView();
     const auto zoom = view->getZoom();
-    const auto xournal = inputContext->getXournal();
     const auto page = setsquareView->getView();
     const auto posX = xCoord - static_cast<double>(page->getX());
     const auto posY = yCoord - static_cast<double>(page->getY());

--- a/src/core/gui/inputdevices/TouchDrawingInputHandler.cpp
+++ b/src/core/gui/inputdevices/TouchDrawingInputHandler.cpp
@@ -60,7 +60,7 @@ auto TouchDrawingInputHandler::handleImpl(InputEvent const& event) -> bool {
     }
 
     // Multitouch
-    if (this->primarySequence && this->primarySequence != event.sequence || this->secondarySequence) {
+    if ((this->primarySequence && this->primarySequence != event.sequence) || this->secondarySequence) {
         if (!this->secondarySequence) {
             this->secondarySequence = event.sequence;
 

--- a/src/core/gui/inputdevices/TouchInputHandler.cpp
+++ b/src/core/gui/inputdevices/TouchInputHandler.cpp
@@ -138,7 +138,6 @@ void TouchInputHandler::zoomStart() {
         zoomControl->setZoomFitMode(false);
     }
 
-    auto* mainWindow = inputContext->getView()->getControl()->getWindow();
     zoomControl->startZoomSequence(center);
 }
 

--- a/src/core/gui/sidebar/Sidebar.cpp
+++ b/src/core/gui/sidebar/Sidebar.cpp
@@ -16,7 +16,7 @@
 #include "previews/page/SidebarPreviewPages.h"        // for SidebarPreviewP...
 #include "util/Util.h"                                // for npos
 
-Sidebar::Sidebar(GladeGui* gui, Control* control): toolbar(this, gui), control(control), gui(gui) {
+Sidebar::Sidebar(GladeGui* gui, Control* control): control(control), gui(gui), toolbar(this, gui) {
     this->tbSelectPage = GTK_TOOLBAR(gui->get("tbSelectSidebarPage"));
     this->buttonCloseSidebar = gui->get("buttonCloseSidebar");
 

--- a/src/core/gui/toolbarMenubar/ToolMenuHandler.cpp
+++ b/src/core/gui/toolbarMenubar/ToolMenuHandler.cpp
@@ -521,13 +521,13 @@ void ToolMenuHandler::initToolItems() {
      * Footer tools
      * ------------------------------------------------------------------------
      */
-    toolPageSpinner = new ToolPageSpinner(gui, listener, "PAGE_SPIN", ACTION_FOOTER_PAGESPIN, iconNameHelper);
+    toolPageSpinner = new ToolPageSpinner(listener, "PAGE_SPIN", ACTION_FOOTER_PAGESPIN, iconNameHelper);
     addToolItem(toolPageSpinner);
 
     auto* toolZoomSlider = new ToolZoomSlider("ZOOM_SLIDER", listener, ACTION_FOOTER_ZOOM_SLIDER, zoom, iconNameHelper);
     addToolItem(toolZoomSlider);
 
-    toolPageLayer = new ToolPageLayer(control->getLayerController(), gui, listener, "LAYER", ACTION_FOOTER_LAYER,
+    toolPageLayer = new ToolPageLayer(control->getLayerController(), listener, "LAYER", ACTION_FOOTER_LAYER,
                                       iconNameHelper);
     addToolItem(toolPageLayer);
 

--- a/src/core/gui/toolbarMenubar/ToolMenuHandler.cpp
+++ b/src/core/gui/toolbarMenubar/ToolMenuHandler.cpp
@@ -78,9 +78,13 @@ ToolMenuHandler::~ToolMenuHandler() {
 }
 
 void ToolMenuHandler::freeDynamicToolbarItems() {
-    for (AbstractToolItem* it: this->toolItems) { it->setUsed(false); }
+    for (AbstractToolItem* it: this->toolItems) {
+        it->setUsed(false);
+    }
 
-    for (ColorToolItem* it: this->toolbarColorItems) { delete it; }
+    for (ColorToolItem* it: this->toolbarColorItems) {
+        delete it;
+    }
     this->toolbarColorItems.clear();
 }
 
@@ -242,11 +246,17 @@ void ToolMenuHandler::addColorToolItem(AbstractToolItem* it) {
 }
 
 void ToolMenuHandler::setTmpDisabled(bool disabled) {
-    for (AbstractToolItem* it: this->toolItems) { it->setTmpDisabled(disabled); }
+    for (AbstractToolItem* it: this->toolItems) {
+        it->setTmpDisabled(disabled);
+    }
 
-    for (MenuItem* it: this->menuItems) { it->setTmpDisabled(disabled); }
+    for (MenuItem* it: this->menuItems) {
+        it->setTmpDisabled(disabled);
+    }
 
-    for (ColorToolItem* it: this->toolbarColorItems) { it->setTmpDisabled(disabled); }
+    for (ColorToolItem* it: this->toolbarColorItems) {
+        it->setTmpDisabled(disabled);
+    }
 
     GtkWidget* menuViewSidebarVisible = gui->get("menuViewSidebarVisible");
     gtk_widget_set_sensitive(menuViewSidebarVisible, !disabled);
@@ -527,8 +537,8 @@ void ToolMenuHandler::initToolItems() {
     auto* toolZoomSlider = new ToolZoomSlider("ZOOM_SLIDER", listener, ACTION_FOOTER_ZOOM_SLIDER, zoom, iconNameHelper);
     addToolItem(toolZoomSlider);
 
-    toolPageLayer = new ToolPageLayer(control->getLayerController(), listener, "LAYER", ACTION_FOOTER_LAYER,
-                                      iconNameHelper);
+    toolPageLayer =
+            new ToolPageLayer(control->getLayerController(), listener, "LAYER", ACTION_FOOTER_LAYER, iconNameHelper);
     addToolItem(toolPageLayer);
 
     addCustomItemTgl("TOOL_FILL", ACTION_TOOL_FILL, GROUP_FILL, false, "fill", _("Fill"));

--- a/src/core/gui/toolbarMenubar/ToolPageLayer.cpp
+++ b/src/core/gui/toolbarMenubar/ToolPageLayer.cpp
@@ -19,8 +19,8 @@
 
 class ActionHandler;
 
-ToolPageLayer::ToolPageLayer(LayerController* lc, ActionHandler* handler, std::string id,
-                             ActionType type, IconNameHelper iconNameHelper):
+ToolPageLayer::ToolPageLayer(LayerController* lc, ActionHandler* handler, std::string id, ActionType type,
+                             IconNameHelper iconNameHelper):
         AbstractToolItem(std::move(id), handler, type, nullptr),
         lc(lc),
         menu(gtk_menu_new()),
@@ -214,7 +214,9 @@ void ToolPageLayer::updateLayerData() {
 
     inMenuUpdate = true;
 
-    for (GtkWidget* widgetPtr: layerItems) { gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(widgetPtr), false); }
+    for (GtkWidget* widgetPtr: layerItems) {
+        gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(widgetPtr), false);
+    }
     gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(layerItems[layerId]), true);
 
     PageRef page = lc->getCurrentPage();

--- a/src/core/gui/toolbarMenubar/ToolPageLayer.cpp
+++ b/src/core/gui/toolbarMenubar/ToolPageLayer.cpp
@@ -19,11 +19,10 @@
 
 class ActionHandler;
 
-ToolPageLayer::ToolPageLayer(LayerController* lc, GladeGui* gui, ActionHandler* handler, std::string id,
+ToolPageLayer::ToolPageLayer(LayerController* lc, ActionHandler* handler, std::string id,
                              ActionType type, IconNameHelper iconNameHelper):
         AbstractToolItem(std::move(id), handler, type, nullptr),
         lc(lc),
-        gui(gui),
         menu(gtk_menu_new()),
         iconNameHelper(iconNameHelper) {
     this->layerLabel = gtk_label_new(_("Loading..."));

--- a/src/core/gui/toolbarMenubar/ToolPageLayer.h
+++ b/src/core/gui/toolbarMenubar/ToolPageLayer.h
@@ -31,7 +31,7 @@ class ActionHandler;
 
 class ToolPageLayer: public AbstractToolItem, public LayerCtrlListener {
 public:
-    ToolPageLayer(LayerController* lc, GladeGui* gui, ActionHandler* handler, std::string id, ActionType type,
+    ToolPageLayer(LayerController* lc, ActionHandler* handler, std::string id, ActionType type,
                   IconNameHelper iconNameHelper);
     ~ToolPageLayer() override;
 
@@ -76,7 +76,6 @@ private:
 
 private:
     LayerController* lc = nullptr;
-    GladeGui* gui = nullptr;
 
     GtkWidget* layerLabel = nullptr;
     GtkWidget* layerButton = nullptr;

--- a/src/core/gui/toolbarMenubar/ToolPageSpinner.cpp
+++ b/src/core/gui/toolbarMenubar/ToolPageSpinner.cpp
@@ -10,9 +10,9 @@
 
 class ActionHandler;
 
-ToolPageSpinner::ToolPageSpinner(GladeGui* gui, ActionHandler* handler, std::string id, ActionType type,
+ToolPageSpinner::ToolPageSpinner(ActionHandler* handler, std::string id, ActionType type,
                                  IconNameHelper iconNameHelper):
-        AbstractToolItem(std::move(id), handler, type, nullptr), gui(gui), iconNameHelper(iconNameHelper) {
+        AbstractToolItem(std::move(id), handler, type, nullptr), iconNameHelper(iconNameHelper) {
     this->pageSpinner = new SpinPageAdapter();
 }
 

--- a/src/core/gui/toolbarMenubar/ToolPageSpinner.h
+++ b/src/core/gui/toolbarMenubar/ToolPageSpinner.h
@@ -22,13 +22,12 @@
 
 #include "AbstractToolItem.h"  // for AbstractToolItem
 
-class GladeGui;
 class SpinPageAdapter;
 class ActionHandler;
 
 class ToolPageSpinner: public AbstractToolItem {
 public:
-    ToolPageSpinner(GladeGui* gui, ActionHandler* handler, std::string id, ActionType type,
+    ToolPageSpinner(ActionHandler* handler, std::string id, ActionType type,
                     IconNameHelper iconNameHelper);
     ~ToolPageSpinner() override;
 
@@ -48,8 +47,6 @@ private:
     void updateLabels();
 
 private:
-    GladeGui* gui = nullptr;
-
     SpinPageAdapter* pageSpinner = nullptr;
     GtkOrientation orientation = GTK_ORIENTATION_HORIZONTAL;
 

--- a/src/core/gui/toolbarMenubar/ToolPageSpinner.h
+++ b/src/core/gui/toolbarMenubar/ToolPageSpinner.h
@@ -27,8 +27,7 @@ class ActionHandler;
 
 class ToolPageSpinner: public AbstractToolItem {
 public:
-    ToolPageSpinner(ActionHandler* handler, std::string id, ActionType type,
-                    IconNameHelper iconNameHelper);
+    ToolPageSpinner(ActionHandler* handler, std::string id, ActionType type, IconNameHelper iconNameHelper);
     ~ToolPageSpinner() override;
 
 public:

--- a/src/core/model/Snapping.cpp
+++ b/src/core/model/Snapping.cpp
@@ -12,12 +12,12 @@ namespace Snapping {
 [[nodiscard]] inline double distance(Point const& a, Point const& b) { return std::hypot(b.x - a.x, b.y - a.y); }
 double snapVertically(double y, double gridSize, double tolerance) {
     double ySnapped = roundToMultiple(y, gridSize);
-    return abs(ySnapped - y) < tolerance * gridSize / 2.0 ? ySnapped : y;
+    return std::abs(ySnapped - y) < tolerance * gridSize / 2.0 ? ySnapped : y;
 }
 
 double snapHorizontally(double x, double gridSize, double tolerance) {
     double xSnapped = roundToMultiple(x, gridSize);
-    return abs(xSnapped - x) < tolerance * gridSize / 2.0 ? xSnapped : x;
+    return std::abs(xSnapped - x) < tolerance * gridSize / 2.0 ? xSnapped : x;
 }
 
 Point snapToGrid(Point const& pos, double gridSize, double tolerance) {

--- a/src/core/model/SplineSegment.cpp
+++ b/src/core/model/SplineSegment.cpp
@@ -4,7 +4,7 @@
 #include <iterator>  // for end
 
 SplineSegment::SplineSegment(const Point& p, const Point& q):
-        firstKnot(p), firstControlPoint(p), secondKnot(q), secondControlPoint(q) {}
+        firstKnot(p), secondKnot(q), firstControlPoint(p), secondControlPoint(q) {}
 
 SplineSegment::SplineSegment(const Point& p, const Point& fp, const Point& sp, const Point& q) {
     firstKnot = p;

--- a/src/core/view/LayerView.h
+++ b/src/core/view/LayerView.h
@@ -13,7 +13,7 @@
 
 class Layer;
 namespace xoj::view {
-struct Context;
+class Context;
 
 class LayerView {
 public:

--- a/src/core/view/View.h
+++ b/src/core/view/View.h
@@ -24,7 +24,8 @@ enum NonAudioTreatment : bool { FADE_OUT_NON_AUDIO_ = true, NORMAL_NON_AUDIO = f
 enum EditionTreatment : bool { SHOW_CURRENT_EDITING = true, HIDE_CURRENT_EDITING = false };
 enum ColorTreatment : bool { COLORBLIND = true, NORMAL_COLOR = false };
 
-struct Context {
+class Context {
+public:
     cairo_t* cr;
     NonAudioTreatment fadeOutNonAudio;
     EditionTreatment showCurrentEdition;

--- a/src/util/serializing/ObjectOutputStream.cpp
+++ b/src/util/serializing/ObjectOutputStream.cpp
@@ -60,11 +60,6 @@ void ObjectOutputStream::writeData(const void* data, int len, int width) {
     }
 }
 
-static auto cairoWriteFunction(GString* string, const unsigned char* data, unsigned int length) -> cairo_status_t {
-    g_string_append_len(string, reinterpret_cast<const gchar*>(data), length);
-    return CAIRO_STATUS_SUCCESS;
-}
-
 void ObjectOutputStream::writeImage(const std::string_view& imgData) {
     this->encoder->addStr("_m");
     size_t len = imgData.length();


### PR DESCRIPTION
Hopefully, I would like to get to a place where there are no warnings outputted to the console by default (if ya'll maintainers agree?) - either by fixes or by excluding the noise by removing the warning check. That way, any warnings or mistakes are obvious and never missed.

This PR includes changes to get rid of a few tens of warnings that are low hanging fruit, that have a very low probability of changing behavior.

To make it easier for review, I'll add comments in places where the application behavior has _potentially_ changed. In all other cases, things should be proven to have identical behavior, according to clang.

Also, I'll note that when passing in `-Wno-conversion -Wno-overloaded-virtual -Wno-delete-non-abstract-non-virtual-dtor -Wno-deprecated-declarations`, then there will be _no_ warnings printed to the console  (clang 14.0.6). So, those aforementioned errors are the only ones that will be dealing with in the future (from a clean build!)