### PR TITLE
Remove deprecated build steps on MacOS

### DIFF
--- a/azure-pipelines/steps/build_mac.yml
+++ b/azure-pipelines/steps/build_mac.yml
@@ -16,11 +16,6 @@ steps:
       cat gtk-bin.tar.gz.* | tar -xz
     displayName: 'Unpack GTK'
   - bash: |
-      curl -L -o libxml.tar.gz https://github.com/xournalpp/xournalpp-pipeline-dependencies/raw/macos-10.15-jhbuild/libxml/libxml.tar.gz
-      sudo tar -xzf libxml.tar.gz -C /
-    enabled: false
-    displayName: 'Unpack libxml'
-  - bash: |
       mkdir build
     displayName: 'Create Build Directory'
   - bash: |

--- a/azure-pipelines/steps/build_mac.yml
+++ b/azure-pipelines/steps/build_mac.yml
@@ -35,15 +35,6 @@ steps:
       unzip ninja-mac.zip -d "${{parameters.generation_path}}"/gtk/inst/bin
     displayName: 'Get Ninja'
   - bash: |
-      # Lua 5.4 is only supported with cmake >= 3.18, so use Lua 5.3 instead
-      cd "${{parameters.generation_path}}"
-      curl -R -O https://www.lua.org/ftp/lua-5.3.6.tar.gz
-      tar zxf lua-5.3.6.tar.gz
-      cd lua-5.3.6
-      make macosx all
-      make install INSTALL_TOP="${{parameters.generation_path}}"/gtk/inst
-    displayName: 'Get Lua'
-  - bash: |
       export PKG_CONFIG_PATH="${{parameters.generation_path}}"/gtk/inst/lib/pkgconfig:"${{parameters.generation_path}}"/gtk/inst/share/pkgconfig:/Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.8/lib/pkgconfig
       export PREFIX="${{parameters.generation_path}}"/gtk/inst
       export PATH="$HOME/.local/bin:"${{parameters.generation_path}}"/gtk/inst/bin:$PATH"

--- a/azure-pipelines/steps/build_mac.yml
+++ b/azure-pipelines/steps/build_mac.yml
@@ -19,13 +19,12 @@ steps:
       mkdir build
     displayName: 'Create Build Directory'
   - bash: |
-      # Ninja >= 1.10.0 binaries depend on Catalina or newer, so use 1.9.0 instead.
-      curl -L -o ninja-mac.zip https://github.com/ninja-build/ninja/releases/download/v1.9.0/ninja-mac.zip
+      curl -L -o ninja-mac.zip https://github.com/ninja-build/ninja/releases/download/v1.11.1/ninja-mac.zip
 
       # curl -L -o ninja-mac.zip $(curl -s https://api.github.com/repos/ninja-build/ninja/releases/latest | grep "browser_download_url.*mac\.zip" | cut -d : -f 2,3 | tr -d '"')
-      # Fallback to version 1.9.0 if the previous request fails for some reason
+      # Fallback to version 1.11.1 if the previous request fails for some reason
       if [ ! -f ninja-mac.zip ]; then
-        curl -L -o ninja-mac.zip https://github.com/ninja-build/ninja/releases/download/v1.9.0/ninja-mac.zip
+        curl -L -o ninja-mac.zip https://github.com/ninja-build/ninja/releases/download/v1.11.1/ninja-mac.zip
       fi
       unzip ninja-mac.zip -d "${{parameters.generation_path}}"/gtk/inst/bin
     displayName: 'Get Ninja'


### PR DESCRIPTION
- The libxml unpacking step was disabled already and there is no `libxml.tar.gz` in the `macos-10.15-jhbuild` branch anyway
- We build on Big Sur (11.7), so no need to get an older Ninja version than 1.11.1.
- Lua 5.4 is included in the MacOS Gtk blob. It should be found since a recent enough version of `cmake` is used on the BigSur image. No need to build it on Azure Pipelines.