### PR TITLE
Fix compile under Visual Studio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ nbproject/
 .idea
 cmake-build-*
 
+# Visual Studio
+.vs/
+
 # API Documentation
 doc/html
 doc/latex
@@ -60,7 +63,7 @@ flatpak-build/
 # Lua
 lua-*
 
-# Clangd 
+# Clangd
 compile_commands.json
 .clangd
 .cache

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -80,14 +80,14 @@ if (WIN32)
   endforeach()
   add_custom_command (
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/win32/xournalpp.ico
-                COMMAND convert ${ICON_DEPS} ${CMAKE_CURRENT_BINARY_DIR}/win32/xournalpp.ico
+                COMMAND magick convert ${ICON_DEPS} ${CMAKE_CURRENT_BINARY_DIR}/win32/xournalpp.ico
                 DEPENDS ${ICON_DEPS}
   )
   unset(ICON_SIZES)
   unset(ICON_DEPS)
   add_custom_target(xournalpp_icon DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/win32/xournalpp.ico)
   add_dependencies(xournalpp xournalpp_icon)
-  
+
   # windows specific source files
   file (GLOB xournalpp-sources-win32 exe/win32/*.cpp exe/win32/*.h)
   target_sources(xournalpp PRIVATE ${xournalpp-sources-win32})


### PR DESCRIPTION
By [default](https://stackoverflow.com/a/42099622), it seems `convert` is no longer installed with ImageMagick on Windows because it conflicts with the PowerShell "builtin" (at least on my computer). This fixes that.

It also adds `.vs/` to the `.gitignore`