### PR TITLE
Use UndoActionPtr instead of UndoAction* for EditSelection methods

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -2179,9 +2179,7 @@ void Control::changeColorOfSelection() {
     if (this->win && toolHandler->hasCapability(TOOL_CAP_COLOR)) {
         EditSelection* sel = this->win->getXournal()->getSelection();
         if (sel) {
-            UndoAction* undo = sel->setColor(toolHandler->getColor());
-            // move into selection
-            undoRedo->addUndoAction(UndoActionPtr(undo));
+            undoRedo->addUndoAction(sel->setColor(toolHandler->getColor()));
         }
 
         TextEditor* edit = getTextEditor();

--- a/src/core/control/tools/EditSelection.cpp
+++ b/src/core/control/tools/EditSelection.cpp
@@ -323,7 +323,7 @@ auto EditSelection::getYOnViewAbsolute() -> int {
  * (or nullptr if nothing is done)
  */
 auto EditSelection::setSize(ToolSize size, const double* thicknessPen, const double* thicknessHighlighter,
-                            const double* thicknessEraser) -> UndoAction* {
+                            const double* thicknessEraser) -> UndoActionPtr {
     return this->contents->setSize(size, thicknessPen, thicknessHighlighter, thicknessEraser);
 }
 
@@ -331,7 +331,7 @@ auto EditSelection::setSize(ToolSize size, const double* thicknessPen, const dou
  * Fills the stroke, return an undo action
  * (Or nullptr if nothing done, e.g. because there is only an image)
  */
-auto EditSelection::setFill(int alphaPen, int alphaHighligther) -> UndoAction* {
+auto EditSelection::setFill(int alphaPen, int alphaHighligther) -> UndoActionPtr {
     return this->contents->setFill(alphaPen, alphaHighligther);
 }
 
@@ -345,13 +345,13 @@ auto EditSelection::setLineStyle(LineStyle style) -> UndoActionPtr { return this
  * Set the color of all elements, return an undo action
  * (Or nullptr if nothing done, e.g. because there is only an image)
  */
-auto EditSelection::setColor(Color color) -> UndoAction* { return this->contents->setColor(color); }
+auto EditSelection::setColor(Color color) -> UndoActionPtr { return this->contents->setColor(color); }
 
 /**
  * Sets the font of all containing text elements, return an undo action
  * (or nullptr if there are no Text elements)
  */
-auto EditSelection::setFont(XojFont& font) -> UndoAction* { return this->contents->setFont(font); }
+auto EditSelection::setFont(XojFont& font) -> UndoActionPtr { return this->contents->setFont(font); }
 
 /**
  * Fills de undo item if the selection is deleted

--- a/src/core/control/tools/EditSelection.h
+++ b/src/core/control/tools/EditSelection.h
@@ -147,8 +147,8 @@ public:
      * Sets the tool size for pen or eraser, returns an undo action
      * (or nullptr if nothing is done)
      */
-    UndoAction* setSize(ToolSize size, const double* thicknessPen, const double* thicknessHighlighter,
-                        const double* thicknessEraser);
+    UndoActionPtr setSize(ToolSize size, const double* thicknessPen, const double* thicknessHighlighter,
+                          const double* thicknessEraser);
 
     /**
      * Set the line style of all strokes, return an undo action
@@ -160,13 +160,13 @@ public:
      * Set the color of all elements, return an undo action
      * (Or nullptr if nothing done, e.g. because there is only an image)
      */
-    UndoAction* setColor(Color color);
+    UndoActionPtr setColor(Color color);
 
     /**
      * Sets the font of all containing text elements, return an undo action
      * (or nullptr if there are no Text elements)
      */
-    UndoAction* setFont(XojFont& font);
+    UndoActionPtr setFont(XojFont& font);
 
     /**
      * Fills the undo item if the selection is deleted
@@ -178,7 +178,7 @@ public:
      * Fills the stroke, return an undo action
      * (Or nullptr if nothing done, e.g. because there is only an image)
      */
-    UndoAction* setFill(int alphaPen, int alphaHighligther);
+    UndoActionPtr setFill(int alphaPen, int alphaHighligther);
 
 public:
     /**

--- a/src/core/control/tools/EditSelectionContents.cpp
+++ b/src/core/control/tools/EditSelectionContents.cpp
@@ -98,8 +98,8 @@ auto EditSelectionContents::getInsertOrder() const -> std::deque<std::pair<Eleme
  * (or nullptr if nothing is done)
  */
 auto EditSelectionContents::setSize(ToolSize size, const double* thicknessPen, const double* thicknessHighlighter,
-                                    const double* thicknessEraser) -> UndoAction* {
-    auto* undo = new SizeUndoAction(this->sourcePage, this->sourceLayer);
+                                    const double* thicknessEraser) -> UndoActionPtr {
+    auto undo = std::make_unique<SizeUndoAction>(this->sourcePage, this->sourceLayer);
 
     bool found = false;
 
@@ -140,8 +140,6 @@ auto EditSelectionContents::setSize(ToolSize size, const double* thicknessPen, c
         return undo;
     }
 
-
-    delete undo;
     return nullptr;
 }
 
@@ -149,8 +147,8 @@ auto EditSelectionContents::setSize(ToolSize size, const double* thicknessPen, c
  * Fills the stroke, return an undo action
  * (Or nullptr if nothing done, e.g. because there is only an image)
  */
-auto EditSelectionContents::setFill(int alphaPen, int alphaHighligther) -> UndoAction* {
-    auto* undo = new FillUndoAction(this->sourcePage, this->sourceLayer);
+auto EditSelectionContents::setFill(int alphaPen, int alphaHighligther) -> UndoActionPtr {
+    auto undo = std::make_unique<FillUndoAction>(this->sourcePage, this->sourceLayer);
 
     bool found = false;
 
@@ -187,8 +185,6 @@ auto EditSelectionContents::setFill(int alphaPen, int alphaHighligther) -> UndoA
         return undo;
     }
 
-
-    delete undo;
     return nullptr;
 }
 
@@ -196,13 +192,13 @@ auto EditSelectionContents::setFill(int alphaPen, int alphaHighligther) -> UndoA
  * Sets the font of all containing text elements, return an undo action
  * (or nullptr if there are no Text elements)
  */
-auto EditSelectionContents::setFont(XojFont& font) -> UndoAction* {
+auto EditSelectionContents::setFont(XojFont& font) -> UndoActionPtr {
     double x1 = 0.0 / 0.0;
     double x2 = 0.0 / 0.0;
     double y1 = 0.0 / 0.0;
     double y2 = 0.0 / 0.0;
 
-    auto* undo = new FontUndoAction(this->sourcePage, this->sourceLayer);
+    auto undo = std::make_unique<FontUndoAction>(this->sourcePage, this->sourceLayer);
 
     for (Element* e: this->selected) {
         if (e->getType() == ELEMENT_TEXT) {
@@ -239,7 +235,7 @@ auto EditSelectionContents::setFont(XojFont& font) -> UndoAction* {
         this->sourceView->getXournal()->repaintSelection();
         return undo;
     }
-    delete undo;
+
     return nullptr;
 }
 
@@ -270,16 +266,15 @@ auto EditSelectionContents::setLineStyle(LineStyle style) -> UndoActionPtr {
         return undo;
     }
 
-
-    return {};
+    return nullptr;
 }
 
 /**
  * Set the color of all elements, return an undo action
  * (Or nullptr if nothing done, e.g. because there is only an image)
  */
-auto EditSelectionContents::setColor(Color color) -> UndoAction* {
-    auto* undo = new ColorUndoAction(this->sourcePage, this->sourceLayer);
+auto EditSelectionContents::setColor(Color color) -> UndoActionPtr {
+    auto undo = std::make_unique<ColorUndoAction>(this->sourcePage, this->sourceLayer);
 
     bool found = false;
 
@@ -300,8 +295,6 @@ auto EditSelectionContents::setColor(Color color) -> UndoAction* {
         return undo;
     }
 
-
-    delete undo;
     return nullptr;
 }
 

--- a/src/core/control/tools/EditSelectionContents.h
+++ b/src/core/control/tools/EditSelectionContents.h
@@ -45,29 +45,29 @@ public:
 
 public:
     /**
-     * Sets the line style for all strokes, returs an undo action
+     * Sets the line style for all strokes, returns an undo action
      * (or nullptr if nothing is done)
      */
     UndoActionPtr setLineStyle(LineStyle style);
 
     /**
-     * Sets the tool size for pen or eraser, returs an undo action
+     * Sets the tool size for pen or eraser, returns an undo action
      * (or nullptr if nothing is done)
      */
-    UndoAction* setSize(ToolSize size, const double* thicknessPen, const double* thicknessHighlighter,
-                        const double* thicknessEraser);
+    UndoActionPtr setSize(ToolSize size, const double* thicknessPen, const double* thicknessHighlighter,
+                          const double* thicknessEraser);
 
     /**
      * Set the color of all elements, return an undo action
      * (Or nullptr if nothing done, e.g. because there is only an image)
      */
-    UndoAction* setColor(Color color);
+    UndoActionPtr setColor(Color color);
 
     /**
      * Sets the font of all containing text elements, return an undo action
      * (or nullptr if there are no Text elements)
      */
-    UndoAction* setFont(XojFont& font);
+    UndoActionPtr setFont(XojFont& font);
 
     /**
      * Fills the undo item if the selection is deleted
@@ -79,7 +79,7 @@ public:
      * Fills the stroke, return an undo action
      * (Or nullptr if nothing done, e.g. because there is only an image)
      */
-    UndoAction* setFill(int alphaPen, int alphaHighligther);
+    UndoActionPtr setFill(int alphaPen, int alphaHighligther);
 
 public:
     /**
@@ -168,7 +168,7 @@ public:
 
 private:
     /**
-     * The original dimensions to calculate the zoom factor for reascaling the items and the offset for moving the
+     * The original dimensions to calculate the zoom factor for rescaling the items and the offset for moving the
      * selection
      */
     xoj::util::Rectangle<double> originalBounds;

--- a/src/core/undo/UndoRedoHandler.cpp
+++ b/src/core/undo/UndoRedoHandler.cpp
@@ -169,18 +169,6 @@ void UndoRedoHandler::addUndoAction(UndoActionPtr action) {
     printContents();
 }
 
-auto UndoRedoHandler::removeUndoAction(UndoAction* action) -> bool {
-    auto iter = std::find_if(begin(this->undoList), end(this->undoList),
-                             [action](UndoActionPtr const& smtr_ptr) { return smtr_ptr.get() == action; });
-    if (iter == end(this->undoList)) {
-        return false;
-    }
-    this->undoList.erase(iter);
-    clearRedo();
-    fireUpdateUndoRedoButtons(action->getPages());
-    return true;
-}
-
 auto UndoRedoHandler::undoDescription() -> string {
     if (!this->undoList.empty()) {
         UndoAction& a = *this->undoList.back();

--- a/src/core/undo/UndoRedoHandler.h
+++ b/src/core/undo/UndoRedoHandler.h
@@ -41,7 +41,6 @@ public:
     bool canRedo();
 
     void addUndoAction(UndoActionPtr action);
-    bool removeUndoAction(UndoAction* action);
 
     std::string undoDescription();
     std::string redoDescription();


### PR DESCRIPTION
More clean up. Also `UndoRedoHandler::removeUndoAction` never called so now removed.