### PR TITLE
[Lua API] extend getToolInfo for selection and add getStrokes as inverse of addStrokes

### DIFF
--- a/src/core/control/tools/EditSelection.cpp
+++ b/src/core/control/tools/EditSelection.cpp
@@ -272,6 +272,26 @@ auto EditSelection::getRect() const -> Rectangle<double> {
 }
 
 /**
+ * gets the minimal bounding box containing all elements of the selection used for e.g. grid snapping
+ */
+auto EditSelection::getSnappedBounds() const -> Rectangle<double> { return Rectangle<double>{this->snappedBounds}; }
+
+/**
+ * get the original bounding rectangle in document coordinates
+ */
+auto EditSelection::getOriginalBounds() const -> Rectangle<double> { return Rectangle<double>{this->contents->getOriginalBounds()}; }
+
+/**
+ * Get the rotation angle of the selection
+ */
+auto EditSelection::getRotation() const -> double { return this->rotation; }
+
+/**
+ * Get if the selection supports being rotated
+ */
+auto EditSelection::isRotationSupported() const -> bool { return this->supportRotation; }
+
+/**
  * Get the source page (where the selection was done)
  */
 auto EditSelection::getSourcePage() -> PageRef { return this->sourcePage; }

--- a/src/core/control/tools/EditSelection.h
+++ b/src/core/control/tools/EditSelection.h
@@ -103,6 +103,26 @@ public:
     xoj::util::Rectangle<double> getRect() const;
 
     /**
+     * gets the minimal bounding box containing all elements of the selection used for e.g. grid snapping
+     */
+    xoj::util::Rectangle<double> getSnappedBounds() const;
+
+    /**
+     * get the original bounding rectangle in document coordinates
+     */
+    xoj::util::Rectangle<double> getOriginalBounds() const;
+
+    /**
+     * Get the rotation angle of the selection
+     */
+    double getRotation() const;
+
+    /**
+     * Get if the selection supports being rotated
+     */
+    bool isRotationSupported() const;
+
+    /**
      * Get the source page (where the selection was done)
      */
     PageRef getSourcePage();

--- a/src/core/control/tools/EditSelectionContents.cpp
+++ b/src/core/control/tools/EditSelectionContents.cpp
@@ -392,6 +392,8 @@ auto EditSelectionContents::getOriginalX() const -> double { return this->origin
 
 auto EditSelectionContents::getOriginalY() const -> double { return this->originalBounds.y; }
 
+auto EditSelectionContents::getOriginalBounds() const -> Rectangle<double> { return Rectangle<double>{this->originalBounds}; }
+
 auto EditSelectionContents::getSourceView() -> XojPageView* { return this->sourceView; }
 
 

--- a/src/core/control/tools/EditSelectionContents.h
+++ b/src/core/control/tools/EditSelectionContents.h
@@ -150,6 +150,11 @@ public:
      */
     double getOriginalY() const;
 
+    /**
+     * Gets the complete original bounding box as rectangle
+     */
+    xoj::util::Rectangle<double> getOriginalBounds() const;
+
     UndoAction* copySelection(PageRef page, XojPageView* view, double x, double y);
 
     const static struct {


### PR DESCRIPTION
Outsourcing of the luaApi stuff of PR https://github.com/xournalpp/xournalpp/pull/2176.

The aim is to have a function `getStrokes` which serves as inverse of the existing `addStrokes`.

TODO:
- [x] getWidthAndHeight -> `getToolInfo("selection")`
- [x] getStrokes
  - [x] documentation of in-/output
  - [x] style stuff (moving lines, outsourcing to helper function)
  - [ ] ~~testing~~