### PR TITLE
Hint placement of color select dialog

### DIFF
--- a/src/core/gui/toolbarMenubar/ColorToolItem.cpp
+++ b/src/core/gui/toolbarMenubar/ColorToolItem.cpp
@@ -23,6 +23,7 @@ ColorToolItem::ColorToolItem(ActionHandler* handler, ToolHandler* toolHandler, G
                              bool selektor):
         AbstractToolItem("", handler, selektor ? ACTION_SELECT_COLOR_CUSTOM : ACTION_SELECT_COLOR),
         namedColor{std::move(namedColor)},
+        parent(parent),
         toolHandler(toolHandler) {
     this->group = GROUP_COLOR;
 }


### PR DESCRIPTION
I have been looking into issue #4519. I have not be able to reproduce. But by looking at how other dialogs are configured elsewhere, I guess 'gtk_window_set_trasient_for' and perhaps also 'gtk_window_set_position' was missing for the dialog.

As I understand it's up to the windows manager of a given system to place the window accordingly to these hints.

Hopefully somebody with a window build and a dual screen setup can try this out.