### PR TITLE
Fix up git clang-format in the pipeline

### DIFF
--- a/azure-pipelines/clang-format-applied.yml
+++ b/azure-pipelines/clang-format-applied.yml
@@ -29,14 +29,19 @@ stages:
         sudo apt-get install -y clang-format
       displayName: 'Install clang-format'
     - bash: |
-        # Checkout the master branch as we require it to get the list of modified files
         git config --global clangFormat.extensions "c,h,cpp,hpp,hxx,cxx,cc,hh'"
         #
-        git fetch origin $(System.PullRequest.TargetBranch)
-        git fetch origin $(System.PullRequest.SourceBranch) 
-        BASE_COMMIT=$(git merge-base $(System.PullRequest.SourceBranch) $(System.PullRequest.TargetBranch))
-        git fetch origin $BASE_COMMIT
+        echo $(git status)
+        git fetch origin $(System.PullRequest.TargetBranch):$(System.PullRequest.TargetBranch)
+        git switch -c this_pr 
+        git switch $(System.PullRequest.TargetBranch)
+        git switch this_pr
+        BASE_COMMIT=$(git merge-base this_pr $(System.PullRequest.TargetBranch))
         #
         echo Computing diff to commit hash $BASE_COMMIT
+        # Exit on git merge-base failure
+        [[ -z "$BASE_COMMIT" ]] && { echo "Error: BASE_COMMIT is empty" ; exit 1; }
+        git fetch origin $BASE_COMMIT
+        
         git clang-format --diff $BASE_COMMIT --
       displayName: 'Run clang-format on modified files'


### PR DESCRIPTION
 - Added a check, if the calculated BaseCommitHash is empty.