### PR TITLE
Cleanup latexcontroller

### DIFF
--- a/src/core/control/LatexController.cpp
+++ b/src/core/control/LatexController.cpp
@@ -117,16 +117,16 @@ void LatexController::findSelectedTexElement() {
         // this will get the position of the Latex properly
         EditSelection* theSelection = control->getWindow()->getXournal()->getSelection();
         xoj::util::Rectangle<double> rect = theSelection->getSnappedBounds();
-        this->posx = static_cast<int>(rect.x);
-        this->posy = static_cast<int>(rect.y);
+        this->posx = rect.x;
+        this->posy = rect.y;
 
         if (auto* img = dynamic_cast<TexImage*>(this->selectedElem)) {
             this->initialTex = img->getText();
         } else if (auto* txt = dynamic_cast<Text*>(this->selectedElem)) {
             this->initialTex = "\\text{" + txt->getText() + "}";
         }
-        this->imgwidth = static_cast<int>(this->selectedElem->getElementWidth());
-        this->imgheight = static_cast<int>(this->selectedElem->getElementHeight());
+        this->imgwidth = this->selectedElem->getElementWidth();
+        this->imgheight = this->selectedElem->getElementHeight();
     } else {
         // This is a new latex object, so here we pick a convenient initial location
         const double zoom = this->control->getWindow()->getXournal()->getZoom();
@@ -137,14 +137,15 @@ void LatexController::findSelectedTexElement() {
         const double centerX = visibleBounds.x + 0.5 * visibleBounds.width;
         const double centerY = visibleBounds.y + 0.5 * visibleBounds.height;
 
-        if (layout->getPageViewAt(static_cast<int>(centerX), static_cast<int>(centerY)) == this->view) {
+        if (layout->getPageViewAt(static_cast<int>(std::round(centerX)), static_cast<int>(std::round(centerY))) ==
+            this->view) {
             // Pick the center of the visible area (converting from screen to page coordinates)
-            this->posx = static_cast<int>((centerX - this->view->getX()) / zoom);
-            this->posy = static_cast<int>((centerY - this->view->getY()) / zoom);
+            this->posx = centerX - this->view->getX() / zoom;
+            this->posy = centerY - this->view->getY() / zoom;
         } else {
             // No better location, so just center it on the page (possibly out of viewport)
-            this->posx = static_cast<int>(this->page->getWidth() / 2);
-            this->posy = static_cast<int>(this->page->getHeight() / 2);
+            this->posx = this->page->getWidth() / 2;
+            this->posy = this->page->getHeight() / 2;
         }
     }
     this->doc->unlock();

--- a/src/core/control/LatexController.cpp
+++ b/src/core/control/LatexController.cpp
@@ -115,16 +115,16 @@ void LatexController::findSelectedTexElement() {
         // this will get the position of the Latex properly
         EditSelection* theSelection = control->getWindow()->getXournal()->getSelection();
         xoj::util::Rectangle<double> rect = theSelection->getSnappedBounds();
-        this->posx = rect.x;
-        this->posy = rect.y;
+        this->posx = static_cast<int>(rect.x);
+        this->posy = static_cast<int>(rect.y);
 
         if (auto* img = dynamic_cast<TexImage*>(this->selectedElem)) {
             this->initialTex = img->getText();
         } else if (auto* txt = dynamic_cast<Text*>(this->selectedElem)) {
             this->initialTex = "\\text{" + txt->getText() + "}";
         }
-        this->imgwidth = this->selectedElem->getElementWidth();
-        this->imgheight = this->selectedElem->getElementHeight();
+        this->imgwidth = static_cast<int>(this->selectedElem->getElementWidth());
+        this->imgheight = static_cast<int>(this->selectedElem->getElementHeight());
     } else {
         // This is a new latex object, so here we pick a convenient initial location
         const double zoom = this->control->getWindow()->getXournal()->getZoom();
@@ -135,7 +135,7 @@ void LatexController::findSelectedTexElement() {
         const double centerX = visibleBounds.x + 0.5 * visibleBounds.width;
         const double centerY = visibleBounds.y + 0.5 * visibleBounds.height;
 
-        if (layout->getPageViewAt(centerX, centerY) == this->view) {
+        if (layout->getPageViewAt(static_cast<int>(centerX), static_cast<int>(centerY)) == this->view) {
             // Pick the center of the visible area (converting from screen to page coordinates)
             this->posx = static_cast<int>((centerX - this->view->getX()) / zoom);
             this->posy = static_cast<int>((centerY - this->view->getY()) / zoom);

--- a/src/core/control/LatexController.cpp
+++ b/src/core/control/LatexController.cpp
@@ -42,10 +42,8 @@
 
 using std::string;
 
-namespace {
 constexpr Color LIGHT_PREVIEW_BACKGROUND = Colors::white;
 constexpr Color DARK_PREVIEW_BACKGROUND = Colors::black;
-}  // namespace
 
 LatexController::LatexController(Control* control):
         control(control),

--- a/src/core/control/LatexController.cpp
+++ b/src/core/control/LatexController.cpp
@@ -42,8 +42,10 @@
 
 using std::string;
 
-const Color LIGHT_PREVIEW_BACKGROUND = Colors::white;
-const Color DARK_PREVIEW_BACKGROUND = Colors::black;
+namespace {
+constexpr Color LIGHT_PREVIEW_BACKGROUND = Colors::white;
+constexpr Color DARK_PREVIEW_BACKGROUND = Colors::black;
+}  // namespace
 
 LatexController::LatexController(Control* control):
         control(control),

--- a/src/core/control/LatexController.h
+++ b/src/core/control/LatexController.h
@@ -167,22 +167,22 @@ private:
     /**
      * X-Position
      */
-    int posx = 0;
+    double posx = 0;
 
     /**
      * Y-Position
      */
-    int posy = 0;
+    double posy = 0;
 
     /**
      * Image width
      */
-    int imgwidth = 0;
+    double imgwidth = 0;
 
     /**
      * Image height
      */
-    int imgheight = 0;
+    double imgheight = 0;
 
     /**
      * Document

--- a/src/core/control/LatexController.h
+++ b/src/core/control/LatexController.h
@@ -57,7 +57,7 @@ private:
      */
     class FindDependencyStatus {
     public:
-        FindDependencyStatus(bool success, std::string errorMsg): success(success), errorMsg(errorMsg){};
+        FindDependencyStatus(bool success, std::string errorMsg): success(success), errorMsg(std::move(errorMsg)){};
         bool success;
         std::string errorMsg;
     };


### PR DESCRIPTION
I have removed some `double` to `int` conversion compiler warnigns. Use constexpr and anonymous namespace for some const parameters. 