### PR TITLE
Only fireZoomChanged when zoom has changed

### DIFF
--- a/src/control/zoom/ZoomControl.cpp
+++ b/src/control/zoom/ZoomControl.cpp
@@ -239,6 +239,9 @@ auto ZoomControl::getZoom() const -> double { return this->zoom; }
 auto ZoomControl::getZoomReal() const -> double { return this->zoom / this->zoom100Value; }
 
 void ZoomControl::setZoom(double zoomI) {
+    if (this->zoom == zoomI) {
+        return;
+    }
     this->zoom = zoomI;
     fireZoomChanged();
 }


### PR DESCRIPTION
`fireZoomChanged` should only be called when the zoom has really changed. This is most notable when you pinch to zoom and have the "Start zoom after a distance ..." setting higher than `0\%`. The VertialSpace tool and the geometry tools from PR #4211 listen to zoom changes and currently need to redraw the mask when `fireZoomChanged` is called, regardless whether the zoom has really changed or not.