### PR TITLE
Fix creating new instances in Gnome dash

### DIFF
--- a/desktop/com.github.xournalpp.xournalpp.desktop
+++ b/desktop/com.github.xournalpp.xournalpp.desktop
@@ -21,3 +21,11 @@ StartupNotify=true
 MimeType=application/x-xoj;application/x-xojpp;application/x-xopp;application/x-xopt;application/pdf;
 Icon=com.github.xournalpp.xournalpp
 Categories=Office;GNOME;GTK;
+Actions=new-instance;
+
+[Desktop Action new-instance]
+Name=New instance
+Name[de]=Neue Instanz
+Name[fr]=Nouvelle instance
+Name[ru]=Новый экземпляр
+Exec=xournalpp %f


### PR DESCRIPTION
Fixes #4759 

I basically followed the advice given in https://askubuntu.com/questions/1068980/how-can-i-get-multiple-instances-of-gnome-calculator-at-same-time to create an additional desktop action.
See also https://gitlab.gnome.org/GNOME/gnome-calculator/-/issues/74 and
https://docs.gtk.org/gio/class.Application.html?q=g_application