### PR TITLE
Fix GList memory leak

### DIFF
--- a/src/core/gui/MainWindow.cpp
+++ b/src/core/gui/MainWindow.cpp
@@ -547,7 +547,7 @@ void MainWindow::setToolbarVisible(bool visible) {
     settings->setToolbarVisible(visible);
     for (int i = 0; i < TOOLBAR_DEFINITIONS_LEN; i++) {
         auto widget = this->toolbarWidgets[i];
-        if (!visible || (GTK_IS_CONTAINER(widget) && gtk_container_get_children(GTK_CONTAINER(widget)))) {
+        if (!visible || (GTK_IS_CONTAINER(widget))) {
             gtk_widget_set_visible(widget, visible);
         }
     }


### PR DESCRIPTION
gtk_container_get_children returns a GList which was newer deallocated In this context the return value is used as a boolean - which always is true and therefore redundant.