### PR TITLE
Use RAII for resource allocation in MainWindow

### DIFF
--- a/src/core/gui/MainWindow.cpp
+++ b/src/core/gui/MainWindow.cpp
@@ -169,10 +169,7 @@ void MainWindow::rebindMenubarAccelerators() {
     gtk_container_foreach(reinterpret_cast<GtkContainer*>(menuBar), rebindAcceleratorsSubMenu, this->globalAccelGroup);
 }
 
-MainWindow::~MainWindow() {
-    delete scrollHandling;
-    scrollHandling = nullptr;
-}
+MainWindow::~MainWindow() = default;
 
 /**
  * Topmost widgets, to check if there is a menu above
@@ -214,9 +211,9 @@ void MainWindow::initXournalWidget() {
 
     gtk_container_add(GTK_CONTAINER(winXournal), vpXournal);
 
-    scrollHandling = new ScrollHandling(GTK_SCROLLABLE(vpXournal));
+    scrollHandling = std::make_unique<ScrollHandling>(GTK_SCROLLABLE(vpXournal));
 
-    this->xournal = std::make_unique<XournalView>(vpXournal, control, scrollHandling);
+    this->xournal = std::make_unique<XournalView>(vpXournal, control, scrollHandling.get());
 
     control->getZoomControl()->initZoomHandler(this->window, winXournal, xournal.get(), control);
     gtk_widget_show_all(winXournal);

--- a/src/core/gui/MainWindow.cpp
+++ b/src/core/gui/MainWindow.cpp
@@ -66,7 +66,7 @@ MainWindow::MainWindow(GladeSearchpath* gladeSearchPath, Control* control, GtkAp
 
     GtkOverlay* overlay = GTK_OVERLAY(get("mainOverlay"));
     this->pdfFloatingToolBox = std::make_unique<PdfFloatingToolbox>(this, overlay);
-    this->floatingToolbox = new FloatingToolbox(this, overlay);
+    this->floatingToolbox = std::make_unique<FloatingToolbox>(this, overlay);
 
     for (int i = 0; i < TOOLBAR_DEFINITIONS_LEN; i++) {
         this->toolbarWidgets[i].reset(get(TOOLBAR_DEFINITIONS[i].guiName), xoj::util::ref);
@@ -170,9 +170,6 @@ void MainWindow::rebindMenubarAccelerators() {
 }
 
 MainWindow::~MainWindow() {
-    delete this->floatingToolbox;
-    this->floatingToolbox = nullptr;
-
     delete this->xournal;
     this->xournal = nullptr;
 
@@ -720,3 +717,5 @@ void MainWindow::loadMainCSS(GladeSearchpath* gladeSearchPath, const gchar* cssF
 }
 
 PdfFloatingToolbox* MainWindow::getPdfToolbox() const { return this->pdfFloatingToolBox.get(); }
+
+FloatingToolbox* MainWindow::getFloatingToolbox() const { return this->floatingToolbox.get(); }

--- a/src/core/gui/MainWindow.cpp
+++ b/src/core/gui/MainWindow.cpp
@@ -170,9 +170,6 @@ void MainWindow::rebindMenubarAccelerators() {
 }
 
 MainWindow::~MainWindow() {
-    delete this->xournal;
-    this->xournal = nullptr;
-
     delete scrollHandling;
     scrollHandling = nullptr;
 }
@@ -219,9 +216,9 @@ void MainWindow::initXournalWidget() {
 
     scrollHandling = new ScrollHandling(GTK_SCROLLABLE(vpXournal));
 
-    this->xournal = new XournalView(vpXournal, control, scrollHandling);
+    this->xournal = std::make_unique<XournalView>(vpXournal, control, scrollHandling);
 
-    control->getZoomControl()->initZoomHandler(this->window, winXournal, xournal, control);
+    control->getZoomControl()->initZoomHandler(this->window, winXournal, xournal.get(), control);
     gtk_widget_show_all(winXournal);
 
     Layout* layout = gtk_xournal_get_layout(this->xournal->getWidget());
@@ -552,7 +549,7 @@ void MainWindow::setMaximized(bool maximized) { this->maximized = maximized; }
 
 auto MainWindow::isMaximized() const -> bool { return this->maximized; }
 
-auto MainWindow::getXournal() const -> XournalView* { return xournal; }
+auto MainWindow::getXournal() const -> XournalView* { return xournal.get(); }
 
 auto MainWindow::windowStateEventCallback(GtkWidget* window, GdkEventWindowState* event, MainWindow* win) -> bool {
     win->setMaximized(gtk_window_is_maximized(GTK_WINDOW(window)));

--- a/src/core/gui/MainWindow.h
+++ b/src/core/gui/MainWindow.h
@@ -181,7 +181,7 @@ private:
 private:
     Control* control;
 
-    XournalView* xournal = nullptr;
+    std::unique_ptr<XournalView> xournal;
     GtkWidget* winXournal = nullptr;
     ScrollHandling* scrollHandling = nullptr;
 

--- a/src/core/gui/MainWindow.h
+++ b/src/core/gui/MainWindow.h
@@ -55,8 +55,6 @@ public:
     void rebuildLayerMenu() override;
     void layerVisibilityChanged() override;
 
-    FloatingToolbox* floatingToolbox;
-public:
     void show(GtkWindow* parent) override;
 
     void toolbarSelected(const std::string& id);
@@ -89,6 +87,7 @@ public:
     Control* getControl() const;
 
     PdfFloatingToolbox* getPdfToolbox() const;
+    FloatingToolbox* getFloatingToolbox() const;
 
     void updateScrollbarSidebarPosition();
 
@@ -189,6 +188,7 @@ private:
     std::atomic_bool gtkTouchscreenScrollingEnabled{true};
 
     std::unique_ptr<PdfFloatingToolbox> pdfFloatingToolBox;
+    std::unique_ptr<FloatingToolbox> floatingToolbox;
 
     // Toolbars
     std::unique_ptr<ToolMenuHandler> toolbar;

--- a/src/core/gui/MainWindow.h
+++ b/src/core/gui/MainWindow.h
@@ -183,7 +183,7 @@ private:
 
     std::unique_ptr<XournalView> xournal;
     GtkWidget* winXournal = nullptr;
-    ScrollHandling* scrollHandling = nullptr;
+    std::unique_ptr<ScrollHandling> scrollHandling;
 
     std::atomic_bool gtkTouchscreenScrollingEnabled{true};
 

--- a/src/core/gui/PageView.cpp
+++ b/src/core/gui/PageView.cpp
@@ -1270,5 +1270,5 @@ void XojPageView::showFloatingToolbox(const PositionInputData& pos) {
     wx += std::lround(pos.x) + this->getX();
     wy += std::lround(pos.y) + this->getY();
 
-    control->getWindow()->floatingToolbox->show(wx, wy);
+    control->getWindow()->getFloatingToolbox()->show(wx, wy);
 }

--- a/src/core/gui/dialog/toolbarCustomize/ToolbarDragDropHandler.cpp
+++ b/src/core/gui/dialog/toolbarCustomize/ToolbarDragDropHandler.cpp
@@ -40,14 +40,14 @@ void ToolbarDragDropHandler::toolbarConfigDialogClosed() {
 
     auto file = Util::getConfigFile(TOOLBAR_CONFIG);
     win->getToolbarModel()->save(file);
-    win->floatingToolbox->hide();
+    win->getFloatingToolbox()->hide();
 }
 
 void ToolbarDragDropHandler::configure() {
     MainWindow* win = control->getWindow();
 
 
-    win->floatingToolbox->showForConfiguration();
+    win->getFloatingToolbox()->showForConfiguration();
 
     this->prepareToolbarsForDragAndDrop();
 


### PR DESCRIPTION
Now all objects allocated with `new` has been changed to use `std::unique_ptr` to ensure their resources are deallocated with MainWindow goes out of scope.