### PR TITLE
Leave Fullscreen / Presentation mode

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -410,6 +410,8 @@ void Control::updatePageNumbers(size_t page, size_t pdfPage) {
 }
 
 void Control::actionPerformed(ActionType type, ActionGroup group, GtkToolButton* toolbutton, bool enabled) {
+    // TODO set esc to leave fulscreen if nothing is selected! (or maybe ctrl esc)
+    
     if (layerController->actionPerformed(type)) {
         return;
     }

--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -410,8 +410,6 @@ void Control::updatePageNumbers(size_t page, size_t pdfPage) {
 }
 
 void Control::actionPerformed(ActionType type, ActionGroup group, GtkToolButton* toolbutton, bool enabled) {
-    // TODO set esc to leave fulscreen if nothing is selected! (or maybe ctrl esc)
-    
     if (layerController->actionPerformed(type)) {
         return;
     }

--- a/src/core/gui/XournalView.cpp
+++ b/src/core/gui/XournalView.cpp
@@ -156,15 +156,6 @@ auto XournalView::onKeyPressEvent(GdkEventKey* event) -> bool {
         }
     }
 
-    // F5 starts presentation modus
-    if (event->keyval == GDK_KEY_F5) {
-        if (!control->isFullscreen()) {
-            control->setViewPresentationMode(true);
-            control->setFullscreen(true);
-            return true;
-        }
-    }
-
     guint state = event->state & gtk_accelerator_get_default_mod_mask();
 
     Layout* layout = gtk_xournal_get_layout(this->widget);

--- a/src/core/gui/XournalView.cpp
+++ b/src/core/gui/XournalView.cpp
@@ -148,14 +148,6 @@ auto XournalView::onKeyPressEvent(GdkEventKey* event) -> bool {
         }
     }
 
-    // Esc leaves fullscreen mode
-    if (event->keyval == GDK_KEY_Escape) {
-        if (control->isFullscreen()) {
-            control->setFullscreen(false);
-            return true;
-        }
-    }
-
     guint state = event->state & gtk_accelerator_get_default_mod_mask();
 
     Layout* layout = gtk_xournal_get_layout(this->widget);

--- a/ui/main.glade
+++ b/ui/main.glade
@@ -567,6 +567,7 @@
                             <property name="label" translatable="yes">_Presentation Mode</property>
                             <property name="use-underline">True</property>
                             <signal name="toggled" handler="ACTION_VIEW_PRESENTATION_MODE" swapped="no"/>
+                            <accelerator key="F5" signal="activate"/>
                           </object>
                         </child>
                         <child>


### PR DESCRIPTION
Solves one task from #4456
- [x] be able to leave presentation mode (currently it is not possible to end it properly, meaning leaving fullscreen mode, properly bringing back menu items)

The accelerator `F5` previously used to enter the presentation mode now also leaves it. Using `esc` to leave the presentation mode (if there is no selection to cancel) only seems confusing.

Also I removed some further code for leaving fullscreen in `XournalView::onKeyPressEvent`, which doesn't seem to do anything. Again using esc only seems confusing here (e.g. editing stuff in fullscreen and accidentally leaving it while cancelling a selection).

*sry for this PR looking kinda messy with all the force-pushing etc...*