### PR TITLE
Fix latex' thin lines

### DIFF
--- a/src/core/control/jobs/RenderJob.h
+++ b/src/core/control/jobs/RenderJob.h
@@ -43,7 +43,7 @@ private:
 
     void rerenderRectangle(xoj::util::Rectangle<double> const& rect);
 
-    void renderToBuffer(cairo_surface_t* buffer) const;
+    void renderToBuffer(cairo_surface_t* buffer, double ratio, double x, double y) const;
 
 private:
     XojPageView* view;


### PR DESCRIPTION
Fixes #4555 

The issue came from the use of `cairo_surface_set_device_scale` on the rendering masks. Replacing it with calls to `cairo_scale` fixed poppler's behaviour. Let me try to explain why.

`cairo_surface_set_device_scale` is supposed to tell a cairo surface that it'll be used in a window with a certain GDK_SCALE value (so HiDPI kinda stuff). In practice, this device scale is very handy, as most operations can then be made without ever caring about the DPI scaling.
Now, I (unknowingly) perverted this function and used it for mask via `cairo_surface_set_device_scale(surf, zoom * dpiScaling, zoom * dpiScaling)`. This works well, except when Poppler is involved... The reason lies in Poppler's screen rendering optimizations (see [the doc](https://poppler.freedesktop.org/api/glib/poppler-Poppler-Page.html#poppler-page-render-for-printing)): PDF files may contain width 0 lines, which should be rendered with "the minimal width the device can do". When printing, this depends on the printer's resolution. When rendering for on-screen view, this depends on the screen resolution. The way Poppler finds this resolution out is by looking at the `cairo_surface_t`'s size (width/height) and device scale.

My messing up the device scale made Poppler believe the pixel size was huge, so width 0 lines appeared very thick.

This PR is a quick fix, but I think we should remove every occurence of `cairo_surface_set_device_scale`. Using it was a mistake of mine.