### PR TITLE
Do not define in `XML_VERSION_STR` variable InputStreamException.cpp file

### DIFF
--- a/src/util/include/util/serializing/Serializable.h
+++ b/src/util/include/util/serializing/Serializable.h
@@ -16,7 +16,7 @@
 class ObjectInputStream;
 class ObjectOutputStream;
 
-extern const char* XML_VERSION_STR;
+const static char* const XML_VERSION_STR = "XojStrm1:";
 
 class Serializable {
 public:

--- a/src/util/serializing/InputStreamException.cpp
+++ b/src/util/serializing/InputStreamException.cpp
@@ -1,7 +1,5 @@
 #include "util/serializing/InputStreamException.h"
 
-const char* XML_VERSION_STR = "XojStrm1:";
-
 InputStreamException::InputStreamException(const std::string& message, const std::string& filename, int line) {
     this->message = message + ", " + filename + ": " + std::to_string(line);
 }

--- a/test/unit_tests/util/ObjectIOStreamTest.cpp
+++ b/test/unit_tests/util/ObjectIOStreamTest.cpp
@@ -12,9 +12,7 @@
 #include "util/serializing/HexObjectEncoding.h"
 #include "util/serializing/ObjectInputStream.h"
 #include "util/serializing/ObjectOutputStream.h"
-
-extern const char* XML_VERSION_STR;
-
+#include "util/serializing/Serializable.h"
 
 template <typename T, unsigned N>
 std::string serializeData(const std::array<T, N>& data) {


### PR DESCRIPTION
We do not use this value in the InputStreamException.cpp and provide it in the Serializable.h using the `extern` declaration.
Considering that we can be sure the serializing utils are always up-to-date when rebuilding the project, there is no problem with having this value header-only for the few usages.

While at it, the value can be made const (as clang-tidy suggested).