### PR TITLE
Fixed bug that closed text fields immediately after creating them with the middle mouse button. 

### DIFF
--- a/src/gui/inputdevices/MouseInputHandler.cpp
+++ b/src/gui/inputdevices/MouseInputHandler.cpp
@@ -124,11 +124,11 @@ auto MouseInputHandler::changeTool(InputEvent const& event) -> bool {
 
     if (toolChanged) {
         ToolType toolType = toolHandler->getToolType();
-        if(toolType == TOOL_TEXT) 
+        if (toolType == TOOL_TEXT)
             toolHandler->selectTool(toolType);
         toolHandler->fireToolChanged();
     }
-    
+
     return true;
 }
 

--- a/src/gui/inputdevices/MouseInputHandler.cpp
+++ b/src/gui/inputdevices/MouseInputHandler.cpp
@@ -122,8 +122,13 @@ auto MouseInputHandler::changeTool(InputEvent const& event) -> bool {
     else
         toolChanged = toolHandler->pointActiveToolToToolbarTool();
 
-    if (toolChanged)
+    if (toolChanged) {
+        ToolType toolType = toolHandler->getToolType();
+        if(toolType == TOOL_TEXT) 
+            toolHandler->selectTool(toolType);
         toolHandler->fireToolChanged();
+    }
+    
     return true;
 }
 

--- a/src/gui/inputdevices/StylusInputHandler.cpp
+++ b/src/gui/inputdevices/StylusInputHandler.cpp
@@ -183,10 +183,10 @@ auto StylusInputHandler::changeTool(InputEvent const& event) -> bool {
 
     if (toolChanged) {
         ToolType toolType = toolHandler->getToolType();
-        if(toolType == TOOL_TEXT) 
+        if (toolType == TOOL_TEXT)
             toolHandler->selectTool(toolType);
         toolHandler->fireToolChanged();
     }
-    
+
     return true;
 }

--- a/src/gui/inputdevices/StylusInputHandler.cpp
+++ b/src/gui/inputdevices/StylusInputHandler.cpp
@@ -181,7 +181,12 @@ auto StylusInputHandler::changeTool(InputEvent const& event) -> bool {
     else
         toolChanged = toolHandler->pointActiveToolToToolbarTool();
 
-    if (toolChanged)
+    if (toolChanged) {
+        ToolType toolType = toolHandler->getToolType();
+        if(toolType == TOOL_TEXT) 
+            toolHandler->selectTool(toolType);
         toolHandler->fireToolChanged();
+    }
+    
     return true;
 }


### PR DESCRIPTION
This is an attempt to fix the bug mentioned in #3983. After testing and debugging I realized that this bug not only appears if you use the middle mouse button, but also if you choose the right mouse button to open a text field.
When this function is used for other tools, releasing the pressed key should return to the previous tool (e.g. the eraser should disappear after releasing the middle/right mouse button). This is not the case with the text tool, since you not only want to create a text box, but also write something down right away.
Therefore, I decided to actually (permanently) select the text tool if you press the middle mouse button. If you think there is a better fix, jut let me know and I can have another look at it. 

