### PR TITLE
chore: Improvements to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,11 +2,9 @@
 .deps
 .dirstamp
 .libs
-*.DS_Store
 *.o
 *.lo
 *.la
-*~
 Makefile
 Makefile.in
 libtool
@@ -38,18 +36,14 @@ nbproject/
 
 # Visual Studio Code
 .vscode/
-*/.vscode/
 
 # CLion
-.idea
+.idea/
 cmake-build-*
 
 # API Documentation
 doc/html
 doc/latex
-
-src/core/view/.DS_Store
-src/core/view/background/.DS_Store
 
 # Flatpak
 repo/
@@ -60,8 +54,12 @@ flatpak-build/
 # Lua
 lua-*
 
-# Clangd 
+# Clangd
 compile_commands.json
-.clangd
-.cache
+.clangd/
+.cache/
 Debug
+
+# Miscellaneous
+.DS_STORE
+*~


### PR DESCRIPTION
- `.*DS_Store` can be `.DS_STORE` and isn't autotools specific
- `*~` isn't autotools specific
- `*/.vscode/` is redundant
- `.idea` can have a trailing slash
- `src/**/.DS_Store` entries are redundant

cc @Febbe wanted to get your OK since you authored e16faa7bcdbceb49d8a4d15e07df3fd963552c85 - in theory both VSCode entries should behave the same, but maybe there was a Git bug or troubles with cached untracked files? Maybe it's fixed by now