### PR TITLE
Fix non-virtual destructor of GeometryToolController and derived class

### DIFF
--- a/src/core/control/CompassController.h
+++ b/src/core/control/CompassController.h
@@ -35,7 +35,7 @@ class Stroke;
 class CompassController: public GeometryToolController {
 public:
     CompassController(XojPageView* view, Compass* compass);
-    ~CompassController();
+    ~CompassController() override;
 
 public:
     GeometryToolType getType() const override;

--- a/src/core/control/GeometryToolController.h
+++ b/src/core/control/GeometryToolController.h
@@ -30,7 +30,7 @@ class Stroke;
 class GeometryToolController {
 public:
     GeometryToolController(XojPageView* view, GeometryTool* geometryTool);
-    ~GeometryToolController();
+    virtual ~GeometryToolController();
 
 public:
     /**

--- a/src/core/control/SetsquareController.h
+++ b/src/core/control/SetsquareController.h
@@ -37,7 +37,7 @@ enum Leg { HYPOTENUSE, LEFT_LEG, RIGHT_LEG };
 class SetsquareController: public GeometryToolController {
 public:
     SetsquareController(XojPageView* view, Setsquare* setsquare);
-    ~SetsquareController();
+    ~SetsquareController() override;
 
 public:
     GeometryToolType getType() const override;


### PR DESCRIPTION
This PR makes the destructor of GeometryToolController virtual, thus fixing a plausible memory leak.