### PR TITLE
Add plugin to fit the page size to the content/selection

### DIFF
--- a/plugins/FitToContent/main.lua
+++ b/plugins/FitToContent/main.lua
@@ -1,0 +1,60 @@
+-- Register all Toolbar actions and intialize all UI stuff
+function initUi()
+    app.registerUi{["menu"] = "Fit page to layer", ["callback"] = "fit_to_layer"};
+    app.registerUi{["menu"] = "Fit page to selection", ["callback"] = "fit_to_selection"};
+end
+
+local function fit_to_layer_or_selection(type)
+    if type ~= "selection" and type ~= "layer" then
+        app.msgbox("Invalid type for fitting", {[1]="Ok"})
+        return
+    end
+
+    local strokes = app.getStrokes(type)
+    -- padd the whole region just a little bit. Might be a thing to configure in the future
+    local padding = {x=0, y=0}
+    -- search for the outermost strokes which span the rectangle of the to be moved area
+    -- take the stroke width, or if set the pressure, into account hereby
+    local mima    = {minX=100000, maxX=0, minY=100000, maxY=0}
+    for _,stroke in ipairs(strokes) do
+        if stroke.pressure then
+            for i,x in ipairs(stroke.x) do
+                mima.maxX = math.max(mima.maxX, x + stroke.pressure[i]/2)
+                mima.minX = math.min(mima.minX, x - stroke.pressure[i]/2)
+            end
+            for i,y in ipairs(stroke.y) do
+                mima.maxY = math.max(mima.maxY, y + stroke.pressure[i]/2)
+                mima.minY = math.min(mima.minY, y - stroke.pressure[i]/2)
+            end
+        else
+            for _,x in ipairs(stroke.x) do
+                mima.maxX = math.max(mima.maxX, x + stroke.width/2)
+                mima.minX = math.min(mima.minX, x - stroke.width/2)
+            end
+            for _,y in ipairs(stroke.y) do
+                mima.maxY = math.max(mima.maxY, y + stroke.width/2)
+                mima.minY = math.min(mima.minY, y - stroke.width/2)
+            end
+        end
+    end
+    -- move strokes by minX and minY
+    for _,stroke in ipairs(strokes) do
+        for i,x in ipairs(stroke.x) do
+            stroke.x[i] = x - mima.minX + padding.x
+        end
+        for i,y in ipairs(stroke.y) do
+            stroke.y[i] = y - mima.minY + padding.y
+        end
+    end
+
+    -- make the current layer invisible and add the moved strokes to a new layer
+    app.setLayerVisibility(false)
+    app.layerAction("ACTION_NEW_LAYER")
+    app.setCurrentLayerName("moved for fitting")
+    app.addStrokes{strokes=strokes}
+
+    app.setPageSize(mima.maxX-mima.minX+2*padding.x, mima.maxY-mima.minY+2*padding.y)
+end
+
+function fit_to_layer() fit_to_layer_or_selection("layer") end
+function fit_to_selection() fit_to_layer_or_selection("selection") end

--- a/plugins/FitToContent/plugin.ini
+++ b/plugins/FitToContent/plugin.ini
@@ -1,0 +1,15 @@
+[about]
+## Author / Copyright notice
+author=Lukas Heindl
+
+description=Fit page size to selection/layer. Useful for creating small images for other documents (e.g. LaTeX), at least to prototype them.
+
+## If the plugin is packed with Xournal++, use
+## <xournalpp> then it gets the same version number
+version=<xournalpp>
+
+[default]
+enabled=false
+
+[plugin]
+mainfile=main.lua


### PR DESCRIPTION
The idea behind this, is to be able to prototype small images for e.g. LaTeX documents (quick and dirty drawing before probably time consuming tikzing the drawing).

Caveat: Only works with strokes, no images and no text boxes are taken into account. Might change in the future, but for this we need get/add api-functions for these types.

Note: Created this as draft since I came up with this just right now. I want to avoid this being merged without thinking about this again. So for me most interesting right now is, what you think about this idea in general. And if you've got ideas regarding the decisions usin
1.  `getStrokes` instead of `toolInfo` and
2. how to handle the padding (reason behind this is we need something to get the whole stroke, as without padding thick strokes are being cut of at the edges)