### PR TITLE
Fix assertion on selection existence when the stylus tip touches the screen

### DIFF
--- a/src/core/gui/PageView.cpp
+++ b/src/core/gui/PageView.cpp
@@ -382,15 +382,25 @@ auto XojPageView::onButtonPressEvent(const PositionInputData& pos) -> bool {
                h->getToolType() == TOOL_PLAY_OBJECT || h->getToolType() == TOOL_SELECT_OBJECT ||
                h->getToolType() == TOOL_SELECT_PDF_TEXT_LINEAR || h->getToolType() == TOOL_SELECT_PDF_TEXT_RECT) {
         if (h->getToolType() == TOOL_SELECT_RECT) {
-            assert(!selection);
-            this->selection = std::make_unique<RectSelection>(x, y);
-            this->overlayViews.emplace_back(std::make_unique<xoj::view::SelectionView>(
-                    this->selection.get(), this, this->settings->getSelectionColor()));
+            if (!selection) {
+                this->selection = std::make_unique<RectSelection>(x, y);
+                this->overlayViews.emplace_back(std::make_unique<xoj::view::SelectionView>(
+                        this->selection.get(), this, this->settings->getSelectionColor()));
+            } else {
+                assert(settings->getInputSystemTPCButtonEnabled() &&
+                       "the selection has already been created by a stylus button press while the stylus was "
+                       "hovering!");
+            }
         } else if (h->getToolType() == TOOL_SELECT_REGION) {
-            assert(!selection);
-            this->selection = std::make_unique<RegionSelect>(x, y);
-            this->overlayViews.emplace_back(std::make_unique<xoj::view::SelectionView>(
-                    this->selection.get(), this, this->settings->getSelectionColor()));
+            if (!selection) {
+                this->selection = std::make_unique<RegionSelect>(x, y);
+                this->overlayViews.emplace_back(std::make_unique<xoj::view::SelectionView>(
+                        this->selection.get(), this, this->settings->getSelectionColor()));
+            } else {
+                assert(settings->getInputSystemTPCButtonEnabled() &&
+                       "the selection has already been created by a stylus button press while the stylus was "
+                       "hovering!");
+            }
         } else if (h->getToolType() == TOOL_SELECT_PDF_TEXT_LINEAR || h->getToolType() == TOOL_SELECT_PDF_TEXT_RECT) {
             // so if we selected something && the pdf selection toolbox is hidden && we hit within the selection
             // we could call the pdf floating toolbox again


### PR DESCRIPTION
Fixes #4375

Here is what happens in `Merging button events with stylus tip events` mode, when the region selection tool is assigned to a stylus button:

- While hovering, press the stylus button -> a button press event is received and a region selection is created (which is also visible on the screen)
- With the tip of the stylus touch the screen -> a button press event is received again and it is falsely asserted that there is no (region) selection => the app crashes.

So the assertion is wrong in `Merging button events with stylus tip events` mode, which explains the fix.