### PR TITLE
feature: add toolbar buttons via plugins

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -3014,6 +3014,10 @@ void Control::clipboardPaste(Element* e) {
     win->getXournal()->setSelection(selection);
 }
 
+void Control::registerPluginToolButtons(ToolMenuHandler* toolMenuHandler) {
+    pluginController->registerToolButtons(toolMenuHandler);
+}
+
 void Control::clipboardPasteXournal(ObjectInputStream& in) {
     auto pNr = getCurrentPageNo();
     if (pNr == npos && win != nullptr) {

--- a/src/core/control/Control.h
+++ b/src/core/control/Control.h
@@ -64,7 +64,7 @@ class Settings;
 class TextEditor;
 class XournalScheduler;
 class ZoomControl;
-
+class ToolMenuHandler;
 class Control:
         public ActionHandler,
         public ToolListener,
@@ -317,6 +317,9 @@ public:
     void deleteSelection() override;
 
     void clipboardPaste(Element* e);
+
+public:
+    void registerPluginToolButtons(ToolMenuHandler* toolMenuHandler);
 
 protected:
     /**

--- a/src/core/gui/MainWindow.cpp
+++ b/src/core/gui/MainWindow.cpp
@@ -86,6 +86,9 @@ MainWindow::MainWindow(GladeSearchpath* gladeSearchPath, Control* control, GtkAp
     // "watch over" all events
     g_signal_connect(this->window, "key-press-event", G_CALLBACK(onKeyPressCallback), this);
 
+    // need to create tool buttons registered in plugins, so they can be added to toolbars
+    control->registerPluginToolButtons(this->toolbar.get());
+
     createToolbar();
 
     setToolbarVisible(control->getSettings()->isToolbarVisible());

--- a/src/core/gui/toolbarMenubar/PluginToolButon.cpp
+++ b/src/core/gui/toolbarMenubar/PluginToolButon.cpp
@@ -1,0 +1,25 @@
+#include <utility>  // for move
+
+#include "PluginToolButton.h"
+
+PluginToolButton::PluginToolButton(ActionHandler* handler, ToolbarButtonEntry* t):
+        ToolButton(handler, std::move(t->toolbarId), ACTION_NONE, std::move(t->iconName), std::move(t->description)),
+        t(t) {}
+
+PluginToolButton::~PluginToolButton() = default;
+
+auto PluginToolButton::createItem(bool horizontal) -> GtkToolItem* {
+    if (this->item) {
+        return this->item;
+    }
+
+    this->item = createTmpItem(horizontal);
+    g_object_ref(this->item);
+
+    // Connect signal
+    g_signal_connect(item, "clicked",
+                     G_CALLBACK(+[](GtkWidget* bt, ToolbarButtonEntry* te) { te->plugin->executeToolbarButton(te); }),
+                     this->t);
+
+    return this->item;
+}

--- a/src/core/gui/toolbarMenubar/PluginToolButton.h
+++ b/src/core/gui/toolbarMenubar/PluginToolButton.h
@@ -1,0 +1,31 @@
+/*
+ * Xournal++
+ *
+ * Part of the customizable toolbars
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+#include <string>  // for string, allocator
+
+#include <gtk/gtk.h>  // for GtkWidget, GtkToolItem
+
+#include "plugin/Plugin.h"
+
+#include "ToolButton.h"  // for AbstractToolItem
+
+class PluginToolButton: public ToolButton {
+public:
+    PluginToolButton(ActionHandler* handler, ToolbarButtonEntry* t);
+
+    ~PluginToolButton() override;
+
+protected:
+    GtkToolItem* createItem(bool horizontal) override;
+    ToolbarButtonEntry* t;
+};

--- a/src/core/gui/toolbarMenubar/ToolMenuHandler.cpp
+++ b/src/core/gui/toolbarMenubar/ToolMenuHandler.cpp
@@ -18,6 +18,7 @@
 #include "gui/toolbarMenubar/model/ToolbarItem.h"    // for ToolbarItem
 #include "gui/toolbarMenubar/model/ToolbarModel.h"   // for ToolbarModel
 #include "model/Font.h"                              // for XojFont
+#include "plugin/Plugin.h"                           // for ToolbarButtonEntr<
 #include "util/NamedColor.h"                         // for NamedColor
 #include "util/PathUtil.h"
 #include "util/StringUtils.h"                        // for StringUtils
@@ -26,6 +27,7 @@
 
 #include "FontButton.h"              // for FontButton
 #include "MenuItem.h"                // for MenuItem
+#include "PluginToolButton.h"        // for ToolButton
 #include "ToolButton.h"              // for ToolButton
 #include "ToolDrawCombocontrol.h"    // for ToolDrawCombocon...
 #include "ToolPageLayer.h"           // for ToolPageLayer
@@ -358,6 +360,11 @@ void ToolMenuHandler::signalConnectCallback(GtkBuilder* builder, GObject* object
     } else {
         g_error("Unsupported signal handler from glade file: \"%s\" / \"%s\"", signalName, handlerName);
     }
+}
+
+void ToolMenuHandler::addPluginItem(ToolbarButtonEntry* t) {
+    PluginToolButton* button = new PluginToolButton(listener, t);
+    addToolItem(button);
 }
 
 void ToolMenuHandler::initToolItems() {

--- a/src/core/gui/toolbarMenubar/ToolMenuHandler.h
+++ b/src/core/gui/toolbarMenubar/ToolMenuHandler.h
@@ -44,6 +44,7 @@ class PageBackgroundChangeController;
 class ActionHandler;
 class ColorToolItem;
 class MenuItem;
+struct ToolbarButtonEntry;
 
 class ToolMenuHandler {
 public:
@@ -70,6 +71,7 @@ public:
     void registerMenupoint(GtkWidget* widget, ActionType type, ActionGroup group = GROUP_NOGROUP);
 
     void initToolItems();
+    void addPluginItem(ToolbarButtonEntry* t);
 
     void setUndoDescription(const std::string& description);
     void setRedoDescription(const std::string& description);

--- a/src/core/plugin/Plugin.cpp
+++ b/src/core/plugin/Plugin.cpp
@@ -14,7 +14,8 @@
 
 #include <utility>  // for move, pair
 
-#include "util/i18n.h"  // for _
+#include "gui/toolbarMenubar/ToolMenuHandler.h"  // for ToolMenuHandler
+#include "util/i18n.h"                           // for _
 #include "util/raii/GObjectSPtr.h"
 
 #include "config.h"  // for PROJECT_VERSION
@@ -114,6 +115,30 @@ void Plugin::executeMenuEntry(MenuEntry* entry) { callFunction(entry->callback, 
 auto Plugin::registerMenu(std::string menu, std::string callback, long mode, std::string accelerator) -> size_t {
     menuEntries.emplace_back(this, std::move(menu), std::move(callback), mode, std::move(accelerator));
     return menuEntries.size() - 1;
+}
+
+void Plugin::registerToolButton(ToolMenuHandler* toolMenuHandler) {
+    if (toolbarButtonEntries.empty() || !this->enabled) {
+        // No entries - nothing to do
+        return;
+    }
+
+    for (auto&& t: toolbarButtonEntries) {
+        g_message("Add toolbar button with id: %s and icon: %s", t.toolbarId.c_str(), t.iconName.c_str());
+        toolMenuHandler->addPluginItem(&t);
+    }
+}
+
+void Plugin::executeToolbarButton(ToolbarButtonEntry* entry) { callFunction(entry->callback, entry->mode); }
+
+void Plugin::registerToolButton(std::string description, std::string toolbarId, std::string iconName,
+                                std::string callback, long mode) {
+    if (toolbarId == "") {
+        return;
+    }
+    toolbarId = "Plugin::" + toolbarId;  // In order to avoid name collisions with built in toolbar id's.
+    toolbarButtonEntries.emplace_back(this, std::move(description), std::move(toolbarId), std::move(iconName),
+                                      std::move(callback), mode);
 }
 
 auto Plugin::getControl() const -> Control* { return control; }

--- a/src/core/plugin/PluginController.cpp
+++ b/src/core/plugin/PluginController.cpp
@@ -143,7 +143,9 @@ PluginController::PluginController(Control* control): control(control) {
 
 void PluginController::registerToolbar() {
 #ifdef ENABLE_PLUGINS
-    for (auto&& p: this->plugins) { p->registerToolbar(); }
+    for (auto&& p: this->plugins) {
+        p->registerToolbar();
+    }
 #endif
 }
 
@@ -169,6 +171,14 @@ auto PluginController::createMenuSections(GtkApplicationWindow* win) -> std::vec
     return sections;
 #else
     return {};
+#endif
+}
+
+void PluginController::registerToolButtons(ToolMenuHandler* toolMenuHandler) {
+#ifdef ENABLE_PLUGINS
+    for (auto&& p: this->plugins) {
+        p->registerToolButton(toolMenuHandler);
+    }
 #endif
 }
 

--- a/src/core/plugin/PluginController.h
+++ b/src/core/plugin/PluginController.h
@@ -21,6 +21,7 @@
 #include "filesystem.h"
 
 class Control;
+class ToolMenuHandler;
 
 class PluginController final {
 public:
@@ -37,6 +38,11 @@ public:
      * The data is owned by the Plugin's themselves - do not unref
      */
     std::vector<GMenuModel*> createMenuSections(GtkApplicationWindow* win);
+
+    /**
+     * Add toolbar buttons
+     */
+    void registerToolButtons(ToolMenuHandler* toolMenuHandler);
 
     /**
      * Show Plugin manager Dialog


### PR DESCRIPTION
Fixes #4669. Fixes #2936. Fixes #2431. Also addresses #3669.

This PR allows registering toolbar buttons (with any ID and any icon in the icon theme) that can be added to any toolbar.

These custom tools (executing plugin callback functions) can be added to the toolbar either by customizing the toolbar in the GUI or by editing `toolbar.ini`. 

The plugin adds the toolbar via e.g. 
```lua
app.registerUi({callback ="blueDashedPen", toolbarId="CUSTOM_PEN_1", iconName="bluePenIcon"})
```

It's also possible to combine adding a toolbar button with adding a menu entry:

```lua
app.registerUi({["menu"] = "Mirror strokes horizontally", ["callback"] = "cb", ["accelerator"] = "<Control>t", ["toolbarId"] = "MIRROR", ["iconName"] = "view-mirror-symbolic"})
```

Here `view-mirror-symbolic` is an icon that actually exists. I found via Gnome's symbol library (it's part of the Adwaita icon theme). 

![grafik](https://user-images.githubusercontent.com/40485433/220704573-b341e663-ba75-4959-8fe6-7f8138072aa1.png)


A little demo (see the icon on the top left, right below the `File` menu):

https://user-images.githubusercontent.com/40485433/220704181-bbcaa122-db17-4366-b91a-fc6aec1cc06d.mp4


