### PR TITLE
Split control/SearchControl into view/controller

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -1749,8 +1749,9 @@ auto Control::getCurrentPageNo() -> size_t {
     return 0;
 }
 
-auto Control::searchTextOnPage(string text, int p, int* occures, double* top) -> bool {
-    return getWindow()->getXournal()->searchTextOnPage(std::move(text), p, occures, top);
+auto Control::searchTextOnPage(const std::string& text, size_t pageNumber, size_t* occurrences,
+                               double* yOfUpperMostMatch) -> bool {
+    return getWindow()->getXournal()->searchTextOnPage(text, pageNumber, occurrences, yOfUpperMostMatch);
 }
 
 auto Control::getCurrentPage() -> PageRef {

--- a/src/core/control/Control.h
+++ b/src/core/control/Control.h
@@ -187,7 +187,14 @@ public:
 
     bool isFullscreen();
 
-    bool searchTextOnPage(std::string text, int p, int* occures, double* top);
+    /**
+     * @brief Search text on the given page. The matches (if any) are stored in the XojPageView::SearchControl instance.
+     * @param occurrences If not nullptr, the pointed variable will contain the number of matches on the page
+     * @param yOfUpperMostMatch If not nullptr, will contain the y coordinate of the first match on the page
+     *                          (Used for scrolling to the first match)
+     * @return true if at least one match was found
+     */
+    bool searchTextOnPage(const std::string& text, size_t pageNumber, size_t* occurrences, double* yOfUpperMostMatch);
 
     /**
      * Fire page selected, but first check if the page Number is valid

--- a/src/core/control/SearchControl.cpp
+++ b/src/core/control/SearchControl.cpp
@@ -9,38 +9,25 @@
 #include "model/Text.h"     // for Text
 #include "model/XojPage.h"  // for XojPage
 #include "view/TextView.h"  // for TextView
+#include "view/overlays/SearchResultView.h"
 
-using std::string;
+SearchControl::SearchControl(const PageRef& page, XojPdfPageSPtr pdf):
+        page(page),
+        pdf(std::move(pdf)),
+        viewPool(std::make_shared<xoj::util::DispatchPool<xoj::view::SearchResultView>>()) {}
 
-SearchControl::SearchControl(const PageRef& page, XojPdfPageSPtr pdf) {
-    this->page = page;
-    this->pdf = std::move(pdf);
-}
-
-SearchControl::~SearchControl() { freeSearchResults(); }
-
-void SearchControl::freeSearchResults() { this->results.clear(); }
-
-void SearchControl::paint(cairo_t* cr, double zoom, const GdkRGBA& color) {
-    // set the line always the same size on display
-    cairo_set_line_width(cr, 1 / zoom);
-
-    for (XojPdfRectangle rect: this->results) {
-        cairo_rectangle(cr, rect.x1, rect.y1, rect.x2 - rect.x1, rect.y2 - rect.y1);
-        gdk_cairo_set_source_rgba(cr, &color);
-        cairo_stroke_preserve(cr);
-        auto applied = GdkRGBA{color.red, color.green, color.blue, 0.3};
-        gdk_cairo_set_source_rgba(cr, &applied);
-        cairo_fill(cr);
-    }
-}
+SearchControl::~SearchControl() = default;
 
 auto SearchControl::search(const std::string& text, size_t* occurrences, double* yOfUpperMostMatch) -> bool {
-    freeSearchResults();
-
     if (text.empty()) {
+        if (!this->results.empty()) {
+            this->results.clear();
+            this->viewPool->dispatch(xoj::view::SearchResultView::SEARCH_CHANGED_NOTIFICATION);
+        }
         return true;
     }
+
+    this->results.clear();
 
     if (this->pdf) {
         this->results = this->pdf->findText(text);
@@ -82,5 +69,6 @@ auto SearchControl::search(const std::string& text, size_t* occurrences, double*
         }
     }
 
+    this->viewPool->dispatch(xoj::view::SearchResultView::SEARCH_CHANGED_NOTIFICATION);
     return !this->results.empty();
 }

--- a/src/core/control/SearchControl.cpp
+++ b/src/core/control/SearchControl.cpp
@@ -35,7 +35,7 @@ void SearchControl::paint(cairo_t* cr, double zoom, const GdkRGBA& color) {
     }
 }
 
-auto SearchControl::search(std::string text, int* occures, double* top) -> bool {
+auto SearchControl::search(const std::string& text, size_t* occurrences, double* yOfUpperMostMatch) -> bool {
     freeSearchResults();
 
     if (text.empty()) {
@@ -62,21 +62,23 @@ auto SearchControl::search(std::string text, int* occures, double* top) -> bool 
         }
     }
 
-    if (occures) {
-        *occures = this->results.size();
+    if (occurrences) {
+        *occurrences = this->results.size();
     }
 
-    if (top) {
+    if (yOfUpperMostMatch) {
         if (this->results.empty()) {
-            *top = 0;
+            *yOfUpperMostMatch = 0;
         } else {
 
-            XojPdfRectangle first = this->results[0];
+            const XojPdfRectangle& first = this->results.front();
 
             double min = first.y1;
-            for (XojPdfRectangle rect: this->results) { min = std::min(min, rect.y1); }
+            for (const XojPdfRectangle& rect: this->results) {
+                min = std::min(min, rect.y1);
+            }
 
-            *top = min;
+            *yOfUpperMostMatch = min;
         }
     }
 

--- a/src/core/control/SearchControl.h
+++ b/src/core/control/SearchControl.h
@@ -25,7 +25,7 @@ public:
     SearchControl(const PageRef& page, XojPdfPageSPtr pdf);
     virtual ~SearchControl();
 
-    bool search(std::string text, int* occures, double* top);
+    bool search(const std::string& text, size_t* occurrences, double* yOfUpperMostMatch);
     void paint(cairo_t* cr, double zoom, const GdkRGBA& color);
 
 private:

--- a/src/core/control/SearchControl.h
+++ b/src/core/control/SearchControl.h
@@ -14,26 +14,34 @@
 #include <string>  // for string
 #include <vector>  // for vector
 
-#include <cairo.h>    // for cairo_t
-#include <gdk/gdk.h>  // for GdkRGBA
-
+#include "model/OverlayBase.h"
 #include "model/PageRef.h"        // for PageRef
 #include "pdf/base/XojPdfPage.h"  // for XojPdfPageSPtr, XojPdfRectangle
+#include "util/DispatchPool.h"
 
-class SearchControl {
+namespace xoj::view {
+class OverlayView;
+class Repaintable;
+class SearchResultView;
+};  // namespace xoj::view
+
+class SearchControl: public OverlayBase {
 public:
     SearchControl(const PageRef& page, XojPdfPageSPtr pdf);
     virtual ~SearchControl();
 
     bool search(const std::string& text, size_t* occurrences, double* yOfUpperMostMatch);
-    void paint(cairo_t* cr, double zoom, const GdkRGBA& color);
 
-private:
-    void freeSearchResults();
+    const std::vector<XojPdfRectangle>& getResults() const { return results; }
+
+    const std::shared_ptr<xoj::util::DispatchPool<xoj::view::SearchResultView>>& getViewPool() const {
+        return viewPool;
+    }
 
 private:
     PageRef page;
     XojPdfPageSPtr pdf;
 
     std::vector<XojPdfRectangle> results;
+    std::shared_ptr<xoj::util::DispatchPool<xoj::view::SearchResultView>> viewPool;
 };

--- a/src/core/gui/PageView.cpp
+++ b/src/core/gui/PageView.cpp
@@ -138,7 +138,7 @@ auto XojPageView::containsPoint(int x, int y, bool local) const -> bool {
     return x >= 0 && y >= 0 && x <= this->getWidth() && y <= this->getHeight();
 }
 
-auto XojPageView::searchTextOnPage(string& text, int* occures, double* top) -> bool {
+auto XojPageView::searchTextOnPage(const std::string& text, size_t* occurrences, double* yOfUpperMostMatch) -> bool {
     if (this->search == nullptr) {
         if (text.empty()) {
             return true;
@@ -156,7 +156,7 @@ auto XojPageView::searchTextOnPage(string& text, int* occures, double* top) -> b
         this->search = new SearchControl(page, pdf);
     }
 
-    bool found = this->search->search(text, occures, top);
+    bool found = this->search->search(text, occurrences, yOfUpperMostMatch);
 
     repaintPage();
 

--- a/src/core/gui/PageView.h
+++ b/src/core/gui/PageView.h
@@ -251,7 +251,7 @@ private:
     /**
      * Search handling
      */
-    SearchControl* search = nullptr;
+    std::unique_ptr<SearchControl> search;
 
     /**
      * Unixtimestam when the page was last time in the visible area

--- a/src/core/gui/PageView.h
+++ b/src/core/gui/PageView.h
@@ -84,7 +84,7 @@ public:
 
     void endText();
 
-    bool searchTextOnPage(std::string& text, int* occures, double* top);
+    bool searchTextOnPage(const std::string& text, size_t* occurrences, double* yOfUpperMostMatch);
 
     bool onKeyPressEvent(GdkEventKey* event);
     bool onKeyReleaseEvent(GdkEventKey* event);

--- a/src/core/gui/SearchBar.h
+++ b/src/core/gui/SearchBar.h
@@ -34,7 +34,7 @@ private:
     void searchPrevious();
 
     void search(const char* text);
-    bool searchTextonCurrentPage(const char* text, int* occures, double* top);
+    bool searchTextonCurrentPage(const char* text, size_t* occurrences, double* yOfUpperMostMatch);
 
 private:
     Control* control;

--- a/src/core/gui/SearchBar.h
+++ b/src/core/gui/SearchBar.h
@@ -30,8 +30,27 @@ private:
     static void buttonNextSearchClicked(GtkButton* button, SearchBar* searchBar);
     static void buttonPreviousSearchClicked(GtkButton* button, SearchBar* searchBar);
 
-    void searchNext();
-    void searchPrevious();
+    /**
+     * @brief Searches the entire document until a match is found, starting from `page = next(currentPage)` and
+     * iterating through the pages via page = next(page). The search stops after the first page with at least one match.
+     * All the match on that page are stored in XojPageView::search of the corresponding page. The current page is not
+     * search!
+     * @param next The parameter `next` must be convertible to size_t(size_t) and satisfy the following assertions
+     *              * Iterating from page = next(currentPage) by page = next(page) must reach page == currentPage at
+     * some point.
+     *              * If page is a valid page number, then so is next(page).
+     */
+    template <class Fun>
+    void search(Fun next) const;
+
+    /**
+     * @brief Named specialization of search(), where next(page) = (page + 1) % pageCount
+     */
+    void searchNext() const;
+    /**
+     * @brief Named specialization of search(), where next(page) = (page + pageCount - 1) % pageCount
+     */
+    void searchPrevious() const;
 
     void search(const char* text);
     bool searchTextonCurrentPage(const char* text, size_t* occurrences, double* yOfUpperMostMatch);

--- a/src/core/gui/XournalView.cpp
+++ b/src/core/gui/XournalView.cpp
@@ -322,13 +322,14 @@ void XournalView::onSettingsChanged() {
 // send the focus back to the appropriate widget
 void XournalView::requestFocus() { gtk_widget_grab_focus(this->widget); }
 
-auto XournalView::searchTextOnPage(std::string text, size_t p, int* occures, double* top) -> bool {
-    if (p == npos || p >= this->viewPages.size()) {
+auto XournalView::searchTextOnPage(const std::string& text, size_t pageNumber, size_t* occurrences,
+                                   double* yOfUpperMostMatch) -> bool {
+    if (pageNumber == npos || pageNumber >= this->viewPages.size()) {
         return false;
     }
-    XojPageView* v = this->viewPages[p];
+    XojPageView* v = this->viewPages[pageNumber];
 
-    return v->searchTextOnPage(text, occures, top);
+    return v->searchTextOnPage(text, occurrences, yOfUpperMostMatch);
 }
 
 void XournalView::forceUpdatePagenumbers() {

--- a/src/core/gui/XournalView.h
+++ b/src/core/gui/XournalView.h
@@ -68,7 +68,7 @@ public:
 
     XojPageView* getViewFor(size_t pageNr) const;
 
-    bool searchTextOnPage(std::string text, size_t p, int* occures, double* top);
+    bool searchTextOnPage(const std::string& text, size_t pageNumber, size_t* occurrences, double* yOfUpperMostMatch);
 
     bool cut();
     bool copy();

--- a/src/core/pdf/base/XojPdfPage.h
+++ b/src/core/pdf/base/XojPdfPage.h
@@ -63,7 +63,7 @@ public:
     virtual void render(cairo_t* cr) const = 0;
     virtual void renderForPrinting(cairo_t* cr) const = 0;
 
-    virtual std::vector<XojPdfRectangle> findText(std::string& text) = 0;
+    virtual std::vector<XojPdfRectangle> findText(const std::string& text) = 0;
 
     /// Retrieve the text contained in the provided rectangle using the given
     /// selection style.

--- a/src/core/pdf/popplerapi/PopplerGlibPage.cpp
+++ b/src/core/pdf/popplerapi/PopplerGlibPage.cpp
@@ -74,7 +74,7 @@ void PopplerGlibPage::renderForPrinting(cairo_t* cr) const { poppler_page_render
 
 auto PopplerGlibPage::getPageId() const -> int { return poppler_page_get_index(page); }
 
-auto PopplerGlibPage::findText(std::string& text) -> std::vector<XojPdfRectangle> {
+auto PopplerGlibPage::findText(const std::string& text) -> std::vector<XojPdfRectangle> {
     std::vector<XojPdfRectangle> findings;
 
     double height = getHeight();

--- a/src/core/pdf/popplerapi/PopplerGlibPage.h
+++ b/src/core/pdf/popplerapi/PopplerGlibPage.h
@@ -34,7 +34,7 @@ public:
     void render(cairo_t* cr) const override;
     void renderForPrinting(cairo_t* cr) const override;
 
-    std::vector<XojPdfRectangle> findText(std::string& text) override;
+    std::vector<XojPdfRectangle> findText(const std::string& text) override;
 
     std::string selectText(const XojPdfRectangle& rect, XojPdfPageSelectionStyle style) override;
 

--- a/src/core/view/TextView.cpp
+++ b/src/core/view/TextView.cpp
@@ -75,7 +75,7 @@ void TextView::draw(const Context& ctx) const {
     cairo_restore(ctx.cr);
 }
 
-auto TextView::findText(const Text* t, std::string& search) -> std::vector<XojPdfRectangle> {
+auto TextView::findText(const Text* t, const std::string& search) -> std::vector<XojPdfRectangle> {
     size_t patternLength = search.length();
     if (patternLength == 0) {
         return {};

--- a/src/core/view/TextView.h
+++ b/src/core/view/TextView.h
@@ -39,7 +39,7 @@ public:
     /**
      * Searches text within a Text model
      */
-    static std::vector<XojPdfRectangle> findText(const Text* t, std::string& search);
+    static std::vector<XojPdfRectangle> findText(const Text* t, const std::string& search);
 
     /**
      * Initialize a Pango layout

--- a/src/core/view/overlays/SearchResultView.cpp
+++ b/src/core/view/overlays/SearchResultView.cpp
@@ -1,0 +1,35 @@
+#include "SearchResultView.h"
+
+#include "control/SearchControl.h"
+#include "util/Range.h"
+#include "util/raii/CairoWrappers.h"
+#include "view/Repaintable.h"
+
+using namespace xoj::view;
+
+SearchResultView::SearchResultView(const SearchControl* searchControl, Repaintable* parent, Color frameColor):
+        OverlayView(parent), searchControl(searchControl), frameColor(frameColor) {
+    this->registerToPool(searchControl->getViewPool());
+}
+
+SearchResultView::~SearchResultView() noexcept { this->unregisterFromPool(); }
+
+void SearchResultView::draw(cairo_t* cr) const {
+    xoj::util::CairoSaveGuard saveGuard(cr);
+
+    cairo_set_line_width(cr, BORDER_WIDTH_IN_PIXELS / this->parent->getZoom());
+
+    for (const XojPdfRectangle& rect: this->searchControl->getResults()) {
+        cairo_rectangle(cr, rect.x1, rect.y1, rect.x2 - rect.x1, rect.y2 - rect.y1);
+        Util::cairo_set_source_rgbi(cr, frameColor);
+        cairo_stroke_preserve(cr);
+        Util::cairo_set_source_rgbi(cr, frameColor, BACKGROUND_OPACITY);
+        cairo_fill(cr);
+    }
+}
+
+bool SearchResultView::isViewOf(const OverlayBase* overlay) const { return overlay == this->searchControl; }
+
+void SearchResultView::on(SearchResultView::SearchChangedNotification) {
+    this->parent->flagDirtyRegion(this->parent->getVisiblePart());
+}

--- a/src/core/view/overlays/SearchResultView.h
+++ b/src/core/view/overlays/SearchResultView.h
@@ -1,0 +1,56 @@
+/*
+ * Xournal++
+ *
+ * View highlighting search results
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+#pragma once
+
+#include <cairo.h>  // for cairo_t
+
+#include "util/Color.h"
+#include "util/DispatchPool.h"  // for Listener
+#include "view/overlays/OverlayView.h"
+
+class OverlayBase;
+class SearchControl;
+class Settings;
+
+namespace xoj::view {
+class Repaintable;
+
+class SearchResultView final: public OverlayView, public xoj::util::Listener<SearchResultView> {
+
+public:
+    SearchResultView(const SearchControl* searchControl, Repaintable* parent, Color frameColor);
+    ~SearchResultView() noexcept override;
+
+    /**
+     * @brief Draws the overlay to the given context
+     */
+    void draw(cairo_t* cr) const override;
+
+    bool isViewOf(const OverlayBase* overlay) const override;
+
+    /**
+     * Listener interface
+     */
+    static constexpr struct SearchChangedNotification {
+    } SEARCH_CHANGED_NOTIFICATION = {};
+    void on(SearchChangedNotification);
+
+private:
+    const SearchControl* searchControl;
+    const Color frameColor;
+
+public:
+    // Width of the line delimiting moved elements
+    static constexpr int BORDER_WIDTH_IN_PIXELS = 1;
+    // Opacity of the background
+    static constexpr double BACKGROUND_OPACITY = 0.3;
+};
+};  // namespace xoj::view


### PR DESCRIPTION
This PR splits control/SearchControl into a view and a controller.

Some small side-refactoring:
- searched strings are now passed by references (instead of by a succession of copies and moves)

Ready for a review.