### PR TITLE
Fix copying images into clipboard

### DIFF
--- a/src/core/control/ClipboardHandler.cpp
+++ b/src/core/control/ClipboardHandler.cpp
@@ -174,7 +174,7 @@ auto ClipboardHandler::copy() -> bool {
     cairo_t* crPng = cairo_create(surfacePng);
     cairo_scale(crPng, dpiFactor, dpiFactor);
 
-    cairo_translate(crPng, -selection->getXOnView(), -selection->getYOnView());
+    cairo_translate(crPng, -selection->getOriginalXOnView(), -selection->getOriginalYOnView());
 
     xoj::view::ElementContainerView view(this->selection);
     view.draw(xoj::view::Context::createDefault(crPng));
@@ -196,6 +196,7 @@ auto ClipboardHandler::copy() -> bool {
                                                 selection->getWidth(), selection->getHeight());
     cairo_t* crSVG = cairo_create(surfaceSVG);
 
+    cairo_translate(crSVG, -selection->getOriginalXOnView(), -selection->getOriginalYOnView());
     view.draw(xoj::view::Context::createDefault(crSVG));
 
     cairo_surface_destroy(surfaceSVG);

--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -2831,7 +2831,7 @@ void Control::clipboardPasteText(string text) {
     Text* t = new Text();
     t->setText(text);
     t->setFont(settings->getFont());
-    t->setColor(toolHandler->getColor());
+    t->setColor(toolHandler->getTool(TOOL_TEXT).getColor());
 
     clipboardPaste(t);
 }

--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -541,12 +541,12 @@ void Control::actionPerformed(ActionType type, ActionGroup group, GtkToolButton*
             changePageBackgroundColor();
             break;
         case ACTION_MOVE_SELECTION_LAYER_UP:
-            // moveSelectionToLayer takes layer number (layerid - 1) not id 
+            // moveSelectionToLayer takes layer number (layerid - 1) not id
             // therefor the new layer is "layerid - 1 + 1"
             moveSelectionToLayer(getCurrentPage()->getSelectedLayerId());
             break;
         case ACTION_MOVE_SELECTION_LAYER_DOWN:
-            if(this->getLayerController()->getCurrentLayerId() >= 2) {
+            if (this->getLayerController()->getCurrentLayerId() >= 2) {
                 // moveSelectionToLayer takes layer number (layerid - 1) not id
                 // therefor the new layer is "layerid - 1 - 1"
                 moveSelectionToLayer(getCurrentPage()->getSelectedLayerId() - 2);
@@ -1808,11 +1808,9 @@ void Control::undoRedoPageChanged(PageRef page) {
 void Control::selectTool(ToolType type) {
     // keep text-selection when switching from text to seletion tool
     auto oldTool = getToolHandler()->getActiveTool();
-    if (oldTool && win
-                && isSelectToolType(type)
-                && oldTool->getToolType() == ToolType::TOOL_TEXT
-                && this->win->getXournal()->getTextEditor()
-                && !(this->win->getXournal()->getTextEditor()->getText()->getText().empty())) {
+    if (oldTool && win && isSelectToolType(type) && oldTool->getToolType() == ToolType::TOOL_TEXT &&
+        this->win->getXournal()->getTextEditor() &&
+        !(this->win->getXournal()->getTextEditor()->getText()->getText().empty())) {
         auto xournal = this->win->getXournal();
         Text* textobj = xournal->getTextEditor()->getText();
         clearSelectionEndText();
@@ -1824,7 +1822,7 @@ void Control::selectTool(ToolType type) {
         PageRef page = this->doc->getPage(pageNr);
         auto selection = new EditSelection(this->undoRedo, textobj, view, page);
         this->doc->unlock();
-    
+
         xournal->setSelection(selection);
     }
 
@@ -3017,8 +3015,9 @@ void Control::moveSelectionToLayer(size_t layerNo) {
 
     auto* oldLayer = currentP->getSelectedLayer();
     auto* newLayer = currentP->getLayers()->at(layerNo);
-    auto moveSelUndo = std::make_unique<MoveSelectionToLayerUndoAction>(currentP, getLayerController(), oldLayer, currentP->getSelectedLayerId() - 1, layerNo);
-    for (auto* e : selection->getElements()) {
+    auto moveSelUndo = std::make_unique<MoveSelectionToLayerUndoAction>(currentP, getLayerController(), oldLayer,
+                                                                        currentP->getSelectedLayerId() - 1, layerNo);
+    for (auto* e: selection->getElements()) {
         moveSelUndo->addElement(newLayer, e, newLayer->indexOf(e));
     }
     undoRedo->addUndoAction(std::move(moveSelUndo));


### PR DESCRIPTION
This fixes copying in  `svg` format into the clipboard and copying images from selections that are translated

Check by pasting into a drawing app like Inkscape
or by using `wl-paste --type image/svg > output.svg` on Wayland

I have also tested with gdk scale factor 2 using `GDK_SCALE=2 GDK_BACKEND=x11 ./xournalpp`