### PR TITLE
Make it possible to scroll an entire page with vim keybindings

### DIFF
--- a/src/core/gui/XournalView.cpp
+++ b/src/core/gui/XournalView.cpp
@@ -224,7 +224,7 @@ auto XournalView::onKeyPressEvent(GdkEventKey* event) -> bool {
     }
 
 
-    if (event->keyval == GDK_KEY_Up || event->keyval == GDK_KEY_k) {
+    if (event->keyval == GDK_KEY_Up || event->keyval == GDK_KEY_k || event->keyval == GDK_KEY_K) {
         if (control->getSettings()->isPresentationMode()) {
             control->getScrollHandler()->goToPreviousPage();
             return true;
@@ -239,7 +239,7 @@ auto XournalView::onKeyPressEvent(GdkEventKey* event) -> bool {
         return true;
     }
 
-    if (event->keyval == GDK_KEY_Down || event->keyval == GDK_KEY_j) {
+    if (event->keyval == GDK_KEY_Down || event->keyval == GDK_KEY_j || event->keyval == GDK_KEY_J) {
         if (control->getSettings()->isPresentationMode()) {
             control->getScrollHandler()->goToNextPage();
             return true;


### PR DESCRIPTION
Until now there was no way to scroll an entire page using vim keybindings, SHIFT + DOWN_ARROW did work, but SHIFT + j didn't do anything. With this pr it is now possible to use SHIFT + j to scroll a page down and SHIFT + k to scroll a page up.