### PR TITLE
Fix Windows build (linking issue)

### DIFF
--- a/azure-pipelines/create-installers.yml
+++ b/azure-pipelines/create-installers.yml
@@ -83,7 +83,7 @@ stages:
           - template: steps/build_windows.yml
             parameters:
               build_type: 'RelWithDebInfo'
-              cmake_flags: '-GNinja -DCMAKE_CXX_FLAGS="-Os -s"'
+              cmake_flags: '-GNinja -DCMAKE_CXX_FLAGS="-Os -s" -DENABLE_GTEST=ON -DDOWNLOAD_GTEST=on'
           - script: |
               set PATH=%PATH%;C:\msys64\usr\bin;C:\msys64\mingw64\bin"
               C:\msys64\usr\bin\bash -lc "./package.sh"

--- a/azure-pipelines/create-installers.yml
+++ b/azure-pipelines/create-installers.yml
@@ -83,7 +83,7 @@ stages:
           - template: steps/build_windows.yml
             parameters:
               build_type: 'RelWithDebInfo'
-              cmake_flags: '-GNinja -DCMAKE_CXX_FLAGS="-Os -s" -DENABLE_GTEST=ON -DDOWNLOAD_GTEST=on'
+              cmake_flags: '-GNinja -DENABLE_GTEST=ON -DDOWNLOAD_GTEST=on'
           - script: |
               set PATH=%PATH%;C:\msys64\usr\bin;C:\msys64\mingw64\bin"
               C:\msys64\usr\bin\bash -lc "./package.sh"


### PR DESCRIPTION
The issue from https://github.com/xournalpp/xournalpp/discussions/4765 (which can be fixed by using a different cmake generator than `Ninja`) is now also visible in the pipeline.
The last PR compiled fine in the CI pipeline, but not in the create installers pipeline. The same dependencies were installed. The main difference appear to be the cmake flags.