### PR TITLE
Default pdf-export name with wildcards

### DIFF
--- a/src/core/control/jobs/BaseExportJob.cpp
+++ b/src/core/control/jobs/BaseExportJob.cpp
@@ -69,7 +69,7 @@ auto BaseExportJob::showFilechooser() -> bool {
     Document* doc = control->getDocument();
     doc->lock();
     fs::path folder = doc->createSaveFolder(settings->getLastSavePath());
-    fs::path name = doc->createSaveFilename(Document::PDF, settings->getDefaultSaveName(), /*defaultPfdName*/settings->getDefaultPdfExportName());
+    fs::path name = doc->createSaveFilename(Document::PDF, settings->getDefaultSaveName(), settings->getDefaultPdfExportName());
     doc->unlock();
 
     gtk_file_chooser_set_local_only(GTK_FILE_CHOOSER(dialog), true);

--- a/src/core/control/jobs/BaseExportJob.cpp
+++ b/src/core/control/jobs/BaseExportJob.cpp
@@ -69,7 +69,7 @@ auto BaseExportJob::showFilechooser() -> bool {
     Document* doc = control->getDocument();
     doc->lock();
     fs::path folder = doc->createSaveFolder(settings->getLastSavePath());
-    fs::path name = doc->createSaveFilename(Document::PDF, settings->getDefaultSaveName());
+    fs::path name = doc->createSaveFilename(Document::PDF, settings->getDefaultSaveName(), /*defaultPfdName*/"%{name}_annotated"); // TODO get defaultPdfName from settings
     doc->unlock();
 
     gtk_file_chooser_set_local_only(GTK_FILE_CHOOSER(dialog), true);

--- a/src/core/control/jobs/BaseExportJob.cpp
+++ b/src/core/control/jobs/BaseExportJob.cpp
@@ -69,7 +69,7 @@ auto BaseExportJob::showFilechooser() -> bool {
     Document* doc = control->getDocument();
     doc->lock();
     fs::path folder = doc->createSaveFolder(settings->getLastSavePath());
-    fs::path name = doc->createSaveFilename(Document::PDF, settings->getDefaultSaveName(), /*defaultPfdName*/"%{name}_annotated"); // TODO get defaultPdfName from settings
+    fs::path name = doc->createSaveFilename(Document::PDF, settings->getDefaultSaveName(), /*defaultPfdName*/settings->getDefaultPdfExportName());
     doc->unlock();
 
     gtk_file_chooser_set_local_only(GTK_FILE_CHOOSER(dialog), true);

--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -454,7 +454,7 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur) {
         this->defaultSaveName = reinterpret_cast<const char*>(value);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("defaultPdfExportName")) == 0) {
         this->defaultPdfExportName = reinterpret_cast<const char*>(value);
-    }else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("pluginEnabled")) == 0) {
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("pluginEnabled")) == 0) {
         this->pluginEnabled = reinterpret_cast<const char*>(value);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("pluginDisabled")) == 0) {
         this->pluginDisabled = reinterpret_cast<const char*>(value);

--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -140,6 +140,8 @@ void Settings::loadDefault() {
 
     this->defaultSaveName = _("%F-Note-%H-%M");
 
+    this->defaultPdfExportName = _("%{name}_annotated");
+
     // Eraser
     this->buttonConfig[BUTTON_ERASER] =
             std::make_unique<ButtonConfig>(TOOL_ERASER, Colors::black, TOOL_SIZE_NONE, DRAWING_TYPE_DEFAULT, ERASER_TYPE_NONE);
@@ -1494,6 +1496,8 @@ void Settings::setAutoloadPdfXoj(bool load) {
 }
 
 auto Settings::getDefaultSaveName() const -> string const& { return this->defaultSaveName; }
+
+auto Settings::getDefaultPdfExportName() const -> string const& { return this->defaultPdfExportName; }
 
 void Settings::setDefaultSaveName(const string& name) {
     if (this->defaultSaveName == name) {

--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -452,7 +452,9 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur) {
         this->useStockIcons = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("defaultSaveName")) == 0) {
         this->defaultSaveName = reinterpret_cast<const char*>(value);
-    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("pluginEnabled")) == 0) {
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("defaultPdfExportName")) == 0) {
+        this->defaultPdfExportName = reinterpret_cast<const char*>(value);
+    }else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("pluginEnabled")) == 0) {
         this->pluginEnabled = reinterpret_cast<const char*>(value);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("pluginDisabled")) == 0) {
         this->pluginDisabled = reinterpret_cast<const char*>(value);
@@ -970,6 +972,7 @@ void Settings::save() {
     SAVE_BOOL_PROP(autoloadMostRecent);
     SAVE_BOOL_PROP(autoloadPdfXoj);
     SAVE_STRING_PROP(defaultSaveName);
+    SAVE_STRING_PROP(defaultPdfExportName);
 
     SAVE_BOOL_PROP(autosaveEnabled);
     SAVE_INT_PROP(autosaveTimeout);

--- a/src/core/control/settings/Settings.h
+++ b/src/core/control/settings/Settings.h
@@ -344,7 +344,12 @@ public:
     std::string const& getDefaultSaveName() const;
     void setDefaultSaveName(const std::string& name);
 
+    std::string const& getDefaultPdfExportName() const;
+
     ButtonConfig* getButtonConfig(unsigned int id);
+
+    std::string const& getFullscreenHideElements() const;
+    void setFullscreenHideElements(std::string elements);
 
     void setViewMode(ViewModeId mode, ViewMode ViewMode);
 
@@ -870,6 +875,8 @@ private:
      * Default name if you save a new document
      */
     std::string defaultSaveName;  // should be string - don't change to path
+
+    std::string defaultPdfExportName;
 
     /**
      * The button config

--- a/src/core/model/Document.cpp
+++ b/src/core/model/Document.cpp
@@ -134,9 +134,9 @@ auto Document::createSaveFolder(fs::path lastSavePath) -> fs::path {
 
 std::string Document::parseFilenameWildcard(const std::string& wildcard) {
     if (wildcard == "name") {
-        fs::path pdfPath = pdfFilepath.filename();
+        fs::path pdfPath = this->pdfFilepath.filename();
         Util::clearExtensions(pdfPath, ".pdf");
-        return pdfPath;
+        return pdfPath.u8string();
     }
     if (wildcard == "date" || wildcard == "time") {
         std::time_t time = std::chrono::system_clock::to_time_t(

--- a/src/core/model/Document.cpp
+++ b/src/core/model/Document.cpp
@@ -170,8 +170,7 @@ auto Document::createSaveFilename(DocumentType type, const std::string& defaultS
             }
 
             std::string wildcard = saveString.substr(pos + 2, endPos - pos - 2);
-            saveString.replace(pos, endPos + 1, parseFilenameWildcard(wildcard));
-
+            saveString.replace(pos, endPos + 1 - pos, parseFilenameWildcard(wildcard));
             pos = saveString.find(DEFAULT_PDF_WILDCARD_START, pos);
         }
 

--- a/src/core/model/Document.cpp
+++ b/src/core/model/Document.cpp
@@ -128,7 +128,7 @@ auto Document::createSaveFolder(fs::path lastSavePath) -> fs::path {
     return lastSavePath;
 }
 
-auto Document::createSaveFilename(DocumentType type, const std::string& defaultSaveName) -> fs::path {
+auto Document::createSaveFilename(DocumentType type, const std::string& defaultSaveName, const std::string& defaultPfdName) -> fs::path {
     if (!filepath.empty()) {
         // This can be any extension
         fs::path p = filepath.filename();
@@ -140,17 +140,23 @@ auto Document::createSaveFilename(DocumentType type, const std::string& defaultS
         Util::clearExtensions(p, ".pdf");
 
         // Building the pdf-filepath according to settings (replace wildcards)
-        std::string saveString = "%{name}_annotated"; // this->getPdfExportFilepath();
+        std::string saveString = (defaultPfdName == "" ? static_cast<std::string>(p) : defaultPfdName);
         std::string startstr = "%{"; // TODO make const
         std::string endstr = "}"; // TODO make const
-
         size_t pos = saveString.find(startstr);
         while (pos != std::string::npos) {
             size_t endPos = saveString.find(endstr, pos + 2);
             if (endPos == std::string::npos) {
                 break;
             }
-            saveString.replace(pos, endPos + 1, p);
+            std::string wildcard = saveString.substr(pos + 2, endPos - pos - 2);
+            std::cout << wildcard << std::endl;
+            if (wildcard == "name") { // additional wildcards can be implemented here
+                wildcard = p;
+            } else {
+                wildcard = "";
+            }
+            saveString.replace(pos, endPos + 1, wildcard);
             pos = saveString.find(startstr, pos);
         }
 
@@ -168,7 +174,7 @@ auto Document::createSaveFilename(DocumentType type, const std::string& defaultS
     // Remove the extension, file format is handled by the filter combo box
     fs::path p = stime;
     Util::clearExtensions(p);
-    return "savename 3";
+    return p;
 }
 
 

--- a/src/core/model/Document.cpp
+++ b/src/core/model/Document.cpp
@@ -139,16 +139,17 @@ auto Document::createSaveFilename(DocumentType type, const std::string& defaultS
         fs::path p = pdfFilepath.filename();
         Util::clearExtensions(p, ".pdf");
 
-        // Building the pdf-filepath according to settings (replace wildcards)
+        // Build the pdf-filepath according to settings (replace wildcards)
         std::string saveString = (defaultPfdName == "" ? static_cast<std::string>(p) : defaultPfdName);
-        std::string startstr = "%{"; // TODO make const
-        std::string endstr = "}"; // TODO make const
-        size_t pos = saveString.find(startstr);
+
+        size_t pos = saveString.find(DEFAULT_PDF_WILDCARD_START);
         while (pos != std::string::npos) {
-            size_t endPos = saveString.find(endstr, pos + 2);
+            size_t endPos = saveString.find(DEFAULT_PDF_WILDCARD_END, pos + 2);
             if (endPos == std::string::npos) {
                 break;
             }
+
+            // parse the current wildcard
             std::string wildcard = saveString.substr(pos + 2, endPos - pos - 2);
             std::cout << wildcard << std::endl;
             if (wildcard == "name") { // additional wildcards can be implemented here
@@ -157,7 +158,8 @@ auto Document::createSaveFilename(DocumentType type, const std::string& defaultS
                 wildcard = "";
             }
             saveString.replace(pos, endPos + 1, wildcard);
-            pos = saveString.find(startstr, pos);
+
+            pos = saveString.find(DEFAULT_PDF_WILDCARD_START);
         }
 
         if (!this->attachPdf) {

--- a/src/core/model/Document.cpp
+++ b/src/core/model/Document.cpp
@@ -137,12 +137,27 @@ auto Document::createSaveFilename(DocumentType type, const std::string& defaultS
     }
     if (!pdfFilepath.empty()) {
         fs::path p = pdfFilepath.filename();
-        if (this->attachPdf) {
-            Util::clearExtensions(p, ".pdf");
-        } else {
-            Util::clearExtensions(p);
+        Util::clearExtensions(p, ".pdf");
+
+        // Building the pdf-filepath according to settings (replace wildcards)
+        std::string saveString = "%{name}_annotated"; // this->getPdfExportFilepath();
+        std::string startstr = "%{"; // TODO make const
+        std::string endstr = "}"; // TODO make const
+
+        size_t pos = saveString.find(startstr);
+        while (pos != std::string::npos) {
+            size_t endPos = saveString.find(endstr, pos + 2);
+            if (endPos == std::string::npos) {
+                break;
+            }
+            saveString.replace(pos, endPos + 1, p);
+            pos = saveString.find(startstr, pos);
         }
-        return p;
+
+        if (!this->attachPdf) {
+            saveString += ".pdf";
+        }
+        return saveString;
     }
 
 
@@ -153,7 +168,7 @@ auto Document::createSaveFilename(DocumentType type, const std::string& defaultS
     // Remove the extension, file format is handled by the filter combo box
     fs::path p = stime;
     Util::clearExtensions(p);
-    return p;
+    return "savename 3";
 }
 
 

--- a/src/core/model/Document.cpp
+++ b/src/core/model/Document.cpp
@@ -141,7 +141,11 @@ auto Document::createSaveFilename(DocumentType type, const std::string& defaultS
         return p;
     }
     if (!pdfFilepath.empty()) {
-        return SaveNameUtils::parseFilenameFromWildcardString(defaultPdfName, this->pdfFilepath.filename(), this->attachPdf);
+        auto saveString = SaveNameUtils::parseFilenameFromWildcardString(defaultPdfName, this->pdfFilepath.filename());
+        if (!this->attachPdf) {
+            saveString += ".pdf";
+        }
+        return saveString;
     }
 
 

--- a/src/core/model/Document.cpp
+++ b/src/core/model/Document.cpp
@@ -1,9 +1,6 @@
 #include "Document.h"
 
-#include <sstream>  // for stringstream
 #include <string>   // for string
-#include <chrono>   // for time
-#include <iomanip>  // put_time
 #include <ctime>    // for size_t, localtime, strf...
 #include <utility>  // for move, pair
 

--- a/src/core/model/Document.h
+++ b/src/core/model/Document.h
@@ -75,7 +75,7 @@ public:
     fs::path getFilepath() const;
     fs::path getPdfFilepath() const;
     fs::path createSaveFolder(fs::path lastSavePath);
-    fs::path createSaveFilename(DocumentType type, const std::string& defaultSaveName);
+    fs::path createSaveFilename(DocumentType type, const std::string& defaultSaveName, const std::string& defaultPfdName = "");
 
     fs::path getEvMetadataFilename() const;
 

--- a/src/core/model/Document.h
+++ b/src/core/model/Document.h
@@ -33,6 +33,9 @@
 class DocumentHandler;
 class XojPdfBookmarkIterator;
 
+constexpr auto DEFAULT_PDF_WILDCARD_START = "%{";
+constexpr auto DEFAULT_PDF_WILDCARD_END = "}";
+
 class Document {
 public:
     Document(DocumentHandler* handler);

--- a/src/core/model/Document.h
+++ b/src/core/model/Document.h
@@ -33,9 +33,6 @@
 class DocumentHandler;
 class XojPdfBookmarkIterator;
 
-constexpr auto DEFAULT_PDF_WILDCARD_START = "%{";
-constexpr auto DEFAULT_PDF_WILDCARD_END = "}";
-
 class Document {
 public:
     Document(DocumentHandler* handler);
@@ -79,7 +76,6 @@ public:
     fs::path getPdfFilepath() const;
     fs::path createSaveFolder(fs::path lastSavePath);
     fs::path createSaveFilename(DocumentType type, const std::string& defaultSaveName, const std::string& defaultPfdName = "");
-    std::string parseFilenameWildcard(const std::string& wildcard);
 
     fs::path getEvMetadataFilename() const;
 

--- a/src/core/model/Document.h
+++ b/src/core/model/Document.h
@@ -79,6 +79,7 @@ public:
     fs::path getPdfFilepath() const;
     fs::path createSaveFolder(fs::path lastSavePath);
     fs::path createSaveFilename(DocumentType type, const std::string& defaultSaveName, const std::string& defaultPfdName = "");
+    std::string parseFilenameWildcard(const std::string& wildcard);
 
     fs::path getEvMetadataFilename() const;
 

--- a/src/util/SaveNameUtils.cpp
+++ b/src/util/SaveNameUtils.cpp
@@ -1,7 +1,8 @@
 #include "util/SaveNameUtils.h"
 
+#include <sstream>            // for stringstream
 #include <chrono>             // for time
-#include <iomanip>            // put_time
+#include <iomanip>            // for put_time
 
 #include "util/PathUtil.h"    // for clearExtensions
 

--- a/src/util/SaveNameUtils.cpp
+++ b/src/util/SaveNameUtils.cpp
@@ -1,0 +1,47 @@
+#include "util/SaveNameUtils.h"
+
+#include <chrono>             // for time
+#include <iomanip>            // put_time
+
+#include "util/PathUtil.h"    // for clearExtensions
+
+
+auto SaveNameUtils::parseFilenameFromWildcardString(const std::string& wildcardString, fs::path defaultFilePath, bool attachPdf) -> std::string {
+    std::string saveString = wildcardString;
+    size_t pos = saveString.find(DEFAULT_WILDCARD_START);
+
+    // parse all wildcards until none are left
+    while (pos != std::string::npos) {
+        size_t wildcardStartLength = std::strlen(DEFAULT_WILDCARD_START);
+        size_t endPos = saveString.find(DEFAULT_WILDCARD_END, pos + wildcardStartLength);
+        if (endPos == std::string::npos) {
+            break;
+        }
+        std::string wildcard = saveString.substr(pos + wildcardStartLength, endPos - pos - wildcardStartLength);
+        saveString.replace(pos, endPos + 1 - pos, parseFilenameWildcard(wildcard, defaultFilePath));
+        pos = saveString.find(DEFAULT_WILDCARD_START, pos);
+    }
+
+    if (!attachPdf) {
+        saveString += ".pdf";
+    }
+    return saveString;
+}
+
+auto SaveNameUtils::parseFilenameWildcard(const std::string& wildcard, fs::path defaultFilePath) -> std::string {
+    if (wildcard == "name") {
+        Util::clearExtensions(defaultFilePath, ".pdf");
+        return defaultFilePath.u8string();
+    }
+    if (wildcard == "date" || wildcard == "time") {
+        std::time_t time = std::chrono::system_clock::to_time_t(
+            std::chrono::system_clock::now()
+        );
+        std::stringstream timestring;
+        timestring << std::put_time(std::localtime(&time),
+                                wildcard == "date" ? "%Y-%m-%d" : "%X");
+        return timestring.str();
+    } 
+    // not a valid wildcard
+    return "";
+}

--- a/src/util/SaveNameUtils.cpp
+++ b/src/util/SaveNameUtils.cpp
@@ -7,7 +7,7 @@
 #include "util/PathUtil.h"    // for clearExtensions
 
 
-auto SaveNameUtils::parseFilenameFromWildcardString(const std::string& wildcardString, fs::path defaultFilePath, bool attachPdf) -> std::string {
+auto SaveNameUtils::parseFilenameFromWildcardString(const std::string& wildcardString, fs::path defaultFilePath) -> std::string {
     std::string saveString = wildcardString;
     size_t pos = saveString.find(DEFAULT_WILDCARD_START);
 
@@ -23,9 +23,6 @@ auto SaveNameUtils::parseFilenameFromWildcardString(const std::string& wildcardS
         pos = saveString.find(DEFAULT_WILDCARD_START, pos);
     }
 
-    if (!attachPdf) {
-        saveString += ".pdf";
-    }
     return saveString;
 }
 

--- a/src/util/SaveNameUtils.cpp
+++ b/src/util/SaveNameUtils.cpp
@@ -18,7 +18,7 @@ auto SaveNameUtils::parseFilenameFromWildcardString(const std::string& wildcardS
             break;
         }
         std::string wildcard = saveString.substr(pos + wildcardStartLength, endPos - pos - wildcardStartLength);
-        saveString.replace(pos, endPos + 1 - pos, parseFilenameWildcard(wildcard, defaultFilePath));
+        saveString.replace(pos, endPos + 1 - pos, parseWildcard(wildcard, defaultFilePath));
         pos = saveString.find(DEFAULT_WILDCARD_START, pos);
     }
 
@@ -28,18 +28,18 @@ auto SaveNameUtils::parseFilenameFromWildcardString(const std::string& wildcardS
     return saveString;
 }
 
-auto SaveNameUtils::parseFilenameWildcard(const std::string& wildcard, fs::path defaultFilePath) -> std::string {
-    if (wildcard == "name") {
+auto SaveNameUtils::parseWildcard(const std::string& wildcard, fs::path defaultFilePath) -> std::string {
+    if (wildcard == WILDCARD_NAME) {
         Util::clearExtensions(defaultFilePath, ".pdf");
         return defaultFilePath.u8string();
     }
-    if (wildcard == "date" || wildcard == "time") {
+    if (wildcard == WILDCARD_DATE || wildcard == WILDCARD_TIME) {
         std::time_t time = std::chrono::system_clock::to_time_t(
             std::chrono::system_clock::now()
         );
         std::stringstream timestring;
         timestring << std::put_time(std::localtime(&time),
-                                wildcard == "date" ? "%Y-%m-%d" : "%X");
+                                wildcard == WILDCARD_DATE ? "%Y-%m-%d" : "%X");
         return timestring.str();
     } 
     // not a valid wildcard

--- a/src/util/SaveNameUtils.cpp
+++ b/src/util/SaveNameUtils.cpp
@@ -7,7 +7,7 @@
 #include "util/PathUtil.h"    // for clearExtensions
 
 
-auto SaveNameUtils::parseFilenameFromWildcardString(const std::string& wildcardString, fs::path defaultFilePath) -> std::string {
+auto SaveNameUtils::parseFilenameFromWildcardString(const std::string& wildcardString, const fs::path& defaultFilePath) -> std::string {
     std::string saveString = wildcardString;
     size_t pos = saveString.find(DEFAULT_WILDCARD_START);
 
@@ -26,10 +26,11 @@ auto SaveNameUtils::parseFilenameFromWildcardString(const std::string& wildcardS
     return saveString;
 }
 
-auto SaveNameUtils::parseWildcard(const std::string& wildcard, fs::path defaultFilePath) -> std::string {
+auto SaveNameUtils::parseWildcard(const std::string& wildcard, const fs::path& defaultFilePath) -> std::string {
     if (wildcard == WILDCARD_NAME) {
-        Util::clearExtensions(defaultFilePath, ".pdf");
-        return defaultFilePath.u8string();
+        fs::path path = defaultFilePath;
+        Util::clearExtensions(path, ".pdf");
+        return path.u8string();
     }
     if (wildcard == WILDCARD_DATE || wildcard == WILDCARD_TIME) {
         std::time_t time = std::chrono::system_clock::to_time_t(

--- a/src/util/SaveNameUtils.cpp
+++ b/src/util/SaveNameUtils.cpp
@@ -18,8 +18,9 @@ auto SaveNameUtils::parseFilenameFromWildcardString(const std::string& wildcardS
         if (endPos == std::string::npos) {
             break;
         }
-        std::string wildcard = saveString.substr(pos + wildcardStartLength, endPos - pos - wildcardStartLength);
-        saveString.replace(pos, endPos + 1 - pos, parseWildcard(wildcard, defaultFilePath));
+        std::string parsedWildcard = parseWildcard(saveString.substr(pos + wildcardStartLength, endPos - pos - wildcardStartLength), defaultFilePath);
+        saveString.replace(pos, endPos + 1 - pos, parsedWildcard);
+        pos += parsedWildcard.size();
         pos = saveString.find(DEFAULT_WILDCARD_START, pos);
     }
 

--- a/src/util/include/util/SaveNameUtils.h
+++ b/src/util/include/util/SaveNameUtils.h
@@ -1,0 +1,28 @@
+/*
+ * Xournal++
+ *
+ * Save-name parsing utility, does wildcard-string to save-name conversions
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+#include <cstring>      // for size_t
+#include <string>       // for string
+
+#include "filesystem.h"       // for path
+
+constexpr auto DEFAULT_WILDCARD_START = "%{";
+constexpr auto DEFAULT_WILDCARD_END = "}";
+
+class SaveNameUtils {
+public:
+    static std::string parseFilenameFromWildcardString(const std::string& wildcardString, fs::path defaultFilePath, bool attachPdf);
+
+private:
+    static std::string parseFilenameWildcard(const std::string& wildcard, fs::path defaultFilePath);
+};

--- a/src/util/include/util/SaveNameUtils.h
+++ b/src/util/include/util/SaveNameUtils.h
@@ -19,7 +19,7 @@
 constexpr auto DEFAULT_WILDCARD_START = "%{";
 constexpr auto DEFAULT_WILDCARD_END = "}";
 
-// wildcards
+// wildcard options
 constexpr auto WILDCARD_NAME = "name"; // default store name, e.g. original pdf name
 constexpr auto WILDCARD_DATE = "date"; // current date
 constexpr auto WILDCARD_TIME = "time"; // current time

--- a/src/util/include/util/SaveNameUtils.h
+++ b/src/util/include/util/SaveNameUtils.h
@@ -19,10 +19,15 @@
 constexpr auto DEFAULT_WILDCARD_START = "%{";
 constexpr auto DEFAULT_WILDCARD_END = "}";
 
+// wildcards
+constexpr auto WILDCARD_NAME = "name"; // default store name, e.g. original pdf name
+constexpr auto WILDCARD_DATE = "date"; // current date
+constexpr auto WILDCARD_TIME = "time"; // current time
+
 class SaveNameUtils {
 public:
     static std::string parseFilenameFromWildcardString(const std::string& wildcardString, fs::path defaultFilePath, bool attachPdf);
 
 private:
-    static std::string parseFilenameWildcard(const std::string& wildcard, fs::path defaultFilePath);
+    static std::string parseWildcard(const std::string& wildcard, fs::path defaultFilePath);
 };

--- a/src/util/include/util/SaveNameUtils.h
+++ b/src/util/include/util/SaveNameUtils.h
@@ -26,7 +26,7 @@ constexpr auto WILDCARD_TIME = "time"; // current time
 
 class SaveNameUtils {
 public:
-    static std::string parseFilenameFromWildcardString(const std::string& wildcardString, fs::path defaultFilePath, bool attachPdf);
+    static std::string parseFilenameFromWildcardString(const std::string& wildcardString, fs::path defaultFilePath);
 
 private:
     static std::string parseWildcard(const std::string& wildcard, fs::path defaultFilePath);

--- a/src/util/include/util/SaveNameUtils.h
+++ b/src/util/include/util/SaveNameUtils.h
@@ -9,9 +9,6 @@
  * @license GNU GPLv2 or later
  */
 
-#pragma once
-
-#include <cstring>      // for size_t
 #include <string>       // for string
 
 #include "filesystem.h"       // for path
@@ -26,8 +23,8 @@ constexpr auto WILDCARD_TIME = "time"; // current time
 
 class SaveNameUtils {
 public:
-    static std::string parseFilenameFromWildcardString(const std::string& wildcardString, fs::path defaultFilePath);
+    static std::string parseFilenameFromWildcardString(const std::string& wildcardString, const fs::path& defaultFilePath);
 
 private:
-    static std::string parseWildcard(const std::string& wildcard, fs::path defaultFilePath);
+    static std::string parseWildcard(const std::string& wildcard, const fs::path& defaultFilePath);
 };

--- a/src/util/include/util/SaveNameUtils.h
+++ b/src/util/include/util/SaveNameUtils.h
@@ -9,6 +9,8 @@
  * @license GNU GPLv2 or later
  */
 
+#pragma once
+
 #include <string>       // for string
 
 #include "filesystem.h"       // for path

--- a/test/unit_tests/util/SaveNameUtilsTest.cpp
+++ b/test/unit_tests/util/SaveNameUtilsTest.cpp
@@ -1,0 +1,34 @@
+/*
+ * Xournal++
+ *
+ * This file is part of the Xournal UnitTests
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+
+#include <gtest/gtest.h>
+
+#include "util/SaveNameUtils.h"
+
+using namespace std;
+
+TEST(SaveNameUtils, testWildcardExpandsion) {
+    EXPECT_EQ(SaveNameUtils::parseFilenameFromWildcardString("", "defaultpath"), "");
+    EXPECT_EQ(SaveNameUtils::parseFilenameFromWildcardString("%{name}}%{name}", "x"), "x}x");
+    EXPECT_EQ(SaveNameUtils::parseFilenameFromWildcardString("%{name}", "defaultpath.pdf"), "defaultpath");
+    EXPECT_EQ(SaveNameUtils::parseFilenameFromWildcardString("%{", "defaultpath"), "%{");
+    EXPECT_EQ(SaveNameUtils::parseFilenameFromWildcardString("%{name%{name}}x", ""), "}x");
+    EXPECT_EQ(SaveNameUtils::parseFilenameFromWildcardString("\\%\\{name%{name}}x", ""), "\\%\\{name}x");
+}
+
+/* Disabled for now - because it makes endless loop in current implementation
+*  suggest we not should allow recursive expandsion
+*/
+TEST(SaveNameUtils, DISABLED_testWildcardRecursiveExpandsion)
+{
+    EXPECT_EQ(SaveNameUtils::parseFilenameFromWildcardString("%{name}", "      %{name}"), "\\%\\{name}x");
+}

--- a/test/unit_tests/util/SaveNameUtilsTest.cpp
+++ b/test/unit_tests/util/SaveNameUtilsTest.cpp
@@ -23,5 +23,5 @@ TEST(SaveNameUtils, testWildcardExpandsion) {
     EXPECT_EQ(SaveNameUtils::parseFilenameFromWildcardString("%{", "defaultpath"), "%{");
     EXPECT_EQ(SaveNameUtils::parseFilenameFromWildcardString("%{name%{name}}x", ""), "}x");
     EXPECT_EQ(SaveNameUtils::parseFilenameFromWildcardString("\\%\\{name%{name}}x", ""), "\\%\\{name}x");
-    EXPECT_EQ(SaveNameUtils::parseFilenameFromWildcardString("%{name}", "      %{name}"), "\\%\\{name}x");
+    EXPECT_EQ(SaveNameUtils::parseFilenameFromWildcardString("%{name}", "      %{name}"), "      %{name}");
 }

--- a/test/unit_tests/util/SaveNameUtilsTest.cpp
+++ b/test/unit_tests/util/SaveNameUtilsTest.cpp
@@ -23,12 +23,5 @@ TEST(SaveNameUtils, testWildcardExpandsion) {
     EXPECT_EQ(SaveNameUtils::parseFilenameFromWildcardString("%{", "defaultpath"), "%{");
     EXPECT_EQ(SaveNameUtils::parseFilenameFromWildcardString("%{name%{name}}x", ""), "}x");
     EXPECT_EQ(SaveNameUtils::parseFilenameFromWildcardString("\\%\\{name%{name}}x", ""), "\\%\\{name}x");
-}
-
-/* Disabled for now - because it makes endless loop in current implementation
-*  suggest we not should allow recursive expandsion
-*/
-TEST(SaveNameUtils, DISABLED_testWildcardRecursiveExpandsion)
-{
     EXPECT_EQ(SaveNameUtils::parseFilenameFromWildcardString("%{name}", "      %{name}"), "\\%\\{name}x");
 }

--- a/test/unit_tests/util/SaveNameUtilsTest.cpp
+++ b/test/unit_tests/util/SaveNameUtilsTest.cpp
@@ -14,9 +14,7 @@
 
 #include "util/SaveNameUtils.h"
 
-using namespace std;
-
-TEST(SaveNameUtils, testWildcardExpandsion) {
+TEST(SaveNameUtils, testWildcardExpansion) {
     EXPECT_EQ(SaveNameUtils::parseFilenameFromWildcardString("", "defaultpath"), "");
     EXPECT_EQ(SaveNameUtils::parseFilenameFromWildcardString("%{name}}%{name}", "x"), "x}x");
     EXPECT_EQ(SaveNameUtils::parseFilenameFromWildcardString("%{name}", "defaultpath.pdf"), "defaultpath");


### PR DESCRIPTION
## Issue
This PR implements the requested enhancement in #2897 

## Feature Description
This PR introduces the possibility to set a default name for exporting pdfs. Among others, this solves the issue of overwriting the background-pdf. Wildcards are used for allowing some file-related naming and use the `%{...}` syntax.

Wildcards | Description
---|---
name | original pdf name
date | current date
time | current time

The default pdf-name will be `%{name}_annotated.pdf`.