### PR TITLE
Use RAII MainWindow toolbarWidgets

### DIFF
--- a/src/core/gui/MainWindow.cpp
+++ b/src/core/gui/MainWindow.cpp
@@ -583,7 +583,9 @@ void MainWindow::toolbarSelected(ToolbarData* d) {
 
 auto MainWindow::clearToolbar() -> ToolbarData* {
     if (this->selectedToolbar != nullptr) {
-        for (int i = 0; i < TOOLBAR_DEFINITIONS_LEN; i++) { ToolMenuHandler::unloadToolbar(this->toolbarWidgets[i].get()); }
+        for (int i = 0; i < TOOLBAR_DEFINITIONS_LEN; i++) {
+            ToolMenuHandler::unloadToolbar(this->toolbarWidgets[i].get());
+        }
 
         this->toolbar->freeDynamicToolbarItems();
     }

--- a/src/core/gui/MainWindow.h
+++ b/src/core/gui/MainWindow.h
@@ -24,10 +24,10 @@
 
 #include "control/layer/LayerCtrlListener.h"  // for LayerCtrlListener
 #include "model/Font.h"                       // for XojFont
-#include "ToolbarDefinitions.h"               // for TOOLBAR_DEFINITIONS_LEN
 #include "util/raii/GObjectSPtr.h"
 
-#include "GladeGui.h"  // for GladeGui
+#include "GladeGui.h"            // for GladeGui
+#include "ToolbarDefinitions.h"  // for TOOLBAR_DEFINITIONS_LEN
 
 class Control;
 class Layout;

--- a/src/core/gui/MainWindow.h
+++ b/src/core/gui/MainWindow.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <array>    // for array
 #include <atomic>   // for atomic_bool
 #include <cstddef>  // for size_t
 #include <memory>   // for unique_ptr
@@ -23,6 +24,7 @@
 
 #include "control/layer/LayerCtrlListener.h"  // for LayerCtrlListener
 #include "model/Font.h"                       // for XojFont
+#include "ToolbarDefinitions.h"               // for TOOLBAR_DEFINITIONS_LEN
 #include "util/raii/GObjectSPtr.h"
 
 #include "GladeGui.h"  // for GladeGui
@@ -40,6 +42,8 @@ class FloatingToolbox;
 class GladeSearchpath;
 
 class Menubar;
+
+typedef std::array<xoj::util::WidgetSPtr, TOOLBAR_DEFINITIONS_LEN> ToolbarWidgetArray;
 
 class MainWindow: public GladeGui, public LayerCtrlListener {
 public:
@@ -104,7 +108,7 @@ public:
     void updateToolbarMenu();
     void updateColorscheme();
 
-    GtkWidget** getToolbarWidgets(int& length) const;
+    const ToolbarWidgetArray& getToolbarWidgets() const;
     const char* getToolbarName(GtkToolbar* toolbar) const;
 
     Layout* getLayout() const;
@@ -194,7 +198,7 @@ private:
 
     bool maximized = false;
 
-    GtkWidget** toolbarWidgets;
+    ToolbarWidgetArray toolbarWidgets;
 
     GtkAccelGroup* globalAccelGroup;
 

--- a/src/core/gui/dialog/toolbarCustomize/ToolbarDragDropHandler.cpp
+++ b/src/core/gui/dialog/toolbarCustomize/ToolbarDragDropHandler.cpp
@@ -16,37 +16,25 @@
 
 ToolbarDragDropHandler::ToolbarDragDropHandler(Control* control): control(control) {}
 
-ToolbarDragDropHandler::~ToolbarDragDropHandler() { clearToolbarsFromDragAndDrop(); }
+ToolbarDragDropHandler::~ToolbarDragDropHandler() = default;
 
 void ToolbarDragDropHandler::prepareToolbarsForDragAndDrop() {
-    int len = 0;
     MainWindow* win = control->getWindow();
-    GtkWidget** widgets = win->getToolbarWidgets(len);
 
-    this->toolbars = new ToolbarAdapter*[len + 1];
-    this->toolbars[len] = nullptr;
+    this->toolbars.clear();
 
-    for (int i = 0; i < len; i++) {
-        GtkWidget* w = widgets[i];
-        this->toolbars[i] = new ToolbarAdapter(w, win->getToolbarName(GTK_TOOLBAR(w)),
-                                               control->getWindow()->getToolMenuHandler(), control->getWindow());
+    for (auto w: win->getToolbarWidgets()) {
+        this->toolbars.emplace_back(std::make_unique<ToolbarAdapter>(w.get(), win->getToolbarName(GTK_TOOLBAR(w.get())),
+                                    control->getWindow()->getToolMenuHandler(), win));
     }
 }
 
 void ToolbarDragDropHandler::clearToolbarsFromDragAndDrop() {
-    if (this->toolbars == nullptr) {
-        return;
-    }
-
-    for (int i = 0; this->toolbars[i]; i++) { delete this->toolbars[i]; }
-    delete[] this->toolbars;
-
-    this->toolbars = nullptr;
+    this->toolbars.clear();
 }
 
 void ToolbarDragDropHandler::toolbarConfigDialogClosed() {
-    delete this->customizeDialog;
-    this->customizeDialog = nullptr;
+    this->customizeDialog.reset();
 
     MainWindow* win = control->getWindow();
 
@@ -65,9 +53,9 @@ void ToolbarDragDropHandler::configure() {
 
     this->prepareToolbarsForDragAndDrop();
 
-    this->customizeDialog = new ToolbarCustomizeDialog(control->getGladeSearchPath(), win, this);
+    this->customizeDialog = std::make_unique<ToolbarCustomizeDialog>(control->getGladeSearchPath(), win, this);
 
     this->customizeDialog->show(GTK_WINDOW(win->getWindow()));
 }
 
-auto ToolbarDragDropHandler::isInDragAndDrop() -> bool { return this->toolbars != nullptr; }
+auto ToolbarDragDropHandler::isInDragAndDrop() -> bool { return !this->toolbars.empty(); }

--- a/src/core/gui/dialog/toolbarCustomize/ToolbarDragDropHandler.cpp
+++ b/src/core/gui/dialog/toolbarCustomize/ToolbarDragDropHandler.cpp
@@ -25,13 +25,11 @@ void ToolbarDragDropHandler::prepareToolbarsForDragAndDrop() {
 
     for (auto w: win->getToolbarWidgets()) {
         this->toolbars.emplace_back(std::make_unique<ToolbarAdapter>(w.get(), win->getToolbarName(GTK_TOOLBAR(w.get())),
-                                    control->getWindow()->getToolMenuHandler(), win));
+                                                                     control->getWindow()->getToolMenuHandler(), win));
     }
 }
 
-void ToolbarDragDropHandler::clearToolbarsFromDragAndDrop() {
-    this->toolbars.clear();
-}
+void ToolbarDragDropHandler::clearToolbarsFromDragAndDrop() { this->toolbars.clear(); }
 
 void ToolbarDragDropHandler::toolbarConfigDialogClosed() {
     this->customizeDialog.reset();

--- a/src/core/gui/dialog/toolbarCustomize/ToolbarDragDropHandler.h
+++ b/src/core/gui/dialog/toolbarCustomize/ToolbarDragDropHandler.h
@@ -37,6 +37,6 @@ public:
 private:
     Control* control;
 
-    std::vector<std::unique_ptr<ToolbarAdapter>> toolbars; 
+    std::vector<std::unique_ptr<ToolbarAdapter>> toolbars;
     std::unique_ptr<ToolbarCustomizeDialog> customizeDialog;
 };

--- a/src/core/gui/dialog/toolbarCustomize/ToolbarDragDropHandler.h
+++ b/src/core/gui/dialog/toolbarCustomize/ToolbarDragDropHandler.h
@@ -11,6 +11,9 @@
 
 #pragma once
 
+#include <memory>
+#include <vector>
+
 class Control;
 class ToolbarAdapter;
 class ToolbarCustomizeDialog;
@@ -34,6 +37,6 @@ public:
 private:
     Control* control;
 
-    ToolbarAdapter** toolbars = nullptr;
-    ToolbarCustomizeDialog* customizeDialog = nullptr;
+    std::vector<std::unique_ptr<ToolbarAdapter>> toolbars; 
+    std::unique_ptr<ToolbarCustomizeDialog> customizeDialog;
 };


### PR DESCRIPTION
Also changed to RAII in ToolbarDragDropHandler as it was using the toolbarWidgets of MainWindow.