### PR TITLE
Fix crash when tex generator is not found

### DIFF
--- a/src/control/latex/LatexGenerator.cpp
+++ b/src/control/latex/LatexGenerator.cpp
@@ -65,9 +65,9 @@ auto LatexGenerator::asyncRun(const fs::path& texDir, const std::string& texFile
                     FS(_F("Failed to find LaTeX generator program in PATH: {1}\n\nSince installation is detected "
                           "within Flatpak, you need to install the Flatpak freedesktop Tex Live extension. For "
                           "example, by running:\n\n$ flatpak install flathub org.freedesktop.Sdk.Extension.texlive") %
-                       prog)};
+                       argv[0])};
         } else {
-            res = GenError{FS(_F("Failed to find LaTeX generator program in PATH: {1}") % prog)};
+            res = GenError{FS(_F("Failed to find LaTeX generator program in PATH: {1}") % argv[0])};
         }
 
         g_strfreev(argv);

--- a/src/control/latex/LatexGenerator.cpp
+++ b/src/control/latex/LatexGenerator.cpp
@@ -71,7 +71,7 @@ auto LatexGenerator::asyncRun(const fs::path& texDir, const std::string& texFile
         }
 
         g_strfreev(argv);
-        g_error_free(err);
+        g_clear_error(&err);
         return res;
     }
     g_free(argv[0]);


### PR DESCRIPTION
Fixes #4334
Also fixes a warning when freeing a `g_error` that has not occured (is `nullptr`)

The PR (built from source) can be tested via `PATH="" ./src/xournalpp`, which makes the `PATH` environment variable not contain the latex generator path.