### PR TITLE
Remove or shrink unnecessary page rerender calls

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -1897,10 +1897,6 @@ void Control::selectTool(ToolType type) {
 
     toolHandler->selectTool(type);
     toolHandler->fireToolChanged();
-
-    if (win) {
-        (win->getXournal()->getViewFor(getCurrentPageNo()))->rerenderPage();
-    }
 }
 
 void Control::selectDefaultTool() {

--- a/src/core/control/layer/LayerController.cpp
+++ b/src/core/control/layer/LayerController.cpp
@@ -328,11 +328,11 @@ void LayerController::switchToLay(Layer::Index layerId, bool hideShow, bool clea
 
     if (hideShow) {
         for (Layer::Index i = 1; i <= p->getLayerCount(); i++) { p->setLayerVisible(i, i <= layerId); }
-    }
 
-    // Repaint page
-    control->getWindow()->getXournal()->layerChanged(selectedPage);
-    fireLayerVisibilityChanged();
+        // Repaint page
+        control->getWindow()->getXournal()->layerChanged(selectedPage);
+        fireLayerVisibilityChanged();
+    }
 }
 
 /**

--- a/src/core/control/tools/EditSelection.cpp
+++ b/src/core/control/tools/EditSelection.cpp
@@ -64,7 +64,7 @@ EditSelection::EditSelection(UndoRedoHandler* undo, const PageRef& page, XojPage
 
 EditSelection::EditSelection(UndoRedoHandler* undo, Selection* selection, XojPageView* view):
         snappingHandler(view->getXournal()->getControl()->getSettings()) {
-    calcSizeFromElements(selection->selectedElements);
+    Range r = calcSizeFromElements(selection->selectedElements);
 
     construct(undo, view, view->getPage());
 
@@ -80,7 +80,7 @@ EditSelection::EditSelection(UndoRedoHandler* undo, Selection* selection, XojPag
         this->sourceLayer->removeElement(e, false);
     }
 
-    view->rerenderPage();
+    view->rerenderRange(r);
 }
 
 EditSelection::EditSelection(UndoRedoHandler* undo, Element* e, XojPageView* view, const PageRef& page):
@@ -97,7 +97,7 @@ EditSelection::EditSelection(UndoRedoHandler* undo, Element* e, XojPageView* vie
 EditSelection::EditSelection(UndoRedoHandler* undo, const vector<Element*>& elements, XojPageView* view,
                              const PageRef& page):
         snappingHandler(view->getXournal()->getControl()->getSettings()) {
-    calcSizeFromElements(elements);
+    Range r = calcSizeFromElements(elements);
     construct(undo, view, page);
 
     for (Element* e: elements) {
@@ -105,13 +105,13 @@ EditSelection::EditSelection(UndoRedoHandler* undo, const vector<Element*>& elem
         this->sourceLayer->removeElement(e, false);
     }
 
-    view->rerenderPage();
+    view->rerenderRange(r);
 }
 
 EditSelection::EditSelection(UndoRedoHandler* undo, XojPageView* view, const PageRef& page, Layer* layer):
         snappingHandler(view->getXournal()->getControl()->getSettings()) {
     const auto& elements = layer->getElements();
-    calcSizeFromElements(elements);
+    Range r = calcSizeFromElements(elements);
     construct(undo, view, page);
 
     long i = 0L;
@@ -122,17 +122,17 @@ EditSelection::EditSelection(UndoRedoHandler* undo, XojPageView* view, const Pag
 
     layer->clearNoFree();
 
-    view->rerenderPage();
+    view->rerenderRange(r);
 }
 
-void EditSelection::calcSizeFromElements(vector<Element*> elements) {
+auto EditSelection::calcSizeFromElements(vector<Element*> elements) -> Range {
     if (elements.empty()) {
         x = 0;
         y = 0;
         width = 0;
         height = 0;
         snappedBounds = Rectangle<double>{};
-        return;
+        return Range();
     }
 
     Element* first = elements.front();
@@ -153,6 +153,7 @@ void EditSelection::calcSizeFromElements(vector<Element*> elements) {
     height = range.getHeight() + 3 * this->btnWidth;
 
     snappedBounds = rect;
+    return range;
 }
 
 void EditSelection::construct(UndoRedoHandler* undo, XojPageView* view, const PageRef& sourcePage) {

--- a/src/core/control/tools/EditSelection.h
+++ b/src/core/control/tools/EditSelection.h
@@ -60,7 +60,7 @@ private:
     /**
      * Calculate the size from the element list
      */
-    void calcSizeFromElements(std::vector<Element*> elements);
+    auto calcSizeFromElements(std::vector<Element*> elements) -> Range;
 
 public:
     /**

--- a/src/core/gui/XournalView.cpp
+++ b/src/core/gui/XournalView.cpp
@@ -628,7 +628,6 @@ void XournalView::deleteSelection(EditSelection* sel) {
 
         clearSelection();
 
-        view->rerenderPage();
         repaintSelection(true);
     }
 }


### PR DESCRIPTION
This requires #4158 that requires fewer explicit redraws when layers are deleted or their visibility is modified. Addresses #4580 in combination with #4158. This reduces the number of page repaints required. Full repaints are still used upon
- finalisation of text edits
- layer changes
- initialisation

TODO:
- [x] More extensive testing
- [x] Remove debug messages