### PR TITLE
Issue #4642 configure tab size

### DIFF
--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -235,6 +235,9 @@ void Settings::loadDefault() {
     this->stabilizerMass = 5.0;
     this->stabilizerFinalizeStroke = true;
     /**/
+
+    this->useSpacesForTab = false;
+    this->numberOfSpacesForTab = 4;
 }
 
 auto Settings::loadViewMode(ViewModeId mode) -> bool {
@@ -644,6 +647,10 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur) {
         this->restoreLineWidthEnabled = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("preferredLocale")) == 0) {
         this->preferredLocale = reinterpret_cast<char*>(value);
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("useSpacesForTab")) == 0) {
+        this->setUseSpacesAsTab(xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0);
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("numberOfSpacesForTab")) == 0) {
+        this->setNumberOfSpacesForTab(g_ascii_strtoull(reinterpret_cast<const char*>(value), nullptr, 10));
         /**
          * Stabilizer related settings
          */
@@ -1117,6 +1124,9 @@ void Settings::save() {
     SAVE_BOOL_PROP(inputSystemDrawOutsideWindow);
 
     SAVE_STRING_PROP(preferredLocale);
+
+    SAVE_BOOL_PROP(useSpacesForTab);
+    SAVE_UINT_PROP(numberOfSpacesForTab);
 
     /**
      * Stabilizer related settings
@@ -2570,3 +2580,19 @@ void Settings::setStabilizerPreprocessor(StrokeStabilizer::Preprocessor preproce
  * @return Palette&
  */
 auto Settings::getColorPalette() -> const Palette& { return *(this->palette); }
+
+
+void Settings::setUseSpacesAsTab(bool useSpaces) { this->useSpacesForTab = useSpaces; }
+bool Settings::getUseSpacesAsTab() { return this->useSpacesForTab; }
+
+void Settings::setNumberOfSpacesForTab(int numberOfSpaces) {
+    // For performance reasons the number of spaces for a tab should be limited
+    // if this limit is exceeded use a default value
+    if (numberOfSpaces < 0 || numberOfSpaces > MAX_SPACES_FOR_TAB) {
+        g_warning("Settings::Invalid number of spaces for tab. Reset to default!");
+        numberOfSpaces = 4;
+    }
+    this->numberOfSpacesForTab = numberOfSpaces;
+}
+
+int Settings::getNumberOfSpacesForTab() { return this->numberOfSpacesForTab; }

--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -2586,6 +2586,10 @@ void Settings::setUseSpacesAsTab(bool useSpaces) { this->useSpacesForTab = useSp
 bool Settings::getUseSpacesAsTab() { return this->useSpacesForTab; }
 
 void Settings::setNumberOfSpacesForTab(int numberOfSpaces) {
+    if (this->numberOfSpacesForTab == numberOfSpaces) {
+        return;
+    }
+
     // For performance reasons the number of spaces for a tab should be limited
     // if this limit is exceeded use a default value
     if (numberOfSpaces < 0 || numberOfSpaces > MAX_SPACES_FOR_TAB) {
@@ -2593,6 +2597,7 @@ void Settings::setNumberOfSpacesForTab(int numberOfSpaces) {
         numberOfSpaces = 4;
     }
     this->numberOfSpacesForTab = numberOfSpaces;
+    save();
 }
 
 int Settings::getNumberOfSpacesForTab() { return this->numberOfSpacesForTab; }

--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -2583,9 +2583,9 @@ auto Settings::getColorPalette() -> const Palette& { return *(this->palette); }
 
 
 void Settings::setUseSpacesAsTab(bool useSpaces) { this->useSpacesForTab = useSpaces; }
-bool Settings::getUseSpacesAsTab() { return this->useSpacesForTab; }
+bool Settings::getUseSpacesAsTab() const { return this->useSpacesForTab; }
 
-void Settings::setNumberOfSpacesForTab(int numberOfSpaces) {
+void Settings::setNumberOfSpacesForTab(unsigned int numberOfSpaces) {
     if (this->numberOfSpacesForTab == numberOfSpaces) {
         return;
     }
@@ -2600,4 +2600,4 @@ void Settings::setNumberOfSpacesForTab(int numberOfSpaces) {
     save();
 }
 
-int Settings::getNumberOfSpacesForTab() { return this->numberOfSpacesForTab; }
+unsigned int Settings::getNumberOfSpacesForTab() const { return this->numberOfSpacesForTab; }

--- a/src/core/control/settings/Settings.h
+++ b/src/core/control/settings/Settings.h
@@ -36,6 +36,7 @@
 struct Palette;
 
 constexpr auto DEFAULT_GRID_SIZE = 14.17;
+constexpr int MAX_SPACES_FOR_TAB = 8;
 
 class ButtonConfig;
 class InputDevice;
@@ -569,6 +570,12 @@ public:
     void setStabilizerPreprocessor(StrokeStabilizer::Preprocessor preprocessor);
 
     const Palette& getColorPalette();
+
+    void setNumberOfSpacesForTab(int numberSpaces);
+    int getNumberOfSpacesForTab();
+
+    void setUseSpacesAsTab(bool useSpaces);
+    bool getUseSpacesAsTab();
 
 public:
     // Custom settings
@@ -1149,4 +1156,11 @@ private:
      *
      */
     std::unique_ptr<Palette> palette;
+
+
+    /**
+     * Tab control settings
+     */
+    bool useSpacesForTab{};
+    unsigned int numberOfSpacesForTab{};
 };

--- a/src/core/control/settings/Settings.h
+++ b/src/core/control/settings/Settings.h
@@ -36,7 +36,7 @@
 struct Palette;
 
 constexpr auto DEFAULT_GRID_SIZE = 14.17;
-constexpr int MAX_SPACES_FOR_TAB = 8;
+constexpr unsigned int MAX_SPACES_FOR_TAB = 8U;
 
 class ButtonConfig;
 class InputDevice;

--- a/src/core/control/settings/Settings.h
+++ b/src/core/control/settings/Settings.h
@@ -571,11 +571,11 @@ public:
 
     const Palette& getColorPalette();
 
-    void setNumberOfSpacesForTab(int numberSpaces);
-    int getNumberOfSpacesForTab();
+    void setNumberOfSpacesForTab(unsigned int numberSpaces);
+    unsigned int getNumberOfSpacesForTab() const;
 
     void setUseSpacesAsTab(bool useSpaces);
-    bool getUseSpacesAsTab();
+    bool getUseSpacesAsTab() const;
 
 public:
     // Custom settings

--- a/src/core/control/tools/TextEditor.cpp
+++ b/src/core/control/tools/TextEditor.cpp
@@ -3,6 +3,7 @@
 #include <cmath>
 #include <cstring>  // for strcmp, size_t
 #include <memory>   // for allocator, make_unique, __shared_p...
+#include <string>   // for std::string()
 #include <utility>  // for move
 
 #include <gdk/gdkkeysyms.h>  // for GDK_KEY_B, GDK_KEY_ISO_Enter, GDK_...
@@ -349,7 +350,13 @@ auto TextEditor::onKeyPressEvent(GdkEventKey* event) -> bool {
               event->keyval == GDK_KEY_ISO_Left_Tab) &&
              !(event->state & GDK_CONTROL_MASK)) {
         resetImContext();
-        iMCommitCallback(nullptr, "\t", this);
+        Settings* settings = control->getSettings();
+        if (!settings->getUseSpacesAsTab()) {
+            iMCommitCallback(nullptr, "\t", this);
+        } else {
+            std::string indent(static_cast<size_t>(settings->getNumberOfSpacesForTab()), ' ');
+            iMCommitCallback(nullptr, indent.c_str(), this);
+        }
         obscure = true;
         retval = true;
     } else {

--- a/src/core/gui/dialog/SettingsDialog.cpp
+++ b/src/core/gui/dialog/SettingsDialog.cpp
@@ -361,8 +361,9 @@ void SettingsDialog::load() {
      * Tab size related settings
      */
     loadCheckbox("cbUseSpacesAsTab", settings->getUseSpacesAsTab());
-    GtkSpinButton* sbNumberOfSpacesForTab = GTK_SPIN_BUTTON(get("sbNumberOfSpacesForTab"));
+    GtkSpinButton* sbNumberOfSpacesForTab = GTK_SPIN_BUTTON(builder.get("sbNumberOfSpacesForTab"));
     gtk_spin_button_set_value(sbNumberOfSpacesForTab, settings->getNumberOfSpacesForTab());
+    gtk_widget_set_sensitive(gtk_widget_get_parent(GTK_WIDGET(sbNumberOfSpacesForTab)), settings->getUseSpacesAsTab());
 
     /**
      * Stabilizer related settings
@@ -704,7 +705,8 @@ void SettingsDialog::save() {
      * Tab size relate settings
      */
     settings->setUseSpacesAsTab(getCheckbox("cbUseSpacesAsTab"));
-    settings->setNumberOfSpacesForTab(gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(get("sbNumberOfSpacesForTab"))));
+    settings->setNumberOfSpacesForTab(
+            gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(builder.get("sbNumberOfSpacesForTab"))));
 
     /**
      * Stabilizer related settings

--- a/src/core/gui/dialog/SettingsDialog.cpp
+++ b/src/core/gui/dialog/SettingsDialog.cpp
@@ -358,6 +358,13 @@ void SettingsDialog::load() {
     loadCheckbox("cbInputSystemDrawOutsideWindow", settings->getInputSystemDrawOutsideWindowEnabled());
 
     /**
+     * Tab size related settings
+     */
+    loadCheckbox("cbUseSpacesAsTab", settings->getUseSpacesAsTab());
+    GtkSpinButton* sbNumberOfSpacesForTab = GTK_SPIN_BUTTON(get("sbNumberOfSpacesForTab"));
+    gtk_spin_button_set_value(sbNumberOfSpacesForTab, settings->getNumberOfSpacesForTab());
+
+    /**
      * Stabilizer related settings
      */
     loadCheckbox("cbStabilizerEnableCuspDetection", settings->getStabilizerCuspDetection());
@@ -693,6 +700,15 @@ void SettingsDialog::save() {
     settings->setScrollbarFadeoutDisabled(getCheckbox("cbDisableScrollbarFadeout"));
     settings->setAudioDisabled(getCheckbox("cbDisableAudio"));
 
+    /**
+     * Tab size relate settings
+     */
+    settings->setUseSpacesAsTab(getCheckbox("cbUseSpacesAsTab"));
+    settings->setNumberOfSpacesForTab(gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(get("sbNumberOfSpacesForTab"))));
+
+    /**
+     * Stabilizer related settings
+     */
     settings->setStabilizerAveragingMethod(static_cast<StrokeStabilizer::AveragingMethod>(
             gtk_combo_box_get_active(GTK_COMBO_BOX(builder.get("cbStabilizerAveragingMethods")))));
     settings->setStabilizerPreprocessor(static_cast<StrokeStabilizer::Preprocessor>(

--- a/src/core/gui/dialog/SettingsDialog.cpp
+++ b/src/core/gui/dialog/SettingsDialog.cpp
@@ -193,6 +193,12 @@ SettingsDialog::SettingsDialog(GladeSearchpath* gladeSearchPath, Settings* setti
                              this);
     g_signal_connect_swapped(builder.get("btCancel"), "clicked", G_CALLBACK(gtk_window_close), window.get());
 
+    g_signal_connect(builder.get("cbUseSpacesAsTab"), "toggled",
+                     G_CALLBACK(+[](GtkCheckButton* checkBox, SettingsDialog* self) {
+                         self->enableWithCheckbox("cbUseSpacesAsTab", "numberOfSpacesContainer");
+                     }),
+                     this);
+
     load();
 }
 

--- a/src/core/gui/dialog/SettingsDialog.cpp
+++ b/src/core/gui/dialog/SettingsDialog.cpp
@@ -711,8 +711,8 @@ void SettingsDialog::save() {
      * Tab size relate settings
      */
     settings->setUseSpacesAsTab(getCheckbox("cbUseSpacesAsTab"));
-    settings->setNumberOfSpacesForTab(
-            gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(builder.get("sbNumberOfSpacesForTab"))));
+    settings->setNumberOfSpacesForTab(static_cast<unsigned int>(
+            gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(builder.get("sbNumberOfSpacesForTab")))));
 
     /**
      * Stabilizer related settings

--- a/src/core/gui/dialog/SettingsDialog.cpp
+++ b/src/core/gui/dialog/SettingsDialog.cpp
@@ -369,7 +369,7 @@ void SettingsDialog::load() {
     loadCheckbox("cbUseSpacesAsTab", settings->getUseSpacesAsTab());
     GtkSpinButton* sbNumberOfSpacesForTab = GTK_SPIN_BUTTON(builder.get("sbNumberOfSpacesForTab"));
     gtk_spin_button_set_value(sbNumberOfSpacesForTab, settings->getNumberOfSpacesForTab());
-    gtk_widget_set_sensitive(gtk_widget_get_parent(GTK_WIDGET(sbNumberOfSpacesForTab)), settings->getUseSpacesAsTab());
+    gtk_widget_set_sensitive(GTK_WIDGET(builder.get("numberOfSpacesContainer")), settings->getUseSpacesAsTab());
 
     /**
      * Stabilizer related settings

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -952,234 +952,6 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkFrame" id="sid88">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
-                                <child>
-                                  <object class="GtkAlignment" id="sid89">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
-                                    <child>
-                                      <object class="GtkBox" id="sid90">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="orientation">vertical</property>
-                                        <child>
-                                          <object class="GtkCheckButton" id="cbInputSystemDrawOutsideWindow">
-                                            <property name="name">cbInputSystemDrawOutsideWindow</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="xalign">0.5</property>
-                                            <property name="draw-indicator">True</property>
-                                            <child>
-                                              <object class="GtkLabel" id="sid92">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">Enable drawing outside of window &lt;i&gt;(Drawing will not stop at the border of the window)&lt;/i&gt;</property>
-                                                <property name="use-markup">True</property>
-                                                <property name="wrap">True</property>
-                                                <property name="xalign">0</property>
-                                              </object>
-                                            </child>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkCheckButton" id="cbInputSystemTPCButton">
-                                            <property name="name">cbInputSystemTPCButton</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="tooltip-markup" translatable="yes">Drag LEFT from start point acts like shift key is being held.
-	    Drag UP acts as if Control key is being held.
-
-            Determination Radius: Radius at which modifiers will lock in until finished drawing.
-
-	    &lt;i&gt;Useful for operating without keyboard.&lt;/i&gt;</property>
-                                            <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
-                                            <child>
-                                              <object class="GtkLabel" id="sid93">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">Merge button events with stylus tip events
-	    &lt;i&gt;(Check this if&lt;/i&gt; "&lt;tt&gt;xsetwacom get *deviceId* TabletPCButton&lt;/tt&gt;" &lt;i&gt;returns&lt;/i&gt; "&lt;tt&gt;on&lt;/tt&gt;"&lt;i&gt;)&lt;/i&gt;</property>
-                                                <property name="use-markup">True</property>
-                                                <property name="wrap">True</property>
-                                                <property name="xalign">0</property>
-                                              </object>
-                                            </child>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">2</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkCheckButton" id="cbEnablePressureInference">
-                                            <property name="name">cbEnablePressureInference</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="tooltip-markup" translatable="yes">Slower strokes are assigned a greater pressure than faster strokes, if pressure information is absent.
-
-&lt;i&gt;This feature may be useful for devices that lack pressure sensitivity. For example, a mouse or touchscreen.&lt;/i&gt;</property>
-                                            <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
-                                            <child>
-                                              <object class="GtkLabel" id="sid201">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">Enable Pressure Inference &lt;i&gt;(Guess pressure from drawing speed when device-supplied pressure is not available)&lt;/i&gt;</property>
-                                                <property name="use-markup">True</property>
-                                                <property name="wrap">True</property>
-                                                <property name="xalign">0</property>
-                                              </object>
-                                            </child>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">3</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child type="label">
-                                  <object class="GtkLabel" id="sid94">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="label" translatable="yes">Options</property>
-                                  </object>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">2</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkFrame" id="sid88">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
-                                <child>
-                                  <object class="GtkBox" id="sid90">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
-                                    <property name="margin-bottom">8</property>
-                                    <property name="orientation">vertical</property>
-                                    <child>
-                                      <object class="GtkCheckButton" id="cbInputSystemDrawOutsideWindow">
-                                        <property name="name">cbInputSystemDrawOutsideWindow</property>
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="draw-indicator">True</property>
-                                        <child>
-                                          <object class="GtkLabel" id="sid92">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">Enable drawing outside of window &lt;i&gt;(Drawing will not stop at the border of the window)&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
-                                            <property name="wrap">True</property>
-                                          </object>
-                                        </child>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">1</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkCheckButton" id="cbInputSystemTPCButton">
-                                        <property name="name">cbInputSystemTPCButton</property>
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="tooltip-markup" translatable="yes">Drag LEFT from start point acts like shift key is being held.
-	    Drag UP acts as if Control key is being held.
-
-            Determination Radius: Radius at which modifiers will lock in until finished drawing.
-
-	    &lt;i&gt;Useful for operating without keyboard.&lt;/i&gt;</property>
-                                        <property name="draw-indicator">True</property>
-                                        <child>
-                                          <object class="GtkLabel" id="sid93">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">Merge button events with stylus tip events
-	    &lt;i&gt;(Check this if&lt;/i&gt; "&lt;tt&gt;xsetwacom get *deviceId* TabletPCButton&lt;/tt&gt;" &lt;i&gt;returns&lt;/i&gt; "&lt;tt&gt;on&lt;/tt&gt;"&lt;i&gt;)&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
-                                            <property name="wrap">True</property>
-                                          </object>
-                                        </child>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">2</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkCheckButton" id="cbEnablePressureInference">
-                                        <property name="name">cbEnablePressureInference</property>
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="tooltip-markup" translatable="yes">Slower strokes are assigned a greater pressure than faster strokes, if pressure information is absent.
-
-&lt;i&gt;This feature may be useful for devices that lack pressure sensitivity. For example, a mouse or touchscreen.&lt;/i&gt;</property>
-                                        <property name="draw-indicator">True</property>
-                                        <child>
-                                          <object class="GtkLabel" id="sid201">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">Enable Pressure Inference &lt;i&gt;(Guess pressure from drawing speed when device-supplied pressure is not available)&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
-                                            <property name="wrap">True</property>
-                                          </object>
-                                        </child>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">3</property>
-                                      </packing>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child type="label">
-                                  <object class="GtkLabel" id="sid94">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="label" translatable="yes">Options</property>
-                                  </object>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">2</property>
-                              </packing>
-                            </child>
-                            <child>
                               <object class="GtkFrame" id="frameStabilizerSettings">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
@@ -1487,6 +1259,234 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                               </packing>
                             </child>
                             <child>
+                              <object class="GtkFrame" id="sid1">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
+                                <child>
+                                  <object class="GtkBox" id="sid2">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">8</property>
+                                    <property name="orientation">vertical</property>
+                                    <child>
+                                      <object class="GtkCheckButton" id="cbInputSystemDrawOutsideWindow1">
+                                        <property name="name">cbInputSystemDrawOutsideWindow</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="draw-indicator">True</property>
+                                        <child>
+                                          <object class="GtkLabel" id="sid3">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">Enable drawing outside of window &lt;i&gt;(Drawing will not stop at the border of the window)&lt;/i&gt;</property>
+                                            <property name="use-markup">True</property>
+                                            <property name="wrap">True</property>
+                                          </object>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="cbInputSystemTPCButton1">
+                                        <property name="name">cbInputSystemTPCButton</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="tooltip-markup" translatable="yes">Drag LEFT from start point acts like shift key is being held.
+	    Drag UP acts as if Control key is being held.
+
+            Determination Radius: Radius at which modifiers will lock in until finished drawing.
+
+	    &lt;i&gt;Useful for operating without keyboard.&lt;/i&gt;</property>
+                                        <property name="draw-indicator">True</property>
+                                        <child>
+                                          <object class="GtkLabel" id="sid4">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">Merge button events with stylus tip events
+	    &lt;i&gt;(Check this if&lt;/i&gt; "&lt;tt&gt;xsetwacom get *deviceId* TabletPCButton&lt;/tt&gt;" &lt;i&gt;returns&lt;/i&gt; "&lt;tt&gt;on&lt;/tt&gt;"&lt;i&gt;)&lt;/i&gt;</property>
+                                            <property name="use-markup">True</property>
+                                            <property name="wrap">True</property>
+                                          </object>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="cbEnablePressureInference1">
+                                        <property name="name">cbEnablePressureInference</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="tooltip-markup" translatable="yes">Slower strokes are assigned a greater pressure than faster strokes, if pressure information is absent.
+
+&lt;i&gt;This feature may be useful for devices that lack pressure sensitivity. For example, a mouse or touchscreen.&lt;/i&gt;</property>
+                                        <property name="draw-indicator">True</property>
+                                        <child>
+                                          <object class="GtkLabel" id="sid5">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">Enable Pressure Inference &lt;i&gt;(Guess pressure from drawing speed when device-supplied pressure is not available)&lt;/i&gt;</property>
+                                            <property name="use-markup">True</property>
+                                            <property name="wrap">True</property>
+                                          </object>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">3</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label">
+                                  <object class="GtkLabel" id="sid6">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">Options</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">2</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkFrame" id="sid88">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
+                                <child>
+                                  <object class="GtkAlignment" id="sid89">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
+                                    <child>
+                                      <object class="GtkBox" id="sid90">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                          <object class="GtkCheckButton" id="cbInputSystemDrawOutsideWindow">
+                                            <property name="name">cbInputSystemDrawOutsideWindow</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="xalign">0.5</property>
+                                            <property name="draw-indicator">True</property>
+                                            <child>
+                                              <object class="GtkLabel" id="sid92">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">Enable drawing outside of window &lt;i&gt;(Drawing will not stop at the border of the window)&lt;/i&gt;</property>
+                                                <property name="use-markup">True</property>
+                                                <property name="wrap">True</property>
+                                                <property name="xalign">0</property>
+                                              </object>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="cbInputSystemTPCButton">
+                                            <property name="name">cbInputSystemTPCButton</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-markup" translatable="yes">Drag LEFT from start point acts like shift key is being held.
+	    Drag UP acts as if Control key is being held.
+
+            Determination Radius: Radius at which modifiers will lock in until finished drawing.
+
+	    &lt;i&gt;Useful for operating without keyboard.&lt;/i&gt;</property>
+                                            <property name="xalign">0</property>
+                                            <property name="draw-indicator">True</property>
+                                            <child>
+                                              <object class="GtkLabel" id="sid93">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">Merge button events with stylus tip events
+	    &lt;i&gt;(Check this if&lt;/i&gt; "&lt;tt&gt;xsetwacom get *deviceId* TabletPCButton&lt;/tt&gt;" &lt;i&gt;returns&lt;/i&gt; "&lt;tt&gt;on&lt;/tt&gt;"&lt;i&gt;)&lt;/i&gt;</property>
+                                                <property name="use-markup">True</property>
+                                                <property name="wrap">True</property>
+                                                <property name="xalign">0</property>
+                                              </object>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">2</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="cbEnablePressureInference">
+                                            <property name="name">cbEnablePressureInference</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-markup" translatable="yes">Slower strokes are assigned a greater pressure than faster strokes, if pressure information is absent.
+
+&lt;i&gt;This feature may be useful for devices that lack pressure sensitivity. For example, a mouse or touchscreen.&lt;/i&gt;</property>
+                                            <property name="xalign">0</property>
+                                            <property name="draw-indicator">True</property>
+                                            <child>
+                                              <object class="GtkLabel" id="sid201">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">Enable Pressure Inference &lt;i&gt;(Guess pressure from drawing speed when device-supplied pressure is not available)&lt;/i&gt;</property>
+                                                <property name="use-markup">True</property>
+                                                <property name="wrap">True</property>
+                                                <property name="xalign">0</property>
+                                              </object>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">3</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label">
+                                  <object class="GtkLabel" id="sid94">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">Options</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">2</property>
+                              </packing>
+                            </child>
+                            <child>
                               <object class="GtkFrame" id="tabSettingsFrame">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
@@ -1497,16 +1497,17 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                     <property name="can-focus">False</property>
                                     <property name="left-padding">12</property>
                                     <child>
+                                      <!-- n-columns=2 n-rows=1 -->
                                       <object class="GtkGrid" id="tabSettingsLayout">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
                                         <property name="margin-end">10</property>
                                         <property name="margin-bottom">10</property>
-                                        <property name="column-homogeneous">True</property>
                                         <property name="row-homogeneous">True</property>
+                                        <property name="column-homogeneous">True</property>
                                         <child>
                                           <object class="GtkCheckButton" id="cbUseSpacesAsTab">
-                                            <property name="label" translatable="yes">Indent using spaces</property> 
+                                            <property name="label" translatable="yes">Indent using spaces</property>
                                             <property name="visible">True</property>
                                             <property name="can-focus">True</property>
                                             <property name="receives-default">False</property>
@@ -1518,7 +1519,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkBox" id ="numberOfSpacesContainer">
+                                          <object class="GtkBox" id="numberOfSpacesContainer">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
                                             <property name="spacing">14</property>
@@ -1546,7 +1547,6 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                                 <property name="input-purpose">number</property>
                                                 <property name="adjustment">adjustmentNumberOfSpacesForTab</property>
                                                 <property name="climb-rate">2</property>
-                                                <property name="digits">0</property>
                                                 <property name="snap-to-ticks">True</property>
                                                 <property name="numeric">True</property>
                                                 <property name="value">5</property>
@@ -2204,7 +2204,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkFrame" id="sid5">
+                              <object class="GtkFrame" id="sid7">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
@@ -6077,7 +6077,7 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                   </object>
                                 </child>
                                 <child type="label">
-                                  <object class="GtkLabel" id="sid4">
+                                  <object class="GtkLabel" id="sid10">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Playback Settings</property>

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.40.0 -->
+<!-- Generated with glade 3.38.2 -->
 <interface>
   <requires lib="gtk+" version="3.24"/>
   <object class="GtkAdjustment" id="adjustmentAudioGain">
@@ -952,6 +952,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                               </packing>
                             </child>
                             <child>
+<<<<<<< HEAD
                               <object class="GtkFrame" id="sid88">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
@@ -1060,6 +1061,8 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                               </packing>
                             </child>
                             <child>
+=======
+>>>>>>> 70d61d00 (Rearranged tab settings)
                               <object class="GtkFrame" id="frameStabilizerSettings">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
@@ -1367,6 +1370,126 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                               </packing>
                             </child>
                             <child>
+                              <object class="GtkFrame" id="sid88">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
+                                <child>
+                                  <object class="GtkAlignment" id="sid89">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
+                                    <child>
+                                      <object class="GtkBox" id="sid90">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                          <object class="GtkCheckButton" id="cbInputSystemDrawOutsideWindow">
+                                            <property name="name">cbInputSystemDrawOutsideWindow</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="xalign">0.5</property>
+                                            <property name="draw-indicator">True</property>
+                                            <child>
+                                              <object class="GtkLabel" id="sid92">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">Enable drawing outside of window &lt;i&gt;(Drawing will not stop at the border of the window)&lt;/i&gt;</property>
+                                                <property name="use-markup">True</property>
+                                                <property name="wrap">True</property>
+                                                <property name="xalign">0</property>
+                                              </object>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="cbInputSystemTPCButton">
+                                            <property name="name">cbInputSystemTPCButton</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-markup" translatable="yes">Drag LEFT from start point acts like shift key is being held.
+	    Drag UP acts as if Control key is being held.
+
+            Determination Radius: Radius at which modifiers will lock in until finished drawing.
+
+	    &lt;i&gt;Useful for operating without keyboard.&lt;/i&gt;</property>
+                                            <property name="xalign">0</property>
+                                            <property name="draw-indicator">True</property>
+                                            <child>
+                                              <object class="GtkLabel" id="sid93">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">Merge button events with stylus tip events
+	    &lt;i&gt;(Check this if&lt;/i&gt; "&lt;tt&gt;xsetwacom get *deviceId* TabletPCButton&lt;/tt&gt;" &lt;i&gt;returns&lt;/i&gt; "&lt;tt&gt;on&lt;/tt&gt;"&lt;i&gt;)&lt;/i&gt;</property>
+                                                <property name="use-markup">True</property>
+                                                <property name="wrap">True</property>
+                                                <property name="xalign">0</property>
+                                              </object>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">2</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="cbEnablePressureInference">
+                                            <property name="name">cbEnablePressureInference</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-markup" translatable="yes">Slower strokes are assigned a greater pressure than faster strokes, if pressure information is absent.
+
+&lt;i&gt;This feature may be useful for devices that lack pressure sensitivity. For example, a mouse or touchscreen.&lt;/i&gt;</property>
+                                            <property name="xalign">0</property>
+                                            <property name="draw-indicator">True</property>
+                                            <child>
+                                              <object class="GtkLabel" id="sid201">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">Enable Pressure Inference &lt;i&gt;(Guess pressure from drawing speed when device-supplied pressure is not available)&lt;/i&gt;</property>
+                                                <property name="use-markup">True</property>
+                                                <property name="wrap">True</property>
+                                                <property name="xalign">0</property>
+                                              </object>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">3</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label">
+                                  <object class="GtkLabel" id="sid94">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">Options</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">2</property>
+                              </packing>
+                            </child>
+                            <child>
                               <object class="GtkFrame" id="frameTabControlSettings">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
@@ -1377,27 +1500,14 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                     <property name="can-focus">False</property>
                                     <property name="left-padding">12</property>
                                     <child>
-                                      <object class="GtkBox">
+                                      <!-- n-columns=2 n-rows=1 -->
+                                      <object class="GtkGrid">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
                                         <property name="margin-end">10</property>
-                                        <property name="margin-bottom">5</property>
-                                        <property name="orientation">vertical</property>
-                                        <property name="spacing">3</property>
-                                        <child>
-                                          <object class="GtkCheckButton" id="cbUseSpacesAsTab">
-                                            <property name="label" translatable="yes">Indent using spaces</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="draw-indicator">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
+                                        <property name="margin-bottom">10</property>
+                                        <property name="row-homogeneous">True</property>
+                                        <property name="column-homogeneous">True</property>
                                         <child>
                                           <object class="GtkBox">
                                             <property name="visible">True</property>
@@ -1427,7 +1537,6 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                                 <property name="input-purpose">number</property>
                                                 <property name="adjustment">adjustmentNumberOfSpacesForTab</property>
                                                 <property name="climb-rate">2</property>
-                                                <property name="digits">0</property>
                                                 <property name="snap-to-ticks">True</property>
                                                 <property name="numeric">True</property>
                                                 <property name="value">5</property>
@@ -1440,9 +1549,22 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                             </child>
                                           </object>
                                           <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="cbUseSpacesAsTab">
+                                            <property name="label" translatable="yes">Indent using spaces</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="halign">start</property>
+                                            <property name="draw-indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
                                         </child>
                                       </object>
@@ -2934,9 +3056,245 @@ This setting can make it easier to draw with touch. </property>
                                             <property name="label" translatable="yes">Show filepath in title bar</property>
                                             <property name="name">cbShowFilepathInTitlebar</property>
                                             <property name="visible">True</property>
+<<<<<<< HEAD
                                             <property name="can-focus">True</property>
                                             <property name="receives-default">False</property>
                                             <property name="draw-indicator">True</property>
+=======
+                                            <property name="can-focus">False</property>
+                                            <property name="label-xalign">0.009999999776482582</property>
+                                            <child>
+                                              <object class="GtkAlignment" id="sid102">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="bottom-padding">8</property>
+                                                <property name="left-padding">12</property>
+                                                <property name="right-padding">12</property>
+                                                <child>
+                                                  <!-- n-columns=3 n-rows=7 -->
+                                                  <object class="GtkGrid" id="grid2">
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">False</property>
+                                                    <child>
+                                                      <object class="GtkLabel" id="label10">
+                                                        <property name="visible">True</property>
+                                                        <property name="can-focus">False</property>
+                                                        <property name="hexpand">True</property>
+                                                        <property name="label" translatable="yes">Border color for current page and other selections</property>
+                                                        <property name="justify">right</property>
+                                                        <property name="xalign">0</property>
+                                                      </object>
+                                                      <packing>
+                                                        <property name="left-attach">0</property>
+                                                        <property name="top-attach">0</property>
+                                                      </packing>
+                                                    </child>
+                                                    <child>
+                                                      <object class="GtkColorButton" id="colorBorder">
+                                                        <property name="name">colorBorder</property>
+                                                        <property name="visible">True</property>
+                                                        <property name="can-focus">True</property>
+                                                        <property name="receives-default">True</property>
+                                                        <property name="title" translatable="yes">Border color</property>
+                                                      </object>
+                                                      <packing>
+                                                        <property name="left-attach">1</property>
+                                                        <property name="top-attach">0</property>
+                                                      </packing>
+                                                    </child>
+                                                    <child>
+                                                      <object class="GtkLabel" id="label13">
+                                                        <property name="visible">True</property>
+                                                        <property name="can-focus">False</property>
+                                                        <property name="label" translatable="yes">Background color between pages</property>
+                                                        <property name="xalign">0</property>
+                                                      </object>
+                                                      <packing>
+                                                        <property name="left-attach">0</property>
+                                                        <property name="top-attach">1</property>
+                                                      </packing>
+                                                    </child>
+                                                    <child>
+                                                      <object class="GtkColorButton" id="colorBackground">
+                                                        <property name="name">colorBackground</property>
+                                                        <property name="visible">True</property>
+                                                        <property name="can-focus">True</property>
+                                                        <property name="receives-default">True</property>
+                                                        <property name="margin-top">5</property>
+                                                      </object>
+                                                      <packing>
+                                                        <property name="left-attach">1</property>
+                                                        <property name="top-attach">1</property>
+                                                      </packing>
+                                                    </child>
+                                                    <child>
+                                                      <object class="GtkLabel" id="label57">
+                                                        <property name="visible">True</property>
+                                                        <property name="can-focus">False</property>
+                                                        <property name="label" translatable="yes">Selection Color (Text, Stroke Selection etc.)</property>
+                                                        <property name="xalign">0</property>
+                                                      </object>
+                                                      <packing>
+                                                        <property name="left-attach">0</property>
+                                                        <property name="top-attach">2</property>
+                                                      </packing>
+                                                    </child>
+                                                    <child>
+                                                      <object class="GtkColorButton" id="colorSelection">
+                                                        <property name="name">colorSelection</property>
+                                                        <property name="visible">True</property>
+                                                        <property name="can-focus">True</property>
+                                                        <property name="receives-default">True</property>
+                                                        <property name="margin-top">5</property>
+                                                      </object>
+                                                      <packing>
+                                                        <property name="left-attach">1</property>
+                                                        <property name="top-attach">2</property>
+                                                      </packing>
+                                                    </child>
+                                                    <child>
+                                                      <object class="GtkLabel">
+                                                        <property name="visible">True</property>
+                                                        <property name="can-focus">False</property>
+                                                        <property name="label" translatable="yes">Active Selection Color (Search Results etc.)</property>
+                                                        <property name="xalign">0</property>
+                                                      </object>
+                                                      <packing>
+                                                        <property name="left-attach">0</property>
+                                                        <property name="top-attach">3</property>
+                                                      </packing>
+                                                    </child>
+                                                    <child>
+                                                      <object class="GtkColorButton" id="colorSelectionActive">
+                                                        <property name="name">colorSelectionActive</property>
+                                                        <property name="visible">True</property>
+                                                        <property name="can-focus">True</property>
+                                                        <property name="receives-default">True</property>
+                                                        <property name="margin-top">5</property>
+                                                      </object>
+                                                      <packing>
+                                                        <property name="left-attach">1</property>
+                                                        <property name="top-attach">3</property>
+                                                      </packing>
+                                                    </child>
+                                                    <child>
+                                                      <object class="GtkBox">
+                                                        <property name="visible">True</property>
+                                                        <property name="can-focus">False</property>
+                                                        <child>
+                                                          <object class="GtkLabel">
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">False</property>
+                                                            <property name="label" translatable="yes">Icon Theme</property>
+                                                            <property name="xalign">0</property>
+                                                          </object>
+                                                          <packing>
+                                                            <property name="expand">False</property>
+                                                            <property name="fill">True</property>
+                                                            <property name="position">0</property>
+                                                          </packing>
+                                                        </child>
+                                                        <child>
+                                                          <object class="GtkComboBoxText" id="cbIconTheme">
+                                                            <property name="name">cbIconTheme</property>
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">False</property>
+                                                            <property name="active">0</property>
+                                                            <items>
+                                                            <item id="iconsColor" translatable="yes">Color</item>
+                                                            <item id="iconsLucide" translatable="yes">Lucide</item>
+                                                            </items>
+                                                          </object>
+                                                          <packing>
+                                                            <property name="expand">False</property>
+                                                            <property name="fill">True</property>
+                                                            <property name="position">1</property>
+                                                          </packing>
+                                                        </child>
+                                                        <child>
+                                                          <object class="GtkLabel">
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">False</property>
+                                                            <property name="label" translatable="yes">(requires restart)</property>
+                                                          </object>
+                                                          <packing>
+                                                            <property name="expand">False</property>
+                                                            <property name="fill">True</property>
+                                                            <property name="position">2</property>
+                                                          </packing>
+                                                        </child>
+                                                      </object>
+                                                      <packing>
+                                                        <property name="left-attach">0</property>
+                                                        <property name="top-attach">4</property>
+                                                        <property name="width">2</property>
+                                                      </packing>
+                                                    </child>
+                                                    <child>
+                                                      <object class="GtkCheckButton" id="cbDarkTheme">
+                                                        <property name="label" translatable="yes">Dark Theme (requires restart)</property>
+                                                        <property name="name">cbDarkTheme</property>
+                                                        <property name="visible">True</property>
+                                                        <property name="can-focus">True</property>
+                                                        <property name="receives-default">False</property>
+                                                        <property name="xalign">0</property>
+                                                        <property name="draw-indicator">True</property>
+                                                      </object>
+                                                      <packing>
+                                                        <property name="left-attach">0</property>
+                                                        <property name="top-attach">5</property>
+                                                        <property name="width">2</property>
+                                                      </packing>
+                                                    </child>
+                                                    <child>
+                                                      <object class="GtkCheckButton" id="cbStockIcons">
+                                                        <property name="label" translatable="yes">Use available Stock Icons (requires restart)</property>
+                                                        <property name="name">cbStockIcons</property>
+                                                        <property name="visible">True</property>
+                                                        <property name="can-focus">True</property>
+                                                        <property name="receives-default">False</property>
+                                                        <property name="xalign">0</property>
+                                                        <property name="draw-indicator">True</property>
+                                                      </object>
+                                                      <packing>
+                                                        <property name="left-attach">0</property>
+                                                        <property name="top-attach">6</property>
+                                                        <property name="width">2</property>
+                                                      </packing>
+                                                    </child>
+                                                    <child>
+                                                      <placeholder/>
+                                                    </child>
+                                                    <child>
+                                                      <placeholder/>
+                                                    </child>
+                                                    <child>
+                                                      <placeholder/>
+                                                    </child>
+                                                    <child>
+                                                      <placeholder/>
+                                                    </child>
+                                                    <child>
+                                                      <placeholder/>
+                                                    </child>
+                                                    <child>
+                                                      <placeholder/>
+                                                    </child>
+                                                    <child>
+                                                      <placeholder/>
+                                                    </child>
+                                                  </object>
+                                                </child>
+                                              </object>
+                                            </child>
+                                            <child type="label">
+                                              <object class="GtkLabel" id="sid103">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">Colors</property>
+                                              </object>
+                                            </child>
+>>>>>>> 70d61d00 (Rearranged tab settings)
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.24"/>
   <object class="GtkAdjustment" id="adjustmentAudioGain">
@@ -952,7 +952,126 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                               </packing>
                             </child>
                             <child>
-<<<<<<< HEAD
+                              <object class="GtkFrame" id="sid88">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
+                                <child>
+                                  <object class="GtkAlignment" id="sid89">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="bottom-padding">8</property>
+                                    <property name="left-padding">12</property>
+                                    <property name="right-padding">12</property>
+                                    <child>
+                                      <object class="GtkBox" id="sid90">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                          <object class="GtkCheckButton" id="cbInputSystemDrawOutsideWindow">
+                                            <property name="name">cbInputSystemDrawOutsideWindow</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="xalign">0.5</property>
+                                            <property name="draw-indicator">True</property>
+                                            <child>
+                                              <object class="GtkLabel" id="sid92">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">Enable drawing outside of window &lt;i&gt;(Drawing will not stop at the border of the window)&lt;/i&gt;</property>
+                                                <property name="use-markup">True</property>
+                                                <property name="wrap">True</property>
+                                                <property name="xalign">0</property>
+                                              </object>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="cbInputSystemTPCButton">
+                                            <property name="name">cbInputSystemTPCButton</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-markup" translatable="yes">Drag LEFT from start point acts like shift key is being held.
+	    Drag UP acts as if Control key is being held.
+
+            Determination Radius: Radius at which modifiers will lock in until finished drawing.
+
+	    &lt;i&gt;Useful for operating without keyboard.&lt;/i&gt;</property>
+                                            <property name="xalign">0</property>
+                                            <property name="draw-indicator">True</property>
+                                            <child>
+                                              <object class="GtkLabel" id="sid93">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">Merge button events with stylus tip events
+	    &lt;i&gt;(Check this if&lt;/i&gt; "&lt;tt&gt;xsetwacom get *deviceId* TabletPCButton&lt;/tt&gt;" &lt;i&gt;returns&lt;/i&gt; "&lt;tt&gt;on&lt;/tt&gt;"&lt;i&gt;)&lt;/i&gt;</property>
+                                                <property name="use-markup">True</property>
+                                                <property name="wrap">True</property>
+                                                <property name="xalign">0</property>
+                                              </object>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">2</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="cbEnablePressureInference">
+                                            <property name="name">cbEnablePressureInference</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-markup" translatable="yes">Slower strokes are assigned a greater pressure than faster strokes, if pressure information is absent.
+
+&lt;i&gt;This feature may be useful for devices that lack pressure sensitivity. For example, a mouse or touchscreen.&lt;/i&gt;</property>
+                                            <property name="xalign">0</property>
+                                            <property name="draw-indicator">True</property>
+                                            <child>
+                                              <object class="GtkLabel" id="sid201">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">Enable Pressure Inference &lt;i&gt;(Guess pressure from drawing speed when device-supplied pressure is not available)&lt;/i&gt;</property>
+                                                <property name="use-markup">True</property>
+                                                <property name="wrap">True</property>
+                                                <property name="xalign">0</property>
+                                              </object>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">3</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label">
+                                  <object class="GtkLabel" id="sid94">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">Options</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">2</property>
+                              </packing>
+                            </child>
+                            <child>
                               <object class="GtkFrame" id="sid88">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
@@ -1061,8 +1180,6 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                               </packing>
                             </child>
                             <child>
-=======
->>>>>>> 70d61d00 (Rearranged tab settings)
                               <object class="GtkFrame" id="frameStabilizerSettings">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
@@ -1370,126 +1487,6 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkFrame" id="sid88">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
-                                <child>
-                                  <object class="GtkAlignment" id="sid89">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
-                                    <child>
-                                      <object class="GtkBox" id="sid90">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="orientation">vertical</property>
-                                        <child>
-                                          <object class="GtkCheckButton" id="cbInputSystemDrawOutsideWindow">
-                                            <property name="name">cbInputSystemDrawOutsideWindow</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="xalign">0.5</property>
-                                            <property name="draw-indicator">True</property>
-                                            <child>
-                                              <object class="GtkLabel" id="sid92">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">Enable drawing outside of window &lt;i&gt;(Drawing will not stop at the border of the window)&lt;/i&gt;</property>
-                                                <property name="use-markup">True</property>
-                                                <property name="wrap">True</property>
-                                                <property name="xalign">0</property>
-                                              </object>
-                                            </child>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkCheckButton" id="cbInputSystemTPCButton">
-                                            <property name="name">cbInputSystemTPCButton</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="tooltip-markup" translatable="yes">Drag LEFT from start point acts like shift key is being held.
-	    Drag UP acts as if Control key is being held.
-
-            Determination Radius: Radius at which modifiers will lock in until finished drawing.
-
-	    &lt;i&gt;Useful for operating without keyboard.&lt;/i&gt;</property>
-                                            <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
-                                            <child>
-                                              <object class="GtkLabel" id="sid93">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">Merge button events with stylus tip events
-	    &lt;i&gt;(Check this if&lt;/i&gt; "&lt;tt&gt;xsetwacom get *deviceId* TabletPCButton&lt;/tt&gt;" &lt;i&gt;returns&lt;/i&gt; "&lt;tt&gt;on&lt;/tt&gt;"&lt;i&gt;)&lt;/i&gt;</property>
-                                                <property name="use-markup">True</property>
-                                                <property name="wrap">True</property>
-                                                <property name="xalign">0</property>
-                                              </object>
-                                            </child>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">2</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkCheckButton" id="cbEnablePressureInference">
-                                            <property name="name">cbEnablePressureInference</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="tooltip-markup" translatable="yes">Slower strokes are assigned a greater pressure than faster strokes, if pressure information is absent.
-
-&lt;i&gt;This feature may be useful for devices that lack pressure sensitivity. For example, a mouse or touchscreen.&lt;/i&gt;</property>
-                                            <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
-                                            <child>
-                                              <object class="GtkLabel" id="sid201">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">Enable Pressure Inference &lt;i&gt;(Guess pressure from drawing speed when device-supplied pressure is not available)&lt;/i&gt;</property>
-                                                <property name="use-markup">True</property>
-                                                <property name="wrap">True</property>
-                                                <property name="xalign">0</property>
-                                              </object>
-                                            </child>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">3</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child type="label">
-                                  <object class="GtkLabel" id="sid94">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="label" translatable="yes">Options</property>
-                                  </object>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">2</property>
-                              </packing>
-                            </child>
-                            <child>
                               <object class="GtkFrame" id="frameTabControlSettings">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
@@ -1500,14 +1497,27 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                     <property name="can-focus">False</property>
                                     <property name="left-padding">12</property>
                                     <child>
-                                      <!-- n-columns=2 n-rows=1 -->
-                                      <object class="GtkGrid">
+                                      <object class="GtkBox">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
                                         <property name="margin-end">10</property>
-                                        <property name="margin-bottom">10</property>
-                                        <property name="row-homogeneous">True</property>
-                                        <property name="column-homogeneous">True</property>
+                                        <property name="margin-bottom">5</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="spacing">3</property>
+                                        <child>
+                                          <object class="GtkCheckButton" id="cbUseSpacesAsTab">
+                                            <property name="label" translatable="yes">Indent using spaces</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="draw-indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
                                         <child>
                                           <object class="GtkBox">
                                             <property name="visible">True</property>
@@ -1537,6 +1547,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                                 <property name="input-purpose">number</property>
                                                 <property name="adjustment">adjustmentNumberOfSpacesForTab</property>
                                                 <property name="climb-rate">2</property>
+                                                <property name="digits">0</property>
                                                 <property name="snap-to-ticks">True</property>
                                                 <property name="numeric">True</property>
                                                 <property name="value">5</property>
@@ -1549,22 +1560,9 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                             </child>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">1</property>
-                                            <property name="top-attach">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkCheckButton" id="cbUseSpacesAsTab">
-                                            <property name="label" translatable="yes">Indent using spaces</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="halign">start</property>
-                                            <property name="draw-indicator">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">0</property>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
                                           </packing>
                                         </child>
                                       </object>
@@ -3056,245 +3054,9 @@ This setting can make it easier to draw with touch. </property>
                                             <property name="label" translatable="yes">Show filepath in title bar</property>
                                             <property name="name">cbShowFilepathInTitlebar</property>
                                             <property name="visible">True</property>
-<<<<<<< HEAD
                                             <property name="can-focus">True</property>
                                             <property name="receives-default">False</property>
                                             <property name="draw-indicator">True</property>
-=======
-                                            <property name="can-focus">False</property>
-                                            <property name="label-xalign">0.009999999776482582</property>
-                                            <child>
-                                              <object class="GtkAlignment" id="sid102">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="bottom-padding">8</property>
-                                                <property name="left-padding">12</property>
-                                                <property name="right-padding">12</property>
-                                                <child>
-                                                  <!-- n-columns=3 n-rows=7 -->
-                                                  <object class="GtkGrid" id="grid2">
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
-                                                    <child>
-                                                      <object class="GtkLabel" id="label10">
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="hexpand">True</property>
-                                                        <property name="label" translatable="yes">Border color for current page and other selections</property>
-                                                        <property name="justify">right</property>
-                                                        <property name="xalign">0</property>
-                                                      </object>
-                                                      <packing>
-                                                        <property name="left-attach">0</property>
-                                                        <property name="top-attach">0</property>
-                                                      </packing>
-                                                    </child>
-                                                    <child>
-                                                      <object class="GtkColorButton" id="colorBorder">
-                                                        <property name="name">colorBorder</property>
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">True</property>
-                                                        <property name="receives-default">True</property>
-                                                        <property name="title" translatable="yes">Border color</property>
-                                                      </object>
-                                                      <packing>
-                                                        <property name="left-attach">1</property>
-                                                        <property name="top-attach">0</property>
-                                                      </packing>
-                                                    </child>
-                                                    <child>
-                                                      <object class="GtkLabel" id="label13">
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="label" translatable="yes">Background color between pages</property>
-                                                        <property name="xalign">0</property>
-                                                      </object>
-                                                      <packing>
-                                                        <property name="left-attach">0</property>
-                                                        <property name="top-attach">1</property>
-                                                      </packing>
-                                                    </child>
-                                                    <child>
-                                                      <object class="GtkColorButton" id="colorBackground">
-                                                        <property name="name">colorBackground</property>
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">True</property>
-                                                        <property name="receives-default">True</property>
-                                                        <property name="margin-top">5</property>
-                                                      </object>
-                                                      <packing>
-                                                        <property name="left-attach">1</property>
-                                                        <property name="top-attach">1</property>
-                                                      </packing>
-                                                    </child>
-                                                    <child>
-                                                      <object class="GtkLabel" id="label57">
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="label" translatable="yes">Selection Color (Text, Stroke Selection etc.)</property>
-                                                        <property name="xalign">0</property>
-                                                      </object>
-                                                      <packing>
-                                                        <property name="left-attach">0</property>
-                                                        <property name="top-attach">2</property>
-                                                      </packing>
-                                                    </child>
-                                                    <child>
-                                                      <object class="GtkColorButton" id="colorSelection">
-                                                        <property name="name">colorSelection</property>
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">True</property>
-                                                        <property name="receives-default">True</property>
-                                                        <property name="margin-top">5</property>
-                                                      </object>
-                                                      <packing>
-                                                        <property name="left-attach">1</property>
-                                                        <property name="top-attach">2</property>
-                                                      </packing>
-                                                    </child>
-                                                    <child>
-                                                      <object class="GtkLabel">
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="label" translatable="yes">Active Selection Color (Search Results etc.)</property>
-                                                        <property name="xalign">0</property>
-                                                      </object>
-                                                      <packing>
-                                                        <property name="left-attach">0</property>
-                                                        <property name="top-attach">3</property>
-                                                      </packing>
-                                                    </child>
-                                                    <child>
-                                                      <object class="GtkColorButton" id="colorSelectionActive">
-                                                        <property name="name">colorSelectionActive</property>
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">True</property>
-                                                        <property name="receives-default">True</property>
-                                                        <property name="margin-top">5</property>
-                                                      </object>
-                                                      <packing>
-                                                        <property name="left-attach">1</property>
-                                                        <property name="top-attach">3</property>
-                                                      </packing>
-                                                    </child>
-                                                    <child>
-                                                      <object class="GtkBox">
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <child>
-                                                          <object class="GtkLabel">
-                                                            <property name="visible">True</property>
-                                                            <property name="can-focus">False</property>
-                                                            <property name="label" translatable="yes">Icon Theme</property>
-                                                            <property name="xalign">0</property>
-                                                          </object>
-                                                          <packing>
-                                                            <property name="expand">False</property>
-                                                            <property name="fill">True</property>
-                                                            <property name="position">0</property>
-                                                          </packing>
-                                                        </child>
-                                                        <child>
-                                                          <object class="GtkComboBoxText" id="cbIconTheme">
-                                                            <property name="name">cbIconTheme</property>
-                                                            <property name="visible">True</property>
-                                                            <property name="can-focus">False</property>
-                                                            <property name="active">0</property>
-                                                            <items>
-                                                            <item id="iconsColor" translatable="yes">Color</item>
-                                                            <item id="iconsLucide" translatable="yes">Lucide</item>
-                                                            </items>
-                                                          </object>
-                                                          <packing>
-                                                            <property name="expand">False</property>
-                                                            <property name="fill">True</property>
-                                                            <property name="position">1</property>
-                                                          </packing>
-                                                        </child>
-                                                        <child>
-                                                          <object class="GtkLabel">
-                                                            <property name="visible">True</property>
-                                                            <property name="can-focus">False</property>
-                                                            <property name="label" translatable="yes">(requires restart)</property>
-                                                          </object>
-                                                          <packing>
-                                                            <property name="expand">False</property>
-                                                            <property name="fill">True</property>
-                                                            <property name="position">2</property>
-                                                          </packing>
-                                                        </child>
-                                                      </object>
-                                                      <packing>
-                                                        <property name="left-attach">0</property>
-                                                        <property name="top-attach">4</property>
-                                                        <property name="width">2</property>
-                                                      </packing>
-                                                    </child>
-                                                    <child>
-                                                      <object class="GtkCheckButton" id="cbDarkTheme">
-                                                        <property name="label" translatable="yes">Dark Theme (requires restart)</property>
-                                                        <property name="name">cbDarkTheme</property>
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">True</property>
-                                                        <property name="receives-default">False</property>
-                                                        <property name="xalign">0</property>
-                                                        <property name="draw-indicator">True</property>
-                                                      </object>
-                                                      <packing>
-                                                        <property name="left-attach">0</property>
-                                                        <property name="top-attach">5</property>
-                                                        <property name="width">2</property>
-                                                      </packing>
-                                                    </child>
-                                                    <child>
-                                                      <object class="GtkCheckButton" id="cbStockIcons">
-                                                        <property name="label" translatable="yes">Use available Stock Icons (requires restart)</property>
-                                                        <property name="name">cbStockIcons</property>
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">True</property>
-                                                        <property name="receives-default">False</property>
-                                                        <property name="xalign">0</property>
-                                                        <property name="draw-indicator">True</property>
-                                                      </object>
-                                                      <packing>
-                                                        <property name="left-attach">0</property>
-                                                        <property name="top-attach">6</property>
-                                                        <property name="width">2</property>
-                                                      </packing>
-                                                    </child>
-                                                    <child>
-                                                      <placeholder/>
-                                                    </child>
-                                                    <child>
-                                                      <placeholder/>
-                                                    </child>
-                                                    <child>
-                                                      <placeholder/>
-                                                    </child>
-                                                    <child>
-                                                      <placeholder/>
-                                                    </child>
-                                                    <child>
-                                                      <placeholder/>
-                                                    </child>
-                                                    <child>
-                                                      <placeholder/>
-                                                    </child>
-                                                    <child>
-                                                      <placeholder/>
-                                                    </child>
-                                                  </object>
-                                                </child>
-                                              </object>
-                                            </child>
-                                            <child type="label">
-                                              <object class="GtkLabel" id="sid103">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">Colors</property>
-                                              </object>
-                                            </child>
->>>>>>> 70d61d00 (Rearranged tab settings)
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -952,6 +952,114 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                               </packing>
                             </child>
                             <child>
+                              <object class="GtkFrame" id="sid88">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
+                                <child>
+                                  <object class="GtkBox" id="sid90">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">8</property>
+                                    <property name="orientation">vertical</property>
+                                    <child>
+                                      <object class="GtkCheckButton" id="cbInputSystemDrawOutsideWindow">
+                                        <property name="name">cbInputSystemDrawOutsideWindow</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="draw-indicator">True</property>
+                                        <child>
+                                          <object class="GtkLabel" id="sid92">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">Enable drawing outside of window &lt;i&gt;(Drawing will not stop at the border of the window)&lt;/i&gt;</property>
+                                            <property name="use-markup">True</property>
+                                            <property name="wrap">True</property>
+                                          </object>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="cbInputSystemTPCButton">
+                                        <property name="name">cbInputSystemTPCButton</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="tooltip-markup" translatable="yes">Drag LEFT from start point acts like shift key is being held.
+	    Drag UP acts as if Control key is being held.
+
+            Determination Radius: Radius at which modifiers will lock in until finished drawing.
+
+	    &lt;i&gt;Useful for operating without keyboard.&lt;/i&gt;</property>
+                                        <property name="draw-indicator">True</property>
+                                        <child>
+                                          <object class="GtkLabel" id="sid93">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">Merge button events with stylus tip events
+	    &lt;i&gt;(Check this if&lt;/i&gt; "&lt;tt&gt;xsetwacom get *deviceId* TabletPCButton&lt;/tt&gt;" &lt;i&gt;returns&lt;/i&gt; "&lt;tt&gt;on&lt;/tt&gt;"&lt;i&gt;)&lt;/i&gt;</property>
+                                            <property name="use-markup">True</property>
+                                            <property name="wrap">True</property>
+                                          </object>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="cbEnablePressureInference">
+                                        <property name="name">cbEnablePressureInference</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="tooltip-markup" translatable="yes">Slower strokes are assigned a greater pressure than faster strokes, if pressure information is absent.
+
+&lt;i&gt;This feature may be useful for devices that lack pressure sensitivity. For example, a mouse or touchscreen.&lt;/i&gt;</property>
+                                        <property name="draw-indicator">True</property>
+                                        <child>
+                                          <object class="GtkLabel" id="sid201">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">Enable Pressure Inference &lt;i&gt;(Guess pressure from drawing speed when device-supplied pressure is not available)&lt;/i&gt;</property>
+                                            <property name="use-markup">True</property>
+                                            <property name="wrap">True</property>
+                                          </object>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">3</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label">
+                                  <object class="GtkLabel" id="sid94">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">Options</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">2</property>
+                              </packing>
+                            </child>
+                            <child>
                               <object class="GtkFrame" id="frameStabilizerSettings">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
@@ -1255,235 +1363,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">2</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkFrame" id="sid1">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
-                                <child>
-                                  <object class="GtkBox" id="sid2">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
-                                    <property name="margin-bottom">8</property>
-                                    <property name="orientation">vertical</property>
-                                    <child>
-                                      <object class="GtkCheckButton" id="cbInputSystemDrawOutsideWindow1">
-                                        <property name="name">cbInputSystemDrawOutsideWindow</property>
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="draw-indicator">True</property>
-                                        <child>
-                                          <object class="GtkLabel" id="sid3">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">Enable drawing outside of window &lt;i&gt;(Drawing will not stop at the border of the window)&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
-                                            <property name="wrap">True</property>
-                                          </object>
-                                        </child>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">1</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkCheckButton" id="cbInputSystemTPCButton1">
-                                        <property name="name">cbInputSystemTPCButton</property>
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="tooltip-markup" translatable="yes">Drag LEFT from start point acts like shift key is being held.
-	    Drag UP acts as if Control key is being held.
-
-            Determination Radius: Radius at which modifiers will lock in until finished drawing.
-
-	    &lt;i&gt;Useful for operating without keyboard.&lt;/i&gt;</property>
-                                        <property name="draw-indicator">True</property>
-                                        <child>
-                                          <object class="GtkLabel" id="sid4">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">Merge button events with stylus tip events
-	    &lt;i&gt;(Check this if&lt;/i&gt; "&lt;tt&gt;xsetwacom get *deviceId* TabletPCButton&lt;/tt&gt;" &lt;i&gt;returns&lt;/i&gt; "&lt;tt&gt;on&lt;/tt&gt;"&lt;i&gt;)&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
-                                            <property name="wrap">True</property>
-                                          </object>
-                                        </child>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">2</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkCheckButton" id="cbEnablePressureInference1">
-                                        <property name="name">cbEnablePressureInference</property>
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="tooltip-markup" translatable="yes">Slower strokes are assigned a greater pressure than faster strokes, if pressure information is absent.
-
-&lt;i&gt;This feature may be useful for devices that lack pressure sensitivity. For example, a mouse or touchscreen.&lt;/i&gt;</property>
-                                        <property name="draw-indicator">True</property>
-                                        <child>
-                                          <object class="GtkLabel" id="sid5">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">Enable Pressure Inference &lt;i&gt;(Guess pressure from drawing speed when device-supplied pressure is not available)&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
-                                            <property name="wrap">True</property>
-                                          </object>
-                                        </child>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">3</property>
-                                      </packing>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child type="label">
-                                  <object class="GtkLabel" id="sid6">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="label" translatable="yes">Options</property>
-                                  </object>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">2</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkFrame" id="sid88">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
-                                <child>
-                                  <object class="GtkAlignment" id="sid89">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
-                                    <child>
-                                      <object class="GtkBox" id="sid90">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="orientation">vertical</property>
-                                        <child>
-                                          <object class="GtkCheckButton" id="cbInputSystemDrawOutsideWindow">
-                                            <property name="name">cbInputSystemDrawOutsideWindow</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="xalign">0.5</property>
-                                            <property name="draw-indicator">True</property>
-                                            <child>
-                                              <object class="GtkLabel" id="sid92">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">Enable drawing outside of window &lt;i&gt;(Drawing will not stop at the border of the window)&lt;/i&gt;</property>
-                                                <property name="use-markup">True</property>
-                                                <property name="wrap">True</property>
-                                                <property name="xalign">0</property>
-                                              </object>
-                                            </child>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkCheckButton" id="cbInputSystemTPCButton">
-                                            <property name="name">cbInputSystemTPCButton</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="tooltip-markup" translatable="yes">Drag LEFT from start point acts like shift key is being held.
-	    Drag UP acts as if Control key is being held.
-
-            Determination Radius: Radius at which modifiers will lock in until finished drawing.
-
-	    &lt;i&gt;Useful for operating without keyboard.&lt;/i&gt;</property>
-                                            <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
-                                            <child>
-                                              <object class="GtkLabel" id="sid93">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">Merge button events with stylus tip events
-	    &lt;i&gt;(Check this if&lt;/i&gt; "&lt;tt&gt;xsetwacom get *deviceId* TabletPCButton&lt;/tt&gt;" &lt;i&gt;returns&lt;/i&gt; "&lt;tt&gt;on&lt;/tt&gt;"&lt;i&gt;)&lt;/i&gt;</property>
-                                                <property name="use-markup">True</property>
-                                                <property name="wrap">True</property>
-                                                <property name="xalign">0</property>
-                                              </object>
-                                            </child>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">2</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkCheckButton" id="cbEnablePressureInference">
-                                            <property name="name">cbEnablePressureInference</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="tooltip-markup" translatable="yes">Slower strokes are assigned a greater pressure than faster strokes, if pressure information is absent.
-
-&lt;i&gt;This feature may be useful for devices that lack pressure sensitivity. For example, a mouse or touchscreen.&lt;/i&gt;</property>
-                                            <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
-                                            <child>
-                                              <object class="GtkLabel" id="sid201">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">Enable Pressure Inference &lt;i&gt;(Guess pressure from drawing speed when device-supplied pressure is not available)&lt;/i&gt;</property>
-                                                <property name="use-markup">True</property>
-                                                <property name="wrap">True</property>
-                                                <property name="xalign">0</property>
-                                              </object>
-                                            </child>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">3</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child type="label">
-                                  <object class="GtkLabel" id="sid94">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="label" translatable="yes">Options</property>
-                                  </object>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">2</property>
+                                <property name="position">3</property>
                               </packing>
                             </child>
                             <child>
@@ -1497,17 +1377,16 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                     <property name="can-focus">False</property>
                                     <property name="left-padding">12</property>
                                     <child>
-                                      <!-- n-columns=2 n-rows=1 -->
                                       <object class="GtkGrid" id="tabSettingsLayout">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
                                         <property name="margin-end">10</property>
                                         <property name="margin-bottom">10</property>
-                                        <property name="row-homogeneous">True</property>
                                         <property name="column-homogeneous">True</property>
+                                        <property name="row-homogeneous">True</property>
                                         <child>
                                           <object class="GtkCheckButton" id="cbUseSpacesAsTab">
-                                            <property name="label" translatable="yes">Indent using spaces</property>
+                                            <property name="label" translatable="yes">Indent using spaces</property> 
                                             <property name="visible">True</property>
                                             <property name="can-focus">True</property>
                                             <property name="receives-default">False</property>
@@ -1519,7 +1398,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkBox" id="numberOfSpacesContainer">
+                                          <object class="GtkBox" id ="numberOfSpacesContainer">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
                                             <property name="spacing">14</property>
@@ -1547,6 +1426,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                                 <property name="input-purpose">number</property>
                                                 <property name="adjustment">adjustmentNumberOfSpacesForTab</property>
                                                 <property name="climb-rate">2</property>
+                                                <property name="digits">0</property>
                                                 <property name="snap-to-ticks">True</property>
                                                 <property name="numeric">True</property>
                                                 <property name="value">5</property>
@@ -2204,7 +2084,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkFrame" id="sid7">
+                              <object class="GtkFrame" id="sid5">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
@@ -6077,7 +5957,7 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                   </object>
                                 </child>
                                 <child type="label">
-                                  <object class="GtkLabel" id="sid10">
+                                  <object class="GtkLabel" id="sid4">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Playback Settings</property>

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -1418,10 +1418,10 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                               </packing>
                                             </child>
                                             <child>
-                                              <object class="GtkSpinButton" id="sbStabilizerMass1">
+                                              <object class="GtkSpinButton" id="sbNumberOfSpacesForTab">
                                                 <property name="visible">True</property>
                                                 <property name="can-focus">True</property>
-                                                <property name="tooltip-text" translatable="yes">Mass: the higher the mass, the more inertia and the more stabilization</property>
+                                                <property name="tooltip-text" translatable="yes">Number of spaces inserted with tab.</property>
                                                 <property name="hexpand">True</property>
                                                 <property name="text" translatable="yes">4</property>
                                                 <property name="input-purpose">number</property>

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -1487,39 +1487,38 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkFrame" id="frameTabControlSettings">
+                              <object class="GtkFrame" id="tabSettingsFrame">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0</property>
                                 <child>
-                                  <object class="GtkAlignment">
+                                  <object class="GtkAlignment" id="tabSettingsAlignment">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
                                     <property name="left-padding">12</property>
                                     <child>
-                                      <object class="GtkBox">
+                                      <object class="GtkGrid" id="tabSettingsLayout">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
                                         <property name="margin-end">10</property>
-                                        <property name="margin-bottom">5</property>
-                                        <property name="orientation">vertical</property>
-                                        <property name="spacing">3</property>
+                                        <property name="margin-bottom">10</property>
+                                        <property name="column-homogeneous">True</property>
+                                        <property name="row-homogeneous">True</property>
                                         <child>
                                           <object class="GtkCheckButton" id="cbUseSpacesAsTab">
-                                            <property name="label" translatable="yes">Indent using spaces</property>
+                                            <property name="label" translatable="yes">Indent using spaces</property> 
                                             <property name="visible">True</property>
                                             <property name="can-focus">True</property>
                                             <property name="receives-default">False</property>
                                             <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkBox">
+                                          <object class="GtkBox" id ="numberOfSpacesContainer">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
                                             <property name="spacing">14</property>
@@ -1560,9 +1559,8 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                             </child>
                                           </object>
                                           <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
                                         </child>
                                       </object>

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -60,6 +60,13 @@
     <property name="step-increment">0.01</property>
     <property name="page-increment">0.5</property>
   </object>
+  <object class="GtkAdjustment" id="adjustmentNumberOfSpacesForTab">
+    <property name="lower">1</property>
+    <property name="upper">8</property>
+    <property name="value">4</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">1</property>
+  </object>
   <object class="GtkAdjustment" id="adjustmentPairsOffset">
     <property name="upper">100</property>
     <property name="step-increment">1</property>
@@ -1356,7 +1363,104 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">3</property>
+                                <property name="position">2</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkFrame" id="frameTabControlSettings">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0</property>
+                                <child>
+                                  <object class="GtkAlignment">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="left-padding">12</property>
+                                    <child>
+                                      <object class="GtkBox">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="margin-end">10</property>
+                                        <property name="margin-bottom">5</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="spacing">3</property>
+                                        <child>
+                                          <object class="GtkCheckButton" id="cbUseSpacesAsTab">
+                                            <property name="label" translatable="yes">Indent using spaces</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="draw-indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkBox">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="spacing">14</property>
+                                            <child>
+                                              <object class="GtkLabel" id="lblNumberOfSpaces">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="margin-start">6</property>
+                                                <property name="margin-end">6</property>
+                                                <property name="label" translatable="yes">Number of Spaces : </property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSpinButton" id="sbStabilizerMass1">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="tooltip-text" translatable="yes">Mass: the higher the mass, the more inertia and the more stabilization</property>
+                                                <property name="hexpand">True</property>
+                                                <property name="text" translatable="yes">4</property>
+                                                <property name="input-purpose">number</property>
+                                                <property name="adjustment">adjustmentNumberOfSpacesForTab</property>
+                                                <property name="climb-rate">2</property>
+                                                <property name="digits">0</property>
+                                                <property name="snap-to-ticks">True</property>
+                                                <property name="numeric">True</property>
+                                                <property name="value">5</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">1</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label">
+                                  <object class="GtkLabel" id="lblTabControlSettings">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">Tab</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">4</property>
                               </packing>
                             </child>
                           </object>


### PR DESCRIPTION
Hi, 

I added a new preference for the tab size.
Instead of using a tabular char, the user can select to insert spaces instead.
Also, the amount of spaces to be inserted can be configured, in the range of 1 - 8. 
For efficiency reasons, I wouldn't allow inserting any more characters with a single stroke. 

I have currently located this preference under "Preferences > Input System > Tab". 
I'm not very happy about that location, but couldn't find something more intuitive.
In the future, a preference page "Controls" (or something like this) would be good.

Solves #4642.