### PR TITLE
Add entry to move pages

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -82,6 +82,7 @@
 #include "undo/AddUndoAction.h"                                  // for AddU...
 #include "undo/InsertDeletePageUndoAction.h"                     // for Inse...
 #include "undo/InsertUndoAction.h"                               // for Inse...
+#include "undo/MovePageUndoAction.h"                             // for Move...
 #include "undo/MoveSelectionToLayerUndoAction.h"                 // for Move...
 #include "undo/UndoAction.h"                                     // for Undo...
 #include "util/Color.h"                                          // for oper...
@@ -1449,14 +1450,13 @@ void Control::movePage(size_t oldPos, size_t newPos) {
     }
 
     doc->lock();
-    PageRef oldPage = doc->getPage(oldPos);
+    PageRef page = doc->getPage(oldPos);
     doc->deletePage(oldPos);
-    doc->insertPage(oldPage, newPos);
+    doc->insertPage(page, newPos);
     doc->unlock();
 
-    // TODO add UndoAction
-    //UndoRedoHandler* undo = getUndoRedoHandler();
-    //undo->addUndoAction(std::make_unique<SwapUndoAction>(oldPos - 1, true, oldPage, otherPage));
+    UndoRedoHandler* undo = getUndoRedoHandler();
+    undo->addUndoAction(std::make_unique<MovePageUndoAction>(page, oldPos, newPos));
 
     firePageDeleted(oldPos);
     firePageInserted(newPos);

--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -1442,6 +1442,28 @@ void Control::deletePage() {
     this->win->getXournal()->forceUpdatePagenumbers();
 }
 
