### PR TITLE
Removed the "DeleteRect" if the hand tool is selected

### DIFF
--- a/src/core/control/tools/EditSelection.cpp
+++ b/src/core/control/tools/EditSelection.cpp
@@ -1037,8 +1037,10 @@ void EditSelection::paint(cairo_t* cr, double zoom) {
     // bottom right
     drawAnchorRect(cr, x + width, y + height, zoom);
 
-
-    drawDeleteRect(cr, std::min(x, x + width) - (DELETE_PADDING + this->btnWidth) / zoom, y, zoom);
+    ToolHandler* toolHandler = view->getXournal()->getControl()->getToolHandler();
+    if (toolHandler->getToolType() != TOOL_HAND) {
+        drawDeleteRect(cr, std::min(x, x + width) - (DELETE_PADDING + this->btnWidth) / zoom, y, zoom);
+    }
 }
 
 void EditSelection::drawAnchorRotation(cairo_t* cr, double x, double y, double zoom) {

--- a/src/core/control/tools/EditSelection.cpp
+++ b/src/core/control/tools/EditSelection.cpp
@@ -1009,36 +1009,36 @@ void EditSelection::paint(cairo_t* cr, double zoom) {
     gdk_cairo_set_source_rgba(cr, &applied);
     cairo_fill(cr);
 
-    cairo_set_dash(cr, nullptr, 0, 0);
-
-    if (!this->aspectRatio) {
-        // top
-        drawAnchorRect(cr, x + width / 2, y, zoom);
-        // bottom
-        drawAnchorRect(cr, x + width / 2, y + height, zoom);
-        // left
-        drawAnchorRect(cr, x, y + height / 2, zoom);
-        // right
-        drawAnchorRect(cr, x + width, y + height / 2, zoom);
-
-        if (supportRotation) {
-            // rotation handle
-            drawAnchorRotation(cr, std::min(x, x + width) + std::abs(width) + (ROTATE_PADDING + this->btnWidth) / zoom,
-                               y + height / 2, zoom);
-        }
-    }
-
-    // top left
-    drawAnchorRect(cr, x, y, zoom);
-    // top right
-    drawAnchorRect(cr, x + width, y, zoom);
-    // bottom left
-    drawAnchorRect(cr, x, y + height, zoom);
-    // bottom right
-    drawAnchorRect(cr, x + width, y + height, zoom);
-
     ToolHandler* toolHandler = view->getXournal()->getControl()->getToolHandler();
     if (toolHandler->getToolType() != TOOL_HAND) {
+        cairo_set_dash(cr, nullptr, 0, 0);
+        if (!this->aspectRatio) {
+            // top
+            drawAnchorRect(cr, x + width / 2, y, zoom);
+            // bottom
+            drawAnchorRect(cr, x + width / 2, y + height, zoom);
+            // left
+            drawAnchorRect(cr, x, y + height / 2, zoom);
+            // right
+            drawAnchorRect(cr, x + width, y + height / 2, zoom);
+
+            if (supportRotation) {
+                // rotation handle
+                drawAnchorRotation(cr,
+                                   std::min(x, x + width) + std::abs(width) + (ROTATE_PADDING + this->btnWidth) / zoom,
+                                   y + height / 2, zoom);
+            }
+        }
+
+        // top left
+        drawAnchorRect(cr, x, y, zoom);
+        // top right
+        drawAnchorRect(cr, x + width, y, zoom);
+        // bottom left
+        drawAnchorRect(cr, x, y + height, zoom);
+        // bottom right
+        drawAnchorRect(cr, x + width, y + height, zoom);
+
         drawDeleteRect(cr, std::min(x, x + width) - (DELETE_PADDING + this->btnWidth) / zoom, y, zoom);
     }
 }


### PR DESCRIPTION
This is an attempt to fix the bug mentioned in #4367.
The user who created this issue wanted to be able to use the hand tool to delete a selected item by clicking on the delete rectangle next to it. However, the hand tool should not be able to do this in the first place.
Still, I feel that the delete rectangle right next to the element can be a bit misleading. So I decided (as discussed in #4367) to simply not draw the "DeleteRect" when the hand tool is selected.