### PR TITLE
Ensure layers are always in a valid state

### DIFF
--- a/src/core/control/GeometryToolController.cpp
+++ b/src/core/control/GeometryToolController.cpp
@@ -62,7 +62,6 @@ void GeometryToolController::markPoint(double x, double y) {
     const auto doc = control->getDocument();
     const auto page = view->getPage();
     doc->lock();
-    control->getLayerController()->ensureLayerExists(page);
     const auto layer = page->getSelectedLayer();
     layer->addElement(cross);
     doc->unlock();
@@ -81,7 +80,6 @@ void GeometryToolController::addStrokeToLayer() {
     const auto page = view->getPage();
 
     doc->lock();
-    control->getLayerController()->ensureLayerExists(page);
     const auto layer = page->getSelectedLayer();
     layer->addElement(stroke.get());
     doc->unlock();

--- a/src/core/control/layer/LayerController.cpp
+++ b/src/core/control/layer/LayerController.cpp
@@ -413,18 +413,3 @@ std::string LayerController::getLayerNameById(Layer::Index id) const {
 
     return name;
 }
-
-/**
- * Make sure there is at least one layer on the page
- */
-void LayerController::ensureLayerExists(PageRef page) {
-    if (page->getSelectedLayerId() > 0) {
-        return;
-    }
-
-    // This creates a layer if none exists
-    page->getSelectedLayer();
-    page->setSelectedLayerId(1);
-
-    fireRebuildLayerMenu();
-}

--- a/src/core/control/layer/LayerController.h
+++ b/src/core/control/layer/LayerController.h
@@ -100,11 +100,6 @@ public:
      */
     void setCurrentLayerName(const std::string& newName);
 
-    /**
-     * Make sure there is at least one layer on the page
-     */
-    void ensureLayerExists(PageRef page);
-
 private:
     Control* control;
 

--- a/src/core/control/tools/BaseShapeHandler.cpp
+++ b/src/core/control/tools/BaseShapeHandler.cpp
@@ -133,8 +133,6 @@ void BaseShapeHandler::onButtonReleaseEvent(const PositionInputData& pos, double
         BaseShapeHandler::lastStrokeTime = pos.timestamp;
     }
 
-    control->getLayerController()->ensureLayerExists(page);
-
     Layer* layer = page->getSelectedLayer();
 
     UndoRedoHandler* undo = control->getUndoRedoHandler();

--- a/src/core/control/tools/SplineHandler.cpp
+++ b/src/core/control/tools/SplineHandler.cpp
@@ -321,7 +321,6 @@ void SplineHandler::finalizeSpline() {
     Rectangle<double> rect = this->computeRepaintRectangle();
 
     stroke->freeUnusedPointItems();
-    control->getLayerController()->ensureLayerExists(page);
 
     Layer* layer = page->getSelectedLayer();
 

--- a/src/core/control/tools/StrokeHandler.cpp
+++ b/src/core/control/tools/StrokeHandler.cpp
@@ -261,8 +261,6 @@ void StrokeHandler::onButtonReleaseEvent(const PositionInputData& pos, double zo
 
     stroke->freeUnusedPointItems();
 
-    control->getLayerController()->ensureLayerExists(page);
-
     Layer* layer = page->getSelectedLayer();
 
     UndoRedoHandler* undo = control->getUndoRedoHandler();

--- a/src/core/control/xojfile/LoadHandler.cpp
+++ b/src/core/control/xojfile/LoadHandler.cpp
@@ -318,7 +318,7 @@ void LoadHandler::parseContents() {
         double width = LoadHandlerHelper::getAttribDouble("width", this);
         double height = LoadHandlerHelper::getAttribDouble("height", this);
 
-        this->page = std::make_unique<XojPage>(width, height);
+        this->page = std::make_unique<XojPage>(width, height, /*suppressLayer*/true);
 
         pages.push_back(this->page);
     } else if (strcmp(elementName, "audio") == 0) {
@@ -903,8 +903,8 @@ void LoadHandler::parserEndElement(GMarkupParseContext* context, const gchar* el
         handler->pos = PASER_POS_FINISHED;
     } else if (handler->pos == PARSER_POS_IN_PAGE && strcmp(elementName, "page") == 0) {
         // handle unnecessary layer insertion in case of existing layers in file
-        if (handler->page->getLayerCount() > 1) {
-            handler->page->removeLayer(handler->page->getLayers()->at(0));
+        if (handler->page->getLayerCount() == 0) {
+            handler->page->addLayer(new Layer());
         }
         handler->pos = PARSER_POS_STARTED;
         handler->page = nullptr;

--- a/src/core/control/xojfile/LoadHandler.cpp
+++ b/src/core/control/xojfile/LoadHandler.cpp
@@ -318,7 +318,7 @@ void LoadHandler::parseContents() {
         double width = LoadHandlerHelper::getAttribDouble("width", this);
         double height = LoadHandlerHelper::getAttribDouble("height", this);
 
-        this->page = std::make_unique<XojPage>(width, height, /*rawCreate*/ true);
+        this->page = std::make_unique<XojPage>(width, height);
 
         pages.push_back(this->page);
     } else if (strcmp(elementName, "audio") == 0) {
@@ -902,9 +902,9 @@ void LoadHandler::parserEndElement(GMarkupParseContext* context, const gchar* el
     if (handler->pos == PARSER_POS_STARTED && strcmp(elementName, handler->endRootTag) == 0) {
         handler->pos = PASER_POS_FINISHED;
     } else if (handler->pos == PARSER_POS_IN_PAGE && strcmp(elementName, "page") == 0) {
-        std::cout << "inserted page with " << handler->page->getLayerCount() << " layers" << std::endl;
-        if (handler->page->getLayerCount() == 0) {
-            handler->page->addLayer(new Layer());
+        // handle unnecessary layer insertion in case of existing layers in file
+        if (handler->page->getLayerCount() > 1) {
+            handler->page->removeLayer(handler->page->getLayers()->at(0));
         }
         handler->pos = PARSER_POS_STARTED;
         handler->page = nullptr;

--- a/src/core/control/xojfile/LoadHandler.cpp
+++ b/src/core/control/xojfile/LoadHandler.cpp
@@ -318,7 +318,7 @@ void LoadHandler::parseContents() {
         double width = LoadHandlerHelper::getAttribDouble("width", this);
         double height = LoadHandlerHelper::getAttribDouble("height", this);
 
-        this->page = std::make_unique<XojPage>(width, height);
+        this->page = std::make_unique<XojPage>(width, height, /*rawCreate*/ true);
 
         pages.push_back(this->page);
     } else if (strcmp(elementName, "audio") == 0) {
@@ -902,6 +902,10 @@ void LoadHandler::parserEndElement(GMarkupParseContext* context, const gchar* el
     if (handler->pos == PARSER_POS_STARTED && strcmp(elementName, handler->endRootTag) == 0) {
         handler->pos = PASER_POS_FINISHED;
     } else if (handler->pos == PARSER_POS_IN_PAGE && strcmp(elementName, "page") == 0) {
+        std::cout << "inserted page with " << handler->page->getLayerCount() << " layers" << std::endl;
+        if (handler->page->getLayerCount() == 0) {
+            handler->page->addLayer(new Layer());
+        }
         handler->pos = PARSER_POS_STARTED;
         handler->page = nullptr;
     } else if (handler->pos == PARSER_POS_IN_LAYER && strcmp(elementName, "layer") == 0) {

--- a/src/core/model/XojPage.cpp
+++ b/src/core/model/XojPage.cpp
@@ -33,10 +33,6 @@ XojPage::XojPage(XojPage const& page):
     this->layer.reserve(page.layer.size());
     std::transform(begin(page.layer), end(page.layer), std::back_inserter(this->layer),
                    [](auto* layer) { return layer->clone(); });
-    // ensure at least one valid layer exists
-    if (this->layer.empty()) {
-        this->addLayer(new Layer());
-    }
 }
 
 auto XojPage::clone() -> XojPage* { return new XojPage(*this); }

--- a/src/core/model/XojPage.cpp
+++ b/src/core/model/XojPage.cpp
@@ -10,9 +10,11 @@
 
 #include "BackgroundImage.h"  // for BackgroundImage
 
-XojPage::XojPage(double width, double height): width(width), height(height), bgType(PageTypeFormat::Lined) {
-    // ensure at least one valid layer exists
-    this->addLayer(new Layer());
+XojPage::XojPage(double width, double height, bool rawCreate): width(width), height(height), bgType(PageTypeFormat::Lined) {
+    if (!rawCreate) {
+        // ensure at least one valid layer exists
+        this->addLayer(new Layer());
+    }
 }
 
 XojPage::~XojPage() {
@@ -32,7 +34,6 @@ XojPage::XojPage(XojPage const& page):
     std::transform(begin(page.layer), end(page.layer), std::back_inserter(this->layer),
                    [](auto* layer) { return layer->clone(); });
     // ensure at least one valid layer exists
-    // (for files before refactor to always valid layer)
     if (this->layer.empty()) {
         this->addLayer(new Layer());
     }

--- a/src/core/model/XojPage.cpp
+++ b/src/core/model/XojPage.cpp
@@ -10,9 +10,11 @@
 
 #include "BackgroundImage.h"  // for BackgroundImage
 
-XojPage::XojPage(double width, double height): width(width), height(height), bgType(PageTypeFormat::Lined) {
-    // ensure at least one valid layer exists
-    this->addLayer(new Layer());
+XojPage::XojPage(double width, double height, bool suppressLayerCreation): width(width), height(height), bgType(PageTypeFormat::Lined) {
+    if (!suppressLayerCreation) {
+        // ensure at least one valid layer exists
+        this->addLayer(new Layer());
+    }
 }
 
 XojPage::~XojPage() {

--- a/src/core/model/XojPage.cpp
+++ b/src/core/model/XojPage.cpp
@@ -10,11 +10,9 @@
 
 #include "BackgroundImage.h"  // for BackgroundImage
 
-XojPage::XojPage(double width, double height, bool rawCreate): width(width), height(height), bgType(PageTypeFormat::Lined) {
-    if (!rawCreate) {
-        // ensure at least one valid layer exists
-        this->addLayer(new Layer());
-    }
+XojPage::XojPage(double width, double height): width(width), height(height), bgType(PageTypeFormat::Lined) {
+    // ensure at least one valid layer exists
+    this->addLayer(new Layer());
 }
 
 XojPage::~XojPage() {

--- a/src/core/model/XojPage.h
+++ b/src/core/model/XojPage.h
@@ -26,7 +26,10 @@
 
 class XojPage: public PageHandler {
 public:
-    XojPage(double width, double height);
+    /**
+     * @param rawInsert ensures no additional correting for validity
+    */
+    XojPage(double width, double height, bool rawCreate = false);
     ~XojPage() override;
     XojPage(const XojPage& page);
     void operator=(const XojPage& p) = delete;

--- a/src/core/model/XojPage.h
+++ b/src/core/model/XojPage.h
@@ -26,7 +26,7 @@
 
 class XojPage: public PageHandler {
 public:
-    XojPage(double width, double height, bool suppressLayerCreations = false);
+    XojPage(double width, double height, bool suppressLayerCreation = false);
     ~XojPage() override;
     XojPage(const XojPage& page);
     void operator=(const XojPage& p) = delete;

--- a/src/core/model/XojPage.h
+++ b/src/core/model/XojPage.h
@@ -26,9 +26,6 @@
 
 class XojPage: public PageHandler {
 public:
-    /**
-     * @param rawInsert ensures no additional correting for validity
-    */
     XojPage(double width, double height);
     ~XojPage() override;
     XojPage(const XojPage& page);

--- a/src/core/model/XojPage.h
+++ b/src/core/model/XojPage.h
@@ -26,7 +26,7 @@
 
 class XojPage: public PageHandler {
 public:
-    XojPage(double width, double height);
+    XojPage(double width, double height, bool suppressLayerCreations = false);
     ~XojPage() override;
     XojPage(const XojPage& page);
     void operator=(const XojPage& p) = delete;

--- a/src/core/model/XojPage.h
+++ b/src/core/model/XojPage.h
@@ -29,7 +29,7 @@ public:
     /**
      * @param rawInsert ensures no additional correting for validity
     */
-    XojPage(double width, double height, bool rawCreate = false);
+    XojPage(double width, double height);
     ~XojPage() override;
     XojPage(const XojPage& page);
     void operator=(const XojPage& p) = delete;


### PR DESCRIPTION
This PR solves #4032 

`getSelectedLayer()` created a layer if none was existent before.
This PR changes the XojPage, so that there is always minimum one valid layer.

I think this should be mostly finished, but I still have to check if there are any exception cases.