### PR TITLE
Catch by const reference

### DIFF
--- a/src/core/audio/PortAudioConsumer.cpp
+++ b/src/core/audio/PortAudioConsumer.cpp
@@ -58,7 +58,7 @@ auto PortAudioConsumer::startPlaying() -> bool {
     portaudio::Device* device = nullptr;
     try {
         device = &sys.deviceByIndex(getSelectedOutputDevice().getIndex());
-    } catch (const portaudio::PaException& e) {
+    } catch (const portaudio::PaException&) {
         g_warning("PortAudioConsumer: Unable to find selected output device");
         return false;
     }
@@ -146,7 +146,7 @@ void PortAudioConsumer::stopPlaying() {
             if (this->outputStream->isActive()) {
                 this->outputStream->stop();
             }
-        } catch (const portaudio::PaException& e) {
+        } catch (const portaudio::PaException&) {
             /*
              * We try closing the stream but this->outputStream might be an invalid object at this time if the stream
              * was previously closed by the backend. Just ignore this as the stream is closed either way.

--- a/src/core/audio/PortAudioConsumer.cpp
+++ b/src/core/audio/PortAudioConsumer.cpp
@@ -31,7 +31,7 @@ auto PortAudioConsumer::getOutputDevices() const -> std::vector<DeviceInfo> {
 auto PortAudioConsumer::getSelectedOutputDevice() const -> DeviceInfo {
     try {
         return DeviceInfo(&sys.deviceByIndex(this->audioPlayer.getSettings().getAudioOutputDevice()), true);
-    } catch (portaudio::PaException& e) {
+    } catch (const portaudio::PaException& e) {
         g_warning("PortAudioConsumer: Selected output device was not found - fallback to default output device\nCaused "
                   "by: %s",
                   e.what());
@@ -58,7 +58,7 @@ auto PortAudioConsumer::startPlaying() -> bool {
     portaudio::Device* device = nullptr;
     try {
         device = &sys.deviceByIndex(getSelectedOutputDevice().getIndex());
-    } catch (portaudio::PaException& e) {
+    } catch (const portaudio::PaException& e) {
         g_warning("PortAudioConsumer: Unable to find selected output device");
         return false;
     }
@@ -78,7 +78,7 @@ auto PortAudioConsumer::startPlaying() -> bool {
     try {
         this->outputStream = std::make_unique<portaudio::MemFunCallbackStream<PortAudioConsumer>>(
                 params, *this, &PortAudioConsumer::playCallback);
-    } catch (portaudio::PaException& e) {
+    } catch (const portaudio::PaException& e) {
         this->audioQueue.signalEndOfStream();
         g_warning("PortAudioConsumer: Unable to open stream to device\nCaused by: %s", e.what());
         return false;
@@ -86,7 +86,7 @@ auto PortAudioConsumer::startPlaying() -> bool {
     // Start the recording
     try {
         this->outputStream->start();
-    } catch (portaudio::PaException& e) {
+    } catch (const portaudio::PaException& e) {
         this->audioQueue.signalEndOfStream();
         g_warning("PortAudioConsumer: Unable to start stream\nCaused by: %s", e.what());
         this->outputStream.reset();
@@ -146,7 +146,7 @@ void PortAudioConsumer::stopPlaying() {
             if (this->outputStream->isActive()) {
                 this->outputStream->stop();
             }
-        } catch (portaudio::PaException& e) {
+        } catch (const portaudio::PaException& e) {
             /*
              * We try closing the stream but this->outputStream might be an invalid object at this time if the stream
              * was previously closed by the backend. Just ignore this as the stream is closed either way.

--- a/src/core/audio/PortAudioProducer.cpp
+++ b/src/core/audio/PortAudioProducer.cpp
@@ -31,7 +31,7 @@ auto PortAudioProducer::getInputDevices() const -> std::vector<DeviceInfo> {
 auto PortAudioProducer::getSelectedInputDevice() const -> DeviceInfo {
     try {
         return DeviceInfo(&sys.deviceByIndex(this->settings.getAudioInputDevice()), true);
-    } catch (portaudio::PaException& e) {
+    } catch (const portaudio::PaException& e) {
         g_message(
                 "PortAudioProducer: Selected input device not found - fallback to default input device\nCaused by: %s",
                 e.what());
@@ -51,7 +51,7 @@ auto PortAudioProducer::startRecording() -> bool {
     portaudio::Device* device = nullptr;
     try {
         device = &sys.deviceByIndex(getSelectedInputDevice().getIndex());
-    } catch (portaudio::PaException& e) {
+    } catch (const portaudio::PaException& e) {
         g_message("PortAudioProducer: Unable to find selected input device");
         return false;
     }
@@ -70,7 +70,7 @@ auto PortAudioProducer::startRecording() -> bool {
     try {
         this->inputStream = std::make_unique<portaudio::MemFunCallbackStream<PortAudioProducer>>(
                 params, *this, &PortAudioProducer::recordCallback);
-    } catch (portaudio::PaException& e) {
+    } catch (const portaudio::PaException& e) {
         g_message("PortAudioProducer: Unable to open stream");
         return false;
     }
@@ -78,7 +78,7 @@ auto PortAudioProducer::startRecording() -> bool {
     // Start the recording
     try {
         this->inputStream->start();
-    } catch (portaudio::PaException& e) {
+    } catch (const portaudio::PaException& e) {
         g_message("PortAudioProducer: Unable to start stream");
         this->inputStream.reset();
         return false;
@@ -108,7 +108,7 @@ void PortAudioProducer::stopRecording() {
             if (this->inputStream->isActive()) {
                 this->inputStream->stop();
             }
-        } catch (portaudio::PaException& e) { g_message("PortAudioProducer: Closing stream failed"); }
+        } catch (const portaudio::PaException& e) { g_message("PortAudioProducer: Closing stream failed"); }
     }
 
     // Notify the consumer at the other side that there will be no more data

--- a/src/core/audio/PortAudioProducer.cpp
+++ b/src/core/audio/PortAudioProducer.cpp
@@ -51,7 +51,7 @@ auto PortAudioProducer::startRecording() -> bool {
     portaudio::Device* device = nullptr;
     try {
         device = &sys.deviceByIndex(getSelectedInputDevice().getIndex());
-    } catch (const portaudio::PaException& e) {
+    } catch (const portaudio::PaException&) {
         g_message("PortAudioProducer: Unable to find selected input device");
         return false;
     }
@@ -70,7 +70,7 @@ auto PortAudioProducer::startRecording() -> bool {
     try {
         this->inputStream = std::make_unique<portaudio::MemFunCallbackStream<PortAudioProducer>>(
                 params, *this, &PortAudioProducer::recordCallback);
-    } catch (const portaudio::PaException& e) {
+    } catch (const portaudio::PaException&) {
         g_message("PortAudioProducer: Unable to open stream");
         return false;
     }
@@ -78,7 +78,7 @@ auto PortAudioProducer::startRecording() -> bool {
     // Start the recording
     try {
         this->inputStream->start();
-    } catch (const portaudio::PaException& e) {
+    } catch (const portaudio::PaException&) {
         g_message("PortAudioProducer: Unable to start stream");
         this->inputStream.reset();
         return false;
@@ -108,7 +108,9 @@ void PortAudioProducer::stopRecording() {
             if (this->inputStream->isActive()) {
                 this->inputStream->stop();
             }
-        } catch (const portaudio::PaException& e) { g_message("PortAudioProducer: Closing stream failed"); }
+        } catch (const portaudio::PaException&) {
+            g_message("PortAudioProducer: Closing stream failed");
+        }
     }
 
     // Notify the consumer at the other side that there will be no more data

--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -242,7 +242,7 @@ void Control::renameLastAutosaveFile() {
     std::vector<string> errors;
     try {
         Util::safeRenameFile(filename, renamed);
-    } catch (fs::filesystem_error const& e) {
+    } catch (const fs::filesystem_error& e) {
         auto fmtstr = _F("Could not rename autosave file from \"{1}\" to \"{2}\": {3}");
         errors.emplace_back(FS(fmtstr % filename.u8string() % renamed.u8string() % e.what()));
     }
@@ -3034,7 +3034,7 @@ void Control::clipboardPasteXournal(ObjectInputStream& in) {
         selection->mouseUp();
 
         win->getXournal()->setSelection(selection);
-    } catch (std::exception& e) {
+    } catch (const std::exception& e) {
         g_warning("could not paste, Exception occurred: %s", e.what());
         Stacktrace::printStracktrace();
         if (selection) {

--- a/src/core/control/XournalMain.cpp
+++ b/src/core/control/XournalMain.cpp
@@ -126,13 +126,12 @@ auto migrateSettings() -> MigrateResult {
                 constexpr auto msg = "Due to a recent update, Xournal++ has changed where its configuration files are "
                                      "stored.\nThey have been automatically copied from\n\t{1}\nto\n\t{2}";
                 return {MigrateStatus::Success, FS(_F(msg) % oldPath.u8string() % newConfigPath.u8string())};
-            } catch (const fs::filesystem_error& except) {
+            } catch (const fs::filesystem_error& e) {
                 constexpr auto msg =
                         "Due to a recent update, Xournal++ has changed where its configuration files are "
                         "stored.\nHowever, when attempting to copy\n\t{1}\nto\n\t{2}\nmigration failed:\n{3}";
-                g_message("Migration failed: %s", except.what());
-                return {MigrateStatus::Failure,
-                        FS(_F(msg) % oldPath.u8string() % newConfigPath.u8string() % except.what())};
+                g_message("Migration failed: %s", e.what());
+                return {MigrateStatus::Failure, FS(_F(msg) % oldPath.u8string() % newConfigPath.u8string() % e.what())};
             }
         }
     }

--- a/src/core/control/XournalMain.cpp
+++ b/src/core/control/XournalMain.cpp
@@ -95,7 +95,7 @@ void initLocalisation() {
     // Not working on GNU g++(mingww) forWindows! Only working on Linux/macOS and with msvc
     try {
         std::locale::global(std::locale(""));  // "" - system default locale
-    } catch (std::runtime_error& e) {
+    } catch (const std::runtime_error& e) {
         g_warning("XournalMain: System default locale could not be set.\n - Caused by: %s\n - Note that it is not "
                   "supported to set the locale using mingw-w64 on windows.\n - This could be solved by compiling "
                   "xournalpp with msvc",
@@ -126,7 +126,7 @@ auto migrateSettings() -> MigrateResult {
                 constexpr auto msg = "Due to a recent update, Xournal++ has changed where its configuration files are "
                                      "stored.\nThey have been automatically copied from\n\t{1}\nto\n\t{2}";
                 return {MigrateStatus::Success, FS(_F(msg) % oldPath.u8string() % newConfigPath.u8string())};
-            } catch (fs::filesystem_error const& except) {
+            } catch (const fs::filesystem_error& except) {
                 constexpr auto msg =
                         "Due to a recent update, Xournal++ has changed where its configuration files are "
                         "stored.\nHowever, when attempting to copy\n\t{1}\nto\n\t{2}\nmigration failed:\n{3}";
@@ -493,7 +493,7 @@ void on_startup(GApplication* application, XMPtr app_data) {
             } else {
                 opened = app_data->control->newFile("", p);
             }
-        } catch (fs::filesystem_error const& e) {
+        } catch (const fs::filesystem_error& e) {
             std::string msg = FS(_F("Sorry, Xournal++ cannot open remote files at the moment.\n"
                                     "You have to copy the file to a local directory.") %
                                  p.u8string() % e.what());
@@ -542,7 +542,7 @@ auto on_handle_local_options(GApplication*, GVariantDict*, XMPtr app_data) -> gi
         try {
             printf("trying\n");
             return fun();
-        } catch (std::exception const& e) {
+        } catch (const std::exception& e) {
             std::cerr << "Error: " << e.what() << std::endl;
             std::cerr << "In: " << s << std::endl;
             print_version();

--- a/src/core/control/jobs/BaseExportJob.cpp
+++ b/src/core/control/jobs/BaseExportJob.cpp
@@ -47,7 +47,7 @@ auto BaseExportJob::checkOverwriteBackgroundPDF(fs::path const& file) const -> b
             XojMsgBox::showErrorToUser(control->getGtkWindow(), msg);
             return false;
         }
-    } catch (fs::filesystem_error const& fe) {
+    } catch (const fs::filesystem_error& fe) {
         g_warning("%s", fe.what());
         auto msg = std::string(_("The check for overwriting the background failed with:\n")) + fe.what() +
                    _("\n Do you want to continue?");
@@ -104,7 +104,7 @@ auto BaseExportJob::testAndSetFilepath(fs::path file) -> bool {
             this->filepath = std::move(file);
             return true;
         }
-    } catch (fs::filesystem_error const& e) {
+    } catch (const fs::filesystem_error& e) {
         string msg = FS(_F("Failed to resolve path with the following error:\n{1}") % e.what());
         XojMsgBox::showErrorToUser(control->getGtkWindow(), msg);
     }

--- a/src/core/control/jobs/SaveJob.cpp
+++ b/src/core/control/jobs/SaveJob.cpp
@@ -112,7 +112,7 @@ auto SaveJob::save() -> bool {
             // Note: The backup must be created for the target as this is the filepath
             // which will be written to. Do not use the `filepath` variable!
             Util::safeRenameFile(target, fs::path{target} += "~");
-        } catch (fs::filesystem_error const& fe) {
+        } catch (const fs::filesystem_error& fe) {
             g_warning("Could not create backup! Failed with %s", fe.what());
             return false;
         }
@@ -133,7 +133,7 @@ auto SaveJob::save() -> bool {
         try {
             // If a backup was created it can be removed now since no error occured during the save
             fs::remove(fs::path{target} += "~");
-        } catch (fs::filesystem_error const& fe) { g_warning("Could not delete backup! Failed with %s", fe.what()); }
+        } catch (const fs::filesystem_error& fe) { g_warning("Could not delete backup! Failed with %s", fe.what()); }
     } else {
         doc->setCreateBackupOnSave(true);
     }

--- a/src/core/control/latex/LatexGenerator.cpp
+++ b/src/core/control/latex/LatexGenerator.cpp
@@ -56,7 +56,7 @@ auto LatexGenerator::asyncRun(const fs::path& texDir, const std::string& texFile
     std::string texFilePathOSEncoding;
     try {
         texFilePathOSEncoding = (Util::getLongPath(texDir) / "tex.tex").string();
-    } catch (fs::filesystem_error const& e) {
+    } catch (const fs::filesystem_error& e) {
         GenError res{FS(_F("Failed to parse LaTeX generator path: {1}") % e.what())};
     }
 

--- a/src/core/control/settings/MetadataManager.cpp
+++ b/src/core/control/settings/MetadataManager.cpp
@@ -33,7 +33,7 @@ void MetadataManager::deleteMetadataFile(fs::path const& path) {
 
     try {
         fs::remove(path);
-    } catch (fs::filesystem_error const&) { g_warning("Could not delete metadata file %s", path.string().c_str()); }
+    } catch (const fs::filesystem_error&) { g_warning("Could not delete metadata file %s", path.string().c_str()); }
 }
 
 /**
@@ -72,7 +72,7 @@ auto MetadataManager::loadList() -> vector<MetadataEntry> {
                 data.push_back(entry);
             }
         }
-    } catch (fs::filesystem_error& e) {
+    } catch (const fs::filesystem_error& e) {
         XojMsgBox::showErrorToUser(nullptr, e.what());
         return data;
     }

--- a/src/core/gui/dialog/ExportDialog.cpp
+++ b/src/core/gui/dialog/ExportDialog.cpp
@@ -31,7 +31,7 @@ ExportDialog::ExportDialog(GladeSearchpath* gladeSearchPath):
                 ElementRange::parse(text_form, self->pageCount);
                 gtk_style_context_remove_class(context, "error");
                 gtk_widget_set_sensitive(btOk, TRUE);
-            } catch (const std::invalid_argument& e) {
+            } catch (const std::invalid_argument&) {
                 gtk_style_context_add_class(context, "error");
                 gtk_widget_set_sensitive(btOk, FALSE);
             }

--- a/src/core/gui/dialog/LanguageConfigGui.cpp
+++ b/src/core/gui/dialog/LanguageConfigGui.cpp
@@ -33,7 +33,9 @@ LanguageConfigGui::LanguageConfigGui(GladeSearchpath* gladeSearchPath, GtkWidget
                 availableLocales.push_back(d.path().filename().u8string());
             }
         }
-    } catch (fs::filesystem_error const& e) { g_warning("%s", e.what()); }
+    } catch (const fs::filesystem_error& e) {
+        g_warning("%s", e.what());
+    }
     std::sort(availableLocales.begin(), availableLocales.end());
 
     // No pot file for English

--- a/src/core/plugin/PluginController.cpp
+++ b/src/core/plugin/PluginController.cpp
@@ -71,11 +71,11 @@ auto load_available_plugins_from(fs::path const& path, Control* control) -> std:
                 }
                 plugin->setEnabled(plugin->isDefaultEnabled());
                 returner.emplace_back(std::move(plugin));
-            } catch (std::exception const& e) {
+            } catch (const std::exception& e) {
                 g_warning("Error loading plugin \"%s\": %s", f.path().string().c_str(), e.what());
             }
         }
-    } catch (fs::filesystem_error const& e) {
+    } catch (const fs::filesystem_error& e) {
         g_warning("Could not open plugin dir: \"%s\": %s", path.string().c_str(), e.what());
     }
     return returner;

--- a/src/util/PathUtil.cpp
+++ b/src/util/PathUtil.cpp
@@ -64,7 +64,7 @@ auto Util::readString(fs::path const& path, bool showErrorToUser) -> std::option
         s.resize(fs::file_size(path));
         ifs.read(s.data(), s.size());
         return {std::move(s)};
-    } catch (fs::filesystem_error const& e) {
+    } catch (const fs::filesystem_error& e) {
         if (showErrorToUser) {
             XojMsgBox::showErrorToUser(nullptr, e.what());
         }
@@ -260,7 +260,7 @@ auto Util::getTmpDirSubfolder(const fs::path& subfolder) -> fs::path {
 auto Util::ensureFolderExists(const fs::path& p) -> fs::path {
     try {
         fs::create_directories(p);
-    } catch (fs::filesystem_error const& fe) {
+    } catch (const fs::filesystem_error& fe) {
         Util::execInUiThread([=]() {
             std::string msg = FS(_F("Could not create folder: {1}\nFailed with error: {2}") % p.u8string() % fe.what());
             g_warning("%s %s", msg.c_str(), fe.what());
@@ -274,7 +274,7 @@ auto Util::isChildOrEquivalent(fs::path const& path, fs::path const& base) -> bo
     auto safeCanonical = [](fs::path const& p) {
         try {
             return fs::weakly_canonical(p);
-        } catch (fs::filesystem_error const& fe) {
+        } catch (const fs::filesystem_error& fe) {
             g_warning("Util::isChildOrEquivalent: Error resolving paths, failed with %s.\nFalling back to "
                       "lexicographical path",
                       fe.what());
@@ -302,7 +302,7 @@ bool Util::safeRenameFile(fs::path const& from, fs::path const& to) {
     try {
         fs::remove(to);
         fs::rename(from, to);
-    } catch (fs::filesystem_error const& fe) {
+    } catch (const fs::filesystem_error& fe) {
         // Attempt copy and delete
         g_warning("Renaming file %s to %s failed with %s. This may happen when source and target are on different "
                   "filesystems. Attempt to copy the file.",

--- a/src/util/serializing/ObjectInputStream.cpp
+++ b/src/util/serializing/ObjectInputStream.cpp
@@ -40,7 +40,7 @@ auto ObjectInputStream::read(const char* data, int data_len) -> bool {
                       version.c_str(), XML_VERSION_STR);
             return false;
         }
-    } catch (InputStreamException& e) {
+    } catch (const InputStreamException& e) {
         g_warning("InputStreamException: %s", e.what());
         return false;
     }

--- a/test/unit_tests/model/ColorPaletteTest.cpp
+++ b/test/unit_tests/model/ColorPaletteTest.cpp
@@ -110,9 +110,9 @@ TEST(ColorPalette, testWrongColor) {
         try {
             palette.load();
             FAIL();
-        } catch (const std::invalid_argument& err) {
+        } catch (const std::invalid_argument& e) {
             // check exception
-            EXPECT_STREQ(std::get<1>(pe).c_str(), err.what());
+            EXPECT_STREQ(std::get<1>(pe).c_str(), e.what());
         }
     }
 }

--- a/test/unit_tests/util/ElementRangeTest.cpp
+++ b/test/unit_tests/util/ElementRangeTest.cpp
@@ -45,7 +45,7 @@ TEST(UtilElementRange, testInvalid) {
         try {
             auto actual = ElementRange::parse(bad_input, maxCount);
             FAIL() << "std::invalid_argument not thrown for bad input.";
-        } catch (const std::invalid_argument& e) {
+        } catch (const std::invalid_argument&) {
             // good, exception is thrown as it should
         } catch (const std::exception& e) { FAIL() << e.what(); } catch (...) {
             FAIL() << "Unexpected exception caught.";
@@ -57,7 +57,7 @@ TEST(UtilElementRange, testPageCountIsZero) {
     try {
         auto actual = ElementRange::parse("", 0);
         FAIL() << "std::logic_error not thrown when maxCount equals 0.";
-    } catch (const std::logic_error& e) {
+    } catch (const std::logic_error&) {
         // good, exception is thrown as it should
     } catch (const std::exception& e) { FAIL() << e.what(); } catch (...) {
         FAIL() << "Unexpected exception caught.";

--- a/test/unit_tests/util/ObjectIOStreamTest.cpp
+++ b/test/unit_tests/util/ObjectIOStreamTest.cpp
@@ -267,7 +267,7 @@ TEST(UtilObjectIOStream, testReadComplexObject) {
 
             stream.endObject();
         }
-    } catch (InputStreamException& e) {
+    } catch (const InputStreamException& e) {
         std::cerr << "InputStreamException testing complex object: " << e.what() << std::endl;
         FAIL();
     }
@@ -342,7 +342,7 @@ TEST(UtilObjectIOStream, testReadStroke) {
             assertStrokeEquality(stroke, in_stroke);
             ++i;
         }
-    } catch (InputStreamException& e) {
+    } catch (const InputStreamException& e) {
         std::cerr << "InputStreamException testing stroke " << i << ": " << e.what() << std::endl;
         FAIL();
     }

--- a/test/unit_tests/util/TinySmallVectorTest.cpp
+++ b/test/unit_tests/util/TinySmallVectorTest.cpp
@@ -75,17 +75,17 @@ TEST(UtilsVectors, testTinyVector) {
         //     try {
         //         vec.push_back(d1);
         //         FAIL() << "TinyVector should have thrown std::length_error";
-        //     } catch (std::length_error& e) {}
+        //     } catch (const std::length_error& e) {}
         //
         //     try {
         //         vec.push_back(std::move(d1));
         //         FAIL() << "TinyVector should have thrown std::length_error";
-        //     } catch (std::length_error& e) {}
+        //     } catch (const std::length_error& e) {}
         //
         //     try {
         //         vec.emplace_back(d1);
         //         FAIL() << "TinyVector should have thrown std::length_error";
-        //     } catch (std::length_error& e) {}
+        //     } catch (const std::length_error& e) {}
 
         vec.pop_back();
         EXPECT_EQ(vec.size(), 4);


### PR DESCRIPTION
This slightly improves the exception handling code by catching by const reference, as per [E.15](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#e15-throw-by-value-catch-exceptions-from-a-hierarchy-by-reference).

Two other inconsistently named exceptions `except` and `err` were also renamed to `e`. Some east-consts were converted to west-consts, as this codebase seems to do.