### PR TITLE
Fix the filename suggestions when annotating PDFs

### DIFF
--- a/src/core/model/Document.cpp
+++ b/src/core/model/Document.cpp
@@ -138,6 +138,11 @@ auto Document::createSaveFilename(DocumentType type, const std::string& defaultS
         return p;
     }
     if (!pdfFilepath.empty()) {
+        if (type != Document::PDF) {
+            fs::path p = pdfFilepath.filename();
+            Util::clearExtensions(p, ".pdf");
+            return p;
+        }
         auto saveString = SaveNameUtils::parseFilenameFromWildcardString(defaultPdfName, this->pdfFilepath.filename());
         if (!this->attachPdf) {
             saveString += ".pdf";


### PR DESCRIPTION
The current implementation of `createSaveFilename`(#4599) causes the suggested filename in the save dialog to be ".pdf" whenever a PDF is opened. This fixes the problem and also removes the pdf extension as the file will be saved as "*.xopp" instead of "*.pdf.xopp".