### PR TITLE
Add new cursor for vertical space

### DIFF
--- a/src/core/gui/PageView.cpp
+++ b/src/core/gui/PageView.cpp
@@ -395,7 +395,7 @@ auto XojPageView::onButtonPressEvent(const PositionInputData& pos) -> bool {
         }
         auto* zoomControl = this->getXournal()->getControl()->getZoomControl();
         this->verticalSpace = std::make_unique<VerticalToolHandler>(this->page, this->settings, y, pos.isControlDown());
-        this->overlayViews.emplace_back(this->verticalSpace->createView(this, zoomControl, this->settings));
+        this->overlayViews.emplace_back(this->verticalSpace->createView(this, zoomControl, this->settings)); // TODO (willnilges) try moving this elsewhere?
     } else if (h->getToolType() == TOOL_SELECT_RECT || h->getToolType() == TOOL_SELECT_REGION ||
                h->getToolType() == TOOL_PLAY_OBJECT || h->getToolType() == TOOL_SELECT_OBJECT ||
                h->getToolType() == TOOL_SELECT_PDF_TEXT_LINEAR || h->getToolType() == TOOL_SELECT_PDF_TEXT_RECT) {

--- a/src/core/gui/PageView.cpp
+++ b/src/core/gui/PageView.cpp
@@ -395,7 +395,7 @@ auto XojPageView::onButtonPressEvent(const PositionInputData& pos) -> bool {
         }
         auto* zoomControl = this->getXournal()->getControl()->getZoomControl();
         this->verticalSpace = std::make_unique<VerticalToolHandler>(this->page, this->settings, y, pos.isControlDown());
-        this->overlayViews.emplace_back(this->verticalSpace->createView(this, zoomControl, this->settings)); // TODO (willnilges) try moving this elsewhere?
+        this->overlayViews.emplace_back(this->verticalSpace->createView(this, zoomControl, this->settings));
     } else if (h->getToolType() == TOOL_SELECT_RECT || h->getToolType() == TOOL_SELECT_REGION ||
                h->getToolType() == TOOL_PLAY_OBJECT || h->getToolType() == TOOL_SELECT_OBJECT ||
                h->getToolType() == TOOL_SELECT_PDF_TEXT_LINEAR || h->getToolType() == TOOL_SELECT_PDF_TEXT_RECT) {

--- a/src/core/gui/XournalppCursor.cpp
+++ b/src/core/gui/XournalppCursor.cpp
@@ -545,6 +545,9 @@ auto XournalppCursor::createHorizontalLineCursor() -> GdkCursor* {
         int width = static_cast<int>(std::round(range.getWidth() * zoom));
         int height = 5; // Five is the default cursor size used elsewhere in the app.
         gint dx = x - static_cast<int>(range.getX() * zoom) - page->getX();
+        if (this->currentCursorFlavour == dx) {
+            return nullptr;
+        }
 
         cairo_surface_t* crCursor = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
         cairo_t* cr = cairo_create(crCursor);
@@ -562,6 +565,7 @@ auto XournalppCursor::createHorizontalLineCursor() -> GdkCursor* {
                 gtk_widget_get_display(theWidget), pixbuf, dx, 0);
         g_object_unref(pixbuf);
         this->currentCursor = CRSR_HORIZONTALLINE;
+        this->currentCursorFlavour = dx;
         return gdkCursor; 
     }
     

--- a/src/core/gui/XournalppCursor.cpp
+++ b/src/core/gui/XournalppCursor.cpp
@@ -532,7 +532,7 @@ auto XournalppCursor::createHorizontalLineCursor(XournalView* xournal, MainWindo
     int px = pv->getX();
     int pw = pv->getDisplayWidth();
 
-    gint x, y;
+    gint x, y, winX, winY;
     GdkDevice *mouse_device;
 
     #if GTK_CHECK_VERSION (3,20,0)
@@ -544,10 +544,11 @@ auto XournalppCursor::createHorizontalLineCursor(XournalView* xournal, MainWindo
     #endif
 
     gdk_window_get_device_position (theWindow, mouse_device, &x, &y, nullptr);
+    gdk_window_get_device_position (mainWindow, mouse_device, &winX, &winY, nullptr);
 
     // Five is the default cursor size used elsewhere in the app.
     int height = 5;
-    //int width = gdk_window_get_width(theWindow);
+    int pageWidth = gdk_window_get_width(theWindow);
     int windowWidth = gdk_window_get_width(mainWindow);
 
     cairo_surface_t* crCursor = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, windowWidth, height);
@@ -569,10 +570,13 @@ auto XournalppCursor::createHorizontalLineCursor(XournalView* xournal, MainWindo
         g_object_unref(pixbuf);
         return gdkCursor;
     } else {
+        // If we're zoomed in enough, just draw the cursor across the whole screen
+        // FIXME (willnilges): Don't draw the cursor over the sidebar, if visible.
+        // FIXME (willnilges): Does the XojView take the sidebar into account?
         cairo_set_line_width(cr, 1.2);
-        cairo_set_source_rgb(cr, 0, 255, 0);
-        cairo_move_to(cr, px, 0);
-        cairo_line_to(cr, windowWidth, 0);
+        cairo_set_source_rgb(cr, 0, 200, 0);
+        cairo_move_to(cr, -winX, 0);
+        cairo_line_to(cr, pw, 0);
         cairo_close_path(cr);
         cairo_stroke(cr);
         cairo_destroy(cr);

--- a/src/core/gui/XournalppCursor.cpp
+++ b/src/core/gui/XournalppCursor.cpp
@@ -306,7 +306,6 @@ void XournalppCursor::updateCursor() {
                 setCursor(CRSR_SB_V_DOUBLE_ARROW);
             } else if (this->insidePage) {
                 cursor = createHorizontalLineCursor();
-                setCursor(CRSR_HORIZONTALLINE);
             }
         } else if (type == TOOL_SELECT_OBJECT) {
             setCursor(CRSR_DEFAULT);
@@ -541,7 +540,6 @@ auto XournalppCursor::createHorizontalLineCursor() -> GdkCursor* {
     // Five is the default cursor size used elsewhere in the app.
     int height = 5;
 
-    // Courtesy of Roland
     Layout* const layout = this->control->getWindow()->getLayout();
     XojPageView* page = layout->getPageViewAt(x, y);
     if (page) {
@@ -562,12 +560,14 @@ auto XournalppCursor::createHorizontalLineCursor() -> GdkCursor* {
         cairo_destroy(cr);
         GdkPixbuf* pixbuf = xoj_pixbuf_get_from_surface(crCursor, 0, 0, width, height);
         cairo_surface_destroy(crCursor);
-        //x = std::clamp(x, 0, windowWidth);
         GdkCursor* gdkCursor = gdk_cursor_new_from_pixbuf(
                 gtk_widget_get_display(theWidget), pixbuf, dx, 0);
         g_object_unref(pixbuf);
+        this->currentCursor = CRSR_HORIZONTALLINE;
         return gdkCursor; 
     }
+    // Use default cursor
+    this->currentCursor = CRSR_nullptr;
     return nullptr;
 }
 

--- a/src/core/gui/XournalppCursor.cpp
+++ b/src/core/gui/XournalppCursor.cpp
@@ -75,7 +75,7 @@ cursorStruct cssCursors[CRSR_END_OF_CURSORS];
 
 XournalppCursor::XournalppCursor(Control* control): control(control) {
     // clang-format off
-	// NOTE: Go ahead and use a fancy css cursor... but specify a common backup cursor. 
+	// NOTE: Go ahead and use a fancy css cursor... but specify a common backup cursor.
 	cssCursors[CRSR_nullptr                ] = 	{"",""};
 	cssCursors[CRSR_BUSY                ] = 	{"wait", 		""					};
 	cssCursors[CRSR_MOVE                ] = 	{"all-scroll", 	""					};
@@ -303,8 +303,7 @@ void XournalppCursor::updateCursor() {
                 setCursor(CRSR_SB_V_DOUBLE_ARROW);
             } else {
                 GdkWindow* theWindow = gtk_widget_get_window(xournal->getWidget());
-
-                cursor = createHorizontalLineCursor(5, 120 / 255.0, theWindow);
+                cursor = createHorizontalLineCursor(theWindow);
             }
         } else if (type == TOOL_SELECT_OBJECT) {
             setCursor(CRSR_DEFAULT);
@@ -519,7 +518,7 @@ auto XournalppCursor::createHighlighterOrPenCursor(int size, double alpha) -> Gd
 }
 
 
-auto XournalppCursor::createHorizontalLineCursor(int size, double alpha, GdkWindow* theWindow) -> GdkCursor* {
+auto XournalppCursor::createHorizontalLineCursor(GdkWindow* theWindow) -> GdkCursor* {
     gint x, y;
     GdkDevice *mouse_device;
 
@@ -533,16 +532,17 @@ auto XournalppCursor::createHorizontalLineCursor(int size, double alpha, GdkWind
 
     gdk_window_get_device_position (theWindow, mouse_device, &x, &y, NULL);
 
-    int height = size;
+    // Five is the default cursor size used elsewhere in the app.
+    int height = 5;
     int width = gdk_window_get_width(theWindow);
 
-    int centerY = height / 2;
+//    int centerY = height / 2;
     cairo_surface_t* crCursor = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
     cairo_t* cr = cairo_create(crCursor);
 
     cairo_set_line_width(cr, 1.2);
-    cairo_move_to(cr, 0, centerY);
-    cairo_line_to(cr, width, centerY);
+    cairo_move_to(cr, 0, 0);
+    cairo_line_to(cr, width, 0);
     cairo_close_path(cr);
     cairo_stroke(cr);
 
@@ -551,7 +551,7 @@ auto XournalppCursor::createHorizontalLineCursor(int size, double alpha, GdkWind
     cairo_surface_destroy(crCursor);
     x = std::clamp(x, 0, width);
     GdkCursor* gdkCursor = gdk_cursor_new_from_pixbuf(
-            gtk_widget_get_display(control->getWindow()->getXournal()->getWidget()), pixbuf, x, centerY);
+            gtk_widget_get_display(control->getWindow()->getXournal()->getWidget()), pixbuf, x, 0);
     g_object_unref(pixbuf);
     return gdkCursor;
 }

--- a/src/core/gui/XournalppCursor.cpp
+++ b/src/core/gui/XournalppCursor.cpp
@@ -523,7 +523,6 @@ auto XournalppCursor::createHighlighterOrPenCursor(int size, double alpha) -> Gd
 
 auto XournalppCursor::createHorizontalLineCursor(int size, double alpha, GdkWindow* theWindow) -> GdkCursor* {
     gint x, y;
-    GdkWindow *window;
     GdkDevice *mouse_device;
 
     #if GTK_CHECK_VERSION (3,20,0)
@@ -534,9 +533,7 @@ auto XournalppCursor::createHorizontalLineCursor(int size, double alpha, GdkWind
     mouse_device = gdk_device_manager_get_client_pointer (devman);
     #endif
 
-    window = gdk_display_get_default_group (gdk_display_get_default ());
     gdk_window_get_device_position (theWindow, mouse_device, &x, &y, NULL);
-    //g_message ("pointer: %i %i", x, y);
 
     int height = size;
     int width = gdk_window_get_width(theWindow);

--- a/src/core/gui/XournalppCursor.cpp
+++ b/src/core/gui/XournalppCursor.cpp
@@ -58,6 +58,7 @@ enum AVAILABLECURSORS {
     CRSR_DRAWDIRCTRL,       // "
     CRSR_DRAWDIRSHIFTCTRL,  // "
     CRSR_RESIZE,
+    CRSR_HORIZONTALLINE,
 
     CRSR_END_OF_CURSORS
 };
@@ -103,7 +104,8 @@ XournalppCursor::XournalppCursor(Control* control): control(control) {
 	cssCursors[CRSR_DRAWDIRSHIFT        ] = 	{"",""};			// "
 	cssCursors[CRSR_DRAWDIRCTRL         ] = 	{"",""};			// "
 	cssCursors[CRSR_DRAWDIRSHIFTCTRL    ] = 	{"",""};			// "
-    cssCursors[CRSR_RESIZE              ] =     {"",""};            // "
+	cssCursors[CRSR_RESIZE              ] = 	{"",""};			// "
+	cssCursors[CRSR_HORIZONTALLINE      ] = 	{"",""};			// "
 };
 // clang-format on
 
@@ -302,8 +304,9 @@ void XournalppCursor::updateCursor() {
         } else if (type == TOOL_VERTICAL_SPACE) {
             if (this->mouseDown) {
                 setCursor(CRSR_SB_V_DOUBLE_ARROW);
-            } else {
+            } else if (this->insidePage) {
                 cursor = createHorizontalLineCursor(xournal);
+                setCursor(CRSR_HORIZONTALLINE);
             }
         } else if (type == TOOL_SELECT_OBJECT) {
             setCursor(CRSR_DEFAULT);
@@ -561,7 +564,7 @@ auto XournalppCursor::createHorizontalLineCursor(XournalView* xournal) -> GdkCur
     cairo_destroy(cr);
     GdkPixbuf* pixbuf = xoj_pixbuf_get_from_surface(crCursor, 0, 0, width, height);
     cairo_surface_destroy(crCursor);
-    x = std::clamp(x, 0, width);
+    //x = std::clamp(x, 0, width);
     GdkCursor* gdkCursor = gdk_cursor_new_from_pixbuf(
             gtk_widget_get_display(control->getWindow()->getXournal()->getWidget()), pixbuf, x, 0);
     g_object_unref(pixbuf);

--- a/src/core/gui/XournalppCursor.cpp
+++ b/src/core/gui/XournalppCursor.cpp
@@ -522,7 +522,6 @@ auto XournalppCursor::createHighlighterOrPenCursor(int size, double alpha) -> Gd
 
 
 auto XournalppCursor::createHorizontalLineCursor(XournalView* xournal, MainWindow* win) -> GdkCursor* {
-
     GdkWindow* theWindow = gtk_widget_get_window(xournal->getWidget());
     GdkWindow* mainWindow = gtk_widget_get_window(win->getWindow());
     size_t page = xournal->getCurrentPage();
@@ -575,16 +574,16 @@ auto XournalppCursor::createHorizontalLineCursor(XournalView* xournal, MainWindo
         // FIXME (willnilges): Does the XojView take the sidebar into account?
         cairo_set_line_width(cr, 1.2);
         cairo_set_source_rgb(cr, 0, 200, 0);
-        cairo_move_to(cr, -winX, 0);
-        cairo_line_to(cr, pw, 0);
+        cairo_move_to(cr, px, 0);
+        cairo_line_to(cr, px + pw + winX, 0);
         cairo_close_path(cr);
         cairo_stroke(cr);
         cairo_destroy(cr);
         GdkPixbuf* pixbuf = xoj_pixbuf_get_from_surface(crCursor, 0, 0, windowWidth, height);
         cairo_surface_destroy(crCursor);
-        x = std::clamp(x, 0, windowWidth);
+        //x = std::clamp(x, 0, windowWidth);
         GdkCursor* gdkCursor = gdk_cursor_new_from_pixbuf(
-                gtk_widget_get_display(control->getWindow()->getWindow()), pixbuf, x, 0);
+                gtk_widget_get_display(control->getWindow()->getXournal()->getWidget()), pixbuf, winX, 0);
         g_object_unref(pixbuf);
         return gdkCursor;
     }

--- a/src/core/gui/XournalppCursor.cpp
+++ b/src/core/gui/XournalppCursor.cpp
@@ -299,7 +299,6 @@ void XournalppCursor::updateCursor() {
         } else if (type == TOOL_FLOATING_TOOLBOX) {
             setCursor(CRSR_DEFAULT);
         } else if (type == TOOL_VERTICAL_SPACE) {
-            // FIXME: (willnilges) Why is this whole block an if/else tree? Could this be a switch statement instead?
             if (this->mouseDown) {
                 setCursor(CRSR_SB_V_DOUBLE_ARROW);
             } else {
@@ -538,9 +537,6 @@ auto XournalppCursor::createHorizontalLineCursor(int size, double alpha, GdkWind
     int height = size;
     int width = gdk_window_get_width(theWindow);
 
-    // We change the drawing method, now the center with the colored dot of the pen
-    // is at the center of the cairo surface, and when we load the cursor, we load it
-    // with the relative offset
     int centerY = height / 2;
     cairo_surface_t* crCursor = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
     cairo_t* cr = cairo_create(crCursor);

--- a/src/core/gui/XournalppCursor.cpp
+++ b/src/core/gui/XournalppCursor.cpp
@@ -566,6 +566,7 @@ auto XournalppCursor::createHorizontalLineCursor() -> GdkCursor* {
         cairo_close_path(cr.get());
         cairo_stroke(cr.get());
         xoj::util::GObjectSPtr<GdkPixbuf> pixbuf(xoj_pixbuf_get_from_surface(crCursor.get(), 0, 0, width, height), xoj::util::adopt);
+        dx = std::clamp(dx, 0, width);
         GdkCursor* gdkCursor = gdk_cursor_new_from_pixbuf(
                 gtk_widget_get_display(theWidget), pixbuf.get(), dx, 0);
         this->currentCursor = CRSR_HORIZONTALLINE;

--- a/src/core/gui/XournalppCursor.cpp
+++ b/src/core/gui/XournalppCursor.cpp
@@ -545,7 +545,7 @@ auto XournalppCursor::createHorizontalLineCursor() -> GdkCursor* {
         int width = static_cast<int>(std::round(range.getWidth() * zoom));
         int height = 5; // Five is the default cursor size used elsewhere in the app.
         gint dx = x - static_cast<int>(range.getX() * zoom) - page->getX();
-        if (this->currentCursorFlavour == dx) {
+        if (this->currentCursorFlavour == (dx << (sizeof(gint) * 4) | width)) {
             return nullptr;
         }
 
@@ -565,7 +565,9 @@ auto XournalppCursor::createHorizontalLineCursor() -> GdkCursor* {
                 gtk_widget_get_display(theWidget), pixbuf, dx, 0);
         g_object_unref(pixbuf);
         this->currentCursor = CRSR_HORIZONTALLINE;
-        this->currentCursorFlavour = dx;
+        // Shift the 'dx' and 'width' variables together to check if we need
+        // to re-draw the cursor.
+        this->currentCursorFlavour = (gulong) (dx << (sizeof(gint) * 4) | width);
         return gdkCursor; 
     }
     

--- a/src/core/gui/XournalppCursor.cpp
+++ b/src/core/gui/XournalppCursor.cpp
@@ -556,8 +556,8 @@ auto XournalppCursor::createHorizontalLineCursor(XournalView* xournal, MainWindo
     if (px + pw < windowWidth) {
         cairo_set_line_width(cr, 1.2);
         cairo_set_source_rgb(cr, 100, 0, 0);
-        cairo_move_to(cr, px, 0);
-        cairo_line_to(cr, px + pw, 0);
+        cairo_move_to(cr, px + (control->getSettings()->isSidebarVisible() ? control->getSettings()->getSidebarWidth() : 0), 0);
+        cairo_line_to(cr, px + pw + (control->getSettings()->isSidebarVisible() ? control->getSettings()->getSidebarWidth() : 0), 0);
         cairo_close_path(cr);
         cairo_stroke(cr);
         cairo_destroy(cr);
@@ -574,7 +574,7 @@ auto XournalppCursor::createHorizontalLineCursor(XournalView* xournal, MainWindo
         // FIXME (willnilges): Does the XojView take the sidebar into account?
         cairo_set_line_width(cr, 1.2);
         cairo_set_source_rgb(cr, 0, 100, 0);
-        cairo_move_to(cr, 0, 0);
+        cairo_move_to(cr, 0 + (control->getSettings()->isSidebarVisible() ? control->getSettings()->getSidebarWidth() : 0), 0);
         cairo_line_to(cr, px + pw + winX, 0);
         cairo_close_path(cr);
         cairo_stroke(cr);

--- a/src/core/gui/XournalppCursor.cpp
+++ b/src/core/gui/XournalppCursor.cpp
@@ -521,16 +521,6 @@ auto XournalppCursor::createHighlighterOrPenCursor(int size, double alpha) -> Gd
 
 
 auto XournalppCursor::createHorizontalLineCursor() -> GdkCursor* {
-    using HorizontalLineFlavour = union {
-      struct {
-        int dx : 32;
-        int width : 32;
-      } data;
-      gulong raw;
-    };
-    static_assert(sizeof(HorizontalLineFlavour{}.data) == sizeof(HorizontalLineFlavour{}.raw),
-                  "Size of packed representation of HorizontalLineFlavour does not match size of integer representation");
-
     GtkWidget* theWidget = control->getWindow()->getXournal()->getWidget();
     GdkWindow* theWindow = gtk_widget_get_window(theWidget);
 
@@ -555,7 +545,7 @@ auto XournalppCursor::createHorizontalLineCursor() -> GdkCursor* {
         int width = static_cast<int>(std::round(range.getWidth() * zoom));
         int height = 5; // Five is the default cursor size used elsewhere in the app.
         gint dx = x - static_cast<int>(range.getX() * zoom) - page->getX();
-        if (this->currentCursorFlavour == HorizontalLineFlavour{{dx, width}}.raw) {
+        if (this->currentCursorFlavour == (dx << (sizeof(gint) * 4) | width)) {
             return nullptr;
         }
 
@@ -579,7 +569,7 @@ auto XournalppCursor::createHorizontalLineCursor() -> GdkCursor* {
         this->currentCursor = CRSR_HORIZONTALLINE;
         // Shift the 'dx' and 'width' variables together to check if we need
         // to re-draw the cursor.
-        this->currentCursorFlavour = HorizontalLineFlavour{{dx, width}}.raw;
+        this->currentCursorFlavour = (gulong) (dx << (sizeof(gint) * 4) | width);
         return gdkCursor; 
     }
     

--- a/src/core/gui/XournalppCursor.cpp
+++ b/src/core/gui/XournalppCursor.cpp
@@ -554,7 +554,7 @@ auto XournalppCursor::createHorizontalLineCursor() -> GdkCursor* {
         cairo_t* cr = cairo_create(crCursor);
 
         cairo_set_line_width(cr, 1.2);
-        cairo_set_source_rgb(cr, 100, 0, 0);
+        Util::cairo_set_source_rgbi(cr, this->control->getSettings()->getSelectionColor());
         cairo_move_to(cr, 0, 0);
         cairo_line_to(cr, width, 0);
         cairo_close_path(cr);

--- a/src/core/gui/XournalppCursor.cpp
+++ b/src/core/gui/XournalppCursor.cpp
@@ -545,7 +545,10 @@ auto XournalppCursor::createHorizontalLineCursor() -> GdkCursor* {
         int width = static_cast<int>(std::round(range.getWidth() * zoom));
         int height = 5; // Five is the default cursor size used elsewhere in the app.
         gint dx = x - static_cast<int>(range.getX() * zoom) - page->getX();
-        if (this->currentCursorFlavour == (dx << (sizeof(gint) * 4) | width)) {
+        // 64-bit field containing the current value of dx and width to check
+        // if we need to re-draw the cursor
+        auto flavour = (gulong) (dx << (sizeof(gint) * 4) | width);
+        if (this->currentCursorFlavour == flavour) {
             return nullptr;
         }
 
@@ -569,7 +572,7 @@ auto XournalppCursor::createHorizontalLineCursor() -> GdkCursor* {
         this->currentCursor = CRSR_HORIZONTALLINE;
         // Shift the 'dx' and 'width' variables together to check if we need
         // to re-draw the cursor.
-        this->currentCursorFlavour = (gulong) (dx << (sizeof(gint) * 4) | width);
+        this->currentCursorFlavour = flavour;
         return gdkCursor; 
     }
     

--- a/src/core/gui/XournalppCursor.cpp
+++ b/src/core/gui/XournalppCursor.cpp
@@ -549,8 +549,10 @@ auto XournalppCursor::createHorizontalLineCursor() -> GdkCursor* {
             return nullptr;
         }
 
-        cairo_surface_t* crCursor = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
-        cairo_t* cr = cairo_create(crCursor);
+        xoj::util::CairoSurfaceSPtr crCursor(
+            cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height), xoj::util::adopt
+        );
+        cairo_t* cr = cairo_create(crCursor.get());
 
         cairo_set_line_width(cr, 1.2);
         Util::cairo_set_source_rgbi(cr, this->control->getSettings()->getSelectionColor());
@@ -559,8 +561,8 @@ auto XournalppCursor::createHorizontalLineCursor() -> GdkCursor* {
         cairo_close_path(cr);
         cairo_stroke(cr);
         cairo_destroy(cr);
-        GdkPixbuf* pixbuf = xoj_pixbuf_get_from_surface(crCursor, 0, 0, width, height);
-        cairo_surface_destroy(crCursor);
+        GdkPixbuf* pixbuf = xoj_pixbuf_get_from_surface(crCursor.get(), 0, 0, width, height);
+        crCursor.release();
         GdkCursor* gdkCursor = gdk_cursor_new_from_pixbuf(
                 gtk_widget_get_display(theWidget), pixbuf, dx, 0);
         g_object_unref(pixbuf);

--- a/src/core/gui/XournalppCursor.cpp
+++ b/src/core/gui/XournalppCursor.cpp
@@ -542,8 +542,8 @@ auto XournalppCursor::createHorizontalLineCursor() -> GdkCursor* {
     if (page) {
         Range range = page->getVisiblePart();
         double zoom = control->getZoomControl()->getZoom();
-        int width = static_cast<int>(std::round(range.getWidth() * zoom));
-        int height = 5; // Five is the default cursor size used elsewhere in the app.
+        const int width = static_cast<int>(std::round(range.getWidth() * zoom));
+        const int height = 5; // Five is the default cursor size used elsewhere in the app.
         gint dx = x - static_cast<int>(range.getX() * zoom) - page->getX();
         // 64-bit field containing the current value of dx and width to check
         // if we need to re-draw the cursor

--- a/src/core/gui/XournalppCursor.cpp
+++ b/src/core/gui/XournalppCursor.cpp
@@ -549,7 +549,7 @@ auto XournalppCursor::createHorizontalLineCursor() -> GdkCursor* {
         auto dx = (int32_t) (x - static_cast<int32_t>(range.getX() * zoom) - page->getX());
         // 64-bit field containing the current value of dx and width to check
         // if we need to re-draw the cursor
-        auto flavour = (int64_t) (dx << (sizeof(gint) * 4) | width);
+        auto flavour = (static_cast<gulong>(dx) << (sizeof(decltype(width)) * 8)) | width;
         if (this->currentCursorFlavour == flavour) {
             return nullptr;
         }

--- a/src/core/gui/XournalppCursor.cpp
+++ b/src/core/gui/XournalppCursor.cpp
@@ -537,15 +537,13 @@ auto XournalppCursor::createHorizontalLineCursor() -> GdkCursor* {
 
     gdk_window_get_device_position (theWindow, mouse_device, &x, &y, nullptr);
 
-    // Five is the default cursor size used elsewhere in the app.
-    int height = 5;
-
     Layout* const layout = this->control->getWindow()->getLayout();
     XojPageView* page = layout->getPageViewAt(x, y);
     if (page) {
         Range range = page->getVisiblePart();
         double zoom = control->getZoomControl()->getZoom();
         int width = static_cast<int>(std::round(range.getWidth() * zoom));
+        int height = 5; // Five is the default cursor size used elsewhere in the app.
         gint dx = x - static_cast<int>(range.getX() * zoom) - page->getX();
 
         cairo_surface_t* crCursor = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
@@ -566,8 +564,14 @@ auto XournalppCursor::createHorizontalLineCursor() -> GdkCursor* {
         this->currentCursor = CRSR_HORIZONTALLINE;
         return gdkCursor; 
     }
-    // Use default cursor
-    this->currentCursor = CRSR_nullptr;
+    
+    // If this somehow gets called when we're not hovering over a page
+    // set the cursor back to the default. If it already is the default,
+    // then just keep it that way to save processing power.
+    if (this->currentCursor != CRSR_DEFAULT) {
+        this->currentCursor = CRSR_DEFAULT;
+        return gdk_cursor_new_from_name(gdk_window_get_display(theWindow), cssCursors[this->currentCursor].cssName);
+    }
     return nullptr;
 }
 

--- a/src/core/gui/XournalppCursor.cpp
+++ b/src/core/gui/XournalppCursor.cpp
@@ -20,6 +20,7 @@
 #include "util/pixbuf-utils.h"               // for xoj_pixbuf_get_from_surface
 
 #include "XournalView.h"  // for XournalView
+#include "PageView.h"
 
 
 // NOTE:  Every cursor change must result in the setting of this->currentCursor to the new cursor type even for custom
@@ -302,8 +303,7 @@ void XournalppCursor::updateCursor() {
             if (this->mouseDown) {
                 setCursor(CRSR_SB_V_DOUBLE_ARROW);
             } else {
-                GdkWindow* theWindow = gtk_widget_get_window(xournal->getWidget());
-                cursor = createHorizontalLineCursor(theWindow);
+                cursor = createHorizontalLineCursor(xournal);
             }
         } else if (type == TOOL_SELECT_OBJECT) {
             setCursor(CRSR_DEFAULT);
@@ -518,7 +518,15 @@ auto XournalppCursor::createHighlighterOrPenCursor(int size, double alpha) -> Gd
 }
 
 
-auto XournalppCursor::createHorizontalLineCursor(GdkWindow* theWindow) -> GdkCursor* {
+auto XournalppCursor::createHorizontalLineCursor(XournalView* xournal) -> GdkCursor* {
+
+    GdkWindow* theWindow = gtk_widget_get_window(xournal->getWidget());
+    size_t page = xournal->getCurrentPage();
+    //auto pvRect = xournal->getVisibleRect(page);
+    XojPageView* pv = xournal->getViewFor(page);
+    int pvWidth = pv->getDisplayWidth();
+    int pageStart = pv->getX();
+
     gint x, y;
     GdkDevice *mouse_device;
 
@@ -536,13 +544,12 @@ auto XournalppCursor::createHorizontalLineCursor(GdkWindow* theWindow) -> GdkCur
     int height = 5;
     int width = gdk_window_get_width(theWindow);
 
-//    int centerY = height / 2;
     cairo_surface_t* crCursor = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
     cairo_t* cr = cairo_create(crCursor);
 
     cairo_set_line_width(cr, 1.2);
-    cairo_move_to(cr, 0, 0);
-    cairo_line_to(cr, width, 0);
+    cairo_move_to(cr, pageStart, 0);
+    cairo_line_to(cr, pageStart + pvWidth, 0);
     cairo_close_path(cr);
     cairo_stroke(cr);
 

--- a/src/core/gui/XournalppCursor.cpp
+++ b/src/core/gui/XournalppCursor.cpp
@@ -521,6 +521,16 @@ auto XournalppCursor::createHighlighterOrPenCursor(int size, double alpha) -> Gd
 
 
 auto XournalppCursor::createHorizontalLineCursor() -> GdkCursor* {
+    using HorizontalLineFlavour = union {
+      struct {
+        int dx : 32;
+        int width : 32;
+      } data;
+      gulong raw;
+    };
+    static_assert(sizeof(HorizontalLineFlavour{}.data) == sizeof(HorizontalLineFlavour{}.raw),
+                  "Size of packed representation of HorizontalLineFlavour does not match size of integer representation");
+
     GtkWidget* theWidget = control->getWindow()->getXournal()->getWidget();
     GdkWindow* theWindow = gtk_widget_get_window(theWidget);
 
@@ -545,7 +555,7 @@ auto XournalppCursor::createHorizontalLineCursor() -> GdkCursor* {
         int width = static_cast<int>(std::round(range.getWidth() * zoom));
         int height = 5; // Five is the default cursor size used elsewhere in the app.
         gint dx = x - static_cast<int>(range.getX() * zoom) - page->getX();
-        if (this->currentCursorFlavour == (dx << (sizeof(gint) * 4) | width)) {
+        if (this->currentCursorFlavour == HorizontalLineFlavour{{dx, width}}.raw) {
             return nullptr;
         }
 
@@ -569,7 +579,7 @@ auto XournalppCursor::createHorizontalLineCursor() -> GdkCursor* {
         this->currentCursor = CRSR_HORIZONTALLINE;
         // Shift the 'dx' and 'width' variables together to check if we need
         // to re-draw the cursor.
-        this->currentCursorFlavour = (gulong) (dx << (sizeof(gint) * 4) | width);
+        this->currentCursorFlavour = HorizontalLineFlavour{{dx, width}}.raw;
         return gdkCursor; 
     }
     

--- a/src/core/gui/XournalppCursor.cpp
+++ b/src/core/gui/XournalppCursor.cpp
@@ -302,7 +302,6 @@ void XournalppCursor::updateCursor() {
             if (this->mouseDown) {
                 setCursor(CRSR_SB_V_DOUBLE_ARROW);
             } else {
-                setCursor(CRSR_TCROSS);
                 GdkWindow* theWindow = gtk_widget_get_window(xournal->getWidget());
 
                 cursor = createHorizontalLineCursor(5, 120 / 255.0, theWindow);

--- a/src/core/gui/XournalppCursor.cpp
+++ b/src/core/gui/XournalppCursor.cpp
@@ -557,6 +557,7 @@ auto XournalppCursor::createHorizontalLineCursor(int size, double alpha, GdkWind
     cairo_destroy(cr);
     GdkPixbuf* pixbuf = xoj_pixbuf_get_from_surface(crCursor, 0, 0, width, height);
     cairo_surface_destroy(crCursor);
+    x = std::clamp(x, 0, width);
     GdkCursor* gdkCursor = gdk_cursor_new_from_pixbuf(
             gtk_widget_get_display(control->getWindow()->getXournal()->getWidget()), pixbuf, x, centerY);
     g_object_unref(pixbuf);

--- a/src/core/gui/XournalppCursor.cpp
+++ b/src/core/gui/XournalppCursor.cpp
@@ -305,7 +305,7 @@ void XournalppCursor::updateCursor() {
             if (this->mouseDown) {
                 setCursor(CRSR_SB_V_DOUBLE_ARROW);
             } else if (this->insidePage) {
-                cursor = createHorizontalLineCursor(xournal, win);
+                cursor = createHorizontalLineCursor();
                 setCursor(CRSR_HORIZONTALLINE);
             }
         } else if (type == TOOL_SELECT_OBJECT) {
@@ -521,11 +521,11 @@ auto XournalppCursor::createHighlighterOrPenCursor(int size, double alpha) -> Gd
 }
 
 
-auto XournalppCursor::createHorizontalLineCursor(XournalView* xournal, MainWindow* win) -> GdkCursor* {
-    GdkWindow* theWindow = gtk_widget_get_window(xournal->getWidget());
-    GdkWindow* mainWindow = gtk_widget_get_window(win->getWindow());
+auto XournalppCursor::createHorizontalLineCursor() -> GdkCursor* {
+    GtkWidget* theWidget = control->getWindow()->getXournal()->getWidget();
+    GdkWindow* theWindow = gtk_widget_get_window(theWidget);
 
-    gint x, y, winX, winY;
+    gint x, y;
     GdkDevice *mouse_device;
 
     #if GTK_CHECK_VERSION (3,20,0)
@@ -537,7 +537,6 @@ auto XournalppCursor::createHorizontalLineCursor(XournalView* xournal, MainWindo
     #endif
 
     gdk_window_get_device_position (theWindow, mouse_device, &x, &y, nullptr);
-    gdk_window_get_device_position (mainWindow, mouse_device, &winX, &winY, nullptr);
 
     // Five is the default cursor size used elsewhere in the app.
     int height = 5;
@@ -565,45 +564,10 @@ auto XournalppCursor::createHorizontalLineCursor(XournalView* xournal, MainWindo
         cairo_surface_destroy(crCursor);
         //x = std::clamp(x, 0, windowWidth);
         GdkCursor* gdkCursor = gdk_cursor_new_from_pixbuf(
-                gtk_widget_get_display(control->getWindow()->getXournal()->getWidget()), pixbuf, dx, 0);
+                gtk_widget_get_display(theWidget), pixbuf, dx, 0);
         g_object_unref(pixbuf);
         return gdkCursor; 
     }
-
-    /*if (px + pw < windowWidth) {
-        cairo_set_line_width(cr, 1.2);
-        cairo_set_source_rgb(cr, 100, 0, 0);
-        cairo_move_to(cr, px + (control->getSettings()->isSidebarVisible() ? control->getSettings()->getSidebarWidth() : 0), 0);
-        cairo_line_to(cr, px + pw + (control->getSettings()->isSidebarVisible() ? control->getSettings()->getSidebarWidth() : 0), 0);
-        cairo_close_path(cr);
-        cairo_stroke(cr);
-        cairo_destroy(cr);
-        GdkPixbuf* pixbuf = xoj_pixbuf_get_from_surface(crCursor, 0, 0, windowWidth, height);
-        cairo_surface_destroy(crCursor);
-        //x = std::clamp(x, 0, windowWidth);
-        GdkCursor* gdkCursor = gdk_cursor_new_from_pixbuf(
-                gtk_widget_get_display(control->getWindow()->getXournal()->getWidget()), pixbuf, winX, 0);
-        g_object_unref(pixbuf);
-        return gdkCursor;
-    } else {
-        // If we're zoomed in enough, just draw the cursor across the whole screen
-        // FIXME (willnilges): Don't draw the cursor over the sidebar, if visible.
-        // FIXME (willnilges): Does the XojView take the sidebar into account?
-        cairo_set_line_width(cr, 1.2);
-        cairo_set_source_rgb(cr, 0, 100, 0);
-        cairo_move_to(cr, 0 + (control->getSettings()->isSidebarVisible() ? control->getSettings()->getSidebarWidth() : 0), 0);
-        cairo_line_to(cr, px + pw + winX, 0);
-        cairo_close_path(cr);
-        cairo_stroke(cr);
-        cairo_destroy(cr);
-        GdkPixbuf* pixbuf = xoj_pixbuf_get_from_surface(crCursor, 0, 0, windowWidth, height);
-        cairo_surface_destroy(crCursor);
-        //x = std::clamp(x, 0, windowWidth);
-        GdkCursor* gdkCursor = gdk_cursor_new_from_pixbuf(
-                gtk_widget_get_display(control->getWindow()->getXournal()->getWidget()), pixbuf, winX, 0);
-        g_object_unref(pixbuf);
-        return gdkCursor;
-    }*/
     return nullptr;
 }
 

--- a/src/core/gui/XournalppCursor.cpp
+++ b/src/core/gui/XournalppCursor.cpp
@@ -527,6 +527,11 @@ auto XournalppCursor::createHorizontalLineCursor(XournalView* xournal) -> GdkCur
     int pvWidth = pv->getDisplayWidth();
     int pageStart = pv->getX();
 
+    int px = pv->getX();
+    int py = pv->getY();
+    int pw = pv->getDisplayWidth();
+    int ph = pv->getDisplayHeight();
+
     gint x, y;
     GdkDevice *mouse_device;
 
@@ -548,8 +553,8 @@ auto XournalppCursor::createHorizontalLineCursor(XournalView* xournal) -> GdkCur
     cairo_t* cr = cairo_create(crCursor);
 
     cairo_set_line_width(cr, 1.2);
-    cairo_move_to(cr, pageStart, 0);
-    cairo_line_to(cr, pageStart + pvWidth, 0);
+    cairo_move_to(cr, px, 0);
+    cairo_line_to(cr, px + pw, 0);
     cairo_close_path(cr);
     cairo_stroke(cr);
 

--- a/src/core/gui/XournalppCursor.cpp
+++ b/src/core/gui/XournalppCursor.cpp
@@ -555,7 +555,7 @@ auto XournalppCursor::createHorizontalLineCursor(XournalView* xournal, MainWindo
 
     if (px + pw < windowWidth) {
         cairo_set_line_width(cr, 1.2);
-        cairo_set_source_rgb(cr, 255, 0, 255);
+        cairo_set_source_rgb(cr, 100, 0, 0);
         cairo_move_to(cr, px, 0);
         cairo_line_to(cr, px + pw, 0);
         cairo_close_path(cr);
@@ -563,9 +563,9 @@ auto XournalppCursor::createHorizontalLineCursor(XournalView* xournal, MainWindo
         cairo_destroy(cr);
         GdkPixbuf* pixbuf = xoj_pixbuf_get_from_surface(crCursor, 0, 0, windowWidth, height);
         cairo_surface_destroy(crCursor);
-        x = std::clamp(x, 0, windowWidth);
+        //x = std::clamp(x, 0, windowWidth);
         GdkCursor* gdkCursor = gdk_cursor_new_from_pixbuf(
-                gtk_widget_get_display(control->getWindow()->getXournal()->getWidget()), pixbuf, x, 0);
+                gtk_widget_get_display(control->getWindow()->getXournal()->getWidget()), pixbuf, winX, 0);
         g_object_unref(pixbuf);
         return gdkCursor;
     } else {
@@ -573,8 +573,8 @@ auto XournalppCursor::createHorizontalLineCursor(XournalView* xournal, MainWindo
         // FIXME (willnilges): Don't draw the cursor over the sidebar, if visible.
         // FIXME (willnilges): Does the XojView take the sidebar into account?
         cairo_set_line_width(cr, 1.2);
-        cairo_set_source_rgb(cr, 0, 200, 0);
-        cairo_move_to(cr, px, 0);
+        cairo_set_source_rgb(cr, 0, 100, 0);
+        cairo_move_to(cr, 0, 0);
         cairo_line_to(cr, px + pw + winX, 0);
         cairo_close_path(cr);
         cairo_stroke(cr);

--- a/src/core/gui/XournalppCursor.h
+++ b/src/core/gui/XournalppCursor.h
@@ -16,6 +16,7 @@
 
 #include "control/tools/CursorSelectionType.h"  // for CursorSelectionType
 #include "gui/inputdevices/InputEvents.h"       // for InputDeviceClass, INP...
+#include "XournalView.h"
 
 class Control;
 
@@ -47,7 +48,7 @@ private:
     GdkCursor* getResizeCursor(double deltaAngle);
 
     GdkCursor* createHighlighterOrPenCursor(int size, double alpha);
-    GdkCursor* createHorizontalLineCursor(GdkWindow* theWindow);
+    GdkCursor* createHorizontalLineCursor(XournalView* xournal);
     GdkCursor* createCustomDrawDirCursor(int size, bool shift, bool ctrl);
 
 private:

--- a/src/core/gui/XournalppCursor.h
+++ b/src/core/gui/XournalppCursor.h
@@ -47,6 +47,7 @@ private:
     GdkCursor* getResizeCursor(double deltaAngle);
 
     GdkCursor* createHighlighterOrPenCursor(int size, double alpha);
+    GdkCursor* createHorizontalLineCursor(int size, double alpha, GdkWindow* theWindow);
     GdkCursor* createCustomDrawDirCursor(int size, bool shift, bool ctrl);
 
 private:

--- a/src/core/gui/XournalppCursor.h
+++ b/src/core/gui/XournalppCursor.h
@@ -47,7 +47,7 @@ private:
     GdkCursor* getResizeCursor(double deltaAngle);
 
     GdkCursor* createHighlighterOrPenCursor(int size, double alpha);
-    GdkCursor* createHorizontalLineCursor(int size, double alpha, GdkWindow* theWindow);
+    GdkCursor* createHorizontalLineCursor(GdkWindow* theWindow);
     GdkCursor* createCustomDrawDirCursor(int size, bool shift, bool ctrl);
 
 private:

--- a/src/core/gui/XournalppCursor.h
+++ b/src/core/gui/XournalppCursor.h
@@ -17,6 +17,7 @@
 #include "control/tools/CursorSelectionType.h"  // for CursorSelectionType
 #include "gui/inputdevices/InputEvents.h"       // for InputDeviceClass, INP...
 #include "XournalView.h"
+#include "MainWindow.h"
 
 class Control;
 
@@ -48,7 +49,7 @@ private:
     GdkCursor* getResizeCursor(double deltaAngle);
 
     GdkCursor* createHighlighterOrPenCursor(int size, double alpha);
-    GdkCursor* createHorizontalLineCursor(XournalView* xournal);
+    GdkCursor* createHorizontalLineCursor(XournalView* xournal, MainWindow* win);
     GdkCursor* createCustomDrawDirCursor(int size, bool shift, bool ctrl);
 
 private:

--- a/src/core/gui/XournalppCursor.h
+++ b/src/core/gui/XournalppCursor.h
@@ -16,8 +16,6 @@
 
 #include "control/tools/CursorSelectionType.h"  // for CursorSelectionType
 #include "gui/inputdevices/InputEvents.h"       // for InputDeviceClass, INP...
-#include "XournalView.h"
-#include "MainWindow.h"
 
 class Control;
 

--- a/src/core/gui/XournalppCursor.h
+++ b/src/core/gui/XournalppCursor.h
@@ -49,7 +49,7 @@ private:
     GdkCursor* getResizeCursor(double deltaAngle);
 
     GdkCursor* createHighlighterOrPenCursor(int size, double alpha);
-    GdkCursor* createHorizontalLineCursor(XournalView* xournal, MainWindow* win);
+    GdkCursor* createHorizontalLineCursor();
     GdkCursor* createCustomDrawDirCursor(int size, bool shift, bool ctrl);
 
 private:


### PR DESCRIPTION
First take on vertical space cursor. Uses width of GTK window and cairo drawing to show where the vertical space will start.