### PR TITLE
PDF goto link feature

### DIFF
--- a/src/core/control/ScrollHandler.cpp
+++ b/src/core/control/ScrollHandler.cpp
@@ -1,21 +1,18 @@
 #include "ScrollHandler.h"
 
 #include <memory>  // for __shared_ptr_access
-#include "gui/Layout.h"
-#include "gui/XournalView.h"
-#include "gui/sidebar/Sidebar.h"
-#include "gui/widgets/SpinPageAdapter.h"
-#include "model/LinkDestination.h"
 
 #include <glib.h>  // for g_error
 
+#include "control/zoom/ZoomControl.h"     // for ZoomControl
 #include "gui/MainWindow.h"               // for MainWindow
 #include "gui/XournalView.h"              // for XournalView
+#include "gui/sidebar/Sidebar.h"          // for Sidebar
 #include "gui/widgets/SpinPageAdapter.h"  // for SpinPageAdapter
 #include "model/Document.h"               // for Document
+#include "model/LinkDestination.h"        // for LinkDestination
 #include "model/XojPage.h"                // for XojPage
 #include "util/Util.h"                    // for npos
-#include "control/zoom/ZoomControl.h"     // for ZoomControl
 
 #include "Control.h"  // for Control
 

--- a/src/core/control/ScrollHandler.h
+++ b/src/core/control/ScrollHandler.h
@@ -17,6 +17,7 @@
 #include "model/PageRef.h"                // for PageRef
 
 class Control;
+class LinkDestination;
 
 class ScrollHandler: public SpinPageListener {
 public:
@@ -34,6 +35,17 @@ public:
     void scrollToPage(size_t page, double top = 0);
 
     void scrollToAnnotatedPage(bool next);
+
+    /**
+     * Scroll to a given link's destination, provided the
+     * destination is a local destination and not a URI.
+     *
+     *  If the destination is a non-existent PDF page,
+     * we ask the user whether to add the missing page or not.
+     *
+     * @param dest is to shown
+     */
+    void scrollToLinkDest(const LinkDestination& dest);
 
     bool isPageVisible(size_t page, int* visibleHeight = nullptr);
 

--- a/src/core/control/ToolEnums.cpp
+++ b/src/core/control/ToolEnums.cpp
@@ -244,3 +244,8 @@ auto eraserTypeFromString(const std::string& type) -> EraserType {
     }
     return ERASER_TYPE_NONE;
 }
+
+
+bool xoj::tool::isPdfSelectionTool(ToolType toolType) {
+    return toolType == TOOL_SELECT_PDF_TEXT_LINEAR || toolType == TOOL_SELECT_PDF_TEXT_RECT;
+}

--- a/src/core/control/ToolEnums.h
+++ b/src/core/control/ToolEnums.h
@@ -108,3 +108,8 @@ enum ToolCapabilities : unsigned int {
     TOOL_CAP_SPLINE = 1 << 11,
     TOOL_CAP_LINE_STYLE = 1 << 12
 };
+
+namespace xoj::tool {
+/// \return Whether the provided tool is used for selecting objects on a PDF.
+bool isPdfSelectionTool(ToolType toolType);
+}  // namespace xoj::tool

--- a/src/core/gui/PageView.cpp
+++ b/src/core/gui/PageView.cpp
@@ -35,6 +35,7 @@
 #include "control/tools/StrokeHandler.h"            // for StrokeHandler
 #include "control/tools/VerticalToolHandler.h"      // for VerticalToolHandler
 #include "control/zoom/ZoomControl.h"               // for ZoomControl
+#include "control/ScrollHandler.h"
 #include "gui/FloatingToolbox.h"                    // for FloatingToolbox
 #include "gui/MainWindow.h"                         // for MainWindow
 #include "gui/PdfFloatingToolbox.h"                 // for PdfFloatingToolbox
@@ -677,8 +678,27 @@ auto XojPageView::onButtonReleaseEvent(const PositionInputData& pos) -> bool {
         } else {
             double zoom = xournal->getZoom();
             if (this->selection->userTapped(zoom)) {
-                SelectObject select(this);
-                select.at(pos.x / zoom, pos.y / zoom);
+                Layer* layer = this->page->getSelectedLayer();
+                const Layer::Index layerId = this->page->getSelectedLayerId();
+                const bool isBackgroundLayer = (layerId == 0);
+
+                // If there's nothing to select (e.g. the background layer)
+                // or we're holding alt...
+                if (isBackgroundLayer || !layer->isAnnotated() || pos.isAltDown()) {
+                    // Attempt PDF selection
+                    auto& pdfDoc = this->xournal->getDocument()->getPdfDocument();
+                    if (this->getPage()->getPdfPageNr() != npos) {
+                        auto page = pdfDoc.getPage(this->getPage()->getPdfPageNr());
+
+                        const double pageX = pos.x / zoom;
+                        const double pageY = pos.y / zoom;
+
+                        displayLinkPopover(page, pageX, pageY);
+                    }
+                } else {
+                    SelectObject select(this);
+                    select.at(pos.x / zoom, pos.y / zoom);
+                }
             }
         }
         this->selection.reset();
