### PR TITLE
[luaAPI] refactor error handling

### DIFF
--- a/src/core/plugin/Plugin.cpp
+++ b/src/core/plugin/Plugin.cpp
@@ -216,9 +216,11 @@ void Plugin::loadScript() {
 
     // Load but don't run the Lua script
     auto luafile = path / mainfile;
-    if (luaL_loadfile(lua.get(), luafile.string().c_str())) {
+    int status = luaL_loadfile(lua.get(), luafile.string().c_str());
+    if (status != LUA_OK) {
+        const char* errMsg = lua_tostring(lua.get(), -1);
         // Error out if file can't be read
-        g_warning("Could not run plugin Lua file: \"%s\"", luafile.string().c_str());
+        g_warning("Could not load plugin Lua file. Error: \"%s\", error code: %d (syntax error: %s)", errMsg, status, status == LUA_ERRSYNTAX ? "true" : "false");
         this->valid = false;
         return;
     }


### PR DESCRIPTION
At some places the API currently prints a `g_warning` and returns for error handling. At other places `luaL_error` is being used. This is supposed to unify error handling.

Still open:
- [x] return nil, "error msg" (L78): this is similar what pcall in lua does. Though not sure what to do with the g_error in this case
- [x] use `return luaL_error()` or `luaL_error() return` [lua reference](https://www.lua.org/manual/5.3/manual.html#luaL_error) suggests using the former one as the `luaL_error` doesn't return anyway.
Currently this is inconsistent, so we should discuss this and unify the style in this aspect as well.
- [x] `changeToolColor` here are some warnings like `key should be a boolean value (or nil)`. I'm not sure if this should be an error (otherwise we should specify in the warning, what is assumed as fallback value for this key)

And I think we should document somewhere how errors in lua should be thrown so that this is specified somewhere. (Error handling should be consistent throughout the API)

**Note:** Please check if all of the `g_warning`s I replaced should really throw an error. The reasoning on my side was, if we throw a lua error, we can handle the error on the lua side (`pcall` -> `if`) if we just do `g_warning` the lua side won't even notice there as an error (if we not return some special value which is not always the case).