### PR TITLE
Fix clipboard pasting when missing owner-change signal

### DIFF
--- a/src/core/control/ClipboardHandler.cpp
+++ b/src/core/control/ClipboardHandler.cpp
@@ -263,7 +263,11 @@ void ClipboardHandler::clipboardUpdated(GdkAtom atom) {
 }
 
 void ClipboardHandler::pasteClipboardImage(GtkClipboard* clipboard, GdkPixbuf* pixbuf, ClipboardHandler* handler) {
-    handler->listener->clipboardPasteImage(pixbuf);
+    if (pixbuf) {
+        handler->listener->clipboardPasteImage(pixbuf);
+    } else {
+        g_warning("Trying to paste image, but pixbuf is null");
+    }
 }
 
 void ClipboardHandler::pasteClipboardContents(GtkClipboard* clipboard, GtkSelectionData* selectionData,

--- a/src/core/control/ClipboardHandler.cpp
+++ b/src/core/control/ClipboardHandler.cpp
@@ -42,6 +42,12 @@ ClipboardHandler::~ClipboardHandler() { g_signal_handler_disconnect(this->clipbo
 static GdkAtom atomXournal = gdk_atom_intern_static_string("application/xournal");
 
 auto ClipboardHandler::paste() -> bool {
+    /* Request targets again, since the owner-change signal is not emitted on MacOS and under X11 with no XFIXES
+     * extension. See https://docs.gtk.org/gdk3/struct.EventOwnerChange.html and
+     * https://gitlab.gnome.org/GNOME/gtk/-/issues/1757 */
+    gtk_clipboard_request_contents(clipboard, gdk_atom_intern_static_string("TARGETS"),
+                                   reinterpret_cast<GtkClipboardReceivedFunc>(receivedClipboardContents), this);
+
     if (this->containsXournal) {
         gtk_clipboard_request_contents(this->clipboard, atomXournal,
                                        reinterpret_cast<GtkClipboardReceivedFunc>(pasteClipboardContents), this);


### PR DESCRIPTION
Fixes #3455. Fixes #2831. Fixes #3044, I think.