### PR TITLE
Make AppImage update respect channels

### DIFF
--- a/azure-pipelines/jobs/release_ubuntu.yml
+++ b/azure-pipelines/jobs/release_ubuntu.yml
@@ -33,10 +33,10 @@ jobs:
           # Build AppImage
           export VERSION=$(cat VERSION | sed '1q;d')
           export ARCH=$(cat VERSION | sed '4q;d')
+          export OUTPUT="xournalpp-$VERSION-$ARCH.AppImage"
           ../azure-pipelines/util/build_appimage.sh
-          # Move and rename the generated AppImage file (and zsync file for AppImageUpdate)
-          find . -name '*.AppImage' -not -name 'linuxdeploy.AppImage' -exec mv {} packages/xournalpp-$VERSION-$ARCH.AppImage \;
-          find . -name '*.AppImage.zsync' -not -name 'linuxdeploy.AppImage.zsync' -exec mv {} packages/xournalpp-$VERSION-$ARCH.AppImage.zsync \;
+
+          mv "$OUTPUT" "$OUTPUT".zsync packages/
         workingDirectory: ./build
         displayName: 'Create AppImage'
         condition: eq('${{ parameters.build_appimage }}', true)

--- a/azure-pipelines/util/build_appimage.sh
+++ b/azure-pipelines/util/build_appimage.sh
@@ -11,6 +11,11 @@ if [ -z "$APPDIR" ]; then
     exit 1
 fi
 
+if [ -z "$VERSION" ]; then
+   echo "Error: VERSION must be a defined environment variable."
+   exit 1
+fi
+
 # linuxdeploy and linuxdeploy GTK plugin locations
 LINUXDEPLOY=${LINUXDEPLOY:-"linuxdeploy.AppImage"}
 LINUXDEPLOY_PLUGIN_GTK="linuxdeploy-plugin-gtk.sh"
@@ -47,7 +52,13 @@ echo "Use the icon file $ICON_FILE and the desktop file $DESKTOP_FILE"
 filename_pattern = 'xournalpp-*x86_64.AppImage.zsync' 
 # See https://github.com/AppImage/AppImageSpec/blob/master/draft.md#update-information
 
-export UPD_INFO="gh-releases-zsync|xournalpp|xournalpp|latest|$filename_pattern"
+if [[ $VERSION = *dev ]]; then
+  gh_tag='nightly'  # latest development version
+else
+  gh_tag='latest'   # latest stable version
+fi
+
+export UPD_INFO="gh-releases-zsync|xournalpp|xournalpp|$gh_tag|$filename_pattern"
 
 appimage_name='appimage'
 

--- a/azure-pipelines/util/build_appimage.sh
+++ b/azure-pipelines/util/build_appimage.sh
@@ -49,7 +49,7 @@ ICON_FILE="$APPDIR"/usr/share/icons/hicolor/scalable/apps/com.github.xournalpp.x
 DESKTOP_FILE="$APPDIR"/usr/share/applications/com.github.xournalpp.xournalpp.desktop
 echo "Use the icon file $ICON_FILE and the desktop file $DESKTOP_FILE"
 
-filename_pattern = 'xournalpp-*x86_64.AppImage.zsync' 
+filename_pattern='xournalpp-*x86_64.AppImage.zsync' 
 # See https://github.com/AppImage/AppImageSpec/blob/master/draft.md#update-information
 
 if [[ $VERSION = *dev ]]; then

--- a/azure-pipelines/util/build_appimage.sh
+++ b/azure-pipelines/util/build_appimage.sh
@@ -59,8 +59,7 @@ else
 fi
 
 export UPD_INFO="gh-releases-zsync|xournalpp|xournalpp|$gh_tag|$filename_pattern"
-
-appimage_name='appimage'
+export VERBOSE=1
 
 # call through linuxdeploy
-./"$LINUXDEPLOY" --appdir="$APPDIR" --plugin gtk --plugin gettext --output "$appimage_name" --icon-file="$ICON_FILE" --desktop-file="$DESKTOP_FILE"
+./"$LINUXDEPLOY" --appdir="$APPDIR" --plugin gtk --plugin gettext --output appimage --icon-file="$ICON_FILE" --desktop-file="$DESKTOP_FILE"


### PR DESCRIPTION
According to the [appimage.org docs](https://docs.appimage.org/packaging-guide/optional/updates.html),
releases should always update to releases,
nightlies always to nightlies, etc. (“channels”)

Until now it was only possible to update to the latest (stable) release, regardless if it was a nightly or a stable build.