### PR TITLE
Replace deprecated stock icons by named icons

### DIFF
--- a/ui/fillOpacity.glade
+++ b/ui/fillOpacity.glade
@@ -100,7 +100,7 @@ Select opacity for fill color</property>
                     <property name="name">imgPreview</property>
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="stock">gtk-missing-image</property>
+                    <property name="icon-name">image-missing</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>

--- a/ui/main.glade
+++ b/ui/main.glade
@@ -2256,7 +2256,7 @@
                                       <object class="GtkImage" id="image8">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="stock">gtk-close</property>
+                                        <property name="icon-name">window-close</property>
                                       </object>
                                     </child>
                                     <style>
@@ -2311,7 +2311,7 @@
                                       <object class="GtkImage" id="image1">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="stock">gtk-go-up</property>
+                                        <property name="icon-name">go-up</property>
                                       </object>
                                     </child>
                                   </object>
@@ -2331,7 +2331,7 @@
                                       <object class="GtkImage" id="image5">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="stock">gtk-go-down</property>
+                                        <property name="icon-name">go-down</property>
                                       </object>
                                     </child>
                                   </object>
@@ -2351,7 +2351,7 @@
                                       <object class="GtkImage" id="image6">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="stock">gtk-copy</property>
+                                        <property name="icon-name">edit-copy</property>
                                       </object>
                                     </child>
                                   </object>
@@ -2371,7 +2371,7 @@
                                       <object class="GtkImage" id="image7">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="stock">gtk-delete</property>
+                                        <property name="icon-name">edit-delete</property>
                                       </object>
                                     </child>
                                   </object>
@@ -2523,7 +2523,7 @@
                                   <object class="GtkImage" id="image3">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="stock">gtk-go-up</property>
+                                    <property name="icon-name">go-up</property>
                                   </object>
                                 </child>
                               </object>
@@ -2545,7 +2545,7 @@
                                   <object class="GtkImage" id="image4">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="stock">gtk-go-down</property>
+                                    <property name="icon-name">go-down</property>
                                   </object>
                                 </child>
                               </object>
@@ -2603,7 +2603,7 @@
                               <object class="GtkImage" id="image2">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
-                                <property name="stock">gtk-close</property>
+                                <property name="icon-name">window-close</property>
                               </object>
                             </child>
                             <style>

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -594,7 +594,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                                   <object class="GtkImage" id="image1">
                                                     <property name="visible">True</property>
                                                     <property name="can-focus">False</property>
-                                                    <property name="stock">gtk-info</property>
+                                                    <property name="icon-name">dialog-information</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>


### PR DESCRIPTION
Stock icons are deprecated since Gtk 3.10. They don't show up on Windows or MacOS any more.

I followed https://lazka.github.io/pgi-docs/Gtk-3.0/constants.html on how to replace the stock icon names.

Tested successfully on Windows 10 and Ubuntu 22.10 (where in my case the go-up and go-down icons look slightly different now). See icons in the sidebar in particular.