### PR TITLE
Switch to macos-11 vmImage on dev Azure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.12)
 cmake_policy(VERSION ${CMAKE_VERSION})
+## The CMAKE_OSX_DEPLOYMENT_TARGET must be set before project(), so don't move the following line further down.
+set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "Minimum OS X deployment version" FORCE)
 
 ## Project related Variables
 ## Also update changelog in debian folder!

--- a/azure-pipelines/continuous-integration.yml
+++ b/azure-pipelines/continuous-integration.yml
@@ -55,7 +55,7 @@ stages:
 
       - job: macOS
         pool:
-          vmImage: 'macOS-10.15'
+          vmImage: 'macOS-11'
         displayName: 'Test Xournal++ on MacOS'
         steps:
           - template: steps/build_mac.yml

--- a/azure-pipelines/create-installers.yml
+++ b/azure-pipelines/create-installers.yml
@@ -100,7 +100,7 @@ stages:
 
       - job: macOS
         pool:
-          vmImage: 'macOS-10.15'
+          vmImage: 'macOS-11'
         displayName: 'Build for macOS'
         steps:
           - template: steps/build_mac.yml

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -119,7 +119,7 @@ stages:
 
       - job: macOS
         pool:
-          vmImage: 'macOS-10.15'
+          vmImage: 'macOS-11'
         displayName: 'Build for macOS'
         steps:
           - template: steps/build_mac.yml


### PR DESCRIPTION
Testing to build the MacOS version on a macos-11 vmImage while building for target >= 10.15.