### PR TITLE
Color tool opens with current color selected

### DIFF
--- a/src/core/gui/toolbarMenubar/ColorToolItem.cpp
+++ b/src/core/gui/toolbarMenubar/ColorToolItem.cpp
@@ -79,9 +79,11 @@ void ColorToolItem::showColorchooser() {
     GtkWidget* dialog = gtk_color_chooser_dialog_new(_("Select color"), parent);
     gtk_color_chooser_set_use_alpha(GTK_COLOR_CHOOSER(dialog), false);
 
+    GdkRGBA color = Util::argb_to_GdkRGBA(getColor(), 1.0);
+    gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(dialog), &color);
+
     int response = gtk_dialog_run(GTK_DIALOG(dialog));
     if (response == GTK_RESPONSE_OK) {
-        GdkRGBA color;
         gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(dialog), &color);
         this->namedColor = NamedColor{Util::GdkRGBA_to_argb(color)};
     }


### PR DESCRIPTION
Fix 'Quality of life changes for Color PIcker #4569'

The dialog now opens up with the current selected color. By right clicking on the color button - you can choose 'customize' which open up the color palette at the hex values of the selected color. The dialogs used for this is the GTK default dialogs for picking colors - they don't behave excatly as google docs picker.