### PR TITLE
Fix GroupUndoAction crash in release-1.1

### DIFF
--- a/src/undo/GroupUndoAction.cpp
+++ b/src/undo/GroupUndoAction.cpp
@@ -3,7 +3,7 @@
 GroupUndoAction::GroupUndoAction(): UndoAction("GroupUndoAction") {}
 
 GroupUndoAction::~GroupUndoAction() {
-    for (auto i = actions.size() - 1; i >= 0; i--) { delete actions[i]; }
+    for (auto i = actions.size(); i > 0; i--) { delete actions[i - 1]; }
 
     actions.clear();
 }


### PR DESCRIPTION
Fixes #4138. The corresponding fix for `master` branch has already been made a while back.