### PR TITLE
Control::checkChangedDocument: notify page changes to subset of listeners

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -64,6 +64,7 @@
 #include "model/Compass.h"                                       // for Comp...
 #include "model/Document.h"                                      // for Docu...
 #include "model/DocumentChangeType.h"                            // for DOCU...
+#include "model/DocumentListener.h"                              // for Docu...
 #include "model/Element.h"                                       // for Element
 #include "model/Font.h"                                          // for XojFont
 #include "model/Image.h"                                         // for Image
@@ -278,7 +279,9 @@ auto Control::checkChangedDocument(Control* control) -> bool {
     for (auto const& page: control->changedPages) {
         auto p = control->doc->indexOf(page);
         if (p != npos) {
-            control->firePageChanged(p);
+            for (DocumentListener* dl: control->changedDocumentListeners) {
+                dl->pageChanged(p);
+            }
         }
     }
     control->changedPages.clear();
@@ -3124,6 +3127,14 @@ void Control::setClipboardHandlerSelection(EditSelection* selection) {
     if (this->clipboardHandler) {
         this->clipboardHandler->setSelection(selection);
     }
+}
+
+void Control::addChangedDocumentListener(DocumentListener* dl) {
+    this->changedDocumentListeners.push_back(dl);
+}
+
+void Control::removeChangedDocumentListener(DocumentListener* dl) {
+    this->changedDocumentListeners.remove(dl);
 }
 
 void Control::setCopyCutEnabled(bool enabled) { this->clipboardHandler->setCopyCutEnabled(enabled); }

--- a/src/core/control/Control.h
+++ b/src/core/control/Control.h
@@ -27,6 +27,7 @@
 #include "enums/ActionGroup.enum.h"         // for ActionGroup
 #include "enums/ActionType.enum.h"          // for ActionType
 #include "model/DocumentHandler.h"          // for DocumentHandler
+#include "model/DocumentListener.h"         // for DocumentListener
 #include "model/GeometryTool.h"             // for GeometryTool
 #include "model/PageRef.h"                  // for PageRef
 #include "undo/UndoRedoHandler.h"           // for UndoRedoHandler (ptr only)
@@ -260,6 +261,9 @@ public:
     void deleteLastAutosaveFile(fs::path newAutosaveFile);
     void setClipboardHandlerSelection(EditSelection* selection);
 
+    void addChangedDocumentListener(DocumentListener* dl);
+    void removeChangedDocumentListener(DocumentListener* dl);
+
     MetadataManager* getMetadataManager() const;
     RecentManager* getRecentManager() const;
     Settings* getSettings() const;
@@ -420,6 +424,11 @@ private:
      * The pages wihch has changed since the last update (for preview update)
      */
     std::vector<PageRef> changedPages;
+
+    /**
+     * DocumentListener instances that are to be updated by checkChangedDocument.
+     */
+    std::list<DocumentListener*> changedDocumentListeners;
 
     /**
      * Our clipboard abstraction

--- a/src/core/gui/sidebar/previews/base/SidebarPreviewBase.cpp
+++ b/src/core/gui/sidebar/previews/base/SidebarPreviewBase.cpp
@@ -44,6 +44,7 @@ SidebarPreviewBase::SidebarPreviewBase(Control* control, GladeGui* gui, SidebarT
     gtk_widget_show(this->iconViewPreview);
 
     registerListener(this->control);
+    this->control->addChangedDocumentListener(this);
 
     g_signal_connect(this->scrollPreview, "size-allocate", G_CALLBACK(sizeChanged), this);
 
@@ -58,6 +59,8 @@ SidebarPreviewBase::~SidebarPreviewBase() {
     this->layoutmanager = nullptr;
 
     this->scrollPreview = nullptr;
+
+    this->control->removeChangedDocumentListener(this);
 
     this->previews.clear();
 }


### PR DESCRIPTION
Continuation of  #4611. I'm splitting this one off as suggested by @bhennion to keep the discussion focused and get some feedback.

As before, I would like to avoid rerendering the entire page after most changes for performance reasons. Instead of using the general-purpose implementation `DocumentHandler` I introduce a similar mechanism in `Control`, which is only used for notifying a subset of `DocumentListener` instances (at the moment all instances of subclasses of `AbstractSidebarPage`).

This approach does not interfere with the existing observer pattern or the general rerendering logic.