### PR TITLE
Fix crash when dragging color select to sidebar

### DIFF
--- a/src/core/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp
+++ b/src/core/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp
@@ -228,8 +228,9 @@ auto ToolbarAdapter::toolbarDragMotionCb(GtkToolbar* toolbar, GdkDragContext* co
     }
 
     if (d->type == TOOL_ITEM_ITEM) {
-        gtk_toolbar_set_drop_highlight_item(toolbar, d->item->createTmpItem(orientation == GTK_ORIENTATION_HORIZONTAL),
-                                            ipos);
+        GtkWidget* iconWidget = d->item->getNewToolIcon();
+        GtkToolItem* it = gtk_tool_button_new(iconWidget, "");
+        gtk_toolbar_set_drop_highlight_item(toolbar, it, ipos);
     } else if (d->type == TOOL_ITEM_SEPARATOR) {
         GtkToolItem* it = gtk_separator_tool_item_new();
         gtk_toolbar_set_drop_highlight_item(toolbar, it, ipos);

--- a/src/core/gui/toolbarMenubar/icon/ColorSelectImage.cpp
+++ b/src/core/gui/toolbarMenubar/icon/ColorSelectImage.cpp
@@ -133,6 +133,8 @@ auto ColorSelectImage::newColorIconSurface(Color color, int size, bool circle) -
     config.size = size;
     config.state = COLOR_ICON_STATE_ENABLED;
     config.circle = circle;
+    config.width = size;
+    config.height = size;
 
     drawWidget(cr, config);
     cairo_destroy(cr);


### PR DESCRIPTION
Fixes issue #4505

Ensure 'getNewToolIcon' is used when dragging the color select tool.

Ensure 'width' and 'height' fields of 'IconConfig' struct is initialized.