### PR TITLE
Override std::exception::what rather than hiding virtual overload

### DIFF
--- a/src/util/include/util/serializing/InputStreamException.h
+++ b/src/util/include/util/serializing/InputStreamException.h
@@ -21,7 +21,7 @@ public:
     ~InputStreamException() override;
 
 public:
-    virtual const char* what();
+    const char* what() const noexcept override;
 
 private:
     std::string message;

--- a/src/util/serializing/InputStreamException.cpp
+++ b/src/util/serializing/InputStreamException.cpp
@@ -8,4 +8,4 @@ InputStreamException::InputStreamException(const std::string& message, const std
 
 InputStreamException::~InputStreamException() = default;
 
-auto InputStreamException::what() -> const char* { return this->message.c_str(); }
+const char* InputStreamException::what() const noexcept { return this->message.c_str(); }


### PR DESCRIPTION
This fixes lots of warnings about this method declaration hiding a virtual overload.

```log
In file included from /home/user/projects/xournalpp/src/util/serializing/ObjectInputStream.cpp:9:
/home/user/projects/xournalpp/src/util/include/util/serializing/InputStreamException.h:24:25: warning: 'InputStreamException::what' hides overloaded virtual function [-Woverloaded-virtual]
    virtual const char* what();
                        ^
/usr/lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/exception.h:76:5: note: hidden overloaded virtual function 'std::exception::what' declared here: different qualifiers ('const' vs unqualified)
    what() const _GLIBCXX_TXN_SAFE_DYN _GLIBCXX_NOTHROW;
```