### PR TITLE
Split PdfElemSelection into View+Controller

### DIFF
--- a/src/core/control/tools/PdfElemSelection.cpp
+++ b/src/core/control/tools/PdfElemSelection.cpp
@@ -1,9 +1,10 @@
 #include "PdfElemSelection.h"
 
 #include <algorithm>  // for max, min
-#include <limits>     // for numeric_limits
-#include <memory>     // for __shared_ptr_access
-#include <utility>    // for move
+#include <cmath>
+#include <limits>   // for numeric_limits
+#include <memory>   // for __shared_ptr_access
+#include <utility>  // for move
 
 #include <cairo.h>    // for cairo_line_to, cairo_region_destroy
 #include <gdk/gdk.h>  // for GdkRGBA, gdk_cairo_set_source_rgba
@@ -17,13 +18,16 @@
 #include "model/PageRef.h"        // for PageRef
 #include "model/XojPage.h"        // for XojPage
 #include "pdf/base/XojPdfPage.h"  // for XojPdfRectangle, XojPdfPageSelectio...
+#include "view/overlays/PdfElementSelectionView.h"
 
-PdfElemSelection::PdfElemSelection(double x, double y, XojPageView* view):
-        view(view), pdf(nullptr), bounds({x, y, x, y}), finalized(false) {
+PdfElemSelection::PdfElemSelection(double x, double y, Control* control):
+        pdf(nullptr),
+        bounds({x, y, x, y}),
+        finalized(false),
+        viewPool(std::make_shared<xoj::util::DispatchPool<xoj::view::PdfElementSelectionView>>()) {
 
-    auto xournal = view->getXournal();
-    if (auto pNr = this->view->getPage()->getPdfPageNr(); pNr != npos) {
-        Document* doc = xournal->getControl()->getDocument();
+    if (auto pNr = control->getCurrentPage()->getPdfPageNr(); pNr != npos) {
+        Document* doc = control->getDocument();
         doc->lock();
         this->pdf = doc->getPdfPage(pNr);
         doc->unlock();
@@ -31,71 +35,30 @@ PdfElemSelection::PdfElemSelection(double x, double y, XojPageView* view):
         this->selectionPageNr = pNr;
     }
 
-    this->toolType = xournal->getControl()->getToolHandler()->getToolType();
+    this->toolType = control->getToolHandler()->getToolType();
 }
 
 PdfElemSelection::~PdfElemSelection() {
-    this->selectedTextRects.clear();
-    if (this->selectedTextRegion) {
-        cairo_region_destroy(this->selectedTextRegion);
-        this->selectedTextRegion = nullptr;
-    }
+    Range rg = getRegionBbox();
+    this->viewPool->dispatchAndClear(xoj::view::PdfElementSelectionView::CANCEL_SELECTION_REQUEST, rg);
 }
 
 auto PdfElemSelection::finalizeSelectionAndRepaint(XojPdfPageSelectionStyle style) -> bool {
+    Range rg = getRegionBbox();
     bool result = this->finalizeSelection(style);
-    this->view->repaintPage();
+    rg = rg.unite(getRegionBbox());
+    this->viewPool->dispatch(xoj::view::PdfElementSelectionView::FLAG_DIRTY_REGION_REQUEST, rg);
     return result;
 }
-
-void PdfElemSelection::doublePress() { this->finalizeSelectionAndRepaint(XojPdfPageSelectionStyle::Word); }
-
-void PdfElemSelection::triplePress() { this->finalizeSelectionAndRepaint(XojPdfPageSelectionStyle::Line); }
 
 bool PdfElemSelection::finalizeSelection(XojPdfPageSelectionStyle style) {
     this->finalized = true;
 
-    if (this->selectedTextRegion) {
-        cairo_region_destroy(this->selectedTextRegion);
-    }
-
     XojPdfPage::TextSelection selection = this->pdf->selectTextLines(this->bounds, style);
-    this->selectedTextRegion = selection.region;
+    this->selectedTextRegion = std::move(selection.region);
     this->selectedTextRects = std::move(selection.rects);
     this->selectedText = this->pdf->selectText(this->bounds, style);
     return !this->selectedTextRects.empty();
-}
-
-void PdfElemSelection::paint(cairo_t* cr, XojPdfPageSelectionStyle style) {
-    if (!this->pdf)
-        return;
-
-    GdkRGBA selectionColor = view->getSelectionColor();
-    auto applied = GdkRGBA{selectionColor.red, selectionColor.green, selectionColor.blue, 0.3};
-
-    if (this->finalized || style != XojPdfPageSelectionStyle::Area) {
-        if (!this->selectedTextRegion || cairo_region_is_empty(this->selectedTextRegion))
-            return;
-
-        gdk_cairo_region(cr, this->selectedTextRegion);
-        gdk_cairo_set_source_rgba(cr, &applied);
-        cairo_fill(cr);
-    } else {
-        double aX = std::min(this->bounds.x1, this->bounds.x2);
-        double bX = std::max(this->bounds.x1, this->bounds.x2);
-
-        double aY = std::min(this->bounds.y1, this->bounds.y2);
-        double bY = std::max(this->bounds.y1, this->bounds.y2);
-
-        cairo_move_to(cr, aX, aY);
-        cairo_line_to(cr, bX, aY);
-        cairo_line_to(cr, bX, bY);
-        cairo_line_to(cr, aX, bY);
-        cairo_close_path(cr);
-
-        gdk_cairo_set_source_rgba(cr, &applied);
-        cairo_fill(cr);
-    }
 }
 
 XojPdfPageSelectionStyle PdfElemSelection::selectionStyleForToolType(ToolType type) {
@@ -107,77 +70,60 @@ XojPdfPageSelectionStyle PdfElemSelection::selectionStyleForToolType(ToolType ty
     }
 }
 
-void PdfElemSelection::currentPos(double x, double y, XojPdfPageSelectionStyle style) {
-    if (!this->pdf)
-        return;
+Range PdfElemSelection::getRegionBbox() const {
+    if (this->selectedTextRegion && cairo_region_num_rectangles(this->selectedTextRegion.get()) > 0) {
+        cairo_rectangle_int_t bbox;
+        cairo_region_get_extents(this->selectedTextRegion.get(), &bbox);
+        return Range(bbox.x, bbox.y, bbox.x + bbox.width, bbox.y + bbox.height);
+    }
+    return Range();  // empty range
+}
 
-    double minX = std::numeric_limits<double>::max();
-    double maxX = std::numeric_limits<double>::min();
-    double minY = minX, maxY = maxX;
+void PdfElemSelection::currentPos(double x, double y, XojPdfPageSelectionStyle style) {
+    if (!this->pdf) {
+        return;
+    }
 
     // Update the end position
     this->bounds.x2 = x;
     this->bounds.y2 = y;
+    Range rg = getRegionBbox();
 
     // Repaint the selected text area
     switch (style) {
         case XojPdfPageSelectionStyle::Linear:
         case XojPdfPageSelectionStyle::Word:
         case XojPdfPageSelectionStyle::Line:
-            // The text region may be split up across multiple lines, so redraw the
-            // enclosing rectangle
-            if (this->selectedTextRegion) {
-                int count = cairo_region_num_rectangles(this->selectedTextRegion);
-                if (count > 0) {
-                    cairo_rectangle_int_t bbox;
-                    cairo_region_get_extents(this->selectedTextRegion, &bbox);
-                    minX = bbox.x;
-                    minY = bbox.y;
-                    maxX = bbox.x + bbox.width;
-                    maxY = bbox.y + bbox.height;
-                    this->view->repaintArea(minX - 20, minY - 20, maxX + 20, maxY + 20);
-                }
-            }
-
-            this->selectTextRegion(style);
+            this->selectedTextRegion.reset(this->pdf->selectTextRegion(this->bounds, style), xoj::util::adopt);
             break;
-        case XojPdfPageSelectionStyle::Area:
-            minX = std::min(this->bounds.x1, std::min(this->bounds.x2, x));
-            minY = std::min(this->bounds.y1, std::min(this->bounds.y2, y));
-
-            maxX = std::max(this->bounds.x1, std::max(this->bounds.x2, x));
-            maxY = std::max(this->bounds.y1, std::max(this->bounds.y2, y));
-
-            this->view->repaintArea(minX - 20, minY - 20, maxX + 20, maxY + 20);
-            break;
+        case XojPdfPageSelectionStyle::Area: {
+            cairo_rectangle_int_t rect;
+            rect.x = static_cast<int>(std::floor(std::min(bounds.x1, bounds.x2)));
+            rect.width = static_cast<int>(std::ceil(std::max(bounds.x1, bounds.x2))) - rect.x;
+            rect.y = static_cast<int>(std::floor(std::min(bounds.y1, bounds.y2)));
+            rect.height = static_cast<int>(std::ceil(std::max(bounds.y1, bounds.y2))) - rect.y;
+            this->selectedTextRegion.reset(cairo_region_create_rectangle(&rect), xoj::util::adopt);
+        } break;
         default:
             g_assert(false && "Unreachable");
     }
+    g_assert(this->selectedTextRegion);
+
+    rg = rg.unite(getRegionBbox());
+    this->viewPool->dispatch(xoj::view::PdfElementSelectionView::FLAG_DIRTY_REGION_REQUEST, rg);
 }
 
 auto PdfElemSelection::contains(double x, double y) -> bool {
-    if (!this->selectedTextRegion)
+    if (!this->selectedTextRegion) {
         return false;
-
-    return cairo_region_contains_point(this->selectedTextRegion, static_cast<int>(x), static_cast<int>(y));
-}
-
-auto PdfElemSelection::selectTextRegion(XojPdfPageSelectionStyle style) -> bool {
-    if (this->selectedTextRegion) {
-        cairo_region_destroy(this->selectedTextRegion);
     }
 
-    this->selectedTextRegion = this->pdf->selectTextRegion(this->bounds, style);
-    g_assert_nonnull(this->selectedTextRegion);
-
-    return !cairo_region_is_empty(this->selectedTextRegion);
+    return cairo_region_contains_point(this->selectedTextRegion.get(), static_cast<int>(x), static_cast<int>(y));
 }
 
 auto PdfElemSelection::getSelectedTextRects() const -> const std::vector<XojPdfRectangle>& { return selectedTextRects; }
 
 auto PdfElemSelection::getSelectedText() const -> const std::string& { return this->selectedText; }
-
-auto PdfElemSelection::getPageView() const -> XojPageView* { return view; }
 
 auto PdfElemSelection::getSelectionPageNr() const -> uint64_t { return selectionPageNr; }
 

--- a/src/core/control/tools/PdfElemSelection.cpp
+++ b/src/core/control/tools/PdfElemSelection.cpp
@@ -72,7 +72,7 @@ XojPdfPageSelectionStyle PdfElemSelection::selectionStyleForToolType(ToolType ty
 
 Range PdfElemSelection::getRegionBbox() const {
     if (this->selectedTextRegion && cairo_region_num_rectangles(this->selectedTextRegion.get()) > 0) {
-        cairo_rectangle_int_t bbox;
+        cairo_rectangle_int_t bbox{};
         cairo_region_get_extents(this->selectedTextRegion.get(), &bbox);
         return Range(bbox.x, bbox.y, bbox.x + bbox.width, bbox.y + bbox.height);
     }

--- a/src/core/control/tools/PdfElemSelection.h
+++ b/src/core/control/tools/PdfElemSelection.h
@@ -72,7 +72,7 @@ public:
     /// Returns the selection style corresponding to the given tool type.
     static XojPdfPageSelectionStyle selectionStyleForToolType(ToolType type);
 
-    const std::shared_ptr<xoj::util::DispatchPool<xoj::view::PdfElementSelectionView>>& getViewPool() const {
+    inline const std::shared_ptr<xoj::util::DispatchPool<xoj::view::PdfElementSelectionView>>& getViewPool() const {
         return viewPool;
     }
 

--- a/src/core/control/tools/PdfElemSelection.h
+++ b/src/core/control/tools/PdfElemSelection.h
@@ -16,16 +16,24 @@
 
 #include <cairo.h>  // for cairo_region_t, cairo_t
 
-#include "control/ToolEnums.h"    // for ToolType
+#include "control/ToolEnums.h"  // for ToolType
+#include "model/OverlayBase.h"
 #include "pdf/base/XojPdfPage.h"  // for XojPdfPageSelectionStyle, XojPdfRec...
-#include "util/Util.h"            // for npos
+#include "util/DispatchPool.h"
+#include "util/Util.h"                // for npos
+#include "util/raii/CairoWrappers.h"  // for CairoRegionSPtr
 
-class XojPageView;
+class Range;
+class Control;
+
+namespace xoj::view {
+class PdfElementSelectionView;
+};
 
 /// Represents elements selected from a PDF page, such as text.
-class PdfElemSelection {
+class PdfElemSelection: public OverlayBase {
 public:
-    PdfElemSelection(double x, double y, XojPageView* view);
+    PdfElemSelection(double x, double y, Control* control);
     PdfElemSelection& operator=(const PdfElemSelection&) = delete;
     PdfElemSelection(const PdfElemSelection&) = delete;
     PdfElemSelection& operator=(PdfElemSelection&&) = default;
@@ -40,9 +48,6 @@ public:
     /// Returns true iff there is text contained within the selection bounds.
     bool finalizeSelection(XojPdfPageSelectionStyle style);
 
-    /// Render the selection visuals with the given style
-    void paint(cairo_t* cr, XojPdfPageSelectionStyle style);
-
     /// Update the (unfinalized) selection bounds with the given
     /// style.
     void currentPos(double x, double y, XojPdfPageSelectionStyle style);
@@ -56,28 +61,27 @@ public:
     /// Returns the text contained in the selection region.
     const std::string& getSelectedText() const;
 
-    XojPageView* getPageView() const;
-
     /// Returns true iff the final selections bounds are known.
     bool isFinalized() const;
-
-    /// Trigger double press selection action, with page repaint.
-    void doublePress();
-
-    /// Trigger triple press selection action, with page repaint.
-    void triplePress();
 
     uint64_t getSelectionPageNr() const;
     void setToolType(ToolType toolType);
 
+    const cairo_region_t* getSelectedRegion() const { return selectedTextRegion.get(); }
+
     /// Returns the selection style corresponding to the given tool type.
     static XojPdfPageSelectionStyle selectionStyleForToolType(ToolType type);
 
+    const std::shared_ptr<xoj::util::DispatchPool<xoj::view::PdfElementSelectionView>>& getViewPool() const {
+        return viewPool;
+    }
+
 private:
     /// Assigns the selected text region to the current selection bounds.
-    bool selectTextRegion(XojPdfPageSelectionStyle style);
+    void selectTextRegion(XojPdfPageSelectionStyle style);
 
-    XojPageView* view;
+    Range getRegionBbox() const;
+
     XojPdfPageSPtr pdf;
 
     /// The rectangles corresponding to the lines of selected text.
@@ -87,7 +91,7 @@ private:
     std::string selectedText;
 
     /// The area containing the selected text. Used for rendering.
-    cairo_region_t* selectedTextRegion = nullptr;
+    xoj::util::CairoRegionSPtr selectedTextRegion;
 
     /// The PDF selection tool used for the selection.
     ToolType toolType;
@@ -100,4 +104,6 @@ private:
     XojPdfRectangle bounds;
 
     bool finalized;
+
+    std::shared_ptr<xoj::util::DispatchPool<xoj::view::PdfElementSelectionView>> viewPool;
 };

--- a/src/core/gui/LegacyRedrawable.cpp
+++ b/src/core/gui/LegacyRedrawable.cpp
@@ -11,7 +11,7 @@ void LegacyRedrawable::repaintRect(double x, double y, double width, double heig
     repaintArea(x, y, x + width, y + height);
 }
 
-void LegacyRedrawable::rerenderRange(Range& r) { rerenderRect(r.getX(), r.getY(), r.getWidth(), r.getHeight()); }
+void LegacyRedrawable::rerenderRange(const Range& r) { rerenderRect(r.getX(), r.getY(), r.getWidth(), r.getHeight()); }
 
 void LegacyRedrawable::rerenderElement(Element* e) {
     rerenderRect(e->getX() - 1, e->getY() - 1, e->getElementWidth() + 2, e->getElementHeight() + 2);

--- a/src/core/gui/LegacyRedrawable.h
+++ b/src/core/gui/LegacyRedrawable.h
@@ -66,7 +66,7 @@ public:
      * Call this if you add an element, remove an element etc.
      */
     void rerenderElement(Element* e);
-    void rerenderRange(Range& r);
+    void rerenderRange(const Range& r);
 
     /**
      * This updated the view buffer and then rerender the the region, call this if you changed the document

--- a/src/core/gui/PageView.cpp
+++ b/src/core/gui/PageView.cpp
@@ -1057,6 +1057,12 @@ void XojPageView::elementChanged(Element* elem) {
     }
 }
 
+void XojPageView::elementsChanged(const std::vector<Element*>& elements, const Range& range) {
+    if (!range.empty()) {
+        rerenderRange(range);
+    }
+}
+
 void XojPageView::showFloatingToolbox(const PositionInputData& pos) {
     Control* control = xournal->getControl();
 

--- a/src/core/gui/PageView.cpp
+++ b/src/core/gui/PageView.cpp
@@ -62,6 +62,7 @@
 #include "util/i18n.h"                              // for FS, _, _F
 #include "view/DebugShowRepaintBounds.h"            // for IF_DEBUG_REPAINT
 #include "view/overlays/OverlayView.h"
+#include "view/overlays/PdfElementSelectionView.h"
 #include "view/overlays/SearchResultView.h"
 #include "view/overlays/ShapeToolView.h"
 
@@ -416,7 +417,9 @@ auto XojPageView::onButtonPressEvent(const PositionInputData& pos) -> bool {
 
             if (this->page->getPdfPageNr() != npos && !pdfToolbox->hasSelection()) {
                 pdfToolbox->selectionStyle = PdfElemSelection::selectionStyleForToolType(h->getToolType());
-                pdfToolbox->newSelection(x, y, this);
+                auto sel = pdfToolbox->newSelection(x, y);
+                this->overlayViews.emplace_back(
+                        std::make_unique<xoj::view::PdfElementSelectionView>(sel, this, settings->getSelectionColor()));
             }
         } else if (h->getToolType() == TOOL_SELECT_OBJECT) {
             SelectObject select(this);
@@ -937,11 +940,6 @@ auto XojPageView::paintPage(cairo_t* cr, GdkRectangle* rect) -> bool {
 
     if (this->textEditor) {
         this->textEditor->paint(cr, zoom);
-    }
-
-    auto* pdfToolbox = this->xournal->getControl()->getWindow()->getPdfToolbox();
-    if (auto* selection = pdfToolbox->getSelection(); selection) {
-        selection->paint(cr, pdfToolbox->selectionStyle);
     }
 
     if (this->inputHandler) {

--- a/src/core/gui/PageView.h
+++ b/src/core/gui/PageView.h
@@ -192,6 +192,7 @@ public:  // listener
     void rangeChanged(Range& range) override;
     void pageChanged() override;
     void elementChanged(Element* elem) override;
+    void elementsChanged(const std::vector<Element*>& elements, const Range& range) override;
 
 private:
     void startText(double x, double y);

--- a/src/core/gui/PdfFloatingToolbox.cpp
+++ b/src/core/gui/PdfFloatingToolbox.cpp
@@ -85,22 +85,22 @@ auto PdfFloatingToolbox::getOverlayPosition(GtkOverlay* overlay, GtkWidget* widg
         allocation->width = natural.width;
         allocation->height = natural.height;
 
-            // Make sure the "pdfFloatingToolbox" is fully displayed.
-            const int gap = 5;
+        // Make sure the "pdfFloatingToolbox" is fully displayed.
+        const int gap = 5;
 
-            // By default, we show the toolbox below and to the right of the selected text.
-            // If the toolbox will go out of the window, then we'll flip the corresponding directions.
+        // By default, we show the toolbox below and to the right of the selected text.
+        // If the toolbox will go out of the window, then we'll flip the corresponding directions.
 
-            GtkAllocation windowAlloc{};
-            gtk_widget_get_allocation(GTK_WIDGET(overlay), &windowAlloc);
+        GtkAllocation windowAlloc{};
+        gtk_widget_get_allocation(GTK_WIDGET(overlay), &windowAlloc);
 
-            bool rightOK = self->position.x + allocation->width + gap <= windowAlloc.width;
-            bool bottomOK = self->position.y + allocation->height + gap <= windowAlloc.height;
+        bool rightOK = self->position.x + allocation->width + gap <= windowAlloc.width;
+        bool bottomOK = self->position.y + allocation->height + gap <= windowAlloc.height;
 
-            allocation->x = rightOK ? self->position.x + gap : self->position.x - allocation->width - gap;
-            allocation->y = bottomOK ? self->position.y + gap : self->position.y - allocation->height - gap;
+        allocation->x = rightOK ? self->position.x + gap : self->position.x - allocation->width - gap;
+        allocation->y = bottomOK ? self->position.y + gap : self->position.y - allocation->height - gap;
 
-            return true;
+        return true;
     }
 
     return false;
@@ -172,7 +172,7 @@ void PdfFloatingToolbox::createStrokes(PdfMarkerStyle position, PdfMarkerStyle w
     auto color = theMainWindow->getXournal()->getControl()->getToolHandler()->getColor();
 
     Range dirtyRange;
-    std::vector<Stroke*> strokes;
+    std::vector<Element*> strokes;
     for (XojPdfRectangle rect: textRects) {
         const double topOfLine = std::min(rect.y1, rect.y2);
         const double middleOfLine = (rect.y1 + rect.y2) / 2;
@@ -202,14 +202,14 @@ void PdfFloatingToolbox::createStrokes(PdfMarkerStyle position, PdfMarkerStyle w
     }
 
     doc->lock();
-    for (Stroke* s: strokes) {
+    for (auto* s: strokes) {
         layer->addElement(s);
     }
     doc->unlock();
-    page->fireRangeChanged(dirtyRange);
+    page->fireElementsChanged(strokes, dirtyRange);
 
     auto undoAct = std::make_unique<GroupUndoAction>();
-    for (Stroke* stroke: strokes) {
+    for (auto* stroke: strokes) {
         undoAct->addAction(std::make_unique<InsertUndoAction>(page, layer, stroke));
     }
     control->getUndoRedoHandler()->addUndoAction(std::move(undoAct));

--- a/src/core/gui/PdfFloatingToolbox.h
+++ b/src/core/gui/PdfFloatingToolbox.h
@@ -7,12 +7,11 @@
 #include <glib.h>     // for gboolean
 #include <gtk/gtk.h>  // for GtkButton, GtkOverlay
 
-#include "control/tools/PdfElemSelection.h"  // for PdfElemSelection
-#include "pdf/base/XojPdfPage.h"             // for XojPdfPageSelectionStyle
+#include "pdf/base/XojPdfPage.h"    // for XojPdfPageSelectionStyle
 #include "util/raii/GObjectSPtr.h"  // for GObjectSPtr
 
 class MainWindow;
-class XojPageView;
+class PdfElemSelection;
 
 enum class PdfMarkerStyle : uint8_t {
     POS_TEXT_BOTTOM = 0,
@@ -31,7 +30,7 @@ public:
     PdfFloatingToolbox(const PdfFloatingToolbox&) = delete;
     PdfFloatingToolbox& operator=(PdfFloatingToolbox&&) = delete;
     PdfFloatingToolbox(PdfFloatingToolbox&&) = delete;
-    ~PdfFloatingToolbox() = default;
+    ~PdfFloatingToolbox();
 
 public:
     /// Show the toolbox at the provided coordinates (relative to the application GTK window).
@@ -52,7 +51,7 @@ public:
     void clearSelection();
 
     /// Create a new selection (without any visual effects)
-    void newSelection(double x, double y, XojPageView* pageView);
+    const PdfElemSelection* newSelection(double x, double y);
 
     /// Returns true iff a PDF element is selected;
     bool hasSelection() const;
@@ -85,7 +84,7 @@ private:
     /// The overlay that the toolbox should be displayed in.
     xoj::util::GObjectSPtr<GtkOverlay> overlay;
 
-    std::unique_ptr<PdfElemSelection> pdfElemSelection = nullptr;
+    std::unique_ptr<PdfElemSelection> pdfElemSelection;
 
     struct {
         int x;

--- a/src/core/model/PageHandler.cpp
+++ b/src/core/model/PageHandler.cpp
@@ -29,6 +29,12 @@ void PageHandler::fireElementChanged(Element* elem) {
     for (PageListener* pl: this->listeners) { pl->elementChanged(elem); }
 }
 
+void PageHandler::fireElementsChanged(const std::vector<Element*>& elements, Range range) {
+    for (PageListener* pl: this->listeners) {
+        pl->elementsChanged(elements, range);
+    }
+}
+
 void PageHandler::firePageChanged() {
     for (PageListener* pl: this->listeners) { pl->pageChanged(); }
 }

--- a/src/core/model/PageHandler.h
+++ b/src/core/model/PageHandler.h
@@ -12,6 +12,9 @@
 #pragma once
 
 #include <list>  // for list
+#include <vector>
+
+#include "util/Range.h"  // for Range
 
 class Element;
 class PageListener;
@@ -30,6 +33,12 @@ public:
     void fireRectChanged(xoj::util::Rectangle<double>& rect);
     void fireRangeChanged(Range& range);
     void fireElementChanged(Element* elem);
+    /**
+     * @brief The listed elements have been changed
+     * @param range (optional) if provided, the Range must contain the bounding boxes of the changed elements, both
+     * before and after they were changed
+     */
+    void fireElementsChanged(const std::vector<Element*>& elements, Range range = Range());
     void firePageChanged();
 
 private:

--- a/src/core/model/PageListener.h
+++ b/src/core/model/PageListener.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <memory>  // for shared_ptr, weak_ptr
+#include <vector>
 
 class Element;
 class PageHandler;
@@ -33,6 +34,7 @@ public:
     virtual void rectChanged(xoj::util::Rectangle<double>& rect) {}
     virtual void rangeChanged(Range& range) {}
     virtual void elementChanged(Element* elem) {}
+    virtual void elementsChanged(const std::vector<Element*>& elements, const Range& range) {}
     virtual void pageChanged() {}
 
 private:

--- a/src/core/model/XojPage.h
+++ b/src/core/model/XojPage.h
@@ -24,9 +24,6 @@
 #include "PageHandler.h"      // for PageHandler
 #include "PageType.h"         // for PageType
 
-template <class T>
-using optional = std::optional<T>;
-
 class XojPage: public PageHandler {
 public:
     XojPage(double width, double height);
@@ -129,7 +126,7 @@ private:
     /**
      * Background name
      */
-    optional<std::string> backgroundName;
+    std::optional<std::string> backgroundName;
 
     // Allow LoadHandler to add layers directly
     friend class LoadHandler;

--- a/src/core/pdf/base/XojPdfPage.h
+++ b/src/core/pdf/base/XojPdfPage.h
@@ -18,6 +18,8 @@
 
 #include <cairo.h>  // for cairo_region_t, cairo_t
 
+#include "util/raii/CairoWrappers.h"
+
 /// Determines how text is selected on a user action.
 enum class XojPdfPageSelectionStyle : uint8_t {
     /// Standard selection, where all text between start and end positions is selected.
@@ -45,7 +47,7 @@ public:
 class XojPdfPage {
 public:
     struct TextSelection {
-        cairo_region_t* region;
+        xoj::util::CairoRegionSPtr region;
         std::vector<XojPdfRectangle> rects;
     };
 

--- a/src/core/pdf/popplerapi/PopplerGlibPage.cpp
+++ b/src/core/pdf/popplerapi/PopplerGlibPage.cpp
@@ -187,11 +187,11 @@ auto PopplerGlibPage::selectTextLines(const XojPdfRectangle& selectRect, XojPdfP
         // We always want to select in the "proper" rectangle.
         PopplerRectangle area{rect.x1, rect.y1, rect.x2, rect.y2};
         if (!poppler_page_get_text_layout_for_area(this->page, &area, &rectArray, &numRects)) {
-            return {.region = cairo_region_create(), .rects = textRects};
+            return {.region = xoj::util::CairoRegionSPtr(cairo_region_create(), xoj::util::adopt), .rects = textRects};
         }
     } else {
         if (!poppler_page_get_text_layout(this->page, &rectArray, &numRects)) {
-            return {.region = cairo_region_create(), .rects = textRects};
+            return {.region = xoj::util::CairoRegionSPtr(cairo_region_create(), xoj::util::adopt), .rects = textRects};
         }
     }
 
@@ -285,5 +285,5 @@ auto PopplerGlibPage::selectTextLines(const XojPdfRectangle& selectRect, XojPdfP
     }
 
     g_assert_nonnull(region);
-    return {.region = region, .rects = textRects};
+    return {.region = xoj::util::CairoRegionSPtr(region, xoj::util::adopt), .rects = textRects};
 }

--- a/src/core/view/overlays/PdfElementSelectionView.cpp
+++ b/src/core/view/overlays/PdfElementSelectionView.cpp
@@ -1,0 +1,37 @@
+#include "PdfElementSelectionView.h"
+
+#include "control/tools/PdfElemSelection.h"
+#include "util/raii/CairoWrappers.h"
+#include "view/Repaintable.h"
+
+class Range;
+
+using namespace xoj::view;
+
+PdfElementSelectionView::PdfElementSelectionView(const PdfElemSelection* selection, Repaintable* parent,
+                                                 Color selectionColor):
+        OverlayView(parent), selection(selection), selectionColor(selectionColor) {
+    this->registerToPool(selection->getViewPool());
+}
+
+PdfElementSelectionView::~PdfElementSelectionView() noexcept { this->unregisterFromPool(); }
+
+void PdfElementSelectionView::draw(cairo_t* cr) const {
+    xoj::util::CairoSaveGuard saveGuard(cr);
+
+    if (auto reg = selection->getSelectedRegion(); reg && !cairo_region_is_empty(reg)) {
+        gdk_cairo_region(cr, reg);
+        Util::cairo_set_source_rgbi(cr, selectionColor, SELECTION_OPACITY);
+        cairo_fill(cr);
+    }
+}
+
+bool PdfElementSelectionView::isViewOf(const OverlayBase* overlay) const { return overlay == this->selection; }
+
+void PdfElementSelectionView::on(PdfElementSelectionView::FlagDirtyRegionRequest, const Range& rg) const {
+    this->parent->flagDirtyRegion(rg);
+}
+
+void PdfElementSelectionView::deleteOn(PdfElementSelectionView::CancelSelectionRequest, const Range& rg) {
+    this->parent->deleteOverlayView(this, rg);
+}

--- a/src/core/view/overlays/PdfElementSelectionView.h
+++ b/src/core/view/overlays/PdfElementSelectionView.h
@@ -1,0 +1,57 @@
+/*
+ * Xournal++
+ *
+ * View pdf selections
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+#pragma once
+
+#include <cairo.h>  // for cairo_t
+
+#include "util/Color.h"
+#include "util/DispatchPool.h"  // for Listener
+#include "view/overlays/OverlayView.h"
+
+class OverlayBase;
+class PdfElemSelection;
+class Range;
+
+namespace xoj::view {
+class Repaintable;
+
+class PdfElementSelectionView final: public OverlayView, public xoj::util::Listener<PdfElementSelectionView> {
+
+public:
+    PdfElementSelectionView(const PdfElemSelection* selection, Repaintable* parent, Color selectionColor);
+    ~PdfElementSelectionView() noexcept override;
+
+    /**
+     * @brief Draws the overlay to the given context
+     */
+    void draw(cairo_t* cr) const override;
+
+    bool isViewOf(const OverlayBase* overlay) const override;
+
+    /**
+     * Listener interface
+     */
+    static constexpr struct CancelSelectionRequest {
+    } CANCEL_SELECTION_REQUEST = {};
+    void deleteOn(CancelSelectionRequest, const Range& rg);
+    static constexpr struct FlagDirtyRegionRequest {
+    } FLAG_DIRTY_REGION_REQUEST = {};
+    void on(FlagDirtyRegionRequest, const Range& rg) const;
+
+private:
+    const PdfElemSelection* selection;
+    const Color selectionColor;
+
+public:
+    // Opacity of the background
+    static constexpr double SELECTION_OPACITY = 0.3;
+};
+};  // namespace xoj::view

--- a/src/core/view/overlays/SearchResultView.h
+++ b/src/core/view/overlays/SearchResultView.h
@@ -18,7 +18,6 @@
 
 class OverlayBase;
 class SearchControl;
-class Settings;
 
 namespace xoj::view {
 class Repaintable;

--- a/src/util/include/util/raii/CairoWrappers.h
+++ b/src/util/include/util/raii/CairoWrappers.h
@@ -38,10 +38,18 @@ public:
     constexpr static auto unref = cairo_surface_destroy;
     constexpr static auto adopt = identity<cairo_surface_t>;
 };
+
+class CairoRegionHandler {
+public:
+    constexpr static auto ref = cairo_region_reference;
+    constexpr static auto unref = cairo_region_destroy;
+    constexpr static auto adopt = identity<cairo_region_t>;
+};
 };  // namespace specialization
 
 using CairoSPtr = CLibrariesSPtr<cairo_t, raii::specialization::CairoHandler>;
 using CairoSurfaceSPtr = CLibrariesSPtr<cairo_surface_t, raii::specialization::CairoSurfaceHandler>;
+using CairoRegionSPtr = CLibrariesSPtr<cairo_region_t, raii::specialization::CairoRegionHandler>;
 
 /**
  * @brief cairo_save(cr)/cairo_restore(cr) RAII implementation


### PR DESCRIPTION
This PR splits control/tools/PdfElemSelection into view+controller.

It also fixes a Segfault I encountered when testing, seemingly due to a datarace upon stroke creation in PdfFloatingToolbox.

With this PR, and all the others in this Splitting series, we should be able to start splitting gui/PageView into a view and a controller :-)

This is based on #4304 (only for PageView::deleteOverlayView()).

- [x] Merge #4304 and rebase