### PR TITLE
fix crash with zero width stroke segments

### DIFF
--- a/src/core/view/StrokeViewHelper.cpp
+++ b/src/core/view/StrokeViewHelper.cpp
@@ -42,7 +42,6 @@ double xoj::view::StrokeViewHelper::drawWithPressure(cairo_t* cr, const std::vec
      * Because the width varies, we need to call cairo_stroke() once per segment
      */
     auto drawSegment = [cr](const Point& p, const Point& q) {
-        assert(p.z > 0.0);
         cairo_set_line_width(cr, p.z);
         cairo_move_to(cr, p.x, p.y);
         cairo_line_to(cr, q.x, q.y);


### PR DESCRIPTION
553588a4c ("Split away helper functions from view/StrokeView", 2022-07-21) split away helper functions but also changed behaviour of the code. In particular, it introduced an assert for non-zero width of stroke segments of strokes with pressure which was not there before. As a consequence, xournalpp crashes on files on which it did not cross before.

Zero width stroke segments can happen for strokes with pressure due to fading as well as rounding. So, remove the assert which was introduced by the split.