### PR TITLE
Enhancement #4436: Made Ctrl-C Shortcut to PDF Text Copy Functionality

### DIFF
--- a/src/core/gui/MainWindow.cpp
+++ b/src/core/gui/MainWindow.cpp
@@ -464,6 +464,14 @@ auto MainWindow::onKeyPressCallback(GtkWidget* widget, GdkEventKey* event, MainW
         // editing text - give that control
         return false;
     }
+    if (event->keyval == GDK_KEY_c && event->state & GDK_CONTROL_MASK) {
+        // Shortcut to get selected PDF text.
+        PdfFloatingToolbox* tool = win->getPdfToolbox();
+        if (tool->hasSelection()) {
+            tool->copyTextToClipboard();
+            return true;
+        }
+    }
     if (event->keyval == GDK_KEY_Escape) {
         win->getControl()->getSearchBar()->showSearchBar(false);
         return true;

--- a/src/core/gui/PdfFloatingToolbox.h
+++ b/src/core/gui/PdfFloatingToolbox.h
@@ -62,6 +62,9 @@ public:
     /// Track selection style used for unfinalized selections
     XojPdfPageSelectionStyle selectionStyle = XojPdfPageSelectionStyle::Linear;
 
+    /// Copy Selection to the Clipboard.
+    void copyTextToClipboard();
+
 private:
     void show();
 
@@ -74,7 +77,6 @@ private:
     static void copyTextCb(GtkButton* button, PdfFloatingToolbox* pft);
     static void highlightCb(GtkButton* button, PdfFloatingToolbox* pft);
 
-    void copyTextToClipboard();
     void createStrokes(PdfMarkerStyle position, PdfMarkerStyle width, int markerOpacity);
 
 private:


### PR DESCRIPTION
## Issue

#4436: PDF text could not be copied with a shortcut.

## Description

A Ctrl-C routine has been added to dive into the PDF Floating Tool Box and make it copy (if applicable) without needing to click the corresponding button.
(Function copyTextToClipboard() was changed from private to public in order to do this.)