### PR TITLE
Add Ubuntu 22.04 build

### DIFF
--- a/azure-pipelines/create-installers.yml
+++ b/azure-pipelines/create-installers.yml
@@ -47,6 +47,10 @@ stages:
         parameters:
           ubuntu_version: 20.04
           job_name: 'Ubuntu20_04'
+      - template: jobs/release_ubuntu.yml
+        parameters:
+          ubuntu_version: 22.04
+          job_name: 'Ubuntu22_04'
       - job: 'Debian'
         pool:
           vmImage: 'ubuntu-18.04'

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -55,6 +55,10 @@ stages:
         parameters:
           ubuntu_version: 20.04
           job_name: 'Ubuntu20_04'
+      - template: jobs/release_ubuntu.yml
+        parameters:
+          ubuntu_version: 22.04
+          job_name: 'Ubuntu22_04'
       - job: 'Debian'
         pool:
           vmImage: 'ubuntu-18.04'


### PR DESCRIPTION
This commit adds an Ubuntu 22.04 release build. Also `/azp run create-installers` will now generate an additional Ubuntu 22.04 build.