### PR TITLE
Hide plugin menu when compiling with -DENABLE_PLUGINS=off

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,15 +135,18 @@ endif ()
 
 find_package(ZLIB REQUIRED)
 find_package(Threads REQUIRED)
+
+option(ENABLE_PLUGINS "Compile with plugin support" ON)
 find_package(Lua 5.3) # Lua 5.4 is only supported with cmake >=3.18
-if (Lua_FOUND)
+if (Lua_FOUND AND ENABLE_PLUGINS)
     # currently not fully supported by cmake
     message("Enable Xournal++ Plugins")
     add_library(lua INTERFACE)
     target_link_libraries(lua INTERFACE ${LUA_LIBRARIES})
     target_include_directories(lua INTERFACE ${LUA_INCLUDE_DIR})
-    target_compile_definitions(lua INTERFACE ENABLE_PLUGINS)
     add_library(Lua::lua ALIAS lua)
+else ()
+    set(ENABLE_PLUGINS OFF)
 endif ()
 
 if (GtkSourceView_FOUND)

--- a/src/core/gui/menus/menubar/Menubar.cpp
+++ b/src/core/gui/menus/menubar/Menubar.cpp
@@ -16,8 +16,13 @@ void Menubar::populate(MainWindow* win) {
     recentDocumentsSubmenu = std::make_unique<RecentDocumentsSubmenu>(ctrl, GTK_APPLICATION_WINDOW(win->getWindow()));
     toolbarSelectionSubmenu =
             std::make_unique<ToolbarSelectionSubmenu>(win, ctrl->getSettings(), win->getToolMenuHandler());
+#ifdef ENABLE_PLUGINS
     pluginsSubmenu =
             std::make_unique<PluginsSubmenu>(ctrl->getPluginController(), GTK_APPLICATION_WINDOW(win->getWindow()));
+#else
+    // If plugins are disabled - hide the entire menu
+    gtk_widget_hide(win->get("menuitemPlugin"));
+#endif
 
     forEachSubmenu([&](auto& subm) { subm.addToMenubar(win); });
 }

--- a/src/core/gui/menus/menubar/Menubar.h
+++ b/src/core/gui/menus/menubar/Menubar.h
@@ -13,6 +13,8 @@
 
 #include <memory>
 
+#include "config-features.h"
+
 class MainWindow;
 
 class RecentDocumentsSubmenu;
@@ -35,12 +37,16 @@ private:
     // Dynamically created submenus -- also add to forEachSubmenu() below
     std::unique_ptr<RecentDocumentsSubmenu> recentDocumentsSubmenu;
     std::unique_ptr<ToolbarSelectionSubmenu> toolbarSelectionSubmenu;
+#ifdef ENABLE_PLUGINS
     std::unique_ptr<PluginsSubmenu> pluginsSubmenu;
+#endif
 
     template <class Fun>
     void forEachSubmenu(Fun&& fun) {
         fun(*recentDocumentsSubmenu);
         fun(*toolbarSelectionSubmenu);
+#ifdef ENABLE_PLUGINS
         fun(*pluginsSubmenu);
+#endif
     }
 };


### PR DESCRIPTION
also fixes the cmake flags so that configuring with -DENABLE_PLUGINS=off actually compiles without plugins (whether Lua is present or not)