### PR TITLE
Use `std::numeric_limits` instead of macros

### DIFF
--- a/src/core/control/tools/EditSelection.cpp
+++ b/src/core/control/tools/EditSelection.cpp
@@ -967,7 +967,7 @@ void EditSelection::paint(cairo_t* cr, double zoom) {
     double y = this->y;
 
 
-    if (std::abs(this->rotation) > __DBL_EPSILON__) {
+    if (std::abs(this->rotation) > std::numeric_limits<double>::epsilon()) {
         this->rotation = snappingHandler.snapAngle(this->rotation, false);
 
 

--- a/src/core/control/tools/EditSelectionContents.cpp
+++ b/src/core/control/tools/EditSelectionContents.cpp
@@ -362,7 +362,7 @@ void EditSelectionContents::finalizeSelection(Rectangle<double> bounds, Rectangl
         fy = f;
     }
     bool scale = (bounds.width != this->originalBounds.width || bounds.height != this->originalBounds.height);
-    bool rotate = (std::abs(this->rotation) > __DBL_EPSILON__);
+    bool rotate = (std::abs(this->rotation) > std::numeric_limits<double>::epsilon());
 
     double mx = bounds.x - this->originalBounds.x;
     double my = bounds.y - this->originalBounds.y;
@@ -419,7 +419,7 @@ void EditSelectionContents::updateContent(Rectangle<double> bounds, Rectangle<do
         fy = f;
     }
 
-    bool rotate = (std::abs(this->rotation - this->lastRotation) > __DBL_EPSILON__);
+    bool rotate = (std::abs(this->rotation - this->lastRotation) > std::numeric_limits<double>::epsilon());
     bool scale = (snappedBounds.width != this->lastSnappedBounds.width ||
                   snappedBounds.height != this->lastSnappedBounds.height);
 
@@ -495,7 +495,7 @@ void EditSelectionContents::paint(cairo_t* cr, double x, double y, double rotati
         this->relativeY = y;
     }
 
-    if (std::abs(rotation) > __DBL_EPSILON__) {
+    if (std::abs(rotation) > std::numeric_limits<double>::epsilon()) {
         this->rotation = rotation;
     }
 
@@ -529,7 +529,7 @@ void EditSelectionContents::paint(cairo_t* cr, double x, double y, double rotati
     double sx = static_cast<double>(wTarget) / wImg;
     double sy = static_cast<double>(hTarget) / hImg;
 
-    if (wTarget != wImg || hTarget != hImg || std::abs(rotation) > __DBL_EPSILON__) {
+    if (wTarget != wImg || hTarget != hImg || std::abs(rotation) > std::numeric_limits<double>::epsilon()) {
         if (!this->rescaleId) {
             this->rescaleId = g_idle_add(reinterpret_cast<GSourceFunc>(repaintSelection), this);
         }

--- a/src/core/control/tools/EditSelectionContents.cpp
+++ b/src/core/control/tools/EditSelectionContents.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>  // for min, max, transform
 #include <cmath>      // for abs, isnan
 #include <iterator>   // for back_insert_iterator
+#include <limits>     // for numeric_limits
 #include <memory>     // for make_unique, __shar...
 
 #include <glib.h>  // for g_idle_add, g_sourc...

--- a/src/core/control/tools/Selection.cpp
+++ b/src/core/control/tools/Selection.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>  // for max, min
 #include <cmath>      // for abs, NAN
-#include <limits>     // for numeric_limits
 #include <memory>     // for __shared_ptr_access
 
 #include <gdk/gdk.h>  // for GdkRGBA, gdk_cairo_set_source_rgba

--- a/src/core/control/tools/Selection.cpp
+++ b/src/core/control/tools/Selection.cpp
@@ -2,13 +2,14 @@
 
 #include <algorithm>  // for max, min
 #include <cmath>      // for abs, NAN
+#include <limits>     // for numeric_limits
 #include <memory>     // for __shared_ptr_access
 
 #include <gdk/gdk.h>  // for GdkRGBA, gdk_cairo_set_source_rgba
 
 #include "gui/LegacyRedrawable.h"  // for Redrawable
-#include "model/Layer.h"     // for Layer
-#include "model/XojPage.h"   // for XojPage
+#include "model/Layer.h"           // for Layer
+#include "model/XojPage.h"         // for XojPage
 
 Selection::Selection(): viewPool(std::make_shared<xoj::util::DispatchPool<xoj::view::SelectionView>>()) {}
 

--- a/src/core/control/tools/Selection.cpp
+++ b/src/core/control/tools/Selection.cpp
@@ -1,7 +1,6 @@
 #include "Selection.h"
 
 #include <algorithm>  // for max, min
-#include <cfloat>     // for DBL_MAX
 #include <cmath>      // for abs, NAN
 #include <memory>     // for __shared_ptr_access
 

--- a/src/core/control/tools/StrokeHandler.cpp
+++ b/src/core/control/tools/StrokeHandler.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>  // for max, min
 #include <cassert>    // for assert
 #include <cmath>      // for ceil, pow, abs
+#include <limits>     // for numeric_limits
 #include <memory>     // for unique_ptr, mak...
 #include <utility>    // for move
 #include <vector>     // for vector

--- a/src/core/control/tools/StrokeHandler.cpp
+++ b/src/core/control/tools/StrokeHandler.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>  // for max, min
 #include <cassert>    // for assert
-#include <cfloat>     // for DBL_EPSILON
 #include <cmath>      // for ceil, pow, abs
 #include <memory>     // for unique_ptr, mak...
 #include <utility>    // for move
@@ -328,10 +327,10 @@ void StrokeHandler::strokeRecognizerDetected(Stroke* recognized, Layer* layer) {
         Point belowRight = Point(snappedBounds.x + snappedBounds.width, snappedBounds.y + snappedBounds.height);
         Point belowRightSnapped = snappingHandler.snapToGrid(belowRight, false);
 
-        double fx = (std::abs(snappedBounds.width) > DBL_EPSILON) ?
+        double fx = (std::abs(snappedBounds.width) > std::numeric_limits<double>::epsilon()) ?
                             (belowRightSnapped.x - topLeftSnapped.x) / snappedBounds.width :
                             1;
-        double fy = (std::abs(snappedBounds.height) > DBL_EPSILON) ?
+        double fy = (std::abs(snappedBounds.height) > std::numeric_limits<double>::epsilon()) ?
                             (belowRightSnapped.y - topLeftSnapped.y) / snappedBounds.height :
                             1;
         recognized->scale(topLeftSnapped.x, topLeftSnapped.y, fx, fy, 0, false);

--- a/src/core/control/tools/StrokeStabilizer.cpp
+++ b/src/core/control/tools/StrokeStabilizer.cpp
@@ -1,7 +1,6 @@
 #include "StrokeStabilizer.h"
 
 #include <algorithm>  // for min
-#include <cfloat>
 #include <iterator>  // for begin, end
 #include <list>      // for list, operator!=
 #include <numeric>   // for accumulate
@@ -113,10 +112,10 @@ void StrokeStabilizer::Active::quadraticSplineTo(const Event& ev) {
     const double normBC = std::sqrt(squaredNormBC);
     const double normAB = vAB.norm();
 
-    if (normBC < DBL_EPSILON) {
+    if (normBC < std::numeric_limits<double>::epsilon()) {
         return;
     }
-    if (normAB < DBL_EPSILON) {
+    if (normAB < std::numeric_limits<double>::epsilon()) {
         g_warning("Last two points of stroke coincide. ");
         drawEvent(ev);
         return;

--- a/src/core/control/tools/StrokeStabilizer.cpp
+++ b/src/core/control/tools/StrokeStabilizer.cpp
@@ -1,10 +1,11 @@
 #include "StrokeStabilizer.h"
 
 #include <algorithm>  // for min
-#include <iterator>  // for begin, end
-#include <list>      // for list, operator!=
-#include <numeric>   // for accumulate
-#include <vector>    // for vector
+#include <iterator>   // for begin, end
+#include <limits>     // for numeric_limits
+#include <list>       // for list, operator!=
+#include <numeric>    // for accumulate
+#include <vector>     // for vector
 
 #include "control/settings/Settings.h"           // for Settings
 #include "control/tools/StrokeStabilizerEnum.h"  // for Preprocessor, Averag...

--- a/src/core/model/Stroke.cpp
+++ b/src/core/model/Stroke.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>  // for min, max, copy
 #include <cassert>    // for assert
-#include <cfloat>     // for DBL_MAX, DBL_MIN
 #include <cinttypes>  // for uint64_t
 #include <cmath>      // for abs, hypot, sqrt
 #include <iterator>   // for back_insert_iterator
@@ -818,10 +817,10 @@ void Stroke::calcSize() const {
         Element::snappedBounds = Rectangle<double>{};
     }
 
-    double minSnapX = DBL_MAX;
-    double maxSnapX = DBL_MIN;
-    double minSnapY = DBL_MAX;
-    double maxSnapY = DBL_MIN;
+    double minSnapX = std::numeric_limits<double>::max();
+    double maxSnapX = std::numeric_limits<double>::min();
+    double minSnapY = std::numeric_limits<double>::max();
+    double maxSnapY = std::numeric_limits<double>::min();
 
     auto halfThick = 0.0;
 

--- a/src/core/model/Stroke.cpp
+++ b/src/core/model/Stroke.cpp
@@ -5,6 +5,7 @@
 #include <cinttypes>  // for uint64_t
 #include <cmath>      // for abs, hypot, sqrt
 #include <iterator>   // for back_insert_iterator
+#include <limits>     // for numeric_limits
 #include <numeric>    // for accumulate
 #include <optional>   // for optional, nullopt
 #include <string>     // for to_string, operator<<

--- a/src/core/plugin/Plugin.cpp
+++ b/src/core/plugin/Plugin.cpp
@@ -240,7 +240,7 @@ auto Plugin::callFunction(const std::string& fnc, long mode) -> bool {
 
     int numArgs = 0;
 
-    if (mode != LONG_MAX) {
+    if (mode != std::numeric_limits<long>::max()) {
         lua_pushinteger(lua.get(), mode);
         numArgs = 1;
     }

--- a/src/core/plugin/Plugin.cpp
+++ b/src/core/plugin/Plugin.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>  // for max
 #include <array>      // for array
+#include <limits>     // for numeric_limits
 #include <map>        // for map
 
 #include <gdk/gdk.h>      // for GdkModifierType

--- a/src/core/plugin/Plugin.cpp
+++ b/src/core/plugin/Plugin.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>  // for max
 #include <array>      // for array
-#include <limits>     // for numeric_limits
 #include <map>        // for map
 
 #include <gdk/gdk.h>      // for GdkModifierType

--- a/src/core/plugin/Plugin.h
+++ b/src/core/plugin/Plugin.h
@@ -42,11 +42,11 @@ struct MenuEntry final {
             mode(mode),
             accelerator(std::move(accelerator)) {}
 
-    GtkWidget* widget = nullptr;  ///< Menu item
-    Plugin* plugin = nullptr;     ///< The Plugin
-    std::string menu{};           ///< Menu display name
-    std::string callback{};       ///< Callback function name
-    long mode{LONG_MAX};          ///< mode in which the callback function is run
+    GtkWidget* widget = nullptr;                  ///< Menu item
+    Plugin* plugin = nullptr;                     ///< The Plugin
+    std::string menu{};                           ///< Menu display name
+    std::string callback{};                       ///< Callback function name
+    long mode{std::numeric_limits<long>::max()};  ///< mode in which the callback function is run
     std::string accelerator{};
     ///< Accelerator key, see
     ///< https://developer.gnome.org/gtk3/stable/gtk3-Keyboard-Accelerators.html#gtk-accelerator-parse
@@ -115,7 +115,7 @@ private:
     void loadIni();
 
     /// Execute lua function
-    auto callFunction(const std::string& fnc, long mode = LONG_MAX) -> bool;
+    auto callFunction(const std::string& fnc, long mode = std::numeric_limits<long>::max()) -> bool;
 
     /// Load custom Lua Libraries
     static void registerXournalppLibs(lua_State* luaPtr);

--- a/src/core/plugin/Plugin.h
+++ b/src/core/plugin/Plugin.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <cstddef>  // for size_t
+#include <limits>   // for numeric_limits
 #include <memory>   // for unique_ptr
 
 #include "config-features.h"  // for ENABLE_PLUGINS

--- a/src/core/plugin/luapi_application.h
+++ b/src/core/plugin/luapi_application.h
@@ -245,7 +245,7 @@ static int applib_registerUi(lua_State* L) {
     const char* accelerator = luaL_optstring(L, -4, nullptr);
     const char* menu = luaL_optstring(L, -3, nullptr);
     const char* callback = luaL_optstring(L, -2, nullptr);
-    const long mode = luaL_optinteger(L, -1, LONG_MAX);
+    const long mode = luaL_optinteger(L, -1, std::numeric_limits<long>::max());
     if (callback == nullptr) {
         luaL_error(L, "Missing callback function!");
     }

--- a/src/core/plugin/luapi_application.h
+++ b/src/core/plugin/luapi_application.h
@@ -12,6 +12,7 @@
 
 #include <climits>
 #include <cstring>
+#include <limits>  // for numeric_limits
 #include <map>
 
 #include <gtk/gtk.h>


### PR DESCRIPTION
This improves consistency with the rest of the codebase. I think this also improves compatability, since it's in #4092 as well