### PR TITLE
Fix #4584 segfault when exporting from cli with missing bg

### DIFF
--- a/src/core/control/xojfile/LoadHandler.cpp
+++ b/src/core/control/xojfile/LoadHandler.cpp
@@ -105,7 +105,7 @@ auto LoadHandler::getLastError() -> string { return this->lastError; }
 
 auto LoadHandler::isAttachedPdfMissing() const -> bool { return this->attachedPdfMissing; }
 
-auto LoadHandler::getMissingPdfFilename() -> string { return this->pdfMissing; }
+auto LoadHandler::getMissingPdfFilename() const -> string { return this->pdfMissing; }
 
 void LoadHandler::removePdfBackground() { this->removePdfBackgroundFlag = true; }
 

--- a/src/core/control/xojfile/LoadHandler.h
+++ b/src/core/control/xojfile/LoadHandler.h
@@ -59,7 +59,7 @@ public:
 
     std::string getLastError();
     bool isAttachedPdfMissing() const;
-    std::string getMissingPdfFilename();
+    std::string getMissingPdfFilename() const;
 
     void removePdfBackground();
     void setPdfReplacement(fs::path filepath, bool attachToDocument);


### PR DESCRIPTION
Fix #4584

Now we give error message on the console stderr, and exit the process with -2.

Note if we return -2 instead of exiting - the gui startup and try to do the exporting ???

This fix ensure we dont segfault. But what should the correct behavior be?