### PR TITLE
Unit test for model/StrokeStyle and refactor

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -3163,7 +3163,7 @@ void Control::setFill(bool fill) {
 }
 
 void Control::setLineStyle(const string& style) {
-    LineStyle stl = StrokeStyle::parseStyle(style.c_str());
+    LineStyle stl = StrokeStyle::parseStyle(style);
 
     EditSelection* sel = nullptr;
     if (this->win) {

--- a/src/core/control/ToolHandler.cpp
+++ b/src/core/control/ToolHandler.cpp
@@ -476,7 +476,7 @@ void ToolHandler::loadSettings() {
 
             std::string style;
             if (st.getString("style", style)) {
-                tool->setLineStyle(StrokeStyle::parseStyle(style.c_str()));
+                tool->setLineStyle(StrokeStyle::parseStyle(style));
             }
 
             std::string value;

--- a/src/core/model/LineStyle.cpp
+++ b/src/core/model/LineStyle.cpp
@@ -29,13 +29,11 @@ void LineStyle::operator=(const LineStyle& other) {
     setDashes(dashes, dashCount);
 }
 
-#ifndef NDEBUG
 bool LineStyle::operator==(const LineStyle& other) const {
     return (this->dashes == nullptr && other.dashes == nullptr) ||
            (this->dashes != nullptr && other.dashes != nullptr &&
             std::equal(this->dashes, this->dashes + this->dashCount, other.dashes, other.dashes + other.dashCount));
 }
-#endif
 
 void LineStyle::serialize(ObjectOutputStream& out) const {
     out.writeObject("LineStyle");

--- a/src/core/model/LineStyle.h
+++ b/src/core/model/LineStyle.h
@@ -24,10 +24,7 @@ public:
     ~LineStyle() override;
 
     void operator=(const LineStyle& other);
-#ifndef NDEBUG
-    // Only use in assert() for now
     bool operator==(const LineStyle& other) const;
-#endif
 
 public:
     // Serialize interface

--- a/src/core/model/StrokeStyle.cpp
+++ b/src/core/model/StrokeStyle.cpp
@@ -64,7 +64,8 @@ auto StrokeStyle::parseStyle(const char* style) -> LineStyle {
         return name;                                                                                       \
     }
 
-auto StrokeStyle::formatStyle(const double* dashes, int count) -> std::string {
+namespace {
+auto formatStyle(const double* dashes, int count) -> std::string {
     FORMAT_STYLE("dash", dashLinePattern);
     FORMAT_STYLE("dashdot", dashDotLinePattern);
     FORMAT_STYLE("dot", dotLinePattern);
@@ -80,12 +81,13 @@ auto StrokeStyle::formatStyle(const double* dashes, int count) -> std::string {
 
     return custom;
 }
+}
 
 auto StrokeStyle::formatStyle(const LineStyle& style) -> std::string {
     const double* dashes = nullptr;
     int dashCount = 0;
     if (style.getDashes(dashes, dashCount)) {
-        return StrokeStyle::formatStyle(dashes, dashCount);
+        return ::formatStyle(dashes, dashCount);
     }
 
     // Should not be returned, in this case the attribute is not written

--- a/src/core/model/StrokeStyle.cpp
+++ b/src/core/model/StrokeStyle.cpp
@@ -45,22 +45,19 @@ auto formatStyle(const double* dashes, int count) -> std::string {
 
 }
 
-auto StrokeStyle::parseStyle(const char* style) -> LineStyle {
-
-    std::string styleStr(style);
-
-    auto it = predefinedPatterns.find(styleStr);
+auto StrokeStyle::parseStyle(const std::string &style) -> LineStyle {
+    auto it = predefinedPatterns.find(style);
     if (it != predefinedPatterns.end()) {
         LineStyle ls;
         ls.setDashes(it->second.data(), static_cast<int>(it->second.size()));
         return ls;
     }
 
-    if (styleStr.substr(0, strlen(CUST_KEY)) != CUST_KEY) {
+    if (style.substr(0, strlen(CUST_KEY)) != CUST_KEY) {
         return LineStyle();
     }
 
-    std::stringstream dashStream(styleStr);
+    std::stringstream dashStream(style);
     std::vector<double> dash;
 
     dashStream.seekg(strlen(CUST_KEY));
@@ -71,13 +68,8 @@ auto StrokeStyle::parseStyle(const char* style) -> LineStyle {
         return LineStyle();
     }
 
-    auto* dashesArr = new double[dash.size()];
-    for (int i = 0; i < static_cast<int>(dash.size()); i++) { dashesArr[i] = dash[i]; }
-
     LineStyle ls;
-    ls.setDashes(dashesArr, static_cast<int>(dash.size()));
-    delete[] dashesArr;
-
+    ls.setDashes(dash.data(), static_cast<int>(dash.size()));
     return ls;
 }
 

--- a/src/core/model/StrokeStyle.h
+++ b/src/core/model/StrokeStyle.h
@@ -20,6 +20,6 @@ private:
     StrokeStyle();
     virtual ~StrokeStyle();
 public:
-    static LineStyle parseStyle(const char* style);
+    static LineStyle parseStyle(const std::string& style);
     static std::string formatStyle(const LineStyle& style);
 };

--- a/src/core/model/StrokeStyle.h
+++ b/src/core/model/StrokeStyle.h
@@ -19,11 +19,7 @@ class StrokeStyle {
 private:
     StrokeStyle();
     virtual ~StrokeStyle();
-
 public:
     static LineStyle parseStyle(const char* style);
-    static std::string formatStyle(const double* dashes, int count);
     static std::string formatStyle(const LineStyle& style);
-
-public:
 };

--- a/test/unit_tests/model/StrokeStyleTest.cpp
+++ b/test/unit_tests/model/StrokeStyleTest.cpp
@@ -1,0 +1,52 @@
+/*
+ * Xournal++
+ *
+ * This file is part of the Xournal UnitTests
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#include <config-test.h>
+#include <gtest/gtest.h>
+
+#include "model/StrokeStyle.h"
+
+namespace {
+constexpr double dashLinePattern[] = {6, 3};
+constexpr double dashDotLinePattern[] = {6, 3, 0.5, 3};
+constexpr double dotLinePattern[] = {0.5, 3};
+constexpr double custPattern[] = {0.01, -1.0, 0.005};
+}
+
+TEST(StrokeStyle, testParseStyle)
+{
+    EXPECT_EQ(StrokeStyle::parseStyle("random"), LineStyle());
+    EXPECT_EQ(StrokeStyle::parseStyle("cust: "), LineStyle());
+    
+    LineStyle l1;
+    double testData[] = {100, 200, 300};
+    l1.setDashes(testData, 3);
+    EXPECT_EQ(StrokeStyle::parseStyle("cust: 100 200 300"), l1);
+}
+
+TEST(StrokeStyle, testFormatStyle)
+{
+    LineStyle dashLine;
+    dashLine.setDashes(dashLinePattern, 2);
+    EXPECT_EQ(StrokeStyle::formatStyle(dashLine), "dash");    
+
+    LineStyle dashDot;
+    dashDot.setDashes(dashDotLinePattern, 4);
+    EXPECT_EQ(StrokeStyle::formatStyle(dashDot), "dashdot");    
+
+    LineStyle dotLine;
+    dotLine.setDashes(dotLinePattern, 2);
+    EXPECT_EQ(StrokeStyle::formatStyle(dotLine), "dot");    
+
+    LineStyle custLine;
+    custLine.setDashes(custPattern, 3);
+    EXPECT_EQ(StrokeStyle::formatStyle(custLine), "cust: 0.01 -1.00 0.01");
+}


### PR DESCRIPTION
Tried to first put existing code under unit test and the refactor to use e.g. map, vector, sstring e.g. instead of mix of glib function and new/delete to allocate dynamic arrays.