### PR TITLE
Refactor SidebarPreviewBase to use std::unique_ptr

### DIFF
--- a/src/core/gui/sidebar/previews/base/SidebarLayout.cpp
+++ b/src/core/gui/sidebar/previews/base/SidebarLayout.cpp
@@ -84,16 +84,16 @@ void SidebarLayout::layout(SidebarPreviewBase* sidebar) {
 
     SidebarRow row(alloc.width);
 
-    for (SidebarPreviewBaseEntry* p: sidebar->previews) {
-        if (row.isSpaceFor(p)) {
-            row.add(p);
+    for (auto &p: sidebar->previews) {
+        if (row.isSpaceFor(p.get())) {
+            row.add(p.get());
         } else {
             y += row.placeAt(y, GTK_LAYOUT(sidebar->iconViewPreview));
 
             width = std::max(width, row.getWidth());
 
             row.clear();
-            row.add(p);
+            row.add(p.get());
         }
     }
 

--- a/src/core/gui/sidebar/previews/base/SidebarPreviewBase.cpp
+++ b/src/core/gui/sidebar/previews/base/SidebarPreviewBase.cpp
@@ -59,7 +59,6 @@ SidebarPreviewBase::~SidebarPreviewBase() {
 
     this->scrollPreview = nullptr;
 
-    for (SidebarPreviewBaseEntry* p: this->previews) { delete p; }
     this->previews.clear();
 }
 
@@ -120,7 +119,7 @@ auto SidebarPreviewBase::scrollToPreview(SidebarPreviewBase* sidebar) -> bool {
     }
 
     if (sidebar->selectedEntry != npos && sidebar->selectedEntry < sidebar->previews.size()) {
-        SidebarPreviewBaseEntry* p = sidebar->previews[sidebar->selectedEntry];
+        auto& p = sidebar->previews[sidebar->selectedEntry];
 
         // scroll to preview
         GtkAdjustment* hadj = gtk_scrolled_window_get_hadjustment(GTK_SCROLLED_WINDOW(sidebar->scrollPreview));

--- a/src/core/gui/sidebar/previews/base/SidebarPreviewBase.h
+++ b/src/core/gui/sidebar/previews/base/SidebarPreviewBase.h
@@ -127,7 +127,7 @@ protected:
     /**
      * The previews
      */
-    std::vector<SidebarPreviewBaseEntry*> previews;
+    std::vector<std::unique_ptr<SidebarPreviewBaseEntry>> previews;
 
     /**
      * The sidebar is enabled


### PR DESCRIPTION
SidebarPreviewBase attribute preiews (vector of SidebarPreviewBaseEntry pointers) has been refactored to a vector of unique_ptr of SidebarPreviewBaseEntry