### PR TITLE
chore: Replace `sprintf` with `PlaceholderString` in `AboutDialog.cpp`

### DIFF
--- a/src/core/gui/dialog/AboutDialog.cpp
+++ b/src/core/gui/dialog/AboutDialog.cpp
@@ -1,11 +1,11 @@
 #include "AboutDialog.h"
 
-#include <cstdio>  // for sprintf
 #include <memory>  // for allocator
 
 #include <gtk/gtk.h>  // for gtk_box_pack_start, gtk_label_set_markup
 
-#include "util/i18n.h"  // for _
+#include "util/PlaceholderString.h"  // for PlaceholderString
+#include "util/i18n.h"               // for _
 
 #include "config-git.h"  // for GIT_COMMIT_ID
 #include "config.h"      // for PROJECT_VERSION
@@ -14,7 +14,7 @@ class GladeSearchpath;
 
 AboutDialog::AboutDialog(GladeSearchpath* gladeSearchPath): GladeGui(gladeSearchPath, "about.glade", "aboutDialog") {
     auto insertPropertyKey = [](GtkGrid* grid, std::string&& str, gint top) {
-        auto widget = gtk_label_new(NULL);
+        auto widget = gtk_label_new(nullptr);
         gtk_label_set_markup(GTK_LABEL(widget), str.insert(0, "<b>").append("</b>").c_str());
         gtk_widget_set_halign(widget, GtkAlign::GTK_ALIGN_START);
         gtk_widget_show(widget);
@@ -37,8 +37,8 @@ AboutDialog::AboutDialog(GladeSearchpath* gladeSearchPath): GladeGui(gladeSearch
     insertPropertyValue(infoGrid, __DATE__ ", " __TIME__, 1);
 
     insertPropertyKey(infoGrid, _("GTK Version"), 2);
-    char gtkVersion[10];
-    sprintf(gtkVersion, "%u.%u.%u", gtk_get_major_version(), gtk_get_minor_version(), gtk_get_micro_version());
+    auto gtkVersion =
+            FS(FORMAT_STR("{1}.{2}.{3}") % gtk_get_major_version() % gtk_get_minor_version() % gtk_get_micro_version());
     insertPropertyValue(infoGrid, gtkVersion, 2);
 
     auto const gitCommitId = std::string{GIT_COMMIT_ID};


### PR DESCRIPTION
Removes another instance of using raw C arrays