### PR TITLE
Split VerticalToolHandler into controller and view

### DIFF
--- a/src/core/control/tools/VerticalToolHandler.cpp
+++ b/src/core/control/tools/VerticalToolHandler.cpp
@@ -10,51 +10,30 @@
 #include <glib.h>            // for g_assert, g_assert...
 
 #include "control/tools/SnapToGridInputHandler.h"  // for SnapToGridInputHan...
-#include "control/zoom/ZoomControl.h"              // for ZoomControl
 #include "gui/LegacyRedrawable.h"                  // for Redrawable
 #include "model/Element.h"                         // for Element
 #include "model/Layer.h"                           // for Layer
 #include "model/XojPage.h"                         // for XojPage
 #include "undo/MoveUndoAction.h"                   // for MoveUndoAction
-#include "util/LoopUtil.h"                         // for for_first_then_each
-#include "util/Rectangle.h"                        // for Rectangle
-#include "view/DebugShowRepaintBounds.h"           // for IF_DEBUG_REPAINT
-#include "view/ElementContainerView.h"             // for ElementContainerView
-#include "view/View.h"                             // for Context
+#include "util/DispatchPool.h"
+#include "view/overlays/VerticalToolView.h"
 
 class Settings;
 
-VerticalToolHandler::VerticalToolHandler(LegacyRedrawable* view, const PageRef& page, Settings* settings, double y,
-                                         bool initiallyReverse, ZoomControl* zoomControl, GdkWindow* window):
-        window(window),
-        view(view),
+VerticalToolHandler::VerticalToolHandler(const PageRef& page, Settings* settings, double y, bool initiallyReverse):
         page(page),
         layer(this->page->getSelectedLayer()),
         spacingSide(initiallyReverse ? Side::Above : Side::Below),
