### PR TITLE
Fix PDF toolbox showing at the wrong position on Wayland

### DIFF
--- a/src/core/gui/PageView.cpp
+++ b/src/core/gui/PageView.cpp
@@ -591,12 +591,15 @@ void XojPageView::onSequenceCancelEvent() {
 }
 
 auto XojPageView::showPdfToolbox(const PositionInputData& pos) -> void {
+    // Compute coords of the canvas relative to the application window origin.
     gint wx = 0, wy = 0;
     GtkWidget* widget = xournal->getWidget();
     gtk_widget_translate_coordinates(widget, gtk_widget_get_toplevel(widget), 0, 0, &wx, &wy);
 
-    wx += static_cast<gint>(std::lround(pos.x)) + this->getX();
-    wy += static_cast<gint>(std::lround(pos.y)) + this->getY();
+    // Add the position of the current page view widget (relative to canvas origin)
+    // and add the input position (relative to the current page view widget).
+    wx += this->getX() + static_cast<gint>(std::lround(pos.x));
+    wy += this->getY() + static_cast<gint>(std::lround(pos.y));
 
     auto* pdfToolbox = this->xournal->getControl()->getWindow()->getPdfToolbox();
     pdfToolbox->show(wx, wy);

--- a/src/core/gui/PdfFloatingToolbox.h
+++ b/src/core/gui/PdfFloatingToolbox.h
@@ -9,6 +9,7 @@
 
 #include "control/tools/PdfElemSelection.h"  // for PdfElemSelection
 #include "pdf/base/XojPdfPage.h"             // for XojPdfPageSelectionStyle
+#include "util/raii/GObjectSPtr.h"  // for GObjectSPtr
 
 class MainWindow;
 class XojPageView;
@@ -33,8 +34,9 @@ public:
     ~PdfFloatingToolbox() = default;
 
 public:
-    /// Show the toolbox at the provided coordinates. Must have an active
-    /// selection.
+    /// Show the toolbox at the provided coordinates (relative to the application GTK window).
+    ///
+    /// Must have an active selection.
     void show(int x, int y);
 
     /// Hide the floating toolbox widget (keeping the current selection).
@@ -79,6 +81,9 @@ private:
 private:
     GtkWidget* floatingToolbox;
     MainWindow* theMainWindow;
+
+    /// The overlay that the toolbox should be displayed in.
+    xoj::util::GObjectSPtr<GtkOverlay> overlay;
 
     std::unique_ptr<PdfElemSelection> pdfElemSelection = nullptr;
 

--- a/src/util/include/util/raii/GObjectSPtr.h
+++ b/src/util/include/util/raii/GObjectSPtr.h
@@ -39,6 +39,10 @@ public:
 };
 };  // namespace specialization
 
-using WidgetSPtr = CLibrariesSPtr<GtkWidget, raii::specialization::GObjectHandler<GtkWidget>>;
+template <typename GlibClass>
+using GObjectSPtr = CLibrariesSPtr<GlibClass, raii::specialization::GObjectHandler<GlibClass>>;
+
+using WidgetSPtr = GObjectSPtr<GtkWidget>;
+
 };  // namespace raii
 };  // namespace xoj::util


### PR DESCRIPTION
Fixes #4298. See the commit message for details.