### PR TITLE
Use view::Mask for buffers

### DIFF
--- a/src/config-debug.h.in
+++ b/src/config-debug.h.in
@@ -46,7 +46,7 @@
 /**
  * Draw the mask in StrokeView
  */
-#cmakedefine DEBUG_SHOW_MASK
+#cmakedefine DEBUG_MASKS
 
 /**
  * Show repainted areas when erasing an highlighter stroke

--- a/src/core/control/PdfCache.h
+++ b/src/core/control/PdfCache.h
@@ -12,13 +12,17 @@
 #pragma once
 
 #include <cstddef>  // for size_t
-#include <list>     // for list, list<>::size_type
+#include <deque>    // for deque
 #include <mutex>    // for mutex
 
 #include <cairo.h>  // for cairo_t, cairo_surface_t
 
 #include "pdf/base/XojPdfDocument.h"  // for XojPdfDocument
 #include "pdf/base/XojPdfPage.h"      // for XojPdfPageSPtr
+
+namespace xoj::view {
+class Mask;
+};
 
 class PdfCacheEntry;
 class Settings;
@@ -70,19 +74,19 @@ private:
     /**
      * @brief Look up for a cache entry for the page with number pdfPgeNo in the PDF.
      */
-    PdfCacheEntry* lookup(size_t pdfPageNo) const;
+    const PdfCacheEntry* lookup(size_t pdfPageNo) const;
     /**
      * @brief Push a cache entry
      */
-    PdfCacheEntry* cache(XojPdfPageSPtr popplerPage, cairo_surface_t* img, double zoom);
+    const PdfCacheEntry* cache(XojPdfPageSPtr popplerPage, xoj::view::Mask&& buffer);
 
 private:
     XojPdfDocument pdfDocument;
 
     std::mutex renderMutex;
 
-    std::list<PdfCacheEntry*> data;
-    std::list<PdfCacheEntry*>::size_type size = 0;
+    std::deque<std::unique_ptr<PdfCacheEntry>> data;
+    decltype(data)::size_type maxSize = 0;
 
     double zoomRefreshThreshold;
 };

--- a/src/core/control/jobs/RenderJob.h
+++ b/src/core/control/jobs/RenderJob.h
@@ -43,7 +43,7 @@ private:
 
     void rerenderRectangle(xoj::util::Rectangle<double> const& rect);
 
-    void renderToBuffer(cairo_surface_t* buffer, double ratio, double x, double y) const;
+    void renderToBuffer(cairo_t* cr) const;
 
 private:
     XojPageView* view;

--- a/src/core/gui/PageView.h
+++ b/src/core/gui/PageView.h
@@ -25,6 +25,7 @@
 #include "model/PageRef.h"            // for PageRef
 #include "util/Rectangle.h"           // for Rectangle
 #include "util/raii/CairoWrappers.h"  // for CairoSurfaceSPtr
+#include "view/Mask.h"                // for Mask
 #include "view/Repaintable.h"         // for Repaintable
 
 #include "Layout.h"            // for Layout
@@ -92,6 +93,7 @@ public:
     void setIsVisible(bool visible);
 
     bool isSelected() const;
+    inline bool isVisible() const { return visible; }
 
     void endText();
 
@@ -127,14 +129,8 @@ public:
     int getMappedCol() const;
 
     GdkRGBA getSelectionColor() override;
-    int getBufferPixels();
+    bool hasBuffer() const;
 
-    /**
-     * 0 if currently visible
-     * -1 if no image is saved (never visible or cleanup)
-     * else the time in Seconds
-     */
-    int getLastVisibleTime();
     TextEditor* getTextEditor();
 
     /**
@@ -269,9 +265,10 @@ private:
      */
     Text* oldtext;
 
+    bool visible = true;
     bool selected = false;
 
-    xoj::util::CairoSurfaceSPtr crBuffer;
+    xoj::view::Mask buffer;
     std::mutex drawingMutex;
 
     bool inEraser = false;
@@ -285,11 +282,6 @@ private:
      * Search handling
      */
     std::unique_ptr<SearchControl> search;
-
-    /**
-     * Unixtimestam when the page was last time in the visible area
-     */
-    long int lastVisibleTime = -1;
 
     std::mutex repaintRectMutex;
     std::vector<xoj::util::Rectangle<double>> rerenderRects;

