### PR TITLE
Automatically create empty last page if last page is drawn on

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -1451,7 +1451,9 @@ void Control::duplicatePage() {
     insertPage(pageCopy, getCurrentPageNo() + 1);
 }
 
-void Control::insertNewPage(size_t position) { pageBackgroundChangeController->insertNewPage(position); }
+void Control::insertNewPage(size_t position, bool shouldScrollToPage) {
+    pageBackgroundChangeController->insertNewPage(position, shouldScrollToPage);
+}
 
 void Control::appendNewPdfPages() {
     auto pageCount = this->doc->getPageCount();
@@ -1489,7 +1491,7 @@ void Control::appendNewPdfPages() {
     }
 }
 
-void Control::insertPage(const PageRef& page, size_t position) {
+void Control::insertPage(const PageRef& page, size_t position, bool shouldScrollToPage) {
     this->doc->lock();
     this->doc->insertPage(page, position);  // insert the new page to the document and update page numbers
     this->doc->unlock();
@@ -1502,8 +1504,11 @@ void Control::insertPage(const PageRef& page, size_t position) {
 
     // make the inserted page fully visible (or at least as much from the top which fits on the screen),
     // and make the page appear selected
-    scrollHandler->scrollToPage(position);
-    firePageSelected(position);
+    if (shouldScrollToPage) {
+        scrollHandler->scrollToPage(position);
+        firePageSelected(position);
+    }
+
 
     updateDeletePageButton();
     undoRedo->addUndoAction(std::make_unique<InsertDeletePageUndoAction>(page, position, true));

--- a/src/core/control/Control.h
+++ b/src/core/control/Control.h
@@ -206,9 +206,9 @@ public:
 
     void addDefaultPage(std::string pageTemplate);
     void duplicatePage();
-    void insertNewPage(size_t position);
+    void insertNewPage(size_t position, bool shouldScrollToPage = true);
     void appendNewPdfPages();
-    void insertPage(const PageRef& page, size_t position);
+    void insertPage(const PageRef& page, size_t position, bool shouldScrollToPage = true);
     void deletePage();
 
     /**

--- a/src/core/control/PageBackgroundChangeController.cpp
+++ b/src/core/control/PageBackgroundChangeController.cpp
@@ -260,7 +260,7 @@ void PageBackgroundChangeController::copyBackgroundFromOtherPage(PageRef target,
     }
 }
 
-void PageBackgroundChangeController::insertNewPage(size_t position) {
+void PageBackgroundChangeController::insertNewPage(size_t position, bool shouldScrollToPage) {
     control->clearSelectionEndText();
 
     Document* doc = control->getDocument();
@@ -293,7 +293,7 @@ void PageBackgroundChangeController::insertNewPage(size_t position) {
         }
     }
 
-    control->insertPage(page, position);
+    control->insertPage(page, position, shouldScrollToPage);
 }
 
 void PageBackgroundChangeController::documentChanged(DocumentChangeType type) {}

--- a/src/core/control/PageBackgroundChangeController.h
+++ b/src/core/control/PageBackgroundChangeController.h
@@ -38,7 +38,7 @@ public:
     virtual void changeCurrentPageBackground(PageType& pageType);
     void changeCurrentPageBackground(PageTypeInfo* info) override;
     void changeAllPagesBackground(const PageType& pt);
-    void insertNewPage(size_t position);
+    void insertNewPage(size_t position, bool shouldScrollToPage = true);
     GtkWidget* getMenu();
 
     // DocumentListener

--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -17,6 +17,7 @@
 #include "control/ToolEnums.h"                      // for ERASER_TYPE_NONE
 #include "control/settings/LatexSettings.h"         // for LatexSettings
 #include "control/settings/SettingsEnums.h"         // for InputDeviceTypeOp...
+#include "control/settings/SettingsEnums.cpp"       // for emptyLastPageAppendFromString
 #include "gui/toolbarMenubar/model/ColorPalette.h"  // for Palette
 #include "model/FormatDefinitions.h"                // for FormatUnits, XOJ_...
 #include "util/Color.h"
@@ -73,6 +74,8 @@ void Settings::loadDefault() {
     this->layoutBottomToTop = false;
 
     this->numPairsOffset = 1;
+
+    this->emptyLastPageAppend = EmptyLastPageAppendType::Disabled;
 
     this->edgePanSpeed = 20.0;
     this->edgePanMaxMult = 5.0;
@@ -528,6 +531,8 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur) {
         this->inputSystemTPCButton = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("inputSystemDrawOutsideWindow")) == 0) {
         this->inputSystemDrawOutsideWindow = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("emptyLastPageAppend")) == 0) {
+        this->emptyLastPageAppend = emptyLastPageAppendFromString(reinterpret_cast<char*>(value));
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("strokeFilterIgnoreTime")) == 0) {
         this->strokeFilterIgnoreTime = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("strokeFilterIgnoreLength")) == 0) {
@@ -902,6 +907,8 @@ void Settings::save() {
     SAVE_BOOL_PROP(layoutRightToLeft);
     SAVE_BOOL_PROP(layoutBottomToTop);
     SAVE_INT_PROP(numPairsOffset);
+    xmlNode = saveProperty("emptyLastPageAppend", emptyLastPageAppendToString(this->emptyLastPageAppend), root);
+    ATTACH_COMMENT("The icon theme, allowed values are \"disabled\", \"onDrawOfLastPage\", and \"onScrollOfLastPage\"");
     SAVE_BOOL_PROP(presentationMode);
 
     SAVE_STRING_PROP(fullscreenHideElements);
@@ -1010,6 +1017,9 @@ void Settings::save() {
 
     SAVE_BOOL_PROP(inputSystemTPCButton);
     SAVE_BOOL_PROP(inputSystemDrawOutsideWindow);
+
+    xmlNode = saveProperty("iconTheme", iconThemeToString(this->iconTheme), root);
+    ATTACH_COMMENT("The icon theme, allowed values are \"iconsColor\", \"iconsLucide\"");
 
     SAVE_STRING_PROP(preferredLocale);
 
@@ -1581,6 +1591,17 @@ void Settings::setPairsOffset(int numOffset) {
 }
 
 auto Settings::getPairsOffset() const -> int { return this->numPairsOffset; }
+
+void Settings::setEmptyLastPageAppend(EmptyLastPageAppendType emptyLastPageAppend) {
+    if (this->emptyLastPageAppend == emptyLastPageAppend) {
+        return;
+    }
+
+    this->emptyLastPageAppend = emptyLastPageAppend;
+    save();
+}
+
+auto Settings::getEmptyLastPageAppend() const -> EmptyLastPageAppendType { return this->emptyLastPageAppend; }
 
 void Settings::setViewColumns(int numColumns) {
     if (this->numColumns == numColumns) {

--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -17,13 +17,12 @@
 #include "control/ToolEnums.h"                      // for ERASER_TYPE_NONE
 #include "control/settings/LatexSettings.h"         // for LatexSettings
 #include "control/settings/SettingsEnums.h"         // for InputDeviceTypeOp...
-#include "control/settings/SettingsEnums.cpp"       // for emptyLastPageAppendFromString
 #include "gui/toolbarMenubar/model/ColorPalette.h"  // for Palette
 #include "model/FormatDefinitions.h"                // for FormatUnits, XOJ_...
 #include "util/Color.h"
-#include "util/PathUtil.h"                          // for getConfigFile
-#include "util/Util.h"                              // for PRECISION_FORMAT_...
-#include "util/i18n.h"                              // for _
+#include "util/PathUtil.h"  // for getConfigFile
+#include "util/Util.h"      // for PRECISION_FORMAT_...
+#include "util/i18n.h"      // for _
 
 #include "ButtonConfig.h"  // for ButtonConfig
 #include "config-dev.h"    // for PALETTE_FILE
@@ -1017,9 +1016,6 @@ void Settings::save() {
 
     SAVE_BOOL_PROP(inputSystemTPCButton);
     SAVE_BOOL_PROP(inputSystemDrawOutsideWindow);
-
-    xmlNode = saveProperty("iconTheme", iconThemeToString(this->iconTheme), root);
-    ATTACH_COMMENT("The icon theme, allowed values are \"iconsColor\", \"iconsLucide\"");
 
     SAVE_STRING_PROP(preferredLocale);
 

--- a/src/core/control/settings/Settings.h
+++ b/src/core/control/settings/Settings.h
@@ -233,6 +233,9 @@ public:
     void setPairsOffset(int numOffset);
     int getPairsOffset() const;
 
+    void setEmptyLastPageAppend(EmptyLastPageAppendType emptyLastPageAppend);
+    EmptyLastPageAppendType getEmptyLastPageAppend() const;
+
     void setViewColumns(int numColumns);
     int getViewColumns() const;
 
@@ -756,6 +759,11 @@ private:
      *  Offsets first page ( to align pairing )
      */
     int numPairsOffset{};
+
+    /**
+     * Use to automatically add an empty last page when the current last page is drawn on
+     */
+    EmptyLastPageAppendType emptyLastPageAppend{};
 
     /**
      *  Use when fixed number of columns

--- a/src/core/control/settings/Settings.h
+++ b/src/core/control/settings/Settings.h
@@ -761,7 +761,7 @@ private:
     int numPairsOffset{};
 
     /**
-     * Use to automatically add an empty last page when the current last page is drawn on
+     * Preference for appending an empty last page to the document
      */
     EmptyLastPageAppendType emptyLastPageAppend{};
 

--- a/src/core/control/settings/SettingsEnums.cpp
+++ b/src/core/control/settings/SettingsEnums.cpp
@@ -29,3 +29,18 @@ auto iconThemeFromString(const std::string& iconThemeStr) -> IconTheme {
     g_warning("Settings::Unknown icon theme: %s\n", iconThemeStr.c_str());
     return ICON_THEME_COLOR;
 }
+
+auto emptyLastPageAppendFromString(std::string const& str) -> EmptyLastPageAppendType {
+    if (str == "disabled") {
+        return EmptyLastPageAppendType::Disabled;
+    }
+    if (str == "onDrawOfLastPage") {
+        return EmptyLastPageAppendType::OnDrawOfLastPage;
+    }
+    if (str == "onScrollOfLastPage") {
+        return EmptyLastPageAppendType::OnScrollToEndOfLastPage;
+    }
+
+    g_warning("Settings::Unknown empty last page append type: %s\n", str.c_str());
+    return EmptyLastPageAppendType::Disabled;
+}

--- a/src/core/control/settings/SettingsEnums.cpp
+++ b/src/core/control/settings/SettingsEnums.cpp
@@ -30,7 +30,7 @@ auto iconThemeFromString(const std::string& iconThemeStr) -> IconTheme {
     return ICON_THEME_COLOR;
 }
 
-auto emptyLastPageAppendFromString(std::string const& str) -> EmptyLastPageAppendType {
+auto emptyLastPageAppendFromString(const std::string& str) -> EmptyLastPageAppendType {
     if (str == "disabled") {
         return EmptyLastPageAppendType::Disabled;
     }

--- a/src/core/control/settings/SettingsEnums.h
+++ b/src/core/control/settings/SettingsEnums.h
@@ -47,6 +47,12 @@ enum ScrollbarHideType {
     SCROLLBAR_HIDE_BOTH = SCROLLBAR_HIDE_HORIZONTAL | SCROLLBAR_HIDE_VERTICAL
 };
 
+enum class EmptyLastPageAppendType {
+    Disabled = 0,
+    OnDrawOfLastPage = 1,
+    OnScrollToEndOfLastPage = 2,
+};
+
 /**
  * The user-selectable device types
  */
@@ -113,6 +119,19 @@ constexpr auto iconThemeToString(IconTheme iconTheme) -> const char* {
             return "iconsColor";
         case ICON_THEME_LUCIDE:
             return "iconsLucide";
+        default:
+            return "unknown";
+    }
+}
+
+constexpr auto emptyLastPageAppendToString(EmptyLastPageAppendType appendType) -> const char* {
+    switch (appendType) {
+        case EmptyLastPageAppendType::Disabled:
+            return "disabled";
+        case EmptyLastPageAppendType::OnDrawOfLastPage:
+            return "onDrawOfLastPage";
+        case EmptyLastPageAppendType::OnScrollToEndOfLastPage:
+            return "onScrollOfLastPage";
         default:
             return "unknown";
     }

--- a/src/core/control/settings/SettingsEnums.h
+++ b/src/core/control/settings/SettingsEnums.h
@@ -139,3 +139,4 @@ constexpr auto emptyLastPageAppendToString(EmptyLastPageAppendType appendType) -
 
 StylusCursorType stylusCursorTypeFromString(const std::string& stylusCursorTypeStr);
 IconTheme iconThemeFromString(const std::string& iconThemeStr);
+EmptyLastPageAppendType emptyLastPageAppendFromString(const std::string& str);

--- a/src/core/control/tools/StrokeHandler.cpp
+++ b/src/core/control/tools/StrokeHandler.cpp
@@ -136,7 +136,7 @@ void StrokeHandler::paintTo(const Point& point) {
                 stroke->setLastPressure(std::max(endPoint.z, point.z) * stroke->getWidth());
             } else {
                 if (const double widthDelta = (point.z - endPoint.z) * stroke->getWidth();
-                    - widthDelta > MAX_WIDTH_VARIATION || widthDelta > MAX_WIDTH_VARIATION) {
+                    -widthDelta > MAX_WIDTH_VARIATION || widthDelta > MAX_WIDTH_VARIATION) {
                     /**
                      * If the width variation is to big, decompose into shorter segments.
                      * Those segments can not be shorter than PIXEL_MOTION_THRESHOLD
@@ -272,9 +272,12 @@ void StrokeHandler::onButtonReleaseEvent(const PositionInputData& pos, double zo
 
     if (settings->getEmptyLastPageAppend() == EmptyLastPageAppendType::OnDrawOfLastPage) {
         auto* doc = control->getDocument();
-        if (doc->getPdfPageCount() == 0) {
-            doc->lock();
+        doc->lock();
+        auto pdfPageCount = doc->getPdfPageCount();
+        doc->unlock();
+        if (pdfPageCount == 0) {
             auto currentPage = control->getCurrentPageNo();
+            doc->lock();
             auto lastPage = doc->getPageCount() - 1;
             doc->unlock();
             if (currentPage == lastPage) {

--- a/src/core/gui/Layout.cpp
+++ b/src/core/gui/Layout.cpp
@@ -1,7 +1,7 @@
 #include "Layout.h"
 
-#include <cmath>        // for abs
 #include <algorithm>    // for max, lower_bound, transform
+#include <cmath>        // for abs
 #include <iterator>     // for begin, end, distance
 #include <numeric>      // for accumulate
 #include <optional>     // for optional
@@ -60,16 +60,18 @@ void Layout::verticalScrollChanged(GtkAdjustment* adjustment, Layout* layout) {
 }
 
 void Layout::maybeAddLastPage(Layout* layout) {
-    auto *control = this->view->getControl();
+    auto* control = this->view->getControl();
     auto* settings = control->getSettings();
     if (settings->getEmptyLastPageAppend() == EmptyLastPageAppendType::OnScrollToEndOfLastPage) {
-        std::cerr << layout->getMinimalHeight() << '\n' << layout->getVisibleRect().y << '\n' << layout->getVisibleRect().height << "\n\n";
-        // If the layout is 5px away from the end of the last page AND
+        // If the layout is 5px away from the end of the last page
         if (std::abs((layout->getMinimalHeight() - layout->getVisibleRect().y) - layout->getVisibleRect().height) < 5) {
             auto* doc = control->getDocument();
-            if (doc->getPdfPageCount() == 0) {
-                doc->lock();
+            doc->lock();
+            auto pdfPageCount = doc->getPdfPageCount();
+            doc->unlock();
+            if (pdfPageCount == 0) {
                 auto currentPage = control->getCurrentPageNo();
+                doc->lock();
                 auto lastPage = doc->getPageCount() - 1;
                 doc->unlock();
                 if (currentPage == lastPage) {

--- a/src/core/gui/Layout.cpp
+++ b/src/core/gui/Layout.cpp
@@ -1,5 +1,6 @@
 #include "Layout.h"
 
+#include <cmath>        // for abs
 #include <algorithm>    // for max, lower_bound, transform
 #include <iterator>     // for begin, end, distance
 #include <numeric>      // for accumulate
@@ -13,6 +14,7 @@
 #include "gui/LayoutMapper.h"           // for LayoutMapper, GridPosition
 #include "gui/PageView.h"               // for XojPageView
 #include "gui/scroll/ScrollHandling.h"  // for ScrollHandling
+#include "model/Document.h"             // for Document
 #include "util/Rectangle.h"             // for Rectangle
 #include "util/safe_casts.h"            // for strict_cast, as_signed, as_si...
 
@@ -53,8 +55,30 @@ void Layout::horizontalScrollChanged(GtkAdjustment* adjustment, Layout* layout) 
 void Layout::verticalScrollChanged(GtkAdjustment* adjustment, Layout* layout) {
     Layout::checkScroll(adjustment, layout->lastScrollVertical);
     layout->updateVisibility();
+
+    layout->maybeAddLastPage(layout);
 }
 
+void Layout::maybeAddLastPage(Layout* layout) {
+    auto *control = this->view->getControl();
+    auto* settings = control->getSettings();
+    if (settings->getEmptyLastPageAppend() == EmptyLastPageAppendType::OnScrollToEndOfLastPage) {
+        std::cerr << layout->getMinimalHeight() << '\n' << layout->getVisibleRect().y << '\n' << layout->getVisibleRect().height << "\n\n";
+        // If the layout is 5px away from the end of the last page AND
+        if (std::abs((layout->getMinimalHeight() - layout->getVisibleRect().y) - layout->getVisibleRect().height) < 5) {
+            auto* doc = control->getDocument();
+            if (doc->getPdfPageCount() == 0) {
+                doc->lock();
+                auto currentPage = control->getCurrentPageNo();
+                auto lastPage = doc->getPageCount() - 1;
+                doc->unlock();
+                if (currentPage == lastPage) {
+                    control->insertNewPage(currentPage + 1, false);
+                }
+            }
+        }
+    }
+}
 
 void Layout::checkScroll(GtkAdjustment* adjustment, double& lastScroll) {
     lastScroll = gtk_adjustment_get_value(adjustment);

--- a/src/core/gui/Layout.h
+++ b/src/core/gui/Layout.h
@@ -149,6 +149,9 @@ protected:
 
 private:
     void recalculate_int() const;
+
+    void maybeAddLastPage(Layout* layout);
+
     // Todo(Fabian): move to ScrollHandling also it must not depend on Layout
     static void checkScroll(GtkAdjustment* adjustment, double& lastScroll);
 

--- a/src/core/gui/dialog/SettingsDialog.cpp
+++ b/src/core/gui/dialog/SettingsDialog.cpp
@@ -426,6 +426,19 @@ void SettingsDialog::load() {
     GtkWidget* spPairsOffset = get("spPairsOffset");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spPairsOffset), settings->getPairsOffset());
 
+    switch (settings->getEmptyLastPageAppend()) {
+    case EmptyLastPageAppendType::OnDrawOfLastPage:
+        gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(get("rdLastPageAppendOnDrawOfLastPage")), true);
+        break;
+    case EmptyLastPageAppendType::OnScrollToEndOfLastPage:
+        gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(get("rdLastPageAppendOnScrollToEndOfLastPage")), true);
+        break;
+    case EmptyLastPageAppendType::Disabled:
+    default:
+        gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(get("rdLastPageAppendDisabled")), true);
+        break;
+    }
+
     GtkWidget* spSnapRotationTolerance = get("spSnapRotationTolerance");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spSnapRotationTolerance), settings->getSnapRotationTolerance());
 
@@ -840,6 +853,16 @@ void SettingsDialog::save() {
     GtkWidget* spPairsOffset = get("spPairsOffset");
     int numPairsOffset = gtk_spin_button_get_value(GTK_SPIN_BUTTON(spPairsOffset));
     settings->setPairsOffset(numPairsOffset);
+
+    if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(get("rdLastPageAppendDisabled")))) {
+        settings->setEmptyLastPageAppend(EmptyLastPageAppendType::Disabled);
+    } else if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(get("rdLastPageAppendOnDrawOfLastPage")))) {
+        settings->setEmptyLastPageAppend(EmptyLastPageAppendType::OnDrawOfLastPage);
+    } else if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(get("rdLastPageAppendOnScrollToEndOfLastPage")))) {
+        settings->setEmptyLastPageAppend(EmptyLastPageAppendType::OnScrollToEndOfLastPage);
+    } else {
+        settings->setEmptyLastPageAppend(EmptyLastPageAppendType::Disabled);
+    }
 
     settings->setEdgePanSpeed(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("edgePanSpeed"))));
     settings->setEdgePanMaxMult(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("edgePanMaxMult"))));

--- a/src/core/gui/dialog/SettingsDialog.cpp
+++ b/src/core/gui/dialog/SettingsDialog.cpp
@@ -426,18 +426,10 @@ void SettingsDialog::load() {
     GtkWidget* spPairsOffset = get("spPairsOffset");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spPairsOffset), settings->getPairsOffset());
 
-    switch (settings->getEmptyLastPageAppend()) {
-    case EmptyLastPageAppendType::OnDrawOfLastPage:
-        gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(get("rdLastPageAppendOnDrawOfLastPage")), true);
-        break;
-    case EmptyLastPageAppendType::OnScrollToEndOfLastPage:
-        gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(get("rdLastPageAppendOnScrollToEndOfLastPage")), true);
-        break;
-    case EmptyLastPageAppendType::Disabled:
-    default:
-        gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(get("rdLastPageAppendDisabled")), true);
-        break;
-    }
+    EmptyLastPageAppendType append = settings->getEmptyLastPageAppend();
+    loadCheckbox("rdLastPageAppendOnDrawOfLastPage", append == EmptyLastPageAppendType::OnDrawOfLastPage);
+    loadCheckbox("rdLastPageAppendOnScrollToEndOfLastPage", append == EmptyLastPageAppendType::OnScrollToEndOfLastPage);
+    loadCheckbox("rdLastPageAppendDisabled", append == EmptyLastPageAppendType::Disabled);
 
     GtkWidget* spSnapRotationTolerance = get("spSnapRotationTolerance");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spSnapRotationTolerance), settings->getSnapRotationTolerance());
@@ -854,11 +846,11 @@ void SettingsDialog::save() {
     int numPairsOffset = gtk_spin_button_get_value(GTK_SPIN_BUTTON(spPairsOffset));
     settings->setPairsOffset(numPairsOffset);
 
-    if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(get("rdLastPageAppendDisabled")))) {
+    if (getCheckbox("rdLastPageAppendDisabled")) {
         settings->setEmptyLastPageAppend(EmptyLastPageAppendType::Disabled);
-    } else if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(get("rdLastPageAppendOnDrawOfLastPage")))) {
+    } else if (getCheckbox("rdLastPageAppendOnDrawOfLastPage")) {
         settings->setEmptyLastPageAppend(EmptyLastPageAppendType::OnDrawOfLastPage);
-    } else if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(get("rdLastPageAppendOnScrollToEndOfLastPage")))) {
+    } else if (getCheckbox("rdLastPageAppendOnScrollToEndOfLastPage")) {
         settings->setEmptyLastPageAppend(EmptyLastPageAppendType::OnScrollToEndOfLastPage);
     } else {
         settings->setEmptyLastPageAppend(EmptyLastPageAppendType::Disabled);

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -4450,18 +4450,18 @@ This setting can make it easier to draw with touch. </property>
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkFrame">
+                              <object class="GtkFrame" id="sid198">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0</property>
                                 <child>
-                                  <object class="GtkAlignment">
+                                  <object class="GtkAlignment" id="sid199">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
                                     <property name="left-padding">12</property>
                                     <child>
-                                      <!-- n-columns=3 n-rows=3 -->
-                                      <object class="GtkGrid">
+                                      <!-- n-columns=1 n-rows=3 -->
+                                      <object class="GtkGrid" id="grid7">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
@@ -4489,8 +4489,6 @@ This setting can make it easier to draw with touch. </property>
                                             <property name="active">True</property>
                                             <property name="draw-indicator">True</property>
                                             <property name="group">rdLastPageAppendDisabled</property>
-                                            <signal name="group-changed" handler="seta" swapped="no"/>
-                                            <signal name="toggled" handler="setb" swapped="no"/>
                                           </object>
                                           <packing>
                                             <property name="left-attach">0</property>
@@ -4511,30 +4509,12 @@ This setting can make it easier to draw with touch. </property>
                                             <property name="top-attach">0</property>
                                           </packing>
                                         </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
                                       </object>
                                     </child>
                                   </object>
                                 </child>
                                 <child type="label">
-                                  <object class="GtkLabel">
+                                  <object class="GtkLabel" id="sid197">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Automatically Add Empty Last Page (excluding PDFs)</property>

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.40.0 -->
+<!-- Generated with glade 3.38.2 -->
 <interface>
   <requires lib="gtk+" version="3.18"/>
   <object class="GtkAdjustment" id="adjustmentAudioGain">
@@ -4450,6 +4450,104 @@ This setting can make it easier to draw with touch. </property>
                               </packing>
                             </child>
                             <child>
+                              <object class="GtkFrame">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0</property>
+                                <child>
+                                  <object class="GtkAlignment">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="left-padding">12</property>
+                                    <child>
+                                      <!-- n-columns=3 n-rows=3 -->
+                                      <object class="GtkGrid">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                          <object class="GtkRadioButton" id="rdLastPageAppendOnScrollToEndOfLastPage">
+                                            <property name="label" translatable="yes">when scrolling to end of last page</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="active">True</property>
+                                            <property name="draw-indicator">True</property>
+                                            <property name="group">rdLastPageAppendDisabled</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">2</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkRadioButton" id="rdLastPageAppendOnDrawOfLastPage">
+                                            <property name="label" translatable="yes">when drawing on last page</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="active">True</property>
+                                            <property name="draw-indicator">True</property>
+                                            <property name="group">rdLastPageAppendDisabled</property>
+                                            <signal name="group-changed" handler="seta" swapped="no"/>
+                                            <signal name="toggled" handler="setb" swapped="no"/>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkRadioButton" id="rdLastPageAppendDisabled">
+                                            <property name="label" translatable="yes">disabled</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="active">True</property>
+                                            <property name="draw-indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label">
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">Automatically Add Empty Last Page (excluding PDFs)</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">2</property>
+                              </packing>
+                            </child>
+                            <child>
                               <object class="GtkFrame" id="sid150">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
@@ -4549,7 +4647,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">2</property>
+                                <property name="position">3</property>
                               </packing>
                             </child>
                             <child>
@@ -4623,7 +4721,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">3</property>
+                                <property name="position">4</property>
                               </packing>
                             </child>
                             <child>
@@ -4782,7 +4880,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">4</property>
+                                <property name="position">5</property>
                               </packing>
                             </child>
                             <child>


### PR DESCRIPTION
Closes #1343

I used `doc->isAttachPdf()` to determine if editing a "pdf" file (so empty last pages aren't created in PDF files), but I'm not sure if that is valid in all cases?

I also added the setting in the third section - is there a better place to put it or a better name?

![image](https://user-images.githubusercontent.com/24364012/195287506-66ba53dd-3911-472d-aa47-db772b64bb0b.png)

