### PR TITLE
Split tools/Selection into view/controller

### DIFF
--- a/src/core/control/ClipboardHandler.cpp
+++ b/src/core/control/ClipboardHandler.cpp
@@ -16,7 +16,7 @@
 #include "util/serializing/BinObjectEncoding.h"   // for BinObjectEncoding
 #include "util/serializing/ObjectInputStream.h"   // for ObjectInputStream
 #include "util/serializing/ObjectOutputStream.h"  // for ObjectOutputStream
-#include "view/SelectionView.h"                   // for SelectionView
+#include "view/ElementContainerView.h"            // for ElementContainerView
 #include "view/View.h"                            // for Context
 
 #include "config.h"  // for PROJECT_STRING
@@ -176,7 +176,7 @@ auto ClipboardHandler::copy() -> bool {
 
     cairo_translate(crPng, -selection->getXOnView(), -selection->getYOnView());
 
-    xoj::view::SelectionView view(this->selection);
+    xoj::view::ElementContainerView view(this->selection);
     view.draw(xoj::view::Context::createDefault(crPng));
 
     cairo_destroy(crPng);

--- a/src/core/control/tools/EditSelectionContents.cpp
+++ b/src/core/control/tools/EditSelectionContents.cpp
@@ -31,7 +31,7 @@
 #include "undo/UndoRedoHandler.h"                 // for UndoRedoHandler
 #include "util/serializing/ObjectInputStream.h"   // for ObjectInputStream
 #include "util/serializing/ObjectOutputStream.h"  // for ObjectOutputStream
-#include "view/SelectionView.h"                   // for SelectionView
+#include "view/ElementContainerView.h"            // for ElementContainerView
 #include "view/View.h"                            // for Context
 
 class XojFont;
@@ -506,7 +506,7 @@ void EditSelectionContents::paint(cairo_t* cr, double x, double y, double rotati
         cairo_translate(cr2, -dx, -dy);
         cairo_scale(cr2, zoom, zoom);
 
-        xoj::view::SelectionView view(this);
+        xoj::view::ElementContainerView view(this);
         view.draw(xoj::view::Context::createDefault(cr2));
 
         cairo_destroy(cr2);

--- a/src/core/control/tools/Selection.cpp
+++ b/src/core/control/tools/Selection.cpp
@@ -11,43 +11,23 @@
 #include "model/Layer.h"     // for Layer
 #include "model/XojPage.h"   // for XojPage
 
-Selection::Selection(LegacyRedrawable* view) {
-    this->view = view;
-    this->page = nullptr;
+Selection::Selection(): viewPool(std::make_shared<xoj::util::DispatchPool<xoj::view::SelectionView>>()) {}
 
-    this->x1Box = 0;
-    this->x2Box = 0;
-    this->y1Box = 0;
-    this->y2Box = 0;
-}
-
-Selection::~Selection() {
-    this->view = nullptr;
-    this->page = nullptr;
-}
+Selection::~Selection() = default;
 
 //////////////////////////////////////////////////////////
 
-RectSelection::RectSelection(double x, double y, LegacyRedrawable* view): Selection(view) {
+RectSelection::RectSelection(double x, double y) {
+    bbox.addPoint(x, y);
     this->sx = x;
     this->sy = y;
     this->ex = x;
     this->ey = y;
-    this->x1 = 0;
-    this->x2 = 0;
-    this->y1 = 0;
-    this->y2 = 0;
 }
 
 RectSelection::~RectSelection() = default;
 
 auto RectSelection::finalize(PageRef page) -> bool {
-    this->x1 = std::min(this->sx, this->ex);
-    this->x2 = std::max(this->sx, this->ex);
-
-    this->y1 = std::min(this->sy, this->ey);
-    this->y2 = std::max(this->sy, this->ey);
-
     this->page = page;
 
     Layer* l = page->getSelectedLayer();
@@ -57,153 +37,70 @@ auto RectSelection::finalize(PageRef page) -> bool {
         }
     }
 
-    view->repaintArea(this->x1 - 10, this->y1 - 10, this->x2 + 10, this->y2 + 10);
+    this->viewPool->dispatchAndClear(xoj::view::SelectionView::DELETE_VIEWS_REQUEST, this->bbox);
 
     return !this->selectedElements.empty();
 }
 
-auto RectSelection::contains(double x, double y) -> bool {
-    if (x < this->x1 || x > this->x2) {
-        return false;
-    }
-    if (y < this->y1 || y > this->y2) {
-        return false;
-    }
-
-    return true;
-}
+auto RectSelection::contains(double x, double y) const -> bool { return bbox.contains(x, y); }
 
 void RectSelection::currentPos(double x, double y) {
-    double aX = std::min(x, this->ex);
-    aX = std::min(aX, this->sx) - 10;
+    bbox = Range(sx, sy);
+    bbox.addPoint(x, y);
 
-    double bX = std::max(x, this->ex);
-    bX = std::max(bX, this->sx) + 10;
-
-    double aY = std::min(y, this->ey);
-    aY = std::min(aY, this->sy) - 10;
-
-    double bY = std::max(y, this->ey);
-    bY = std::max(bY, this->sy) + 10;
-
-    view->repaintArea(aX, aY, bX, bY);
+    Range rg = bbox;
+    rg.addPoint(ex, ey);  // in case the selection is shrinking
 
     this->ex = x;
     this->ey = y;
 
+    boundaryPoints = {{sx, sy}, {sx, ey}, {ex, ey}, {ex, sy}};
+
+    this->viewPool->dispatch(xoj::view::SelectionView::FLAG_DIRTY_REGION, rg);
+
     this->maxDist = std::max({this->maxDist, x - this->sx, this->sx - x, y - this->sy, this->sy - y});
 }
 
-auto RectSelection::userTapped(double zoom) -> bool { return this->maxDist < 10 / zoom; }
+auto RectSelection::userTapped(double zoom) const -> bool { return this->maxDist < 10 / zoom; }
 
-void RectSelection::paint(cairo_t* cr, double zoom) {
-    GdkRGBA selectionColor = view->getSelectionColor();
-
-    // set the line always the same size on display
-    cairo_set_line_width(cr, 1 / zoom);
-    gdk_cairo_set_source_rgba(cr, &selectionColor);
-
-    int aX = std::min(this->sx, this->ex);
-    int bX = std::max(this->sx, this->ex);
-
-    int aY = std::min(this->sy, this->ey);
-    int bY = std::max(this->sy, this->ey);
-
-    cairo_move_to(cr, aX, aY);
-    cairo_line_to(cr, bX, aY);
-    cairo_line_to(cr, bX, bY);
-    cairo_line_to(cr, aX, bY);
-    cairo_close_path(cr);
-
-    cairo_stroke_preserve(cr);
-    auto applied = GdkRGBA{selectionColor.red, selectionColor.green, selectionColor.blue, 0.3};
-    gdk_cairo_set_source_rgba(cr, &applied);
-    cairo_fill(cr);
-}
+auto RectSelection::getBoundary() const -> const std::vector<BoundaryPoint>& { return boundaryPoints; }
 
 //////////////////////////////////////////////////////////
 
-class RegionPoint {
-public:
-    RegionPoint(double x, double y) {
-        this->x = x;
-        this->y = y;
-    }
-
-    double x;
-    double y;
-};
-
-RegionSelect::RegionSelect(double x, double y, LegacyRedrawable* view): Selection(view) { currentPos(x, y); }
-
-void RegionSelect::paint(cairo_t* cr, double zoom) {
-    // at least three points needed
-    if (points.size() >= 3) {
-        GdkRGBA selectionColor = view->getSelectionColor();
-
-        // set the line always the same size on display
-        cairo_set_line_width(cr, 1 / zoom);
-        gdk_cairo_set_source_rgba(cr, &selectionColor);
-
-        const RegionPoint& r0 = points.front();
-        cairo_move_to(cr, r0.x, r0.y);
-
-        for (auto pointIterator = points.begin() + 1; pointIterator != points.end(); ++pointIterator) {
-            cairo_line_to(cr, pointIterator->x, pointIterator->y);
-        }
-
-        cairo_line_to(cr, r0.x, r0.y);
-
-        cairo_stroke_preserve(cr);
-        auto applied = GdkRGBA{selectionColor.red, selectionColor.green, selectionColor.blue, 0.3};
-        gdk_cairo_set_source_rgba(cr, &applied);
-        cairo_fill(cr);
-    }
-}
+RegionSelect::RegionSelect(double x, double y) { currentPos(x, y); }
 
 void RegionSelect::currentPos(double x, double y) {
-    points.emplace_back(x, y);
+    boundaryPoints.emplace_back(x, y);
+    bbox.addPoint(x, y);
 
     // at least three points needed
-    if (points.size() >= 3) {
-        const RegionPoint& r0 = points.front();
-        double ax = r0.x;
-        double bx = r0.x;
-        double ay = r0.y;
-        double by = r0.y;
+    if (boundaryPoints.size() >= 3) {
+        Range rg(x, y);
+        const BoundaryPoint& penultimatePoint = boundaryPoints[boundaryPoints.size() - 2];
+        rg.addPoint(penultimatePoint.x, penultimatePoint.y);
+        // rg contains the added segment
+        // add the first point to make sure the filling is painted correctly
+        rg.addPoint(boundaryPoints.front().x, boundaryPoints.front().y);
 
-        for (const RegionPoint& p: points) {
-            ax = std::min(ax, p.x);
-            bx = std::max(bx, p.x);
-            ay = std::min(ay, p.y);
-            by = std::max(by, p.y);
-        }
-
-        view->repaintArea(ax, ay, bx, by);
+        this->viewPool->dispatch(xoj::view::SelectionView::FLAG_DIRTY_REGION, rg);
     }
 }
 
-auto RegionSelect::contains(double x, double y) -> bool {
-    if (x < this->x1Box || x > this->x2Box) {
-        return false;
-    }
-    if (y < this->y1Box || y > this->y2Box) {
-        return false;
-    }
-    if (points.size() <= 2) {
+auto RegionSelect::contains(double x, double y) const -> bool {
+    if (boundaryPoints.size() <= 2 || !this->bbox.contains(x, y)) {
         return false;
     }
 
     int hits = 0;
 
-    const RegionPoint& last = points.back();
+    const BoundaryPoint& last = boundaryPoints.back();
 
     double lastx = last.x;
     double lasty = last.y;
     double curx = NAN, cury = NAN;
 
     // Walk the edges of the polygon
-    for (auto pointIterator = points.begin(); pointIterator != points.end();
+    for (auto pointIterator = boundaryPoints.begin(); pointIterator != boundaryPoints.end();
          lastx = curx, lasty = cury, ++pointIterator) {
         curx = pointIterator->x;
         cury = pointIterator->y;
@@ -259,18 +156,6 @@ auto RegionSelect::contains(double x, double y) -> bool {
 auto RegionSelect::finalize(PageRef page) -> bool {
     this->page = page;
 
-    this->x1Box = DBL_MAX;
-    this->x2Box = 0;
-    this->y1Box = DBL_MAX;
-    this->y2Box = 0;
-
-    for (const RegionPoint& p: points) {
-        this->x1Box = std::min(this->x1Box, p.x);
-        this->x2Box = std::max(this->x2Box, p.x);
-        this->y1Box = std::min(this->y1Box, p.y);
-        this->y2Box = std::max(this->y2Box, p.y);
-    }
-
     Layer* l = page->getSelectedLayer();
     for (Element* e: l->getElements()) {
         if (e->isInSelection(this)) {
@@ -278,18 +163,20 @@ auto RegionSelect::finalize(PageRef page) -> bool {
         }
     }
 
-    view->repaintArea(this->x1Box - 10, this->y1Box - 10, this->x2Box + 10, this->y2Box + 10);
+    this->viewPool->dispatchAndClear(xoj::view::SelectionView::DELETE_VIEWS_REQUEST, this->bbox);
 
     return !this->selectedElements.empty();
 }
 
-auto RegionSelect::userTapped(double zoom) -> bool {
+auto RegionSelect::userTapped(double zoom) const -> bool {
     double maxDist = 10 / zoom;
-    const RegionPoint& r0 = points.front();
-    for (const RegionPoint& p: points) {
+    const BoundaryPoint& r0 = boundaryPoints.front();
+    for (const BoundaryPoint& p: boundaryPoints) {
         if (std::abs(r0.x - p.x) > maxDist || std::abs(r0.y - p.y) > maxDist) {
             return false;
         }
     }
     return true;
 }
+
+auto RegionSelect::getBoundary() const -> const std::vector<BoundaryPoint>& { return boundaryPoints; }

--- a/src/core/control/tools/Selection.h
+++ b/src/core/control/tools/Selection.h
@@ -13,50 +13,56 @@
 
 #include <vector>  // for vector
 
-#include <cairo.h>  // for cairo_t
-
 #include "model/Element.h"  // for Element (ptr only), ShapeContainer
+#include "model/OverlayBase.h"
 #include "model/PageRef.h"  // for PageRef
+#include "util/DispatchPool.h"
+#include "util/Point.h"
+#include "util/Range.h"
+#include "view/overlays/SelectionView.h"
 
-class LegacyRedrawable;
-
-
-class Selection: public ShapeContainer {
+class Selection: public ShapeContainer, public OverlayBase {
 public:
-    Selection(LegacyRedrawable* view);
+    Selection();
     ~Selection() override;
+
+    using BoundaryPoint = utl::Point<double>;
 
 public:
     virtual bool finalize(PageRef page) = 0;
-    virtual void paint(cairo_t* cr, double zoom) = 0;
     virtual void currentPos(double x, double y) = 0;
-    virtual bool userTapped(double zoom) = 0;
+    virtual bool userTapped(double zoom) const = 0;
+    virtual const std::vector<BoundaryPoint>& getBoundary() const = 0;
+
+    inline const std::shared_ptr<xoj::util::DispatchPool<xoj::view::SelectionView>>& getViewPool() const {
+        return viewPool;
+    }
 
 private:
 protected:
+    std::vector<BoundaryPoint> boundaryPoints;
+
     std::vector<Element*> selectedElements;
     PageRef page;
-    LegacyRedrawable* view;
 
-    double x1Box;
-    double x2Box;
-    double y1Box;
-    double y2Box;
+    Range bbox;
+
+    std::shared_ptr<xoj::util::DispatchPool<xoj::view::SelectionView>> viewPool;
 
     friend class EditSelection;
 };
 
 class RectSelection: public Selection {
 public:
-    RectSelection(double x, double y, LegacyRedrawable* view);
+    RectSelection(double x, double y);
     ~RectSelection() override;
 
 public:
     bool finalize(PageRef page) override;
-    void paint(cairo_t* cr, double zoom) override;
     void currentPos(double x, double y) override;
-    bool contains(double x, double y) override;
-    bool userTapped(double zoom) override;
+    bool contains(double x, double y) const override;
+    bool userTapped(double zoom) const override;
+    const std::vector<BoundaryPoint>& getBoundary() const override;
 
 private:
     double sx;
@@ -64,29 +70,16 @@ private:
     double ex;
     double ey;
     double maxDist = 0;
-
-    /**
-     * In zoom coordinates
-     */
-    double x1;
-    double x2;
-    double y1;
-    double y2;
 };
-
-class RegionPoint;
 
 class RegionSelect: public Selection {
 public:
-    RegionSelect(double x, double y, LegacyRedrawable* view);
+    RegionSelect(double x, double y);
 
 public:
     bool finalize(PageRef page) override;
-    void paint(cairo_t* cr, double zoom) override;
     void currentPos(double x, double y) override;
-    bool contains(double x, double y) override;
-    bool userTapped(double zoom) override;
-
-private:
-    std::vector<RegionPoint> points;
+    bool contains(double x, double y) const override;
+    bool userTapped(double zoom) const override;
+    const std::vector<BoundaryPoint>& getBoundary() const override;
 };

--- a/src/core/control/tools/VerticalToolHandler.cpp
+++ b/src/core/control/tools/VerticalToolHandler.cpp
@@ -19,7 +19,7 @@
 #include "util/LoopUtil.h"                         // for for_first_then_each
 #include "util/Rectangle.h"                        // for Rectangle
 #include "view/DebugShowRepaintBounds.h"           // for IF_DEBUG_REPAINT
-#include "view/SelectionView.h"                    // for SelectionView
+#include "view/ElementContainerView.h"             // for ElementContainerView
 #include "view/View.h"                             // for Context
 
 class Settings;
@@ -96,7 +96,7 @@ void VerticalToolHandler::redrawBuffer() {
     } else {
         g_assert(this->spacingSide == Side::Above);
     }
-    xoj::view::SelectionView v(this);
+    xoj::view::ElementContainerView v(this);
     v.draw(xoj::view::Context::createDefault(cr));
 
     cairo_destroy(cr);

--- a/src/core/gui/PageView.h
+++ b/src/core/gui/PageView.h
@@ -66,6 +66,11 @@ public:
      *      Used to avoid blinking when a tool finished editing an element
      */
     void drawAndDeleteToolView(xoj::view::ToolView* v, const Range& rg) override;
+    /**
+     * @brief Simply deletes an overlay and any trace of it on the display (provided the overlay is contained in the
+     * given range)
+     */
+    void deleteOverlayView(xoj::view::OverlayView* v, const Range& rg) override;
 
     int getDPIScaling() const override;
     double getZoom() const override;
@@ -224,7 +229,7 @@ private:
     /**
      * The selected (while selection)
      */
-    Selection* selection = nullptr;
+    std::unique_ptr<Selection> selection;
 
     /**
      * The text editor View

--- a/src/core/model/Element.h
+++ b/src/core/model/Element.h
@@ -26,7 +26,7 @@ enum ElementType { ELEMENT_STROKE = 1, ELEMENT_IMAGE, ELEMENT_TEXIMAGE, ELEMENT_
 
 class ShapeContainer {
 public:
-    virtual bool contains(double x, double y) = 0;
+    virtual bool contains(double x, double y) const = 0;
 
     virtual ~ShapeContainer() = default;
 };

--- a/src/core/view/ElementContainerView.cpp
+++ b/src/core/view/ElementContainerView.cpp
@@ -1,4 +1,4 @@
-#include "SelectionView.h"
+#include "ElementContainerView.h"
 
 #include <memory>  // for unique_ptr
 #include <vector>  // for vector
@@ -11,9 +11,9 @@ class Element;
 
 using namespace xoj::view;
 
-SelectionView::SelectionView(const ElementContainer* container): container(container) {}
+ElementContainerView::ElementContainerView(const ElementContainer* container): container(container) {}
 
-void SelectionView::draw(const Context& ctx) const {
+void ElementContainerView::draw(const Context& ctx) const {
     for (Element* e: container->getElements()) {
         auto elementView = ElementView::createFromElement(e);
         elementView->draw(ctx);

--- a/src/core/view/ElementContainerView.h
+++ b/src/core/view/ElementContainerView.h
@@ -16,9 +16,9 @@ class ElementContainer;
 namespace xoj::view {
 class Context;
 
-class SelectionView {
+class ElementContainerView {
 public:
-    SelectionView(const ElementContainer* container);
+    ElementContainerView(const ElementContainer* container);
 
     /**
      * @brief Draws the container to the given context

--- a/src/core/view/Repaintable.h
+++ b/src/core/view/Repaintable.h
@@ -13,6 +13,7 @@
 class Range;
 
 namespace xoj::view {
+class OverlayView;
 class ToolView;
 
 class Repaintable {
@@ -44,9 +45,16 @@ public:
     virtual void flagDirtyRegion(const Range& rg) const = 0;
 
     /**
-     * @brief Remove a tool view and repaint the given range
+     * @brief Draw the ToolView to the repaintable buffer (if any), remove a tool view and repaint the given range
      *      Called just before the tool sequence ends and the handler is deleted.
      */
     virtual void drawAndDeleteToolView(ToolView* v, const Range& rg) = 0;
+
+    /**
+     * @brief Remove a overlay view and repaint the given range
+     *      The given range is supposed to be big enough so that repainting this area will indeed erase the overlay from
+     * the display
+     */
+    virtual void deleteOverlayView(OverlayView* v, const Range& rg) = 0;
 };
 };  // namespace xoj::view

--- a/src/core/view/overlays/SelectionView.cpp
+++ b/src/core/view/overlays/SelectionView.cpp
@@ -1,0 +1,56 @@
+#include "SelectionView.h"
+
+#include <vector>
+
+#include "control/tools/Selection.h"
+#include "util/Color.h"
+#include "util/LoopUtil.h"
+#include "util/Range.h"
+#include "util/raii/CairoWrappers.h"
+#include "view/Repaintable.h"
+
+using namespace xoj::view;
+
+SelectionView::SelectionView(const Selection* selection, Repaintable* parent, Color selectionColor):
+        OverlayView(parent), selection(selection), selectionColor(selectionColor) {
+    this->registerToPool(selection->getViewPool());
+}
+
+SelectionView::~SelectionView() noexcept { this->unregisterFromPool(); }
+
+void SelectionView::draw(cairo_t* cr) const {
+    auto pts = this->selection->getBoundary();
+    if (pts.size() < 3) {
+        // To few points to draw
+        return;
+    }
+
+    xoj::util::CairoSaveGuard saveGuard(cr);  // cairo_save
+
+    // set the line always the same size on display
+    cairo_set_line_width(cr, BORDER_WIDTH_IN_PIXELS / this->parent->getZoom());
+
+    Util::cairo_set_source_rgbi(cr, selectionColor);
+
+    cairo_new_path(cr);
+    for (auto& p: pts) {
+        cairo_line_to(cr, p.x, p.y);
+    }
+    cairo_close_path(cr);
+
+    cairo_stroke_preserve(cr);
+    Util::cairo_set_source_rgbi(cr, selectionColor, FILLING_OPACITY);
+    cairo_fill(cr);
+}
+
+bool SelectionView::isViewOf(const OverlayBase* overlay) const { return overlay == this->selection; }
+
+void SelectionView::on(SelectionView::FlagDirtyRegionRequest, Range rg) {
+    rg.addPadding(BORDER_WIDTH_IN_PIXELS / this->parent->getZoom());
+    this->parent->flagDirtyRegion(rg);
+}
+
+void xoj::view::SelectionView::deleteOn(xoj::view::SelectionView::DeleteViewsRequest, Range rg) {
+    rg.addPadding(BORDER_WIDTH_IN_PIXELS / this->parent->getZoom());
+    this->parent->deleteOverlayView(this, rg);
+}

--- a/src/core/view/overlays/SelectionView.h
+++ b/src/core/view/overlays/SelectionView.h
@@ -1,0 +1,51 @@
+/*
+ * Xournal++
+ *
+ * Displays the content of a selection
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+#pragma once
+
+#include "util/Color.h"
+#include "util/DispatchPool.h"
+
+#include "OverlayView.h"
+#include "cairo.h"
+
+class Selection;
+class Range;
+
+namespace xoj::view {
+class Repaintable;
+
+class SelectionView: public OverlayView, public xoj::util::Listener<SelectionView> {
+public:
+    SelectionView(const Selection* selection, Repaintable* parent, Color selectionColor);
+    virtual ~SelectionView() noexcept;
+
+    /**
+     * @brief Draws the container to the given context
+     */
+    void draw(cairo_t* cr) const override;
+    bool isViewOf(const OverlayBase* overlay) const override;
+
+    static constexpr struct FlagDirtyRegionRequest {
+    } FLAG_DIRTY_REGION = {};
+    void on(FlagDirtyRegionRequest, Range rg);
+
+    static constexpr struct DeleteViewsRequest {
+    } DELETE_VIEWS_REQUEST = {};
+    void deleteOn(DeleteViewsRequest, Range rg);
+
+private:
+    const Selection* selection;
+    Color selectionColor;
+
+    static constexpr double BORDER_WIDTH_IN_PIXELS = 1;
+    static constexpr double FILLING_OPACITY = 0.3;
+};
+};  // namespace xoj::view

--- a/src/util/Range.cpp
+++ b/src/util/Range.cpp
@@ -45,3 +45,5 @@ auto Range::empty() const -> bool {
 }
 
 bool Range::isValid() const { return minX <= maxX && minY <= maxY; }
+
+bool Range::contains(double x, double y) const { return x > minX && x < maxX && y > minY && y < maxY; }

--- a/src/util/include/util/Range.h
+++ b/src/util/include/util/Range.h
@@ -39,6 +39,7 @@ public:
 
     [[nodiscard]] bool empty() const;
     [[nodiscard]] bool isValid() const;
+    [[nodiscard]] bool contains(double x, double y) const;
 
     double minX = std::numeric_limits<double>::max();
     double minY = std::numeric_limits<double>::max();


### PR DESCRIPTION
This PR split the selection tools (rectangle selection or region selection) into view+controller.

It also:
- simplifies and optimizes some of the code in tools/Selection
- optimizes the size of the areas repainted (upon input events)

(Note that tools/Selection only handles the selection process, tools/EditSelection is the tool handling the selection moving, resizing, copying and so on)

This is ready for a review for whoever feels like it.