-        zoom(0),
-        zoomControl(zoomControl),
-        snappingHandler(settings) {
+        snappingHandler(settings),
+        viewPool(std::make_shared<xoj::util::DispatchPool<xoj::view::VerticalToolView>>()) {
     double ySnapped = snappingHandler.snapVertically(y, false);
     this->startY = ySnapped;
     this->endY = ySnapped;
 
-    this->updateZoom(zoomControl->getZoom());
-
     this->adoptElements(this->spacingSide);
-
-    if (auto rect = this->getElementsBoundingRect()) {
-        view->rerenderRect(rect->x, rect->y, rect->width, rect->height);
-    }
 }
 
-VerticalToolHandler::~VerticalToolHandler() {
-    this->view = nullptr;
-
-    if (this->crBuffer) {
-        cairo_surface_destroy(this->crBuffer);
-        this->crBuffer = nullptr;
-    }
-}
+VerticalToolHandler::~VerticalToolHandler() = default;
 
 void VerticalToolHandler::adoptElements(const Side side) {
     this->spacingSide = side;
@@ -73,63 +52,12 @@ void VerticalToolHandler::adoptElements(const Side side) {
 
     for (Element* e: this->elements) { this->layer->removeElement(e, false); }
 
-    if (this->crBuffer) {
-        redrawBuffer();
+    Range rg = this->ownedElementsOriginalBoundingBox;
+    this->ownedElementsOriginalBoundingBox = this->computeElementsBoundingBox();
+    rg = rg.unite(this->ownedElementsOriginalBoundingBox);
+    if (!rg.empty()) {
+        this->page->fireRangeChanged(rg);
     }
-}
-
-void VerticalToolHandler::redrawBuffer() {
-    g_assert_nonnull(this->crBuffer);
-
-    cairo_t* cr = cairo_create(this->crBuffer);
-
-    // Clear the buffer first
-    cairo_save(cr);
-    cairo_set_operator(cr, CAIRO_OPERATOR_CLEAR);
-    cairo_paint(cr);
-    cairo_restore(cr);
-
-    // if below, render elements translated so that startY is 0.
-    // if above, 0 is already the top of the page.
-    if (this->spacingSide == Side::Below) {
-        cairo_translate(cr, 0, -this->startY);
-    } else {
-        g_assert(this->spacingSide == Side::Above);
-    }
-    xoj::view::ElementContainerView v(this);
-    v.draw(xoj::view::Context::createDefault(cr));
-
-    cairo_destroy(cr);
-}
-
-void VerticalToolHandler::paint(cairo_t* cr) {
-    GdkRGBA selectionColor = view->getSelectionColor();
-
-    cairo_set_line_width(cr, 1);
-
-    gdk_cairo_set_source_rgba(cr, &selectionColor);
-
-    const double y = std::min(this->startY, this->endY);
-    const double dy = this->endY - this->startY;
-
-    cairo_rectangle(cr, 0, y, this->page->getWidth(), std::abs(dy));
-
-    cairo_stroke_preserve(cr);
-    auto applied = GdkRGBA{selectionColor.red, selectionColor.green, selectionColor.blue, 0.3};
-    gdk_cairo_set_source_rgba(cr, &applied);
-    cairo_fill(cr);
-
-
-    const double elemY = (this->spacingSide == Side::Below ? this->endY : dy);
-    cairo_set_source_surface(cr, this->crBuffer, 0, elemY);
-    cairo_paint(cr);
-
-    IF_DEBUG_REPAINT({
-        cairo_rectangle(cr, 0, elemY, cairo_image_surface_get_width(this->crBuffer),
-                        cairo_image_surface_get_height(this->crBuffer));
-        cairo_set_source_rgba(cr, 1.0, 0, 0, 0.3);
-        cairo_fill(cr);
-    });
 }
 
 void VerticalToolHandler::currentPos(double x, double y) {
@@ -137,24 +65,15 @@ void VerticalToolHandler::currentPos(double x, double y) {
     if (this->endY == ySnapped) {
         return;
     }
-
-    const double oldEnd = this->endY;
     this->endY = ySnapped;
-
-    if (this->spacingSide == Side::Below) {
-        const double min = std::min(oldEnd, ySnapped);
-        this->view->repaintRect(0, min, this->page->getWidth(), this->page->getHeight() - min);
-    } else {
-        g_assert(this->spacingSide == Side::Above);
-        this->view->repaintRect(0, 0, this->page->getWidth(), std::max(oldEnd, ySnapped));
-    }
+    this->viewPool->dispatch(xoj::view::VerticalToolView::SET_VERTICAL_SHIFT_REQUEST, ySnapped);
 }
 
 bool VerticalToolHandler::onKeyPressEvent(GdkEventKey* event) {
     if ((event->keyval == GDK_KEY_Control_L || event->keyval == GDK_KEY_Control_R) &&
         this->spacingSide == Side::Below) {
         this->adoptElements(Side::Above);
-        this->view->rerenderPage();
+        this->viewPool->dispatch(xoj::view::VerticalToolView::SWITCH_DIRECTION_REQUEST);
         return true;
     }
     return false;
@@ -164,7 +83,7 @@ bool VerticalToolHandler::onKeyReleaseEvent(GdkEventKey* event) {
     if ((event->keyval == GDK_KEY_Control_L || event->keyval == GDK_KEY_Control_R) &&
         this->spacingSide == Side::Above) {
         this->adoptElements(Side::Below);
-        this->view->rerenderPage();
+        this->viewPool->dispatch(xoj::view::VerticalToolView::SWITCH_DIRECTION_REQUEST);
         return true;
     }
     return false;
@@ -172,27 +91,22 @@ bool VerticalToolHandler::onKeyReleaseEvent(GdkEventKey* event) {
 
 auto VerticalToolHandler::getElements() const -> const std::vector<Element*>& { return this->elements; }
 
-auto VerticalToolHandler::getElementsBoundingRect() const -> std::optional<xoj::util::Rectangle<double>> {
-    if (this->elements.empty()) {
-        return std::nullopt;
+auto VerticalToolHandler::computeElementsBoundingBox() const -> Range {
+    Range rg;
+    for (Element* e: this->elements) {
+        rg = rg.unite(Range(e->boundingRect()));
     }
-    xoj::util::Rectangle<double> rect;
-    for_first_then_each(
-            this->elements, [&](Element* e) { rect = e->boundingRect(); },
-            [&](Element* e) { rect.unite(e->boundingRect()); });
-    return rect;
+    return rg;
 }
 
 auto VerticalToolHandler::finalize() -> std::unique_ptr<MoveUndoAction> {
+
+    // Erase the blue area indicating the shift
+    this->viewPool->dispatchAndClear(xoj::view::VerticalToolView::FINALIZATION_REQUEST);
+
     if (this->elements.empty()) {
-        auto [min, max] = std::minmax(this->startY, this->endY);
-        // Erase the blue area indicating the shift
-        this->view->repaintRect(0, min, this->page->getWidth(), max - min);
         return nullptr;
     }
-
-    std::optional<xoj::util::Rectangle<double>> rect = this->getElementsBoundingRect();
-    assert(rect);
 
     const double dY = this->endY - this->startY;
     auto undo =
@@ -205,41 +119,15 @@ auto VerticalToolHandler::finalize() -> std::unique_ptr<MoveUndoAction> {
     }
     this->elements.clear();
 
-    view->rerenderRect(rect->x, rect->y + dY, rect->width, rect->height);
+    this->ownedElementsOriginalBoundingBox.translate(0, dY);
+    page->fireRangeChanged(this->ownedElementsOriginalBoundingBox);
 
     return undo;
 }
 
-void VerticalToolHandler::zoomChanged() {
-    updateZoom(this->zoomControl->getZoom());
-    redrawBuffer();
+double VerticalToolHandler::getPageWidth() const { return page->getWidth(); }
+
+auto VerticalToolHandler::createView(xoj::view::Repaintable* parent, ZoomControl* zoomControl,
+                                     const Settings* settings) const -> std::unique_ptr<xoj::view::OverlayView> {
+    return std::make_unique<xoj::view::VerticalToolView>(this, parent, zoomControl, settings);
 }
-
-void VerticalToolHandler::updateZoom(const double newZoom) {
-    const auto oldZoom = this->zoom;
-    this->zoom = newZoom;
-
-    // The buffer only needs to be recreated if the zoom has increased.
-    if (newZoom < oldZoom) {
-        assert(this->crBuffer);
-        cairo_surface_set_device_scale(this->crBuffer, newZoom, newZoom);
-        return;
-    }
-
-    const int bufWidth = static_cast<int>(this->page->getWidth() * this->zoom);
-    const int bufHeight = static_cast<int>(std::max(this->startY, this->page->getHeight() - this->startY) * this->zoom);
-
-    if (this->crBuffer) {
-        cairo_surface_destroy(this->crBuffer);
-        this->crBuffer = nullptr;
-    }
-
-    if (this->window) {
-        const int scale = gdk_window_get_scale_factor(this->window);
-        this->crBuffer = gdk_window_create_similar_image_surface(this->window, CAIRO_FORMAT_ARGB32, bufWidth * scale,
-                                                                 bufHeight * scale, scale);
-    } else {
-        this->crBuffer = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, bufWidth, bufHeight);
-    }
-    cairo_surface_set_device_scale(this->crBuffer, newZoom, newZoom);
-};

--- a/src/core/control/tools/VerticalToolHandler.h
+++ b/src/core/control/tools/VerticalToolHandler.h
@@ -80,12 +80,12 @@ public:
         Below = 1,
     };
 
-    double getStartY() const { return startY; }
-    double getEndY() const { return endY; }
-    Side getSide() const { return spacingSide; }
+    inline double getStartY() const { return startY; }
+    inline double getEndY() const { return endY; }
+    inline Side getSide() const { return spacingSide; }
     double getPageWidth() const;
 
-    auto getViewPool() const -> std::shared_ptr<xoj::util::DispatchPool<xoj::view::VerticalToolView>> {
+    inline auto getViewPool() const -> std::shared_ptr<xoj::util::DispatchPool<xoj::view::VerticalToolView>> {
         return viewPool;
     }
 
@@ -107,6 +107,10 @@ private:
     PageRef page;
     Layer* layer;
     std::vector<Element*> elements;
+    /**
+     * @brief Stores the smallest box containing all the adopted elements. 
+     *     Used to only refresh the part of the screen that needs refreshing.
+     */
     Range ownedElementsOriginalBoundingBox;
 
     double startY;

--- a/src/core/control/tools/VerticalToolHandler.h
+++ b/src/core/control/tools/VerticalToolHandler.h
@@ -18,34 +18,40 @@
 #include <cairo.h>    // for cairo_surface_t, cairo_t
 #include <gdk/gdk.h>  // for GdkEventKey, GdkWindow
 
-#include "control/zoom/ZoomListener.h"  // for ZoomListener
-#include "model/ElementContainer.h"     // for ElementContainer
-#include "model/PageRef.h"              // for PageRef
+#include "model/ElementContainer.h"  // for ElementContainer
+#include "model/OverlayBase.h"
+#include "model/PageRef.h"  // for PageRef
+#include "util/Range.h"
 
 #include "SnapToGridInputHandler.h"  // for SnapToGridInputHandler
 
-class ZoomControl;
 class Element;
 class Layer;
 class MoveUndoAction;
-class LegacyRedrawable;
 class Settings;
+class ZoomControl;
+
+namespace xoj::view {
+class OverlayView;
+class Repaintable;
+class VerticalToolView;
+};  // namespace xoj::view
+
 namespace xoj::util {
 template <class T>
-class Rectangle;
-}  // namespace xoj::util
+class DispatchPool;
+};  // namespace xoj::util
 
 /**
  * Handler class for the Vertical Spacing tool.
  */
-class VerticalToolHandler: public ElementContainer, public ZoomListener {
+class VerticalToolHandler: public ElementContainer, public OverlayBase {
 public:
     /**
      * @param initiallyReverse Set this to true if the user has the reverse mode
      * button (e.g., Ctrl) held down when a vertical selection is started.
      */
-    VerticalToolHandler(LegacyRedrawable* view, const PageRef& page, Settings* settings, double y,
-                        bool initiallyReverse, ZoomControl* zoomControl, GdkWindow* window);
+    VerticalToolHandler(const PageRef& page, Settings* settings, double y, bool initiallyReverse);
     ~VerticalToolHandler() override;
     VerticalToolHandler(VerticalToolHandler&) = delete;
     VerticalToolHandler& operator=(VerticalToolHandler&) = delete;
@@ -64,9 +70,9 @@ public:
 
     const std::vector<Element*>& getElements() const override;
 
-    void zoomChanged() override;
+    auto createView(xoj::view::Repaintable* parent, ZoomControl* zoomControl, const Settings* settings) const
+            -> std::unique_ptr<xoj::view::OverlayView>;
 
-private:
     enum class Side {
         /** elements above the reference line */
         Above = -1,
@@ -74,6 +80,16 @@ private:
         Below = 1,
     };
 
+    double getStartY() const { return startY; }
+    double getEndY() const { return endY; }
+    Side getSide() const { return spacingSide; }
+    double getPageWidth() const;
+
+    auto getViewPool() const -> std::shared_ptr<xoj::util::DispatchPool<xoj::view::VerticalToolView>> {
+        return viewPool;
+    }
+
+private:
     /**
      * Clear the currently moved elements, and then select all elements
      * above/below startY (depending on the side) to use for the spacing.
@@ -82,33 +98,16 @@ private:
     void adoptElements(Side side);
 
     /**
-     * Recreate the buffer if the new zoom value is higher.
+     * @brief Get the bounding range of the collection of elements we have adopted
+     * @return The returned range may be empty if no elements have been adopted
      */
-    void updateZoom(double newZoom);
+    Range computeElementsBoundingBox() const;
 
-    /**
-     * Clear the buffer and redraw the elements being spaced.
-     */
-    void redrawBuffer();
 
-    /**
-     * @brief Get the bounding rect of the collection of elements we have adopted
-     * @return std::nullopt if no elements have been adopted, otherwise, the bounding rectangle
-     */
-    std::optional<xoj::util::Rectangle<double>> getElementsBoundingRect() const;
-
-    GdkWindow* window;
-    LegacyRedrawable* view;
     PageRef page;
     Layer* layer;
     std::vector<Element*> elements;
-
-    /**
-     * Image buffer containing a rendering of the elements being spaced. This
-     * buffer is rendered below the endY if direction is below, or above the
-     * endY if the direction is above.
-     */
-    cairo_surface_t* crBuffer = nullptr;
+    Range ownedElementsOriginalBoundingBox;
 
     double startY;
     double endY;
@@ -119,13 +118,9 @@ private:
     Side spacingSide;
 
     /**
-     * Current zoom level.
-     */
-    double zoom;
-    ZoomControl* zoomControl;
-
-    /**
      * The handler for snapping points
      */
     SnapToGridInputHandler snappingHandler;
+
+    std::shared_ptr<xoj::util::DispatchPool<xoj::view::VerticalToolView>> viewPool;
 };

--- a/src/core/gui/PageView.h
+++ b/src/core/gui/PageView.h
@@ -251,7 +251,7 @@ private:
     /**
      * Vertical Space
      */
-    VerticalToolHandler* verticalSpace{};
+    std::unique_ptr<VerticalToolHandler> verticalSpace;
 
     /**
      * Search handling

--- a/src/core/view/Mask.cpp
+++ b/src/core/view/Mask.cpp
@@ -71,6 +71,12 @@ void Mask::blitTo(cairo_t* targetCr) const {
     cairo_mask_surface(targetCr, cairo_get_target(const_cast<cairo_t*>(cr.get())), 0.0, 0.0);
 }
 
+void Mask::paintTo(cairo_t* targetCr) const {
+    assert(isInitialized());
+    cairo_set_source_surface(targetCr, cairo_get_target(const_cast<cairo_t*>(cr.get())), 0.0, 0.0);
+    cairo_paint(targetCr);
+}
+
 void Mask::wipe() {
     assert(isInitialized());
     xoj::util::CairoSaveGuard saveGuard(cr.get());
@@ -82,6 +88,8 @@ void Mask::wipe() {
         cairo_paint(cr.get());
     });
 }
+
+void Mask::reset() { cr.reset(); }
 
 #ifdef DEBUG_MASKS
 namespace {

--- a/src/core/view/Mask.h
+++ b/src/core/view/Mask.h
@@ -39,8 +39,23 @@ public:
          cairo_content_t contentType = CAIRO_CONTENT_ALPHA);
     cairo_t* get();
     bool isInitialized() const;
+    /**
+     * @brief Use the surface as a mask
+     */
     void blitTo(cairo_t* targetCr) const;
+    /**
+     * @brief Paint the content of the surface to the target cairo context
+     */
+    void paintTo(cairo_t* targetCr) const;
+    /**
+     * @brief Erase all the surface's content
+     */
     void wipe();
+
+    /**
+     * @brief Delete the mask
+     */
+    void reset();
 
 private:
     xoj::util::CairoSPtr cr;

--- a/src/core/view/overlays/VerticalToolView.cpp
+++ b/src/core/view/overlays/VerticalToolView.cpp
@@ -1,0 +1,126 @@
+#include "VerticalToolView.h"
+
+#include "control/settings/Settings.h"
+#include "control/zoom/ZoomControl.h"
+#include "util/raii/CairoWrappers.h"
+#include "view/ElementContainerView.h"
+#include "view/Repaintable.h"
+#include "view/View.h"
+
+using namespace xoj::view;
+
+VerticalToolView::VerticalToolView(const VerticalToolHandler* handler, Repaintable* parent, ZoomControl* zoomControl,
+                                   const Settings* settings):
+        ToolView(parent), toolHandler(handler), zoomControl(zoomControl), aidColor(settings->getSelectionColor()) {
+    this->registerToPool(handler->getViewPool());
+    zoomControl->addZoomListener(this);
+}
+
+VerticalToolView::~VerticalToolView() noexcept {
+    zoomControl->removeZoomListener(this);
+    this->unregisterFromPool();
+}
+
+void VerticalToolView::draw(cairo_t* cr) const {
+    xoj::util::CairoSaveGuard saveGuard(cr);
+
+    const double startY = toolHandler->getStartY();
+    const double endY = toolHandler->getEndY();
+
+    cairo_rectangle(cr, 0, startY, toolHandler->getPageWidth(), endY - startY);
+
+    cairo_set_line_width(cr, BORDER_WIDTH_IN_PIXELS / this->parent->getZoom());
+    Util::cairo_set_source_rgbi(cr, this->aidColor);
+    cairo_stroke_preserve(cr);
+
+    Util::cairo_set_source_rgbi(cr, this->aidColor, BACKGROUND_OPACITY);
+    cairo_fill(cr);
+
+    this->drawWithoutDrawingAids(cr);
+}
+
+void VerticalToolView::drawWithoutDrawingAids(cairo_t* cr) const {
+    xoj::util::CairoSaveGuard saveGuard(cr);
+
+    if (!mask.isInitialized()) {
+        // Initialize the mask on first call, when changing sides or upon zoom change
+        mask = createMask(cr);
+        xoj::view::ElementContainerView v(this->toolHandler);
+        v.draw(xoj::view::Context::createDefault(mask.get()));
+    }
+
+    cairo_translate(cr, 0, toolHandler->getEndY() - toolHandler->getStartY());
+
+    mask.paintTo(cr);
+}
+
+bool VerticalToolView::isViewOf(const OverlayBase* overlay) const { return overlay == this->toolHandler; }
+
+void VerticalToolView::on(VerticalToolView::SetVerticalShiftRequest, double shift) {
+    Range rg = this->parent->getVisiblePart();
+    auto side = this->toolHandler->getSide();
+
+    // Padding for taking into account the drawing aid line width
+    const double padding = 0.5 * BORDER_WIDTH_IN_PIXELS / this->parent->getZoom();
+    if (side == VerticalToolHandler::Side::Above) {
+        rg.maxY = std::min(std::max(shift, this->lastShift) + padding, rg.maxY);
+    } else {
+        rg.minY = std::max(std::min(shift, this->lastShift) - padding, rg.minY);
+    }
+    this->parent->flagDirtyRegion(rg);
+    this->lastShift = shift;
+}
+
+void VerticalToolView::on(VerticalToolView::SwitchDirectionRequest) {
+    mask.reset();
+    this->parent->flagDirtyRegion(this->parent->getVisiblePart());
+}
+
+void VerticalToolView::deleteOn(VerticalToolView::FinalizationRequest) {
+    auto [minY, maxY] = std::minmax(toolHandler->getStartY(), toolHandler->getEndY());
+
+    // Padding for taking into account the drawing aid line width
+    const double padding = 0.5 * BORDER_WIDTH_IN_PIXELS / this->parent->getZoom();
+
+    // Get a range containing exactly the drawing aid blue rectangle
+    Range rg(std::numeric_limits<double>::lowest(), minY - padding, std::numeric_limits<double>::max(), maxY + padding);
+    rg = rg.intersect(this->parent->getVisiblePart());
+
+    this->parent->drawAndDeleteToolView(this, rg);
+}
+
+Mask VerticalToolView::createMask(cairo_t* tgtcr) const {
+    auto side = toolHandler->getSide();
+    auto startY = toolHandler->getStartY();
+    /*
+     * Create a mask that
+     *      * starts at startY if side == Side::Below
+     *      * ends at startY if side == Side::Above
+     *      * has height and width those of the visible area
+     * This mask is as small as possible, and still allows the user to see all elements go up or down, as long as the
+     * cursor remains in the affected page.
+     * TODO find a way to have the mask big enough for all situations:
+     *              * If the previous page is partially visible, the mask is to short
+     *              * If the cursor goes into the toolbar, the mask is to short
+     *              * If several views are implemented, the mask size should depend on the possible cursor positions
+     *                within the acted upon view, not the current view
+     *                      (the entire page is not an option for infinite pages...)
+     */
+    const double zoom = this->parent->getZoom();
+    const int dpiScaling = this->parent->getDPIScaling();
+    Range range = this->parent->getVisiblePart();
+
+    if (side == VerticalToolHandler::Side::Above) {
+        range.translate(0, startY - range.maxY);
+    } else {
+        range.translate(0, startY - range.minY);
+    }
+
+    return Mask(cairo_get_target(tgtcr), range, zoom, dpiScaling, CAIRO_CONTENT_COLOR_ALPHA);
+}
+
+void VerticalToolView::zoomChanged() {
+    // If zooming in, the mask needs redrawing to get a suitable definition
+    // If zooming out, the mask needs redrawing to cover a bigger part of the page
+    mask.reset();
+}

--- a/src/core/view/overlays/VerticalToolView.h
+++ b/src/core/view/overlays/VerticalToolView.h
@@ -1,0 +1,82 @@
+/*
+ * Xournal++
+ *
+ * View active VerticalTool (move elements up and down)
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+#pragma once
+
+#include <cairo.h>  // for cairo_t
+
+#include "control/tools/VerticalToolHandler.h"  // for Side
+#include "control/zoom/ZoomListener.h"
+#include "util/Color.h"
+#include "util/DispatchPool.h"  // for Listener
+#include "view/Mask.h"
+#include "view/overlays/OverlayView.h"
+
+class OverlayBase;
+class Range;
+class Settings;
+class ZoomControl;
+
+namespace xoj::view {
+class Repaintable;
+
+class VerticalToolView final: public ToolView, public ZoomListener, public xoj::util::Listener<VerticalToolView> {
+
+public:
+    VerticalToolView(const VerticalToolHandler* handler, Repaintable* parent, ZoomControl* zoomControl,
+                     const Settings* settings);
+    ~VerticalToolView() noexcept override;
+
+    /**
+     * @brief Draws the overlay to the given context
+     */
+    void draw(cairo_t* cr) const override;
+    void drawWithoutDrawingAids(cairo_t* cr) const override;
+
+    bool isViewOf(const OverlayBase* overlay) const override;
+
+    /**
+     * Zoom interface
+     */
+    void zoomChanged() override;
+
+    /**
+     * Listener interface
+     */
+    static constexpr struct SetVerticalShiftRequest {
+    } SET_VERTICAL_SHIFT_REQUEST = {};
+    void on(SetVerticalShiftRequest, double shift);
+
+    static constexpr struct SwitchDirectionRequest {
+    } SWITCH_DIRECTION_REQUEST = {};
+    void on(SwitchDirectionRequest);
+
+    static constexpr struct FinalizationRequest {
+    } FINALIZATION_REQUEST = {};
+    void deleteOn(FinalizationRequest);
+
+private:
+    Mask createMask(cairo_t* tgtcr) const;
+
+private:
+    const VerticalToolHandler* toolHandler;
+    ZoomControl* zoomControl;
+    double lastShift = 0.0;
+    const Color aidColor;
+
+    mutable Mask mask;
+
+public:
+    // Width of the line delimiting moved elements
+    static constexpr int BORDER_WIDTH_IN_PIXELS = 1;
+    // Opacity of the background
+    static constexpr double BACKGROUND_OPACITY = 0.3;
+};
+};  // namespace xoj::view

--- a/src/util/Range.cpp
+++ b/src/util/Range.cpp
@@ -39,6 +39,13 @@ void Range::addPadding(double padding) {
     this->maxY += padding;
 }
 
+void Range::translate(double dx, double dy) {
+    this->minX += dx;
+    this->maxX += dx;
+    this->minY += dy;
+    this->maxY += dy;
+}
+
 auto Range::empty() const -> bool {
     Range empty;
     return this->minX == empty.minX && this->minY == empty.minY && this->maxX == empty.maxX && this->maxY == empty.maxY;
@@ -46,4 +53,4 @@ auto Range::empty() const -> bool {
 
 bool Range::isValid() const { return minX <= maxX && minY <= maxY; }
 
-bool Range::contains(double x, double y) const { return x > minX && x < maxX && y > minY && y < maxY; }
+bool Range::contains(double x, double y) const { return x >= minX && x <= maxX && y >= minY && y <= maxY; }

--- a/src/util/include/util/Range.h
+++ b/src/util/include/util/Range.h
@@ -36,6 +36,7 @@ public:
     [[nodiscard]] double getHeight() const;
 
     void addPadding(double padding);
+    void translate(double dx, double dy);
 
     [[nodiscard]] bool empty() const;
     [[nodiscard]] bool isValid() const;


### PR DESCRIPTION
This PR splits tools/VerticalToolHandler into controller and view.

- reduces the buffer size
- reduces the repainted/rerendered areas

This is not battle ready yet: for performance reasons (also necessary in order to potentially allow for infinite pages at some point), the size of the buffer had to be reduced (it used to be half of the entire page).
The new (and imperfect) buffer is the size of the visible part of the page, but it starts just below (or ends just above, if ctrl is pressed) the event starting the VerticalTool. This works perfectly as long as the user ends their vertical shift whthin the current page.
In particular, in the following two situations, the buffer is to small:

1. If the view is in between pages: starting the vertical tool on the bottom page and dragging it all above the page border will (can) show that the mask is to small at the bottom.
2. After starting the vertical tool whereever on a page, move your mouse (without releasing the button) to the top of the tool bar. You''ll see the mask is to short at the bottom as well.

The solution is probably to have the mask exactly the height of the window area (or something like that). I need to think on it. If anyone has an idea on the matter, please share!