### PR TITLE
Make visibility of eraser cursor configurable

### DIFF
--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -102,6 +102,7 @@ void Settings::loadDefault() {
     this->autoloadPdfXoj = true;
 
     this->stylusCursorType = STYLUS_CURSOR_DOT;
+    this->eraserVisibility = ERASER_VISIBILITY_ALWAYS;
     this->iconTheme = ICON_THEME_COLOR;
     this->highlightPosition = false;
     this->cursorHighlightColor = 0x80FFFF00;  // Yellow with 50% opacity
@@ -434,6 +435,8 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur) {
         this->autoloadPdfXoj = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("stylusCursorType")) == 0) {
         this->stylusCursorType = stylusCursorTypeFromString(reinterpret_cast<const char*>(value));
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("eraserVisibility")) == 0) {
+        this->eraserVisibility = eraserVisibilityFromString(reinterpret_cast<const char*>(value));
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("iconTheme")) == 0) {
         this->iconTheme = iconThemeFromString(reinterpret_cast<const char*>(value));
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("highlightPosition")) == 0) {
@@ -944,6 +947,9 @@ void Settings::save() {
     xmlNode = saveProperty("stylusCursorType", stylusCursorTypeToString(this->stylusCursorType), root);
     ATTACH_COMMENT("The cursor icon used with a stylus, allowed values are \"none\", \"dot\", \"big\", \"arrow\"");
 
+    xmlNode = saveProperty("eraserVisibility", eraserVisibilityToString(this->eraserVisibility), root);
+    ATTACH_COMMENT("The eraser cursor visibility used with a stylus, allowed values are \"never\", \"always\", \"hover\", \"touch\"");
+
     xmlNode = saveProperty("iconTheme", iconThemeToString(this->iconTheme), root);
     ATTACH_COMMENT("The icon theme, allowed values are \"iconsColor\", \"iconsLucide\"");
 
@@ -1297,6 +1303,18 @@ void Settings::setStylusCursorType(StylusCursorType type) {
     }
 
     this->stylusCursorType = type;
+
+    save();
+}
+
+auto Settings::getEraserVisibility() const -> EraserVisibility { return this->eraserVisibility; }
+
+void Settings::setEraserVisibility(EraserVisibility eraserVisibility) {
+    if (this->eraserVisibility == eraserVisibility) {
+        return;
+    }
+
+    this->eraserVisibility = eraserVisibility;
 
     save();
 }

--- a/src/core/control/settings/Settings.h
+++ b/src/core/control/settings/Settings.h
@@ -317,6 +317,9 @@ public:
     StylusCursorType getStylusCursorType() const;
     void setStylusCursorType(StylusCursorType stylusCursorType);
 
+    EraserVisibility getEraserVisibility() const;
+    void setEraserVisibility(EraserVisibility eraserVisibility);
+
     IconTheme getIconTheme() const;
     void setIconTheme(IconTheme iconTheme);
 
@@ -626,6 +629,11 @@ private:
      *  Type of cursor icon to use with a stylus
      */
     StylusCursorType stylusCursorType;
+
+    /**
+     * Visibility of eraser cursor
+     */
+    EraserVisibility eraserVisibility;
 
     /**
      * Icon Theme

--- a/src/core/control/settings/SettingsEnums.cpp
+++ b/src/core/control/settings/SettingsEnums.cpp
@@ -19,6 +19,23 @@ auto stylusCursorTypeFromString(const std::string& stylusCursorTypeStr) -> Stylu
     return STYLUS_CURSOR_DOT;
 }
 
+auto eraserVisibilityFromString(const std::string& eraserVisibility) -> EraserVisibility {
+    if (eraserVisibility == "never") {
+        return ERASER_VISIBILITY_NEVER;
+    }
+    if (eraserVisibility == "always") {
+        return ERASER_VISIBILITY_ALWAYS;
+    }
+    if (eraserVisibility == "hover") {
+        return ERASER_VISIBILITY_HOVER;
+    }
+    if (eraserVisibility == "touch") {
+        return ERASER_VISIBILITY_TOUCH;
+    }
+    g_warning("Settings::Unknown eraser visibility: %s\n", eraserVisibility.c_str());
+    return ERASER_VISIBILITY_ALWAYS;
+}
+
 auto iconThemeFromString(const std::string& iconThemeStr) -> IconTheme {
     if (iconThemeStr == "iconsColor") {
         return ICON_THEME_COLOR;

--- a/src/core/control/settings/SettingsEnums.h
+++ b/src/core/control/settings/SettingsEnums.h
@@ -72,6 +72,13 @@ enum StylusCursorType {
     STYLUS_CURSOR_ARROW = 3,
 };
 
+enum EraserVisibility {
+    ERASER_VISIBILITY_NEVER = 0,
+    ERASER_VISIBILITY_ALWAYS = 1,
+    ERASER_VISIBILITY_HOVER = 2,
+    ERASER_VISIBILITY_TOUCH = 3,
+};
+
 enum IconTheme {
     ICON_THEME_COLOR = 0,
     ICON_THEME_LUCIDE = 1,
@@ -113,6 +120,21 @@ constexpr auto stylusCursorTypeToString(StylusCursorType stylusCursorType) -> co
     }
 }
 
+constexpr auto eraserVisibilityToString(EraserVisibility eraserVisibility) -> const char* {
+    switch (eraserVisibility) {
+        case ERASER_VISIBILITY_NEVER:
+            return "never";
+        case ERASER_VISIBILITY_ALWAYS:
+            return "always";
+        case ERASER_VISIBILITY_HOVER:
+            return "hover";
+        case ERASER_VISIBILITY_TOUCH:
+            return "touch";
+        default:
+            return "unknown";
+    }
+}
+
 constexpr auto iconThemeToString(IconTheme iconTheme) -> const char* {
     switch (iconTheme) {
         case ICON_THEME_COLOR:
@@ -138,5 +160,6 @@ constexpr auto emptyLastPageAppendToString(EmptyLastPageAppendType appendType) -
 }
 
 StylusCursorType stylusCursorTypeFromString(const std::string& stylusCursorTypeStr);
+EraserVisibility eraserVisibilityFromString(const std::string& eraserVisibilityStr);
 IconTheme iconThemeFromString(const std::string& iconThemeStr);
 EmptyLastPageAppendType emptyLastPageAppendFromString(const std::string& str);

--- a/src/core/gui/XournalppCursor.cpp
+++ b/src/core/gui/XournalppCursor.cpp
@@ -136,7 +136,7 @@ void XournalppCursor::setMouseDown(bool mouseDown) {
     ToolType type = handler->getToolType();
 
     // Not always an update is needed
-    if (type == TOOL_HAND || type == TOOL_VERTICAL_SPACE) {
+    if (type == TOOL_HAND || type == TOOL_VERTICAL_SPACE || type == TOOL_ERASER) {
         updateCursor();
     }
 }
@@ -285,7 +285,14 @@ void XournalppCursor::updateCursor() {
                 }
             }
         } else if (type == TOOL_ERASER) {
-            cursor = getEraserCursor();
+            EraserVisibility visibility = control->getSettings()->getEraserVisibility();
+            if ((this->inputDevice == INPUT_DEVICE_PEN || this->inputDevice == INPUT_DEVICE_ERASER) &&
+                (visibility == ERASER_VISIBILITY_NEVER || (visibility == ERASER_VISIBILITY_HOVER && this->mouseDown) ||
+                 (visibility == ERASER_VISIBILITY_TOUCH && !this->mouseDown))) {
+                setCursor(CRSR_BLANK_CURSOR);
+            } else {
+                cursor = getEraserCursor();
+            }
         }
 
         else if (type == TOOL_TEXT) {

--- a/src/core/gui/dialog/SettingsDialog.cpp
+++ b/src/core/gui/dialog/SettingsDialog.cpp
@@ -518,6 +518,22 @@ void SettingsDialog::load() {
             break;
     }
 
+    switch (settings->getEraserVisibility()) {
+        case ERASER_VISIBILITY_NEVER:
+            gtk_combo_box_set_active(GTK_COMBO_BOX(get("cbEraserVisibility")), 0);
+            break;
+        case ERASER_VISIBILITY_HOVER:
+            gtk_combo_box_set_active(GTK_COMBO_BOX(get("cbEraserVisibility")), 2);
+            break;
+        case ERASER_VISIBILITY_TOUCH:
+            gtk_combo_box_set_active(GTK_COMBO_BOX(get("cbEraserVisibility")), 3);
+            break;
+        case ERASER_VISIBILITY_ALWAYS:
+        default:
+            gtk_combo_box_set_active(GTK_COMBO_BOX(get("cbEraserVisibility")), 1);
+            break;
+    }
+
     switch (settings->getIconTheme()) {
         case ICON_THEME_LUCIDE:
             gtk_combo_box_set_active(GTK_COMBO_BOX(get("cbIconTheme")), 1);
@@ -733,6 +749,22 @@ void SettingsDialog::save() {
         case 1:
         default:
             settings->setStylusCursorType(STYLUS_CURSOR_DOT);
+            break;
+    }
+
+    switch (gtk_combo_box_get_active(GTK_COMBO_BOX(get("cbEraserVisibility")))) {
+        case 0:
+            settings->setEraserVisibility(ERASER_VISIBILITY_NEVER);
+            break;
+        case 2:
+            settings->setEraserVisibility(ERASER_VISIBILITY_HOVER);
+            break;
+        case 3:
+            settings->setEraserVisibility(ERASER_VISIBILITY_TOUCH);
+            break;
+        case 1:
+        default:
+            settings->setEraserVisibility(ERASER_VISIBILITY_ALWAYS);
             break;
     }
 

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -1952,6 +1952,85 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                 <property name="position">2</property>
                               </packing>
                             </child>
+                            <child>
+                              <object class="GtkFrame" id="sid5">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
+                                <child>
+                                  <object class="GtkAlignment" id="sid7">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
+                                    <child>
+                                      <object class="GtkBox" id="sid8">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                          <object class="GtkBox">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="spacing">5</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">Stylus-based eraser is visible</property>
+                                                <property name="xalign">0</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkComboBoxText" id="cbEraserVisibility">
+                                                <property name="name">cbEraserVisibility</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="active">0</property>
+                                                <items>
+                                                  <item id="never" translatable="yes" context="eraser is never visible">Never</item>
+                                                  <item id="always" translatable="yes" context="eraser is always visible">Always</item>
+                                                  <item id="float" translatable="yes" context="eraser is only visible when floating">When floating</item>
+                                                  <item id="touch" translatable="yes" context="eraser is only visible when touching the screen">When touching</item>
+                                                </items>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">1</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">2</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label">
+                                  <object class="GtkLabel" id="sid74">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">Eraser visibility</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">3</property>
+                              </packing>
+                            </child>
                           </object>
                         </child>
                       </object>


### PR DESCRIPTION
This only applies when used with a stylus. Generalisation of #3940.

I've added a setting to the "view" pane. This one might make more sense in the "stylus" pane.