### PR TITLE
Hotfix: Prevent `g_object_get` segfault

### DIFF
--- a/src/gui/dialog/toolbarCustomize/ToolbarDragDropHelper.cpp
+++ b/src/gui/dialog/toolbarCustomize/ToolbarDragDropHelper.cpp
@@ -34,7 +34,7 @@ auto gdk_context_set_icon_from_image(GdkDragContext* ctx, GtkWidget* widget) -> 
         }
         case GTK_IMAGE_SURFACE: {
             cairo_surface_t* surface{};
-            g_object_get(G_OBJECT(image), "surface", &surface);
+            g_object_get(G_OBJECT(image), "surface", &surface, nullptr);
             cairo_surface_set_device_offset(surface, -2, -2);
             gtk_drag_set_icon_surface(ctx, surface);
             return true;


### PR DESCRIPTION
As mentioned [here](https://github.com/xournalpp/xournalpp/pull/4285#discussion_r989221493) in #4285, this PR fixes a potential segfault, but against `release-1.1` instead of `master`
