### PR TITLE
Remove rerender padding

### DIFF
--- a/src/core/control/jobs/RenderJob.cpp
+++ b/src/core/control/jobs/RenderJob.cpp
@@ -34,10 +34,18 @@ void RenderJob::rerenderRectangle(Rectangle<double> const& rect) {
      * For example, if rect.x = m + 0.9, rect.width = n + 0.2 and ratio = 1 and m and n are integers
      * We need a mask of width n+2 pixels for that...
      **/
-    const auto x = std::floor(rect.x * ratio);
-    const auto y = std::floor(rect.y * ratio);
-    const auto width = int(std::ceil(rect.width * ratio)) + 1;
-    const auto height = int(std::ceil(rect.height * ratio)) + 1;
+    constexpr int RENDER_PADDING_X_Y = 1;
+    constexpr int RENDER_PADDING_WIDTH_HEIGHT = 2;
+
+    const auto rx = rect.x - RENDER_PADDING_X_Y;
+    const auto ry = rect.y - RENDER_PADDING_X_Y;
+    const auto rwidth = rect.width + RENDER_PADDING_WIDTH_HEIGHT;
+    const auto rheight = rect.height + RENDER_PADDING_WIDTH_HEIGHT;
+
+    const auto x = std::floor(rx * ratio);
+    const auto y = std::floor(ry * ratio);
+    const auto width = int(std::ceil(rwidth * ratio)) + 1;
+    const auto height = int(std::ceil(rheight * ratio)) + 1;
 
     xoj::util::CairoSurfaceSPtr rectBuffer(cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height),
                                            xoj::util::adopt);
@@ -51,7 +59,7 @@ void RenderJob::rerenderRectangle(Rectangle<double> const& rect) {
 
     cairo_set_operator(crPageBuffer.get(), CAIRO_OPERATOR_SOURCE);
     cairo_set_source_surface(crPageBuffer.get(), rectBuffer.get(), 0, 0);
-    cairo_rectangle(crPageBuffer.get(), rect.x, rect.y, rect.width, rect.height);
+    cairo_rectangle(crPageBuffer.get(), rx, ry, rwidth, rheight);
     cairo_fill(crPageBuffer.get());
 }
 

--- a/src/core/control/jobs/RenderJob.cpp
+++ b/src/core/control/jobs/RenderJob.cpp
@@ -30,22 +30,22 @@ void RenderJob::rerenderRectangle(Rectangle<double> const& rect) {
     const double ratio = view->xournal->getZoom() * this->view->xournal->getDpiScaleFactor();
 
     /**
-     * The +1 makes sure the mask is big enough
-     * For example, if rect.x = m + 0.9, rect.width = n + 0.2 and ratio = 1 and m and n are integers
-     * We need a mask of width n+2 pixels for that...
+     * Padding seems to be necessary to prevent artefacts of most strokes.
+     * These artefacts are most pronounced when using the stroke deletion
+     * tool on ellipses, but also occur occasionally when removing regular
+     * strokes.
      **/
-    constexpr int RENDER_PADDING_X_Y = 1;
-    constexpr int RENDER_PADDING_WIDTH_HEIGHT = 2;
+    constexpr int RENDER_PADDING = 1;
 
-    const auto rx = rect.x - RENDER_PADDING_X_Y;
-    const auto ry = rect.y - RENDER_PADDING_X_Y;
-    const auto rwidth = rect.width + RENDER_PADDING_WIDTH_HEIGHT;
-    const auto rheight = rect.height + RENDER_PADDING_WIDTH_HEIGHT;
+    const auto rx = rect.x - RENDER_PADDING;
+    const auto ry = rect.y - RENDER_PADDING;
+    const auto rwidth = rect.width + 2 * RENDER_PADDING;
+    const auto rheight = rect.height + 2 * RENDER_PADDING;
 
     const auto x = std::floor(rx * ratio);
     const auto y = std::floor(ry * ratio);
-    const auto width = int(std::ceil(rwidth * ratio)) + 1;
-    const auto height = int(std::ceil(rheight * ratio)) + 1;
+    const auto width = static_cast<int>(std::ceil((rx + rwidth) * ratio) - x);
+    const auto height = static_cast<int>(std::ceil((ry + rheight) * ratio) - y);
 
     xoj::util::CairoSurfaceSPtr rectBuffer(cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height),
                                            xoj::util::adopt);

