### PR TITLE
Repaint only areas instead of the entire widget

### DIFF
--- a/src/core/control/jobs/RenderJob.cpp
+++ b/src/core/control/jobs/RenderJob.cpp
@@ -90,11 +90,7 @@ void RenderJob::run() {
 }
 
 void RenderJob::repaintPage() {
-    int x1 = view->getX();
-    int y1 = view->getY();
-    int x2 = x1 + view->getDisplayWidth();
-    int y2 = y1 + view->getDisplayHeight();
-    repaintWidgetArea(view->xournal->getWidget(), x1, y1, x2, y2);
+    repaintWidgetArea(view->xournal->getWidget(), 0, 0, view->getWidth(), view->getHeight());
 }
 
 void RenderJob::repaintPageArea(double x1, double y1, double x2, double y2) {

--- a/src/core/control/jobs/RenderJob.cpp
+++ b/src/core/control/jobs/RenderJob.cpp
@@ -96,7 +96,7 @@ static void repaintWidgetArea(GtkWidget* widget, int x1, int y1, int x2, int y2)
 }
 
 void RenderJob::repaintPage() const {
-    repaintWidgetArea(view->xournal->getWidget(), 0, 0, view->getWidth(), view->getHeight());
+    repaintPageArea(0, 0, view->getWidth(), view->getHeight());
 }
 
 void RenderJob::repaintPageArea(double x1, double y1, double x2, double y2) const {

--- a/src/core/control/jobs/RenderJob.cpp
+++ b/src/core/control/jobs/RenderJob.cpp
@@ -98,9 +98,10 @@ void RenderJob::repaintPage() {
 }
 
 void RenderJob::repaintPageArea(double x1, double y1, double x2, double y2) {
+    double zoom = view->xournal->getZoom();
     int x = view->getX();
     int y = view->getY();
-    repaintWidgetArea(view->xournal->getWidget(), std::floor(x + x1), std::floor(y + y1), std::ceil(x + x2), std::ceil(y + y2));
+    repaintWidgetArea(view->xournal->getWidget(), std::floor(zoom * (x + x1)), std::floor(zoom * (y + y1)), std::ceil(zoom * (x + x2)), std::ceil(zoom * (y + y2)));
 }
 
 void RenderJob::repaintWidgetArea(GtkWidget* widget, int x1, int y1, int x2, int y2) {

--- a/src/core/control/jobs/RenderJob.cpp
+++ b/src/core/control/jobs/RenderJob.cpp
@@ -101,7 +101,7 @@ void RenderJob::repaintPageArea(double x1, double y1, double x2, double y2) {
     double zoom = view->xournal->getZoom();
     int x = view->getX();
     int y = view->getY();
-    repaintWidgetArea(view->xournal->getWidget(), std::floor(zoom * (x + x1)), std::floor(zoom * (y + y1)), std::ceil(zoom * (x + x2)), std::ceil(zoom * (y + y2)));
+    repaintWidgetArea(view->xournal->getWidget(), x + std::floor(zoom * x1), y + std::floor(zoom * y1), x + std::ceil(zoom * x2), y + std::ceil(zoom * y2));
 }
 
 void RenderJob::repaintWidgetArea(GtkWidget* widget, int x1, int y1, int x2, int y2) {

--- a/src/core/control/jobs/RenderJob.cpp
+++ b/src/core/control/jobs/RenderJob.cpp
@@ -91,19 +91,19 @@ void RenderJob::run() {
     }
 }
 
-void RenderJob::repaintPage() {
+static void repaintWidgetArea(GtkWidget* widget, int x1, int y1, int x2, int y2) {
+    Util::execInUiThread([=]() { gtk_xournal_repaint_area(widget, x1, y1, x2, y2); });
+}
+
+void RenderJob::repaintPage() const {
     repaintWidgetArea(view->xournal->getWidget(), 0, 0, view->getWidth(), view->getHeight());
 }
 
-void RenderJob::repaintPageArea(double x1, double y1, double x2, double y2) {
+void RenderJob::repaintPageArea(double x1, double y1, double x2, double y2) const {
     double zoom = view->xournal->getZoom();
     int x = view->getX();
     int y = view->getY();
     repaintWidgetArea(view->xournal->getWidget(), x + std::floor(zoom * x1), y + std::floor(zoom * y1), x + std::ceil(zoom * x2), y + std::ceil(zoom * y2));
-}
-
-void RenderJob::repaintWidgetArea(GtkWidget* widget, int x1, int y1, int x2, int y2) {
-    Util::execInUiThread([=]() { gtk_xournal_repaint_area(widget, x1, y1, x2, y2); });
 }
 
 void RenderJob::renderToBuffer(cairo_surface_t* buffer) const {

--- a/src/core/control/jobs/RenderJob.cpp
+++ b/src/core/control/jobs/RenderJob.cpp
@@ -78,8 +78,10 @@ void RenderJob::run() {
 
         renderToBuffer(newBuffer.get());
 
-        std::lock_guard lock(this->view->drawingMutex);
-        std::swap(this->view->crBuffer, newBuffer);
+        {
+            std::lock_guard lock(this->view->drawingMutex);
+            std::swap(this->view->crBuffer, newBuffer);
+        }
         repaintPage();
     } else {
         for (Rectangle<double> const& rect: rerenderRects) {

--- a/src/core/control/jobs/RenderJob.cpp
+++ b/src/core/control/jobs/RenderJob.cpp
@@ -52,6 +52,8 @@ void RenderJob::rerenderRectangle(Rectangle<double> const& rect) {
     cairo_set_source_surface(crPageBuffer.get(), rectBuffer.get(), 0, 0);
     cairo_rectangle(crPageBuffer.get(), rect.x, rect.y, rect.width, rect.height);
     cairo_fill(crPageBuffer.get());
+
+    this->view->repaintArea(rect.x, rect.y, rect.x + rect.width, rect.y + rect.height);
 }
 
 void RenderJob::run() {
@@ -79,12 +81,10 @@ void RenderJob::run() {
 
         std::lock_guard lock(this->view->drawingMutex);
         std::swap(this->view->crBuffer, newBuffer);
+        this->view->repaintPage();
     } else {
         for (Rectangle<double> const& rect: rerenderRects) { rerenderRectangle(rect); }
     }
-
-    // Schedule a repaint of the widget
-    repaintWidget(this->view->getXournal()->getWidget());
 }
 
 void RenderJob::renderToBuffer(cairo_surface_t* buffer) const {

--- a/src/core/control/jobs/RenderJob.cpp
+++ b/src/core/control/jobs/RenderJob.cpp
@@ -99,15 +99,4 @@ void RenderJob::renderToBuffer(cairo_surface_t* buffer) const {
     localView.drawPage(this->view->page, crRect.get(), false);
 }
 
-
-/**
- * Repaint the widget in UI Thread
- */
-void RenderJob::repaintWidget(GtkWidget* widget) {
-    // "this" is not needed, "widget" is in
-    // the closure, therefore no sync needed
-    // Because of this the argument "widget" is needed
-    Util::execInUiThread([=]() { gtk_widget_queue_draw(widget); });
-}
-
 auto RenderJob::getType() -> JobType { return JOB_TYPE_RENDER; }

--- a/src/core/control/jobs/RenderJob.h
+++ b/src/core/control/jobs/RenderJob.h
@@ -37,6 +37,12 @@ public:
     void run() override;
 
 private:
+    void repaintPage();
+
+    void repaintPageArea(double x1, double y1, double x2, double y2);
+
+    void repaintWidgetArea(GtkWidget* widget, int x1, int y1, int x2, int y2);
+
     void rerenderRectangle(xoj::util::Rectangle<double> const& rect);
 
     void renderToBuffer(cairo_surface_t* buffer) const;

--- a/src/core/control/jobs/RenderJob.h
+++ b/src/core/control/jobs/RenderJob.h
@@ -37,11 +37,6 @@ public:
     void run() override;
 
 private:
-    /**
-     * Repaint the widget in UI Thread
-     */
-    static void repaintWidget(GtkWidget* widget);
-
     void rerenderRectangle(xoj::util::Rectangle<double> const& rect);
 
     void renderToBuffer(cairo_surface_t* buffer) const;

--- a/src/core/control/jobs/RenderJob.h
+++ b/src/core/control/jobs/RenderJob.h
@@ -37,11 +37,9 @@ public:
     void run() override;
 
 private:
-    void repaintPage();
+    void repaintPage() const;
 
-    void repaintPageArea(double x1, double y1, double x2, double y2);
-
-    void repaintWidgetArea(GtkWidget* widget, int x1, int y1, int x2, int y2);
+    void repaintPageArea(double x1, double y1, double x2, double y2) const;
 
     void rerenderRectangle(xoj::util::Rectangle<double> const& rect);
 


### PR DESCRIPTION
Previously the entire widget would be repainted, causing a noticeable delay on electrophoretic displays. Solution suggested by @bhennion here: https://github.com/xournalpp/xournalpp/discussions/4494#discussioncomment-4371802 