### PR TITLE
Implemented color switching by number hotkeys

### DIFF
--- a/src/core/gui/XournalView.cpp
+++ b/src/core/gui/XournalView.cpp
@@ -26,6 +26,8 @@
 #include "gui/PdfFloatingToolbox.h"             // for PdfFloatingToolbox
 #include "gui/inputdevices/HandRecognition.h"   // for HandRecognition
 #include "gui/inputdevices/InputContext.h"      // for InputContext
+#include "gui/toolbarMenubar/ColorToolItem.h"   // for ColorToolItem
+#include "gui/toolbarMenubar/ToolMenuHandler.h" // for ToolMenuHandler
 #include "gui/widgets/XournalWidget.h"          // for gtk_xournal_get_layout
 #include "model/Document.h"                     // for Document
 #include "model/Element.h"                      // for Element, ELEMENT_STROKE
@@ -287,6 +289,20 @@ auto XournalView::onKeyPressEvent(GdkEventKey* event) -> bool {
         return true;
     }
 
+    // Switch color on number key
+    auto &colors = control->getWindow()->getToolMenuHandler()->getColorToolItems();
+    if ((event->keyval >= GDK_KEY_0)
+        && (event->keyval < GDK_KEY_0 + std::min((std::size_t)10,
+                                                 colors.size()))) {
+            std::size_t index = std::min(colors.size() - 1,
+                                         (std::size_t)(9 + (event->keyval - GDK_KEY_0)) % 10);
+            auto colorToolItem = colors.at(index);
+            if (colorToolItem->isEnabled()) {
+                gtk_toggle_tool_button_set_active(
+                    GTK_TOGGLE_TOOL_BUTTON(colorToolItem->getItem()), true);
+            }
+            return true;
+    }
     return false;
 }
 

--- a/src/core/gui/toolbarMenubar/AbstractToolItem.cpp
+++ b/src/core/gui/toolbarMenubar/AbstractToolItem.cpp
@@ -20,6 +20,10 @@ AbstractToolItem::~AbstractToolItem() {
     }
 }
 
+auto AbstractToolItem::getItem() const -> GtkToolItem* {
+    return this->item;
+}
+
 void AbstractToolItem::selected(ActionGroup group, ActionType action) {
     if (this->item == nullptr) {
         return;

--- a/src/core/gui/toolbarMenubar/AbstractToolItem.h
+++ b/src/core/gui/toolbarMenubar/AbstractToolItem.h
@@ -67,6 +67,8 @@ public:
      */
     void enable(bool enabled) override;
 
+    GtkToolItem* getItem() const;
+
 protected:
     virtual GtkToolItem* newItem() = 0;
 

--- a/src/core/gui/toolbarMenubar/ToolMenuHandler.cpp
+++ b/src/core/gui/toolbarMenubar/ToolMenuHandler.cpp
@@ -610,6 +610,8 @@ auto ToolMenuHandler::isColorInUse(Color color) -> bool {
 
 auto ToolMenuHandler::getToolItems() -> std::vector<AbstractToolItem*>* { return &this->toolItems; }
 
+auto ToolMenuHandler::getColorToolItems() const -> const std::vector<ColorToolItem*>& { return this->toolbarColorItems; }
+
 void ToolMenuHandler::disableAudioPlaybackButtons() {
     setAudioPlaybackPaused(false);
 

--- a/src/core/gui/toolbarMenubar/ToolMenuHandler.h
+++ b/src/core/gui/toolbarMenubar/ToolMenuHandler.h
@@ -86,6 +86,7 @@ public:
     ToolbarModel* getModel();
 
     std::vector<AbstractToolItem*>* getToolItems();
+    const std::vector<ColorToolItem*>& getColorToolItems() const;
 
     Control* getControl();
 


### PR DESCRIPTION
Implements #2007, that is, switching colors by using the 0-9 number keys.

I tested it while using various tools and it works. It has no conflicts with the text tool (so, if you are writing inside a textbox the number `1`, the first color won't be selected). 

(Note that I could have used metaprogramming to shorten the code _a lot_ but I decided not to in the name of clarity, so right now there are a lot of `if` statements, as done in other parts of the codebase)