### PR TITLE
Page type radio button incorrect when changing to page type there fails.

### DIFF
--- a/src/core/control/pagetype/PageTypeHandler.cpp
+++ b/src/core/control/pagetype/PageTypeHandler.cpp
@@ -1,5 +1,6 @@
 #include "PageTypeHandler.h"
 
+#include <memory>
 #include <utility>
 
 #include "gui/GladeSearchpath.h"
@@ -33,10 +34,7 @@ PageTypeHandler::PageTypeHandler(GladeSearchpath* gladeSearchPath) {
     addPageTypeInfo(_("Image"), PageTypeFormat::Image, "");
 }
 
-PageTypeHandler::~PageTypeHandler() {
-    for (PageTypeInfo* t: types) { delete t; }
-    types.clear();
-}
+PageTypeHandler::~PageTypeHandler() = default;
 
 auto PageTypeHandler::parseIni(fs::path const& filepath) -> bool {
     GKeyFile* config = g_key_file_new();
@@ -82,15 +80,15 @@ void PageTypeHandler::loadFormat(GKeyFile* config, const char* group) {
 }
 
 void PageTypeHandler::addPageTypeInfo(string name, PageTypeFormat format, string config) {
-    auto pt = new PageTypeInfo();
+    auto pt = std::make_unique<PageTypeInfo>();
     pt->name = std::move(name);
     pt->page.format = format;
     pt->page.config = std::move(config);
 
-    this->types.push_back(pt);
+    this->types.emplace_back(std::move(pt));
 }
 
-auto PageTypeHandler::getPageTypes() -> std::vector<PageTypeInfo*>& { return this->types; }
+auto PageTypeHandler::getPageTypes() -> const std::vector<std::unique_ptr<PageTypeInfo>>& { return this->types; }
 
 auto PageTypeHandler::getPageTypeFormatForString(const string& format) -> PageTypeFormat {
     if (format == "plain") {

--- a/src/core/control/pagetype/PageTypeHandler.h
+++ b/src/core/control/pagetype/PageTypeHandler.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <memory>  // for std::unique_ptr
 #include <string>  // for string
 #include <vector>  // for vector
 
@@ -33,8 +34,7 @@ public:
     PageTypeHandler(GladeSearchpath* gladeSearchPath);
     virtual ~PageTypeHandler();
 
-public:
-    std::vector<PageTypeInfo*>& getPageTypes();
+    const std::vector<std::unique_ptr<PageTypeInfo>>& getPageTypes();
     static PageTypeFormat getPageTypeFormatForString(const std::string& format);
     static std::string getStringForPageTypeFormat(const PageTypeFormat& format);
 
@@ -43,6 +43,5 @@ private:
     bool parseIni(fs::path const& filepath);
     void loadFormat(GKeyFile* config, const char* group);
 
-private:
-    std::vector<PageTypeInfo*> types;
+    std::vector<std::unique_ptr<PageTypeInfo>> types;
 };

--- a/src/core/control/pagetype/PageTypeMenu.cpp
+++ b/src/core/control/pagetype/PageTypeMenu.cpp
@@ -228,7 +228,7 @@ auto PageTypeMenu::createApplyMenuItem(const char* text) -> GtkWidget* {
 
 void PageTypeMenu::initDefaultMenu() {
     bool special = false;
-    for (PageTypeInfo* t: this->types->getPageTypes()) {
+    for (auto& t: this->types->getPageTypes()) {
         if (!showSpecial && t->page.isSpecial()) {
             continue;
         }
@@ -250,7 +250,7 @@ void PageTypeMenu::initDefaultMenu() {
                 gtk_container_add(GTK_CONTAINER(menu), separator);
             }
         }
-        addMenuEntry(t);
+        addMenuEntry(t.get());
     }
 }
 


### PR DESCRIPTION
The radio button showing the current selected page type was
incorrect. E.g. create a new document, select pdf background
which fails due to no pdf file. The radio button still shows
pdf background even the page type was not changed.