### PR TITLE
Add EditorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_size = 4
+indent_style = space
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+indent_size = 2
+trim_trailing_whitespace = false


### PR DESCRIPTION
I [mentioned](https://github.com/xournalpp/xournalpp/issues/4295#issuecomment-1272725392) in #4295 that an [EditorConfig](https://editorconfig.org) file would make it much easier to onboard new contributors because editor settings such as indentation, spacing, and trailing newline are automatically configured and just work. Additionally, it prevents bugs relating to ending files with a newline on POSIX since `insert_final_newline = true`. Thought it would be good to create a PR for this, as it's a pretty simple change