### PR TITLE
Declare a default virtual destructor in XmlNode

### DIFF
--- a/src/core/control/xml/XmlNode.h
+++ b/src/core/control/xml/XmlNode.h
@@ -24,6 +24,7 @@ class OutputStream;
 class XmlNode {
 public:
     XmlNode(const char* tag);
+    virtual ~XmlNode() = default;
 
 public:
     void setAttrib(const char* attrib, std::string value);


### PR DESCRIPTION
This fixes the issue where Base classes in C++ need to have an explicitly declared virtual destructor (in this case, default destructor), so when instantitated derived classes (with a static type of the base class) are destructured, it's not UB. This shuts up a compiler warning diagnostic and [isn't present in release-1.1](https://github.com/xournalpp/xournalpp/blob/e2f7f0f562645f4c971b43b6e44dd2dc39c61763/src/control/xml/XmlNode.h#L23)