### PR TITLE
Add spacer for drag&drop in toolbar customization

### DIFF
--- a/src/core/gui/ToolitemDragDrop.cpp
+++ b/src/core/gui/ToolitemDragDrop.cpp
@@ -59,7 +59,10 @@ auto ToolitemDragDrop::getIcon(ToolItemDragDropData* data) -> GtkWidget* {
         return data->item->getNewToolIcon();
     }
     if (data->type == TOOL_ITEM_SEPARATOR) {
-        return ToolbarSeparatorImage::newImage();
+        return ToolbarSeparatorImage::newImage(SeparatorType::SEPARATOR);
+    }
+    if (data->type == TOOL_ITEM_SPACER) {
+        return ToolbarSeparatorImage::newImage(SeparatorType::SPACER);
     }
 
     g_warning("ToolitemDragDrop::getIcon unhandled type: %i\n", data->type);
@@ -71,7 +74,10 @@ auto ToolitemDragDrop::getPixbuf(ToolItemDragDropData* data) -> GdkPixbuf* {
         return data->item->getNewToolPixbuf();
     }
     if (data->type == TOOL_ITEM_SEPARATOR) {
-        return ToolbarSeparatorImage::getNewToolPixbuf();
+        return ToolbarSeparatorImage::getNewToolPixbuf(SeparatorType::SEPARATOR);
+    }
+    if (data->type == TOOL_ITEM_SPACER) {
+        return ToolbarSeparatorImage::getNewToolPixbuf(SeparatorType::SPACER);
     }
     g_error("ToolitemDragDrop::getIcon unhandled type: %i\n", data->type);
 }

