### PR TITLE
Unify tap filtering across tools

### DIFF
--- a/src/core/control/ToolHandler.cpp
+++ b/src/core/control/ToolHandler.cpp
@@ -577,6 +577,18 @@ auto ToolHandler::isSinglePageTool() const -> bool {
            toolType == TOOL_SELECT_PDF_TEXT_RECT;
 }
 
+auto ToolHandler::supportsTapFilter() const -> bool {
+    ToolType toolType = this->getToolType();
+
+    return toolType == TOOL_PEN || toolType == TOOL_HIGHLIGHTER || toolType == TOOL_DRAW_RECT ||
+           toolType == TOOL_DRAW_ELLIPSE || toolType == TOOL_DRAW_COORDINATE_SYSTEM || toolType == TOOL_DRAW_ARROW ||
+           toolType == TOOL_DRAW_DOUBLE_ARROW || toolType == TOOL_DRAW_SPLINE;
+    // Add toolType == TOOL_ERASER
+    // Add? || toolType == TOOL_SELECT_REGION || toolType == TOOL_SELECT_RECT || toolType == TOOL_SELECT_OBJECT  ||
+    // toolType == TOOL_FLOATING_TOOLBOX || toolType == TOOL_SELECT_PDF_TEXT_LINEAR || toolType ==
+    // TOOL_SELECT_PDF_TEXT_RECT
+}
+
 auto ToolHandler::getSelectedTool(SelectedTool selectedTool) const -> Tool* {
     switch (selectedTool) {
         case SelectedTool::active:

--- a/src/core/control/ToolHandler.cpp
+++ b/src/core/control/ToolHandler.cpp
@@ -580,13 +580,9 @@ auto ToolHandler::isSinglePageTool() const -> bool {
 auto ToolHandler::supportsTapFilter() const -> bool {
     ToolType toolType = this->getToolType();
 
-    return toolType == TOOL_PEN || toolType == TOOL_HIGHLIGHTER || toolType == TOOL_DRAW_RECT ||
-           toolType == TOOL_DRAW_ELLIPSE || toolType == TOOL_DRAW_COORDINATE_SYSTEM || toolType == TOOL_DRAW_ARROW ||
-           toolType == TOOL_DRAW_DOUBLE_ARROW || toolType == TOOL_DRAW_SPLINE;
-    // Add toolType == TOOL_ERASER
-    // Add? || toolType == TOOL_SELECT_REGION || toolType == TOOL_SELECT_RECT || toolType == TOOL_SELECT_OBJECT  ||
-    // toolType == TOOL_FLOATING_TOOLBOX || toolType == TOOL_SELECT_PDF_TEXT_LINEAR || toolType ==
-    // TOOL_SELECT_PDF_TEXT_RECT
+    return toolType == TOOL_PEN || toolType == TOOL_HIGHLIGHTER || toolType == TOOL_HAND ||
+           toolType == TOOL_DRAW_RECT || toolType == TOOL_DRAW_ELLIPSE || toolType == TOOL_DRAW_COORDINATE_SYSTEM ||
+           toolType == TOOL_DRAW_ARROW || toolType == TOOL_DRAW_DOUBLE_ARROW || toolType == TOOL_DRAW_SPLINE;
 }
 
 auto ToolHandler::getSelectedTool(SelectedTool selectedTool) const -> Tool* {

--- a/src/core/control/ToolHandler.h
+++ b/src/core/control/ToolHandler.h
@@ -337,6 +337,12 @@ public:
      */
     bool isSinglePageTool() const;
 
+    /**
+     * @brief Whether the tool supports short taps filtering (for floating toolbox or selection)
+     * see Preferences->Drawing Area->Action on Tool tap
+     */
+    bool supportsTapFilter() const;
+
 protected:
     void initTools();
 

--- a/src/core/control/tools/BaseShapeHandler.cpp
+++ b/src/core/control/tools/BaseShapeHandler.cpp
@@ -22,8 +22,6 @@
 #include "util/DispatchPool.h"                     // for DispatchPool
 #include "view/overlays/ShapeToolView.h"           // for ShapeToolView
 
-guint32 BaseShapeHandler::lastStrokeTime;  // persist for next stroke
-
 
 BaseShapeHandler::BaseShapeHandler(Control* control, const PageRef& page, bool flipShift, bool flipControl):
         InputHandler(control, page),
@@ -100,39 +98,6 @@ void BaseShapeHandler::onButtonReleaseEvent(const PositionInputData& pos, double
         return;
     }
 
-    Settings* settings = control->getSettings();
-
-    if (settings->getStrokeFilterEnabled())  // Note: For simple strokes see StrokeHandler which has a slightly
-                                             // different version of this filter.  See //!
-    {
-        int strokeFilterIgnoreTime = 0, strokeFilterSuccessiveTime = 0;
-        double strokeFilterIgnoreLength = NAN;
-
-        settings->getStrokeFilter(&strokeFilterIgnoreTime, &strokeFilterIgnoreLength, &strokeFilterSuccessiveTime);
-        double dpmm = settings->getDisplayDpi() / 25.4;
-
-        double lengthSqrd = (pow(((pos.x / zoom) - (this->buttonDownPoint.x)), 2) +
-                             pow(((pos.y / zoom) - (this->buttonDownPoint.y)), 2)) *
-                            pow(zoom, 2);
-
-        if (lengthSqrd < pow((strokeFilterIgnoreLength * dpmm), 2) &&
-            pos.timestamp - this->startStrokeTime < strokeFilterIgnoreTime) {
-            if (pos.timestamp - BaseShapeHandler::lastStrokeTime > strokeFilterSuccessiveTime) {
-                // stroke not being added to layer... delete here.
-                this->cancelStroke();
-
-                this->userTapped = true;
-
-                BaseShapeHandler::lastStrokeTime = pos.timestamp;
-
-                control->getCursor()->updateCursor();
-
-                return;
-            }
-        }
-        BaseShapeHandler::lastStrokeTime = pos.timestamp;
-    }
-
     Layer* layer = page->getSelectedLayer();
 
     UndoRedoHandler* undo = control->getUndoRedoHandler();
@@ -160,7 +125,6 @@ void BaseShapeHandler::onButtonPressEvent(const PositionInputData& pos, double z
     this->buttonDownPoint.x = pos.x / zoom;
     this->buttonDownPoint.y = pos.y / zoom;
 
-    this->startStrokeTime = pos.timestamp;
     this->startPoint = snappingHandler.snapToGrid(this->buttonDownPoint, pos.isAltDown());
     this->currPoint = this->startPoint;
 

--- a/src/core/control/tools/BaseShapeHandler.h
+++ b/src/core/control/tools/BaseShapeHandler.h
@@ -16,7 +16,6 @@
 #include <vector>   // for vector
 
 #include <gdk/gdk.h>  // for GdkEventKey
-#include <glib.h>     // for guint32
 
 #include "model/PageRef.h"  // for PageRef
 #include "model/Point.h"    // for Point
@@ -105,10 +104,6 @@ protected:
     bool modShift = false;
     bool modControl = false;
     SnapToGridInputHandler snappingHandler;
-
-    // to filter out short strokes (usually the user tapping on the page to select it)
-    guint32 startStrokeTime{};
-    static guint32 lastStrokeTime;  // persist across strokes - allow us to not ignore persistent dotting.
 
     Point currPoint;
     Point buttonDownPoint;  // used for tapSelect and filtering - never snapped to grid.

--- a/src/core/control/tools/InputHandler.h
+++ b/src/core/control/tools/InputHandler.h
@@ -87,11 +87,6 @@ public:
 
     Stroke* getStroke() const;
 
-    /**
-     * userTapped - experimental feature to take action on filtered draw. See cbDoActionOnStrokeFilter
-     */
-    bool userTapped = false;
-
 protected:
     [[nodiscard]] static std::unique_ptr<Stroke> createStroke(Control* control);
 

--- a/src/core/control/tools/SplineHandler.h
+++ b/src/core/control/tools/SplineHandler.h
@@ -16,7 +16,6 @@
 #include <vector>    // for vector
 
 #include <gdk/gdk.h>  // for GdkEventKey
-#include <glib.h>     // for guint32
 
 #include "control/zoom/ZoomListener.h"
 #include "model/PageRef.h"   // for PageRef
@@ -107,11 +106,6 @@ private:
      * @brief Clears out the spline and remove the views. Assumes the spline has at most 1 definitive knot
      */
     void clearTinySpline();
-
-    // to filter out short strokes (usually the user tapping on the page to select it)
-    guint32 startStrokeTime{};
-    static guint32 lastStrokeTime;  // persist across strokes - allow us to not ignore persistent dotting.
-
 
 private:
     std::vector<Point> knots{};

--- a/src/core/control/tools/StrokeHandler.h
+++ b/src/core/control/tools/StrokeHandler.h
@@ -14,7 +14,6 @@
 #include <memory>  // for unique_ptr
 
 #include <gdk/gdk.h>  // for GdkEventKey
-#include <glib.h>     // for guint32
 
 #include "model/PageRef.h"  // for PageRef
 #include "model/Point.h"    // for Point
@@ -90,10 +89,6 @@ protected:
     SnapToGridInputHandler snappingHandler;
 
 private:
-    // to filter out short strokes (usually the user tapping on the page to select it)
-    guint32 startStrokeTime{};
-    static guint32 lastStrokeTime;  // persist across strokes - allow us to not ignore persistent dotting.
-
     /**
      * @brief Pointer to the Stabilizer instance
      */

--- a/src/core/gui/PageView.h
+++ b/src/core/gui/PageView.h
@@ -182,6 +182,7 @@ public:  // event handler
     bool onButtonTriplePressEvent(const PositionInputData& pos);
     bool onMotionNotifyEvent(const PositionInputData& pos);
     void onSequenceCancelEvent();
+    void onTapEvent(const PositionInputData& pos);
 
     /**
      * This event fires after onButtonPressEvent and also

--- a/src/core/gui/inputdevices/PenInputHandler.h
+++ b/src/core/gui/inputdevices/PenInputHandler.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "gui/inputdevices/InputEvents.h"  // for InputEvent
+#include "util/Point.h"
 
 #include "AbstractInputHandler.h"  // for AbstractInputHandler
 
@@ -71,6 +72,13 @@ protected:
      * Page a selection started at as we require this for motion updates
      */
     XojPageView* sequenceStartPage = nullptr;
+
+    /**
+     * For tap event filtering. See Preferences->Drawing Area->Action on Tool Tap
+     */
+    guint32 lastActionEndTimeStamp = 0U;
+    guint32 lastActionStartTimeStamp = 0U;
+    utl::Point<double> sequenceStartPosition;
 
 public:
     explicit PenInputHandler(InputContext* inputContext);


### PR DESCRIPTION
Various tools are filtering tap events (e.g. to show the floating toolbox).

This PR removes code duplication and makes tap events fully supported by PenInputHandler (which handles every pointing devices -- mouse, stylus, touch).

~~This PR is base on #4159.~~ merged since