### PR TITLE
Don't allocate dialogs on heap

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -1530,16 +1530,14 @@ void Control::insertPage(const PageRef& page, size_t position, bool shouldScroll
 }
 
 void Control::gotoPage() {
-    auto* dlg = new GotoDialog(this->gladeSearchPath, int(this->doc->getPageCount()));
+    auto dlg = GotoDialog(this->gladeSearchPath, int(this->doc->getPageCount()));
 
-    dlg->show(GTK_WINDOW(this->win->getWindow()));
-    auto page = dlg->getSelectedPage();
+    dlg.show(GTK_WINDOW(this->win->getWindow()));
+    auto page = dlg.getSelectedPage();
 
     if (page > 0) {
         this->scrollHandler->scrollToPage(size_t(page - 1), 0);
     }
-
-    delete dlg;
 }
 
 void Control::updateBackgroundSizeButton() {
@@ -1563,10 +1561,10 @@ void Control::updateBackgroundSizeButton() {
 }
 
 void Control::paperTemplate() {
-    auto dlg = std::make_unique<PageTemplateDialog>(this->gladeSearchPath, settings, pageTypes);
-    dlg->show(GTK_WINDOW(this->win->getWindow()));
+    auto dlg = PageTemplateDialog(this->gladeSearchPath, settings, pageTypes);
+    dlg.show(GTK_WINDOW(this->win->getWindow()));
 
-    if (dlg->isSaved()) {
+    if (dlg.isSaved()) {
         newPageType->loadDefaultPage();
     }
 }
@@ -1578,11 +1576,11 @@ void Control::paperFormat() {
     }
     clearSelectionEndText();
 
-    auto* dlg = new FormatDialog(this->gladeSearchPath, settings, page->getWidth(), page->getHeight());
-    dlg->show(GTK_WINDOW(this->win->getWindow()));
+    auto dlg = FormatDialog(this->gladeSearchPath, settings, page->getWidth(), page->getHeight());
+    dlg.show(GTK_WINDOW(this->win->getWindow()));
 
-    double width = dlg->getWidth();
-    double height = dlg->getHeight();
+    double width = dlg.getWidth();
+    double height = dlg.getHeight();
 
     if (width > 0) {
         this->doc->lock();
@@ -1594,8 +1592,6 @@ void Control::paperFormat() {
     if (pageNo != npos && pageNo < doc->getPageCount()) {
         this->firePageSizeChanged(pageNo);
     }
-
-    delete dlg;
 }
 
 void Control::changePageBackgroundColor() {
@@ -2206,8 +2202,8 @@ void Control::showSettings() {
     StylusCursorType stylusCursorType = settings->getStylusCursorType();
     bool highlightPosition = settings->isHighlightPosition();
 
-    auto* dlg = new SettingsDialog(this->gladeSearchPath, settings, this);
-    dlg->show(GTK_WINDOW(this->win->getWindow()));
+    auto dlg = SettingsDialog(this->gladeSearchPath, settings, this);
+    dlg.show(GTK_WINDOW(this->win->getWindow()));
 
     // note which settings have changed and act accordingly
     if (selectionColor != settings->getBorderColor()) {
@@ -2236,8 +2232,6 @@ void Control::showSettings() {
 
     getWindow()->getXournal()->getHandRecognition()->reload();
     getWindow()->updateColorscheme();
-
-    delete dlg;
 }
 
 auto Control::newFile(string pageTemplate, fs::path filepath) -> bool {

--- a/src/core/control/PageBackgroundChangeController.cpp
+++ b/src/core/control/PageBackgroundChangeController.cpp
@@ -205,13 +205,12 @@ auto PageBackgroundChangeController::applyPdfBackground(PageRef page) -> bool {
     }
 
     doc->lock();
-    auto* dlg = new PdfPagesDialog(control->getGladeSearchPath(), doc, control->getSettings());
+    auto dlg = PdfPagesDialog(control->getGladeSearchPath(), doc, control->getSettings());
     doc->unlock();
 
-    dlg->show(GTK_WINDOW(control->getGtkWindow()));
+    dlg.show(GTK_WINDOW(control->getGtkWindow()));
 
-    int selected = dlg->getSelectedPage();
-    delete dlg;
+    int selected = dlg.getSelectedPage();
 
     if (selected >= 0 && selected < static_cast<int>(doc->getPdfPageCount())) {
         // no need to set a type, if we set the page number the type is also set

--- a/src/core/gui/dialog/PageTemplateDialog.cpp
+++ b/src/core/gui/dialog/PageTemplateDialog.cpp
@@ -149,12 +149,11 @@ void PageTemplateDialog::updatePageSize() {
 }
 
 void PageTemplateDialog::showPageSizeDialog() {
-    auto dlg =
-            std::make_unique<FormatDialog>(getGladeSearchPath(), settings, model.getPageWidth(), model.getPageHeight());
-    dlg->show(GTK_WINDOW(this->window));
+    auto dlg = FormatDialog(getGladeSearchPath(), settings, model.getPageWidth(), model.getPageHeight());
+    dlg.show(GTK_WINDOW(this->window));
 
-    const double width = dlg->getWidth();
-    const double height = dlg->getHeight();
+    const double width = dlg.getWidth();
+    const double height = dlg.getHeight();
 
     if (width > 0) {
         model.setPageWidth(width);


### PR DESCRIPTION
Some dialogs was allocated on heap other on stack. I have now align them to be allocated on stack. The benefit is that we then don't need to explict deallocate them.