### PR TITLE
Fix dark background color of tex dialog

### DIFF
--- a/src/util/Color.cpp
+++ b/src/util/Color.cpp
@@ -22,8 +22,8 @@ float Util::get_color_contrast(Color color1, Color color2) {
 auto Util::rgb_to_hex_string(Color rgb) -> std::string {
     char resultHex[7];
 
-    // 06: Pad with zeroes to a length of 6.
-    assert(std::snprintf(resultHex, 7, "%06x", uint32_t(rgb)) > 0);
+    // 06: Disregard alpha channel and pad with zeroes to a length of 6.
+    assert(std::snprintf(resultHex, 7, "%06x", uint32_t(rgb) & 0xffffff) > 0);
 
     std::stringstream result;
     result << "#" << resultHex;

--- a/src/util/include/util/Color.h
+++ b/src/util/include/util/Color.h
@@ -128,7 +128,7 @@ float as_grayscale_color(Color color);
 float get_color_contrast(Color color1, Color color2);
 
 /**
- * @param rgb Color to get a representation for.
+ * @param rgb Color to get a representation for, while ignoring the alpha channel.
  * @return a CSS-style representation of the color, in hex. For example,
  *          red might be #ff0000, green, #00ff00, and blue, #0000ff.
  */
@@ -204,12 +204,12 @@ constexpr auto Util::GdkRGBA_to_ColorU16(const GdkRGBA& color) -> ColorU16 {
 }
 
 namespace Colors {
-    /*
-     * A palette of predefined colors. The names are the relevant CSS4 named
-     * color, if exists, else the name of the named color with the smallest
-     * distance from it as an (r, g, b) vector with the prefix "xopp_",
-     * see https://www.w3.org/TR/css-color-4/#named-colors
-     */
+/*
+ * A palette of predefined colors. The names are the relevant CSS4 named
+ * color, if exists, else the name of the named color with the smallest
+ * distance from it as an (r, g, b) vector with the prefix "xopp_",
+ * see https://www.w3.org/TR/css-color-4/#named-colors
+ */
 constexpr Color black{0xff000000U};
 constexpr Color gray{0xff808080U};
 constexpr Color green{0xff008000U};
@@ -244,5 +244,4 @@ constexpr Color xopp_pink{0xffffc0d4U};
 constexpr Color xopp_royalblue{0xff3333ccU};
 constexpr Color xopp_silver{0xffbdbdbdU};
 constexpr Color xopp_snow{0xfffafaf9U};
-} // namespace Colors
-
+}  // namespace Colors


### PR DESCRIPTION
Fixes a regression introduced in 727730512cd2ad85d93184816166f25201095da8 by setting the alpha channel of `Colors::black` (used as a background color for the TeX dialog when the text color is light) to `0xff`. This was incompatible with `rgb_to_hex_string`, that turned it into `#ff0000` instead of `#000000`. 

Bad: 
![grafik](https://user-images.githubusercontent.com/40485433/225424322-70de3d3d-fde1-4b9b-834a-81a4319ed077.png)

Good:
![grafik](https://user-images.githubusercontent.com/40485433/225424507-be56eabf-8b99-4b3c-8339-7c6f00ba2936.png)
