### PR TITLE
Preset view modes

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -2895,7 +2895,7 @@ void Control::showAbout() {
     dlg.show(GTK_WINDOW(this->win->getWindow()));
 }
 
-auto Control::loadViewMode(size_t mode) -> bool {
+auto Control::loadViewMode(ViewModeId mode) -> bool {
     if (!settings->loadViewMode(mode)) {
         return false;
     }

--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -886,7 +886,7 @@ void Control::actionPerformed(ActionType type, ActionGroup group, GtkToolButton*
             break;
 
         case ACTION_FULLSCREEN:
-            setFullscreen(enabled);
+            setViewFullscreenMode(enabled);
             break;
 
         case ACTION_TOGGLE_PAIRS_PARITY: {
@@ -1614,6 +1614,14 @@ void Control::setViewPairedPages(bool enabled) {
     fireActionSelected(GROUP_PAIRED_PAGES, enabled ? ACTION_VIEW_PAIRED_PAGES : ACTION_NOT_SELECTED);
     win->getXournal()->layoutPages();
     scrollHandler->scrollToPage(getCurrentPageNo());
+}
+
+void Control::setViewFullscreenMode(bool enabled) {
+    if (enabled) {
+        this->loadViewMode(1);
+    } else {
+        this->loadViewMode(0);
+    }
 }
 
 void Control::setViewPresentationMode(bool enabled) {

--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -2898,7 +2898,6 @@ auto Control::loadViewMode(size_t mode) -> bool {
     if (!settings->loadViewMode(mode)) {
         return false;
     }
-    std::cout << "Toolbar=" << settings->isToolbarVisible() << " & sidebar=" << settings->isSidebarVisible() << std::endl;
     if (settings->isMenubarVisible()) { // TODO move if...else into new method in MainWindow.cpp
         gtk_widget_hide(this->win->get("mainMenubar"));
     } else {

--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -2898,6 +2898,7 @@ auto Control::loadViewMode(size_t mode) -> bool {
     if (!settings->loadViewMode(mode)) {
         return false;
     }
+    std::cout << "Toolbar=" << settings->isToolbarVisible() << " & sidebar=" << settings->isSidebarVisible() << std::endl;
     if (settings->isMenubarVisible()) { // TODO move if...else into new method in MainWindow.cpp
         gtk_widget_hide(this->win->get("mainMenubar"));
     } else {

--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -2882,6 +2882,17 @@ void Control::showAbout() {
     dlg.show(GTK_WINDOW(this->win->getWindow()));
 }
 
+auto Control::loadViewMode() -> bool {
+    if (settings->isMenubarVisible()) { // TODO move if...else into new method in MainWindow.cpp
+        gtk_widget_hide(this->win->get("mainMenubar"));
+    } else {
+        gtk_widget_show(this->win->get("mainMenubar"));
+    }
+    this->win->setToolbarVisible(settings->isToolbarVisible());
+    this->win->setSidebarVisible(settings->isSidebarVisible());
+    return false;
+}
+
 void Control::clipboardCutCopyEnabled(bool enabled) {
     fireEnableAction(ACTION_CUT, enabled);
     fireEnableAction(ACTION_COPY, enabled);

--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -2898,11 +2898,7 @@ auto Control::loadViewMode(size_t mode) -> bool {
     if (!settings->loadViewMode(mode)) {
         return false;
     }
-    if (settings->isMenubarVisible()) { // TODO move if...else into new method in MainWindow.cpp
-        gtk_widget_hide(this->win->get("mainMenubar"));
-    } else {
-        gtk_widget_show(this->win->get("mainMenubar"));
-    }
+    this->win->setMenubarVisible(settings->isMenubarVisible());
     this->win->setToolbarVisible(settings->isToolbarVisible());
     this->win->setSidebarVisible(settings->isSidebarVisible());
     setFullscreen(settings->isFullscreen());

--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -33,6 +33,7 @@
 #include "control/settings/PageTemplateSettings.h"               // for Page...
 #include "control/settings/Settings.h"                           // for Sett...
 #include "control/settings/SettingsEnums.h"                      // for Button
+#include "control/settings/ViewModes.h"                          // for ViewM..
 #include "control/tools/EditSelection.h"                         // for Edit...
 #include "control/xojfile/LoadHandler.h"                         // for Load...
 #include "control/zoom/ZoomControl.h"                            // for Zoom...
@@ -1618,15 +1619,15 @@ void Control::setViewPairedPages(bool enabled) {
 
 void Control::setViewFullscreenMode(bool enabled) {
     if (enabled) {
-        this->loadViewMode(1);
+        this->loadViewMode(VIEW_MODE_FULLSCREEN);
     } else {
-        this->loadViewMode(0);
+        this->loadViewMode(VIEW_MODE_DEFAULT);
     }
 }
 
 void Control::setViewPresentationMode(bool enabled) {
     if (enabled) {
-        this->loadViewMode(2);
+        this->loadViewMode(VIEW_MODE_PRESENTATION);
 
         bool success = zoom->updateZoomPresentationValue();
         if (!success) {
@@ -1635,7 +1636,7 @@ void Control::setViewPresentationMode(bool enabled) {
             return;
         }
     } else {
-        this->loadViewMode(0);
+        this->loadViewMode(VIEW_MODE_DEFAULT);
 
         if (settings->isViewFixedRows()) {
             setViewRows(settings->getViewRows());

--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -1618,6 +1618,8 @@ void Control::setViewPairedPages(bool enabled) {
 
 void Control::setViewPresentationMode(bool enabled) {
     if (enabled) {
+        this->loadViewMode(2);
+
         bool success = zoom->updateZoomPresentationValue();
         if (!success) {
             g_warning("Error calculating zoom value");
@@ -1625,6 +1627,8 @@ void Control::setViewPresentationMode(bool enabled) {
             return;
         }
     } else {
+        this->loadViewMode(0);
+
         if (settings->isViewFixedRows()) {
             setViewRows(settings->getViewRows());
         } else {
@@ -2882,7 +2886,10 @@ void Control::showAbout() {
     dlg.show(GTK_WINDOW(this->win->getWindow()));
 }
 
-auto Control::loadViewMode() -> bool {
+auto Control::loadViewMode(size_t mode) -> bool {
+    if (!settings->loadViewMode(mode)) {
+        return false;
+    }
     if (settings->isMenubarVisible()) { // TODO move if...else into new method in MainWindow.cpp
         gtk_widget_hide(this->win->get("mainMenubar"));
     } else {
@@ -2890,6 +2897,7 @@ auto Control::loadViewMode() -> bool {
     }
     this->win->setToolbarVisible(settings->isToolbarVisible());
     this->win->setSidebarVisible(settings->isSidebarVisible());
+    setFullscreen(settings->isFullscreen());
     return false;
 }
 

--- a/src/core/control/Control.h
+++ b/src/core/control/Control.h
@@ -160,6 +160,7 @@ public:
 
     void updateWindowTitle();
     void setViewPairedPages(bool enabled);
+    void setViewFullscreenMode(bool enabled);
     void setViewPresentationMode(bool enabled);
     void setPairsOffset(int numOffset);
     void setViewColumns(int numColumns);

--- a/src/core/control/Control.h
+++ b/src/core/control/Control.h
@@ -186,9 +186,9 @@ public:
     bool isInDragAndDropToolbar();
 
     /**
-     * Loads the view mode according to the settings
+     * Loads the view mode (hide/show menu-,tool-&sidebar)
      */
-    bool loadViewMode();
+    bool loadViewMode(size_t mode);
 
     bool isFullscreen();
 

--- a/src/core/control/Control.h
+++ b/src/core/control/Control.h
@@ -185,6 +185,11 @@ public:
     void startDragDropToolbar();
     bool isInDragAndDropToolbar();
 
+    /**
+     * Loads the view mode according to the settings
+     */
+    bool loadViewMode();
+
     bool isFullscreen();
 
     /**

--- a/src/core/control/Control.h
+++ b/src/core/control/Control.h
@@ -23,6 +23,7 @@
 
 #include "control/ToolEnums.h"              // for ToolSize, ToolType
 #include "control/jobs/ProgressListener.h"  // for ProgressListener
+#include "control/settings/ViewModes.h"     // for ViewModeId
 #include "enums/ActionGroup.enum.h"         // for ActionGroup
 #include "enums/ActionType.enum.h"          // for ActionType
 #include "model/DocumentHandler.h"          // for DocumentHandler
@@ -189,7 +190,7 @@ public:
     /**
      * Loads the view mode (hide/show menu-,tool-&sidebar)
      */
-    bool loadViewMode(size_t mode);
+    bool loadViewMode(ViewModeId mode);
 
     bool isFullscreen();
 

--- a/src/core/control/FullscreenHandler.cpp
+++ b/src/core/control/FullscreenHandler.cpp
@@ -59,9 +59,6 @@ void FullscreenHandler::hideWidget(MainWindow* win, const std::string& widgetNam
 
 void FullscreenHandler::enableFullscreen(MainWindow* win) {
     gtk_window_fullscreen(static_cast<GtkWindow*>(*win));
-
-    string hideWidgets = settings->getFullscreenHideElements();
-    for (const string& s: StringUtils::split(hideWidgets, ',')) { hideWidget(win, s); }
 }
 
 void FullscreenHandler::disableFullscreen(MainWindow* win) {

--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -168,7 +168,7 @@ void Settings::loadDefault() {
             new ButtonConfig(TOOL_NONE, Colors::black, TOOL_SIZE_NONE, DRAWING_TYPE_DEFAULT, ERASER_TYPE_NONE);
 
     // default view modes
-    this->activeViewMode = ViewModeId::VIEW_MODE_DEFAULT;
+    this->activeViewMode = PresetViewModeIds::VIEW_MODE_DEFAULT;
     this->viewModes = std::vector<ViewMode>{VIEW_MODE_STRUCT_DEFAULT, VIEW_MODE_STRUCT_FULLSCREEN, VIEW_MODE_STRUCT_PRESENTATION};
 
     this->touchZoomStartThreshold = 0.0;
@@ -229,7 +229,7 @@ void Settings::loadDefault() {
     /**/
 }
 
-auto Settings::loadViewMode(size_t mode) -> bool {
+auto Settings::loadViewMode(ViewModeId mode) -> bool {
     if (mode < 0 || mode >= viewModes.size()) {
         return false;
     }
@@ -470,11 +470,11 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur) {
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("autosaveTimeout")) == 0) {
         this->autosaveTimeout = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("defaultViewModeAttributes")) == 0) {
-        this->viewModes.at(ViewModeId::VIEW_MODE_DEFAULT) = settingsStringToViewMode(reinterpret_cast<const char*>(value));
+        this->viewModes.at(PresetViewModeIds::VIEW_MODE_DEFAULT) = settingsStringToViewMode(reinterpret_cast<const char*>(value));
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("fullscreenViewModeAttributes")) == 0) {
-        this->viewModes.at(ViewModeId::VIEW_MODE_FULLSCREEN) = settingsStringToViewMode(reinterpret_cast<const char*>(value));
+        this->viewModes.at(PresetViewModeIds::VIEW_MODE_FULLSCREEN) = settingsStringToViewMode(reinterpret_cast<const char*>(value));
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("presentationViewModeAttributes")) == 0) {
-        this->viewModes.at(ViewModeId::VIEW_MODE_PRESENTATION) = settingsStringToViewMode(reinterpret_cast<const char*>(value));
+        this->viewModes.at(PresetViewModeIds::VIEW_MODE_PRESENTATION) = settingsStringToViewMode(reinterpret_cast<const char*>(value));
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("touchZoomStartThreshold")) == 0) {
         this->touchZoomStartThreshold = g_ascii_strtod(reinterpret_cast<const char*>(value), nullptr);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("pageRerenderThreshold")) == 0) {
@@ -932,9 +932,9 @@ void Settings::save() {
     ATTACH_COMMENT("The icon theme, allowed values are \"disabled\", \"onDrawOfLastPage\", and \"onScrollOfLastPage\"");
     SAVE_BOOL_PROP(presentationMode);
 
-    auto defaultViewModeAttributes = viewModeToSettingsString(viewModes.at(ViewModeId::VIEW_MODE_DEFAULT));
-    auto fullscreenViewModeAttributes = viewModeToSettingsString(viewModes.at(ViewModeId::VIEW_MODE_FULLSCREEN));
-    auto presentationViewModeAttributes = viewModeToSettingsString(viewModes.at(ViewModeId::VIEW_MODE_PRESENTATION));
+    auto defaultViewModeAttributes = viewModeToSettingsString(viewModes.at(PresetViewModeIds::VIEW_MODE_DEFAULT));
+    auto fullscreenViewModeAttributes = viewModeToSettingsString(viewModes.at(PresetViewModeIds::VIEW_MODE_FULLSCREEN));
+    auto presentationViewModeAttributes = viewModeToSettingsString(viewModes.at(PresetViewModeIds::VIEW_MODE_PRESENTATION));
     SAVE_STRING_PROP(defaultViewModeAttributes);
     ATTACH_COMMENT("Which GUI elements are shown in default view mode, separated by a colon (,)");
     SAVE_STRING_PROP(fullscreenViewModeAttributes);
@@ -1588,13 +1588,13 @@ void Settings::setPresentationMode(bool presentationMode) {
         return;
     }
     if (presentationMode) {
-        this->activeViewMode = ViewModeId::VIEW_MODE_PRESENTATION;
+        this->activeViewMode = PresetViewModeIds::VIEW_MODE_PRESENTATION;
     }
     this->presentationMode = presentationMode;
     save();
 }
 
-auto Settings::isPresentationMode() const -> bool { return this->activeViewMode == ViewModeId::VIEW_MODE_PRESENTATION; }
+auto Settings::isPresentationMode() const -> bool { return this->activeViewMode == PresetViewModeIds::VIEW_MODE_PRESENTATION; }
 
 void Settings::setPressureSensitivity(gboolean presureSensitivity) {
     if (this->pressureSensitivity == presureSensitivity) {
@@ -1863,7 +1863,7 @@ auto Settings::getButtonConfig(int id) -> ButtonConfig* {
     return this->buttonConfig[id];
 }
 
-void Settings::setViewMode(size_t mode, ViewMode viewMode) {
+void Settings::setViewMode(ViewModeId mode, ViewMode viewMode) {
     viewModes.at(mode) = viewMode;
 }
 

--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -169,7 +169,7 @@ void Settings::loadDefault() {
             new ButtonConfig(TOOL_NONE, Colors::black, TOOL_SIZE_NONE, DRAWING_TYPE_DEFAULT, ERASER_TYPE_NONE);
 
     // view modes
-    this->activeViewMode = VIEW_MODE_DEFAULT;
+    this->activeViewMode = ViewMode::VIEW_MODE_DEFAULT;
     this->viewModes = std::vector<std::string>{"default","fullscreen","presentation"};
     this->viewModeAttributes =std::vector<std::string>{"showMenubar,showToolbar,showSidebar","showToolbar,showSidebar,goFullscreen","goFullscreen"};
 
@@ -491,11 +491,11 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur) {
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("autosaveTimeout")) == 0) {
         this->autosaveTimeout = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("defaultViewModeAttributes")) == 0) {
-        this->viewModeAttributes.at(VIEW_MODE_DEFAULT) = reinterpret_cast<const char*>(value);
+        this->viewModeAttributes.at(ViewMode::VIEW_MODE_DEFAULT) = reinterpret_cast<const char*>(value);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("fullscreenViewModeAttributes")) == 0) {
-        this->viewModeAttributes.at(VIEW_MODE_FULLSCREEN) = reinterpret_cast<const char*>(value);
+        this->viewModeAttributes.at(ViewMode::VIEW_MODE_FULLSCREEN) = reinterpret_cast<const char*>(value);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("presentationViewModeAttributes")) == 0) {
-        this->viewModeAttributes.at(VIEW_MODE_PRESENTATION) = reinterpret_cast<const char*>(value);
+        this->viewModeAttributes.at(ViewMode::VIEW_MODE_PRESENTATION) = reinterpret_cast<const char*>(value);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("touchZoomStartThreshold")) == 0) {
         this->touchZoomStartThreshold = g_ascii_strtod(reinterpret_cast<const char*>(value), nullptr);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("pageRerenderThreshold")) == 0) {
@@ -953,9 +953,9 @@ void Settings::save() {
     ATTACH_COMMENT("The icon theme, allowed values are \"disabled\", \"onDrawOfLastPage\", and \"onScrollOfLastPage\"");
     SAVE_BOOL_PROP(presentationMode);
 
-    auto defaultViewModeAttributes = viewModeAttributes.at(VIEW_MODE_DEFAULT);
-    auto fullscreenViewModeAttributes = viewModeAttributes.at(VIEW_MODE_FULLSCREEN);
-    auto presentationViewModeAttributes = viewModeAttributes.at(VIEW_MODE_PRESENTATION);
+    auto defaultViewModeAttributes = viewModeAttributes.at(ViewMode::VIEW_MODE_DEFAULT);
+    auto fullscreenViewModeAttributes = viewModeAttributes.at(ViewMode::VIEW_MODE_FULLSCREEN);
+    auto presentationViewModeAttributes = viewModeAttributes.at(ViewMode::VIEW_MODE_PRESENTATION);
     SAVE_STRING_PROP(defaultViewModeAttributes);
     ATTACH_COMMENT("Which gui elements are shown in default view mode, separated by a colon (,)");
     SAVE_STRING_PROP(fullscreenViewModeAttributes);
@@ -1609,12 +1609,12 @@ void Settings::setPresentationMode(bool presentationMode) {
         return;
     }
 
-    this->activeViewMode = VIEW_MODE_PRESENTATION;
+    this->activeViewMode = ViewMode::VIEW_MODE_PRESENTATION;
     this->presentationMode = presentationMode;
     save();
 }
 
-auto Settings::isPresentationMode() const -> bool { return this->activeViewMode == VIEW_MODE_PRESENTATION; }
+auto Settings::isPresentationMode() const -> bool { return this->activeViewMode == ViewMode::VIEW_MODE_PRESENTATION; }
 
 void Settings::setPressureSensitivity(gboolean presureSensitivity) {
     if (this->pressureSensitivity == presureSensitivity) {

--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -91,6 +91,8 @@ void Settings::loadDefault() {
     this->mainWndWidth = 800;
     this->mainWndHeight = 600;
 
+    this->fullscreenActive = false;
+
     this->showSidebar = true;
     this->sidebarWidth = 150;
 
@@ -168,7 +170,7 @@ void Settings::loadDefault() {
 
     // view modes
     this->viewModes = std::vector<std::string>{"default","fullscreen","presentation"};
-    this->showElements =std::vector<std::string>{"menubar,toolbar,sidebar","toolbar,sidebar",""};
+    this->viewModeAttributes =std::vector<std::string>{"showMenubar,showToolbar,showSidebar","showToolbar,showSidebar,fullscreen","fullscreen"};
     // deprecated since view modes introduced
     this->fullscreenHideElements = "mainMenubar";
     this->presentationHideElements = "mainMenubar,sidebarContents";
@@ -232,20 +234,23 @@ void Settings::loadDefault() {
 }
 
 auto Settings::loadViewMode(size_t mode) -> bool {
-    if (mode < 0 || mode > showElements.size()) {
+    if (mode < 0 || mode > viewModeAttributes.size()) {
         return false;
     }
-    auto elements = showElements.at(mode);
+    auto attributes = viewModeAttributes.at(mode);
     menubarVisible = false;
     showSidebar = false;
     showToolbar = false;
-    for (const string& element: StringUtils::split(elements, ',')) {
-        if (element == "menubar" || element == "mainMenubar") {
+    fullscreenActive = false;
+    for (const string& attr: StringUtils::split(attributes, ',')) {
+        if (attr == "showMenubar" || attr == "mainMenubar") {
             menubarVisible = true;
-        } else if (element == "sidebar" || element == "sidebarContents") {
+        } else if (attr == "showSidebar" || attr == "sidebarContents") {
             showSidebar = true;
-        } else if (element == "toolbar") {
+        } else if (attr == "showToolbar") {
             showToolbar = true;
+        } else if (attr == "fullscreen") {
+            fullscreenActive = true;
         }
     }
     this->activeViewMode = mode;
@@ -1793,6 +1798,12 @@ void Settings::setAreStockIconsUsed(bool use) {
 }
 
 auto Settings::areStockIconsUsed() const -> bool { return this->useStockIcons; }
+
+auto Settings::isFullscreen() const -> bool { return this->fullscreenActive; }
+
+void Settings::setIsFullscreen(bool isFullscreen) {
+    this->fullscreenActive = isFullscreen;
+}
 
 auto Settings::isSidebarVisible() const -> bool { return this->showSidebar; }
 

--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -171,7 +171,7 @@ void Settings::loadDefault() {
     // view modes
     this->activeViewMode = ViewMode::VIEW_MODE_DEFAULT;
     this->viewModes = std::vector<std::string>{"default","fullscreen","presentation"};
-    this->viewModeAttributes =std::vector<std::string>{"showMenubar,showToolbar,showSidebar","showToolbar,showSidebar,goFullscreen","goFullscreen"};
+    this->viewModeAttributes =std::vector<std::string>{"showMenubar,showToolbar,showSidebar","showToolbar,showSidebar,goFullscreen","showToolbar,goFullscreen"};
 
     this->touchZoomStartThreshold = 0.0;
 

--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -20,9 +20,10 @@
 #include "gui/toolbarMenubar/model/ColorPalette.h"  // for Palette
 #include "model/FormatDefinitions.h"                // for FormatUnits, XOJ_...
 #include "util/Color.h"
-#include "util/PathUtil.h"  // for getConfigFile
-#include "util/Util.h"      // for PRECISION_FORMAT_...
-#include "util/i18n.h"      // for _
+#include "util/PathUtil.h"                          // for getConfigFile
+#include "util/StringUtils.h"                       // for StringUtils...
+#include "util/Util.h"                              // for PRECISION_FORMAT_...
+#include "util/i18n.h"                              // for _
 
 #include "ButtonConfig.h"  // for ButtonConfig
 #include "config-dev.h"    // for PALETTE_FILE
@@ -165,6 +166,10 @@ void Settings::loadDefault() {
     this->buttonConfig[BUTTON_STYLUS_TWO] =
             new ButtonConfig(TOOL_NONE, Colors::black, TOOL_SIZE_NONE, DRAWING_TYPE_DEFAULT, ERASER_TYPE_NONE);
 
+    // view modes
+    this->viewModes = std::vector<std::string>{"default","fullscreen","presentation"};
+    this->showElements =std::vector<std::string>{"menubar,toolbar,sidebar","toolbar,sidebar",""};
+    // deprecated since view modes introduced
     this->fullscreenHideElements = "mainMenubar";
     this->presentationHideElements = "mainMenubar,sidebarContents";
 
@@ -224,6 +229,35 @@ void Settings::loadDefault() {
     this->stabilizerMass = 5.0;
     this->stabilizerFinalizeStroke = true;
     /**/
+}
+
+auto Settings::loadViewMode(size_t mode) -> bool {
+    if (mode < 0 || mode > showElements.size()) {
+        return false;
+    }
+    auto elements = showElements.at(mode);
+    menubarVisible = false;
+    showSidebar = false;
+    showToolbar = false;
+    for (const string& element: StringUtils::split(elements, ',')) {
+        if (element == "menubar" || element == "mainMenubar") {
+            menubarVisible = true;
+        } else if (element == "sidebar" || element == "sidebarContents") {
+            showSidebar = true;
+        } else if (element == "toolbar") {
+            showToolbar = true;
+        }
+    }
+    this->activeViewMode = mode;
+    return true;
+}
+
+auto Settings::getActiveViewMode() const -> bool {
+    return activeViewMode;
+}
+
+auto Settings::getViewModeStrings() const -> std::vector<std::string> {
+    return viewModes;
 }
 
 /**

--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -171,7 +171,7 @@ void Settings::loadDefault() {
     // view modes
     this->activeViewMode = VIEW_MODE_DEFAULT;
     this->viewModes = std::vector<std::string>{"default","fullscreen","presentation"};
-    this->viewModeAttributes =std::vector<std::string>{"showMenubar,showToolbar,showSidebar","showToolbar,showSidebar,fullscreen","fullscreen"};
+    this->viewModeAttributes =std::vector<std::string>{"showMenubar,showToolbar,showSidebar","showToolbar,showSidebar,goFullscreen","goFullscreen"};
 
     this->touchZoomStartThreshold = 0.0;
 
@@ -247,7 +247,7 @@ auto Settings::loadViewMode(size_t mode) -> bool {
             showSidebar = true;
         } else if (attr == "showToolbar") {
             showToolbar = true;
-        } else if (attr == "fullscreen") {
+        } else if (attr == "goFullscreen") {
             fullscreenActive = true;
         }
     }

--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -169,6 +169,7 @@ void Settings::loadDefault() {
             new ButtonConfig(TOOL_NONE, Colors::black, TOOL_SIZE_NONE, DRAWING_TYPE_DEFAULT, ERASER_TYPE_NONE);
 
     // view modes
+    this->activeViewMode = VIEW_MODE_DEFAULT;
     this->viewModes = std::vector<std::string>{"default","fullscreen","presentation"};
     this->viewModeAttributes =std::vector<std::string>{"showMenubar,showToolbar,showSidebar","showToolbar,showSidebar,fullscreen","fullscreen"};
     // deprecated since view modes introduced
@@ -1601,11 +1602,12 @@ void Settings::setPresentationMode(bool presentationMode) {
         return;
     }
 
+    this->activeViewMode = VIEW_MODE_PRESENTATION;
     this->presentationMode = presentationMode;
     save();
 }
 
-auto Settings::isPresentationMode() const -> bool { return this->presentationMode; }
+auto Settings::isPresentationMode() const -> bool { return this->activeViewMode == VIEW_MODE_PRESENTATION; }
 
 void Settings::setPressureSensitivity(gboolean presureSensitivity) {
     if (this->pressureSensitivity == presureSensitivity) {

--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -168,19 +168,8 @@ void Settings::loadDefault() {
             new ButtonConfig(TOOL_NONE, Colors::black, TOOL_SIZE_NONE, DRAWING_TYPE_DEFAULT, ERASER_TYPE_NONE);
 
     // default view modes
-    this->activeViewMode = VIEW_MODE_DEFAULT;
-    ViewMode viewModeDefault;
-    viewModeDefault.showMenubar = true;
-    viewModeDefault.showToolbar = true;
-    viewModeDefault.showSidebar = true;
-    ViewMode viewModeFullsceen;
-    viewModeFullsceen.goFullscreen = true;
-    viewModeFullsceen.showToolbar = true;
-    viewModeFullsceen.showSidebar = true;
-    ViewMode viewModePresentation;
-    viewModePresentation.goFullscreen = true;
-    viewModePresentation.showToolbar = true;
-    this->viewModes = std::vector<ViewMode>{viewModeDefault, viewModeFullsceen, viewModePresentation};
+    this->activeViewMode = ViewModeId::VIEW_MODE_DEFAULT;
+    this->viewModes = std::vector<ViewMode>{VIEW_MODE_STRUCT_DEFAULT, VIEW_MODE_STRUCT_FULLSCREEN, VIEW_MODE_STRUCT_PRESENTATION};
 
     this->touchZoomStartThreshold = 0.0;
 
@@ -481,11 +470,11 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur) {
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("autosaveTimeout")) == 0) {
         this->autosaveTimeout = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("defaultViewModeAttributes")) == 0) {
-        this->viewModes.at(VIEW_MODE_DEFAULT) = settingsStringToViewMode(reinterpret_cast<const char*>(value));
+        this->viewModes.at(ViewModeId::VIEW_MODE_DEFAULT) = settingsStringToViewMode(reinterpret_cast<const char*>(value));
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("fullscreenViewModeAttributes")) == 0) {
-        this->viewModes.at(VIEW_MODE_FULLSCREEN) = settingsStringToViewMode(reinterpret_cast<const char*>(value));
+        this->viewModes.at(ViewModeId::VIEW_MODE_FULLSCREEN) = settingsStringToViewMode(reinterpret_cast<const char*>(value));
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("presentationViewModeAttributes")) == 0) {
-        this->viewModes.at(VIEW_MODE_PRESENTATION) = settingsStringToViewMode(reinterpret_cast<const char*>(value));
+        this->viewModes.at(ViewModeId::VIEW_MODE_PRESENTATION) = settingsStringToViewMode(reinterpret_cast<const char*>(value));
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("touchZoomStartThreshold")) == 0) {
         this->touchZoomStartThreshold = g_ascii_strtod(reinterpret_cast<const char*>(value), nullptr);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("pageRerenderThreshold")) == 0) {
@@ -943,15 +932,15 @@ void Settings::save() {
     ATTACH_COMMENT("The icon theme, allowed values are \"disabled\", \"onDrawOfLastPage\", and \"onScrollOfLastPage\"");
     SAVE_BOOL_PROP(presentationMode);
 
-    auto defaultViewModeAttributes = viewModeToSettingsString(viewModes.at(VIEW_MODE_DEFAULT));
-    auto fullscreenViewModeAttributes = viewModeToSettingsString(viewModes.at(VIEW_MODE_FULLSCREEN));
-    auto presentationViewModeAttributes = viewModeToSettingsString(viewModes.at(VIEW_MODE_PRESENTATION));
+    auto defaultViewModeAttributes = viewModeToSettingsString(viewModes.at(ViewModeId::VIEW_MODE_DEFAULT));
+    auto fullscreenViewModeAttributes = viewModeToSettingsString(viewModes.at(ViewModeId::VIEW_MODE_FULLSCREEN));
+    auto presentationViewModeAttributes = viewModeToSettingsString(viewModes.at(ViewModeId::VIEW_MODE_PRESENTATION));
     SAVE_STRING_PROP(defaultViewModeAttributes);
-    ATTACH_COMMENT("Which gui elements are shown in default view mode, separated by a colon (,)");
+    ATTACH_COMMENT("Which GUI elements are shown in default view mode, separated by a colon (,)");
     SAVE_STRING_PROP(fullscreenViewModeAttributes);
-    ATTACH_COMMENT("Which gui elements are shown in fullscreen view mode, separated by a colon (,)");
+    ATTACH_COMMENT("Which GUI elements are shown in fullscreen view mode, separated by a colon (,)");
     SAVE_STRING_PROP(presentationViewModeAttributes);
-    ATTACH_COMMENT("Which gui elements are shown in presentation view mode, separated by a colon (,)");
+    ATTACH_COMMENT("Which GUI elements are shown in presentation view mode, separated by a colon (,)");
 
     xmlNode = saveProperty("stylusCursorType", stylusCursorTypeToString(this->stylusCursorType), root);
     ATTACH_COMMENT("The cursor icon used with a stylus, allowed values are \"none\", \"dot\", \"big\", \"arrow\"");
@@ -1599,13 +1588,13 @@ void Settings::setPresentationMode(bool presentationMode) {
         return;
     }
     if (presentationMode) {
-        this->activeViewMode = VIEW_MODE_PRESENTATION;
+        this->activeViewMode = ViewModeId::VIEW_MODE_PRESENTATION;
     }
     this->presentationMode = presentationMode;
     save();
 }
 
-auto Settings::isPresentationMode() const -> bool { return this->activeViewMode == VIEW_MODE_PRESENTATION; }
+auto Settings::isPresentationMode() const -> bool { return this->activeViewMode == ViewModeId::VIEW_MODE_PRESENTATION; }
 
 void Settings::setPressureSensitivity(gboolean presureSensitivity) {
     if (this->pressureSensitivity == presureSensitivity) {

--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -1598,8 +1598,9 @@ void Settings::setPresentationMode(bool presentationMode) {
     if (this->presentationMode == presentationMode) {
         return;
     }
-
-    this->activeViewMode = VIEW_MODE_PRESENTATION;
+    if (presentationMode) {
+        this->activeViewMode = VIEW_MODE_PRESENTATION;
+    }
     this->presentationMode = presentationMode;
     save();
 }

--- a/src/core/control/settings/Settings.h
+++ b/src/core/control/settings/Settings.h
@@ -34,6 +34,9 @@
 struct Palette;
 
 constexpr auto DEFAULT_GRID_SIZE = 14.17;
+constexpr auto VIEW_MODE_DEFAULT = 0;
+constexpr auto VIEW_MODE_FULLSCREEN = 1;
+constexpr auto VIEW_MODE_PRESENTATION = 2;
 
 class ButtonConfig;
 class InputDevice;

--- a/src/core/control/settings/Settings.h
+++ b/src/core/control/settings/Settings.h
@@ -34,9 +34,6 @@
 struct Palette;
 
 constexpr auto DEFAULT_GRID_SIZE = 14.17;
-constexpr auto VIEW_MODE_DEFAULT = 0;
-constexpr auto VIEW_MODE_FULLSCREEN = 1;
-constexpr auto VIEW_MODE_PRESENTATION = 2;
 
 class ButtonConfig;
 class InputDevice;

--- a/src/core/control/settings/Settings.h
+++ b/src/core/control/settings/Settings.h
@@ -888,7 +888,7 @@ private:
     /**
      * View mode attributes, separated by a colon (,)
      * - showMenubar,showToolbar,showSidebar = show widget
-     * - fullscreen                          = fullscreen
+     * - goFullscreen                        = fullscreen
      */
     std::vector<std::string> viewModeAttributes;
 

--- a/src/core/control/settings/Settings.h
+++ b/src/core/control/settings/Settings.h
@@ -30,6 +30,7 @@
 #include "LatexSettings.h"  // for LatexSettings
 #include "SettingsEnums.h"  // for InputDeviceTypeOption
 #include "filesystem.h"     // for path
+#include "ViewModes.h"      // for ViewModes
 
 struct Palette;
 
@@ -122,9 +123,7 @@ public:
     bool loadViewMode(size_t mode);
 
     // Getter- / Setter
-    bool getActiveViewMode() const;
-    std::vector<std::string> getViewModeStrings() const;
-    std::vector<std::string> getViewModeAttributes() const;
+    const std::vector<ViewMode>& getViewModes() const;
 
     bool isPressureSensitivity() const;
     void setPressureSensitivity(gboolean presureSensitivity);
@@ -346,7 +345,7 @@ public:
 
     ButtonConfig* getButtonConfig(int id);
 
-    void setViewModeAttributes(size_t mode, std::string attributes);
+    void setViewMode(size_t mode, ViewMode ViewMode);
 
     Color getBorderColor() const;
     void setBorderColor(Color color);
@@ -877,17 +876,10 @@ private:
     ButtonConfig* buttonConfig[BUTTON_COUNT]{};
 
     /**
-     * View-modes, 0=default, 1=fullscreen, 2=presentation
+     * View-modes. Predefined: 0=default, 1=fullscreen, 2=presentation
      */
     size_t activeViewMode;
-    std::vector<std::string> viewModes;
-
-    /**
-     * View mode attributes, separated by a colon (,)
-     * - showMenubar,showToolbar,showSidebar = show widget
-     * - goFullscreen                        = fullscreen
-     */
-    std::vector<std::string> viewModeAttributes;
+    std::vector<ViewMode> viewModes;
 
     /**
      *  The count of pages which will be cached

--- a/src/core/control/settings/Settings.h
+++ b/src/core/control/settings/Settings.h
@@ -120,7 +120,7 @@ private:
 
 public:
     // View Mode
-    bool loadViewMode(size_t mode);
+    bool loadViewMode(ViewModeId mode);
 
     // Getter- / Setter
     const std::vector<ViewMode>& getViewModes() const;
@@ -345,7 +345,7 @@ public:
 
     ButtonConfig* getButtonConfig(int id);
 
-    void setViewMode(size_t mode, ViewMode ViewMode);
+    void setViewMode(ViewModeId mode, ViewMode ViewMode);
 
     Color getBorderColor() const;
     void setBorderColor(Color color);

--- a/src/core/control/settings/Settings.h
+++ b/src/core/control/settings/Settings.h
@@ -127,6 +127,7 @@ public:
     // Getter- / Setter
     bool getActiveViewMode() const;
     std::vector<std::string> getViewModeStrings() const;
+    std::vector<std::string> getViewModeAttributes() const;
 
     bool isPressureSensitivity() const;
     void setPressureSensitivity(gboolean presureSensitivity);
@@ -348,11 +349,7 @@ public:
 
     ButtonConfig* getButtonConfig(int id);
 
-    std::string const& getFullscreenHideElements() const;
-    void setFullscreenHideElements(std::string elements);
-
-    std::string const& getPresentationHideElements() const;
-    void setPresentationHideElements(std::string elements);
+    void setViewModeAttributes(size_t mode, std::string attributes);
 
     Color getBorderColor() const;
     void setBorderColor(Color color);
@@ -883,19 +880,17 @@ private:
     ButtonConfig* buttonConfig[BUTTON_COUNT]{};
 
     /**
-     * View-modes, 0=default, 1=fullscreen, 2=presentation, +3=custom
+     * View-modes, 0=default, 1=fullscreen, 2=presentation
      */
     size_t activeViewMode;
     std::vector<std::string> viewModes;
 
     /**
      * View mode attributes, separated by a colon (,)
-     * showMenubar,showToolbar,showSidebar,fullscreen
+     * - showMenubar,showToolbar,showSidebar = show widget
+     * - fullscreen                          = fullscreen
      */
     std::vector<std::string> viewModeAttributes;
-    // deprecated since view mode introduction
-    std::string fullscreenHideElements;
-    std::string presentationHideElements;
 
     /**
      *  The count of pages which will be cached

--- a/src/core/control/settings/Settings.h
+++ b/src/core/control/settings/Settings.h
@@ -209,6 +209,9 @@ public:
     int getMainWndHeight() const;
     bool isMainWndMaximized() const;
 
+    bool isFullscreen() const;
+    void setIsFullscreen(bool isFullscreen);
+
     bool isSidebarVisible() const;
     void setSidebarVisible(bool visible);
 
@@ -593,6 +596,11 @@ private:
     bool zoomGesturesEnabled{};
 
     /**
+     *  If fullscreen is active
+     */
+    bool fullscreenActive{};
+
+    /**
      *  If the sidebar is visible
      */
     bool showSidebar{};
@@ -878,10 +886,10 @@ private:
     std::vector<std::string> viewModes;
 
     /**
-     * Which gui elements are shown for different view modes,
-     * separated by a colon (,)
+     * View mode attributes, separated by a colon (,)
+     * showMenubar,showToolbar,showSidebar,fullscreen
      */
-    std::vector<std::string> showElements;
+    std::vector<std::string> viewModeAttributes;
     // deprecated since view mode introduction
     std::string fullscreenHideElements;
     std::string presentationHideElements;

--- a/src/core/control/settings/Settings.h
+++ b/src/core/control/settings/Settings.h
@@ -878,7 +878,7 @@ private:
     /**
      * View-modes. Predefined: 0=default, 1=fullscreen, 2=presentation
      */
-    size_t activeViewMode;
+    ViewModeId activeViewMode;
     std::vector<ViewMode> viewModes;
 
     /**

--- a/src/core/control/settings/Settings.h
+++ b/src/core/control/settings/Settings.h
@@ -118,7 +118,13 @@ private:
     void loadButtonConfig();
 
 public:
+    // View Mode
+    bool loadViewMode(size_t mode);
+
     // Getter- / Setter
+    bool getActiveViewMode() const;
+    std::vector<std::string> getViewModeStrings() const;
+
     bool isPressureSensitivity() const;
     void setPressureSensitivity(gboolean presureSensitivity);
 
@@ -866,9 +872,17 @@ private:
     ButtonConfig* buttonConfig[BUTTON_COUNT]{};
 
     /**
-     * Which gui elements are hidden if you are in Fullscreen mode,
+     * View-modes, 0=default, 1=fullscreen, 2=presentation, +3=custom
+     */
+    size_t activeViewMode;
+    std::vector<std::string> viewModes;
+
+    /**
+     * Which gui elements are shown for different view modes,
      * separated by a colon (,)
      */
+    std::vector<std::string> showElements;
+    // deprecated since view mode introduction
     std::string fullscreenHideElements;
     std::string presentationHideElements;
 

--- a/src/core/control/settings/SettingsEnums.h
+++ b/src/core/control/settings/SettingsEnums.h
@@ -39,6 +39,12 @@ enum AttributeType {
     ATTRIBUTE_TYPE_BOOLEAN,
 };
 
+enum ViewMode {
+    VIEW_MODE_DEFAULT = 0,
+    VIEW_MODE_FULLSCREEN = 1,
+    VIEW_MODE_PRESENTATION = 2
+};
+
 // use this as a bit flag
 enum ScrollbarHideType {
     SCROLLBAR_HIDE_NONE = 0,

--- a/src/core/control/settings/SettingsEnums.h
+++ b/src/core/control/settings/SettingsEnums.h
@@ -39,12 +39,6 @@ enum AttributeType {
     ATTRIBUTE_TYPE_BOOLEAN,
 };
 
-enum ViewMode {
-    VIEW_MODE_DEFAULT = 0,
-    VIEW_MODE_FULLSCREEN = 1,
-    VIEW_MODE_PRESENTATION = 2
-};
-
 // use this as a bit flag
 enum ScrollbarHideType {
     SCROLLBAR_HIDE_NONE = 0,

--- a/src/core/control/settings/ViewModes.cpp
+++ b/src/core/control/settings/ViewModes.cpp
@@ -1,0 +1,30 @@
+#include "ViewModes.h"
+#include "util/StringUtils.h"
+
+#include <iostream>
+
+struct ViewMode settingsStringToViewMode(std::string viewModeString) {
+    struct ViewMode viewMode;
+    for (const std::string& attr : StringUtils::split(viewModeString, ',')) {
+        if (attr.compare(ATTR_GO_FULLSCREEN) == 0) {
+            viewMode.goFullscreen = true;
+        } else if (attr.compare(ATTR_SHOW_MENUBAR) == 0) {
+            viewMode.showMenubar = true;
+        } else if (attr.compare(ATTR_SHOW_TOOLBAR) == 0) {
+            viewMode.showToolbar = true;
+        } else if (attr.compare(ATTR_SHOW_SIDEBAR) == 0) {
+            viewMode.showSidebar = true;
+        }
+    }
+    return viewMode;
+}
+
+const std::string viewModeToSettingsString(struct ViewMode viewMode) {
+    if (!(viewMode.goFullscreen || viewMode.showMenubar || viewMode.showToolbar || viewMode.showSidebar)) {
+        return "";
+    }
+    return ((viewMode.goFullscreen ? "," + static_cast<std::string>(ATTR_GO_FULLSCREEN) : "")
+        + (viewMode.showMenubar ? "," + static_cast<std::string>(ATTR_SHOW_MENUBAR) : "")
+        + (viewMode.showToolbar ? "," + static_cast<std::string>(ATTR_SHOW_TOOLBAR) : "")
+        + (viewMode.showSidebar ? "," + static_cast<std::string>(ATTR_SHOW_SIDEBAR) : "")).erase(0,1);
+}

--- a/src/core/control/settings/ViewModes.h
+++ b/src/core/control/settings/ViewModes.h
@@ -1,0 +1,39 @@
+/*
+ * Xournal++
+ *
+ * View Mode struct & attribute definitions
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+#include <string>           // for string
+#include <vector>           // for vector
+#include <unordered_map>    // for unordered_map
+
+// reserved default view mode ids
+constexpr auto VIEW_MODE_DEFAULT = 0;
+constexpr auto VIEW_MODE_FULLSCREEN = 1;
+constexpr auto VIEW_MODE_PRESENTATION = 2;
+
+// view mode attributes
+constexpr auto ATTR_GO_FULLSCREEN = "goFullscren";
+constexpr auto ATTR_SHOW_MENUBAR  = "showMenubar";
+constexpr auto ATTR_SHOW_TOOLBAR  = "showToolbar";
+constexpr auto ATTR_SHOW_SIDEBAR  = "showSidebar";
+
+struct ViewMode {
+    std::string name{""};
+    // view mode attribues
+    bool goFullscreen{false};
+    bool showMenubar{false};
+    bool showToolbar{false};
+    bool showSidebar{false};
+};
+
+struct ViewMode settingsStringToViewMode(std::string viewModeString);
+const std::string viewModeToSettingsString(struct ViewMode viewMode);

--- a/src/core/control/settings/ViewModes.h
+++ b/src/core/control/settings/ViewModes.h
@@ -27,8 +27,6 @@ constexpr auto ATTR_SHOW_TOOLBAR  = "showToolbar";
 constexpr auto ATTR_SHOW_SIDEBAR  = "showSidebar";
 
 struct ViewMode {
-    std::string name{""};
-    // view mode attribues
     bool goFullscreen{false};
     bool showMenubar{false};
     bool showToolbar{false};

--- a/src/core/control/settings/ViewModes.h
+++ b/src/core/control/settings/ViewModes.h
@@ -15,8 +15,10 @@
 #include <vector>           // for vector
 #include <unordered_map>    // for unordered_map
 
+using ViewModeId = size_t;
+
 // reserved default view mode ids
-enum ViewModeId {
+enum PresetViewModeIds {
     VIEW_MODE_DEFAULT = 0,
     VIEW_MODE_FULLSCREEN = 1,
     VIEW_MODE_PRESENTATION = 2

--- a/src/core/control/settings/ViewModes.h
+++ b/src/core/control/settings/ViewModes.h
@@ -16,9 +16,11 @@
 #include <unordered_map>    // for unordered_map
 
 // reserved default view mode ids
-constexpr auto VIEW_MODE_DEFAULT = 0;
-constexpr auto VIEW_MODE_FULLSCREEN = 1;
-constexpr auto VIEW_MODE_PRESENTATION = 2;
+enum ViewModeId {
+    VIEW_MODE_DEFAULT = 0,
+    VIEW_MODE_FULLSCREEN = 1,
+    VIEW_MODE_PRESENTATION = 2
+};
 
 // view mode attributes
 constexpr auto ATTR_GO_FULLSCREEN = "goFullscren";
@@ -32,6 +34,11 @@ struct ViewMode {
     bool showToolbar{false};
     bool showSidebar{false};
 };
+
+// default ViewModes
+constexpr ViewMode VIEW_MODE_STRUCT_DEFAULT{false, true, true, true};
+constexpr ViewMode VIEW_MODE_STRUCT_FULLSCREEN{true, false, true, true};
+constexpr ViewMode VIEW_MODE_STRUCT_PRESENTATION{true, false, true, false};
 
 struct ViewMode settingsStringToViewMode(std::string viewModeString);
 const std::string viewModeToSettingsString(struct ViewMode viewMode);

--- a/src/core/gui/MainWindow.cpp
+++ b/src/core/gui/MainWindow.cpp
@@ -513,6 +513,15 @@ auto MainWindow::deleteEventCallback(GtkWidget* widget, GdkEvent* event, Control
     return true;
 }
 
+void MainWindow::setMenubarVisible(bool visible) {
+    GtkWidget* menu = get("mainMenubar");
+    if (visible && !gtk_widget_is_visible(menu)) {
+        toggleMenuBar(this);
+    } else if (!visible && gtk_widget_is_visible(menu)) {
+        toggleMenuBar(this);
+    }
+}
+
 void MainWindow::setSidebarVisible(bool visible) {
     Settings* settings = control->getSettings();
 

--- a/src/core/gui/MainWindow.h
+++ b/src/core/gui/MainWindow.h
@@ -78,6 +78,7 @@ public:
 
     XournalView* getXournal() const;
 
+    void setMenubarVisible(bool visible);
     void setSidebarVisible(bool visible);
     void setToolbarVisible(bool visible);
 

--- a/src/core/gui/dialog/SettingsDialog.cpp
+++ b/src/core/gui/dialog/SettingsDialog.cpp
@@ -536,7 +536,7 @@ void SettingsDialog::load() {
     bool showPresentationSidebar = false;
     bool goPresentationFullscreen = false;
 
-    string hidden = settings->getViewModeAttributes().at(1); // TODO replace hardcoded size_t
+    string hidden = settings->getViewModeAttributes().at(ViewMode::VIEW_MODE_FULLSCREEN);
     for (const string& attr : StringUtils::split(hidden, ',')) {
         if (attr == "showMenubar") {
             showFullscreenMenubar = true;
@@ -547,7 +547,7 @@ void SettingsDialog::load() {
         }
     }
 
-    hidden = settings->getViewModeAttributes().at(2); // TODO replace hardcoded size_t
+    hidden = settings->getViewModeAttributes().at(ViewMode::VIEW_MODE_PRESENTATION);
     for (const string& attr : StringUtils::split(hidden, ',')) {
         if (attr == "showMenubar") {
             showPresentationMenubar = true;
@@ -838,15 +838,15 @@ void SettingsDialog::save() {
     bool showFullscreenMenubar = getCheckbox("cbShowFullscreenMenubar");
     bool showFullscreenToolbar = getCheckbox("cbShowFullscreenToolbar");
     bool showFullscreenSidebar = getCheckbox("cbShowFullscreenSidebar");
-    settings->setViewModeAttributes( // TODO replace hardcoded size_t 1
-                    1, updateHideString(settings->getViewModeAttributes().at(1), showFullscreenMenubar, showFullscreenToolbar, showFullscreenSidebar, true));
+    settings->setViewModeAttributes(
+                    ViewMode::VIEW_MODE_FULLSCREEN, updateHideString(settings->getViewModeAttributes().at(ViewMode::VIEW_MODE_FULLSCREEN), showFullscreenMenubar, showFullscreenToolbar, showFullscreenSidebar, true));
     
     bool showPresentationMenubar = getCheckbox("cbShowPresentationMenubar");
     bool showPresentationToolbar = getCheckbox("cbShowPresentationToolbar");
     bool showPresentationSidebar = getCheckbox("cbShowPresentationSidebar");
     bool goPresentationFullscreen = getCheckbox("cbPresentationGoFullscreen");
-    settings->setViewModeAttributes( // TODO replace hardcoded size_t 2
-                    2, updateHideString(settings->getViewModeAttributes().at(2), showPresentationMenubar, showPresentationToolbar, showPresentationSidebar, goPresentationFullscreen));
+    settings->setViewModeAttributes(
+                    ViewMode::VIEW_MODE_PRESENTATION, updateHideString(settings->getViewModeAttributes().at(ViewMode::VIEW_MODE_PRESENTATION), showPresentationMenubar, showPresentationToolbar, showPresentationSidebar, goPresentationFullscreen));
 
     settings->setMenubarVisible(getCheckbox("cbHideMenubarStartup"));
     settings->setFilepathInTitlebarShown(getCheckbox("cbShowFilepathInTitlebar"));

--- a/src/core/gui/dialog/SettingsDialog.cpp
+++ b/src/core/gui/dialog/SettingsDialog.cpp
@@ -528,27 +528,26 @@ void SettingsDialog::load() {
             break;
     }
 
-    bool hideFullscreenMenubar = false;
-    bool hideFullscreenSidebar = false;
-    bool hidePresentationMenubar = false;
-    bool hidePresentationSidebar = false;
+    bool hideFullscreenMenubar = true;
+    bool hideFullscreenSidebar = true;
+    bool hidePresentationMenubar = true;
+    bool hidePresentationSidebar = true;
 
-    string hidden = settings->getFullscreenHideElements();
-
+    string hidden = settings->getViewModeAttributes().at(1); // TODO replace hardcoded size_t
     for (const string& element: StringUtils::split(hidden, ',')) {
-        if (element == "mainMenubar") {
-            hideFullscreenMenubar = true;
-        } else if (element == "sidebarContents") {
-            hideFullscreenSidebar = true;
+        if (element == "showMenubar") {
+            hideFullscreenMenubar = false;
+        } else if (element == "showSidebar") {
+            hideFullscreenSidebar = false;
         }
     }
 
-    hidden = settings->getPresentationHideElements();
+    hidden = settings->getViewModeAttributes().at(2); // TODO replace hardcoded size_t
     for (const string& element: StringUtils::split(hidden, ',')) {
-        if (element == "mainMenubar") {
-            hidePresentationMenubar = true;
-        } else if (element == "sidebarContents") {
-            hidePresentationSidebar = true;
+        if (element == "showMenubar") {
+            hidePresentationMenubar = false;
+        } else if (element == "showSidebar") {
+            hidePresentationSidebar = false;
         }
     }
 
@@ -662,13 +661,13 @@ auto SettingsDialog::updateHideString(const string& hidden, bool hideMenubar, bo
     string newHidden;
 
     for (const string& element: StringUtils::split(hidden, ',')) {
-        if (element == "mainMenubar") {
+        if (element == "showMenubar") {
             if (hideMenubar) {
                 hideMenubar = false;
             } else {
                 continue;
             }
-        } else if (element == "sidebarContents") {
+        } else if (element == "showSidebar") {
             if (hideSidebar) {
                 hideSidebar = false;
             } else {
@@ -686,14 +685,14 @@ auto SettingsDialog::updateHideString(const string& hidden, bool hideMenubar, bo
         if (!newHidden.empty()) {
             newHidden += ",";
         }
-        newHidden += "mainMenubar";
+        newHidden += "showMenubar";
     }
 
     if (hideSidebar) {
         if (!newHidden.empty()) {
             newHidden += ",";
         }
-        newHidden += "sidebarContents";
+        newHidden += "showSidebar";
     }
 
     return newHidden;
@@ -800,13 +799,13 @@ void SettingsDialog::save() {
 
     bool hideFullscreenMenubar = getCheckbox("cbHideFullscreenMenubar");
     bool hideFullscreenSidebar = getCheckbox("cbHideFullscreenSidebar");
-    settings->setFullscreenHideElements(
-            updateHideString(settings->getFullscreenHideElements(), hideFullscreenMenubar, hideFullscreenSidebar));
+    settings->setViewModeAttributes(
+                    1, updateHideString(settings->getViewModeAttributes().at(1), !hideFullscreenMenubar, !hideFullscreenSidebar)); // TODO replace hardcoded size_t
 
     bool hidePresentationMenubar = getCheckbox("cbHidePresentationMenubar");
     bool hidePresentationSidebar = getCheckbox("cbHidePresentationSidebar");
-    settings->setPresentationHideElements(updateHideString(settings->getPresentationHideElements(),
-                                                           hidePresentationMenubar, hidePresentationSidebar));
+    settings->setViewModeAttributes(
+                    2, updateHideString(settings->getViewModeAttributes().at(2), !hidePresentationMenubar, !hidePresentationSidebar)); // TODO replace hardcoded size_t
 
     settings->setMenubarVisible(getCheckbox("cbHideMenubarStartup"));
     settings->setFilepathInTitlebarShown(getCheckbox("cbShowFilepathInTitlebar"));

--- a/src/core/gui/dialog/SettingsDialog.cpp
+++ b/src/core/gui/dialog/SettingsDialog.cpp
@@ -528,11 +528,11 @@ void SettingsDialog::load() {
             break;
     }
 
-    auto viewMode = settings->getViewModes().at(ViewModeId::VIEW_MODE_FULLSCREEN);
-    bool showFullscreenMenubar = viewMode.goFullscreen;
+    auto viewMode = settings->getViewModes().at(PresetViewModeIds::VIEW_MODE_FULLSCREEN);
+    bool showFullscreenMenubar = viewMode.showMenubar;
     bool showFullscreenToolbar = viewMode.showToolbar;
     bool showFullscreenSidebar = viewMode.showSidebar;
-    viewMode = settings->getViewModes().at(ViewModeId::VIEW_MODE_PRESENTATION);
+    viewMode = settings->getViewModes().at(PresetViewModeIds::VIEW_MODE_PRESENTATION);
     bool showPresentationMenubar = viewMode.showMenubar;
     bool showPresentationToolbar = viewMode.showToolbar;
     bool showPresentationSidebar = viewMode.showSidebar;
@@ -751,14 +751,14 @@ void SettingsDialog::save() {
     viewModeFullscreen.showMenubar = getCheckbox("cbShowFullscreenMenubar");
     viewModeFullscreen.showToolbar = getCheckbox("cbShowFullscreenToolbar");
     viewModeFullscreen.showSidebar = getCheckbox("cbShowFullscreenSidebar");
-    settings->setViewMode(ViewModeId::VIEW_MODE_FULLSCREEN, viewModeFullscreen);
+    settings->setViewMode(PresetViewModeIds::VIEW_MODE_FULLSCREEN, viewModeFullscreen);
     
     ViewMode viewModePresentation;
     viewModePresentation.showMenubar = getCheckbox("cbShowPresentationMenubar");
     viewModePresentation.showToolbar = getCheckbox("cbShowPresentationToolbar");
     viewModePresentation.showSidebar = getCheckbox("cbShowPresentationSidebar");
     viewModePresentation.goFullscreen = getCheckbox("cbPresentationGoFullscreen");
-    settings->setViewMode(ViewModeId::VIEW_MODE_PRESENTATION, viewModePresentation);
+    settings->setViewMode(PresetViewModeIds::VIEW_MODE_PRESENTATION, viewModePresentation);
 
     settings->setMenubarVisible(getCheckbox("cbHideMenubarStartup"));
     settings->setFilepathInTitlebarShown(getCheckbox("cbShowFilepathInTitlebar"));

--- a/src/core/gui/dialog/SettingsDialog.cpp
+++ b/src/core/gui/dialog/SettingsDialog.cpp
@@ -528,15 +528,15 @@ void SettingsDialog::load() {
             break;
     }
 
-    auto activeViewMode = settings->getViewModes().at(VIEW_MODE_FULLSCREEN);
-    bool showFullscreenMenubar = activeViewMode.goFullscreen;
-    bool showFullscreenToolbar = activeViewMode.showToolbar;
-    bool showFullscreenSidebar = activeViewMode.showSidebar;
-    activeViewMode = settings->getViewModes().at(VIEW_MODE_PRESENTATION);
-    bool showPresentationMenubar = activeViewMode.showMenubar;
-    bool showPresentationToolbar = activeViewMode.showToolbar;
-    bool showPresentationSidebar = activeViewMode.showSidebar;
-    bool goPresentationFullscreen = activeViewMode.goFullscreen;
+    auto viewMode = settings->getViewModes().at(ViewModeId::VIEW_MODE_FULLSCREEN);
+    bool showFullscreenMenubar = viewMode.goFullscreen;
+    bool showFullscreenToolbar = viewMode.showToolbar;
+    bool showFullscreenSidebar = viewMode.showSidebar;
+    viewMode = settings->getViewModes().at(ViewModeId::VIEW_MODE_PRESENTATION);
+    bool showPresentationMenubar = viewMode.showMenubar;
+    bool showPresentationToolbar = viewMode.showToolbar;
+    bool showPresentationSidebar = viewMode.showSidebar;
+    bool goPresentationFullscreen = viewMode.goFullscreen;
 
     loadCheckbox("cbShowFullscreenMenubar", showFullscreenMenubar);
     loadCheckbox("cbShowFullscreenToolbar", showFullscreenToolbar);
@@ -751,14 +751,14 @@ void SettingsDialog::save() {
     viewModeFullscreen.showMenubar = getCheckbox("cbShowFullscreenMenubar");
     viewModeFullscreen.showToolbar = getCheckbox("cbShowFullscreenToolbar");
     viewModeFullscreen.showSidebar = getCheckbox("cbShowFullscreenSidebar");
-    settings->setViewMode(VIEW_MODE_FULLSCREEN, viewModeFullscreen);
+    settings->setViewMode(ViewModeId::VIEW_MODE_FULLSCREEN, viewModeFullscreen);
     
     ViewMode viewModePresentation;
     viewModePresentation.showMenubar = getCheckbox("cbShowPresentationMenubar");
     viewModePresentation.showToolbar = getCheckbox("cbShowPresentationToolbar");
     viewModePresentation.showSidebar = getCheckbox("cbShowPresentationSidebar");
     viewModePresentation.goFullscreen = getCheckbox("cbPresentationGoFullscreen");
-    settings->setViewMode(VIEW_MODE_PRESENTATION, viewModePresentation);
+    settings->setViewMode(ViewModeId::VIEW_MODE_PRESENTATION, viewModePresentation);
 
     settings->setMenubarVisible(getCheckbox("cbHideMenubarStartup"));
     settings->setFilepathInTitlebarShown(getCheckbox("cbShowFilepathInTitlebar"));

--- a/src/core/gui/dialog/SettingsDialog.h
+++ b/src/core/gui/dialog/SettingsDialog.h
@@ -69,7 +69,7 @@ private:
     void loadSlider(const char* name, double value);
     double getSlider(const char* name);
 
-    static std::string updateHideString(const std::string& hidden, bool hideMenubar, bool hideSidebar);
+    static std::string updateHideString(const std::string& hidden, bool showMenubar, bool showToolbar, bool showSidebar, bool goFullscreen);
 
     void initMouseButtonEvents();
     void initMouseButtonEvents(const char* hbox, int button, bool withDevice = false);

--- a/src/core/gui/dialog/SettingsDialog.h
+++ b/src/core/gui/dialog/SettingsDialog.h
@@ -69,8 +69,6 @@ private:
     void loadSlider(const char* name, double value);
     double getSlider(const char* name);
 
-    static std::string updateHideString(const std::string& hidden, bool showMenubar, bool showToolbar, bool showSidebar, bool goFullscreen);
-
     void initMouseButtonEvents();
     void initMouseButtonEvents(const char* hbox, int button, bool withDevice = false);
 

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -3589,9 +3589,9 @@ This setting can make it easier to draw with touch. </property>
                                         <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
-                                          <object class="GtkCheckButton" id="cbHideFullscreenMenubar">
-                                            <property name="label" translatable="yes">Hide Menubar</property>
-                                            <property name="name">cbHideFullscreenMenubar</property>
+                                          <object class="GtkCheckButton" id="cbShowFullscreenMenubar">
+                                            <property name="label" translatable="yes">Show Menubar</property>
+                                            <property name="name">cbShowFullscreenMenubar</property>
                                             <property name="visible">True</property>
                                             <property name="can-focus">True</property>
                                             <property name="receives-default">False</property>
@@ -3605,9 +3605,25 @@ This setting can make it easier to draw with touch. </property>
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkCheckButton" id="cbHideFullscreenSidebar">
-                                            <property name="label" translatable="yes">Hide Sidebar</property>
-                                            <property name="name">cbHideFullscreenSidebar</property>
+                                          <object class="GtkCheckButton" id="cbShowFullscreenToolbar">
+                                            <property name="label" translatable="yes">Show Toolbar</property>
+                                            <property name="name">cbShowFullscreenToolbar</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="xalign">0</property>
+                                            <property name="draw-indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="cbShowFullscreenSidebar">
+                                            <property name="label" translatable="yes">Show Sidebar</property>
+                                            <property name="name">cbShowFullscreenSidebar</property>
                                             <property name="visible">True</property>
                                             <property name="can-focus">True</property>
                                             <property name="receives-default">False</property>
@@ -3656,9 +3672,9 @@ This setting can make it easier to draw with touch. </property>
                                         <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
-                                          <object class="GtkCheckButton" id="cbHidePresentationMenubar">
-                                            <property name="label" translatable="yes">Hide Menubar</property>
-                                            <property name="name">cbHidePresentationMenubar</property>
+                                          <object class="GtkCheckButton" id="cbShowPresentationMenubar">
+                                            <property name="label" translatable="yes">Show Menubar</property>
+                                            <property name="name">cbShowPresentationMenubar</property>
                                             <property name="visible">True</property>
                                             <property name="can-focus">True</property>
                                             <property name="receives-default">False</property>
@@ -3672,9 +3688,41 @@ This setting can make it easier to draw with touch. </property>
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkCheckButton" id="cbHidePresentationSidebar">
-                                            <property name="label" translatable="yes">Hide Sidebar</property>
-                                            <property name="name">cbHidePresentationSidebar</property>
+                                          <object class="GtkCheckButton" id="cbShowPresentationToolbar">
+                                            <property name="label" translatable="yes">Show Toolbar</property>
+                                            <property name="name">cbShowPresentationToolbar</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="xalign">0</property>
+                                            <property name="draw-indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="cbShowPresentationSidebar">
+                                            <property name="label" translatable="yes">Show Sidebar</property>
+                                            <property name="name">cbShowPresentationSidebar</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="xalign">0</property>
+                                            <property name="draw-indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="cbPresentationGoFullscreen">
+                                            <property name="label" translatable="yes">Go Fullscreen</property>
+                                            <property name="name">cbPresentationGoFullscreen</property>
                                             <property name="visible">True</property>
                                             <property name="can-focus">True</property>
                                             <property name="receives-default">False</property>


### PR DESCRIPTION
## Issue
This PR solves the `automatically hide the sidebar, menubar, etc` TODO in #4456 (as well as #2773)

## Changes
#### This PR
This PR introduces better view-modes. This means the default-, fullscreen- and presentation mode are now refactored to being `view modes` in the settings, with customizable attributes (hide/show widgets & go into fullscreen).

According attributes can be changed in the settings under `View` (where previously similar attributes were shown, but had no effect).

#### Future possibilities
This implementation not only fixes the  `automatically hide the sidebar, menubar, etc` TODO in #4456, but also allows for easy future changes with these modes. Also custom additional modes might be implemented in future.