--- a/src/core/gui/LegacyRedrawable.cpp
+++ b/src/core/gui/LegacyRedrawable.cpp
@@ -14,5 +14,5 @@ void LegacyRedrawable::repaintRect(double x, double y, double width, double heig
 void LegacyRedrawable::rerenderRange(const Range& r) { rerenderRect(r.getX(), r.getY(), r.getWidth(), r.getHeight()); }
 
 void LegacyRedrawable::rerenderElement(Element* e) {
-    rerenderRect(e->getX() - 1, e->getY() - 1, e->getElementWidth() + 2, e->getElementHeight() + 2);
+    rerenderRect(e->getX(), e->getY(), e->getElementWidth(), e->getElementHeight());
 }

--- a/src/core/gui/PageView.cpp
+++ b/src/core/gui/PageView.cpp
@@ -836,15 +836,6 @@ double XojPageView::getWidth() const { return page->getWidth(); }
 double XojPageView::getHeight() const { return page->getHeight(); }
 
 void XojPageView::rerenderRect(double x, double y, double width, double height) {
-    int rx = std::lround(std::max(x - 10, 0.0));
-    int ry = std::lround(std::max(y - 10, 0.0));
-    int rwidth = std::lround(width + 20);
-    int rheight = std::lround(height + 20);
-
-    addRerenderRect(rx, ry, rwidth, rheight);
-}
-
-void XojPageView::addRerenderRect(double x, double y, double width, double height) {
     if (this->rerenderComplete) {
         return;
     }

--- a/src/core/gui/PageView.cpp
+++ b/src/core/gui/PageView.cpp
@@ -798,8 +798,8 @@ void XojPageView::repaintPage() const { xournal->getRepaintHandler()->repaintPag
 
 void XojPageView::repaintArea(double x1, double y1, double x2, double y2) const {
     double zoom = xournal->getZoom();
-    xournal->getRepaintHandler()->repaintPageArea(this, std::lround(x1 * zoom) - 10, std::lround(y1 * zoom) - 10,
-                                                  std::lround(x2 * zoom) + 20, std::lround(y2 * zoom) + 20);
+    xournal->getRepaintHandler()->repaintPageArea(this, std::floor(x1 * zoom), std::floor(y1 * zoom),
+                                                  std::ceil(x2 * zoom), std::ceil(y2 * zoom));
 }
 
 void XojPageView::flagDirtyRegion(const Range& rg) const { repaintArea(rg.minX, rg.minY, rg.maxX, rg.maxY); }

--- a/src/core/gui/PageView.h
+++ b/src/core/gui/PageView.h
@@ -202,8 +202,6 @@ public:  // listener
 private:
     void startText(double x, double y);
 
-    void addRerenderRect(double x, double y, double width, double height);
-
     void drawLoadingPage(cairo_t* cr);
 
     /**

--- a/src/core/model/Compass.cpp
+++ b/src/core/model/Compass.cpp
@@ -24,7 +24,11 @@ auto Compass::getToolRange(bool transformed) const -> Range {
         rg.addPoint(-h, -h);
         rg.addPoint(h, h);
     }
-    rg.addPadding(2 + .5 * xoj::view::CompassView::LINE_WIDTH_IN_CM * CM);  // account for line width
+
+    // Padding required to fully render the boundary red lines and last blue digit
+    constexpr double RENDER_PADDING = 2.0;
+
+    rg.addPadding(RENDER_PADDING + .5 * xoj::view::CompassView::LINE_WIDTH_IN_CM * CM);  // account for line width
     return rg;
 }
 

--- a/src/core/model/Compass.cpp
+++ b/src/core/model/Compass.cpp
@@ -24,7 +24,7 @@ auto Compass::getToolRange(bool transformed) const -> Range {
         rg.addPoint(-h, -h);
         rg.addPoint(h, h);
     }
-    rg.addPadding(.5 * xoj::view::CompassView::LINE_WIDTH_IN_CM * CM);  // account for line width
+    rg.addPadding(2 + .5 * xoj::view::CompassView::LINE_WIDTH_IN_CM * CM);  // account for line width
     return rg;
 }
 

--- a/src/core/model/Setsquare.cpp
+++ b/src/core/model/Setsquare.cpp
@@ -30,7 +30,7 @@ auto Setsquare::getToolRange(bool transformed) const -> Range {
         rg.addPoint(-h, 0);
         rg.addPoint(0, h);
     }
-    rg.addPadding(.5 * xoj::view::SetsquareView::LINE_WIDTH_IN_CM * CM);  // account for line width
+    rg.addPadding(1 + .5 * xoj::view::SetsquareView::LINE_WIDTH_IN_CM * CM);  // account for line width
     return rg;
 }
 

--- a/src/core/model/Setsquare.cpp
+++ b/src/core/model/Setsquare.cpp
@@ -30,7 +30,11 @@ auto Setsquare::getToolRange(bool transformed) const -> Range {
         rg.addPoint(-h, 0);
         rg.addPoint(0, h);
     }
-    rg.addPadding(1 + .5 * xoj::view::SetsquareView::LINE_WIDTH_IN_CM * CM);  // account for line width
+
+    // Padding required to fully render the boundary red lines
+    constexpr double RENDER_PADDING = 1.0;
+
+    rg.addPadding(RENDER_PADDING + .5 * xoj::view::SetsquareView::LINE_WIDTH_IN_CM * CM);  // account for line width
     return rg;
 }
 


### PR DESCRIPTION
As discussed with @bhennion (https://github.com/xournalpp/xournalpp/discussions/4071). Evolution of https://github.com/xournalpp/xournalpp/pull/4492.

Padding can be removed without introducing rendering artifacts. Removing padding completely causes artifacts when drawing ellipses.

Keeping the area to be redrawn small speeds up xournal++ when used with electrophoretic displays.

Tested with most tools on three zoom levels and three line widths. More extensive testing is welcome.
