### PR TITLE
Fix rendering artefacts in standard eraser - 2nd try

### DIFF
--- a/src/core/control/tools/EraseHandler.cpp
+++ b/src/core/control/tools/EraseHandler.cpp
@@ -119,7 +119,6 @@ void EraseHandler::eraseStroke(Layer* l, Stroke* s, double x, double y, Range& r
             doc->unlock();
             this->eraseUndoAction->addOriginal(l, s, pos);
             erasable->beginErasure(intersectionParameters, range);
-            paddedEraserBox.addToRange(range);
         }
     } else {
         /**

--- a/src/core/model/PathParameter.h
+++ b/src/core/model/PathParameter.h
@@ -23,7 +23,7 @@ struct PathParameter {
     bool operator<=(const PathParameter& p) const { return index < p.index || (index == p.index && t <= p.t); };
     bool operator>=(const PathParameter& p) const { return index > p.index || (index == p.index && t >= p.t); };
 
-    bool isValid() const { return t <= 1.0 && (t > 0.0 || (t == 0.0 && index == 0U)); }
+    bool isValid() const { return t <= 1.0 && t >= 0.0; }
 
     size_t index;
     double t;

--- a/src/core/model/Stroke.cpp
+++ b/src/core/model/Stroke.cpp
@@ -274,14 +274,9 @@ Point Stroke::getPoint(PathParameter parameter) const {
     assert(parameter.isValid() && parameter.index < this->points.size() - 1);
 
     const Point& p = this->points[parameter.index];
-    if (parameter.index == this->points.size() - 2) {
-        // Need to handle the pressure value separately, since the last pressure value of a stroke is not set.
-        Point q = this->points[parameter.index + 1];
-        q.z = p.z;
-        return p.relativeLineTo(q, parameter.t);
-    }
-    const Point& q = this->points[parameter.index + 1];
-    return p.relativeLineTo(q, parameter.t);
+    Point res = p.relativeLineTo(this->points[parameter.index + 1], parameter.t);
+    res.z = p.z;  // The point's width should be that of the segment's first point
+    return res;
 }
 
 auto Stroke::getPoints() const -> const Point* { return this->points.data(); }

--- a/src/core/model/eraser/ErasableStroke.h
+++ b/src/core/model/eraser/ErasableStroke.h
@@ -83,12 +83,16 @@ public:
      * @brief Get the bounding box of a subsection.
      * The bounding box is either pulled from cache or computed and added to cache
      * @return The bounding box.
-     * NB: The bounding boxes obtained here are imprecise: they do not take pressure into account but use the stroke's
-     * width instead.
      */
-    xoj::util::Rectangle<double> getSubSectionBoundingBox(const SubSection& section) const;
+    const Range& getSubSectionBoundingBox(const SubSection& section) const;
 
 protected:
+    /**
+     * @brief Compute the bounding box of a subsection.
+     * @return The bounding box.
+     */
+    Range computeSubSectionBoundingBox(const SubSection& section) const;
+
     /**
      * @brief Given a vector of subsections, compute (coarsely) where those subsections overlap.
      * @param subsections The input subsections
@@ -115,7 +119,7 @@ protected:
      * Usually pretty small (< 10): std::vector is faster than std::map
      * Protected by the associated mutex
      */
-    mutable std::vector<std::pair<SubSection, xoj::util::Rectangle<double>>> boundingBoxes;
+    mutable std::vector<std::pair<SubSection, Range>> boundingBoxes;
     mutable std::mutex boxesMutex;
 
     /**

--- a/src/core/view/ErasableStrokeView.cpp
+++ b/src/core/view/ErasableStrokeView.cpp
@@ -256,8 +256,7 @@ void ErasableStrokeView::paintFilledHighlighter(cairo_t* cr) const {
         /**
          * Create a mask tailored to the union of the sections' bounding boxes
          */
-        Rectangle<double> box = erasableStroke.getSubSectionBoundingBox(first);
-        box.unite(erasableStroke.getSubSectionBoundingBox(last));
+        Range box = erasableStroke.getSubSectionBoundingBox(first).unite(erasableStroke.getSubSectionBoundingBox(last));
 
         auto [crMask, surfMask] = createMask(box, matrix.xx);
         cairo_set_line_cap(crMask, linecap);
@@ -326,15 +325,14 @@ void ErasableStrokeView::paintFilledHighlighter(cairo_t* cr) const {
     cairo_restore(cr);
 }
 
-std::pair<cairo_t*, cairo_surface_t*> ErasableStrokeView::createMask(const Rectangle<double>& box,
-                                                                     double scaling) const {
-    const int width = static_cast<int>(std::ceil(box.width * scaling));
-    const int height = static_cast<int>(std::ceil(box.height * scaling));
+std::pair<cairo_t*, cairo_surface_t*> ErasableStrokeView::createMask(const Range& box, double scaling) const {
+    const int width = static_cast<int>(std::ceil(box.getWidth() * scaling));
+    const int height = static_cast<int>(std::ceil(box.getHeight() * scaling));
 
     cairo_surface_t* surfMask = cairo_image_surface_create(CAIRO_FORMAT_A8, width, height);
 
     // Apply offset and scaling
-    cairo_surface_set_device_offset(surfMask, -box.x * scaling, -box.y * scaling);
+    cairo_surface_set_device_offset(surfMask, -box.minX * scaling, -box.minY * scaling);
     cairo_surface_set_device_scale(surfMask, scaling, scaling);
 
     // Get a context to draw on our mask

--- a/src/core/view/ErasableStrokeView.h
+++ b/src/core/view/ErasableStrokeView.h
@@ -16,10 +16,7 @@
 #include <cairo.h>  // for cairo_t, cairo_surface_t
 
 class ErasableStroke;
-namespace xoj::util {
-template <class T>
-class Rectangle;
-}  // namespace xoj::util
+class Range;
 
 namespace xoj {
 namespace view {
@@ -54,7 +51,7 @@ private:
      * @param scaling A scaling ratio to apply to the mask
      * @return Pointers to the newly created cairo context and surface (mask)
      */
-    std::pair<cairo_t*, cairo_surface_t*> createMask(const xoj::util::Rectangle<double>& box, double scaling) const;
+    std::pair<cairo_t*, cairo_surface_t*> createMask(const Range& box, double scaling) const;
 
 private:
     const ErasableStroke& erasableStroke;

--- a/test/unit_tests/model/ErasableStrokeTest.cpp
+++ b/test/unit_tests/model/ErasableStrokeTest.cpp
@@ -134,16 +134,16 @@ TEST(ErasableStroke, testGetStrokes) {
     std::array<std::vector<std::vector<Point>>, 3> resultingPaths;
     resultingPaths[0] = std::vector<std::vector<Point>>(3);
     resultingPaths[0][0] = {{0, 0, 2}, {2, 2, 2.5}, {3.5, 2}};
-    resultingPaths[0][1] = {{6, 3, 2.75}, {7, 4, 2.5}, {5, 5}};
-    resultingPaths[0][2] = {{2.5, 7, 1.75}, {2, 8, 1.5}, {5, 11, 1}, {7, 10, 1.5},
-                            {7, 6, 2},      {6, 7, 2.5}, {4, 4, 3},  {1, 3}};
+    resultingPaths[0][1] = {{6, 3, 3}, {7, 4, 2.5}, {5, 5}};
+    resultingPaths[0][2] = {{2.5, 7, 2}, {2, 8, 1.5}, {5, 11, 1}, {7, 10, 1.5},
+                            {7, 6, 2},   {6, 7, 2.5}, {4, 4, 3},  {1, 3}};
 
     resultingPaths[1] = std::vector<std::vector<Point>>(2);
     resultingPaths[1][0] = {{1.5, 3, 2}, {0, 0, 2}, {2, 2, 2.5}, {3.5, 2}};
-    resultingPaths[1][1] = {{3, 3, 2.75}, {1, 4, 2.5}, {2, 5}};
+    resultingPaths[1][1] = {{3, 3, 3}, {1, 4, 2.5}, {2, 5}};
 
     resultingPaths[2] = std::vector<std::vector<Point>>(1);
-    resultingPaths[2][0] = {{3, 3, 2.75}, {1, 4, 2.5}, {2, 5}};
+    resultingPaths[2][0] = {{3, 3, 3}, {1, 4, 2.5}, {2, 5}};
 
     unsigned int i = 0;
     for (auto& erasable: erasables) {


### PR DESCRIPTION
This PR replaces #4612, with a more precise computation of the rerendered boxes.