### PR TITLE
Adds missing check to selectTool()

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -1786,6 +1786,7 @@ void Control::selectTool(ToolType type) {
     if (oldTool && win
                 && isSelectToolType(type)
                 && oldTool->getToolType() == ToolType::TOOL_TEXT
+                && this->win->getXournal()->getTextEditor()
                 && !(this->win->getXournal()->getTextEditor()->getText()->getText().empty())) {
         auto xournal = this->win->getXournal();
         Text* textobj = xournal->getTextEditor()->getText();


### PR DESCRIPTION
A bug added in [this](https://github.com/xournalpp/xournalpp/pull/4315) pull request where xournalpp crashes when switching from the text tool to the selection tool without having a text selected. This occurred because of a missing check in the if statement.
This check is being added with this pull request