### PR TITLE
Fix build failure on Ubuntu 18.04 and 20.04

### DIFF
--- a/src/core/gui/PageView.cpp
+++ b/src/core/gui/PageView.cpp
@@ -995,7 +995,7 @@ bool XojPageView::displayLinkPopover(std::shared_ptr<XojPdfPage> page, double pa
 
                         delete state;
                     }),
-                    new std::tuple(this, dest, popover));
+                    new std::tuple(std::make_tuple(this, dest, popover)));
         }
 
         gtk_widget_show_all(popover);


### PR DESCRIPTION
Fixes a build regression due to #4412.

We will be dropping support for 18.04 soon, but this failure also happens on 20.04, so we should fix the issue regardless.