--- a/src/core/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp
+++ b/src/core/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp
@@ -240,6 +240,10 @@ auto ToolbarAdapter::toolbarDragMotionCb(GtkToolbar* toolbar, GdkDragContext* co
     } else if (d->type == TOOL_ITEM_SEPARATOR) {
         GtkToolItem* it = gtk_separator_tool_item_new();
         gtk_toolbar_set_drop_highlight_item(toolbar, it, ipos);
+    } else if (d->type == TOOL_ITEM_SPACER) {
+        GtkToolItem* it = gtk_separator_tool_item_new();
+        gtk_tool_item_set_expand(it, true);
+        gtk_toolbar_set_drop_highlight_item(toolbar, it, ipos);
     } else if (d->type == TOOL_ITEM_COLOR) {
         GtkWidget* iconWidget = ColorSelectImage::newColorIcon(d->namedColor->getColor(), 16, true);
         GtkToolItem* it = gtk_tool_button_new(iconWidget, "");
@@ -309,6 +313,19 @@ void ToolbarAdapter::toolbarDragDataReceivedCb(GtkToolbar* toolbar, GdkDragConte
 
         int newId = tb->insertItem(name, "SEPARATOR", pos);
         ToolitemDragDrop::attachMetadata(GTK_WIDGET(it), newId, TOOL_ITEM_SEPARATOR);
+    } else if (d->type == TOOL_ITEM_SPACER) {
+        GtkToolItem* it = gtk_separator_tool_item_new();
+        gtk_separator_tool_item_set_draw(GTK_SEPARATOR_TOOL_ITEM(it), false);
+        gtk_tool_item_set_expand(it, true);
+        gtk_widget_show_all(GTK_WIDGET(it));
+        gtk_toolbar_insert(toolbar, it, pos);
+        adapter->prepareToolItem(it);
+
+        ToolbarData* tb = adapter->window->getSelectedToolbar();
+        const char* name = adapter->window->getToolbarName(toolbar);
+
+        int newId = tb->insertItem(name, "SPACER", pos);
+        ToolitemDragDrop::attachMetadata(GTK_WIDGET(it), newId, TOOL_ITEM_SPACER);
     } else {
         g_warning("toolbarDragDataReceivedCb: ToolItemType %i not handled!", d->type);
     }

--- a/src/core/gui/dialog/toolbarCustomize/ToolbarCustomizeDialog.h
+++ b/src/core/gui/dialog/toolbarCustomize/ToolbarCustomizeDialog.h
@@ -25,6 +25,7 @@ class GladeSearchpath;
 
 typedef struct _ToolItemDragData ToolItemDragData;
 typedef struct _ColorToolItemDragData ColorToolItemDragData;
+typedef struct _SeparatorData SeparatorData;
 
 class ToolbarCustomizeDialog: public GladeGui {
 public:

--- a/src/core/gui/toolbarMenubar/icon/ToolbarSeparatorImage.cpp
+++ b/src/core/gui/toolbarMenubar/icon/ToolbarSeparatorImage.cpp
@@ -3,25 +3,44 @@
 #include <cairo.h>        // for cairo_create, cairo_destroy, cairo_image_su...
 #include <gdk/gdk.h>      // for gdk_pixbuf_get_from_surface
 #include <glib-object.h>  // for g_object_unref
+#include <util/Color.h>   // for Colors::red, Colors::gray
+#include <util/Util.h>    // for cairo_set_source_rgbi
 
-auto ToolbarSeparatorImage::newImage() -> GtkWidget* {
-    GdkPixbuf* pixbuf = ToolbarSeparatorImage::getNewToolPixbuf();
+constexpr double LINE_WIDTH = 5.;
+constexpr double MARGIN = 3.;
+constexpr double TAIL_SIZE = 5.;
+
+auto ToolbarSeparatorImage::newImage(SeparatorType separator) -> GtkWidget* {
+    GdkPixbuf* pixbuf = ToolbarSeparatorImage::getNewToolPixbuf(separator);
     GtkWidget* w = gtk_image_new_from_pixbuf(pixbuf);
     g_object_unref(pixbuf);
     return w;
 }
 
-auto ToolbarSeparatorImage::getNewToolPixbuf() -> GdkPixbuf* {
+auto ToolbarSeparatorImage::getNewToolPixbuf(SeparatorType separator) -> GdkPixbuf* {
     constexpr auto width = 30;
     constexpr auto height = 30;
     cairo_surface_t* crImage = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
     cairo_t* cr = cairo_create(crImage);
 
-    cairo_set_source_rgb(cr, 255, 0, 0);
-    cairo_set_line_width(cr, 5);
+    Util::cairo_set_source_rgbi(cr, Colors::red);
+    cairo_set_line_width(cr, LINE_WIDTH);
     cairo_move_to(cr, width / 2, 0);
     cairo_line_to(cr, width / 2, height);
     cairo_stroke(cr);
+    if (separator == SeparatorType::SPACER) {  // add double arrow tails
+        Util::cairo_set_source_rgbi(cr, Colors::gray);
+
+        cairo_move_to(cr, MARGIN + TAIL_SIZE, height / 2 - TAIL_SIZE);
+        cairo_line_to(cr, MARGIN, height / 2);
+        cairo_line_to(cr, MARGIN + TAIL_SIZE, height / 2 + TAIL_SIZE);
+
+        cairo_move_to(cr, width - MARGIN - TAIL_SIZE, height / 2 - TAIL_SIZE);
+        cairo_line_to(cr, width - MARGIN, height / 2);
+        cairo_line_to(cr, width - MARGIN - TAIL_SIZE, height / 2 + TAIL_SIZE);
+
+        cairo_stroke(cr);
+    }
     cairo_destroy(cr);
     GdkPixbuf* pixbuf = gdk_pixbuf_get_from_surface(crImage, 0, 0, width, height);
     cairo_surface_destroy(crImage);

--- a/src/core/gui/toolbarMenubar/icon/ToolbarSeparatorImage.h
+++ b/src/core/gui/toolbarMenubar/icon/ToolbarSeparatorImage.h
@@ -14,6 +14,8 @@
 #include <gdk-pixbuf/gdk-pixbuf.h>  // for GdkPixbuf
 #include <gtk/gtk.h>                // for GtkWidget
 
+enum SeparatorType { SEPARATOR, SPACER };
+
 /**
  * Menuitem handler
  */
@@ -25,7 +27,7 @@ namespace ToolbarSeparatorImage {
  *
  * @return GtkWidget* Separator
  */
-GtkWidget* newImage();
+GtkWidget* newImage(SeparatorType separator);
 
 /**
  * @brief Create Separator Pixbuf
@@ -34,5 +36,5 @@ GtkWidget* newImage();
  *
  * @return GdkPixbuf* Seperator
  */
-GdkPixbuf* getNewToolPixbuf();
+GdkPixbuf* getNewToolPixbuf(SeparatorType separator);
 };  // namespace ToolbarSeparatorImage

--- a/ui/toolbarCustomizeDialog.glade
+++ b/ui/toolbarCustomizeDialog.glade
@@ -193,7 +193,7 @@
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="xalign">0</property>
-                            <property name="label" translatable="yes">&lt;b&gt;Separator&lt;/b&gt;</property>
+                            <property name="label" translatable="yes">&lt;b&gt;Separators&lt;/b&gt;</property>
                             <property name="use_markup">True</property>
                           </object>
                           <packing>


### PR DESCRIPTION
Fixes #4644 

This PR adds an icon for the spacer to the toolbar customization dialog (painted in `ToolbarSeparatorImage.cpp` as a variant of the separator icon) and allows for drag&drop for the spacer.
![grafik](https://user-images.githubusercontent.com/40485433/220976319-357060a3-6652-4624-ba22-a15b49c4c6ae.png)
