### PR TITLE
Improve technical documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,25 +5,31 @@ completely by volunteers in their spare time, so any contribution--no matter how
 small--is greatly appreciated. In this file, we'll outline how you can
 contribute to the project.
 
+If you have questions after reading this, you can join our Gitter channel via
+the badge at the top of `./README.md`.
+
 ## Overview
 
 Several of the main ways that you can contribute to the project include:
 
-* Updating [the website](https://github.com/xournalpp/xournalpp.github.io)
-  with additional information.
-* Submitting translation improvements via Crowdin (see below).
-* Contributing code changes with pull requests (PRs).
+* [Contributing website improvements](#contributing-website-improvements)
+* [Contributing translation improvements](#contributing-translation-improvements)
+* [Contributing code improvements](#contributing-code-improvements)
 
-## Contributing translations
+## Contributing website improvements
 
-If you would like to contribute translations, you can submit improvements to
-[our project on Crowdin](https://crowdin.com/project/xournalpp). The Crowdin
-translations are merged back into the main code periodically, after which they
+For making changes to the website, please go to [xournalpp/xournalpp.github.io](https://github.com/xournalpp/xournalpp.github.io).
+
+## Contributing translation improvements
+
+We use via [Crowdin](https://crowdin.com) for contributing translation
+improvements. To do this, see [our project on Crowdin](https://crowdin.com/project/xournalpp). The Crowdin
+translations are merged back into the main code periodically, after which, they
 become available available in the nightly builds.
 
-## Contributing code changes with pull requests (PRs)
+## Contributing code improvements
 
-Xournal++ development primarily occurs on [GitHub at the xournalpp/xournalpp
+Xournal++ development primarily occurs on GitHub at the [xournalpp/xournalpp
 repository](https://github.com/xournalpp/xournalpp). As a contributor, you
 probably have a particular bug or feature that you are interested in working on.
 Before you start, you should first look in the [issue
@@ -32,7 +38,7 @@ reported your bug or has a similar idea for a feature. If not, you should first
 submit a new issue detailing what you are about to do. This will allow you to
 get feedback and ensure that you do not end up duplicating work. You can obtain
 additional help by contacting community members through one of our [official
-communication channels](https://xournalpp.github.io/community/help/).
+communication channels](https://xournalpp.github.io/community/help).
 
 The process for contributing code changes works as follows:
 
@@ -42,6 +48,15 @@ The process for contributing code changes works as follows:
 3. Wait for maintainers to review the PR and address the relevant feedback.
 4. After receiving maintainer approval, the PR is merged after a short grace
    period.
+
+You may want to see some details on the [Branching Strategy](./readme/Releases.md#branching-strategy).
+
+When developing new features, create an issue or comment on an existing issue to let others know what you are doing.
+
+During development, create a fork and use the master as base. Create a pull request for each fix.
+
+_Do not_ create big pull requests. As long as you don't break anything features also can be
+merged, even if they are not 100% finished.
 
 ### Creating a fork
 
@@ -55,10 +70,11 @@ Straub, which is available online for free
 [here](https://git-scm.com/book/en/v2).
 
 You should try to first clone your fork and then compile it manually. The
-instructions for compiling Xournal++ on your operating system can be found at
-[`LinuxBuild.md`](readme/LinuxBuild.md), [`MacBuild.md`](readme/MacBuild.md),
-and [`WindowsBuild.md`](readme/WindowsBuild.md). Once you are set up, you will
-be ready to make code changes.
+instructions for compiling Xournal++ depend on your operating system:
+
+* [`LinuxBuild.md`](readme/LinuxBuild.md)
+* [`MacBuild.md`](readme/MacBuild.md),
+* [`WindowsBuild.md`](readme/WindowsBuild.md)
 
 ### Code conventions and guidelines
 
@@ -106,7 +122,7 @@ Mechanical issues:
 * Although we do not have a strong opinion on code style, we use `clang-format`
   to enforce a _consistent_ code style. Feel free to write your code in whatever
   style you prefer, as long as you run `clang-format` to format your code
-  afterwards. 
+  afterwards.
   * The code style will be automatically checked by the CI system. PRs that are
     not formatted correctly will fail to build; to remedy this, the "Clang
     Format Applied" check will also provide a patch that can be applied to fix
@@ -116,8 +132,7 @@ Mechanical issues:
     and review.
 * **Optimize your code for clarity and readability, but do not be overly
   verbose**.
-  * Use meaningful variable names whenever possible, e.g. use `centerX =
-    (posRect.x2 - posRect.x1) / 2` instead of `a = (r.x2 - r.x1) / 2`.
+  * Use meaningful variable names whenever possible, e.g. use `centerX = (posRect.x2 - posRect.x1) / 2` instead of `a = (r.x2 - r.x1) / 2`.
   * However, if it is clear from the context what the meaning of a variable is,
     prefer using a short name, e.g. `cx = (pos.x2 - pos.x1) / 2`.
   * If the type of a variable in a variable declaration is clear from the
@@ -136,6 +151,8 @@ Mechanical issues:
     to create your own memory managing RAII ref count wrapper. This will also
     reduce the time others must spend to verify your code because it is correct
     by design.
+
+See more details on coding conventions [at the Wiki](https://github.com/xournalpp/xournalpp/wiki/Coding-conventions).
 
 ### Sending your contributions for review
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ the badge at the top of `./README.md`.
 
 Several of the main ways that you can contribute to the project include:
 
-* [Contributing website improvements](#contributing-website-improvements)
+* Updating the [website](https://github.com/xournalpp/xournalpp.github.io)
 * [Contributing translation improvements](#contributing-translation-improvements)
 * [Contributing code improvements](#contributing-code-improvements)
 
@@ -22,9 +22,9 @@ For making changes to the website, please go to [xournalpp/xournalpp.github.io](
 
 ## Contributing translation improvements
 
-We use via [Crowdin](https://crowdin.com) for contributing translation
-improvements. To do this, see [our project on Crowdin](https://crowdin.com/project/xournalpp). The Crowdin
-translations are merged back into the main code periodically, after which, they
+If you would like to contribute translations, you can submit improvements to
+[our project on Crowdin](https://crowdin.com/project/xournalpp). The Crowdin
+translations are merged back into the main code periodically, after which they
 become available available in the nightly builds.
 
 ## Contributing code improvements
@@ -48,15 +48,6 @@ The process for contributing code changes works as follows:
 3. Wait for maintainers to review the PR and address the relevant feedback.
 4. After receiving maintainer approval, the PR is merged after a short grace
    period.
-
-You may want to see some details on the [Branching Strategy](./readme/Releases.md#branching-strategy).
-
-When developing new features, create an issue or comment on an existing issue to let others know what you are doing.
-
-During development, create a fork and use the master as base. Create a pull request for each fix.
-
-_Do not_ create big pull requests. As long as you don't break anything features also can be
-merged, even if they are not 100% finished.
 
 ### Creating a fork
 
@@ -152,7 +143,7 @@ Mechanical issues:
     reduce the time others must spend to verify your code because it is correct
     by design.
 
-See more details on coding conventions [at the Wiki](https://github.com/xournalpp/xournalpp/wiki/Coding-conventions).
+See [the corresponding Wiki article](https://github.com/xournalpp/xournalpp/wiki/Coding-conventions) for more details on coding conventions.
 
 ### Sending your contributions for review
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,7 @@ completely by volunteers in their spare time, so any contribution--no matter how
 small--is greatly appreciated. In this file, we'll outline how you can
 contribute to the project.
 
-If you have questions after reading this, you can join our Gitter channel via
-the badge at the top of `./README.md`.
+If you have questions after reading this file, feel free to ask them on our [Gitter channel](https://gitter.im/xournalpp/xournalpp).
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -335,8 +335,6 @@ We support building on five operating systems:
 - [Linux](readme/LinuxBuild.md)
 - [MacOS](readme/MacBuild.md)
 - [Windows](readme/WindowsBuild.md)
-- [Android](https://gitlab.com/TheOneWithTheBraid/xournalpp_mobile#getting-started)
-- [iOS](https://gitlab.com/TheOneWithTheBraid/xournalpp_mobile#getting-started)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ of some popular GNU/Linux distros and platforms.
 
 On Debian bookworm and Debian sid the `xournalpp` package (stable version) is contained in the official repositories. Simply install via
 
-```bash
+```sh
 sudo apt install xournalpp
 ```
 
@@ -177,14 +177,14 @@ _unstable_ [automated nightly releases](https://github.com/xournalpp/xournalpp/r
 On distros based on Ubuntu 22.04 Jammy Jellyfish (and later) the `xournalpp` package (stable version) is contained in the official repositories.
 Simply install via
 
-```bash
+```sh
 sudo apt install xournalpp
 ```
 
 #### Stable PPA
 The latest stable version is available via the following [_unofficial_ PPA](https://github.com/xournalpp/xournalpp/issues/1013#issuecomment-692656810):
 
-```bash
+```sh
 sudo add-apt-repository ppa:apandada1/xournalpp-stable
 sudo apt update
 sudo apt install xournalpp
@@ -193,7 +193,7 @@ sudo apt install xournalpp
 #### Unstable PPA
 An _unstable_, nightly release is available for Ubuntu-based distributions via the following PPA:
 
-```bash
+```sh
 sudo add-apt-repository ppa:andreasbutti/xournalpp-master
 sudo apt update
 sudo apt install xournalpp
@@ -210,13 +210,13 @@ xournalpp](https://src.fedoraproject.org/rpms/xournalpp) is available in the
 [main repository](https://bodhi.fedoraproject.org/updates/?packages=xournalpp)
 via _Software_ application or the following command:
 
-```bash
+```sh
 sudo dnf install xournalpp
 ```
 
 or
 
-```bash
+```sh
 pkcon install xournalpp
 ```
 
@@ -228,7 +228,7 @@ The bleeding edge packages synced to xournalpp git master on a daily basis are a
 On openSUSE Tumbleweed, the released version of Xournal++ is available from the
 main repository:
 
-```bash
+```sh
 sudo zypper in xournalpp
 ```
 
@@ -251,7 +251,7 @@ package](https://aur.archlinux.org/packages/xournalpp-git/).
 
 The latest stable release is available in the main repository:
 
-```bash
+```sh
 sudo eopkg it xournalpp
 ```
 
@@ -261,7 +261,7 @@ The Xournal++ team officially supports a [FlatHub
 release](https://flathub.org/apps/details/com.github.xournalpp.xournalpp), which
 can be installed with
 
-```bash
+```sh
 flatpak install flathub com.github.xournalpp.xournalpp
 ```
 
@@ -269,7 +269,7 @@ Note that for Xournal++ to work properly, you must have at least one GTK theme
 and one icon theme installed on Flatpak. To enable LaTeX support, you will also
 need to install the TeX Live extension:
 
-```bash
+```sh
 flatpak install flathub org.freedesktop.Sdk.Extension.texlive
 ```
 
@@ -320,38 +320,24 @@ page](https://github.com/xournalpp/xournalpp/releases).
 
 ## File format
 
-The file format _.xopp is an XML which is .gz compressed. PDFs are not embedded into the file, so if the PDF is deleted, the background is lost. _.xopp is basically the same file format as _.xoj, which is used by Xournal. Therefore Xournal++ is able to read _.xoj files, and can also export to _.xoj. As soon as notes are exported to a _.xoj-file, all Xournal++ specific extensions, like additional background types, are lost.
+The file extension `.xopp` is a gzipped XML file. PDFs are not embedded into the file, so if the PDF is deleted, the background is lost. `.xopp` is basically the same file format as `.xoj`, which is used by Xournal. Therefore, Xournal++ is able to read `.xoj` files, and can also export to `.xoj`. As soon as notes are exported to a `.xoj` file, all Xournal++ specific extensions like additional background types, are lost.
 
-\*.xopp can theoretically be read by Xournal, as long as you do not use any new feature. Xournal does not open files that contain new attributes or unknown values, so Xournal++ will add the extension .xopp to all saved files to indicate the potential presence of Xournal++-only features.
+`.xopp` files can theoretically be read by Xournal, as long as you do not use any new features. Xournal does not open files that contain new attributes or unknown values, so Xournal++ will add the extension `.xopp` to all saved files to indicate the potential presence of Xournal++-only features.
 
-All new files will be saved as _.xopp. If an _.xoj file that was created by Xournal is opened, the Save-As dialog will be displayed on save. If the \*.xoj file was created by Xournal++, the file will be overwritten on save and the file extension will not change.
+All new files will be saved as `.xopp`. If an `.xoj` file that was created by Xournal is opened, the Save-As dialog will be displayed on save. If the `.xoj` file was created by Xournal++, the file will be overwritten on save and the file extension will not change.
 
 **We are currently introducing a new file format that can efficiently store attached PDF files and other attachments internally. We will still allow for attachments that are linked to external files. Please refer to [#937](https://github.com/xournalpp/xournalpp/issues/937) for further details.**
 
-## Development
+## Building
 
-For developing new features, create an issue or comment on an existing issue to let others know what you are doing.
-For development, create a fork and use the master as base. Create a pull request for each fix.
-Do not create big pull requests, as long as you don't break anything features also can be
-merged, even if they are not 100% finished.
+We support building on five operating systems:
 
-See [GitHub:xournalpp](http://github.com/xournalpp/xournalpp) for current development. You can also join
-our Gitter channel via the badge on top.
+- [Linux](readme/LinuxBuild.md)
+- [MacOS](readme/MacBuild.md)
+- [Windows](readme/WindowsBuild.md)
+- [Android](https://gitlab.com/TheOneWithTheBraid/xournalpp_mobile#getting-started)
+- [iOS](https://gitlab.com/TheOneWithTheBraid/xournalpp_mobile#getting-started)
 
-Also take a look at our [coding conventions](https://github.com/xournalpp/xournalpp/wiki/Coding-conventions)
+## Contributing
 
-## Code documentation
-
-The code documentation is generated using Doxygen.
-
-In order to generate the documentation yourself, first install Doxygen and graphviz, i.e.
-
-```bash
-sudo apt install doxygen
-sudo apt install graphviz
-```
-
-on Debian or Ubuntu. Finally, execute `doxygen` in the root directory of the repository.
-The documentation can be found in `doc/html` and `doc/latex`. Conveniently display the
-documentation with `python3 -m http.server 8000` and visit the shown URL to view the
-documentation.
+See [CONTRIBUTING.md](./CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ All new files will be saved as `.xopp`. If an `.xoj` file that was created by Xo
 
 ## Building
 
-We support building on five operating systems:
+We support building on three operating systems:
 
 - [Linux](readme/LinuxBuild.md)
 - [MacOS](readme/MacBuild.md)

--- a/readme/Compile.md
+++ b/readme/Compile.md
@@ -1,6 +1,6 @@
 # Compilation and Testing
 
-This file contains cross-platform instructions for compiling and developing locally. For instructions on how to create platform-specific packages, or instructions on preliminary steps for building Xournal++, please see your see these platform-specific instructions:
+This file contains platform-independent instructions for compiling and developing locally. For instructions on how to create platform-specific packages, or instructions on preliminary steps for building Xournal++, please see these platform-specific instructions:
 
 - [LinuxBuild.md](./LinuxBuild.md)
 - [MacBuild.md](./MacBuild.md)
@@ -24,8 +24,6 @@ cmake --build . # For a faster build, set the flag -DCMAKE_BUILD_TYPE=RelWithDeb
 ```
 
 - Use `cmake-gui ..` to graphically configure CMake
-- With Cairo 1.16 PDF Bookmarks will be possible, but this version is not yet
-commonly available; therefore the Cairo PDF Export does not include PDF Bookmarks
 
 ## Run
 

--- a/readme/Compile.md
+++ b/readme/Compile.md
@@ -1,5 +1,11 @@
 # Compilation and Testing
 
+This file contains cross-platform instructions for compiling and developing locally. For instructions on how to create platform-specific packages, or instructions on preliminary steps for building Xournal++, please see your see these platform-specific instructions:
+
+- [LinuxBuild.md](./LinuxBuild.md)
+- [MacBuild.md](./MacBuild.md)
+- [WindowsBuild.md](./WindowsBuild.md)
+
 ## Get sources
 
 ```sh
@@ -24,7 +30,7 @@ commonly available; therefore the Cairo PDF Export does not include PDF Bookmark
 ## Run
 
 ```sh
-# Ensure you're in the './build' directory
+# Before running this command, ensure you're in the './build' directory
 ./xournalpp
 ```
 

--- a/readme/Compile.md
+++ b/readme/Compile.md
@@ -1,0 +1,47 @@
+# Compilation and Testing
+
+## Get sources
+
+```sh
+git clone http://github.com/xournalpp/xournalpp
+cd xournalpp
+```
+
+## Compile
+
+```sh
+mkdir build
+cd build
+
+cmake ..
+cmake --build . # For a faster build, set the flag -DCMAKE_BUILD_TYPE=RelWithDebInfo
+```
+
+- Use `cmake-gui ..` to graphically configure CMake
+- With Cairo 1.16 PDF Bookmarks will be possible, but this version is not yet
+commonly available; therefore the Cairo PDF Export does not include PDF Bookmarks
+
+## Run
+
+```sh
+# Ensure you're in the './build' directory
+./xournalpp
+```
+
+## Test
+
+The unit tests can be enabled by setting `-DENABLE_GTEST=on` when running the
+CMake command. This requires having `googletest` available, either through your
+system's package manager or by setting `-DDOWNLOAD_GTEST=on` to automatically
+download and build `googletest`.
+
+```sh
+mkdir build
+cd build
+
+# Build unit test executables
+cmake --build . --target test-units
+
+# Run unit tests
+cmake --build . --target test
+```

--- a/readme/LinuxBuild.md
+++ b/readme/LinuxBuild.md
@@ -1,100 +1,86 @@
-# Xournal++ Linux Build
+# Linux Build
 
-## Install dependencies
+## Introduction
 
-Xournal++ is programmed with c++17 and needs the <optional> header and one filesystem library, either the STL or the boost implementation.
+Xournal++ is programmed with C++17 and needs the `<optional>` header and one filesystem library, either the STL or the boost implementation.
 Therefore it is required to install a compiler implementing those features.
-We recommend g++-8 or clang-9 and above.
+We recommend using at least GCC 8 or Clang 9.
 
-Please create pull requests (or file issues) if you have more precise dependencies.
+Please create file an issue or create a pull request if you require more precise dependencies.
 
-Lua is needed for plugins, if it is missing, the plugins will be disabled.
+Lua is needed for plugins; if it is missing, the plugins will be disabled.
 
+### Install Dependencies
 
-### CMake Generator
+The minimum required CMake version is 3.13, but we recommend using >=3.15. Also, either `make` or `ninja` must be installed.
 
-The installation instructions don't assume any specific build tool (other than CMake), 
-but they do require make, ninja, or another supported CMake generator. It is required 
-that such a tool is installed in order to build xournalpp.
-
-The minimum required CMake version is 3.13, but we recommend to use >=3.15.
-
-### Distribution specific commands
-
-#### For Arch
-```bash
+#### For Arch Linux:
+```sh
 sudo pacman -S cmake gtk3 base-devel libxml2 portaudio libsndfile \
 poppler-glib texlive-bin texlive-pictures gettext libzip lua53 lua53-lgi \
 gtksourceview4
 ```
 
 #### For Fedora:
-```bash
+```sh
 sudo dnf install gcc-c++ cmake gtk3-devel libxml2-devel portaudio-devel libsndfile-devel \
-poppler-glib-devel texlive-scheme-basic texlive-dvipng 'tex(standalone.cls)' gettext libzip-devel \
-librsvg2-devel lua-devel lua-lgi gtksourceview4-devel
+  poppler-glib-devel texlive-scheme-basic texlive-dvipng 'tex(standalone.cls)' gettext libzip-devel \
+  librsvg2-devel lua-devel lua-lgi gtksourceview4-devel
 ```
 
 #### For CentOS/RHEL:
-```bash
+```sh
 sudo dnf install gcc-c++ cmake gtk3-devel libxml2-devel cppunit-devel portaudio-devel libsndfile-devel \
-poppler-glib-devel texlive-scheme-basic texlive-dvipng 'tex(standalone.cls)' gettext libzip-devel \
-librsvg2-devel gtksourceview4-devel
+  poppler-glib-devel texlive-scheme-basic texlive-dvipng 'tex(standalone.cls)' gettext libzip-devel \
+  librsvg2-devel gtksourceview4-devel
 ```
 
-
 #### For Ubuntu/Debian and Raspberry Pi OS:
-````bash
+```sh
 sudo apt-get install cmake libgtk-3-dev libpoppler-glib-dev portaudio19-dev libsndfile-dev \
-dvipng texlive libxml2-dev liblua5.3-dev libzip-dev librsvg2-dev gettext lua-lgi \
-libgtksourceview-4-dev
-````
+  dvipng texlive libxml2-dev liblua5.3-dev libzip-dev librsvg2-dev gettext lua-lgi \
+  libgtksourceview-4-dev
+```
 
 #### For openSUSE:
-```bash
+```sh
 sudo zypper install cmake gtk3-devel portaudio-devel libsndfile-devel \
-texlive-dvipng texlive libxml2-devel libpoppler-glib-devel libzip-devel librsvg-devel lua-devel lua-lgi \
-gtksourceview4-devel
+  texlive-dvipng texlive libxml2-devel libpoppler-glib-devel libzip-devel librsvg-devel lua-devel lua-lgi \
+  gtksourceview4-devel
 ```
 
 #### For Solus:
-```bash
+```sh
 sudo eopkg it -c system.devel
 sudo eopkg it cmake libgtk-3-devel libxml2-devel poppler-devel libzip-devel \
-portaudio-devel libsndfile-devel alsa-lib-devel lua-devel \
-librsvg-devel gettext libgtksourceview-devel
+  portaudio-devel libsndfile-devel alsa-lib-devel lua-devel \
+  librsvg-devel gettext libgtksourceview-devel
 ```
 
-## Compiling
+## Building and Testing
 
-The basic steps to compile Xournal++ are:
+See [Compile.md](./Compile.md)
 
-```bash
-git clone http://github.com/xournalpp/xournalpp.git
-cd xournalpp
-mkdir build
-cd build
-cmake ..
-cmake --build .
-# For a faster build, set the flag -DCMAKE_BUILD_TYPE=RelWithDebInfo
+## Building Documentation
+
+The code documentation is generated using Doxygen. Both Doxygen and graphviz must be
+installed. For example, with apt:
+
+```sh
+sudo apt install doxygen graphviz
 ```
 
-Use `cmake-gui ..` to graphically configure compilation.
-
-With Cairo 1.16 PDF Bookmarks will be possible, but this Version is not yet
-common available, therefore the Cairo PDF Export is without PDF Bookmarks.
-
-The binary executable will be placed directly into the `build/` directory. 
-You can run it by executing `./xournalpp` from that directory. For testing
-purposes packaging and installation on the system are not required.
+Then, execute `doxygen` in the root directory of the repository. The documentation
+can be found in `doc/html` and `doc/latex`. Conveniently view it in a browser with
+`python3 -m http.server 8000` and visit the URL it shows.
 
 ## Packaging and Installation
 
-### Creating Packages for Package Managers
+### Packaging
 
 Please ensure that the `translations` target has been built before
 attempting to generate any package.
-```bash
+```sh
 cmake --build . --target translations
 ```
 
@@ -102,7 +88,7 @@ After compilation, select which packages you want to generate (see the relevant
 sections below) and then run the `package` target. The generated packages will
 be located in `build/packages`. For example:
 
-```bash
+```sh
 cmake .. -DCPACK_GENERATOR="TGZ;DEB"  # Generate .tar.gz and .deb packages
 cmake --build . --target package
 ```
@@ -111,14 +97,14 @@ By default, a standalone `.tar.gz` package will be generated. For
 distro-agnostic packaging platforms such as AppImages and Flatpaks, see the
 relevant sections below.
 
-#### .deb packages
+#### `.deb` packages
 
-```bash
+```sh
 cmake .. -DCPACK_GENERATOR="DEB" ..
 cmake --build . --target package
 ```
 
-#### .rpm packages
+#### `.rpm` packages
 
 TODO
 
@@ -128,7 +114,7 @@ The quickest way to generate an AppImage is to first generate the `.tar.gz`
 package and then use that with the `azure-pipelines/util/build_appimage.sh`
 script.
 
-```bash
+```sh
 cmake .. -DCPACK_GENERATOR="TGZ"
 cmake --build . --target package
 ../azure-pipelines/util/build_appimage.sh
@@ -147,8 +133,9 @@ The Flatpak manifest for Xournal++ is located at
 https://github.com/flathub/com.github.xournalpp.xournalpp, which should be
 cloned into a separate directory before building.
 
-```bash
+```sh
 git clone https://github.com/flathub/com.github.xournalpp.xournalpp xournalpp-flatpak
+cd xournalpp-flatpak
 ```
 
 By default, the Flatpak manifest will build the latest stable version of
@@ -180,32 +167,16 @@ package, an AppImage or Flatpak instead. Instructions are above.
 If you don't want to make a package, you can install Xournal++ into your user
 folder (or any other folder) by specifying `CMAKE_INSTALL_PREFIX`:
 
-```bash
-cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/.local
+```sh
+cmake .. -DCMAKE_INSTALL_PREFIX="$HOME/.local"
 cmake --build . --target install
 ./cmake/postinst configure
 ```
 
-If you want to install Xournal++ systemwide directly from the build directory, run
+If you want to install Xournal++ system-wide directly from the build directory, run
 
-```bash
+```sh
 cmake .. -DCMAKE_INSTALL_PREFIX=/usr
 sudo cmake --build . --target install
 ./cmake/postinst configure
-```
-
-## Running tests
-
-The unit tests can be enabled by setting `-DENABLE_GTEST=on` when running the
-CMake command. This requires having `googletest` available, either through your
-system's package manager or by setting `-DDOWNLOAD_GTEST=on` to automatically
-download and build `googletest`.
-
-The tests can be run as follows:
-```
-# build unit test executables
-cmake --build . --target test-units
-
-# run unit tests
-cmake --build . --target test
 ```

--- a/readme/LinuxBuild.md
+++ b/readme/LinuxBuild.md
@@ -71,31 +71,10 @@ sudo apt install doxygen graphviz
 ```
 
 Then, execute `doxygen` in the root directory of the repository. The documentation
-can be found in `doc/html` and `doc/latex`. Conveniently view it in a browser with
-`python3 -m http.server 8000` and visit the URL it shows.
+can be found in `doc/html` and `doc/latex`. Launch a server hosting the files with
+`python3 -m http.server 8000` and visit the URL that the command shows.
 
 ## Packaging and Installation
-
-### Packaging
-
-Please ensure that the `translations` target has been built before
-attempting to generate any package.
-```sh
-cmake --build . --target translations
-```
-
-After compilation, select which packages you want to generate (see the relevant
-sections below) and then run the `package` target. The generated packages will
-be located in `build/packages`. For example:
-
-```sh
-cmake .. -DCPACK_GENERATOR="TGZ;DEB"  # Generate .tar.gz and .deb packages
-cmake --build . --target package
-```
-
-By default, a standalone `.tar.gz` package will be generated. For
-distro-agnostic packaging platforms such as AppImages and Flatpaks, see the
-relevant sections below.
 
 #### `.deb` packages
 

--- a/readme/MacBuild.md
+++ b/readme/MacBuild.md
@@ -1,4 +1,5 @@
-# Xournal++ MacOS .app Build
+# MacOS Build (.app)
+
 Do not install macports or homebrew. If you have installed it, you need to
 create a new user, and use this for the whole process. jhbuild does not work,
 if there is such an environment installed.
@@ -6,15 +7,15 @@ if there is such an environment installed.
 One possible way to use jhbuild alongside brew is to unlink all brew modules before running jhbuild. After finishing the build they can be relinked. This is untested though and might fail.
 
 ## Make sure the Development environment is installed
-Open a Terminal, and type in `git`, confirm popup from Appstore with "Install" to install development tools.
+Open a Terminal, and type in `git`, confirm popup from the App Store with "Install" to install development tools.
 
 ## Build Libraries (needs to be done once)
 Please take the OS version dependent problems for each step into account. The errors will vary with different versions of the libraries. If you encounter a yet unknown error, feel free to add it to this set of instructions.
 
 ### 1. Build GTK
-````bash
+```sh
 ./build-gtk3.sh
-````
+```
 #### Potential Errors
 ##### itstool (version 2.0.6 on macOS High Sierra 10.13)
 itstool might fail in configure step searching for libxml2 python bindings.
@@ -22,51 +23,51 @@ itstool might fail in configure step searching for libxml2 python bindings.
 Follow these steps to resolve the issue:
 1. Open a shell with option 4
 2. Change Python to version 2.7 with `export PYTHON=/usr/bin/python2.7`
-3. Run the configure step manually with `./configure --prefix $HOME/gtk/inst`
+3. Run the configure step manually with `./configure --prefix "$HOME/gtk/inst"`
 4. Exit the shell with `exit`
 5. Continue the build with option 2
 
 ##### expat (macOS Mojave 10.14)
 The build might fail on expat:
-````bash
+```sh
 configure: error: C compiler cannot create executables
-````
+```
 
 Follow these steps to resolve the issue:
 1. Open a shell with option 4
-2. Run the configure step manually with `./configure --prefix $HOME/gtk/inst`
+2. Run the configure step manually with `./configure --prefix "$HOME/gtk/inst"`
 3. Exit the shell with `exit`
 4. Continue the build with option 2
 
 ### 2. Start a jhbuild shell
-````bash
-$HOME/.new_local/bin/jhbuild shell
-````
+```sh
+"$HOME"/.new_local/bin/jhbuild shell
+```
 
 ### 3. Build Poppler
 Execute in this folder.
-````bash
+```sh
 ./build-poppler.sh
-````
+```
 
 ### 4. Build PortAudio
 
-````bash
+```sh
 ./build-portaudio.sh
-````
+```
 
 ### 5. Build LibZip
 
-````bash
+```sh
 ./build-libzip.sh
-````
+```
 #### Potential Errors
 ##### Unknown module (macOS Mojave 10.14)
 
 If there is an error like:
-````bash
-xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance
-````
+```sh
+xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer directory'/Library/Developer/CommandLineTools' is a command line tools instance
+```
 
 Follow these steps to resolve the issue:
 1. Install Xcode (get it from [here](https://developer.apple.com/xcode/)) if you don't have it yet.
@@ -82,43 +83,43 @@ Steps are from this [source](https://stackoverflow.com/questions/17980759/xcode-
 
 ### 6. Build sndfile
 **Recording and playing audio is not yet supported for MacOS.**
-````bash
+```sh
 ./build-sndfile.sh
-````
+```
 
 ### 7. Build adwaita icon theme
-````bash
+```sh
 jhbuild build adwaita-icon-theme
-````
+```
 
 ### 8. Build GtkSourceView
-````bash
+```sh
 jhbuild build gtksourceview3
-````
+```
 
 ## Build Xournal++ and package it as .app
 
 ### Automated step
 
-````bash
+```sh
 ./complete-build.sh $HOME/gtk
-````
+```
 
 ### Manual steps
 
 #### Build Xournal++
-````bash
+```sh
 export PATH="$HOME/.local/bin:$HOME/gtk/inst/bin:$PATH"
 
 cmake -DCMAKE_INSTALL_PREFIX:PATH=$HOME/gtk/inst ..
 make -j 4
 make install
-````
+```
 
 #### Build App
-````bash
-./build-app.sh $HOME/gtk
-````
+```sh
+./build-app.sh "$HOME/gtk"
+```
 
 # Xournal++ Mac Homebrew Build
 
@@ -127,24 +128,14 @@ make install
 It is highly recommended to either use an official or nightly release.
 Should you still want to build your own version please refer to the app-build above.
 
-## Install Homebrew
-https://brew.sh/
-
-````bash
-/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-````
-
 ## Install dependencies
-````bash
-brew install cmake pkg-config gtk+3 poppler librsvg adwaita-icon-theme libzip portaudio libsndfile
-````
 
-## Build Xournal++:
-````bash
-git clone http://github.com/xournalpp/xournalpp.git
-cd xournalpp
-mkdir build
-cd build
-cmake ..
-make
-````
+Brew must be installed. See [https://brew.sh](https://brew.sh) for installation instructions
+
+```sh
+brew install cmake pkg-config gtk+3 poppler librsvg adwaita-icon-theme libzip portaudio libsndfile
+```
+
+## Building and Testing
+
+See [Compile.md](./Compile.md)

--- a/readme/MacBuild.md
+++ b/readme/MacBuild.md
@@ -1,6 +1,6 @@
 # MacOS Build (.app)
 
-Do not install macports or homebrew. If you have installed it, you need to
+Do not install with MacPorts or Homebrew. If you have installed it, you need to
 create a new user, and use this for the whole process. jhbuild does not work,
 if there is such an environment installed.
 
@@ -130,7 +130,7 @@ Should you still want to build your own version please refer to the app-build ab
 
 ## Install dependencies
 
-Brew must be installed. See [https://brew.sh](https://brew.sh) for installation instructions
+Homebrew must be installed. See [https://brew.sh](https://brew.sh) for installation instructions
 
 ```sh
 brew install cmake pkg-config gtk+3 poppler librsvg adwaita-icon-theme libzip portaudio libsndfile

--- a/readme/MacBuild.md
+++ b/readme/MacBuild.md
@@ -121,14 +121,14 @@ make install
 ./build-app.sh "$HOME/gtk"
 ```
 
-# Xournal++ Mac Homebrew Build
+## Xournal++ Mac Homebrew Build
 
 **We do not officially support builds with Homebrew. They are solely for convenience.**
 
 It is highly recommended to either use an official or nightly release.
 Should you still want to build your own version please refer to the app-build above.
 
-## Install dependencies
+### Install dependencies
 
 Homebrew must be installed. See [https://brew.sh](https://brew.sh) for installation instructions
 
@@ -136,6 +136,6 @@ Homebrew must be installed. See [https://brew.sh](https://brew.sh) for installat
 brew install cmake pkg-config gtk+3 poppler librsvg adwaita-icon-theme libzip portaudio libsndfile
 ```
 
-## Building and Testing
+### Building and Testing
 
 See [Compile.md](./Compile.md)

--- a/readme/Releases.md
+++ b/readme/Releases.md
@@ -1,9 +1,11 @@
-# Versioning
+# Releases
+
+## Versioning
 
 Every release of Xournal++ is tagged with a unique incrementing version. In the history of the project, two changes to the versioning scheme happened. Be careful when trying to automatically parse older versions.
 The current versioning scheme adheres to the rules of [Debian upstream_version](https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-version).
 
-## Main Version
+### Main Version
 
 We follow the common versioning scheme of major, minor and patch versions in this order, separated by dots.
 
@@ -22,7 +24,7 @@ To help you understand when we use what version increment, use these rules:
 
 Whenever a bump of the major version happens, minor and patch versions are reset to `0`. Equally the patch version is reset to `0` when the minor version is bumped.
 
-## Version Suffix
+### Version Suffix
 
 The main version string may be followed by a suffix. This suffix is used to describe unreleased versions and hotfixes.
 
@@ -37,7 +39,7 @@ We mainly use suffixes to specify development versions. Our main development bra
 
 When we start our release process, we branch off a release branch. At this point of time it is clear what changes we include in the release and we can use the above rules to determine the correct version. From this point on we will change the main version string to this new version and use the suffix `~dev`. This describes our intent of working towards this release.
 
-# Branching Strategy
+## Branching Strategy
 
 Our branching model knows five types of branches:
 
@@ -47,11 +49,11 @@ Our branching model knows five types of branches:
 - Feature branches (`feature-*`) are commonly used for Pull Requests with new features. Such branches are always merged into the main development branch.
 - Bugfix branches (`bugfix-*`) are used for Pull Requests with a bugfix for a maintained release or the current development version. Depending on their target they must be merged into the appropriate branch.
 
-# Helper Script
+## Helper Script
 
 To help with the task of versioning, we provide a helper script, that does most of the work for you. You can find the script at `scripts/release_helper.sh`.
 
-## Preparing a new minor/major release
+### Preparing a new minor/major release
 The starting point of a new minor/major release is always the main development branch. You may use `release_helper.sh prepare <version>` to prepare the release. `<version>` Shall be replaced with the appropriate version. Be aware that the patch version must be `0`.
 
 The script will:
@@ -62,7 +64,7 @@ The script will:
 
 Whatever version suffix you choose, will be appended by `~dev` to signify that this is not yet the release version but development progresses towards this release.
 
-## Preparing a hotfix
+### Preparing a hotfix
 The starting point of a hotfix release is the tagged commit of the release this hotfix is based upon. You must check out this release and then call `release_helper.sh prepare <version><+suffix>` where the version equals the currently checked out version and the chosen suffix. The suffix must start with a `+` as only hotfixes based on top of this version are allowed.
 
 The script will:
@@ -71,7 +73,7 @@ The script will:
 2. Check the new branch out
 3. Apply the supplied version to all relevant files suffixed by `~dev`.
 
-## Publishing a release
+### Publishing a release
 Publishing a release can only happen on a release branch or a hotfix branch. It can be triggered by `release_helper.sh publish` and will initiate the process of publishing the release.
 
 The script will:

--- a/readme/WindowsBuild.md
+++ b/readme/WindowsBuild.md
@@ -2,39 +2,35 @@
 
 ![Screenshot](./main-win.png?raw=true "Xournal++ Screenshot on Win10")
 
-### Install Dependencies
+## Install Dependencies
 
-Xournall requires the following software to build:
+Xournal++ requires the following software to build:
 
 1. Install [MSYS2](https://www.msys2.org/) to a short path without spaces.
 2. Install [NSIS](https://nsis.sourceforge.io/Download) to the standard directory.
 3. Start Mingw-w64 64bit. (Always check if it says **MINGW64** - not 32bit and not MSYS2)
 
-This will open a console. The following steps happen in this console:
+This will open the MINGW64 console. All following steps in this document happen in this console, unless specified otherwise.
 
 ### Update MSYS2
 
-Do this multiple times, close the Terminal after each update
+Open a MSYS2 console (**not** the MINGW64 console -- close them if you have any open) and run the following command twice. Reopen the MSYS2 console each time you run the command.
 
 ```sh
 pacman -Syuu
 ```
 
-### Install Git
-
-```sh
-pacman -S git
-```
-
 ### Install Build tools
 
 ```sh
-pacman -S mingw-w64-x86_64-toolchain \
+pacman -S \
+  mingw-w64-x86_64-toolchain \
   mingw-w64-x86_64-cmake \
   mingw-w64-x86_64-ninja \
+  mingw-w64-x86_64-imagemagick \
   patch \
   make \
-  mingw-w64-x86_64-imagemagick
+  git
 ```
 
 If prompted, confirm or use all default values.
@@ -42,7 +38,8 @@ If prompted, confirm or use all default values.
 ### Install dependencies
 
 ```sh
-pacman -S mingw-w64-x86_64-poppler \
+pacman -S \
+  mingw-w64-x86_64-poppler \
   mingw-w64-x86_64-gtk3 \
   mingw-w64-x86_64-libsndfile \
   mingw-w64-x86_64-libzip \

--- a/readme/WindowsBuild.md
+++ b/readme/WindowsBuild.md
@@ -1,66 +1,61 @@
-# Xournal++ Windows Build
+# Windows Build
 
-![Screenshot](main-win.png?raw=true "Xournal++ Screenshot on Win10")
+![Screenshot](./main-win.png?raw=true "Xournal++ Screenshot on Win10")
 
-## Preparation
+### Install Dependencies
+
+Xournall requires the following software to build:
+
 1. Install [MSYS2](https://www.msys2.org/) to a short path without spaces.
 2. Install [NSIS](https://nsis.sourceforge.io/Download) to the standard directory.
 3. Start Mingw-w64 64bit. (Always check if it says **MINGW64** - not 32bit and not MSYS2)
 
-This will open a console. All following steps happen in this console.
+This will open a console. The following steps happen in this console:
 
-## Update MSYS2
+### Update MSYS2
 
 Do this multiple times, close the Terminal after each update
-```bash
+
+```sh
 pacman -Syuu
 ```
 
-## Install GIT
+### Install Git
 
-```bash
+```sh
 pacman -S git
 ```
 
-## Install Build tools
+### Install Build tools
 
-```bash
+```sh
 pacman -S mingw-w64-x86_64-toolchain \
-          mingw-w64-x86_64-cmake \
-          mingw-w64-x86_64-ninja \
-          patch \
-          make \
-          mingw-w64-x86_64-imagemagick
+  mingw-w64-x86_64-cmake \
+  mingw-w64-x86_64-ninja \
+  patch \
+  make \
+  mingw-w64-x86_64-imagemagick
 ```
--> press enter multiple times / confirm all default values
 
-## Install dependencies
+If prompted, confirm or use all default values.
 
-```bash
+### Install dependencies
+
+```sh
 pacman -S mingw-w64-x86_64-poppler \
-          mingw-w64-x86_64-gtk3 \
-          mingw-w64-x86_64-libsndfile \
-          mingw-w64-x86_64-libzip \
-          mingw-w64-x86_64-lua \
-          mingw-w64-x86_64-portaudio
-```
--> press enter multiple times / confirm all default values
-
-## Get sources
-
-```bash
-git clone https://github.com/xournalpp/xournalpp.git
-cd xournalpp/
+  mingw-w64-x86_64-gtk3 \
+  mingw-w64-x86_64-libsndfile \
+  mingw-w64-x86_64-libzip \
+  mingw-w64-x86_64-lua \
+  mingw-w64-x86_64-portaudio
 ```
 
-## Build Xournal++
+If prompted, confirm or use all default values.
 
-```bash
-mkdir build
-cd build/
-cmake ..
-cmake --build .
-```
+## Building and Testing
+
+See [Compile.md](./Compile.md)
+
 ## Modify Path Environment Variable
 
 Add `C:\msys64\mingw64\bin` and `C:\msys64\usr\bin` to the top of 
@@ -68,15 +63,16 @@ your PATH environment variable in the Windows Advanced system
 settings (assuming default installation folder for MSYS2). 
 
 You can now run Xournal++ with
-```bash
+```sh
 ./xournalpp.exe
 ```
 or package it in an installer (see below).
 
 ## Packaging and Setup
+
 Create the installer with
-```bash
-windows-setup/package.sh
+```sh
+./windows-setup/package.sh
 ```
 
 The installer will be located at `windows-setup/xournalpp-setup.exe`. This


### PR DESCRIPTION
This implements some of the documentation improvement suggestions proposed in #4295. Namely, it:

- Moves common build commands into a `Compile.md`
- Link to the branching strategy in CONTRIBUTING.md
- Move all documentation related to contributing to one place (CONTRIBUTING.md)
  - Previously, links to the Wiki and generating documentation were hidden in the README.md
- Convert some inline paragraph lists to a bullet-point format that's easier to read
- Delegate some documentation to other sites
  - For example, the current "Brew installation instructions" were outdated and incorrect. Now, we link to the website directly as to prevent any outdated instructions
- Rename triple backtick "bash" code snippets to "sh" (it is more semantically correct)
- Reestablish title hierarchy (in some files, there were multiple level-1 headings, which made the docs look "off")
- Improve miscellaneous formatting and wording

I tried my best to keep the same writing style (sort of verbose, repetitive), so let me know if there is anything I should change

closes #4295