### PR TITLE
Shrink padding for rerendering and repainting

### DIFF
--- a/src/core/gui/PageView.cpp
+++ b/src/core/gui/PageView.cpp
@@ -755,8 +755,8 @@ void XojPageView::repaintPage() const { xournal->getRepaintHandler()->repaintPag
 
 void XojPageView::repaintArea(double x1, double y1, double x2, double y2) const {
     double zoom = xournal->getZoom();
-    xournal->getRepaintHandler()->repaintPageArea(this, std::lround(x1 * zoom) - 10, std::lround(y1 * zoom) - 10,
-                                                  std::lround(x2 * zoom) + 20, std::lround(y2 * zoom) + 20);
+    xournal->getRepaintHandler()->repaintPageArea(this, std::lround(x1 * zoom) - 1, std::lround(y1 * zoom) - 1,
+                                                  std::lround(x2 * zoom) + 1, std::lround(y2 * zoom) + 1);
 }
 
 void XojPageView::flagDirtyRegion(const Range& rg) const { repaintArea(rg.minX, rg.minY, rg.maxX, rg.maxY); }
@@ -793,10 +793,10 @@ double XojPageView::getWidth() const { return page->getWidth(); }
 double XojPageView::getHeight() const { return page->getHeight(); }
 
 void XojPageView::rerenderRect(double x, double y, double width, double height) {
-    int rx = std::lround(std::max(x - 10, 0.0));
-    int ry = std::lround(std::max(y - 10, 0.0));
-    int rwidth = std::lround(width + 20);
-    int rheight = std::lround(height + 20);
+    int rx = std::lround(std::max(x - 1, 0.0));
+    int ry = std::lround(std::max(y - 1, 0.0));
+    int rwidth = std::lround(width + 2);
+    int rheight = std::lround(height + 2);
 
     addRerenderRect(rx, ry, rwidth, rheight);
 }


### PR DESCRIPTION
Padding can be reduced significantly without introducing rendering artifacts. Removing padding completely causes artifacts when drawing ellipses.

Keeping the area to be redrawn small speeds up xournal++ when used with electrophoretic displays.

Tested with most tools on three zoom levels and three line widths. More extensive testing is welcome.