### PR TITLE
Fix unwanted position change after editing LaTex elements

### DIFF
--- a/src/core/control/LatexController.cpp
+++ b/src/core/control/LatexController.cpp
@@ -114,8 +114,10 @@ void LatexController::findSelectedTexElement() {
     if (this->selectedElem) {
         // this will get the position of the Latex properly
         EditSelection* theSelection = control->getWindow()->getXournal()->getSelection();
-        this->posx = theSelection->getXOnView();
-        this->posy = theSelection->getYOnView();
+        // when latex is edited by double-clicking on it the selection is updated to the double clicked latex element
+        // therefore we can assume there's exactly one element in the selection
+        this->posx = theSelection->getElements()[0]->getX();
+        this->posy = theSelection->getElements()[0]->getY();
 
         if (auto* img = dynamic_cast<TexImage*>(this->selectedElem)) {
             this->initialTex = img->getText();

--- a/src/core/control/LatexController.cpp
+++ b/src/core/control/LatexController.cpp
@@ -114,10 +114,9 @@ void LatexController::findSelectedTexElement() {
     if (this->selectedElem) {
         // this will get the position of the Latex properly
         EditSelection* theSelection = control->getWindow()->getXournal()->getSelection();
-        // when latex is edited by double-clicking on it the selection is updated to the double clicked latex element
-        // therefore we can assume there's exactly one element in the selection
-        this->posx = theSelection->getElements()[0]->getX();
-        this->posy = theSelection->getElements()[0]->getY();
+        xoj::util::Rectangle<double> rect = theSelection->getSnappedBounds();
+        this->posx = rect.x;
+        this->posy = rect.y;
 
         if (auto* img = dynamic_cast<TexImage*>(this->selectedElem)) {
             this->initialTex = img->getText();


### PR DESCRIPTION
This PR fixes #4415. The reason for the changing position of the new LaTex element was that the coordinates of the selection were used as the new x and y position. The selection box has however a margin and is bigger than the actual LaTex element which caused an offset on completing editing. The commit in this PR updates the code to use the actual element coordinates of the old LaTex element fixing the bug.