### PR TITLE
Use `optional` instead of -1 for exportImg parameters

### DIFF
--- a/src/core/control/ExportHelper.cpp
+++ b/src/core/control/ExportHelper.cpp
@@ -34,8 +34,9 @@ namespace ExportHelper {
  *
  * @return 0 on success, -3 on export failure
  */
-auto exportImg(Document* doc, const char* output, const char* range, const char* layerRange, int pngDpi, int pngWidth,
-               int pngHeight, ExportBackgroundType exportBackground) -> int {
+auto exportImg(Document* doc, const char* output, const char* range, const char* layerRange,
+               std::optional<unsigned int> pngDpi, std::optional<unsigned int> pngWidth,
+               std::optional<unsigned int> pngHeight, ExportBackgroundType exportBackground) -> int {
 
     fs::path const path(output);
 
@@ -57,12 +58,12 @@ auto exportImg(Document* doc, const char* output, const char* range, const char*
     ImageExport imgExport(doc, path, format, exportBackground, exportRange);
 
     if (format == EXPORT_GRAPHICS_PNG) {
-        if (pngDpi > 0) {
-            imgExport.setQualityParameter(EXPORT_QUALITY_DPI, pngDpi);
-        } else if (pngWidth > 0) {
-            imgExport.setQualityParameter(EXPORT_QUALITY_WIDTH, pngWidth);
-        } else if (pngHeight > 0) {
-            imgExport.setQualityParameter(EXPORT_QUALITY_HEIGHT, pngHeight);
+        if (pngDpi) {
+            imgExport.setQualityParameter(EXPORT_QUALITY_DPI, pngDpi.value());
+        } else if (pngWidth) {
+            imgExport.setQualityParameter(EXPORT_QUALITY_WIDTH, pngWidth.value());
+        } else if (pngHeight) {
+            imgExport.setQualityParameter(EXPORT_QUALITY_HEIGHT, pngHeight.value());
         }
     }
 

--- a/src/core/control/ExportHelper.h
+++ b/src/core/control/ExportHelper.h
@@ -14,6 +14,8 @@
 
 #include "control/jobs/BaseExportJob.h"  // for ExportBackgroundType
 
+#include <optional>
+
 class Document;
 
 namespace ExportHelper {
@@ -26,17 +28,18 @@ namespace ExportHelper {
  * @param layerRange Layer range to be parsed. Will only export those layers, for every exported page.
  *                  If a number is too high for the number of layers on a given page, it is just ignored.
  *                  If range=nullptr, exports all layers.
- * @param pngDpi Set dpi for Png files. Non positive values are ignored
- * @param pngWidth Set the width for Png files. Non positive values are ignored
- * @param pngHeight Set the height for Png files. Non positive values are ignored
+ * @param pngDpi Set dpi for Png files.
+ * @param pngWidth Set the width for Png files.
+ * @param pngHeight Set the height for Png files.
  * @param exportBackground If EXPORT_BACKGROUND_NONE, the exported image file has transparent background
  *
  *  The priority is: pngDpi overwrites pngWidth overwrites pngHeight
  *
  * @return 0 on success, -2 on failure opening the input file, -3 on export failure
  */
-int exportImg(Document* doc, const char* output, const char* range, const char* layerRange, int pngDpi, int pngWidth,
-              int pngHeight, ExportBackgroundType exportBackground);
+int exportImg(Document* doc, const char* output, const char* range, const char* layerRange,
+              std::optional<unsigned int> pngDpi, std::optional<unsigned int> pngWidth,
+              std::optional<unsigned int> pngHeight, ExportBackgroundType exportBackground);
 
 /**
  * @brief Export the input file as pdf

--- a/src/core/control/XournalMain.cpp
+++ b/src/core/control/XournalMain.cpp
@@ -254,8 +254,9 @@ void checkForEmergencySave(Control* control) {
  *
  * @return 0 on success, -2 on failure opening the input file, -3 on export failure
  */
-auto exportImg(const char* input, const char* output, const char* range, const char* layerRange, int pngDpi,
-               int pngWidth, int pngHeight, ExportBackgroundType exportBackground) -> int {
+auto exportImg(const char* input, const char* output, const char* range, const char* layerRange,
+               std::optional<unsigned int> pngDpi, std::optional<unsigned int> pngWidth,
+               std::optional<unsigned int> pngHeight, ExportBackgroundType exportBackground) -> int {
     LoadHandler loader;
 
     Document* doc = loader.loadDocument(input);
@@ -311,9 +312,9 @@ struct XournalMainPrivate {
     int openAtPageNumber = 0;  // when no --page is used, the document opens at the page specified in the metadata file
     gchar* exportRange{};
     gchar* exportLayerRange{};
-    int exportPngDpi = -1;
-    int exportPngWidth = -1;
-    int exportPngHeight = -1;
+    std::optional<unsigned int> exportPngDpi;
+    std::optional<unsigned int> exportPngWidth;
+    std::optional<unsigned int> exportPngHeight;
     gboolean exportNoBackground = false;
     gboolean exportNoRuling = false;
     gboolean progressiveMode = false;


### PR DESCRIPTION
Many places '-1' is used as 'none'. Use 'std::optional' instead. Batch exporting to image is one of those places.