+void Control::movePage(size_t oldPos, size_t newPos) {
+    Document* doc = getDocument();
+    if (oldPos == newPos || doc->getPageCount() <= 1 || oldPos > doc->getPageCount() || newPos > doc->getPageCount()) {
+        return;
+    }
+
+    doc->lock();
+    PageRef oldPage = doc->getPage(oldPos);
+    doc->deletePage(oldPos);
+    doc->insertPage(oldPage, newPos);
+    doc->unlock();
+
+    // TODO add UndoAction
+    //UndoRedoHandler* undo = getUndoRedoHandler();
+    //undo->addUndoAction(std::make_unique<SwapUndoAction>(oldPos - 1, true, oldPage, otherPage));
+
+    firePageDeleted(oldPos);
+    firePageInserted(newPos);
+    firePageSelected(newPos);
+    getScrollHandler()->scrollToPage(newPos);
+}
+
 void Control::duplicatePage() {
     auto page = getCurrentPage();
     if (!page) {

--- a/src/core/control/Control.h
+++ b/src/core/control/Control.h
@@ -217,6 +217,7 @@ public:
     void appendNewPdfPages();
     void insertPage(const PageRef& page, size_t position, bool shouldScrollToPage = true);
     void deletePage();
+    void movePage(size_t oldPos, size_t newPos);
 
     /**
      * Disable / enable delete page button

--- a/src/core/gui/sidebar/previews/page/SidebarPreviewPages.cpp
+++ b/src/core/gui/sidebar/previews/page/SidebarPreviewPages.cpp
@@ -92,67 +92,13 @@ auto SidebarPreviewPages::getIconName() -> std::string { return this->iconNameHe
 void SidebarPreviewPages::actionPerformed(SidebarActions action) {
     switch (action) {
         case SIDEBAR_ACTION_MOVE_UP: {
-            Document* doc = control->getDocument();
-            PageRef swappedPage = control->getCurrentPage();
-            if (!swappedPage || doc->getPageCount() <= 1) {
-                return;
-            }
-
-            doc->lock();
-            size_t page = doc->indexOf(swappedPage);
-            PageRef otherPage = doc->getPage(page - 1);
-
-            if (!otherPage) {
-                doc->unlock();
-                return;
-            }
-
-            if (page != npos) {
-                doc->deletePage(page);
-                doc->insertPage(swappedPage, page - 1);
-            }
-            doc->unlock();
-
-            UndoRedoHandler* undo = control->getUndoRedoHandler();
-            undo->addUndoAction(std::make_unique<SwapUndoAction>(page - 1, true, swappedPage, otherPage));
-
-            control->firePageDeleted(page);
-            control->firePageInserted(page - 1);
-            control->firePageSelected(page - 1);
-
-            control->getScrollHandler()->scrollToPage(page - 1);
+            size_t currentPageNo = control->getCurrentPageNo();
+            control->movePage(currentPageNo, currentPageNo - 1);
             break;
         }
         case SIDEBAR_ACTION_MOVE_DOWN: {
-            Document* doc = control->getDocument();
-            PageRef swappedPage = control->getCurrentPage();
-            if (!swappedPage || doc->getPageCount() <= 1) {
-                return;
-            }
-
-            doc->lock();
-            size_t page = doc->indexOf(swappedPage);
-            PageRef otherPage = doc->getPage(page + 1);
-
-            if (!otherPage) {
-                doc->unlock();
-                return;
-            }
-
-            if (page != npos) {
-                doc->deletePage(page);
-                doc->insertPage(swappedPage, page + 1);
-            }
-            doc->unlock();
-
-            UndoRedoHandler* undo = control->getUndoRedoHandler();
-            undo->addUndoAction(std::make_unique<SwapUndoAction>(page, false, swappedPage, otherPage));
-
-            control->firePageDeleted(page);
-            control->firePageInserted(page + 1);
-            control->firePageSelected(page + 1);
-
-            control->getScrollHandler()->scrollToPage(page + 1);
+            size_t currentPageNo = control->getCurrentPageNo();
+            control->movePage(currentPageNo, currentPageNo + 1);
             break;
         }
         case SIDEBAR_ACTION_COPY: {

--- a/src/core/undo/MovePageUndoAction.cpp
+++ b/src/core/undo/MovePageUndoAction.cpp
@@ -1,0 +1,35 @@
+#include "MovePageUndoAction.h"
+
+#include "control/Control.h"        // for Control
+#include "control/ScrollHandler.h"  // for ScrollHandler
+#include "gui/XournalppCursor.h"    // for XournalppCursor
+#include "model/Document.h"         // for Document
+#include "model/PageRef.h"          // for PageRef
+#include "undo/UndoAction.h"        // for UndoAction
+#include "util/Util.h"              // for npos
+#include "util/i18n.h"              // for _
+
+MovePageUndoAction::MovePageUndoAction(const PageRef& page, size_t oldPos, size_t newPos):
+        UndoAction("MovePageUndoAction"),
+        oldPos(page, newPos, true),
+        newPos(page, oldPos, false) {
+    this->page = page;
+}
+
+MovePageUndoAction::~MovePageUndoAction() { this->page = nullptr; }
+
+auto MovePageUndoAction::undo(Control* control) -> bool {
+    bool oldRes = oldPos.undo(control);
+    bool newRes = newPos.undo(control);
+    return oldRes && newRes;
+}
+
+auto MovePageUndoAction::redo(Control* control) -> bool {
+    bool newRes = newPos.redo(control);
+    bool oldRes = oldPos.redo(control);
+    return oldRes && newRes;
+}
+
+auto MovePageUndoAction::getText() -> std::string {
+    return _("Page move");
+}

--- a/src/core/undo/MovePageUndoAction.h
+++ b/src/core/undo/MovePageUndoAction.h
@@ -1,0 +1,37 @@
+/*
+ * Xournal++
+ *
+ * Undo action for moving page
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+#include <string>  // for string
+
+#include "model/PageRef.h"                      // for PageRef
+#include "undo/InsertDeletePageUndoAction.h"    // for ...s
+#include "UndoAction.h"                         // for UndoAction
+
+class Control;
+
+
+class MovePageUndoAction: public UndoAction {
+public:
+    MovePageUndoAction(const PageRef& page, size_t oldPos, size_t newPos);
+    ~MovePageUndoAction() override;
+
+public:
+    bool undo(Control* control) override;
+    bool redo(Control* control) override;
+
+    std::string getText() override;
+
+private:
+    InsertDeletePageUndoAction oldPos; // page delete at old position
+    InsertDeletePageUndoAction newPos; // page insert at new position
+};


### PR DESCRIPTION
## Goals
This Pr aims to do 2 major things:
- [x] refactor the page movement logic from `actionPerformed()` in `SidebarPreviewPages` to a more general `movePage(from, to)` in `Control`. The old placement of this logic seems very wrong.
- [ ] add a menu entry `Journal > Move page to page number`, where the user is able to move pages more easily, entering the new page number in a pop-up window (discussed in #3724)

## Additional Comments
- If desired, I can split this into 2 PRs.
- Currently the page movement is very limited in Xournal++, only allowing to move pages through a right click in the Sidebar
-  `Journal > Move page up/down` entries could also be added, but are also covered by the move to page number entry