--- a/src/core/gui/XournalView.cpp
+++ b/src/core/gui/XournalView.cpp
@@ -106,15 +106,6 @@ XournalView::~XournalView() {
     this->handRecognition = nullptr;
 }
 
-auto pageViewIncreasingClockTime(XojPageView* a, XojPageView* b) -> gint {
-    return a->getLastVisibleTime() - b->getLastVisibleTime();  // >0 will put a after b
-}
-
-void XournalView::staticLayoutPages(GtkWidget* widget, GtkAllocation* allocation, void* data) {
-    auto* xv = static_cast<XournalView*>(data);
-    xv->layoutPages();
-}
-
 
 auto XournalView::clearMemoryTimer(XournalView* widget) -> gboolean {
     widget->cleanupBufferCache();
@@ -129,7 +120,7 @@ auto XournalView::cleanupBufferCache() -> void {
         auto&& page = this->viewPages[i];
         const size_t pageNum = i + 1;
         const bool isPreload = pagesLower <= pageNum && pageNum <= pagesUpper;
-        if (!isPreload && page->getLastVisibleTime() > 0 && page->getBufferPixels() > 0) {
+        if (!isPreload && !page->isVisible() && page->hasBuffer()) {
             page->deleteViewBuffer();
         }
     }
@@ -385,7 +376,7 @@ void XournalView::pageSelected(size_t page) {
     const auto& [pagesLower, pagesUpper] = preloadPageBounds(page, this->viewPages.size());
     g_assert(pagesLower <= pagesUpper);
     for (size_t i = pagesLower; i < pagesUpper; i++) {
-        if (this->viewPages[i]->getBufferPixels() == 0) {
+        if (!this->viewPages[i]->hasBuffer()) {
             this->viewPages[i]->rerenderPage();
         }
     }

--- a/src/core/gui/XournalView.h
+++ b/src/core/gui/XournalView.h
@@ -154,8 +154,6 @@ private:
 
     void cleanupBufferCache();
 
-    static void staticLayoutPages(GtkWidget* widget, GtkAllocation* allocation, void* data);
-
 private:
     /**
      * Scrollbars

--- a/src/core/model/eraser/ErasableStroke.cpp
+++ b/src/core/model/eraser/ErasableStroke.cpp
@@ -25,20 +25,7 @@ ErasableStroke::ErasableStroke(const Stroke& stroke): stroke(stroke) {
     closedStroke = pts.size() >= 3 && pts.front().lineLengthTo(pts.back()) < CLOSED_STROKE_DISTANCE;
 }
 
-#ifdef DEBUG_ERASABLE_STROKE_BOXES
-ErasableStroke::~ErasableStroke() {
-    if (this->surfDebug) {
-        cairo_surface_destroy(this->surfDebug);
-        this->surfDebug = nullptr;
-    }
-    if (this->crDebug) {
-        cairo_destroy(this->crDebug);
-        this->crDebug = nullptr;
-    }
-}
-#else
 ErasableStroke::~ErasableStroke() = default;
-#endif
 
 /**
  * Erasure works as follows:
@@ -355,7 +342,7 @@ void ErasableStroke::addOverlapsToRange(const std::vector<SubSection>& subsectio
                     overlapTrees[j].populate(*it2, this->stroke);
                 }
 #ifdef DEBUG_ERASABLE_STROKE_BOXES
-                overlapTrees[i].addOverlapsToRange(overlapTrees[j], halfWidth, range, crDebug);
+                overlapTrees[i].addOverlapsToRange(overlapTrees[j], halfWidth, range, debugMask.get());
 #else
                 overlapTrees[i].addOverlapsToRange(overlapTrees[j], halfWidth, range);
 #endif

--- a/src/core/model/eraser/ErasableStroke.h
+++ b/src/core/model/eraser/ErasableStroke.h
@@ -17,8 +17,6 @@
 #include <utility>  // for pair
 #include <vector>   // for vector
 
-#include <cairo.h>  // for cairo_t, cairo_surface_t
-
 #include "model/PathParameter.h"    // for PathParameter
 #include "model/Stroke.h"           // for Stroke (ptr only), IntersectionPa...
 #include "util/Interval.h"          // for Interval
@@ -26,6 +24,12 @@
 #include "util/UnionOfIntervals.h"  // for UnionOfIntervals
 
 #include "config-debug.h"  // for DEBUG_ERASABLE_STROKE_BOXES
+
+#ifdef DEBUG_ERASABLE_STROKE_BOXES
+#include <cairo.h>  // for cairo_t
+
+#include "view/Mask.h"
+#endif
 
 class Range;
 struct PaddedBox;
@@ -135,8 +139,7 @@ protected:
 
 #ifdef DEBUG_ERASABLE_STROKE_BOXES
 public:
-    mutable cairo_surface_t* surfDebug = nullptr;
-    mutable cairo_t* crDebug = nullptr;
+    mutable xoj::view::Mask debugMask;
 
     static void paintDebugRect(const xoj::util::Rectangle<double>& rect, char color, cairo_t* cr);
 #endif

--- a/src/core/view/ErasableStrokeView.h
+++ b/src/core/view/ErasableStrokeView.h
@@ -13,13 +13,15 @@
 
 #include <utility>  // for pair
 
-#include <cairo.h>  // for cairo_t, cairo_surface_t
+#include <cairo.h>  // for cairo_t
 
 class ErasableStroke;
 class Range;
 
 namespace xoj {
 namespace view {
+class Mask;
+
 class ErasableStrokeView {
 public:
     ErasableStrokeView(const ErasableStroke& erasableStroke);
@@ -47,11 +49,11 @@ public:
 private:
     /**
      * @brief Create a cairo mask for a given rectangle and sets up a context for drawing on it
-     * @param box The rectangle delimiting the mask
-     * @param scaling A scaling ratio to apply to the mask
-     * @return Pointers to the newly created cairo context and surface (mask)
+     * @param target A cairo context on which the mask would be used
+     * @param box The range delimiting the mask
+     * @param zoom A zoom ratio to apply to the mask
      */
-    std::pair<cairo_t*, cairo_surface_t*> createMask(const Range& box, double scaling) const;
+    xoj::view::Mask createMask(cairo_t* target, const Range& box, double zoom) const;
 
 private:
     const ErasableStroke& erasableStroke;

--- a/src/core/view/GeometryToolView.cpp
+++ b/src/core/view/GeometryToolView.cpp
@@ -47,9 +47,8 @@ void GeometryToolView::drawTemporaryStroke(cairo_t* cr) const {
 
 auto GeometryToolView::createMask(cairo_t* targetCr) const -> Mask {
     const double zoom = this->parent->getZoom();
-    const int dpiScaling = this->parent->getDPIScaling();
     Range rg = geometryTool->getToolRange(false);
-    return Mask(cairo_get_target(targetCr), rg, zoom, dpiScaling, CAIRO_CONTENT_COLOR_ALPHA);
+    return Mask(cairo_get_target(targetCr), rg, zoom, CAIRO_CONTENT_COLOR_ALPHA);
 }
 
 void GeometryToolView::on(ResetMaskRequest) { mask.reset(); }

--- a/src/core/view/Mask.h
+++ b/src/core/view/Mask.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <cairo.h>
+#include <gdk/gdk.h>
 
 #include "util/raii/CairoWrappers.h"
 
@@ -32,11 +33,20 @@ public:
      * @param extent The extent of the mask, in local coordinates (i.e. in the coordinates of the cairo context(s) on
      * which the mask will be used).
      * @param zoom The local zoom ratio (zoom ratio of the cairo context(s) on which the mask will be used).
-     * @param DPIScaling The targeted screen DPI scaling
      * @param contentType The intended content of the mask
      */
-    Mask(cairo_surface_t* target, const Range& extent, double zoom, int DPIScaling,
-         cairo_content_t contentType = CAIRO_CONTENT_ALPHA);
+    Mask(cairo_surface_t* target, const Range& extent, double zoom, cairo_content_t contentType = CAIRO_CONTENT_ALPHA);
+
+    /**
+     * @brief Create a mask tailored for the specified target
+     * @param DPIScaling The DPI scaling of the targeted use monitor
+     * @param extent The extent of the mask, in local coordinates (i.e. in the coordinates of the cairo context(s) on
+     * which the mask will be used).
+     * @param zoom The local zoom ratio (zoom ratio of the cairo context(s) on which the mask will be used).
+     * @param contentType The intended content of the mask
+     */
+    Mask(int DPIScaling, const Range& extent, double zoom, cairo_content_t contentType = CAIRO_CONTENT_ALPHA);
+
     cairo_t* get();
     bool isInitialized() const;
     /**
@@ -63,7 +73,15 @@ public:
      */
     void reset();
 
+    inline double getZoom() const { return zoom; }
+
 private:
+    template <typename DPIInfoType>
+    void constructorImpl(DPIInfoType dpiInfo, const Range& extent, double zoom, cairo_content_t contentType);
+
     xoj::util::CairoSPtr cr;
+    int xOffset = 0;
+    int yOffset = 0;
+    double zoom = 1.0;
 };
 };  // namespace xoj::view

--- a/src/core/view/overlays/BaseStrokeToolView.cpp
+++ b/src/core/view/overlays/BaseStrokeToolView.cpp
@@ -33,7 +33,6 @@ Color BaseStrokeToolView::strokeColorWithAlpha(const Stroke& s) {
 
 auto BaseStrokeToolView::createMask(cairo_t* tgtcr) const -> Mask {
     const double zoom = this->parent->getZoom();
-    const int dpiScaling = this->parent->getDPIScaling();
     Range visibleRange = this->parent->getVisiblePart();
 
     if (!visibleRange.isValid()) {
@@ -48,7 +47,7 @@ auto BaseStrokeToolView::createMask(cairo_t* tgtcr) const -> Mask {
     // area's border
     visibleRange.addPadding(0.5 * this->strokeWidth);
 
-    Mask mask(cairo_get_target(tgtcr), visibleRange, zoom, dpiScaling);
+    Mask mask(cairo_get_target(tgtcr), visibleRange, zoom);
     cairo_t* cr = mask.get();
 
     cairo_set_source_rgba(cr, 1, 1, 1, 1);

--- a/src/core/view/overlays/StrokeToolFilledHighlighterView.cpp
+++ b/src/core/view/overlays/StrokeToolFilledHighlighterView.cpp
@@ -69,5 +69,5 @@ void StrokeToolFilledHighlighterView::draw(cairo_t* cr) const {
     Util::cairo_set_source_argb(cr, this->strokeColor);
     cairo_set_operator(cr, this->cairoOp);
 
-    cairo_mask_surface(cr, cairo_get_target(this->mask.get()), 0, 0);
+    this->mask.blitTo(cr);
 }

--- a/src/core/view/overlays/StrokeToolView.cpp
+++ b/src/core/view/overlays/StrokeToolView.cpp
@@ -75,7 +75,7 @@ void StrokeToolView::draw(cairo_t* cr) const {
         this->drawDot(this->mask.get(), pts.back());
     }
 
-    cairo_mask_surface(cr, cairo_get_target(this->mask.get()), 0, 0);
+    this->mask.blitTo(cr);
 }
 
 void StrokeToolView::on(StrokeToolView::AddPointRequest, const Point& p) {

--- a/src/core/view/overlays/VerticalToolView.cpp
+++ b/src/core/view/overlays/VerticalToolView.cpp
@@ -109,7 +109,6 @@ Mask VerticalToolView::createMask(cairo_t* tgtcr) const {
      *                      (the entire page is not an option for infinite pages...)
      */
     const double zoom = this->parent->getZoom();
-    const int dpiScaling = this->parent->getDPIScaling();
     Range range = this->parent->getVisiblePart();
 
     if (side == VerticalToolHandler::Side::Above) {
@@ -118,7 +117,7 @@ Mask VerticalToolView::createMask(cairo_t* tgtcr) const {
         range.translate(0, startY - range.minY);
     }
 
-    return Mask(cairo_get_target(tgtcr), range, zoom, dpiScaling, CAIRO_CONTENT_COLOR_ALPHA);
+    return Mask(cairo_get_target(tgtcr), range, zoom, CAIRO_CONTENT_COLOR_ALPHA);
 }
 
 void VerticalToolView::zoomChanged() {


### PR DESCRIPTION
This PR makes use of view::Mask for the PageView::buffer, as well as for the mask in StrokeView and ErasableStrokeView and the cache in PdfCache.

It also uses `cairo_surface_create_similar()` instead of `cairo_image_surface_create()` for those surface, thus using the most suitable Cairo backend available. This should improve performances (closes #4179).
The emoji part of #3692 is also fixed, and the issue underlying #4555 (ugly-fixed with #4566) is cleaned up: no more unsuitable use of `cairo_surface_set_device_scale()`.

The 3 commits are self contained and can be reviewed separately.