@@ -891,6 +911,52 @@ void XojPageView::drawLoadingPage(cairo_t* cr) {
     cairo_show_text(cr, txtLoading.c_str());
 
     rerenderPage();
+}
+
+bool XojPageView::displayLinkPopover(std::shared_ptr<XojPdfPage> page, double pageX, double pageY) {
+    // Search for selected link
+    const auto links = page->getLinks();
+
+    for (auto&& [rect, uri]: links) {
+        if (!(rect.x1 <= pageX && pageX <= rect.x2 && rect.y1 <= pageY && pageY <= rect.y2)) {
+            continue;
+        }
+
+        char* uriStr = g_uri_to_string(uri);
+        char* uriText = g_markup_escape_text(uriStr, -1);
+        char* labelMarkup = g_strdup_printf("<a href=\"%s\">%s</a>", uriStr, uriText);
+        g_free(uriStr);
+        g_free(uriText);
+        GtkWidget* label = gtk_label_new(nullptr);
+        gtk_label_set_markup(GTK_LABEL(label), labelMarkup);
+        GtkWidget* box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
+        gtk_container_add(GTK_CONTAINER(box), label);
+
+        GtkWidget* popover = makePopover(rect, box);
+        gtk_widget_show_all(popover);
+        gtk_popover_popup(GTK_POPOVER(popover));
+        return true;
+    }
+
+    return false;
+}
+
+GtkWidget* XojPageView::makePopover(const XojPdfRectangle& rect, GtkWidget* child) {
+    double zoom = xournal->getZoom();
+
+    GtkWidget* popover = gtk_popover_new(this->getXournal()->getWidget());
+    gtk_container_add(GTK_CONTAINER(popover), child);
+
+    auto x = static_cast<int>(this->getX() + rect.x1 * zoom);
+    auto y = static_cast<int>(this->getY() + rect.y1 * zoom);
+    auto w = static_cast<int>((rect.x2 - rect.x1) * zoom);
+    auto h = static_cast<int>((rect.y2 - rect.y1) * zoom);
+
+    GdkRectangle canvasRect{x, y, w, h};
+    gtk_popover_set_pointing_to(GTK_POPOVER(popover), &canvasRect);
+    gtk_popover_set_constrain_to(GTK_POPOVER(popover), GTK_POPOVER_CONSTRAINT_WINDOW);
+
+    return popover;
 }
 
 auto XojPageView::paintPage(cairo_t* cr, GdkRectangle* rect) -> bool {

--- a/src/core/gui/PageView.cpp
+++ b/src/core/gui/PageView.cpp
@@ -6,6 +6,7 @@
 #include <memory>     // for __shared_ptr_access
 #include <optional>   // for optional
 #include <utility>    // for move
+#include <sstream>    // for stringstream
 
 #include <gdk/gdk.h>         // for GdkRectangle, Gdk...
 #include <gdk/gdkkeysyms.h>  // for GDK_KEY_Escape
@@ -60,7 +61,10 @@
 #include "util/Rectangle.h"                         // for Rectangle
 #include "util/Util.h"                              // for npos
 #include "util/XojMsgBox.h"                         // for XojMsgBox
-#include "util/i18n.h"                              // for FS, _, _F
+#include "util/i18n.h"                              // for _F, FC, FS, _
+#include "util/raii/CLibrariesSPtr.h"               // for adopt
+#include "util/serdesstream.h"                      // for serdes_stream
+#include "util/gtk4_helper.h"                       // for gtk_box_append
 #include "view/DebugShowRepaintBounds.h"            // for IF_DEBUG_REPAINT
 #include "view/overlays/OverlayView.h"
 #include "view/overlays/PdfElementSelectionView.h"
@@ -917,22 +921,64 @@ bool XojPageView::displayLinkPopover(std::shared_ptr<XojPdfPage> page, double pa
     // Search for selected link
     const auto links = page->getLinks();
 
-    for (auto&& [rect, uri]: links) {
+    for (auto&& [rect, action]: links) {
+        std::shared_ptr<const LinkDestination> dest = action->getDestination();
+
         if (!(rect.x1 <= pageX && pageX <= rect.x2 && rect.y1 <= pageY && pageY <= rect.y2)) {
             continue;
         }
 
-        char* uriStr = g_uri_to_string(uri);
-        char* uriText = g_markup_escape_text(uriStr, -1);
-        char* labelMarkup = g_strdup_printf("<a href=\"%s\">%s</a>", uriStr, uriText);
-        g_free(uriStr);
-        g_free(uriText);
-        GtkWidget* label = gtk_label_new(nullptr);
-        gtk_label_set_markup(GTK_LABEL(label), labelMarkup);
         GtkWidget* box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
-        gtk_container_add(GTK_CONTAINER(box), label);
-
         GtkWidget* popover = makePopover(rect, box);
+
+        if (auto uriOpt = dest->getURI()) {
+            const std::string& uri = uriOpt.value();
+            char* uriLabel = g_markup_escape_text(uri.c_str(), -1);
+
+            auto labelMarkup = serdes_stream<std::stringstream>();
+            labelMarkup << "<a href=" << std::quoted(uri) << ">" << uriLabel << "</a>";
+
+            std::string linkMarkup = labelMarkup.str();
+
+            g_free(uriLabel);
+
+            GtkWidget* label = gtk_label_new(nullptr);
+            gtk_label_set_markup(GTK_LABEL(label), linkMarkup.c_str());
+            gtk_box_append(GTK_BOX(box), label);
+        } else {
+            size_t pdfPage = dest->getPdfPage();
+
+            Document* doc = xournal->getControl()->getDocument();
+            doc->lock();
+            const size_t pageId = doc->findPdfPage(pdfPage);
+            doc->unlock();
+
+            GtkWidget* button{};
+            if (pageId != npos) {
+                const auto pageNo = static_cast<int64_t>(pageId + 1);
+                button = gtk_button_new_with_label(FC(_F("Scroll to page {1}") % pageNo));
+            } else {
+                button = gtk_button_new_with_label(FC(_F("Add missing page")));
+            }
+            gtk_box_append(GTK_BOX(box), button);
+
+            g_signal_connect(
+                    button, "clicked",
+                    G_CALLBACK(+[](GtkButton* bt,
+                                   std::tuple<XojPageView*, std::shared_ptr<LinkDestination>, GtkWidget*>* state) {
+                        XojPageView* self;
+                        std::shared_ptr<LinkDestination> dest;
+                        GtkWidget* popover;
+                        std::tie(self, dest, popover) = *state;
+
+                        self->getXournal()->getControl()->getScrollHandler()->scrollToLinkDest(*dest);
+                        gtk_popover_popdown(GTK_POPOVER(popover));
+
+                        delete state;
+                    }),
+                    new std::tuple(this, dest, popover));
+        }
+
         gtk_widget_show_all(popover);
         gtk_popover_popup(GTK_POPOVER(popover));
         return true;

--- a/src/core/gui/PageView.h
+++ b/src/core/gui/PageView.h
@@ -41,6 +41,8 @@ class Element;
 class PositionInputData;
 class Range;
 class TexImage;
+class XojPdfRectangle;
+class XojPdfPage;
 
 namespace xoj::view {
 class OverlayView;
@@ -201,6 +203,26 @@ private:
 
     void drawLoadingPage(cairo_t* cr);
 
+    /**
+     * @brief Make and display a popover dialog near the given location.
+     *
+     * @param rect specifies the location of the dialog.
+     * @param child is added to the dialog before displaying.
+     * @returns a pointer to the popover dialog.
+     */
+    GtkWidget* makePopover(const XojPdfRectangle& rect, GtkWidget* child);
+
+    /**
+     * @brief Display a popover with link-related actions, if one
+     *  is at a given location on the page.
+     *
+     * @param page is the current page
+     * @param targetX
+     * @param targetY the link must contain (targetX, targetY)
+     * @returns true iff a URI link exists near/at (targetX, targetY) => a popover was shown
+     */
+    bool displayLinkPopover(std::shared_ptr<XojPdfPage> page, double targetX, double targetY);
+
     void setX(int x);
     void setY(int y);
 
@@ -262,7 +284,7 @@ private:
     /**
      * Unixtimestam when the page was last time in the visible area
      */
-    int lastVisibleTime = -1;
+    long int lastVisibleTime = -1;
 
     std::mutex repaintRectMutex;
     std::vector<xoj::util::Rectangle<double>> rerenderRects;

--- a/src/core/gui/PageView.h
+++ b/src/core/gui/PageView.h
@@ -11,22 +11,24 @@
 
 #pragma once
 
-#include <memory>  // for unique_ptr
-#include <mutex>   // for mutex
-#include <string>  // for string
-#include <vector>  // for vector
+#include <cstddef>  // for size_t
+#include <memory>   // for unique_ptr, shared_ptr
+#include <mutex>    // for mutex
+#include <string>   // for string
+#include <vector>   // for vector
 
-#include <cairo.h>    // for cairo_t, cairo_surface_t
-#include <gdk/gdk.h>  // for GdkEventKey, GdkRectangle, GdkEventB...
+#include <cairo.h>    // for cairo_t
+#include <gdk/gdk.h>  // for GdkEventKey, GdkRGBA, GdkRectangle
+#include <gtk/gtk.h>  // for GtkWidget
 
 #include "model/PageListener.h"       // for PageListener
 #include "model/PageRef.h"            // for PageRef
 #include "util/Rectangle.h"           // for Rectangle
-#include "util/raii/CairoWrappers.h"  // for CairoSurfaceSPtr, CairoSPtr
-#include "view/Repaintable.h"
+#include "util/raii/CairoWrappers.h"  // for CairoSurfaceSPtr
+#include "view/Repaintable.h"         // for Repaintable
 
-#include "Layout.h"      // for Layout
-#include "LegacyRedrawable.h"  // for Redrawable
+#include "Layout.h"            // for Layout
+#include "LegacyRedrawable.h"  // for LegacyRedrawable
 
 class EraseHandler;
 class InputHandler;

--- a/src/core/gui/sidebar/Sidebar.cpp
+++ b/src/core/gui/sidebar/Sidebar.cpp
@@ -1,24 +1,28 @@
 #include "Sidebar.h"
 
-#include <memory>  // for allocator, make...
-#include <string>  // for string
+#include <cassert>    // for assert
+#include <cinttypes>  // for int64_t
+#include <memory>     // for make_shared
+#include <string>     // for string
+
 #include <config-features.h>
-#include <gtk/gtk.h>
 #include <gdk/gdk.h>      // for gdk_display_get...
 #include <glib-object.h>  // for G_CALLBACK, g_s...
+#include <gtk/gtk.h>      // for gtk_dialog_add_...
 
 #include "control/Control.h"                          // for Control
 #include "control/settings/Settings.h"                // for Settings
 #include "gui/GladeGui.h"                             // for GladeGui
 #include "gui/sidebar/AbstractSidebarPage.h"          // for AbstractSidebar...
 #include "gui/sidebar/indextree/SidebarIndexPage.h"   // for SidebarIndexPage
+#include "model/Document.h"                           // for Document
+#include "model/XojPage.h"                            // for XojPage
+#include "pdf/base/XojPdfPage.h"                      // for XojPdfPageSPtr
 #include "previews/layer/SidebarLayersContextMenu.h"  // for SidebarLayersCo...
 #include "previews/layer/SidebarPreviewLayers.h"      // for SidebarPreviewL...
 #include "previews/page/SidebarPreviewPages.h"        // for SidebarPreviewP...
 #include "util/Util.h"                                // for npos
-#include "util/i18n.h"
-#include "model/Document.h"
-#include "model/XojPage.h"
+#include "util/i18n.h"                                // for _, FC, _F
 
 Sidebar::Sidebar(GladeGui* gui, Control* control): control(control), gui(gui), toolbar(this, gui) {
     this->tbSelectPage = GTK_TOOLBAR(gui->get("tbSelectSidebarPage"));

--- a/src/core/gui/sidebar/Sidebar.h
+++ b/src/core/gui/sidebar/Sidebar.h
@@ -74,6 +74,12 @@ public:
      */
     SidebarToolbar* getToolbar();
 
+    /**
+     * Ask the user whether a page with the given id
+     * should be added to the document.
+     */
+    void askInsertPdfPage(size_t pdfPage);
+
 public:
     // DocumentListener interface
     void documentChanged(DocumentChangeType type) override;

--- a/src/core/gui/sidebar/indextree/SidebarIndexPage.cpp
+++ b/src/core/gui/sidebar/indextree/SidebarIndexPage.cpp
@@ -81,47 +81,6 @@ void SidebarIndexPage::disableSidebar() {
     // Nothing to do at the moment
 }
 
-void SidebarIndexPage::askInsertPdfPage(size_t pdfPage) {
-    GtkWidget* dialog = gtk_message_dialog_new(control->getGtkWindow(), GTK_DIALOG_MODAL, GTK_MESSAGE_QUESTION,
-                                               GTK_BUTTONS_NONE, "%s",
-                                               FC(_F("Your current document does not contain PDF Page no {1}\n"
-                                                     "Would you like to insert this page?\n\n"
-                                                     "Tip: You can select Journal → Paper Background → PDF Background "
-                                                     "to insert a PDF page.") %
-                                                  (pdfPage + 1)));
-
-    gtk_dialog_add_button(GTK_DIALOG(dialog), "Cancel", 1);
-    gtk_dialog_add_button(GTK_DIALOG(dialog), "Insert after", 2);
-    gtk_dialog_add_button(GTK_DIALOG(dialog), "Insert at end", 3);
-
-    gtk_window_set_transient_for(GTK_WINDOW(dialog), control->getGtkWindow());
-    int res = gtk_dialog_run(GTK_DIALOG(dialog));
-    gtk_widget_destroy(dialog);
-    if (res == 1) {
-        return;
-    }
-
-    size_t position = 0;
-
-    Document* doc = control->getDocument();
-
-    if (res == 2) {
-        position = control->getCurrentPageNo() + 1;
-    } else if (res == 3) {
-        position = doc->getPageCount();
-    }
-
-    doc->lock();
-    XojPdfPageSPtr pdf = doc->getPdfPage(pdfPage);
-    doc->unlock();
-
-    if (pdf) {
-        auto page = std::make_shared<XojPage>(pdf->getWidth(), pdf->getHeight());
-        page->setBackgroundPdfPageNr(pdfPage);
-        control->insertPage(std::move(page), position);
-    }
-}
-
 auto SidebarIndexPage::treeBookmarkSelected(GtkWidget* treeview, SidebarIndexPage* sidebar) -> bool {
     if (sidebar->searchTimeout) {
         return false;
@@ -142,27 +101,7 @@ auto SidebarIndexPage::treeBookmarkSelected(GtkWidget* treeview, SidebarIndexPag
             if (link && link->dest) {
                 LinkDestination* dest = link->dest;
 
-                size_t pdfPage = dest->getPdfPage();
-
-                if (pdfPage != npos) {
-                    Document* doc = sidebar->control->getDocument();
-                    doc->lock();
-                    size_t page = doc->findPdfPage(pdfPage);
-                    doc->unlock();
-
-                    if (page == npos) {
-                        sidebar->askInsertPdfPage(pdfPage);
-                    } else {
-                        if (dest->shouldChangeTop()) {
-                            sidebar->control->getScrollHandler()->scrollToPage(
-                                    page, dest->getTop() * sidebar->control->getZoomControl()->getZoom());
-                        } else {
-                            if (sidebar->control->getCurrentPageNo() != page) {
-                                sidebar->control->getScrollHandler()->scrollToPage(page);
-                            }
-                        }
-                    }
-                }
+                sidebar->control->getScrollHandler()->scrollToLinkDest(*dest);
             }
             g_object_unref(link);
 

--- a/src/core/gui/sidebar/indextree/SidebarIndexPage.cpp
+++ b/src/core/gui/sidebar/indextree/SidebarIndexPage.cpp
@@ -1,22 +1,16 @@
 #include "SidebarIndexPage.h"
 
-#include <cstring>  // for size_t, strlen
-#include <memory>   // for __shared_ptr_a...
-#include <utility>  // for move
+#include <cstring>  // for strlen
 
 #include <glib-object.h>  // for g_object_unref
 #include <pango/pango.h>  // for PangoLogAttr
 
 #include "control/Control.h"                           // for Control
 #include "control/ScrollHandler.h"                     // for ScrollHandler
-#include "control/zoom/ZoomControl.h"                  // for ZoomControl
 #include "gui/sidebar/previews/base/SidebarToolbar.h"  // for SidebarToolbar
 #include "model/Document.h"                            // for Document
 #include "model/LinkDestination.h"                     // for XojLinkDest
-#include "model/XojPage.h"                             // for XojPage
-#include "pdf/base/XojPdfPage.h"                       // for XojPdfPageSPtr
-#include "util/Util.h"                                 // for npos
-#include "util/i18n.h"                                 // for FC, _, _F
+#include "util/i18n.h"                                 // for _
 
 SidebarIndexPage::SidebarIndexPage(Control* control, SidebarToolbar* toolbar):
         AbstractSidebarPage(control, toolbar), iconNameHelper(control->getSettings()) {

--- a/src/core/gui/sidebar/indextree/SidebarIndexPage.h
+++ b/src/core/gui/sidebar/indextree/SidebarIndexPage.h
@@ -81,11 +81,6 @@ private:
     static bool treeBookmarkSelected(GtkWidget* treeview, SidebarIndexPage* sidebar);
 
     /**
-     * If you select a Bookmark which is currently not in the Xournal document, only in the PDF (page deleted or so)
-     */
-    void askInsertPdfPage(size_t pdfPage);
-
-    /**
      * The function which is called after a search timeout
      */
     static bool searchTimeoutFunc(SidebarIndexPage* sidebar);

--- a/src/core/model/Document.cpp
+++ b/src/core/model/Document.cpp
@@ -199,7 +199,9 @@ void Document::buildTreeContentsModel(GtkTreeIter* parent, XojPdfBookmarkIterato
         GtkTreeIter treeIter = {0};
 
         XojPdfAction* action = iter->getAction();
-        XojLinkDest* link = action->getDestination();
+        LinkDestination* dest = new LinkDestination(*action->getDestination());
+        XojLinkDest* link = link_dest_new();
+        link->dest = dest;
 
         if (action->getTitle().empty()) {
             g_object_unref(link);

--- a/src/core/model/LinkDestination.cpp
+++ b/src/core/model/LinkDestination.cpp
@@ -1,6 +1,7 @@
 #include "LinkDestination.h"
 
-#include <utility>
+#include <utility>  // for move
+#include <variant>
 
 #include "util/Util.h"
 
@@ -36,16 +37,17 @@ static void link_dest_class_init(XojLinkDestClass* linkClass) {
 
 auto link_dest_new() -> XojLinkDest* { return LINK_DEST(g_object_new(TYPE_LINK_DEST, nullptr)); }
 
-LinkDestination::LinkDestination() {
-    this->page = npos;
-    this->changeLeft = false;
-    this->changeZoom = false;
-    this->changeTop = false;
-    this->zoom = 0;
-    this->left = 0;
-    this->top = 0;
-    this->expand = false;
-}
+LinkDestination::LinkDestination():
+        page(npos),
+        expand(false),
+        left(0),
+        top(0),
+        zoom(0),
+        changeLeft(false),
+        changeZoom(false),
+        changeTop(false),
+        name(""),
+        contents(UnknownType{}) {}
 
 LinkDestination::~LinkDestination() = default;
 
@@ -83,5 +85,16 @@ void LinkDestination::setChangeTop(double top) {
 }
 
 void LinkDestination::setName(std::string name) { this->name = std::move(name); }
+auto LinkDestination::getName() const -> const std::string& { return name; }
 
-auto LinkDestination::getName() -> std::string { return this->name; }
+void LinkDestination::setURI(std::string uri) { this->contents = LinkType{std::move(uri)}; }
+
+auto LinkDestination::isURI() const -> bool { return std::holds_alternative<LinkDestination::LinkType>(contents); }
+
+auto LinkDestination::getURI() const -> std::optional<std::string> {
+    if (auto* t = std::get_if<LinkDestination::LinkType>(&contents)) {
+        return t->uri;
+    } else {
+        return std::nullopt;
+    }
+}

--- a/src/core/model/LinkDestination.cpp
+++ b/src/core/model/LinkDestination.cpp
@@ -1,9 +1,8 @@
 #include "LinkDestination.h"
 
 #include <utility>  // for move
-#include <variant>
 
-#include "util/Util.h"
+#include "util/Util.h"  // for npos
 
 struct _LinkDestClass {
     GObjectClass base_class;

--- a/src/core/model/LinkDestination.h
+++ b/src/core/model/LinkDestination.h
@@ -11,8 +11,10 @@
 
 #pragma once
 
-#include <cstddef>  // for size_t
-#include <string>   // for string
+#include <cstddef>   // for size_t
+#include <optional>  // for optional
+#include <string>    // for string
+#include <variant>   // for variant
 
 #include <glib-object.h>  // for G_TYPE_CHECK_INSTANCE_CAST, GObject, GType
 #include <glib.h>         // for G_GNUC_CONST
@@ -27,6 +29,16 @@ class LinkDestination {
 public:
     LinkDestination();
     virtual ~LinkDestination();
+
+    /// A link to a URI.
+    struct LinkType {
+        std::string uri;
+    };
+    /// A link to some unknown PDF action.
+    struct UnknownType {};
+
+    /// Represents a possible PDF link action.
+    using Type = std::variant<UnknownType, LinkType>;
 
 public:
     size_t getPdfPage() const;
@@ -47,7 +59,15 @@ public:
     void setChangeTop(double top);
 
     void setName(std::string name);
-    std::string getName();
+    const std::string& getName() const;
+
+    /// \return Whether this link refers to a URI.
+    bool isURI() const;
+
+    std::optional<std::string> getURI() const;
+
+    /// \return Changes this link to refer to the given URI.
+    void setURI(std::string uri);
 
 private:
     size_t page;
@@ -62,6 +82,7 @@ private:
     bool changeTop;
 
     std::string name;
+    Type contents;
 };
 
 struct _LinkDest {

--- a/src/core/pdf/base/XojPdfAction.h
+++ b/src/core/pdf/base/XojPdfAction.h
@@ -12,6 +12,8 @@
 #pragma once
 
 #include <string>  // for string
+#include <memory>
+#include <vector>
 
 #include "model/LinkDestination.h"  // for XojLinkDest
 
@@ -22,7 +24,7 @@ public:
     virtual ~XojPdfAction();
 
 public:
-    virtual XojLinkDest* getDestination() = 0;
+    virtual std::shared_ptr<const LinkDestination> getDestination() = 0;
     virtual std::string getTitle() = 0;
 
 private:

--- a/src/core/pdf/base/XojPdfDocument.h
+++ b/src/core/pdf/base/XojPdfDocument.h
@@ -13,6 +13,9 @@
 
 #include <cstddef>  // for size_t
 #include <string>   // for string
+#include <optional>
+#include <string>
+#include <vector>
 
 #include <glib.h>  // for GError, gpointer, gsize
 

--- a/src/core/pdf/base/XojPdfPage.h
+++ b/src/core/pdf/base/XojPdfPage.h
@@ -20,6 +20,9 @@
 #include <cairo.h>  // for cairo_region_t, cairo_t
 
 #include "util/raii/CairoWrappers.h"
+#include "XojPdfAction.h"
+
+class XojPdfLink;
 
 /// Determines how text is selected on a user action.
 enum class XojPdfPageSelectionStyle : uint8_t {
@@ -52,7 +55,10 @@ public:
         std::vector<XojPdfRectangle> rects;
     };
 
-    using Link = std::pair<XojPdfRectangle, GUri*>;
+    struct Link {
+        XojPdfRectangle bounds;
+        std::unique_ptr<XojPdfAction> action;
+    };
 
     virtual double getWidth() const = 0;
     virtual double getHeight() const = 0;

--- a/src/core/pdf/base/XojPdfPage.h
+++ b/src/core/pdf/base/XojPdfPage.h
@@ -16,6 +16,7 @@
 #include <string>     // for string
 #include <vector>     // for vector
 
+#include <glib.h> // for GURI
 #include <cairo.h>  // for cairo_region_t, cairo_t
 
 #include "util/raii/CairoWrappers.h"
@@ -50,6 +51,8 @@ public:
         xoj::util::CairoRegionSPtr region;
         std::vector<XojPdfRectangle> rects;
     };
+
+    using Link = std::pair<XojPdfRectangle, GUri*>;
 
     virtual double getWidth() const = 0;
     virtual double getHeight() const = 0;
@@ -87,6 +90,11 @@ public:
     /// @param style The text selection style
     /// @return The rectangles that cover the text that would be selected.
     virtual TextSelection selectTextLines(const XojPdfRectangle& rect, XojPdfPageSelectionStyle style) = 0;
+
+    /**
+     * @return A list of Links in the current page.
+     */
+    virtual auto getLinks() -> std::vector<Link> = 0;
 
     virtual int getPageId() const = 0;
 

--- a/src/core/pdf/popplerapi/PopplerGlibAction.cpp
+++ b/src/core/pdf/popplerapi/PopplerGlibAction.cpp
@@ -1,13 +1,16 @@
 #include "PopplerGlibAction.h"
 
 #include <algorithm>  // for min
+#include <cstddef>    // for size_t
 
-#include <glib.h>              // for g_warning
-#include <poppler-action.h>    // for poppler_action_free, poppler_dest_free
-#include <poppler-document.h>  // for poppler_document_find_dest, poppler_do...
+#include <glib.h>              // for g_warning, gchar
+#include <poppler-action.h>    // for poppler_dest_free, PopplerActi...
+#include <poppler-document.h>  // for poppler_document_find_dest
 #include <poppler-page.h>      // for poppler_page_get_size
 
-#include "util/Util.h"  // for npos
+#include "model/LinkDestination.h"     // for LinkDestination
+#include "util/Util.h"                 // for npos
+#include "util/raii/CLibrariesSPtr.h"  // for ref
 
 using std::string;
 

--- a/src/core/pdf/popplerapi/PopplerGlibAction.h
+++ b/src/core/pdf/popplerapi/PopplerGlibAction.h
@@ -11,12 +11,17 @@
 
 #pragma once
 
+#include <memory>
 #include <string>  // for string
+#include <vector>
 
 #include <poppler.h>  // for PopplerAction, PopplerDocument
 
 #include "model/LinkDestination.h"  // for LinkDestination (ptr only), XojLi...
 #include "pdf/base/XojPdfAction.h"  // for XojPdfAction
+#include "util/raii/GObjectSPtr.h"  // for GObjectSPtr
+
+class LinkDestination;
 
 
 class PopplerGlibAction: public XojPdfAction {
@@ -25,13 +30,15 @@ public:
     ~PopplerGlibAction() override;
 
 public:
-    XojLinkDest* getDestination() override;
-    std::string getTitle() override;
+    virtual std::shared_ptr<const LinkDestination> getDestination() override;
+    virtual std::string getTitle() override;
 
 private:
-    void linkFromDest(LinkDestination* link, PopplerDest* pDest);
+    virtual std::shared_ptr<const LinkDestination> getDestination(PopplerAction* action);
+    void linkFromDest(LinkDestination& link, PopplerDest* pDest);
 
 private:
-    PopplerAction* action;
-    PopplerDocument* document;
+    xoj::util::raii::GObjectSPtr<PopplerDocument> document;
+    std::shared_ptr<const LinkDestination> destination;
+    std::string title;
 };

--- a/src/core/pdf/popplerapi/PopplerGlibAction.h
+++ b/src/core/pdf/popplerapi/PopplerGlibAction.h
@@ -11,13 +11,11 @@
 
 #pragma once
 
-#include <memory>
+#include <memory>  // for shared_ptr
 #include <string>  // for string
-#include <vector>
 
 #include <poppler.h>  // for PopplerAction, PopplerDocument
 
-#include "model/LinkDestination.h"  // for LinkDestination (ptr only), XojLi...
 #include "pdf/base/XojPdfAction.h"  // for XojPdfAction
 #include "util/raii/GObjectSPtr.h"  // for GObjectSPtr
 

--- a/src/core/pdf/popplerapi/PopplerGlibDocument.cpp
+++ b/src/core/pdf/popplerapi/PopplerGlibDocument.cpp
@@ -90,7 +90,7 @@ auto PopplerGlibDocument::getPage(size_t page) const -> XojPdfPageSPtr {
     }
 
     PopplerPage* pg = poppler_document_get_page(document, int(page));
-    XojPdfPageSPtr pageptr = std::make_shared<PopplerGlibPage>(pg);
+    XojPdfPageSPtr pageptr = std::make_shared<PopplerGlibPage>(pg, document);
     g_object_unref(pg);
 
     return pageptr;

--- a/src/core/pdf/popplerapi/PopplerGlibPage.cpp
+++ b/src/core/pdf/popplerapi/PopplerGlibPage.cpp
@@ -287,3 +287,23 @@ auto PopplerGlibPage::selectTextLines(const XojPdfRectangle& selectRect, XojPdfP
     g_assert_nonnull(region);
     return {.region = xoj::util::CairoRegionSPtr(region, xoj::util::adopt), .rects = textRects};
 }
+
+auto PopplerGlibPage::getLinks() -> std::vector<Link> {
+    std::vector<Link> results;
+    const double height = getHeight();
+
+    GList* links = poppler_page_get_link_mapping(this->page);
+    for (GList* l = links; l != NULL; l = g_list_next(l)) {
+        auto* link = static_cast<PopplerLinkMapping*>(l->data);
+        if (link->action->type == POPPLER_ACTION_URI && link->action->uri.uri) {
+            GUri* uri = g_uri_parse(link->action->uri.uri, G_URI_FLAGS_NONE, nullptr);
+            if (uri) {
+                XojPdfRectangle rect{link->area.x1, height - link->area.y2, link->area.x2, height - link->area.y1};
+                results.emplace_back(rect, uri);
+            }
+        }
+    }
+    poppler_page_free_link_mapping(links);
+
+    return results;
+}

--- a/src/core/pdf/popplerapi/PopplerGlibPage.cpp
+++ b/src/core/pdf/popplerapi/PopplerGlibPage.cpp
@@ -1,18 +1,22 @@
 #include "PopplerGlibPage.h"
 
 #include <algorithm>  // for max, min
-#include <cstdlib>    // for abs, ptrdiff_t
-#include <sstream>    // for operator<<, ostringstream, basic_os...
+#include <cstdlib>    // for abs, NULL, ptrdiff_t
+#include <memory>     // for make_unique
+#include <sstream>    // for operator<<, ostringstream, bas...
 
 #include <glib.h>          // for g_free, g_utf8_offset_to_pointer
-#include <poppler-page.h>  // for _PopplerRectangle, poppler_page_get...
-#include <poppler.h>       // for PopplerRectangle, g_object_ref, g_o...
+#include <poppler-page.h>  // for _PopplerRectangle, _PopplerLin...
+#include <poppler.h>       // for PopplerRectangle, g_object_ref
 
-#include "pdf/base/XojPdfPage.h"  // for XojPdfRectangle, XojPdfPageSelectio...
-#include "util/GListView.h"       // for GListView, GListView<>::GListViewIter
-#include "PopplerGlibAction.h"
+#include "pdf/base/XojPdfAction.h"     // for XojPdfAction
+#include "pdf/base/XojPdfPage.h"       // for XojPdfRectangle, XojPdfPage::Link
+#include "util/GListView.h"            // for GListView, GListView<>::GListV...
+#include "util/raii/CLibrariesSPtr.h"  // for adopt
+#include "util/raii/CairoWrappers.h"   // for CairoRegionSPtr
 
-#include "cairo.h"  // for cairo_region_create, cairo_region_c...
+#include "PopplerGlibAction.h"  // for PopplerGlibAction
+#include "cairo.h"              // for cairo_region_create, cairo_reg...
 
 PopplerGlibPage::PopplerGlibPage(PopplerPage* page, PopplerDocument* parentDoc): page(page), document(parentDoc) {
     if (page != nullptr) {

--- a/src/core/pdf/popplerapi/PopplerGlibPage.cpp
+++ b/src/core/pdf/popplerapi/PopplerGlibPage.cpp
@@ -10,19 +10,22 @@
 
 #include "pdf/base/XojPdfPage.h"  // for XojPdfRectangle, XojPdfPageSelectio...
 #include "util/GListView.h"       // for GListView, GListView<>::GListViewIter
+#include "PopplerGlibAction.h"
 
 #include "cairo.h"  // for cairo_region_create, cairo_region_c...
 
-PopplerGlibPage::PopplerGlibPage(PopplerPage* page): page(page) {
+PopplerGlibPage::PopplerGlibPage(PopplerPage* page, PopplerDocument* parentDoc): page(page), document(parentDoc) {
     if (page != nullptr) {
         g_object_ref(page);
     }
 }
 
-PopplerGlibPage::PopplerGlibPage(const PopplerGlibPage& other): page(other.page) {
+PopplerGlibPage::PopplerGlibPage(const PopplerGlibPage& other): page(other.page), document(other.document) {
     if (page != nullptr) {
         g_object_ref(page);
     }
+
+    document = nullptr;
 }
 
 PopplerGlibPage::~PopplerGlibPage() {
@@ -45,19 +48,22 @@ PopplerGlibPage& PopplerGlibPage::operator=(const PopplerGlibPage& other) {
     if (page != nullptr) {
         g_object_ref(page);
     }
+
+    document = other.document;
+
     return *this;
 }
 
 auto PopplerGlibPage::getWidth() const -> double {
     double width = 0;
-    poppler_page_get_size(page, &width, nullptr);
+    poppler_page_get_size(const_cast<PopplerPage*>(page), &width, nullptr);
 
     return width;
 }
 
 auto PopplerGlibPage::getHeight() const -> double {
     double height = 0;
-    poppler_page_get_size(page, nullptr, &height);
+    poppler_page_get_size(const_cast<PopplerPage*>(page), nullptr, &height);
 
     return height;
 }
@@ -294,13 +300,11 @@ auto PopplerGlibPage::getLinks() -> std::vector<Link> {
 
     GList* links = poppler_page_get_link_mapping(this->page);
     for (GList* l = links; l != NULL; l = g_list_next(l)) {
-        auto* link = static_cast<PopplerLinkMapping*>(l->data);
-        if (link->action->type == POPPLER_ACTION_URI && link->action->uri.uri) {
-            GUri* uri = g_uri_parse(link->action->uri.uri, G_URI_FLAGS_NONE, nullptr);
-            if (uri) {
-                XojPdfRectangle rect{link->area.x1, height - link->area.y2, link->area.x2, height - link->area.y1};
-                results.emplace_back(rect, uri);
-            }
+        const auto& link = *static_cast<PopplerLinkMapping*>(l->data);
+
+        if (link.action) {
+            XojPdfRectangle rect{link.area.x1, height - link.area.y2, link.area.x2, height - link.area.y1};
+            results.emplace_back(Link{rect, std::make_unique<PopplerGlibAction>(link.action, document)});
         }
     }
     poppler_page_free_link_mapping(links);

--- a/src/core/pdf/popplerapi/PopplerGlibPage.h
+++ b/src/core/pdf/popplerapi/PopplerGlibPage.h
@@ -42,6 +42,7 @@ public:
 
     TextSelection selectTextLines(const XojPdfRectangle& rect, XojPdfPageSelectionStyle style) override;
 
+    auto getLinks() -> std::vector<Link> override;
 
     int getPageId() const override;
 

--- a/src/core/pdf/popplerapi/PopplerGlibPage.h
+++ b/src/core/pdf/popplerapi/PopplerGlibPage.h
@@ -22,7 +22,7 @@
 
 class PopplerGlibPage: public XojPdfPage {
 public:
-    PopplerGlibPage(PopplerPage* page);
+    PopplerGlibPage(PopplerPage* page, PopplerDocument* doc);
     PopplerGlibPage(const PopplerGlibPage& other);
     virtual ~PopplerGlibPage();
     PopplerGlibPage& operator=(const PopplerGlibPage& other);
@@ -48,4 +48,5 @@ public:
 
 private:
     PopplerPage* page;
+    PopplerDocument* document;
 };

--- a/src/core/pdf/popplerapi/PopplerGlibPageBookmarkIterator.cpp
+++ b/src/core/pdf/popplerapi/PopplerGlibPageBookmarkIterator.cpp
@@ -41,5 +41,8 @@ auto PopplerGlibPageBookmarkIterator::getAction() -> XojPdfAction* {
         return nullptr;
     }
 
-    return new PopplerGlibAction(action, document);
+    XojPdfAction* result = new PopplerGlibAction(action, document);
+    poppler_action_free(action);  // XojPdfAction does not own action.
+
+    return result;
 }

--- a/src/core/pdf/popplerapi/PopplerGlibPageBookmarkIterator.cpp
+++ b/src/core/pdf/popplerapi/PopplerGlibPageBookmarkIterator.cpp
@@ -1,5 +1,6 @@
 #include "PopplerGlibPageBookmarkIterator.h"
 
+#include <poppler-action.h>    // for poppler_action_free
 #include <poppler-document.h>  // for poppler_index_iter_free
 
 #include "pdf/popplerapi/PopplerGlibAction.h"  // for PopplerGlibAction

--- a/src/util/include/util/gtk4_helper.h
+++ b/src/util/include/util/gtk4_helper.h
@@ -15,9 +15,9 @@
 #include <gtk/gtk.h>
 
 
-void gtk_box_append(GtkBox* box, GtkWidget* child) {
+inline void gtk_box_append(GtkBox* box, GtkWidget* child) {
     constexpr auto default_expand = false;
     gtk_box_pack_start(GTK_BOX(box), child, default_expand, true, 0);
 }
 
-void gtk_box_remove(GtkBox* box, GtkWidget* child) { gtk_container_remove(GTK_CONTAINER(box), child); }
+inline void gtk_box_remove(GtkBox* box, GtkWidget* child) { gtk_container_remove(GTK_CONTAINER(box), child); }


### PR DESCRIPTION
This PR adds support for navigating to links contained in a PDF background file. Implements #1027.

* Alt-clicking on a link (both a URI or a link to another page) will open a popup.
    * For a URI, the popup will show the URI, which can be clicked to open the default application for that URI (e.g., web browser for http/https, email client for mailto).
    * For an internal link, the application will scroll to that page. If the page is missing, the "missing PDF page" dialog will be displayed.

This PR is a rebased version of #3851 which is a rebased version of #2660.

### TODO
* [ ] The changes required to support relative links are rather complicated, and could be moved into a separate PR.
* [x] Use the PDF text selection tools instead of the element selection tools.
* [x] Run IWYU to fix the includes (help appreciated here -- I can't get it to work on my computer)
* [x] Apply my own code suggestions from #3851 
* [x] ~For touchscreen, we could add long-tap to open the link popup.~ (This is somewhat unnecessary. Touchscreen works fine with the PDF text selection tools when touch drawing is enabled).
* [x] Fix macOS build failure