### PR TITLE
Simplify custom export job

### DIFF
--- a/src/core/control/jobs/BaseExportJob.cpp
+++ b/src/core/control/jobs/BaseExportJob.cpp
@@ -98,10 +98,10 @@ auto BaseExportJob::showFilechooser() -> bool {
     return true;
 }
 
-auto BaseExportJob::testAndSetFilepath(fs::path file) -> bool {
+auto BaseExportJob::testAndSetFilepath(const fs::path& file) -> bool {
     try {
         if (fs::is_directory(file.parent_path())) {
-            this->filepath = std::move(file);
+            this->filepath = file;
             return true;
         }
     } catch (const fs::filesystem_error& e) {

--- a/src/core/control/jobs/BaseExportJob.h
+++ b/src/core/control/jobs/BaseExportJob.h
@@ -46,7 +46,7 @@ protected:
     virtual void addFilterToDialog() = 0;
     void addFileFilterToDialog(const std::string& name, const std::string& pattern);
     bool checkOverwriteBackgroundPDF(fs::path const& file) const;
-    virtual bool testAndSetFilepath(fs::path file);
+    virtual bool testAndSetFilepath(const fs::path& file);
 
 private:
 protected:

--- a/src/core/control/jobs/BaseExportJob.h
+++ b/src/core/control/jobs/BaseExportJob.h
@@ -63,6 +63,6 @@ protected:
     public:
         std::string extension;
 
-        ExportType(std::string ext): extension(ext) {}
+        ExportType(std::string ext): extension(std::move(ext)) {}
     };
 };

--- a/src/core/control/jobs/CustomExportJob.cpp
+++ b/src/core/control/jobs/CustomExportJob.cpp
@@ -23,10 +23,10 @@
 
 CustomExportJob::CustomExportJob(Control* control): BaseExportJob(control, _("Custom Export")) {
     // Supported filters
-    filters[_("PDF files")] = std::make_unique<ExportType>(".pdf");
-    filters[_("PNG graphics")] = std::make_unique<ExportType>(".png");
-    filters[_("SVG graphics")] = std::make_unique<ExportType>(".svg");
-    filters[_("Xournal (Compatibility)")] = std::make_unique<ExportType>(".xoj");
+    filters.insert({_("PDF files"), ExportType(".pdf")});
+    filters.insert({_("PNG graphics"), ExportType(".png")});
+    filters.insert({_("SVG graphics"), ExportType(".svg")});
+    filters.insert({_("Xournal (Compatibility)"), ExportType(".xoj")});
 }
 
 CustomExportJob::~CustomExportJob() = default;
@@ -34,11 +34,11 @@ CustomExportJob::~CustomExportJob() = default;
 void CustomExportJob::addFilterToDialog() {
     // Runs on every filter inside the filters map
     for (auto& filter: filters) {
-        addFileFilterToDialog(filter.first, "*" + filter.second->extension);  // Adds * for the pattern
+        addFileFilterToDialog(filter.first, "*" + filter.second.extension);  // Adds * for the pattern
     }
 }
 
-auto CustomExportJob::testAndSetFilepath(fs::path file) -> bool {
+auto CustomExportJob::testAndSetFilepath(const fs::path& file) -> bool {
     if (!BaseExportJob::testAndSetFilepath(std::move(file))) {
         return false;
     }
@@ -48,8 +48,8 @@ auto CustomExportJob::testAndSetFilepath(fs::path file) -> bool {
     const auto& chosenFilter = filters.at(this->chosenFilterName);
 
     // Remove any pre-existing extension and adds the chosen one
-    Util::clearExtensions(filepath, chosenFilter->extension);
-    filepath += chosenFilter->extension;
+    Util::clearExtensions(filepath, chosenFilter.extension);
+    filepath += chosenFilter.extension;
 
     return checkOverwriteBackgroundPDF(filepath);
 }

--- a/src/core/control/jobs/CustomExportJob.cpp
+++ b/src/core/control/jobs/CustomExportJob.cpp
@@ -23,15 +23,13 @@
 
 CustomExportJob::CustomExportJob(Control* control): BaseExportJob(control, _("Custom Export")) {
     // Supported filters
-    filters[_("PDF files")] = new ExportType(".pdf");
-    filters[_("PNG graphics")] = new ExportType(".png");
-    filters[_("SVG graphics")] = new ExportType(".svg");
-    filters[_("Xournal (Compatibility)")] = new ExportType(".xoj");
+    filters[_("PDF files")] = std::make_unique<ExportType>(".pdf");
+    filters[_("PNG graphics")] = std::make_unique<ExportType>(".png");
+    filters[_("SVG graphics")] = std::make_unique<ExportType>(".svg");
+    filters[_("Xournal (Compatibility)")] = std::make_unique<ExportType>(".xoj");
 }
 
-CustomExportJob::~CustomExportJob() {
-    for (auto& filter: filters) { delete filter.second; }
-}
+CustomExportJob::~CustomExportJob() = default;
 
 void CustomExportJob::addFilterToDialog() {
     // Runs on every filter inside the filters map
@@ -47,7 +45,7 @@ auto CustomExportJob::testAndSetFilepath(fs::path file) -> bool {
 
     // Extract the file filter selected
     this->chosenFilterName = BaseExportJob::getFilterName();
-    auto chosenFilter = filters.at(this->chosenFilterName);
+    const auto& chosenFilter = filters.at(this->chosenFilterName);
 
     // Remove any pre-existing extension and adds the chosen one
     Util::clearExtensions(filepath, chosenFilter->extension);

--- a/src/core/control/jobs/CustomExportJob.h
+++ b/src/core/control/jobs/CustomExportJob.h
@@ -46,7 +46,7 @@ protected:
      */
     void exportGraphics();
 
-    bool testAndSetFilepath(fs::path file) override;
+    bool testAndSetFilepath(const fs::path& file) override;
 
 private:
     /**
@@ -83,5 +83,5 @@ private:
 
     std::string chosenFilterName;
 
-    std::map<std::string, std::unique_ptr<ExportType>> filters;
+    std::map<std::string, ExportType> filters;
 };

--- a/src/core/control/jobs/CustomExportJob.h
+++ b/src/core/control/jobs/CustomExportJob.h
@@ -83,5 +83,5 @@ private:
 
     std::string chosenFilterName;
 
-    std::map<std::string, ExportType*> filters;
+    std::map<std::string, std::unique_ptr<ExportType>> filters;
 };

--- a/src/core/control/jobs/PdfExportJob.cpp
+++ b/src/core/control/jobs/PdfExportJob.cpp
@@ -16,10 +16,12 @@ PdfExportJob::PdfExportJob(Control* control): BaseExportJob(control, _("PDF Expo
 
 PdfExportJob::~PdfExportJob() = default;
 
-void PdfExportJob::addFilterToDialog() { addFileFilterToDialog(_("PDF files"), "*.pdf"); }
+void PdfExportJob::addFilterToDialog() {
+     addFileFilterToDialog(_("PDF files"), ".pdf");
+}
 
-auto PdfExportJob::testAndSetFilepath(fs::path file) -> bool {
-    if (!BaseExportJob::testAndSetFilepath(std::move(file))) {
+auto PdfExportJob::testAndSetFilepath(const fs::path& file) -> bool {
+    if (!BaseExportJob::testAndSetFilepath(file)) {
         return false;
     }
 

--- a/src/core/control/jobs/PdfExportJob.h
+++ b/src/core/control/jobs/PdfExportJob.h
@@ -28,7 +28,7 @@ public:
 
 protected:
     void addFilterToDialog() override;
-    bool testAndSetFilepath(fs::path file) override;
+    bool testAndSetFilepath(const fs::path& file) override;
 
 private:
 };


### PR DESCRIPTION
My first idea was to remove the use of new/delete for ExportType object. Why do we use dynamic allocation for this? I search the git history for the PR where it went in, and stubbled over the following comment:

https://github.com/xournalpp/xournalpp/pull/594#discussion_r243860463

And therefore changed it to not use dynamic allocation for the ExportType.

