### PR TITLE
Fix #4675 No error on save if we don't have write permission

### DIFF
--- a/src/core/control/jobs/SaveJob.cpp
+++ b/src/core/control/jobs/SaveJob.cpp
@@ -114,6 +114,10 @@ auto SaveJob::save() -> bool {
             Util::safeRenameFile(target, fs::path{target} += "~");
         } catch (const fs::filesystem_error& fe) {
             g_warning("Could not create backup! Failed with %s", fe.what());
+            this->lastError = FS(_F("Save file error, can't backup: {1}") % std::string(fe.what()));
+            if (!control->getWindow()) {
+                g_error("%s", this->lastError.c_str());
+            }
             return false;
         }
     }


### PR DESCRIPTION
During save we try to make a backup of the current file. This fails if there is no write permission to the file, and before this PR we returned without notifiy the user.