### PR TITLE
More gtk4 dialogs

### DIFF
--- a/src/core/control/AudioController.cpp
+++ b/src/core/control/AudioController.cpp
@@ -117,7 +117,6 @@ auto AudioController::getAudioFolder() const -> fs::path {
     if (!fs::is_directory(af)) {
         string msg = _("Audio folder not set or invalid! Recording won't work!\nPlease set the "
                        "recording folder under \"Preferences > Audio recording\"");
-        g_warning("%s", msg.c_str());
         XojMsgBox::showErrorToUser(this->control.getGtkWindow(), msg);
         return fs::path{};
     }

--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -3247,9 +3247,15 @@ void Control::fontChanged() {
  * The core handler for inserting latex
  */
 void Control::runLatex() {
-    LatexController latex(this);
-    latex.run();
+    /*
+     * LatexController::run() will open a non-blocking dialog. This dialog uses the LatexController instance until its
+     * completion. The LatexController instance must thus outlive this scope. It'll get deleted when the dialog is
+     * closed (see LatexController::showTexEditDialog())
+     */
+    this->latexController = std::make_unique<LatexController>(this);
+    this->latexController->run();
 }
+void Control::deleteLatexController() { this->latexController.reset(); }
 
 /**
  * GETTER / SETTER

--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -1239,13 +1239,13 @@ auto Control::firePageSelected(const PageRef& page) -> size_t {
 void Control::firePageSelected(size_t page) { DocumentHandler::firePageSelected(page); }
 
 void Control::manageToolbars() {
-    ToolbarManageDialog dlg(this->gladeSearchPath, this->win->getToolbarModel());
+    xoj::popup::PopupWindowWrapper<ToolbarManageDialog> dlg(this->gladeSearchPath, this->win->getToolbarModel(),
+                                                            [win = this->win]() {
+                                                                win->updateToolbarMenu();
+                                                                auto filepath = Util::getConfigFile(TOOLBAR_CONFIG);
+                                                                win->getToolbarModel()->save(filepath);
+                                                            });
     dlg.show(GTK_WINDOW(this->win->getWindow()));
-
-    this->win->updateToolbarMenu();
-
-    auto filepath = Util::getConfigFile(TOOLBAR_CONFIG);
-    this->win->getToolbarModel()->save(filepath);
 }
 
 void Control::customizeToolbars() {

--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -1585,13 +1585,11 @@ void Control::changePageBackgroundColor() {
         return;
     }
 
-    SelectBackgroundColorDialog dlg(this);
+    xoj::popup::PopupWindowWrapper<SelectBackgroundColorDialog> dlg(this, [p, pNr, ctrl = this](Color color) {
+        p->setBackgroundColor(color);
+        ctrl->firePageChanged(pNr);
+    });
     dlg.show(GTK_WINDOW(this->win->getWindow()));
-
-    if (auto optColor = dlg.getSelectedColor(); optColor) {
-        p->setBackgroundColor(*optColor);
-        firePageChanged(pNr);
-    }
 }
 
 void Control::setViewPairedPages(bool enabled) {

--- a/src/core/control/Control.h
+++ b/src/core/control/Control.h
@@ -51,6 +51,7 @@ class PageBackgroundChangeController;
 class PageTypeHandler;
 class PageTypeMenu;
 class BaseExportJob;
+class LatexController;
 class LayerController;
 class PluginController;
 class Document;
@@ -127,6 +128,7 @@ public:
 
     // The core handler for inserting latex
     void runLatex();
+    void deleteLatexController();
 
     // Menu Help
     void showAbout();
@@ -465,6 +467,8 @@ private:
 
     std::unique_ptr<GeometryTool> geometryTool;
     std::unique_ptr<GeometryToolController> geometryToolController;
+
+    std::unique_ptr<LatexController> latexController;
 
     /**
      * Manage all Xournal++ plugins

--- a/src/core/control/LatexController.h
+++ b/src/core/control/LatexController.h
@@ -22,7 +22,6 @@
 #include <poppler.h>  // for GObject
 
 #include "control/latex/LatexGenerator.h"  // for LatexGenerator
-#include "gui/dialog/LatexDialog.h"        // for LatexDialog
 #include "model/PageRef.h"                 // for PageRef
 
 #include "filesystem.h"  // for path
@@ -34,14 +33,15 @@ class XojPageView;
 class Layer;
 class Element;
 class LatexSettings;
+class LatexDialog;
 
-class LatexController {
+class LatexController final {
 public:
     LatexController() = delete;
     LatexController(const LatexController& other) = delete;
     LatexController& operator=(const LatexController& other) = delete;
     LatexController(Control* control);
-    virtual ~LatexController();
+    ~LatexController();
 
 public:
     /**
@@ -85,17 +85,15 @@ private:
     void triggerImageUpdate(const std::string& texString);
 
     /**
-     * Show the LaTex Editor dialog, returning the final formula input by the
-     * user. If the input was cancelled, the resulting string will be the same
-     * as the initial formula.
+     * Show the LaTex Editor dialog and process its output
      */
-    std::string showTexEditDialog();
+    void showTexEditDialog();
 
     /**
      * Signal handler, updates the rendered image when the text in the editor
      * changes.
      */
-    static void handleTexChanged(GtkTextBuffer* buffer, LatexController* self);
+    static void handleTexChanged(LatexController* self);
 
     /**
      * Updates the display once the PDF file is generated.
@@ -130,7 +128,7 @@ private:
     /**
      * LaTex editor dialog
      */
-    LatexDialog dlg;
+    LatexDialog* dlg = nullptr;
 
     /**
      * Tex binary full path

--- a/src/core/control/PrintHandler.cpp
+++ b/src/core/control/PrintHandler.cpp
@@ -14,6 +14,7 @@
 #include "model/PageType.h"       // for PageType
 #include "model/XojPage.h"        // for XojPage
 #include "pdf/base/XojPdfPage.h"  // for XojPdfPageSPtr, XojPdfPage
+#include "util/Assert.h"          // for xoj_assert
 #include "util/PathUtil.h"        // for getConfigFile
 #include "util/XojMsgBox.h"       // for XojMsgBox
 #include "util/i18n.h"            // for _
@@ -109,12 +110,14 @@ void PrintHandler::print(Document* doc, size_t currentPage, GtkWindow* parent) {
     GtkPrintOperationResult res = gtk_print_operation_run(op, GTK_PRINT_OPERATION_ACTION_PRINT_DIALOG, parent, &error);
     g_object_unref(settings);
     if (GTK_PRINT_OPERATION_RESULT_APPLY == res) {
+        xoj_assert(!error);
         settings = gtk_print_operation_get_print_settings(op);
         gtk_print_settings_to_file(settings, filepath.u8string().c_str(), nullptr);
     } else if (GTK_PRINT_OPERATION_RESULT_ERROR == res) {
-        constexpr auto msg = "Running print operation failed with %s";
-        XojMsgBox::showErrorToUser(nullptr, _(msg));
-        handlePrintError(error, msg);
+        xoj_assert(error);
+        std::string msg = FS(_F("Running print operation failed with {1}") % error->message);
+        XojMsgBox::showErrorToUser(nullptr, msg);
+        g_error_free(error);
     }
 
     g_object_unref(op);

--- a/src/core/control/jobs/AutosaveJob.cpp
+++ b/src/core/control/jobs/AutosaveJob.cpp
@@ -19,7 +19,6 @@ AutosaveJob::~AutosaveJob() = default;
 
 void AutosaveJob::afterRun() {
     std::string msg = FS(_F("Error while autosaving: {1}") % this->error);
-    g_warning("%s", msg.c_str());
     XojMsgBox::showErrorToUser(control->getGtkWindow(), msg);
 }
 

--- a/src/core/control/layer/LayerController.cpp
+++ b/src/core/control/layer/LayerController.cpp
@@ -4,8 +4,9 @@
 #include <utility>  // for move
 #include <vector>   // for vector
 
-#include "control/Control.h"                // for Control
-#include "gui/MainWindow.h"                 // for MainWindow
+#include "control/Control.h"  // for Control
+#include "gui/MainWindow.h"   // for MainWindow
+#include "gui/PopupWindowWrapper.h"
 #include "gui/XournalView.h"                // for XournalView
 #include "gui/dialog/RenameLayerDialog.h"   // for RenameLayerDialog
 #include "model/Document.h"                 // for Document
@@ -103,8 +104,9 @@ auto LayerController::actionPerformed(ActionType type) -> bool {
         }
             return true;
         case ACTION_RENAME_LAYER: {
-            RenameLayerDialog dialog(control->getGladeSearchPath(), control->getUndoRedoHandler(), this,
-                                     getCurrentPage()->getSelectedLayer());
+            xoj::popup::PopupWindowWrapper<RenameLayerDialog> dialog(control->getGladeSearchPath(),
+                                                                     control->getUndoRedoHandler(), this,
+                                                                     getCurrentPage()->getSelectedLayer());
             dialog.show(control->getGtkWindow());
         }
             return true;

--- a/src/core/gui/GladeGui.cpp
+++ b/src/core/gui/GladeGui.cpp
@@ -27,12 +27,9 @@ GladeGui::GladeGui(GladeSearchpath* gladeSearchPath, const std::string& glade, c
         if (error != nullptr) {
             msg += "\n";
             msg += error->message;
+            g_error_free(error);
         }
-        XojMsgBox::showErrorToUser(nullptr, msg);
-
-        g_error_free(error);
-
-        exit(-1);
+        XojMsgBox::showErrorAndQuit(msg, -1);
     }
 
     this->window = get(mainWnd);

--- a/src/core/gui/PopupWindowWrapper.h
+++ b/src/core/gui/PopupWindowWrapper.h
@@ -15,6 +15,7 @@
 
 #include <gtk/gtk.h>
 
+#include "util/Assert.h"
 #include "util/gtk4_helper.h"
 
 namespace xoj::popup {
@@ -27,6 +28,10 @@ namespace xoj::popup {
 template <class PopupType>
 class PopupWindowWrapper {
 public:
+    PopupWindowWrapper() = delete;
+    PopupWindowWrapper(const PopupWindowWrapper&) = delete;
+    PopupWindowWrapper(PopupWindowWrapper&&) = delete;
+
     template <class... Args>
     PopupWindowWrapper(Args&&... args) {
         popup = new PopupType(std::forward<Args>(args)...);
@@ -51,6 +56,11 @@ public:
          * The popup will get destroy by the signal connected above.
          */
         popup = nullptr;
+    }
+
+    PopupType* getPopup() const {
+        xoj_assert_message(popup, "Do not call getPopup() after show()!");
+        return popup;
     }
 
 private:

--- a/src/core/gui/dialog/ButtonConfigGui.h
+++ b/src/core/gui/dialog/ButtonConfigGui.h
@@ -19,23 +19,19 @@
 
 #include "control/DeviceListHelper.h"  // for InputDevice
 #include "control/ToolEnums.h"         // for ToolSize
-#include "gui/GladeGui.h"              // for GladeGui
 #include "gui/IconNameHelper.h"        // for IconNameHelper
 
 class Settings;
 class GladeSearchpath;
 
-class ButtonConfigGui: public GladeGui {
+class ButtonConfigGui {
 public:
-    ButtonConfigGui(GladeSearchpath* gladeSearchPath, GtkWidget* w, Settings* settings, int button, bool withDevice);
-    ~ButtonConfigGui() override;
+    ButtonConfigGui(GladeSearchpath* gladeSearchPath, GtkBox* box, Settings* settings, unsigned int button,
+                    bool withDevice);
 
 public:
     void loadSettings();
     void saveSettings();
-
-    // Not implemented! This is not a dialog!
-    void show(GtkWindow* parent) override;
 
 private:
     static void cbSelectCallback(GtkComboBox* widget, ButtonConfigGui* gui);
@@ -57,7 +53,7 @@ private:
 
     std::vector<InputDevice> deviceList;
 
-    int button = 0;
+    unsigned int button = 0;
     bool withDevice = false;
 
     typedef std::map<int, ToolSize> ToolSizeIndexMap;

--- a/src/core/gui/dialog/DeviceClassConfigGui.cpp
+++ b/src/core/gui/dialog/DeviceClassConfigGui.cpp
@@ -7,28 +7,27 @@
 #include "control/DeviceListHelper.h"        // for InputDevice
 #include "control/settings/Settings.h"       // for Settings
 #include "control/settings/SettingsEnums.h"  // for InputDeviceTypeOption
+#include "gui/Builder.h"                     // for Builder
 #include "util/Assert.h"                     // for xoj_assert
+#include "util/gtk4_helper.h"                // for gtk_box_append
 
 class GladeSearchpath;
 
-DeviceClassConfigGui::DeviceClassConfigGui(GladeSearchpath* gladeSearchPath, GtkWidget* w, Settings* settings,
-                                           const InputDevice& device):
-        GladeGui(gladeSearchPath, "settingsDeviceClassConfig.glade", "offscreenwindow"),
-        settings(settings),
-        device(device) {
-    GtkWidget* mainGrid = get("deviceClassGrid");
-    gtk_container_remove(GTK_CONTAINER(getWindow()), mainGrid);
-    gtk_box_pack_end(GTK_BOX(w), mainGrid, true, true, 0);
-    gtk_widget_show_all(mainGrid);
+constexpr auto UI_FILE = "settingsDeviceClassConfig.glade";
+constexpr auto UI_WIDGET_NAME = "deviceClassBox";
 
-    this->labelDevice = get("labelDevice");
-    this->cbDeviceClass = get("cbDeviceClass");
+DeviceClassConfigGui::DeviceClassConfigGui(GladeSearchpath* gladeSearchPath, GtkBox* box, Settings* settings,
+                                           const InputDevice& device):
+        settings(settings), device(device) {
+    Builder builder(gladeSearchPath, UI_FILE);
+    gtk_box_append(box, builder.get(UI_WIDGET_NAME));  // box takes ownership of it all!
+
+    this->labelDevice = builder.get("labelDevice");
+    this->cbDeviceClass = builder.get("cbDeviceClass");
     gtk_label_set_text(GTK_LABEL(this->labelDevice), (device.getName() + " (" + device.getType() + ")").c_str());
 
     loadSettings();
 }
-
-DeviceClassConfigGui::~DeviceClassConfigGui() = default;
 
 void DeviceClassConfigGui::loadSettings() {
     // Get device class of device if available or
@@ -37,10 +36,6 @@ void DeviceClassConfigGui::loadSettings() {
     // Use the ID of each option in case the combo box options get rearranged in the future
     gtk_combo_box_set_active_id(GTK_COMBO_BOX(this->cbDeviceClass),
                                 g_strdup_printf("%i", static_cast<int>(deviceType)));
-}
-
-void DeviceClassConfigGui::show(GtkWindow* parent) {
-    // Not implemented! This is not a dialog!
 }
 
 void DeviceClassConfigGui::saveSettings() {

--- a/src/core/gui/dialog/DeviceClassConfigGui.h
+++ b/src/core/gui/dialog/DeviceClassConfigGui.h
@@ -14,22 +14,17 @@
 #include <gtk/gtk.h>  // for GtkWidget, GtkComboBox, GtkWindow
 
 #include "control/DeviceListHelper.h"  // for InputDevice
-#include "gui/GladeGui.h"              // for GladeGui
 
 class Settings;
 class GladeSearchpath;
 
-class DeviceClassConfigGui: public GladeGui {
+class DeviceClassConfigGui {
 public:
-    DeviceClassConfigGui(GladeSearchpath* gladeSearchPath, GtkWidget* w, Settings* settings, const InputDevice& device);
-    ~DeviceClassConfigGui() override;
+    DeviceClassConfigGui(GladeSearchpath* gladeSearchPath, GtkBox* box, Settings* settings, const InputDevice& device);
 
 public:
     void loadSettings();
     void saveSettings();
-
-    // Not implemented! This is not a dialog!
-    void show(GtkWindow* parent) override;
 
 private:
     static void cbSelectCallback(GtkComboBox* widget, DeviceClassConfigGui* gui);

--- a/src/core/gui/dialog/LatexDialog.cpp
+++ b/src/core/gui/dialog/LatexDialog.cpp
@@ -14,11 +14,10 @@
 #include "LatexDialog.h"
 
 #include <algorithm>  // for max, min
-#include <cstddef>    // for NULL
+#include <cmath>
 #include <sstream>    // for operator<<, basic_ostream
 #include <utility>    // for move
 
-#include <gdk/gdk.h>           // for GdkRectangle
 #include <glib.h>              // for g_free, gpointer, guint
 #include <poppler-document.h>  // for poppler_document_get_n_p...
 #include <poppler-page.h>      // for poppler_page_get_size
@@ -28,43 +27,61 @@
 #endif
 
 #include "control/settings/LatexSettings.h"  // for LatexSettings
-#include "model/Font.h"                      // for XojFont
-#include "util/StringUtils.h"                // for replace_pair, StringUtils
+#include "gui/Builder.h"
+#include "model/Font.h"  // for XojFont
+#include "util/Range.h"
+#include "util/StringUtils.h"  // for replace_pair, StringUtils
+#include "util/gtk4_helper.h"
+#include "util/raii/CStringWrapper.h"
 
 class GladeSearchpath;
 
 // Default background color of the preview.
 const Color DEFAULT_PREVIEW_BACKGROUND = Colors::white;
 
-// Callbacks for gtk to render the dialog's preview.
-extern "C" {
-/**
- * @brief Called on 'size-allocate' signal.
- * @param widget is the event's target.
- * @param allocation provides the region given to the widget.
- */
-static void resizePreviewCallback(GtkWidget* widget, GdkRectangle* allocation, gpointer _unused);
-}
+constexpr auto UI_FILE_NAME = "texdialog.glade";
+constexpr auto UI_DIALOG_ID = "texDialog";
 
-LatexDialog::LatexDialog(GladeSearchpath* gladeSearchPath, const LatexSettings& settings):
-        GladeGui(gladeSearchPath, "texdialog.glade", "texDialog"), previewBackgroundColor{DEFAULT_PREVIEW_BACKGROUND} {
-    GtkContainer* texBoxContainer = GTK_CONTAINER(get("texBoxContainer"));
+constexpr auto TEX_BOX_WIDGET_NAME = "texBox";
+constexpr auto PREVIEW_WIDGET_ID = "texImage";
 
-    this->cssProvider = gtk_css_provider_new();
+LatexDialog::LatexDialog(GladeSearchpath* gladeSearchPath, const LatexSettings& settings, const std::string initialTex,
+                         bool selectAll, std::function<void()> callback):
+        cssProvider(gtk_css_provider_new(), xoj::util::adopt),
+        previewBackgroundColor{DEFAULT_PREVIEW_BACKGROUND},
+        callback(std::move(callback)) {
+    Builder builder(gladeSearchPath, UI_FILE_NAME);
+    window.reset(GTK_WINDOW(builder.get(UI_DIALOG_ID)));
+
+    previewDrawingArea = GTK_DRAWING_AREA(builder.get(PREVIEW_WIDGET_ID));
+    btOk = GTK_BUTTON(builder.get("btOk"));
+    texErrorLabel = GTK_LABEL(builder.get("texErrorLabel"));
+    compilationOutputTextBuffer = gtk_text_view_get_buffer(GTK_TEXT_VIEW(builder.get("texCommandOutputText")));
+
 #ifdef USE_GTK_SOURCEVIEW
     this->texBox = gtk_source_view_new();
 #else
     this->texBox = gtk_text_view_new();
 #endif
 
-    gtk_widget_set_name(this->texBox, "texBox");
-    gtk_container_add(texBoxContainer, this->texBox);
+    gtk_widget_set_name(this->texBox, TEX_BOX_WIDGET_NAME);
     gtk_text_view_set_editable(GTK_TEXT_VIEW(this->texBox), true);
-    gtk_widget_show_all(GTK_WIDGET(texBoxContainer));
 
     this->textBuffer = gtk_text_view_get_buffer(GTK_TEXT_VIEW(this->texBox));
-    this->texTempRender = get("texImage");
-    gtk_widget_set_name(GTK_WIDGET(this->texTempRender), "texImage");
+    gtk_text_buffer_set_text(this->textBuffer, initialTex.c_str(), -1);
+    if (selectAll) {
+        GtkTextIter start, end;
+        gtk_text_buffer_get_bounds(this->textBuffer, &start, &end);
+        gtk_text_buffer_select_range(this->textBuffer, &start, &end);
+    }
+
+#if GTK_MAJOR_VERSION == 3
+    // Widgets are visible by default in gtk4
+    gtk_widget_show_all(GTK_WIDGET(texBox));
+#endif
+
+    gtk_scrolled_window_set_child(GTK_SCROLLED_WINDOW(builder.get("texBoxContainer")), this->texBox);
+
 
 #ifdef USE_GTK_SOURCEVIEW
     // We own neither the languageManager, the styleSchemeManager, nor the sourceLanguage.
@@ -73,7 +90,7 @@ LatexDialog::LatexDialog(GladeSearchpath* gladeSearchPath, const LatexSettings& 
     GtkSourceLanguageManager* lm = gtk_source_language_manager_get_default();
 
     // Select the TeX highlighting scheme
-    GtkSourceLanguage* lang = gtk_source_language_manager_guess_language(lm, "file.tex", NULL);
+    GtkSourceLanguage* lang = gtk_source_language_manager_guess_language(lm, "file.tex", nullptr);
     std::string styleSchemeId = settings.sourceViewThemeId;
     GtkSourceStyleScheme* styleScheme =
             gtk_source_style_scheme_manager_get_scheme(styleSchemeManager, styleSchemeId.c_str());
@@ -100,9 +117,7 @@ LatexDialog::LatexDialog(GladeSearchpath* gladeSearchPath, const LatexSettings& 
 
     gtk_text_view_set_wrap_mode(GTK_TEXT_VIEW(this->texBox), texBoxWrapMode);
 
-    // Connect to redraw events for the texImage.
-    g_signal_connect(G_OBJECT(this->texTempRender), "draw", G_CALLBACK(drawPreviewCallback), this);
-    g_signal_connect(G_OBJECT(this->texTempRender), "size-allocate", G_CALLBACK(resizePreviewCallback), nullptr);
+    gtk_drawing_area_set_draw_func(this->previewDrawingArea, GtkDrawingAreaDrawFunc(previewDrawFunc), this, nullptr);
 
     std::stringstream texBoxCssBuilder;
     if (settings.useCustomEditorFont) {
@@ -112,223 +127,95 @@ LatexDialog::LatexDialog(GladeSearchpath* gladeSearchPath, const LatexSettings& 
         StringUtils::replaceAllChars(fontName, {replace_pair('\\', "\\\\")});
         StringUtils::replaceAllChars(fontName, {replace_pair('\'', "\\'")});
 
+        texBoxCssBuilder << "#" << TEX_BOX_WIDGET_NAME << " {";
         texBoxCssBuilder << "  font-size: " << settings.editorFont.getSize() << "pt;";
-        texBoxCssBuilder << "  font-family: '" << settings.editorFont.getName() << "';";
+        texBoxCssBuilder << "  font-family: '" << fontName << "';";
+        texBoxCssBuilder << " } ";
+
+        gtk_css_provider_load_from_data(this->cssProvider.get(), texBoxCssBuilder.str().c_str(), -1, nullptr);
+
+        // Apply the CSS to both the texBox and the drawing area.
+        gtk_style_context_add_provider(gtk_widget_get_style_context(GTK_WIDGET(this->previewDrawingArea)),
+                                       GTK_STYLE_PROVIDER(this->cssProvider.get()),
+                                       GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+        gtk_style_context_add_provider(gtk_widget_get_style_context(GTK_WIDGET(this->texBox)),
+                                       GTK_STYLE_PROVIDER(this->cssProvider.get()),
+                                       GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
     }
 
-    this->texBoxCss = texBoxCssBuilder.str();
-
-    setupCSS();
+    g_signal_connect_swapped(builder.get("btCancel"), "clicked", G_CALLBACK(gtk_window_close), this->window.get());
+    g_signal_connect_swapped(builder.get("btOk"), "clicked", G_CALLBACK(+[](LatexDialog* self) {
+                                 self->callback();
+                                 gtk_window_close(self->window.get());
+                             }),
+                             this);
 }
 
-LatexDialog::~LatexDialog() {
-    if (this->tempRenderSource != nullptr) {
-        g_clear_object(&this->tempRenderSource);
-    }
+LatexDialog::~LatexDialog() = default;
 
-    if (this->scaledRender != nullptr) {
-        cairo_surface_destroy(this->scaledRender);
-        this->scaledRender = nullptr;
-    }
+void LatexDialog::setCompilationStatus(bool isTexValid, bool isCompilationDone, const std::string& compilationOutput) {
+    gtk_widget_set_sensitive(GTK_WIDGET(btOk), isTexValid && isCompilationDone);
+
+    // Show error warning only if LaTeX is invalid.
+    gtk_widget_set_opacity(GTK_WIDGET(texErrorLabel), isTexValid ? 0 : 1);
+
+    // Update the output pane.
+    gtk_text_buffer_set_text(compilationOutputTextBuffer, compilationOutput.c_str(), -1);
 }
-
-void LatexDialog::setupCSS() {
-    std::stringstream widgetCss;
-
-    widgetCss << "#texBox {";
-    widgetCss << this->texBoxCss;
-    widgetCss << "} ";
-
-    // Background color for the temporary render, default is white because
-    // on dark themed DE the LaTeX is hard to read
-    widgetCss << "#texImage {";
-    widgetCss << "    background-color: " << Util::rgb_to_hex_string(this->previewBackgroundColor) << ";";
-    widgetCss << "    padding: 10px;";
-    widgetCss << "} ";
-
-    std::string widgetCssStr = widgetCss.str();
-
-    gtk_css_provider_load_from_data(this->cssProvider, widgetCssStr.c_str(), -1, nullptr);
-
-    // Apply the CSS to both the texBox and the drawing area.
-    gtk_style_context_add_provider(gtk_widget_get_style_context(GTK_WIDGET(this->texTempRender)),
-                                   GTK_STYLE_PROVIDER(this->cssProvider), GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
-    gtk_style_context_add_provider(gtk_widget_get_style_context(GTK_WIDGET(this->texBox)),
-                                   GTK_STYLE_PROVIDER(this->cssProvider), GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
-}
-
-void LatexDialog::setFinalTex(std::string texString) { this->finalLatex = std::move(texString); }
-
-auto LatexDialog::getFinalTex() -> std::string { return this->finalLatex; }
 
 void LatexDialog::setTempRender(PopplerDocument* pdf) {
     if (poppler_document_get_n_pages(pdf) < 1) {
         return;
     }
 
-    // If a previous render exists, destroy it
-    if (this->scaledRender != nullptr) {
-        cairo_surface_destroy(this->scaledRender);
-        this->scaledRender = nullptr;
-    }
-
-    if (this->tempRenderSource != nullptr) {
-        g_clear_object(&this->tempRenderSource);
-    }
-
-    this->tempRenderSource = poppler_document_get_page(pdf, 0);
-    g_object_ref(this->tempRenderSource);
-
-    renderScaledPreview();
+    this->previewPdfPage.reset(poppler_document_get_page(pdf, 0), xoj::util::adopt);
+    this->previewMask.reset();
 
     // Queue rendering the changed preview.
-    gtk_widget_queue_draw(GTK_WIDGET(this->texTempRender));
+    gtk_widget_queue_draw(GTK_WIDGET(this->previewDrawingArea));
 }
 
-void LatexDialog::setPreviewBackgroundColor(Color newColor) {
-    if (newColor == this->previewBackgroundColor) {
-        return;
-    }
-
-    this->previewBackgroundColor = newColor;
-    setupCSS();
-}
-
-auto LatexDialog::getPreviewScale(double srcWidth, double srcHeight) const -> double {
-    // We need to get the width and height of texTempRender. This shouldn't
-    // change the widget, so a const_cast here is appropriate.
-    GtkWidget* widget = const_cast<GtkWidget*>(this->texTempRender);
-
-    double widgetWidth = gtk_widget_get_allocated_width(widget);
-    double widgetHeight = gtk_widget_get_allocated_height(widget);
-
-    double xFillScaleFactor = widgetWidth / srcWidth;
-    double yFillScaleFactor = widgetHeight / srcHeight;
-
-    return std::min(xFillScaleFactor, yFillScaleFactor);
-}
-
-auto LatexDialog::getPreviewScale() const -> double {
-    if (this->scaledRender == nullptr) {
-        return 1.0;
-    }
-
-    cairo_surface_t* surface = const_cast<cairo_surface_t*>(this->scaledRender);
-    int renderedWidth = cairo_image_surface_get_width(surface);
-    int renderedHeight = cairo_image_surface_get_height(surface);
-
-    // Empty previews: No scaling.
-    if (renderedWidth == 0 || renderedHeight == 0) {
-        return 1.0;
-    }
-
-    return getPreviewScale(renderedWidth, renderedHeight);
-}
-
-void LatexDialog::renderScaledPreview() {
-    double zoom, pageWidth = 0, pageHeight = 0;
-    poppler_page_get_size(this->tempRenderSource, &pageWidth, &pageHeight);
-
-    zoom = getPreviewScale(pageWidth, pageHeight);
-
-    this->scaledRender = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, static_cast<int>(pageWidth * zoom),
-                                                    static_cast<int>(pageHeight * zoom));
-    cairo_t* cr = cairo_create(this->scaledRender);
-
-    cairo_scale(cr, zoom, zoom);
-    poppler_page_render(this->tempRenderSource, cr);
-
-    // Free resources.
-    cairo_destroy(cr);
-}
+void LatexDialog::setPreviewBackgroundColor(Color newColor) { this->previewBackgroundColor = newColor; }
 
 auto LatexDialog::getTextBuffer() -> GtkTextBuffer* { return this->textBuffer; }
 
 auto LatexDialog::getBufferContents() -> std::string {
     GtkTextIter start, end;
     gtk_text_buffer_get_bounds(this->textBuffer, &start, &end);
-    gchar* chars = gtk_text_buffer_get_text(this->textBuffer, &start, &end, false);
-    std::string s = chars;
-    g_free(chars);
-    return s;
+    auto content =
+            xoj::util::OwnedCString::assumeOwnership(gtk_text_buffer_get_text(this->textBuffer, &start, &end, false));
+    return content.get();
 }
 
-void LatexDialog::drawPreviewCallback(GtkWidget* widget, cairo_t* cr, LatexDialog* self) {
-    GtkStyleContext* context = gtk_widget_get_style_context(widget);
-
-    guint widgetWidth = gtk_widget_get_allocated_width(widget);
-    guint widgetHeight = gtk_widget_get_allocated_height(widget);
-
-    gtk_render_background(context, cr, 0, 0, widgetWidth, widgetHeight);
+void LatexDialog::previewDrawFunc(GtkDrawingArea*, cairo_t* cr, int width, int height, LatexDialog* self) {
 
     // If we have nothing to render, do nothing!
-    if (!self->tempRenderSource) {
+    if (!self->previewPdfPage) {
         return;
     }
 
-    double scaleFactor = self->getPreviewScale();
+    Range pageRange(0, 0, 0, 0);
+    poppler_page_get_size(self->previewPdfPage.get(), &pageRange.maxX, &pageRange.maxY);
 
-    // If possible, try not to make the preview larger than rendered.
-    if (scaleFactor > 1.0) {
-        self->renderScaledPreview();
+    const double zoom =
+            std::min(static_cast<double>(width) / pageRange.maxX, static_cast<double>(height) / pageRange.maxY);
 
-        // Don't increase the size of the preview if we're at the maximum scale.
-        scaleFactor = std::max(1.0, self->getPreviewScale());
+
+    if (!self->previewMask.isInitialized() || self->previewMask.getZoom() < zoom) {
+        // Need to rerender the preview
+        self->previewMask = xoj::view::Mask(gtk_widget_get_scale_factor(GTK_WIDGET(self->previewDrawingArea)),
+                                            pageRange, zoom, CAIRO_CONTENT_COLOR_ALPHA);
+        poppler_page_render(self->previewPdfPage.get(), self->previewMask.get());
     }
 
-    int renderedWidth = cairo_image_surface_get_width(self->scaledRender);
-    int renderedHeight = cairo_image_surface_get_height(self->scaledRender);
 
-    // Don't render empty previews.
-    if (renderedWidth == 0 || renderedHeight == 0) {
-        return;
-    }
-
-    // Center the image horizontally and vertically.
-    double translateX = 0.0, translateY = 0.0;
-
-    double extraHorizontalSpace = std::max(0.0, widgetWidth - renderedWidth * scaleFactor);
-    double extraVerticalSpace = std::max(0.0, widgetHeight - renderedHeight * scaleFactor);
-
-    translateX = extraHorizontalSpace / 2.0;
-    translateY = extraVerticalSpace / 2.0;
-
-    cairo_matrix_t matOriginal;
-    cairo_matrix_t matTransformed;
-    cairo_get_matrix(cr, &matOriginal);
-    cairo_get_matrix(cr, &matTransformed);
-
-    matTransformed.xx = scaleFactor;
-    matTransformed.yy = scaleFactor;
-    matTransformed.xy = 0;
-    matTransformed.yx = 0;
-    matTransformed.x0 += translateX;
-    matTransformed.y0 += translateY;
-
-    cairo_set_matrix(cr, &matTransformed);
-    cairo_set_source_surface(cr, self->scaledRender, 0, 0);
+    Util::cairo_set_source_rgbi(cr, self->previewBackgroundColor);
     cairo_paint(cr);
 
-    cairo_set_matrix(cr, &matOriginal);
-}
-
-static void resizePreviewCallback(GtkWidget* widget, GdkRectangle* allocation, gpointer _unused) {
-    gtk_widget_queue_draw(widget);
-}
-
-void LatexDialog::show(GtkWindow* parent) { this->show(parent, false); }
-
-void LatexDialog::show(GtkWindow* parent, bool selectText) {
-    gtk_text_buffer_set_text(this->textBuffer, this->finalLatex.c_str(), -1);
-    if (selectText) {
-        GtkTextIter start, end;
-        gtk_text_buffer_get_bounds(this->textBuffer, &start, &end);
-        gtk_text_buffer_select_range(this->textBuffer, &start, &end);
-    }
-
-    gtk_window_set_transient_for(GTK_WINDOW(this->window), parent);
-    int res = gtk_dialog_run(GTK_DIALOG(this->window));
-    this->finalLatex = res == GTK_RESPONSE_OK ? this->getBufferContents() : "";
-
-    gtk_widget_hide(this->window);
+    // Center the rendering
+    const double extraHorizontalSpace = std::max(0.0, width - pageRange.maxX * zoom);
+    const double extraVerticalSpace = std::max(0.0, height - pageRange.maxY * zoom);
+    cairo_translate(cr, 0.5 * extraHorizontalSpace, 0.5 * extraVerticalSpace);
+    cairo_scale(cr, zoom, zoom);
+    self->previewMask.paintTo(cr);
 }

--- a/src/core/gui/dialog/LatexSettingsPanel.h
+++ b/src/core/gui/dialog/LatexSettingsPanel.h
@@ -13,24 +13,23 @@
 
 #include <gtk/gtk.h>  // for GtkToggleButton, GtkFileChooser, GtkWidget
 
-#include "gui/GladeGui.h"  // for GladeGui
+#include "gui/Builder.h"
 
 class GladeSearchpath;
 class LatexSettings;
 
-class LatexSettingsPanel: public GladeGui {
+class LatexSettingsPanel {
 public:
-    LatexSettingsPanel(GladeSearchpath*);
+    explicit LatexSettingsPanel(GladeSearchpath*);
     LatexSettingsPanel(const LatexSettingsPanel&) = delete;
     LatexSettingsPanel& operator=(const LatexSettingsPanel&) = delete;
     LatexSettingsPanel(const LatexSettingsPanel&&) = delete;
     LatexSettingsPanel& operator=(const LatexSettingsPanel&&) = delete;
-    ~LatexSettingsPanel() override;
-
-    void show(GtkWindow* parent) override;
 
     void load(const LatexSettings& settings);
     void save(LatexSettings& settings);
+
+    inline GtkWidget* getPanel() const { return GTK_WIDGET(panel); }
 
 private:
     void checkDeps();
@@ -41,8 +40,11 @@ private:
      */
     void updateWidgetSensitivity();
 
-    GtkToggleButton* cbAutoDepCheck;
+    Builder builder;
+    GtkScrolledWindow* panel;
+
+    GtkCheckButton* cbAutoDepCheck;
     GtkFileChooser* globalTemplateChooser;
     GtkWidget* sourceViewThemeSelector;
-    GtkToggleButton* cbUseSystemFont;
+    GtkCheckButton* cbUseSystemFont;
 };

--- a/src/core/gui/dialog/PluginDialog.h
+++ b/src/core/gui/dialog/PluginDialog.h
@@ -11,27 +11,29 @@
 
 #pragma once
 
+#include "config-features.h"
+
+#ifdef ENABLE_PLUGINS
+
 #include <memory>  // for unique_ptr
 #include <vector>  // for vector
 
-#include <gtk/gtk.h>  // for GtkWindow
-
-#include "gui/GladeGui.h"  // for GladeGui
+#include "util/raii/GtkWindowUPtr.h"
 
 #include "PluginDialogEntry.h"  // for PluginDialogEntry
 
+class Plugin;
 class PluginController;
 class Settings;
 class GladeSearchpath;
 
-class PluginDialog: public GladeGui {
+class PluginDialog {
 public:
-    PluginDialog(GladeSearchpath* gladeSearchPath, Settings* settings);
-    ~PluginDialog() override = default;
+    PluginDialog(GladeSearchpath* gladeSearchPath, Settings* settings,
+                 const std::vector<std::unique_ptr<Plugin>>& plugins);
 
 public:
-    void loadPluginList(PluginController const* pc);
-    void show(GtkWindow* parent) override;
+    inline GtkWindow* getWindow() const { return window.get(); }
 
 private:
     void saveSettings();
@@ -40,4 +42,7 @@ private:
     Settings* settings;
 
     std::vector<std::unique_ptr<PluginDialogEntry>> plugins;
+    xoj::util::GtkWindowUPtr window;
 };
+
+#endif

--- a/src/core/gui/dialog/PluginDialogEntry.h
+++ b/src/core/gui/dialog/PluginDialogEntry.h
@@ -11,30 +11,30 @@
 
 #pragma once
 
+#include "config-features.h"
+
+#ifdef ENABLE_PLUGINS
 #include <string>  // for string
 
-#include <gtk/gtk.h>  // for GtkWidget, GtkWindow
-
-#include "gui/GladeGui.h"  // for GladeGui
+#include <gtk/gtk.h>
 
 class Plugin;
 class GladeSearchpath;
 
-class PluginDialogEntry: public GladeGui {
+class PluginDialogEntry {
 public:
-    PluginDialogEntry(Plugin* plugin, GladeSearchpath* gladeSearchPath, GtkWidget* w);
-    ~PluginDialogEntry() override = default;
+    PluginDialogEntry(Plugin* plugin, GladeSearchpath* gladeSearchPath, GtkBox* box);
 
 public:
-    void loadSettings();
     void saveSettings(std::string& pluginEnabled, std::string& pluginDisabled);
 
-    // Not implemented! This is not a dialog!
-    void show(GtkWindow* parent) override;
 
 private:
     /**
      * Plugin instance
      */
     Plugin* plugin;
+
+    GtkCheckButton* stateButton;
 };
+#endif

--- a/src/core/gui/dialog/RenameLayerDialog.cpp
+++ b/src/core/gui/dialog/RenameLayerDialog.cpp
@@ -6,39 +6,34 @@
 #include <glib-object.h>  // for G_CALLBACK, g_signal_connect
 
 #include "control/layer/LayerController.h"  // for LayerController
-#include "undo/LayerRenameUndoAction.h"     // for LayerRenameUndoAction
-#include "undo/UndoRedoHandler.h"           // for UndoRedoHandler
+#include "gui/Builder.h"
+#include "undo/LayerRenameUndoAction.h"  // for LayerRenameUndoAction
+#include "undo/UndoRedoHandler.h"        // for UndoRedoHandler
 
 class GladeSearchpath;
 class Layer;
 
+constexpr auto UI_FILE = "renameLayerDialog.glade";
+constexpr auto UI_DIALOG_NAME = "renameLayerDialog";
+
 RenameLayerDialog::RenameLayerDialog(GladeSearchpath* gladeSearchPath, UndoRedoHandler* undo, LayerController* lc,
                                      Layer* l):
-        GladeGui(gladeSearchPath, "renameLayerDialog.glade", "renameLayerDialog"), lc(lc), undo(undo), l(l) {
-    gtk_entry_set_text(GTK_ENTRY(get("layerNameEntry")), lc->getCurrentLayerName().c_str());
+        lc(lc), undo(undo), l(l) {
+    Builder builder(gladeSearchPath, UI_FILE);
+    window.reset(GTK_WINDOW(builder.get(UI_DIALOG_NAME)));
+    layerNameEntry = GTK_ENTRY(builder.get("layerNameEntry"));
 
-    g_signal_connect(get("renameButton"), "clicked", G_CALLBACK(renameSuccessful), this);
-    g_signal_connect(get("cancelButton"), "clicked", G_CALLBACK(exitDialog), this);
-}
+    gtk_entry_set_text(layerNameEntry, lc->getCurrentLayerName().c_str());
 
-void RenameLayerDialog::renameSuccessful(GtkButton* bttn, RenameLayerDialog* rld) {
-    std::string newName = gtk_entry_get_text(GTK_ENTRY(rld->get("layerNameEntry")));
+    g_signal_connect_swapped(builder.get("btCancel"), "clicked", G_CALLBACK(gtk_window_close), this->window.get());
+    g_signal_connect_swapped(builder.get("btOk"), "clicked", G_CALLBACK(+[](RenameLayerDialog* self) {
+                                 std::string newName = gtk_entry_get_text(self->layerNameEntry);
 
-    rld->undo->addUndoAction(
-            std::make_unique<LayerRenameUndoAction>(rld->lc, rld->l, newName, rld->lc->getCurrentLayerName()));
+                                 self->undo->addUndoAction(std::make_unique<LayerRenameUndoAction>(
+                                         self->lc, self->l, newName, self->lc->getCurrentLayerName()));
 
-    rld->lc->setCurrentLayerName(newName);
-    gtk_window_close(GTK_WINDOW(rld->window));
-}
-
-void RenameLayerDialog::exitDialog(GtkButton* bttn, RenameLayerDialog* rld) {
-    gtk_window_close(GTK_WINDOW(rld->window));
-}
-
-RenameLayerDialog::~RenameLayerDialog() = default;
-
-void RenameLayerDialog::show(GtkWindow* parent) {
-    gtk_window_set_transient_for(GTK_WINDOW(this->window), parent);
-    gtk_dialog_run(GTK_DIALOG(this->window));
-    gtk_widget_hide(this->window);
+                                 self->lc->setCurrentLayerName(newName);
+                                 gtk_window_close(self->window.get());
+                             }),
+                             this);
 }

--- a/src/core/gui/dialog/RenameLayerDialog.h
+++ b/src/core/gui/dialog/RenameLayerDialog.h
@@ -11,29 +11,26 @@
 
 #pragma once
 
-#include <gtk/gtk.h>  // for GtkButton, GtkWindow
+#include <gtk/gtk.h>
 
-#include "gui/GladeGui.h"  // for GladeGui
+#include "util/raii/GtkWindowUPtr.h"
 
 class GladeSearchpath;
 class Layer;
 class LayerController;
 class UndoRedoHandler;
 
-class RenameLayerDialog: public GladeGui {
+class RenameLayerDialog {
 public:
     RenameLayerDialog(GladeSearchpath* gladeSearchPath, UndoRedoHandler* undo, LayerController* lc, Layer* l);
-    ~RenameLayerDialog() override;
 
-public:
-    void show(GtkWindow* parent) override;
-
-private:
-    static void exitDialog(GtkButton* bttn, RenameLayerDialog* rld);
-    static void renameSuccessful(GtkButton* bttn, RenameLayerDialog* rld);
+    inline GtkWindow* getWindow() const { return window.get(); }
 
 private:
     LayerController* lc;
     UndoRedoHandler* undo;
     Layer* l;
+
+    xoj::util::GtkWindowUPtr window;
+    GtkEntry* layerNameEntry;
 };

--- a/src/core/gui/dialog/SelectBackgroundColorDialog.h
+++ b/src/core/gui/dialog/SelectBackgroundColorDialog.h
@@ -1,7 +1,7 @@
 /*
  * Xournal++
  *
- * The about dialog
+ * Dialog for selecting a background color
  *
  * @author Xournal++ Team
  * https://github.com/xournalpp/xournalpp
@@ -12,12 +12,13 @@
 #pragma once
 
 #include <array>     // for array
-#include <optional>  // for optional
+#include <functional>
 
 #include <gdk/gdk.h>  // for GdkRGBA
 #include <gtk/gtk.h>  // for GtkWindow
 
-#include "util/Color.h"  // for Color
+#include "util/Color.h"
+#include "util/raii/GtkWindowUPtr.h"
 
 class Control;
 
@@ -29,18 +30,12 @@ const int LAST_BACKGROUND_COLOR_COUNT = 9;
 
 class SelectBackgroundColorDialog {
 public:
-    explicit SelectBackgroundColorDialog(Control* control);
+    SelectBackgroundColorDialog(Control* control, std::function<void(Color)> callback);
 
-public:
-    void show(GtkWindow* parent);
-
-    /**
-     * Return the selected color as RGB, nullopt if no color is selected
-     */
-    auto getSelectedColor() const -> std::optional<Color>;
+    inline GtkWindow* getWindow() const { return window.get(); }
 
 private:
-    void storeLastUsedValuesInSettings();
+    void storeLastUsedValuesInSettings(GdkRGBA color);
 
 private:
     Control* control{nullptr};
@@ -50,8 +45,6 @@ private:
      */
     std::array<GdkRGBA, LAST_BACKGROUND_COLOR_COUNT> lastBackgroundColors{};
 
-    /**
-     * Selected color
-     */
-    std::optional<Color> selected;
+    xoj::util::GtkWindowUPtr window;
+    std::function<void(Color)> callback;
 };

--- a/src/core/gui/dialog/SettingsDialog.cpp
+++ b/src/core/gui/dialog/SettingsDialog.cpp
@@ -63,7 +63,7 @@ SettingsDialog::SettingsDialog(GladeSearchpath* gladeSearchPath, Settings* setti
     initMouseButtonEvents(gladeSearchPath);
 
     vector<InputDevice> deviceList = DeviceListHelper::getDeviceList(this->settings);
-    GtkWidget* container = builder.get("hboxInputDeviceClasses");
+    GtkBox* container = GTK_BOX(builder.get("hboxInputDeviceClasses"));
     for (const InputDevice& inputDevice: deviceList) {
         // Only add real devices (core pointers have vendor and product id nullptr)
         this->deviceClassConfigs.emplace_back(gladeSearchPath, container, settings, inputDevice);

--- a/src/core/gui/dialog/SettingsDialog.cpp
+++ b/src/core/gui/dialog/SettingsDialog.cpp
@@ -16,9 +16,6 @@
 #include "control/tools/StrokeStabilizerEnum.h"  // for AveragingMethod, Pre...
 #include "gui/MainWindow.h"                      // for MainWindow
 #include "gui/XournalView.h"                     // for XournalView
-#include "gui/dialog/DeviceClassConfigGui.h"     // for DeviceClassConfigGui
-#include "gui/dialog/LanguageConfigGui.h"        // for LanguageConfigGui
-#include "gui/dialog/LatexSettingsPanel.h"       // for LatexSettingsPanel
 #include "gui/widgets/ZoomCallib.h"              // for zoomcallib_new, zoom...
 #include "model/PageType.h"                      // for PageType
 #include "util/Color.h"                          // for GdkRGBA_to_argb, rgb...
@@ -28,134 +25,124 @@
 #include "util/i18n.h"                           // for _
 #include "util/raii/CairoWrappers.h"             // for CairoSurfaceSPtr
 
-#include "ButtonConfigGui.h"  // for ButtonConfigGui
-#include "filesystem.h"       // for is_directory
+#include "ButtonConfigGui.h"       // for ButtonConfigGui
+#include "DeviceClassConfigGui.h"  // for DeviceClassConfigGui
+#include "LanguageConfigGui.h"     // for LanguageConfigGui
+#include "LatexSettingsPanel.h"    // for LatexSettingsPanel
+#include "filesystem.h"            // for is_directory
 
 class GladeSearchpath;
 
 using std::string;
 using std::vector;
 
+constexpr auto UI_FILE = "settings.glade";
+constexpr auto UI_DIALOG_NAME = "settingsDialog";
+
 SettingsDialog::SettingsDialog(GladeSearchpath* gladeSearchPath, Settings* settings, Control* control):
-        GladeGui(gladeSearchPath, "settings.glade", "settingsDialog"),
         settings(settings),
         control(control),
         callib(zoomcallib_new()),
+        builder(gladeSearchPath, UI_FILE),
+        window(GTK_WINDOW(builder.get(UI_DIALOG_NAME))),
+        languageConfig(gladeSearchPath, builder.get("hboxLanguageSelect"), settings),
         latexPanel(gladeSearchPath) {
-    GtkWidget* vbox = get("zoomVBox");
-    g_return_if_fail(vbox != nullptr);
+    GtkWidget* vbox = builder.get("zoomVBox");
 
-    GtkWidget* zoomCalibSlider = get("zoomCallibSlider");
-    g_return_if_fail(zoomCalibSlider != nullptr);
-    g_signal_connect(zoomCalibSlider, "change-value",
-                     G_CALLBACK(+[](GtkRange* range, GtkScrollType scroll, gdouble value, SettingsDialog* self) {
-                         self->setDpi((int)value);
+    g_signal_connect(builder.get("zoomCallibSlider"), "change-value",
+                     G_CALLBACK(+[](GtkRange*, GtkScrollType, gdouble value, SettingsDialog* self) {
+                         self->setDpi(static_cast<int>(std::round(value)));
                      }),
                      this);
 
-    g_signal_connect(
-            get("cbEnablePressureInference"), "toggled",
-            G_CALLBACK(+[](GtkComboBox* comboBox, SettingsDialog* self) { self->updatePressureSensitivityOptions(); }),
+    g_signal_connect_swapped(builder.get("cbEnablePressureInference"), "toggled",
+                             G_CALLBACK(+[](SettingsDialog* self) { self->updatePressureSensitivityOptions(); }), this);
+
+    g_signal_connect_swapped(builder.get("cbSettingPresureSensitivity"), "toggled",
+                             G_CALLBACK(+[](SettingsDialog* self) { self->updatePressureSensitivityOptions(); }), this);
+
+    g_signal_connect_swapped(
+            builder.get("cbAutosave"), "toggled",
+            G_CALLBACK(+[](SettingsDialog* self) { self->enableWithCheckbox("cbAutosave", "boxAutosave"); }), this);
+
+    g_signal_connect_swapped(builder.get("cbIgnoreFirstStylusEvents"), "toggled", G_CALLBACK(+[](SettingsDialog* self) {
+                                 self->enableWithCheckbox("cbIgnoreFirstStylusEvents", "spNumIgnoredStylusEvents");
+                             }),
+                             this);
+
+
+    g_signal_connect_swapped(
+            builder.get("btTestEnable"), "clicked", G_CALLBACK(+[](SettingsDialog* self) {
+                Util::systemWithMessage(gtk_entry_get_text(GTK_ENTRY(self->builder.get("txtEnableTouchCommand"))));
+            }),
             this);
 
-    g_signal_connect(
-            get("cbSettingPresureSensitivity"), "toggled",
-            G_CALLBACK(+[](GtkComboBox* comboBox, SettingsDialog* self) { self->updatePressureSensitivityOptions(); }),
+    g_signal_connect_swapped(
+            builder.get("btTestDisable"), "clicked", G_CALLBACK(+[](SettingsDialog* self) {
+                Util::systemWithMessage(gtk_entry_get_text(GTK_ENTRY(self->builder.get("txtDisableTouchCommand"))));
+            }),
             this);
 
-    g_signal_connect(get("cbAutosave"), "toggled", G_CALLBACK(+[](GtkToggleButton* togglebutton, SettingsDialog* self) {
-                         self->enableWithCheckbox("cbAutosave", "boxAutosave");
-                     }),
-                     this);
+    g_signal_connect_swapped(builder.get("cbAddVerticalSpace"), "toggled", G_CALLBACK(+[](SettingsDialog* self) {
+                                 self->enableWithCheckbox("cbAddVerticalSpace", "spAddVerticalSpaceAbove");
+                                 self->enableWithCheckbox("cbAddVerticalSpace", "spAddVerticalSpaceBelow");
+                             }),
+                             this);
 
-    g_signal_connect(get("cbIgnoreFirstStylusEvents"), "toggled",
-                     G_CALLBACK(+[](GtkToggleButton* togglebutton, SettingsDialog* self) {
-                         self->enableWithCheckbox("cbIgnoreFirstStylusEvents", "spNumIgnoredStylusEvents");
-                     }),
-                     this);
+    g_signal_connect_swapped(builder.get("cbAddHorizontalSpace"), "toggled", G_CALLBACK(+[](SettingsDialog* self) {
+                                 self->enableWithCheckbox("cbAddHorizontalSpace", "spAddHorizontalSpaceLeft");
+                                 self->enableWithCheckbox("cbAddHorizontalSpace", "spAddHorizontalSpaceRight");
+                             }),
+                             this);
 
+    g_signal_connect_swapped(builder.get("cbUnlimitedScrolling"), "toggled", G_CALLBACK(+[](SettingsDialog* self) {
+                                 self->disableWithCheckbox("cbUnlimitedScrolling", "cbAddHorizontalSpace");
+                                 self->disableWithCheckbox("cbUnlimitedScrolling", "cbAddVerticalSpace");
+                                 self->enableWithEnabledCheckbox("cbAddHorizontalSpace", "spAddHorizontalSpaceLeft");
+                                 self->enableWithEnabledCheckbox("cbAddVerticalSpace", "spAddVerticalSpaceAbove");
+                                 self->enableWithEnabledCheckbox("cbAddHorizontalSpace", "spAddHorizontalSpaceRight");
+                                 self->enableWithEnabledCheckbox("cbAddVerticalSpace", "spAddVerticalSpaceBelow");
+                             }),
+                             this);
 
-    g_signal_connect(get("btTestEnable"), "clicked", G_CALLBACK(+[](GtkButton* bt, SettingsDialog* self) {
-                         Util::systemWithMessage(gtk_entry_get_text(GTK_ENTRY(self->get("txtEnableTouchCommand"))));
-                     }),
-                     this);
+    g_signal_connect_swapped(builder.get("cbDrawDirModsEnabled"), "toggled", G_CALLBACK(+[](SettingsDialog* self) {
+                                 self->enableWithCheckbox("cbDrawDirModsEnabled", "spDrawDirModsRadius");
+                             }),
+                             this);
 
-    g_signal_connect(get("btTestDisable"), "clicked", G_CALLBACK(+[](GtkButton* bt, SettingsDialog* self) {
-                         Util::systemWithMessage(gtk_entry_get_text(GTK_ENTRY(self->get("txtDisableTouchCommand"))));
-                     }),
-                     this);
+    g_signal_connect_swapped(builder.get("cbStrokeFilterEnabled"), "toggled", G_CALLBACK(+[](SettingsDialog* self) {
+                                 self->enableWithCheckbox("cbStrokeFilterEnabled", "spStrokeIgnoreTime");
+                                 self->enableWithCheckbox("cbStrokeFilterEnabled", "spStrokeIgnoreLength");
+                                 self->enableWithCheckbox("cbStrokeFilterEnabled", "spStrokeSuccessiveTime");
+                                 self->enableWithCheckbox("cbStrokeFilterEnabled", "cbDoActionOnStrokeFiltered");
+                                 self->enableWithCheckbox("cbStrokeFilterEnabled", "cbTrySelectOnStrokeFiltered");
+                             }),
+                             this);
 
-    g_signal_connect(get("cbAddVerticalSpace"), "toggled",
-                     G_CALLBACK(+[](GtkToggleButton* togglebutton, SettingsDialog* self) {
-                         self->enableWithCheckbox("cbAddVerticalSpace", "spAddVerticalSpaceAbove");
-                         self->enableWithCheckbox("cbAddVerticalSpace", "spAddVerticalSpaceBelow");
-                     }),
-                     this);
+    g_signal_connect_swapped(builder.get("cbDisableTouchOnPenNear"), "toggled", G_CALLBACK(+[](SettingsDialog* self) {
+                                 self->enableWithCheckbox("cbDisableTouchOnPenNear", "boxInternalHandRecognition");
+                             }),
+                             this);
 
-    g_signal_connect(get("cbAddHorizontalSpace"), "toggled",
-                     G_CALLBACK(+[](GtkToggleButton* togglebutton, SettingsDialog* self) {
-                         self->enableWithCheckbox("cbAddHorizontalSpace", "spAddHorizontalSpaceLeft");
-                         self->enableWithCheckbox("cbAddHorizontalSpace", "spAddHorizontalSpaceRight");
-                     }),
-                     this);
+    g_signal_connect_swapped(builder.get("cbTouchDisableMethod"), "changed",
+                             G_CALLBACK(+[](SettingsDialog* self) { self->customHandRecognitionToggled(); }), this);
 
-    g_signal_connect(get("cbUnlimitedScrolling"), "toggled",
-                     G_CALLBACK(+[](GtkToggleButton* togglebutton, SettingsDialog* self) {
-                         self->disableWithCheckbox("cbUnlimitedScrolling", "cbAddHorizontalSpace");
-                         self->disableWithCheckbox("cbUnlimitedScrolling", "cbAddVerticalSpace");
-                         self->enableWithEnabledCheckbox("cbAddHorizontalSpace", "spAddHorizontalSpaceLeft");
-                         self->enableWithEnabledCheckbox("cbAddVerticalSpace", "spAddVerticalSpaceAbove");
-                         self->enableWithEnabledCheckbox("cbAddHorizontalSpace", "spAddHorizontalSpaceRight");
-                         self->enableWithEnabledCheckbox("cbAddVerticalSpace", "spAddVerticalSpaceBelow");
-                     }),
-                     this);
+    g_signal_connect_swapped(builder.get("cbEnableZoomGestures"), "toggled", G_CALLBACK(+[](SettingsDialog* self) {
+                                 self->enableWithCheckbox("cbEnableZoomGestures", "gdStartZoomAtSetting");
+                             }),
+                             this);
 
-    g_signal_connect(get("cbDrawDirModsEnabled"), "toggled",
-                     G_CALLBACK(+[](GtkToggleButton* togglebutton, SettingsDialog* self) {
-                         self->enableWithCheckbox("cbDrawDirModsEnabled", "spDrawDirModsRadius");
-                     }),
-                     this);
+    g_signal_connect_swapped(builder.get("cbStylusCursorType"), "changed",
+                             G_CALLBACK(+[](SettingsDialog* self) { self->customStylusIconTypeChanged(); }), this);
 
-    g_signal_connect(get("cbStrokeFilterEnabled"), "toggled",
-                     G_CALLBACK(+[](GtkToggleButton* togglebutton, SettingsDialog* self) {
-                         self->enableWithCheckbox("cbStrokeFilterEnabled", "spStrokeIgnoreTime");
-                         self->enableWithCheckbox("cbStrokeFilterEnabled", "spStrokeIgnoreLength");
-                         self->enableWithCheckbox("cbStrokeFilterEnabled", "spStrokeSuccessiveTime");
-                         self->enableWithCheckbox("cbStrokeFilterEnabled", "cbDoActionOnStrokeFiltered");
-                         self->enableWithCheckbox("cbStrokeFilterEnabled", "cbTrySelectOnStrokeFiltered");
-                     }),
-                     this);
-
-    g_signal_connect(get("cbDisableTouchOnPenNear"), "toggled",
-                     G_CALLBACK(+[](GtkToggleButton* togglebutton, SettingsDialog* self) {
-                         self->enableWithCheckbox("cbDisableTouchOnPenNear", "boxInternalHandRecognition");
-                     }),
-                     this);
-
-    g_signal_connect(
-            get("cbTouchDisableMethod"), "changed",
-            G_CALLBACK(+[](GtkComboBox* comboBox, SettingsDialog* self) { self->customHandRecognitionToggled(); }),
-            this);
-
-    g_signal_connect(get("cbEnableZoomGestures"), "toggled",
-                     G_CALLBACK(+[](GtkComboBox* comboBox, SettingsDialog* self) {
-                         self->enableWithCheckbox("cbEnableZoomGestures", "gdStartZoomAtSetting");
-                     }),
-                     this);
-
-    g_signal_connect(get("cbStylusCursorType"), "changed", G_CALLBACK(+[](GtkComboBox* comboBox, SettingsDialog* self) {
-                         self->customStylusIconTypeChanged();
-                     }),
-                     this);
-
-    g_signal_connect(get("cbStabilizerAveragingMethods"), "changed",
+    g_signal_connect(builder.get("cbStabilizerAveragingMethods"), "changed",
                      G_CALLBACK(+[](GtkComboBox* comboBox, SettingsDialog* self) {
                          self->showStabilizerAvMethodOptions(
                                  static_cast<StrokeStabilizer::AveragingMethod>(gtk_combo_box_get_active(comboBox)));
                      }),
                      this);
 
-    g_signal_connect(get("cbStabilizerPreprocessors"), "changed",
+    g_signal_connect(builder.get("cbStabilizerPreprocessors"), "changed",
                      G_CALLBACK(+[](GtkComboBox* comboBox, SettingsDialog* self) {
                          self->showStabilizerPreprocessorOptions(
                                  static_cast<StrokeStabilizer::Preprocessor>(gtk_combo_box_get_active(comboBox)));
@@ -167,21 +154,19 @@ SettingsDialog::SettingsDialog(GladeSearchpath* gladeSearchPath, Settings* setti
                                                 xoj::util::adopt);
     GtkWidget* preview = gtk_image_new_from_surface(img.get());
 
-    gtk_box_pack_start(GTK_BOX(get("pagePreviewImage")), preview, false, true, 0);
+    gtk_box_pack_start(GTK_BOX(builder.get("pagePreviewImage")), preview, false, true, 0);
     gtk_widget_show(preview);
 
     gtk_box_pack_start(GTK_BOX(vbox), callib, false, true, 0);
     gtk_widget_show(callib);
 
-    initLanguageSettings();
-    initMouseButtonEvents();
+    initMouseButtonEvents(gladeSearchPath);
 
     vector<InputDevice> deviceList = DeviceListHelper::getDeviceList(this->settings);
-    GtkWidget* container = get("hboxInputDeviceClasses");
+    GtkWidget* container = builder.get("hboxInputDeviceClasses");
     for (const InputDevice& inputDevice: deviceList) {
         // Only add real devices (core pointers have vendor and product id nullptr)
-        this->deviceClassConfigs.emplace_back(
-                std::make_unique<DeviceClassConfigGui>(getGladeSearchPath(), container, settings, inputDevice));
+        this->deviceClassConfigs.emplace_back(gladeSearchPath, container, settings, inputDevice);
     }
     if (deviceList.empty()) {
         GtkWidget* label = gtk_label_new("");
@@ -191,29 +176,22 @@ SettingsDialog::SettingsDialog(GladeSearchpath* gladeSearchPath, Settings* setti
         gtk_widget_show(label);
     }
 
-    gtk_container_add(GTK_CONTAINER(this->get("latexTabBox")), this->latexPanel.get("latexSettingsPanel"));
+    gtk_container_add(GTK_CONTAINER(builder.get("latexTabBox")), this->latexPanel.get("latexSettingsPanel"));
 }
 
-SettingsDialog::~SettingsDialog() = default;
+void SettingsDialog::initMouseButtonEvents(GladeSearchpath* gladeSearchPath) {
+    auto emplaceButton = [gladeSearchPath, &btns = buttonConfigs, settings = settings, &bld = builder](
+                                 const char* hbox, Button button, bool withDevice = false) {
+        btns.emplace_back(gladeSearchPath, bld.get(hbox), settings, button, withDevice);
+    };
 
-void SettingsDialog::initLanguageSettings() {
-    languageConfig = std::make_unique<LanguageConfigGui>(getGladeSearchPath(), get("hboxLanguageSelect"), settings);
-}
-
-void SettingsDialog::initMouseButtonEvents(const char* hbox, int button, bool withDevice) {
-    this->buttonConfigs.emplace_back(
-            std::make_unique<ButtonConfigGui>(getGladeSearchPath(), get(hbox), settings, button, withDevice));
-}
-
-void SettingsDialog::initMouseButtonEvents() {
-    initMouseButtonEvents("hboxMidleMouse", BUTTON_MOUSE_MIDDLE);
-    initMouseButtonEvents("hboxRightMouse", BUTTON_MOUSE_RIGHT);
-    initMouseButtonEvents("hboxEraser", BUTTON_ERASER);
-    initMouseButtonEvents("hboxTouch", BUTTON_TOUCH, true);
-    initMouseButtonEvents("hboxPenButton1", BUTTON_STYLUS_ONE);
-    initMouseButtonEvents("hboxPenButton2", BUTTON_STYLUS_TWO);
-
-    initMouseButtonEvents("hboxDefaultTool", BUTTON_DEFAULT);
+    emplaceButton("hboxMiddleMouse", BUTTON_MOUSE_MIDDLE);
+    emplaceButton("hboxRightMouse", BUTTON_MOUSE_RIGHT);
+    emplaceButton("hboxEraser", BUTTON_ERASER);
+    emplaceButton("hboxTouch", BUTTON_TOUCH, true);
+    emplaceButton("hboxPenButton1", BUTTON_STYLUS_ONE);
+    emplaceButton("hboxPenButton2", BUTTON_STYLUS_TWO);
+    emplaceButton("hboxDefaultTool", BUTTON_DEFAULT);
 }
 
 void SettingsDialog::setDpi(int dpi) {
@@ -249,39 +227,39 @@ void SettingsDialog::show(GtkWindow* parent) {
             } else if (workarea.height > 620) {
                 h = 600;
             }
-            gtk_window_set_default_size(GTK_WINDOW(this->window), w, h);
+            gtk_window_set_default_size(this->window.get(), w, h);
         } else {
             g_message("Parent window does not have a GDK Window. This is unexpected.");
         }
     }
 
-    gtk_window_set_transient_for(GTK_WINDOW(this->window), parent);
-    int res = gtk_dialog_run(GTK_DIALOG(this->window));
+    gtk_window_set_transient_for(this->window.get(), parent);
+    int res = gtk_dialog_run(GTK_DIALOG(this->window.get()));
 
     if (res == 1) {
         this->save();
     }
 
-    gtk_widget_hide(this->window);
+    gtk_widget_hide(GTK_WIDGET(this->window.get()));
 }
 
-void SettingsDialog::loadCheckbox(const char* name, gboolean value) {
-    GtkToggleButton* b = GTK_TOGGLE_BUTTON(get(name));
+void SettingsDialog::loadCheckbox(const char* name, bool value) {
+    GtkToggleButton* b = GTK_TOGGLE_BUTTON(builder.get(name));
     gtk_toggle_button_set_active(b, value);
 }
 
 auto SettingsDialog::getCheckbox(const char* name) -> bool {
-    GtkToggleButton* b = GTK_TOGGLE_BUTTON(get(name));
+    GtkToggleButton* b = GTK_TOGGLE_BUTTON(builder.get(name));
     return gtk_toggle_button_get_active(b);
 }
 
 void SettingsDialog::loadSlider(const char* name, double value) {
-    GtkRange* range = GTK_RANGE(get(name));
+    GtkRange* range = GTK_RANGE(builder.get(name));
     gtk_range_set_value(range, value);
 }
 
 auto SettingsDialog::getSlider(const char* name) -> double {
-    GtkRange* range = GTK_RANGE(get(name));
+    GtkRange* range = GTK_RANGE(builder.get(name));
     return gtk_range_get_value(range);
 }
 
@@ -289,23 +267,23 @@ auto SettingsDialog::getSlider(const char* name) -> double {
  * Checkbox was toggled, enable / disable it
  */
 void SettingsDialog::enableWithCheckbox(const string& checkboxId, const string& widgetId) {
-    GtkWidget* checkboxWidget = get(checkboxId);
+    GtkWidget* checkboxWidget = builder.get(checkboxId);
     bool const enabled = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(checkboxWidget));
-    gtk_widget_set_sensitive(get(widgetId), enabled);
+    gtk_widget_set_sensitive(builder.get(widgetId), enabled);
 }
 
 void SettingsDialog::disableWithCheckbox(const string& checkboxId, const string& widgetId) {
-    GtkWidget* checkboxWidget = get(checkboxId);
+    GtkWidget* checkboxWidget = builder.get(checkboxId);
     bool const enabled = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(checkboxWidget));
-    gtk_widget_set_sensitive(get(widgetId), !enabled);
+    gtk_widget_set_sensitive(builder.get(widgetId), !enabled);
 }
 
 /**
  * similar to enableWithCheckbox, but also disables widget if the checkbox is disabled
  */
 void SettingsDialog::enableWithEnabledCheckbox(const string& checkboxId, const string& widgetId) {
-    GtkWidget* checkboxWidget = get(checkboxId);
-    GtkWidget* widget = get(widgetId);
+    GtkWidget* checkboxWidget = builder.get(checkboxId);
+    GtkWidget* widget = builder.get(widgetId);
     bool const disabled = !gtk_widget_get_sensitive(checkboxWidget);
     if (disabled) {
         gtk_widget_set_sensitive(widget, false);
@@ -316,7 +294,7 @@ void SettingsDialog::enableWithEnabledCheckbox(const string& checkboxId, const s
 }
 
 void SettingsDialog::updatePressureSensitivityOptions() {
-    GtkWidget* sensitivityOptionsFrame = get("framePressureSensitivityScale");
+    GtkWidget* sensitivityOptionsFrame = builder.get("framePressureSensitivityScale");
     bool havePressureInput = getCheckbox("cbSettingPresureSensitivity") || getCheckbox("cbEnablePressureInference");
 
     if (!havePressureInput) {
@@ -332,50 +310,51 @@ void SettingsDialog::updatePressureSensitivityOptions() {
 }
 
 void SettingsDialog::customHandRecognitionToggled() {
-    GtkWidget* cbTouchDisableMethod = get("cbTouchDisableMethod");
+    GtkWidget* cbTouchDisableMethod = builder.get("cbTouchDisableMethod");
     int touchMethod = gtk_combo_box_get_active(GTK_COMBO_BOX(cbTouchDisableMethod));
-    gtk_widget_set_sensitive(get("boxCustomTouchDisableSettings"), touchMethod == 2);
+    gtk_widget_set_sensitive(builder.get("boxCustomTouchDisableSettings"), touchMethod == 2);
 }
 
 void SettingsDialog::customStylusIconTypeChanged() {
-    GtkWidget* cbStylusCursorType = get("cbStylusCursorType");
+    GtkWidget* cbStylusCursorType = builder.get("cbStylusCursorType");
     int stylusCursorType = gtk_combo_box_get_active(GTK_COMBO_BOX(cbStylusCursorType));
     bool showCursorHighlightOptions =
             (stylusCursorType != STYLUS_CURSOR_NONE && stylusCursorType != STYLUS_CURSOR_ARROW);
-    gtk_widget_set_sensitive(get("highlightCursorGrid"), showCursorHighlightOptions);
+    gtk_widget_set_sensitive(builder.get("highlightCursorGrid"), showCursorHighlightOptions);
 }
 
 void SettingsDialog::showStabilizerAvMethodOptions(StrokeStabilizer::AveragingMethod method) {
     bool showArithmetic = method == StrokeStabilizer::AveragingMethod::ARITHMETIC;
-    gtk_widget_set_visible(get("lbStabilizerBuffersize"), showArithmetic);
-    gtk_widget_set_visible(get("sbStabilizerBuffersize"), showArithmetic);
+    gtk_widget_set_visible(builder.get("lbStabilizerBuffersize"), showArithmetic);
+    gtk_widget_set_visible(builder.get("sbStabilizerBuffersize"), showArithmetic);
 
     bool showSigma = method == StrokeStabilizer::AveragingMethod::VELOCITY_GAUSSIAN;
-    gtk_widget_set_visible(get("lbStabilizerSigma"), showSigma);
-    gtk_widget_set_visible(get("sbStabilizerSigma"), showSigma);
+    gtk_widget_set_visible(builder.get("lbStabilizerSigma"), showSigma);
+    gtk_widget_set_visible(builder.get("sbStabilizerSigma"), showSigma);
 
     bool preprocessorOn = static_cast<StrokeStabilizer::Preprocessor>(gtk_combo_box_get_active(GTK_COMBO_BOX(
-                                  get("cbStabilizerPreprocessors")))) != StrokeStabilizer::Preprocessor::NONE;
+                                  builder.get("cbStabilizerPreprocessors")))) != StrokeStabilizer::Preprocessor::NONE;
     bool sensitive = showSigma || showArithmetic || preprocessorOn;
-    gtk_widget_set_sensitive(get("cbStabilizerEnableFinalizeStroke"), sensitive);
+    gtk_widget_set_sensitive(builder.get("cbStabilizerEnableFinalizeStroke"), sensitive);
 }
 
 void SettingsDialog::showStabilizerPreprocessorOptions(StrokeStabilizer::Preprocessor preprocessor) {
     bool showDeadzone = preprocessor == StrokeStabilizer::Preprocessor::DEADZONE;
-    gtk_widget_set_visible(get("lbStabilizerDeadzoneRadius"), showDeadzone);
-    gtk_widget_set_visible(get("sbStabilizerDeadzoneRadius"), showDeadzone);
-    gtk_widget_set_visible(get("cbStabilizerEnableCuspDetection"), showDeadzone);
+    gtk_widget_set_visible(builder.get("lbStabilizerDeadzoneRadius"), showDeadzone);
+    gtk_widget_set_visible(builder.get("sbStabilizerDeadzoneRadius"), showDeadzone);
+    gtk_widget_set_visible(builder.get("cbStabilizerEnableCuspDetection"), showDeadzone);
 
     bool showInertia = preprocessor == StrokeStabilizer::Preprocessor::INERTIA;
-    gtk_widget_set_visible(get("lbStabilizerDrag"), showInertia);
-    gtk_widget_set_visible(get("sbStabilizerDrag"), showInertia);
-    gtk_widget_set_visible(get("lbStabilizerMass"), showInertia);
-    gtk_widget_set_visible(get("sbStabilizerMass"), showInertia);
+    gtk_widget_set_visible(builder.get("lbStabilizerDrag"), showInertia);
+    gtk_widget_set_visible(builder.get("sbStabilizerDrag"), showInertia);
+    gtk_widget_set_visible(builder.get("lbStabilizerMass"), showInertia);
+    gtk_widget_set_visible(builder.get("sbStabilizerMass"), showInertia);
 
-    bool averagingOn = static_cast<StrokeStabilizer::AveragingMethod>(gtk_combo_box_get_active(GTK_COMBO_BOX(
-                               get("cbStabilizerAveragingMethods")))) != StrokeStabilizer::AveragingMethod::NONE;
+    bool averagingOn = static_cast<StrokeStabilizer::AveragingMethod>(
+                               gtk_combo_box_get_active(GTK_COMBO_BOX(builder.get("cbStabilizerAveragingMethods")))) !=
+                       StrokeStabilizer::AveragingMethod::NONE;
     bool sensitive = showDeadzone || showInertia || averagingOn;
-    gtk_widget_set_sensitive(get("cbStabilizerEnableFinalizeStroke"), sensitive);
+    gtk_widget_set_sensitive(builder.get("cbStabilizerEnableFinalizeStroke"), sensitive);
 }
 
 void SettingsDialog::load() {
@@ -414,49 +393,49 @@ void SettingsDialog::load() {
     loadCheckbox("cbStabilizerEnableCuspDetection", settings->getStabilizerCuspDetection());
     loadCheckbox("cbStabilizerEnableFinalizeStroke", settings->getStabilizerFinalizeStroke());
 
-    GtkWidget* sbStabilizerBuffersize = get("sbStabilizerBuffersize");
+    GtkWidget* sbStabilizerBuffersize = builder.get("sbStabilizerBuffersize");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(sbStabilizerBuffersize),
                               static_cast<double>(settings->getStabilizerBuffersize()));
-    GtkWidget* sbStabilizerDeadzoneRadius = get("sbStabilizerDeadzoneRadius");
+    GtkWidget* sbStabilizerDeadzoneRadius = builder.get("sbStabilizerDeadzoneRadius");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(sbStabilizerDeadzoneRadius), settings->getStabilizerDeadzoneRadius());
-    GtkWidget* sbStabilizerDrag = get("sbStabilizerDrag");
+    GtkWidget* sbStabilizerDrag = builder.get("sbStabilizerDrag");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(sbStabilizerDrag), settings->getStabilizerDrag());
-    GtkWidget* sbStabilizerMass = get("sbStabilizerMass");
+    GtkWidget* sbStabilizerMass = builder.get("sbStabilizerMass");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(sbStabilizerMass), settings->getStabilizerMass());
-    GtkWidget* sbStabilizerSigma = get("sbStabilizerSigma");
+    GtkWidget* sbStabilizerSigma = builder.get("sbStabilizerSigma");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(sbStabilizerSigma), settings->getStabilizerSigma());
 
-    GtkComboBox* cbStabilizerAveragingMethods = GTK_COMBO_BOX(get("cbStabilizerAveragingMethods"));
+    GtkComboBox* cbStabilizerAveragingMethods = GTK_COMBO_BOX(builder.get("cbStabilizerAveragingMethods"));
     gtk_combo_box_set_active(cbStabilizerAveragingMethods, static_cast<int>(settings->getStabilizerAveragingMethod()));
     showStabilizerAvMethodOptions(settings->getStabilizerAveragingMethod());
-    GtkComboBox* cbStabilizerPreprocessors = GTK_COMBO_BOX(get("cbStabilizerPreprocessors"));
+    GtkComboBox* cbStabilizerPreprocessors = GTK_COMBO_BOX(builder.get("cbStabilizerPreprocessors"));
     gtk_combo_box_set_active(cbStabilizerPreprocessors, static_cast<int>(settings->getStabilizerPreprocessor()));
     showStabilizerPreprocessorOptions(settings->getStabilizerPreprocessor());
     /***********/
 
-    GtkComboBox* cbSidebarNumberingStyle = GTK_COMBO_BOX(get("cbSidebarPageNumberStyle"));
+    GtkComboBox* cbSidebarNumberingStyle = GTK_COMBO_BOX(builder.get("cbSidebarPageNumberStyle"));
     gtk_combo_box_set_active(cbSidebarNumberingStyle, static_cast<int>(settings->getSidebarNumberingStyle()));
 
-    GtkWidget* txtDefaultSaveName = get("txtDefaultSaveName");
+    GtkWidget* txtDefaultSaveName = builder.get("txtDefaultSaveName");
     gtk_entry_set_text(GTK_ENTRY(txtDefaultSaveName), settings->getDefaultSaveName().c_str());
 
-    GtkWidget* txtDefaultPdfName = get("txtDefaultPdfName");
+    GtkWidget* txtDefaultPdfName = builder.get("txtDefaultPdfName");
     gtk_entry_set_text(GTK_ENTRY(txtDefaultPdfName), settings->getDefaultPdfExportName().c_str());
 
-    gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(get("fcAudioPath")),
+    gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(builder.get("fcAudioPath")),
                                         Util::toGFilename(settings->getAudioFolder()).c_str());
 
-    GtkWidget* spAutosaveTimeout = get("spAutosaveTimeout");
+    GtkWidget* spAutosaveTimeout = builder.get("spAutosaveTimeout");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spAutosaveTimeout), settings->getAutosaveTimeout());
 
-    GtkWidget* spNumIgnoredStylusEvents = get("spNumIgnoredStylusEvents");
+    GtkWidget* spNumIgnoredStylusEvents = builder.get("spNumIgnoredStylusEvents");
     if (!ignoreStylusEventsEnabled) {  // The spinButton's value should be >= 1
         gtk_spin_button_set_value(GTK_SPIN_BUTTON(spNumIgnoredStylusEvents), 1);
     } else {
         gtk_spin_button_set_value(GTK_SPIN_BUTTON(spNumIgnoredStylusEvents), settings->getIgnoredStylusEvents());
     }
 
-    GtkWidget* spPairsOffset = get("spPairsOffset");
+    GtkWidget* spPairsOffset = builder.get("spPairsOffset");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spPairsOffset), settings->getPairsOffset());
 
     EmptyLastPageAppendType append = settings->getEmptyLastPageAppend();
@@ -464,46 +443,46 @@ void SettingsDialog::load() {
     loadCheckbox("rdLastPageAppendOnScrollToEndOfLastPage", append == EmptyLastPageAppendType::OnScrollToEndOfLastPage);
     loadCheckbox("rdLastPageAppendDisabled", append == EmptyLastPageAppendType::Disabled);
 
-    GtkWidget* spSnapRotationTolerance = get("spSnapRotationTolerance");
+    GtkWidget* spSnapRotationTolerance = builder.get("spSnapRotationTolerance");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spSnapRotationTolerance), settings->getSnapRotationTolerance());
 
-    GtkWidget* spSnapGridTolerance = get("spSnapGridTolerance");
+    GtkWidget* spSnapGridTolerance = builder.get("spSnapGridTolerance");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spSnapGridTolerance), settings->getSnapGridTolerance());
 
-    GtkWidget* spSnapGridSize = get("spSnapGridSize");
+    GtkWidget* spSnapGridSize = builder.get("spSnapGridSize");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spSnapGridSize), settings->getSnapGridSize() / DEFAULT_GRID_SIZE);
 
-    GtkWidget* spStrokeRecognizerMinSize = get("spStrokeRecognizerMinSize");
+    GtkWidget* spStrokeRecognizerMinSize = builder.get("spStrokeRecognizerMinSize");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spStrokeRecognizerMinSize), settings->getStrokeRecognizerMinSize());
 
-    gtk_spin_button_set_value(GTK_SPIN_BUTTON(get("edgePanSpeed")), settings->getEdgePanSpeed());
-    gtk_spin_button_set_value(GTK_SPIN_BUTTON(get("edgePanMaxMult")), settings->getEdgePanMaxMult());
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(builder.get("edgePanSpeed")), settings->getEdgePanSpeed());
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(builder.get("edgePanMaxMult")), settings->getEdgePanMaxMult());
 
-    GtkWidget* spZoomStep = get("spZoomStep");
+    GtkWidget* spZoomStep = builder.get("spZoomStep");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spZoomStep), settings->getZoomStep());
 
-    GtkWidget* spZoomStepScroll = get("spZoomStepScroll");
+    GtkWidget* spZoomStepScroll = builder.get("spZoomStepScroll");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spZoomStepScroll), settings->getZoomStepScroll());
 
-    GtkWidget* spAddHorizontalSpaceRight = get("spAddHorizontalSpaceRight");
+    GtkWidget* spAddHorizontalSpaceRight = builder.get("spAddHorizontalSpaceRight");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spAddHorizontalSpaceRight), settings->getAddHorizontalSpaceAmountRight());
 
-    GtkWidget* spAddVerticalSpaceAbove = get("spAddVerticalSpaceAbove");
+    GtkWidget* spAddVerticalSpaceAbove = builder.get("spAddVerticalSpaceAbove");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spAddVerticalSpaceAbove), settings->getAddVerticalSpaceAmountAbove());
 
-    GtkWidget* spAddHorizontalSpaceLeft = get("spAddHorizontalSpaceLeft");
+    GtkWidget* spAddHorizontalSpaceLeft = builder.get("spAddHorizontalSpaceLeft");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spAddHorizontalSpaceLeft), settings->getAddHorizontalSpaceAmountLeft());
 
-    GtkWidget* spAddVerticalSpaceBelow = get("spAddVerticalSpaceBelow");
+    GtkWidget* spAddVerticalSpaceBelow = builder.get("spAddVerticalSpaceBelow");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spAddVerticalSpaceBelow), settings->getAddVerticalSpaceAmountBelow());
 
-    GtkWidget* spDrawDirModsRadius = get("spDrawDirModsRadius");
+    GtkWidget* spDrawDirModsRadius = builder.get("spDrawDirModsRadius");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spDrawDirModsRadius), settings->getDrawDirModsRadius());
 
-    GtkWidget* spReRenderThreshold = get("spReRenderThreshold");
+    GtkWidget* spReRenderThreshold = builder.get("spReRenderThreshold");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spReRenderThreshold), settings->getPDFPageRerenderThreshold());
 
-    GtkWidget* spTouchZoomStartThreshold = get("spTouchZoomStartThreshold");
+    GtkWidget* spTouchZoomStartThreshold = builder.get("spTouchZoomStartThreshold");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spTouchZoomStartThreshold), settings->getTouchZoomStartThreshold());
 
     {
@@ -512,11 +491,11 @@ void SettingsDialog::load() {
         int successive = 0;
         settings->getStrokeFilter(&time, &length, &successive);
 
-        GtkWidget* spStrokeIgnoreTime = get("spStrokeIgnoreTime");
+        GtkWidget* spStrokeIgnoreTime = builder.get("spStrokeIgnoreTime");
         gtk_spin_button_set_value(GTK_SPIN_BUTTON(spStrokeIgnoreTime), time);
-        GtkWidget* spStrokeIgnoreLength = get("spStrokeIgnoreLength");
+        GtkWidget* spStrokeIgnoreLength = builder.get("spStrokeIgnoreLength");
         gtk_spin_button_set_value(GTK_SPIN_BUTTON(spStrokeIgnoreLength), length);
-        GtkWidget* spStrokeSuccessiveTime = get("spStrokeSuccessiveTime");
+        GtkWidget* spStrokeSuccessiveTime = builder.get("spStrokeSuccessiveTime");
         gtk_spin_button_set_value(GTK_SPIN_BUTTON(spStrokeSuccessiveTime), successive);
     }
 
@@ -526,62 +505,63 @@ void SettingsDialog::load() {
     loadSlider("scalePressureMultiplier", settings->getPressureMultiplier());
 
     GdkRGBA color = Util::rgb_to_GdkRGBA(settings->getBorderColor());
-    gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(get("colorBorder")), &color);
+    gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(builder.get("colorBorder")), &color);
     color = Util::rgb_to_GdkRGBA(settings->getBackgroundColor());
-    gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(get("colorBackground")), &color);
+    gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(builder.get("colorBackground")), &color);
     color = Util::rgb_to_GdkRGBA(settings->getSelectionColor());
-    gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(get("colorSelection")), &color);
+    gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(builder.get("colorSelection")), &color);
     color = Util::rgb_to_GdkRGBA(settings->getActiveSelectionColor());
-    gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(get("colorSelectionActive")), &color);
+    gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(builder.get("colorSelectionActive")), &color);
 
     loadCheckbox("cbHighlightPosition", settings->isHighlightPosition());
     color = Util::argb_to_GdkRGBA(settings->getCursorHighlightColor());
-    gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(get("cursorHighlightColor")), &color);
+    gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(builder.get("cursorHighlightColor")), &color);
     color = Util::argb_to_GdkRGBA(settings->getCursorHighlightBorderColor());
-    gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(get("cursorHighlightBorderColor")), &color);
-    gtk_spin_button_set_value(GTK_SPIN_BUTTON(get("cursorHighlightRadius")), settings->getCursorHighlightRadius());
-    gtk_spin_button_set_value(GTK_SPIN_BUTTON(get("cursorHighlightBorderWidth")),
+    gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(builder.get("cursorHighlightBorderColor")), &color);
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(builder.get("cursorHighlightRadius")),
+                              settings->getCursorHighlightRadius());
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(builder.get("cursorHighlightBorderWidth")),
                               settings->getCursorHighlightBorderWidth());
 
     switch (settings->getStylusCursorType()) {
         case STYLUS_CURSOR_NONE:
-            gtk_combo_box_set_active(GTK_COMBO_BOX(get("cbStylusCursorType")), 0);
+            gtk_combo_box_set_active(GTK_COMBO_BOX(builder.get("cbStylusCursorType")), 0);
             break;
         case STYLUS_CURSOR_BIG:
-            gtk_combo_box_set_active(GTK_COMBO_BOX(get("cbStylusCursorType")), 2);
+            gtk_combo_box_set_active(GTK_COMBO_BOX(builder.get("cbStylusCursorType")), 2);
             break;
         case STYLUS_CURSOR_ARROW:
-            gtk_combo_box_set_active(GTK_COMBO_BOX(get("cbStylusCursorType")), 3);
+            gtk_combo_box_set_active(GTK_COMBO_BOX(builder.get("cbStylusCursorType")), 3);
             break;
         case STYLUS_CURSOR_DOT:
         default:
-            gtk_combo_box_set_active(GTK_COMBO_BOX(get("cbStylusCursorType")), 1);
+            gtk_combo_box_set_active(GTK_COMBO_BOX(builder.get("cbStylusCursorType")), 1);
             break;
     }
 
     switch (settings->getEraserVisibility()) {
         case ERASER_VISIBILITY_NEVER:
-            gtk_combo_box_set_active(GTK_COMBO_BOX(get("cbEraserVisibility")), 0);
+            gtk_combo_box_set_active(GTK_COMBO_BOX(builder.get("cbEraserVisibility")), 0);
             break;
         case ERASER_VISIBILITY_HOVER:
-            gtk_combo_box_set_active(GTK_COMBO_BOX(get("cbEraserVisibility")), 2);
+            gtk_combo_box_set_active(GTK_COMBO_BOX(builder.get("cbEraserVisibility")), 2);
             break;
         case ERASER_VISIBILITY_TOUCH:
-            gtk_combo_box_set_active(GTK_COMBO_BOX(get("cbEraserVisibility")), 3);
+            gtk_combo_box_set_active(GTK_COMBO_BOX(builder.get("cbEraserVisibility")), 3);
             break;
         case ERASER_VISIBILITY_ALWAYS:
         default:
-            gtk_combo_box_set_active(GTK_COMBO_BOX(get("cbEraserVisibility")), 1);
+            gtk_combo_box_set_active(GTK_COMBO_BOX(builder.get("cbEraserVisibility")), 1);
             break;
     }
 
     switch (settings->getIconTheme()) {
         case ICON_THEME_LUCIDE:
-            gtk_combo_box_set_active(GTK_COMBO_BOX(get("cbIconTheme")), 1);
+            gtk_combo_box_set_active(GTK_COMBO_BOX(builder.get("cbIconTheme")), 1);
             break;
         case ICON_THEME_COLOR:
         default:
-            gtk_combo_box_set_active(GTK_COMBO_BOX(get("cbIconTheme")), 0);
+            gtk_combo_box_set_active(GTK_COMBO_BOX(builder.get("cbIconTheme")), 0);
             break;
     }
 
@@ -606,9 +586,9 @@ void SettingsDialog::load() {
     loadCheckbox("cbShowFilepathInTitlebar", settings->isFilepathInTitlebarShown());
     loadCheckbox("cbShowPageNumberInTitlebar", settings->isPageNumberInTitlebarShown());
 
-    gtk_spin_button_set_value(GTK_SPIN_BUTTON(get("preloadPagesBefore")),
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(builder.get("preloadPagesBefore")),
                               static_cast<double>(settings->getPreloadPagesBefore()));
-    gtk_spin_button_set_value(GTK_SPIN_BUTTON(get("preloadPagesAfter")),
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(builder.get("preloadPagesAfter")),
                               static_cast<double>(settings->getPreloadPagesAfter()));
     loadCheckbox("cbEagerPageCleanup", settings->isEagerPageCleanup());
 
@@ -648,64 +628,64 @@ void SettingsDialog::load() {
         methodId = 2;
     }
 
-    gtk_combo_box_set_active(GTK_COMBO_BOX(get("cbTouchDisableMethod")), methodId);
+    gtk_combo_box_set_active(GTK_COMBO_BOX(builder.get("cbTouchDisableMethod")), methodId);
 
     string cmd;
     touch.getString("cmdEnable", cmd);
-    gtk_entry_set_text(GTK_ENTRY(get("txtEnableTouchCommand")), cmd.c_str());
+    gtk_entry_set_text(GTK_ENTRY(builder.get("txtEnableTouchCommand")), cmd.c_str());
 
     cmd = "";
     touch.getString("cmdDisable", cmd);
-    gtk_entry_set_text(GTK_ENTRY(get("txtDisableTouchCommand")), cmd.c_str());
+    gtk_entry_set_text(GTK_ENTRY(builder.get("txtDisableTouchCommand")), cmd.c_str());
 
     int timeoutMs = 1000;
     touch.getInt("timeout", timeoutMs);
-    gtk_spin_button_set_value(GTK_SPIN_BUTTON(get("spTouchDisableTimeout")), timeoutMs / 1000.0);
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(builder.get("spTouchDisableTimeout")), timeoutMs / 1000.0);
 
     this->audioInputDevices = this->control->getAudioController()->getInputDevices();
-    gtk_combo_box_text_append(GTK_COMBO_BOX_TEXT(get("cbAudioInputDevice")), "", "System default");
-    gtk_combo_box_set_active(GTK_COMBO_BOX(get("cbAudioInputDevice")), 0);
+    gtk_combo_box_text_append(GTK_COMBO_BOX_TEXT(builder.get("cbAudioInputDevice")), "", "System default");
+    gtk_combo_box_set_active(GTK_COMBO_BOX(builder.get("cbAudioInputDevice")), 0);
     for (auto& audioInputDevice: this->audioInputDevices) {
-        gtk_combo_box_text_append(GTK_COMBO_BOX_TEXT(get("cbAudioInputDevice")), "",
+        gtk_combo_box_text_append(GTK_COMBO_BOX_TEXT(builder.get("cbAudioInputDevice")), "",
                                   audioInputDevice.getDeviceName().c_str());
     }
     for (size_t i = 0; i < this->audioInputDevices.size(); i++) {
         if (this->audioInputDevices[i].getSelected()) {
-            gtk_combo_box_set_active(GTK_COMBO_BOX(get("cbAudioInputDevice")), static_cast<gint>(i + 1));
+            gtk_combo_box_set_active(GTK_COMBO_BOX(builder.get("cbAudioInputDevice")), static_cast<gint>(i + 1));
         }
     }
 
     this->audioOutputDevices = this->control->getAudioController()->getOutputDevices();
-    gtk_combo_box_text_append(GTK_COMBO_BOX_TEXT(get("cbAudioOutputDevice")), "", "System default");
-    gtk_combo_box_set_active(GTK_COMBO_BOX(get("cbAudioOutputDevice")), 0);
+    gtk_combo_box_text_append(GTK_COMBO_BOX_TEXT(builder.get("cbAudioOutputDevice")), "", "System default");
+    gtk_combo_box_set_active(GTK_COMBO_BOX(builder.get("cbAudioOutputDevice")), 0);
     for (auto& audioOutputDevice: this->audioOutputDevices) {
-        gtk_combo_box_text_append(GTK_COMBO_BOX_TEXT(get("cbAudioOutputDevice")), "",
+        gtk_combo_box_text_append(GTK_COMBO_BOX_TEXT(builder.get("cbAudioOutputDevice")), "",
                                   audioOutputDevice.getDeviceName().c_str());
     }
     for (size_t i = 0; i < this->audioOutputDevices.size(); i++) {
         if (this->audioOutputDevices[i].getSelected()) {
-            gtk_combo_box_set_active(GTK_COMBO_BOX(get("cbAudioOutputDevice")), static_cast<gint>(i + 1));
+            gtk_combo_box_set_active(GTK_COMBO_BOX(builder.get("cbAudioOutputDevice")), static_cast<gint>(i + 1));
         }
     }
 
     switch (static_cast<int>(settings->getAudioSampleRate())) {
         case 16000:
-            gtk_combo_box_set_active(GTK_COMBO_BOX(get("cbAudioSampleRate")), 0);
+            gtk_combo_box_set_active(GTK_COMBO_BOX(builder.get("cbAudioSampleRate")), 0);
             break;
         case 96000:
-            gtk_combo_box_set_active(GTK_COMBO_BOX(get("cbAudioSampleRate")), 2);
+            gtk_combo_box_set_active(GTK_COMBO_BOX(builder.get("cbAudioSampleRate")), 2);
             break;
         case 192000:
-            gtk_combo_box_set_active(GTK_COMBO_BOX(get("cbAudioSampleRate")), 3);
+            gtk_combo_box_set_active(GTK_COMBO_BOX(builder.get("cbAudioSampleRate")), 3);
             break;
         case 44100:
         default:
-            gtk_combo_box_set_active(GTK_COMBO_BOX(get("cbAudioSampleRate")), 1);
+            gtk_combo_box_set_active(GTK_COMBO_BOX(builder.get("cbAudioSampleRate")), 1);
             break;
     }
 
-    gtk_spin_button_set_value(GTK_SPIN_BUTTON(get("spAudioGain")), settings->getAudioGain());
-    gtk_spin_button_set_value(GTK_SPIN_BUTTON(get("spDefaultSeekTime")), settings->getDefaultSeekTime());
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(builder.get("spAudioGain")), settings->getAudioGain());
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(builder.get("spDefaultSeekTime")), settings->getDefaultSeekTime());
 
     this->latexPanel.load(settings->latexSettings);
 }
@@ -741,21 +721,21 @@ void SettingsDialog::save() {
     settings->setScrollbarFadeoutDisabled(getCheckbox("cbDisableScrollbarFadeout"));
 
     settings->setStabilizerAveragingMethod(static_cast<StrokeStabilizer::AveragingMethod>(
-            gtk_combo_box_get_active(GTK_COMBO_BOX(get("cbStabilizerAveragingMethods")))));
+            gtk_combo_box_get_active(GTK_COMBO_BOX(builder.get("cbStabilizerAveragingMethods")))));
     settings->setStabilizerPreprocessor(static_cast<StrokeStabilizer::Preprocessor>(
-            gtk_combo_box_get_active(GTK_COMBO_BOX(get("cbStabilizerPreprocessors")))));
-    settings->setStabilizerBuffersize(
-            static_cast<size_t>(gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(get("sbStabilizerBuffersize")))));
+            gtk_combo_box_get_active(GTK_COMBO_BOX(builder.get("cbStabilizerPreprocessors")))));
+    settings->setStabilizerBuffersize(static_cast<size_t>(
+            gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(builder.get("sbStabilizerBuffersize")))));
     settings->setStabilizerDeadzoneRadius(
-            gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("sbStabilizerDeadzoneRadius"))));
-    settings->setStabilizerDrag(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("sbStabilizerDrag"))));
-    settings->setStabilizerMass(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("sbStabilizerMass"))));
-    settings->setStabilizerSigma(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("sbStabilizerSigma"))));
+            gtk_spin_button_get_value(GTK_SPIN_BUTTON(builder.get("sbStabilizerDeadzoneRadius"))));
+    settings->setStabilizerDrag(gtk_spin_button_get_value(GTK_SPIN_BUTTON(builder.get("sbStabilizerDrag"))));
+    settings->setStabilizerMass(gtk_spin_button_get_value(GTK_SPIN_BUTTON(builder.get("sbStabilizerMass"))));
+    settings->setStabilizerSigma(gtk_spin_button_get_value(GTK_SPIN_BUTTON(builder.get("sbStabilizerSigma"))));
     settings->setStabilizerCuspDetection(getCheckbox("cbStabilizerEnableCuspDetection"));
     settings->setStabilizerFinalizeStroke(getCheckbox("cbStabilizerEnableFinalizeStroke"));
 
     settings->setSidebarNumberingStyle(static_cast<SidebarNumberingStyle>(
-            gtk_combo_box_get_active(GTK_COMBO_BOX(get("cbSidebarPageNumberStyle")))));
+            gtk_combo_box_get_active(GTK_COMBO_BOX(builder.get("cbSidebarPageNumberStyle")))));
 
     auto scrollbarHideType =
             static_cast<std::make_unsigned<std::underlying_type<ScrollbarHideType>::type>::type>(SCROLLBAR_HIDE_NONE);
@@ -768,29 +748,29 @@ void SettingsDialog::save() {
     settings->setScrollbarHideType(static_cast<ScrollbarHideType>(scrollbarHideType));
 
     GdkRGBA color;
-    gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(get("colorBorder")), &color);
+    gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(builder.get("colorBorder")), &color);
     settings->setBorderColor(Util::GdkRGBA_to_argb(color));
 
-    gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(get("colorBackground")), &color);
+    gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(builder.get("colorBackground")), &color);
     settings->setBackgroundColor(Util::GdkRGBA_to_argb(color));
 
-    gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(get("colorSelection")), &color);
+    gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(builder.get("colorSelection")), &color);
     settings->setSelectionColor(Util::GdkRGBA_to_argb(color));
 
-    gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(get("colorSelectionActive")), &color);
+    gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(builder.get("colorSelectionActive")), &color);
     settings->setActiveSelectionColor(Util::GdkRGBA_to_argb(color));
 
     settings->setHighlightPosition(getCheckbox("cbHighlightPosition"));
-    gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(get("cursorHighlightColor")), &color);
+    gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(builder.get("cursorHighlightColor")), &color);
     settings->setCursorHighlightColor(Util::GdkRGBA_to_argb(color));
-    gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(get("cursorHighlightBorderColor")), &color);
+    gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(builder.get("cursorHighlightBorderColor")), &color);
     settings->setCursorHighlightBorderColor(Util::GdkRGBA_to_argb(color));
-    GtkWidget* spCursorHighlightRadius = get("cursorHighlightRadius");
+    GtkWidget* spCursorHighlightRadius = builder.get("cursorHighlightRadius");
     settings->setCursorHighlightRadius(gtk_spin_button_get_value(GTK_SPIN_BUTTON(spCursorHighlightRadius)));
-    GtkWidget* spCursorHighlightBorderWidth = get("cursorHighlightBorderWidth");
+    GtkWidget* spCursorHighlightBorderWidth = builder.get("cursorHighlightBorderWidth");
     settings->setCursorHighlightBorderWidth(gtk_spin_button_get_value(GTK_SPIN_BUTTON(spCursorHighlightBorderWidth)));
 
-    switch (gtk_combo_box_get_active(GTK_COMBO_BOX(get("cbStylusCursorType")))) {
+    switch (gtk_combo_box_get_active(GTK_COMBO_BOX(builder.get("cbStylusCursorType")))) {
         case 0:
             settings->setStylusCursorType(STYLUS_CURSOR_NONE);
             break;
@@ -806,7 +786,7 @@ void SettingsDialog::save() {
             break;
     }
 
-    switch (gtk_combo_box_get_active(GTK_COMBO_BOX(get("cbEraserVisibility")))) {
+    switch (gtk_combo_box_get_active(GTK_COMBO_BOX(builder.get("cbEraserVisibility")))) {
         case 0:
             settings->setEraserVisibility(ERASER_VISIBILITY_NEVER);
             break;
@@ -822,7 +802,7 @@ void SettingsDialog::save() {
             break;
     }
 
-    switch (gtk_combo_box_get_active(GTK_COMBO_BOX(get("cbIconTheme")))) {
+    switch (gtk_combo_box_get_active(GTK_COMBO_BOX(builder.get("cbIconTheme")))) {
         case 1:
             settings->setIconTheme(ICON_THEME_LUCIDE);
             break;
@@ -854,28 +834,28 @@ void SettingsDialog::save() {
         int v = gtk_spin_button_get_value_as_int(btn);
         return v < 0 ? 0U : static_cast<unsigned int>(v);
     };
-    unsigned int preloadPagesBefore = spinAsUint(GTK_SPIN_BUTTON(get("preloadPagesBefore")));
-    unsigned int preloadPagesAfter = spinAsUint(GTK_SPIN_BUTTON(get("preloadPagesAfter")));
+    unsigned int preloadPagesBefore = spinAsUint(GTK_SPIN_BUTTON(builder.get("preloadPagesBefore")));
+    unsigned int preloadPagesAfter = spinAsUint(GTK_SPIN_BUTTON(builder.get("preloadPagesAfter")));
     settings->setPreloadPagesAfter(preloadPagesAfter);
     settings->setPreloadPagesBefore(preloadPagesBefore);
     settings->setEagerPageCleanup(getCheckbox("cbEagerPageCleanup"));
 
-    settings->setDefaultSaveName(gtk_entry_get_text(GTK_ENTRY(get("txtDefaultSaveName"))));
-    settings->setDefaultPdfExportName(gtk_entry_get_text(GTK_ENTRY(get("txtDefaultPdfName"))));
+    settings->setDefaultSaveName(gtk_entry_get_text(GTK_ENTRY(builder.get("txtDefaultSaveName"))));
+    settings->setDefaultPdfExportName(gtk_entry_get_text(GTK_ENTRY(builder.get("txtDefaultPdfName"))));
     // Todo(fabian): use Util::fromGFilename!
-    auto file = gtk_file_chooser_get_file(GTK_FILE_CHOOSER(get("fcAudioPath")));
+    auto file = gtk_file_chooser_get_file(GTK_FILE_CHOOSER(builder.get("fcAudioPath")));
     auto path = Util::fromGFile(file);
     g_object_unref(file);
     if (fs::is_directory(path)) {
         settings->setAudioFolder(path);
     }
 
-    GtkWidget* spAutosaveTimeout = get("spAutosaveTimeout");
+    GtkWidget* spAutosaveTimeout = builder.get("spAutosaveTimeout");
     int autosaveTimeout = static_cast<int>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(spAutosaveTimeout)));
     settings->setAutosaveTimeout(autosaveTimeout);
 
     if (getCheckbox("cbIgnoreFirstStylusEvents")) {
-        GtkWidget* spNumIgnoredStylusEvents = get("spNumIgnoredStylusEvents");
+        GtkWidget* spNumIgnoredStylusEvents = builder.get("spNumIgnoredStylusEvents");
         int numIgnoredStylusEvents =
                 static_cast<int>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(spNumIgnoredStylusEvents)));
         settings->setIgnoredStylusEvents(numIgnoredStylusEvents);
@@ -883,7 +863,7 @@ void SettingsDialog::save() {
         settings->setIgnoredStylusEvents(0);  // This means nothing will be ignored
     }
 
-    GtkWidget* spPairsOffset = get("spPairsOffset");
+    GtkWidget* spPairsOffset = builder.get("spPairsOffset");
     int numPairsOffset = static_cast<int>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(spPairsOffset)));
     settings->setPairsOffset(numPairsOffset);
 
@@ -897,56 +877,56 @@ void SettingsDialog::save() {
         settings->setEmptyLastPageAppend(EmptyLastPageAppendType::Disabled);
     }
 
-    settings->setEdgePanSpeed(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("edgePanSpeed"))));
-    settings->setEdgePanMaxMult(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("edgePanMaxMult"))));
+    settings->setEdgePanSpeed(gtk_spin_button_get_value(GTK_SPIN_BUTTON(builder.get("edgePanSpeed"))));
+    settings->setEdgePanMaxMult(gtk_spin_button_get_value(GTK_SPIN_BUTTON(builder.get("edgePanMaxMult"))));
 
-    GtkWidget* spZoomStep = get("spZoomStep");
+    GtkWidget* spZoomStep = builder.get("spZoomStep");
     double zoomStep = gtk_spin_button_get_value(GTK_SPIN_BUTTON(spZoomStep));
     settings->setZoomStep(zoomStep);
 
-    GtkWidget* spZoomStepScroll = get("spZoomStepScroll");
+    GtkWidget* spZoomStepScroll = builder.get("spZoomStepScroll");
     double zoomStepScroll = gtk_spin_button_get_value(GTK_SPIN_BUTTON(spZoomStepScroll));
     settings->setZoomStepScroll(zoomStepScroll);
 
 
-    GtkWidget* spAddHorizontalSpaceRight = get("spAddHorizontalSpaceRight");
+    GtkWidget* spAddHorizontalSpaceRight = builder.get("spAddHorizontalSpaceRight");
     const int addHorizontalSpaceAmountRight =
             static_cast<int>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(spAddHorizontalSpaceRight)));
     settings->setAddHorizontalSpaceAmountRight(addHorizontalSpaceAmountRight);
 
-    GtkWidget* spAddVerticalSpaceAbove = get("spAddVerticalSpaceAbove");
+    GtkWidget* spAddVerticalSpaceAbove = builder.get("spAddVerticalSpaceAbove");
     const int addVerticalSpaceAmountAbove =
             static_cast<int>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(spAddVerticalSpaceAbove)));
     settings->setAddVerticalSpaceAmountAbove(addVerticalSpaceAmountAbove);
 
-    GtkWidget* spAddHorizontalSpaceLeft = get("spAddHorizontalSpaceLeft");
+    GtkWidget* spAddHorizontalSpaceLeft = builder.get("spAddHorizontalSpaceLeft");
     const int addHorizontalSpaceAmountLeft =
             static_cast<int>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(spAddHorizontalSpaceLeft)));
     settings->setAddHorizontalSpaceAmountLeft(addHorizontalSpaceAmountLeft);
 
-    GtkWidget* spAddVerticalSpaceBelow = get("spAddVerticalSpaceBelow");
+    GtkWidget* spAddVerticalSpaceBelow = builder.get("spAddVerticalSpaceBelow");
     const int addVerticalSpaceAmountBelow =
             static_cast<int>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(spAddVerticalSpaceBelow)));
     settings->setAddVerticalSpaceAmountBelow(addVerticalSpaceAmountBelow);
 
 
-    GtkWidget* spDrawDirModsRadius = get("spDrawDirModsRadius");
+    GtkWidget* spDrawDirModsRadius = builder.get("spDrawDirModsRadius");
     int drawDirModsRadius = static_cast<int>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(spDrawDirModsRadius)));
     settings->setDrawDirModsRadius(drawDirModsRadius);
 
-    GtkWidget* spStrokeIgnoreTime = get("spStrokeIgnoreTime");
+    GtkWidget* spStrokeIgnoreTime = builder.get("spStrokeIgnoreTime");
     int strokeIgnoreTime = static_cast<int>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(spStrokeIgnoreTime)));
-    GtkWidget* spStrokeIgnoreLength = get("spStrokeIgnoreLength");
+    GtkWidget* spStrokeIgnoreLength = builder.get("spStrokeIgnoreLength");
     double strokeIgnoreLength = gtk_spin_button_get_value(GTK_SPIN_BUTTON(spStrokeIgnoreLength));
-    GtkWidget* spStrokeSuccessiveTime = get("spStrokeSuccessiveTime");
+    GtkWidget* spStrokeSuccessiveTime = builder.get("spStrokeSuccessiveTime");
     int strokeSuccessiveTime = static_cast<int>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(spStrokeSuccessiveTime)));
     settings->setStrokeFilter(strokeIgnoreTime, strokeIgnoreLength, strokeSuccessiveTime);
 
-    GtkWidget* spTouchZoomStartThreshold = get("spTouchZoomStartThreshold");
+    GtkWidget* spTouchZoomStartThreshold = builder.get("spTouchZoomStartThreshold");
     double zoomStartThreshold = gtk_spin_button_get_value(GTK_SPIN_BUTTON(spTouchZoomStartThreshold));
     settings->setTouchZoomStartThreshold(zoomStartThreshold);
 
-    GtkWidget* spReRenderThreshold = get("spReRenderThreshold");
+    GtkWidget* spReRenderThreshold = builder.get("spReRenderThreshold");
     double rerenderThreshold = gtk_spin_button_get_value(GTK_SPIN_BUTTON(spReRenderThreshold));
     settings->setPDFPageRerenderThreshold(rerenderThreshold);
 
@@ -954,14 +934,14 @@ void SettingsDialog::save() {
     settings->setDisplayDpi(dpi);
 
     for (auto& bcg: this->buttonConfigs) {
-        bcg->saveSettings();
+        bcg.saveSettings();
     }
 
-    languageConfig->saveSettings();
+    languageConfig.saveSettings();
 
     SElement& touch = settings->getCustomElement("touch");
     touch.setBool("disableTouch", getCheckbox("cbDisableTouchOnPenNear"));
-    int touchMethod = gtk_combo_box_get_active(GTK_COMBO_BOX(get("cbTouchDisableMethod")));
+    int touchMethod = gtk_combo_box_get_active(GTK_COMBO_BOX(builder.get("cbTouchDisableMethod")));
 
     switch (touchMethod) {
         case 1:
@@ -974,24 +954,25 @@ void SettingsDialog::save() {
         default:
             touch.setString("method", "auto");
     }
-    touch.setString("cmdEnable", gtk_entry_get_text(GTK_ENTRY(get("txtEnableTouchCommand"))));
-    touch.setString("cmdDisable", gtk_entry_get_text(GTK_ENTRY(get("txtDisableTouchCommand"))));
+    touch.setString("cmdEnable", gtk_entry_get_text(GTK_ENTRY(builder.get("txtEnableTouchCommand"))));
+    touch.setString("cmdDisable", gtk_entry_get_text(GTK_ENTRY(builder.get("txtDisableTouchCommand"))));
 
-    touch.setInt("timeout",
-                 static_cast<int>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spTouchDisableTimeout"))) * 1000));
+    touch.setInt(
+            "timeout",
+            static_cast<int>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(builder.get("spTouchDisableTimeout"))) * 1000));
 
     settings->setSnapRotationTolerance(
-            static_cast<double>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spSnapRotationTolerance")))));
+            static_cast<double>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(builder.get("spSnapRotationTolerance")))));
     settings->setSnapGridTolerance(
-            static_cast<double>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spSnapGridTolerance")))));
-    settings->setSnapGridSize(
-            static_cast<double>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spSnapGridSize"))) * DEFAULT_GRID_SIZE));
+            static_cast<double>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(builder.get("spSnapGridTolerance")))));
+    settings->setSnapGridSize(static_cast<double>(
+            gtk_spin_button_get_value(GTK_SPIN_BUTTON(builder.get("spSnapGridSize"))) * DEFAULT_GRID_SIZE));
 
     settings->setStrokeRecognizerMinSize(
-            static_cast<double>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spStrokeRecognizerMinSize")))));
+            static_cast<double>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(builder.get("spStrokeRecognizerMinSize")))));
 
     size_t selectedInputDeviceIndex =
-            static_cast<size_t>(gtk_combo_box_get_active(GTK_COMBO_BOX(get("cbAudioInputDevice"))));
+            static_cast<size_t>(gtk_combo_box_get_active(GTK_COMBO_BOX(builder.get("cbAudioInputDevice"))));
     if (selectedInputDeviceIndex == 0) {
         settings->setAudioInputDevice(Settings::AUDIO_INPUT_SYSTEM_DEFAULT);
     } else if (selectedInputDeviceIndex - 1 < this->audioInputDevices.size()) {
@@ -999,14 +980,14 @@ void SettingsDialog::save() {
     }
 
     size_t selectedOutputDeviceIndex =
-            static_cast<size_t>(gtk_combo_box_get_active(GTK_COMBO_BOX(get("cbAudioOutputDevice"))));
+            static_cast<size_t>(gtk_combo_box_get_active(GTK_COMBO_BOX(builder.get("cbAudioOutputDevice"))));
     if (selectedOutputDeviceIndex == 0) {
         settings->setAudioOutputDevice(Settings::AUDIO_OUTPUT_SYSTEM_DEFAULT);
     } else if (selectedOutputDeviceIndex < this->audioOutputDevices.size()) {
         settings->setAudioOutputDevice(this->audioOutputDevices[selectedOutputDeviceIndex].getIndex());
     }
 
-    switch (gtk_combo_box_get_active(GTK_COMBO_BOX(get("cbAudioSampleRate")))) {
+    switch (gtk_combo_box_get_active(GTK_COMBO_BOX(builder.get("cbAudioSampleRate")))) {
         case 0:
             settings->setAudioSampleRate(16000.0);
             break;
@@ -1022,12 +1003,12 @@ void SettingsDialog::save() {
             break;
     }
 
-    settings->setAudioGain(static_cast<double>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spAudioGain")))));
+    settings->setAudioGain(static_cast<double>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(builder.get("spAudioGain")))));
     settings->setDefaultSeekTime(
-            static_cast<unsigned int>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spDefaultSeekTime")))));
+            static_cast<unsigned int>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(builder.get("spDefaultSeekTime")))));
 
     for (auto& deviceClassConfigGui: this->deviceClassConfigs) {
-        deviceClassConfigGui->saveSettings();
+        deviceClassConfigGui.saveSettings();
     }
 
     this->latexPanel.save(settings->latexSettings);

--- a/src/core/gui/dialog/SettingsDialog.cpp
+++ b/src/core/gui/dialog/SettingsDialog.cpp
@@ -76,7 +76,7 @@ SettingsDialog::SettingsDialog(GladeSearchpath* gladeSearchPath, Settings* setti
         gtk_widget_show(label);
     }
 
-    gtk_box_append(GTK_BOX(builder.get("latexTabBox")), this->latexPanel.get("latexSettingsPanel"));
+    gtk_box_append(GTK_BOX(builder.get("latexTabBox")), this->latexPanel.getPanel());
 
     g_signal_connect(builder.get("zoomCallibSlider"), "change-value",
                      G_CALLBACK(+[](GtkRange*, GtkScrollType, gdouble value, SettingsDialog* self) {

--- a/src/core/gui/dialog/SettingsDialog.cpp
+++ b/src/core/gui/dialog/SettingsDialog.cpp
@@ -192,7 +192,7 @@ SettingsDialog::SettingsDialog(GladeSearchpath* gladeSearchPath, Settings* setti
 void SettingsDialog::initMouseButtonEvents(GladeSearchpath* gladeSearchPath) {
     auto emplaceButton = [gladeSearchPath, &btns = buttonConfigs, settings = settings, &bld = builder](
                                  const char* hbox, Button button, bool withDevice = false) {
-        btns.emplace_back(gladeSearchPath, bld.get(hbox), settings, button, withDevice);
+        btns.emplace_back(gladeSearchPath, GTK_BOX(bld.get(hbox)), settings, button, withDevice);
     };
 
     emplaceButton("hboxMiddleMouse", BUTTON_MOUSE_MIDDLE);

--- a/src/core/gui/dialog/SettingsDialog.h
+++ b/src/core/gui/dialog/SettingsDialog.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <functional>
 #include <string>  // for string
 #include <vector>  // for vector
 
@@ -31,13 +32,12 @@ class Settings;
 
 class SettingsDialog {
 public:
-    SettingsDialog(GladeSearchpath* gladeSearchPath, Settings* settings, Control* control);
+    SettingsDialog(GladeSearchpath* gladeSearchPath, Settings* settings, Control* control,
+                   std::function<void()> callback);
 
-public:
     inline GtkWindow* getWindow() const { return window.get(); }
 
-    void show(GtkWindow* parent);
-
+private:
     void save();
 
     void setDpi(int dpi);
@@ -90,4 +90,6 @@ private:
     std::vector<DeviceClassConfigGui> deviceClassConfigs;
 
     LatexSettingsPanel latexPanel;
+
+    std::function<void()> callback;
 };

--- a/src/core/gui/dialog/SettingsDialog.h
+++ b/src/core/gui/dialog/SettingsDialog.h
@@ -11,33 +11,32 @@
 
 #pragma once
 
-#include <memory>  // for unique_ptr
 #include <string>  // for string
 #include <vector>  // for vector
 
-#include <glib.h>     // for gboolean
 #include <gtk/gtk.h>  // for GtkWidget, GtkWindow
 
 #include "audio/DeviceInfo.h"                    // for DeviceInfo
 #include "control/tools/StrokeStabilizerEnum.h"  // for AveragingMethod, Pre...
-#include "gui/GladeGui.h"                        // for GladeGui
+#include "gui/Builder.h"
+#include "util/raii/GtkWindowUPtr.h"
 
-#include "LatexSettingsPanel.h"  // for LatexSettingsPanel
+#include "ButtonConfigGui.h"
+#include "DeviceClassConfigGui.h"
+#include "LanguageConfigGui.h"
+#include "LatexSettingsPanel.h"
 
-class ButtonConfigGui;
 class Control;
-class DeviceClassConfigGui;
-class GladeSearchpath;
-class LanguageConfigGui;
 class Settings;
 
-class SettingsDialog: public GladeGui {
+class SettingsDialog {
 public:
     SettingsDialog(GladeSearchpath* gladeSearchPath, Settings* settings, Control* control);
-    ~SettingsDialog() override;
 
 public:
-    void show(GtkWindow* parent) override;
+    inline GtkWindow* getWindow() const { return window.get(); }
+
+    void show(GtkWindow* parent);
 
     void save();
 
@@ -64,16 +63,13 @@ public:
 
 private:
     void load();
-    void loadCheckbox(const char* name, gboolean value);
+    void loadCheckbox(const char* name, bool value);
     bool getCheckbox(const char* name);
 
     void loadSlider(const char* name, double value);
     double getSlider(const char* name);
 
-    void initMouseButtonEvents();
-    void initMouseButtonEvents(const char* hbox, int button, bool withDevice = false);
-
-    void initLanguageSettings();
+    void initMouseButtonEvents(GladeSearchpath* gladeSearchPath);
 
     void showStabilizerAvMethodOptions(StrokeStabilizer::AveragingMethod method);
     void showStabilizerPreprocessorOptions(StrokeStabilizer::Preprocessor preprocessor);
@@ -86,9 +82,12 @@ private:
     std::vector<DeviceInfo> audioInputDevices;
     std::vector<DeviceInfo> audioOutputDevices;
 
-    std::unique_ptr<LanguageConfigGui> languageConfig;
-    std::vector<std::unique_ptr<ButtonConfigGui>> buttonConfigs;
-    std::vector<std::unique_ptr<DeviceClassConfigGui>> deviceClassConfigs;
+    Builder builder;
+    xoj::util::GtkWindowUPtr window;
+
+    LanguageConfigGui languageConfig;
+    std::vector<ButtonConfigGui> buttonConfigs;
+    std::vector<DeviceClassConfigGui> deviceClassConfigs;
 
     LatexSettingsPanel latexPanel;
 };

--- a/src/core/gui/dialog/ToolbarManageDialog.cpp
+++ b/src/core/gui/dialog/ToolbarManageDialog.cpp
@@ -6,68 +6,82 @@
 #include <glib-object.h>  // for g_signal_connect
 #include <pango/pango.h>  // for PANGO_WEIGHT_NORMAL
 
+#include "gui/Builder.h"
 #include "gui/toolbarMenubar/model/ToolbarData.h"   // for ToolbarData
 #include "gui/toolbarMenubar/model/ToolbarModel.h"  // for ToolbarModel
+#include "util/Assert.h"                            // for xoj_assert
 #include "util/i18n.h"                              // for _
 
 class GladeSearchpath;
 
+constexpr auto UI_FILE = "toolbarManageDialog.glade";
+constexpr auto UI_DIALOG_NAME = "manageToolbarsDialog";
+
 enum { COLUMN_STRING, COLUMN_BOLD, COLUMN_POINTER, COLUMN_EDITABLE, N_COLUMNS };
 
-ToolbarManageDialog::ToolbarManageDialog(GladeSearchpath* gladeSearchPath, ToolbarModel* model):
-        GladeGui(gladeSearchPath, "toolbarManageDialog.glade", "DialogManageToolbar"), tbModel(model) {
+static xoj::util::GObjectSPtr<GtkListStore> createModel(ToolbarModel* tb) {
+    xoj_assert(tb);
     GtkTreeIter iter;
-    this->model = gtk_list_store_new(N_COLUMNS, G_TYPE_STRING, G_TYPE_INT, G_TYPE_POINTER, G_TYPE_BOOLEAN);
-    gtk_list_store_append(this->model, &iter);
-    gtk_list_store_set(this->model, &iter, COLUMN_STRING, _("Predefined"), COLUMN_BOLD, PANGO_WEIGHT_BOLD,
-                       COLUMN_POINTER, nullptr, COLUMN_EDITABLE, false, -1);
+    GtkListStore* model = gtk_list_store_new(N_COLUMNS, G_TYPE_STRING, G_TYPE_INT, G_TYPE_POINTER, G_TYPE_BOOLEAN);
+    gtk_list_store_append(model, &iter);
+    gtk_list_store_set(model, &iter, COLUMN_STRING, _("Predefined"), COLUMN_BOLD, PANGO_WEIGHT_BOLD, COLUMN_POINTER,
+                       nullptr, COLUMN_EDITABLE, false, -1);
 
-    for (ToolbarData* data: *model->getToolbars()) {
+    for (ToolbarData* data: *tb->getToolbars()) {
         if (data->isPredefined()) {
-            gtk_list_store_append(this->model, &iter);
-            gtk_list_store_set(this->model, &iter, COLUMN_STRING, data->getName().c_str(), COLUMN_BOLD,
-                               PANGO_WEIGHT_NORMAL, COLUMN_POINTER, data, COLUMN_EDITABLE, false, -1);
+            gtk_list_store_append(model, &iter);
+            gtk_list_store_set(model, &iter, COLUMN_STRING, data->getName().c_str(), COLUMN_BOLD, PANGO_WEIGHT_NORMAL,
+                               COLUMN_POINTER, data, COLUMN_EDITABLE, false, -1);
         }
     }
 
-    gtk_list_store_append(this->model, &iter);
-    gtk_list_store_set(this->model, &iter, COLUMN_STRING, _("Customized"), COLUMN_BOLD, PANGO_WEIGHT_BOLD,
-                       COLUMN_POINTER, nullptr, COLUMN_EDITABLE, false, -1);
+    gtk_list_store_append(model, &iter);
+    gtk_list_store_set(model, &iter, COLUMN_STRING, _("Customized"), COLUMN_BOLD, PANGO_WEIGHT_BOLD, COLUMN_POINTER,
+                       nullptr, COLUMN_EDITABLE, false, -1);
 
-    for (ToolbarData* data: *model->getToolbars()) {
+    for (ToolbarData* data: *tb->getToolbars()) {
         if (!data->isPredefined()) {
-            gtk_list_store_append(this->model, &iter);
-            gtk_list_store_set(this->model, &iter, COLUMN_STRING, data->getName().c_str(), COLUMN_BOLD,
-                               PANGO_WEIGHT_NORMAL, COLUMN_POINTER, data, COLUMN_EDITABLE, true, -1);
+            gtk_list_store_append(model, &iter);
+            gtk_list_store_set(model, &iter, COLUMN_STRING, data->getName().c_str(), COLUMN_BOLD, PANGO_WEIGHT_NORMAL,
+                               COLUMN_POINTER, data, COLUMN_EDITABLE, true, -1);
         }
     }
+    return xoj::util::GObjectSPtr<GtkListStore>(model, xoj::util::adopt);
+}
 
-    GtkWidget* tree = get("toolbarList");
-    gtk_tree_view_set_model(GTK_TREE_VIEW(tree), GTK_TREE_MODEL(this->model));
+ToolbarManageDialog::ToolbarManageDialog(GladeSearchpath* gladeSearchPath, ToolbarModel* tbModel,
+                                         std::function<void()> callback):
+        tbModel(tbModel), model(createModel(tbModel)), callback(callback) {
+    Builder builder(gladeSearchPath, UI_FILE);
+    window.reset(GTK_WINDOW(builder.get(UI_DIALOG_NAME)));
+    tree = GTK_TREE_VIEW(builder.get("toolbarList"));
+    copyButton = builder.get("btCopy");
+    deleteButton = builder.get("btDelete");
+
+    gtk_tree_view_set_model(tree, GTK_TREE_MODEL(this->model.get()));
 
     GtkCellRenderer* renderer = gtk_cell_renderer_text_new();
     GtkTreeViewColumn* column =
             gtk_tree_view_column_new_with_attributes(_("Toolbars"), renderer, "text", COLUMN_STRING, "weight",
                                                      COLUMN_BOLD, "editable", COLUMN_EDITABLE, nullptr);
 
-    gtk_tree_view_append_column(GTK_TREE_VIEW(tree), column);
+    gtk_tree_view_append_column(tree, column);
 
-    GtkTreeSelection* select = gtk_tree_view_get_selection(GTK_TREE_VIEW(tree));
+    GtkTreeSelection* select = gtk_tree_view_get_selection(tree);
     gtk_tree_selection_set_mode(select, GTK_SELECTION_SINGLE);
-    g_signal_connect(G_OBJECT(select), "changed", G_CALLBACK(treeSelectionChangedCallback), this);
+    g_signal_connect(select, "changed", G_CALLBACK(treeSelectionChangedCallback), this);
 
-    g_signal_connect(renderer, "edited", (GCallback)treeCellEditedCallback, this);
+    g_signal_connect(renderer, "edited", G_CALLBACK(treeCellEditedCallback), this);
 
-    g_signal_connect(get("btNew"), "clicked", G_CALLBACK(buttonNewCallback), this);
-    g_signal_connect(get("btDelete"), "clicked", G_CALLBACK(buttonDeleteCallback), this);
-    g_signal_connect(get("btCopy"), "clicked", G_CALLBACK(buttonCopyCallback), this);
+    g_signal_connect(builder.get("btNew"), "clicked", G_CALLBACK(buttonNewCallback), this);
+    g_signal_connect(deleteButton, "clicked", G_CALLBACK(buttonDeleteCallback), this);
+    g_signal_connect(copyButton, "clicked", G_CALLBACK(buttonCopyCallback), this);
 
-    entrySelected(nullptr);
-}
-
-ToolbarManageDialog::~ToolbarManageDialog() {
-    g_object_unref(this->model);
-    this->tbModel = nullptr;
+    g_signal_connect_swapped(builder.get("btClose"), "clicked", G_CALLBACK(+[](ToolbarManageDialog* self) {
+                                 self->callback();
+                                 gtk_window_close(self->window.get());
+                             }),
+                             this);
 }
 
 void ToolbarManageDialog::buttonNewCallback(GtkButton* button, ToolbarManageDialog* dlg) {
@@ -85,17 +99,18 @@ void ToolbarManageDialog::buttonDeleteCallback(GtkButton* button, ToolbarManageD
     }
 
     dlg->tbModel->remove(selected);
+    GtkTreeModel* model = GTK_TREE_MODEL(dlg->model.get());
     GtkTreeIter iter;
-    if (gtk_tree_model_get_iter_first(GTK_TREE_MODEL(dlg->model), &iter)) {
+    if (gtk_tree_model_get_iter_first(model, &iter)) {
         do {
             ToolbarData* data = nullptr;
-            gtk_tree_model_get(GTK_TREE_MODEL(dlg->model), &iter, COLUMN_POINTER, &data, -1);
+            gtk_tree_model_get(model, &iter, COLUMN_POINTER, &data, -1);
 
             if (data == selected) {
-                gtk_list_store_remove(dlg->model, &iter);
+                gtk_list_store_remove(dlg->model.get(), &iter);
                 break;
             }
-        } while (gtk_tree_model_iter_next(GTK_TREE_MODEL(dlg->model), &iter));
+        } while (gtk_tree_model_iter_next(model, &iter));
     }
 
     dlg->updateSelectionData();
@@ -116,16 +131,14 @@ void ToolbarManageDialog::buttonCopyCallback(GtkButton* button, ToolbarManageDia
 void ToolbarManageDialog::addToolbarData(ToolbarData* data) {
     this->tbModel->add(data);
     GtkTreeIter iter;
-    gtk_list_store_append(this->model, &iter);
-    gtk_list_store_set(this->model, &iter, COLUMN_STRING, data->getName().c_str(), COLUMN_BOLD, PANGO_WEIGHT_NORMAL,
-                       COLUMN_POINTER, data, COLUMN_EDITABLE, true, -1);
+    gtk_list_store_append(this->model.get(), &iter);
+    gtk_list_store_set(this->model.get(), &iter, COLUMN_STRING, data->getName().c_str(), COLUMN_BOLD,
+                       PANGO_WEIGHT_NORMAL, COLUMN_POINTER, data, COLUMN_EDITABLE, true, -1);
 
-    GtkWidget* tree = get("toolbarList");
+    GtkTreePath* path = gtk_tree_model_get_path(GTK_TREE_MODEL(this->model.get()), &iter);
+    GtkTreeViewColumn* column = gtk_tree_view_get_column(tree, 0);
 
-    GtkTreePath* path = gtk_tree_model_get_path(GTK_TREE_MODEL(this->model), &iter);
-    GtkTreeViewColumn* column = gtk_tree_view_get_column(GTK_TREE_VIEW(tree), 0);
-
-    gtk_tree_view_set_cursor(GTK_TREE_VIEW(tree), path, column, true);
+    gtk_tree_view_set_cursor(tree, path, column, true);
 }
 
 void ToolbarManageDialog::treeCellEditedCallback(GtkCellRendererText* renderer, gchar* pathString, gchar* newText,
@@ -133,24 +146,21 @@ void ToolbarManageDialog::treeCellEditedCallback(GtkCellRendererText* renderer, 
     GtkTreeIter iter;
     ToolbarData* data = nullptr;
 
-    gtk_tree_model_get_iter_from_string(GTK_TREE_MODEL(dlg->model), &iter, pathString);
-    gtk_tree_model_get(GTK_TREE_MODEL(dlg->model), &iter, COLUMN_POINTER, &data, -1);
+    gtk_tree_model_get_iter_from_string(GTK_TREE_MODEL(dlg->model.get()), &iter, pathString);
+    gtk_tree_model_get(GTK_TREE_MODEL(dlg->model.get()), &iter, COLUMN_POINTER, &data, -1);
     if (data) {
-        gtk_list_store_set(dlg->model, &iter, COLUMN_STRING, newText, -1);
+        gtk_list_store_set(dlg->model.get(), &iter, COLUMN_STRING, newText, -1);
         data->setName(newText);
     }
 }
 
 void ToolbarManageDialog::entrySelected(ToolbarData* data) {
-    GtkWidget* btCopy = get("btCopy");
-    GtkWidget* btDelete = get("btDelete");
-
     if (data == nullptr) {
-        gtk_widget_set_sensitive(btCopy, false);
-        gtk_widget_set_sensitive(btDelete, false);
+        gtk_widget_set_sensitive(copyButton, false);
+        gtk_widget_set_sensitive(deleteButton, false);
     } else {
-        gtk_widget_set_sensitive(btCopy, true);
-        gtk_widget_set_sensitive(btDelete, !data->isPredefined());
+        gtk_widget_set_sensitive(copyButton, true);
+        gtk_widget_set_sensitive(deleteButton, !data->isPredefined());
     }
 }
 
@@ -159,9 +169,7 @@ auto ToolbarManageDialog::getSelectedEntry() -> ToolbarData* {
     GtkTreeModel* model = nullptr;
     ToolbarData* data = nullptr;
 
-    GtkWidget* tree = get("toolbarList");
-
-    GtkTreeSelection* selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(tree));
+    GtkTreeSelection* selection = gtk_tree_view_get_selection(tree);
     if (selection == nullptr) {
         return nullptr;
     }
@@ -171,7 +179,6 @@ auto ToolbarManageDialog::getSelectedEntry() -> ToolbarData* {
         return data;
     }
 
-
     return nullptr;
 }
 
@@ -179,10 +186,4 @@ void ToolbarManageDialog::updateSelectionData() { entrySelected(getSelectedEntry
 
 void ToolbarManageDialog::treeSelectionChangedCallback(GtkTreeSelection* selection, ToolbarManageDialog* dlg) {
     dlg->updateSelectionData();
-}
-
-void ToolbarManageDialog::show(GtkWindow* parent) {
-    gtk_window_set_transient_for(GTK_WINDOW(this->window), parent);
-    gtk_dialog_run(GTK_DIALOG(this->window));
-    gtk_widget_hide(this->window);
 }

--- a/src/core/gui/dialog/ToolbarManageDialog.h
+++ b/src/core/gui/dialog/ToolbarManageDialog.h
@@ -11,22 +11,24 @@
 
 #pragma once
 
+#include <functional>
+
 #include <glib.h>     // for gchar
 #include <gtk/gtk.h>  // for GtkButton, GtkCellRendererText, GtkListStore
 
-#include "gui/GladeGui.h"  // for GladeGui
+#include "util/raii/GObjectSPtr.h"
+#include "util/raii/GtkWindowUPtr.h"
 
 class ToolbarData;
 class ToolbarModel;
 class GladeSearchpath;
 
-class ToolbarManageDialog: public GladeGui {
+class ToolbarManageDialog {
 public:
-    ToolbarManageDialog(GladeSearchpath* gladeSearchPath, ToolbarModel* model);
-    ~ToolbarManageDialog() override;
+    ToolbarManageDialog(GladeSearchpath* gladeSearchPath, ToolbarModel* model, std::function<void()> callback);
 
 public:
-    void show(GtkWindow* parent) override;
+    inline GtkWindow* getWindow() const { return window.get(); }
 
 private:
     static void treeSelectionChangedCallback(GtkTreeSelection* selection, ToolbarManageDialog* dlg);
@@ -46,5 +48,12 @@ private:
 
 private:
     ToolbarModel* tbModel;
-    GtkListStore* model;
+    xoj::util::GObjectSPtr<GtkListStore> model;
+
+    GtkTreeView* tree;
+    GtkWidget* copyButton;
+    GtkWidget* deleteButton;
+
+    xoj::util::GtkWindowUPtr window;
+    std::function<void()> callback;
 };

--- a/src/core/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp
+++ b/src/core/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp
@@ -15,7 +15,8 @@
 #include "util/Assert.h"                               // for xoj_assert
 #include "util/NamedColor.h"                           // for NamedColor
 #include "util/PlaceholderString.h"                    // for PlaceholderString
-#include "util/i18n.h"                                 // for FS, _F
+#include "util/gtk4_helper.h"
+#include "util/i18n.h"
 
 #include "ToolItemDragCurrentData.h"  // for ToolItemDragCu...
 #include "ToolbarDragDropHelper.h"    // for dragDestAddToo...
@@ -41,8 +42,7 @@ ToolbarAdapter::ToolbarAdapter(GtkWidget* toolbar, string toolbarName, ToolMenuH
     showToolbar();
     prepareToolItems();
 
-    GtkStyleContext* ctx = gtk_widget_get_style_context(w);
-    gtk_style_context_add_class(ctx, "editing");
+    gtk_widget_add_css_class(w, "editing");
 }
 
 ToolbarAdapter::~ToolbarAdapter() {
@@ -53,8 +53,7 @@ ToolbarAdapter::~ToolbarAdapter() {
 
     cleanupToolbars();
 
-    GtkStyleContext* ctx = gtk_widget_get_style_context(w);
-    gtk_style_context_remove_class(ctx, "editing");
+    gtk_widget_remove_css_class(w, "editing");
 
     g_object_unref(this->w);
 }

--- a/src/core/gui/dialog/toolbarCustomize/ToolbarCustomizeDialog.cpp
+++ b/src/core/gui/dialog/toolbarCustomize/ToolbarCustomizeDialog.cpp
@@ -8,8 +8,9 @@
 #include <gdk-pixbuf/gdk-pixbuf.h>  // for GdkPixbuf
 #include <glib-object.h>            // for G_CALLBACK
 
-#include "control/Control.h"                                // for Control
-#include "control/settings/Settings.h"                      // for Settings
+#include "control/Control.h"            // for Control
+#include "control/settings/Settings.h"  // for Settings
+#include "gui/Builder.h"
 #include "gui/MainWindow.h"                                 // for MainWindow
 #include "gui/ToolitemDragDrop.h"                           // for ToolItemD...
 #include "gui/toolbarMenubar/AbstractToolItem.h"            // for AbstractT...
@@ -17,10 +18,13 @@
 #include "gui/toolbarMenubar/icon/ColorSelectImage.h"       // for ColorSele...
 #include "gui/toolbarMenubar/icon/ToolbarSeparatorImage.h"  // for getNewToo...
 #include "gui/toolbarMenubar/model/ColorPalette.h"          // for Palette
+#include "util/Assert.h"                                    // for xoj_assert
 #include "util/Color.h"                                     // for Color
 #include "util/GListView.h"                                 // for GListView
 #include "util/NamedColor.h"                                // for NamedColor
-#include "util/i18n.h"                                      // for _
+#include "util/gtk4_helper.h"
+#include "util/i18n.h"  // for _
+#include "util/raii/GObjectSPtr.h"
 
 #include "ToolItemDragCurrentData.h"  // for ToolItemD...
 #include "ToolbarDragDropHandler.h"   // for ToolbarDr...
@@ -32,94 +36,91 @@ class GladeSearchpath;
  * struct used for data necessary for dragging
  * during toolbar customization
  */
-struct _ToolItemDragData {
+struct ToolbarCustomizeDialog::ToolItemDragData {
     ToolbarCustomizeDialog* dlg;
     GtkWidget* icon;  ///< Currently must be an GtkImage
     AbstractToolItem* item;
-    GtkWidget* ebox;
+    xoj::util::WidgetSPtr ebox;
 };
 
-struct _ColorToolItemDragData {
+struct ToolbarCustomizeDialog::ColorToolItemDragData {
     ToolbarCustomizeDialog* dlg;
-    GdkPixbuf* icon;
     const NamedColor* namedColor;
-    GtkWidget* ebox;
+    xoj::util::WidgetSPtr ebox;
 };
 
 // Separator and spacer
-struct _SeparatorData {
+struct ToolbarCustomizeDialog::SeparatorData {
     ToolItemType type;
     int pos;
     SeparatorType separator;
     const char* label;
 };
 
-SeparatorData dataSeparator = {TOOL_ITEM_SEPARATOR, 0, SeparatorType::SEPARATOR, _("Separator")};
-SeparatorData dataSpacer = {TOOL_ITEM_SPACER, 1, SeparatorType::SPACER, _("Spacer")};
+std::array<ToolbarCustomizeDialog::SeparatorData, 2> ToolbarCustomizeDialog::separators = {
+        ToolbarCustomizeDialog::SeparatorData{TOOL_ITEM_SEPARATOR, 0, SeparatorType::SEPARATOR, _("Separator")},
+        ToolbarCustomizeDialog::SeparatorData{TOOL_ITEM_SPACER, 1, SeparatorType::SPACER, _("Spacer")}};
+
+
+constexpr auto UI_FILE = "toolbarCustomizeDialog.glade";
+constexpr auto UI_DIALOG_NAME = "DialogCustomizeToolbar";
 
 ToolbarCustomizeDialog::ToolbarCustomizeDialog(GladeSearchpath* gladeSearchPath, MainWindow* win,
                                                ToolbarDragDropHandler* handler):
-        GladeGui(gladeSearchPath, "toolbarCustomizeDialog.glade", "DialogCustomizeToolbar") {
-    this->win = win;
-    this->handler = handler;
+        itemData(buildToolDataVector(*win->getToolMenuHandler()->getToolItems())),
+        colorItemData(buildColorDataVector(handler->getControl()->getSettings()->getColorPalette())) {
+    Builder builder(gladeSearchPath, UI_FILE);
+    window.reset(GTK_WINDOW(builder.get(UI_DIALOG_NAME)));
+    toolTable = GTK_GRID(builder.get("tbDefaultTools"));
+    colorTable = GTK_GRID(builder.get("tbColor"));
 
     rebuildIconview();
-    rebuildColorIcons();
 
-    GtkWidget* target = get("viewport1");
+    int i = 0;
+    for (auto& data: colorItemData) {
+        // In the dialog 5 colors are shown per row
+        const int x = i % 5;
+        const int y = i / 5;
 
+        gtk_grid_attach(colorTable, data.ebox.get(), x, y, 1, 1);
+        i++;
+    }
+
+    // init separator and spacer
+    GtkWidget* tbSeparators = builder.get("tbSeparator");
+
+    for (SeparatorData& data: separators) {
+        GtkBox* box = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, 2));
+        gtk_box_append(box, ToolbarSeparatorImage::newImage(data.separator));
+        gtk_box_append(box, gtk_label_new(data.label));
+
+        GtkWidget* ebox = gtk_event_box_new();
+        gtk_container_add(GTK_CONTAINER(ebox), GTK_WIDGET(box));
+        gtk_widget_show_all(ebox);
+
+        // make ebox a drag source
+        gtk_drag_source_set(ebox, GDK_BUTTON1_MASK, &ToolbarDragDropHelper::dropTargetEntry, 1, GDK_ACTION_MOVE);
+        ToolbarDragDropHelper::dragSourceAddToolbar(ebox);
+
+        g_signal_connect(ebox, "drag-begin", G_CALLBACK(toolitemDragBeginSeparator), &data);
+        g_signal_connect(ebox, "drag-end", G_CALLBACK(toolitemDragEndSeparator), &data);
+        g_signal_connect(ebox, "drag-data-get", G_CALLBACK(toolitemDragDataGetSeparator), &data);
+        gtk_grid_attach(GTK_GRID(tbSeparators), ebox, data.pos, 0, 1, 1);
+    }
+
+    GtkWidget* target = builder.get("viewport1");
     // prepare drag & drop
     gtk_drag_dest_set(target, GTK_DEST_DEFAULT_ALL, nullptr, 0, GDK_ACTION_MOVE);
     ToolbarDragDropHelper::dragDestAddToolbar(target);
 
     g_signal_connect(target, "drag-data-received", G_CALLBACK(dragDataReceived), this);
 
-    // init separator and spacer
-    GtkWidget* tbSeparators = get("tbSeparator");
-
-    for (SeparatorData* data: {&dataSeparator, &dataSpacer}) {
-        GtkWidget* icon = ToolbarSeparatorImage::newImage(data->separator);
-        g_return_if_fail(icon != nullptr);
-        GtkWidget* box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 2);
-        gtk_widget_show(box);
-
-        GtkWidget* label = gtk_label_new(data->label);
-        gtk_widget_show(label);
-        gtk_box_pack_end(GTK_BOX(box), label, false, false, 0);
-
-        gtk_widget_show(icon);
-        gtk_box_pack_end(GTK_BOX(box), icon, false, false, 0);
-
-        GtkWidget* ebox = gtk_event_box_new();
-        gtk_container_add(GTK_CONTAINER(ebox), box);
-        gtk_widget_show(ebox);
-
-        // make ebox a drag source
-        gtk_drag_source_set(ebox, GDK_BUTTON1_MASK, &ToolbarDragDropHelper::dropTargetEntry, 1, GDK_ACTION_MOVE);
-        ToolbarDragDropHelper::dragSourceAddToolbar(ebox);
-
-        g_signal_connect(ebox, "drag-begin", G_CALLBACK(toolitemDragBeginSeparator), data);
-        g_signal_connect(ebox, "drag-end", G_CALLBACK(toolitemDragEndSeparator), data);
-        g_signal_connect(ebox, "drag-data-get", G_CALLBACK(toolitemDragDataGetSeparator), data);
-        gtk_grid_attach(GTK_GRID(tbSeparators), ebox, data->pos, 0, 1, 1);
-    }
+    g_signal_connect_swapped(builder.get("btClose"), "clicked", G_CALLBACK(gtk_window_close), window.get());
+    g_signal_connect_swapped(window.get(), "delete-event",
+                             G_CALLBACK(+[](ToolbarDragDropHandler* h) { h->toolbarConfigDialogClosed(); }), handler);
 }
 
-ToolbarCustomizeDialog::~ToolbarCustomizeDialog() {
-    freeIconview();
-    freeColorIconview();
-
-    /* We can only delete this list at the end, it would be better to delete this list
-     * after a refresh and after drag_end is called...
-     */
-    for (ToolItemDragData* data: this->itemDatalist) {
-        if (data->icon != nullptr) {
-            g_object_unref(data->icon);
-        }
-        g_object_unref(data->ebox);
-        g_free(data);
-    }
-}
+ToolbarCustomizeDialog::~ToolbarCustomizeDialog() = default;
 
 void ToolbarCustomizeDialog::toolitemDragBeginSeparator(GtkWidget* widget, GdkDragContext* context, void* data) {
     SeparatorData* sepData = static_cast<SeparatorData*>(data);
@@ -154,7 +155,7 @@ void ToolbarCustomizeDialog::toolitemDragBegin(GtkWidget* widget, GdkDragContext
     if (data->icon) {
         ToolbarDragDropHelper::gdk_context_set_icon_from_image(context, data->icon);
     }
-    gtk_widget_hide(data->ebox);
+    gtk_widget_hide(data->ebox.get());
 }
 
 /**
@@ -162,7 +163,7 @@ void ToolbarCustomizeDialog::toolitemDragBegin(GtkWidget* widget, GdkDragContext
  */
 void ToolbarCustomizeDialog::toolitemDragEnd(GtkWidget* widget, GdkDragContext* context, ToolItemDragData* data) {
     ToolItemDragCurrentData::clearData();
-    gtk_widget_show(data->ebox);
+    gtk_widget_show(data->ebox.get());
 }
 
 void ToolbarCustomizeDialog::toolitemDragDataGet(GtkWidget* widget, GdkDragContext* context,
@@ -172,7 +173,6 @@ void ToolbarCustomizeDialog::toolitemDragDataGet(GtkWidget* widget, GdkDragConte
     g_return_if_fail(data->item != nullptr);
 
     data->item->setUsed(true);
-    data->dlg->rebuildIconview();
 
     ToolItemDragDropData* it = ToolitemDragDrop::ToolItemDragDropData_new(data->item);
 
@@ -180,10 +180,12 @@ void ToolbarCustomizeDialog::toolitemDragDataGet(GtkWidget* widget, GdkDragConte
                            sizeof(ToolItemDragDropData));
 
     g_free(it);
+
+    data->dlg->rebuildIconview();
 }
 
 /**
- * Drag a Toolitem from dialog
+ * Drag a ColorToolitem from dialog
  */
 void ToolbarCustomizeDialog::toolitemColorDragBegin(GtkWidget* widget, GdkDragContext* context,
                                                     ColorToolItemDragData* data) {
@@ -195,14 +197,11 @@ void ToolbarCustomizeDialog::toolitemColorDragBegin(GtkWidget* widget, GdkDragCo
 }
 
 /**
- * Drag a Toolitem from dialog STOPPED
+ * Drag a ColorToolitem from dialog STOPPED
  */
 void ToolbarCustomizeDialog::toolitemColorDragEnd(GtkWidget* widget, GdkDragContext* context,
                                                   ColorToolItemDragData* data) {
     ToolItemDragCurrentData::clearData();
-    gtk_widget_show(widget);
-
-    data->dlg->rebuildColorIcons();
 }
 
 void ToolbarCustomizeDialog::toolitemColorDragDataGet(GtkWidget* widget, GdkDragContext* context,
@@ -266,11 +265,9 @@ void ToolbarCustomizeDialog::dragDataReceived(GtkWidget* widget, GdkDragContext*
  * clear the icon list
  */
 void ToolbarCustomizeDialog::freeIconview() {
-    GtkGrid* table = GTK_GRID(get("tbDefaultTools"));
-
-    GList* children = gtk_container_get_children(GTK_CONTAINER(table));
+    GList* children = gtk_container_get_children(GTK_CONTAINER(toolTable));
     for (auto& w: GListView<GtkWidget>(children)) {
-        gtk_container_remove(GTK_CONTAINER(table), &w);
+        gtk_container_remove(GTK_CONTAINER(toolTable), &w);
     }
     g_list_free(children);
 }
@@ -278,153 +275,90 @@ void ToolbarCustomizeDialog::freeIconview() {
 /**
  * builds up the icon list
  */
-void ToolbarCustomizeDialog::rebuildIconview() {
-    freeIconview();
-
-    GtkGrid* table = GTK_GRID(get("tbDefaultTools"));
-
-    int i = 0;
-    for (AbstractToolItem* item: *this->win->getToolMenuHandler()->getToolItems()) {
-        if (item->isUsed()) {
-            continue;
-        }
-
+auto ToolbarCustomizeDialog::buildToolDataVector(const std::vector<AbstractToolItem*>& tools)
+        -> std::vector<ToolItemDragData> {
+    // By reserving, we ensure no reallocation is done, so the pointer `&data` used below is not invalidated
+    std::vector<ToolItemDragData> database;
+    database.reserve(tools.size());
+    for (AbstractToolItem* item: tools) {
         std::string name = item->getToolDisplayName();
         GtkWidget* icon = item->getNewToolIcon(); /* floating */
-        g_return_if_fail(icon != nullptr);
+        xoj_assert(icon);
 
-        GtkWidget* box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 3);
-        gtk_widget_show(box);
-
-        GtkWidget* label = gtk_label_new(name.c_str());
-        gtk_widget_show(label);
-        gtk_box_pack_end(GTK_BOX(box), label, false, false, 0);
+        GtkBox* box = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, 3));
+        gtk_box_append(box, icon);
+        gtk_box_append(box, gtk_label_new(name.c_str()));
 
         GtkWidget* ebox = gtk_event_box_new();
-        gtk_container_add(GTK_CONTAINER(ebox), box);
-        gtk_widget_show(ebox);
+        gtk_container_add(GTK_CONTAINER(ebox), GTK_WIDGET(box));
+        gtk_widget_show_all(GTK_WIDGET(ebox));
 
-        gtk_widget_show(icon);
-
-        gtk_box_pack_end(GTK_BOX(box), icon, false, false, 0);
+        auto& data = database.emplace_back();
+        data.dlg = this;
+        data.icon = icon;
+        data.item = item;
+        data.ebox.reset(ebox, xoj::util::adopt);
 
         // make ebox a drag source
         gtk_drag_source_set(ebox, GDK_BUTTON1_MASK, &ToolbarDragDropHelper::dropTargetEntry, 1, GDK_ACTION_MOVE);
         ToolbarDragDropHelper::dragSourceAddToolbar(ebox);
 
-        ToolItemDragData* data = g_new(ToolItemDragData, 1);
-        data->dlg = this;
-        data->icon = GTK_WIDGET(g_object_ref(icon));
-        data->item = item;
-        // store reference to ebox
-        data->ebox = ebox;
-        g_object_ref(ebox);
+        g_signal_connect(ebox, "drag-begin", G_CALLBACK(toolitemDragBegin), &data);
+        g_signal_connect(ebox, "drag-end", G_CALLBACK(toolitemDragEnd), &data);
+        g_signal_connect(ebox, "drag-data-get", G_CALLBACK(toolitemDragDataGet), &data);
+    }
+    return database;
+}
 
-        this->itemDatalist.push_front(data);
+void ToolbarCustomizeDialog::rebuildIconview() {
+    freeIconview();
+    int i = 0;
+    for (auto& data: itemData) {
+        if (!data.item->isUsed()) {
+            const int x = i % 3;
+            const int y = i / 3;
+            gtk_grid_attach(toolTable, data.ebox.get(), x, y, 1, 1);
 
-        g_signal_connect(ebox, "drag-begin", G_CALLBACK(toolitemDragBegin), data);
-        g_signal_connect(ebox, "drag-end", G_CALLBACK(toolitemDragEnd), data);
-
-        g_signal_connect(ebox, "drag-data-get", G_CALLBACK(toolitemDragDataGet), data);
-
-        const int x = i % 3;
-        const int y = i / 3;
-        gtk_grid_attach(table, ebox, x, y, 1, 1);
-
-        i++;
+            i++;
+        }
     }
 }
 
-/**
- * clear the icon list
- */
-void ToolbarCustomizeDialog::freeColorIconview() {
-    GtkGrid* table = GTK_GRID(get("tbColor"));
-
-    GList* children = gtk_container_get_children(GTK_CONTAINER(table));
-    for (auto& w: GListView<GtkWidget>(children)) {
-        gtk_container_remove(GTK_CONTAINER(table), &w);
-    }
-
-    g_list_free(children);
-}
-
-void ToolbarCustomizeDialog::rebuildColorIcons() {
-    GtkGrid* table = GTK_GRID(get("tbColor"));
-    g_return_if_fail(table != nullptr);
-
-    freeColorIconview();
-
-    const Palette& palette = this->win->getToolMenuHandler()->getControl()->getSettings()->getColorPalette();
-
-    for (size_t i{}; i < palette.size(); i++) {
+auto ToolbarCustomizeDialog::buildColorDataVector(const Palette& palette) -> std::vector<ColorToolItemDragData> {
+    // By reserving, we ensure no reallocation is done, so the pointer `&data` used below is not invalidated
+    std::vector<ColorToolItemDragData> database;
+    database.reserve(palette.size());
+    for (size_t i = 0; i < palette.size(); i++) {
         // namedColor needs to be a pointer to pass it into a ColorToolItemDragData
         const NamedColor* namedColor = &(palette.getColorAt(i));
-        const Color c = namedColor->getColor();
-        GtkWidget* icon = ColorSelectImage::newColorIcon(c, 16, true);
 
-        GtkWidget* box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 3);
-        gtk_widget_show(box);
-
-        GtkWidget* label = gtk_label_new(namedColor->getName().c_str());
-        gtk_widget_show(label);
-        gtk_box_pack_end(GTK_BOX(box), label, false, false, 0);
+        GtkBox* box = GTK_BOX(gtk_box_new(GTK_ORIENTATION_VERTICAL, 3));
+        gtk_box_append(box, ColorSelectImage::newColorIcon(namedColor->getColor(), 16, true));
+        gtk_box_append(box, gtk_label_new(namedColor->getName().c_str()));
 
         GtkWidget* ebox = gtk_event_box_new();
-        gtk_container_add(GTK_CONTAINER(ebox), box);
-        gtk_widget_show(ebox);
-
-        gtk_widget_show(icon);
-
-        gtk_box_pack_end(GTK_BOX(box), icon, false, false, 0);
+        gtk_container_add(GTK_CONTAINER(ebox), GTK_WIDGET(box));
+        gtk_widget_show_all(GTK_WIDGET(ebox));
 
         // make ebox a drag source
         gtk_drag_source_set(ebox, GDK_BUTTON1_MASK, &ToolbarDragDropHelper::dropTargetEntry, 1, GDK_ACTION_MOVE);
         ToolbarDragDropHelper::dragSourceAddToolbar(ebox);
 
+        auto& data = database.emplace_back();
+        data.dlg = this;
+        data.namedColor = namedColor;
+        data.ebox.reset(ebox, xoj::util::ref);
 
-        ColorToolItemDragData* data = g_new(ColorToolItemDragData, 1);
-        data->dlg = this;
-        data->icon = nullptr;
-
-        /*
-         * Since namedColor actually is a const reference, the reference will be valid even once namedColor goes out of
-         * scope
-         */
-        data->namedColor = namedColor;
-        data->ebox = ebox;
-
-        g_signal_connect(ebox, "drag-begin", G_CALLBACK(toolitemColorDragBegin), data);
-        g_signal_connect(ebox, "drag-end", G_CALLBACK(toolitemColorDragEnd), data);
-        g_signal_connect(ebox, "drag-data-get", G_CALLBACK(toolitemColorDragDataGet), data);
-
-        if (i >= std::numeric_limits<int>::max())
-            g_error("Int overflow because of two many colors defined in Palette");
-        const int ii = static_cast<int>(i);
-
-        // In the dialog 5 colors are shown per row
-        const int x = ii % 5;
-        const int y = ii / 5;
-
-        gtk_grid_attach(table, ebox, x, y, 1, 1);
+        g_signal_connect(ebox, "drag-begin", G_CALLBACK(toolitemColorDragBegin), &data);
+        g_signal_connect(ebox, "drag-end", G_CALLBACK(toolitemColorDragEnd), &data);
+        g_signal_connect(ebox, "drag-data-get", G_CALLBACK(toolitemColorDragDataGet), &data);
     }
-
-    gtk_widget_show_all(GTK_WIDGET(table));
+    return database;
 }
 
-void ToolbarCustomizeDialog::windowResponseCb(GtkDialog* dialog, int response, ToolbarCustomizeDialog* dlg) {
-    gtk_widget_hide(GTK_WIDGET(dialog));
-
-    dlg->handler->toolbarConfigDialogClosed();
-}
-
-/**
- * Displays the dialog
- */
 void ToolbarCustomizeDialog::show(GtkWindow* parent) {
-    g_signal_connect(this->window, "response", G_CALLBACK(windowResponseCb), this);
+    gtk_window_set_transient_for(this->window.get(), parent);
 
-    gtk_window_set_transient_for(GTK_WINDOW(this->window), parent);
-
-    gtk_widget_show_all(this->window);
+    gtk_window_set_position(this->window.get(), GTK_WIN_POS_CENTER_ON_PARENT);
+    gtk_widget_show_all(GTK_WIDGET(this->window.get()));
 }

--- a/src/core/gui/dialog/toolbarCustomize/ToolbarDragDropHandler.h
+++ b/src/core/gui/dialog/toolbarCustomize/ToolbarDragDropHandler.h
@@ -32,6 +32,8 @@ public:
     void prepareToolbarsForDragAndDrop();
     void clearToolbarsFromDragAndDrop();
 
+    inline Control* getControl() const { return control; }
+
 private:
     Control* control;
 

--- a/src/core/model/TexImage.cpp
+++ b/src/core/model/TexImage.cpp
@@ -26,7 +26,7 @@ void TexImage::freeImageAndPdf() {
     this->pdf.reset();
 }
 
-auto TexImage::clone() const -> Element* {
+auto TexImage::clone() const -> TexImage* {
     auto* img = new TexImage();
     img->x = this->x;
     img->y = this->y;

--- a/src/core/model/TexImage.h
+++ b/src/core/model/TexImage.h
@@ -62,7 +62,7 @@ public:
     void setText(std::string text);
     std::string getText() const;
 
-    Element* clone() const override;
+    TexImage* clone() const override;
 
     /**
      * @return true if the binary data (PNG or PDF) was loaded successfully.

--- a/src/core/plugin/Plugin.cpp
+++ b/src/core/plugin/Plugin.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>  // for max
 #include <array>      // for array
-#include <map>        // for map
 
 #include <gdk/gdk.h>      // for GdkModifierType
 #include <glib-object.h>  // for G_CALLBACK, g_signal_connect
@@ -245,6 +244,8 @@ void Plugin::loadScript() {
     int status = luaL_loadfile(lua.get(), luafile.string().c_str());
     if (status != LUA_OK) {
         const char* errMsg = lua_tostring(lua.get(), -1);
+        XojMsgBox::showPluginMessage(name, errMsg, true);
+
         // Error out if file can't be read
         g_warning("Could not load plugin Lua file. Error: \"%s\", error code: %d (syntax error: %s)", errMsg, status, status == LUA_ERRSYNTAX ? "true" : "false");
         this->valid = false;
@@ -262,9 +263,7 @@ void Plugin::loadScript() {
     // Run the loaded Lua script
     if (lua_pcall(lua.get(), 0, 0, 0) != LUA_OK) {
         const char* errMsg = lua_tostring(lua.get(), -1);
-        std::map<int, std::string> button;
-        button.insert(std::pair<int, std::string>(0, _("OK")));
-        XojMsgBox::showPluginMessage(name, errMsg, button, true);
+        XojMsgBox::showPluginMessage(name, errMsg, true);
 
         g_warning("Could not run plugin Lua file: \"%s\", error: \"%s\"", luafile.string().c_str(), errMsg);
         this->valid = false;
@@ -285,9 +284,7 @@ auto Plugin::callFunction(const std::string& fnc, long mode) -> bool {
     // Run the function
     if (lua_pcall(lua.get(), numArgs, 0, 0)) {
         const char* errMsg = lua_tostring(lua.get(), -1);
-        std::map<int, std::string> button;
-        button.insert(std::pair<int, std::string>(0, _("OK")));
-        XojMsgBox::showPluginMessage(name, errMsg, button, true);
+        XojMsgBox::showPluginMessage(name, errMsg, true);
 
         g_warning("Error in Plugin: \"%s\", error: \"%s\"", name.c_str(), errMsg);
         return false;

--- a/src/core/plugin/PluginController.cpp
+++ b/src/core/plugin/PluginController.cpp
@@ -15,6 +15,7 @@
 
 #include "control/settings/Settings.h"
 #include "gui/GladeSearchpath.h"
+#include "gui/PopupWindowWrapper.h"
 #include "gui/dialog/PluginDialog.h"
 #include "util/PathUtil.h"
 #include "util/StringUtils.h"
@@ -151,8 +152,8 @@ void PluginController::registerToolbar() {
 
 void PluginController::showPluginManager() const {
 #ifdef ENABLE_PLUGINS
-    PluginDialog dlg(control->getGladeSearchPath(), control->getSettings());
-    dlg.loadPluginList(this);
+    xoj::popup::PopupWindowWrapper<PluginDialog> dlg(control->getGladeSearchPath(), control->getSettings(),
+                                                     this->plugins);
     dlg.show(control->getGtkWindow());
 #endif
 }
@@ -179,16 +180,5 @@ void PluginController::registerToolButtons(ToolMenuHandler* toolMenuHandler) {
     for (auto&& p: this->plugins) {
         p->registerToolButton(toolMenuHandler);
     }
-#endif
-}
-
-auto PluginController::getPlugins() const -> std::vector<Plugin*> {
-#ifdef ENABLE_PLUGINS
-    std::vector<Plugin*> pl;
-    pl.reserve(plugins.size());
-    std::transform(begin(plugins), end(plugins), std::back_inserter(pl), [](auto&& plugin) { return plugin.get(); });
-    return pl;
-#else
-    return {};
 #endif
 }

--- a/src/core/plugin/PluginController.h
+++ b/src/core/plugin/PluginController.h
@@ -49,11 +49,6 @@ public:
      */
     void showPluginManager() const;
 
-    /**
-     * Return the plugin list
-     */
-    auto getPlugins() const -> std::vector<Plugin*>;
-
 private:
     /**
      * The main controller

--- a/src/core/plugin/luapi_application.h
+++ b/src/core/plugin/luapi_application.h
@@ -201,19 +201,19 @@ static int applib_msgbox(lua_State* L) {
 
     lua_pushnil(L);  // initial key for table traversal with `next`
 
-    std::map<int, std::string> button;
+    std::vector<XojMsgBox::Button> buttons;
 
     while (lua_next(L, 2) != 0) {
-        int index = lua_tointeger(L, -2);
+        int index = static_cast<int>(lua_tointeger(L, -2));
         const char* buttonText = luaL_checkstring(L, -1);
         lua_pop(L, 1);
 
-        button.insert(button.begin(), std::pair<int, std::string>(index, buttonText));
+        buttons.emplace_back(buttonText, index);
     }
 
     Plugin* plugin = Plugin::getPluginFromLua(L);
 
-    int result = XojMsgBox::showPluginMessage(plugin->getName(), msg, button);
+    int result = XojMsgBox::askPluginQuestion(plugin->getName(), msg, buttons);
     lua_pushinteger(L, result);
     return 1;
 }

--- a/src/util/PathUtil.cpp
+++ b/src/util/PathUtil.cpp
@@ -263,7 +263,6 @@ auto Util::ensureFolderExists(const fs::path& p) -> fs::path {
     } catch (const fs::filesystem_error& fe) {
         Util::execInUiThread([=]() {
             std::string msg = FS(_F("Could not create folder: {1}\nFailed with error: {2}") % p.u8string() % fe.what());
-            g_warning("%s %s", msg.c_str(), fe.what());
             XojMsgBox::showErrorToUser(nullptr, msg);
         });
     }

--- a/src/util/include/util/XojMsgBox.h
+++ b/src/util/include/util/XojMsgBox.h
@@ -11,25 +11,55 @@
 
 #pragma once
 
-#include <map>
+#include <functional>
 #include <string>
+#include <vector>
 
 #include <gtk/gtk.h>
 
-class XojMsgBox {
+#include "util/raii/GtkWindowUPtr.h"
+
+class XojMsgBox final {
+public:
+    XojMsgBox(
+            GtkDialog* dialog, std::function<void(int)> callback = [](int) {});
+    ~XojMsgBox() = default;
+
+    inline GtkWindow* getWindow() const { return window.get(); }
+
 private:
-    XojMsgBox();
-    virtual ~XojMsgBox();
+    xoj::util::GtkWindowUPtr window;
+    std::function<void(int)> callback;  ///< The parameter is the dialog's response ID
 
 public:
+    struct Button {
+        Button(std::string l, int r): label(std::move(l)), response(r) {}
+        std::string label;
+        int response;
+    };
+
     /**
      * Set window for messages without window
      */
     static void setDefaultWindow(GtkWindow* win);
 
+    static void askQuestion(GtkWindow* win, const std::string& maintext, const std::string& secondarytext,
+                            const std::vector<Button>& buttons, std::function<void(int)> callback);
+
+    /**
+     * @brief Shows a message with title markupTitle and message content msg.
+     * The title is formatted according to any Pango markups it contains.
+     */
+    static void showMarkupMessageToUser(GtkWindow* win, const std::string_view& markupTitle, const std::string& msg,
+                                        GtkMessageType type);
+    static void showMessageToUser(GtkWindow* win, const std::string& msg, GtkMessageType type);
+    static void showMessageToUser(GtkWindow* win, const std::string& title, const std::string& msg,
+                                  GtkMessageType type);
     static void showErrorToUser(GtkWindow* win, const std::string& msg);
-    static int showPluginMessage(const std::string& pluginName, const std::string& msg,
-                                 const std::map<int, std::string>& button, bool error = false);
+    static void showErrorAndQuit(std::string& msg, int exitCode);
+    static void showPluginMessage(const std::string& pluginName, const std::string& msg, bool error = false);
+    static int askPluginQuestion(const std::string& pluginName, const std::string& msg,
+                                 const std::vector<Button>& buttons, bool error = false);
     static int replaceFileQuestion(GtkWindow* win, const std::string& msg);
     static void showHelp(GtkWindow* win);
 };

--- a/src/util/include/util/gtk4_helper.h
+++ b/src/util/include/util/gtk4_helper.h
@@ -14,6 +14,7 @@
 
 #include <gtk/gtk.h>
 
+#include "util/Assert.h"
 
 inline void gtk_box_append(GtkBox* box, GtkWidget* child) {
     constexpr auto default_expand = false;
@@ -38,3 +39,44 @@ inline void gtk_widget_add_css_class(GtkWidget* widget, const char* css_class) {
 inline void gtk_widget_remove_css_class(GtkWidget* widget, const char* css_class) {
     gtk_style_context_remove_class(gtk_widget_get_style_context(widget), css_class);
 }
+
+typedef void (*GtkDrawingAreaDrawFunc)(GtkDrawingArea* drawing_area, cairo_t* cr, int width, int height,
+                                       gpointer user_data);
+/// WARNING: unsetting (via draw_func = nullptr) or replacing the function is not implemented here.
+inline void gtk_drawing_area_set_draw_func(GtkDrawingArea* area, GtkDrawingAreaDrawFunc draw_func, gpointer user_data,
+                                           GDestroyNotify destroy) {
+    xoj_assert(draw_func != nullptr);
+    struct Data {
+        gpointer data;
+        GtkDrawingAreaDrawFunc draw_func;
+        GDestroyNotify destroy;
+    };
+    Data* data = new Data{user_data, draw_func, destroy};
+    g_signal_connect_data(area, "draw", G_CALLBACK(+[](GtkDrawingArea* self, cairo_t* cr, Data* d) {
+                              GtkAllocation alloc;
+                              gtk_widget_get_allocation(GTK_WIDGET(self), &alloc);
+                              d->draw_func(self, cr, alloc.width, alloc.height, d->data);
+                          }),
+                          data, GClosureNotify(+[](Data* d, GClosure*) {
+                              if (d && d->destroy) {
+                                  d->destroy(d->data);
+                              }
+                              delete d;
+                          }),
+                          GConnectFlags(0U));  // 0 = G_CONNECT_DEFAULT only introduced in GObject 2.74
+}
+
+namespace gtk4_helper {
+template <class GtkBinType>
+static inline void set_child(GtkBinType* c, GtkWidget* child) {
+    gtk_container_foreach(
+            GTK_CONTAINER(c), +[](GtkWidget* child, gpointer c) { gtk_container_remove(GTK_CONTAINER(c), child); }, c);
+    gtk_container_add(GTK_CONTAINER(c), child);
+}
+template <class GtkBinType>
+static inline GtkWidget* get_child(GtkBinType* c) {
+    return gtk_bin_get_child(GTK_BIN(c));
+}
+};  // namespace gtk4_helper
+constexpr auto gtk_scrolled_window_set_child = gtk4_helper::set_child<GtkScrolledWindow>;
+constexpr auto gtk_scrolled_window_get_child = gtk4_helper::get_child<GtkScrolledWindow>;

--- a/ui/latexSettings.glade
+++ b/ui/latexSettings.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
-  <requires lib="gtk+" version="3.16"/>
+  <requires lib="gtk+" version="3.24"/>
   <object class="GtkFileFilter" id="filefilter1">
     <mime-types>
       <mime-type>application/x-latex</mime-type>
@@ -29,55 +29,13 @@
                 <property name="can-focus">False</property>
                 <property name="label-xalign">0.009999999776482582</property>
                 <child>
-                  <object class="GtkAlignment">
+                  <object class="GtkCheckButton" id="latexSettingsRunCheck">
+                    <property name="label" translatable="yes">Always check LaTeX dependencies before running</property>
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="bottom-padding">8</property>
-                    <property name="left-padding">12</property>
-                    <property name="right-padding">12</property>
-                    <child>
-                      <!-- n-columns=3 n-rows=3 -->
-                      <object class="GtkGrid">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <child>
-                          <object class="GtkCheckButton" id="latexSettingsRunCheck">
-                            <property name="label" translatable="yes">Always check LaTeX dependencies before running</property>
-                            <property name="visible">True</property>
-                            <property name="can-focus">True</property>
-                            <property name="receives-default">False</property>
-                            <property name="tooltip-text" translatable="yes">If enabled, check that required LaTeX packages are installed and that the LaTeX commands are available before running the LaTeX tool.</property>
-                            <property name="draw-indicator">True</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">0</property>
-                            <property name="top-attach">0</property>
-                            <property name="width">2</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                      </object>
-                    </child>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">False</property>
+                    <property name="tooltip-text" translatable="yes">If enabled, check that required LaTeX packages are installed and that the LaTeX commands are available before running the LaTeX tool.</property>
+                    <property name="draw-indicator">True</property>
                   </object>
                 </child>
                 <child type="label">
@@ -100,16 +58,12 @@
                 <property name="can-focus">False</property>
                 <property name="label-xalign">0</property>
                 <child>
-                  <object class="GtkAlignment">
+                  <object class="GtkEntry" id="latexDefaultEntry">
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="left-padding">12</property>
-                    <child>
-                      <object class="GtkEntry" id="latexDefaultEntry">
-                        <property name="visible">True</property>
-                        <property name="can-focus">True</property>
-                      </object>
-                    </child>
+                    <property name="can-focus">True</property>
+                    <property name="margin-start">12</property>
+                    <property name="margin-end">12</property>
+                    <property name="margin-bottom">4</property>
                   </object>
                 </child>
                 <child type="label">
@@ -132,129 +86,102 @@
                 <property name="can-focus">False</property>
                 <property name="label-xalign">0.009999999776482582</property>
                 <child>
-                  <object class="GtkAlignment">
+                  <!-- n-columns=2 n-rows=4 -->
+                  <object class="GtkGrid">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="bottom-padding">8</property>
-                    <property name="left-padding">12</property>
-                    <property name="right-padding">12</property>
+                    <property name="margin-start">12</property>
+                    <property name="margin-end">12</property>
+                    <property name="margin-bottom">8</property>
+                    <property name="row-spacing">5</property>
+                    <property name="column-spacing">20</property>
                     <child>
-                      <!-- n-columns=3 n-rows=5 -->
-                      <object class="GtkGrid">
+                      <object class="GtkLabel">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="row-spacing">5</property>
-                        <property name="column-spacing">20</property>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="tooltip-text" translatable="yes">The LaTeX file to use as a template for the LaTeX tool.</property>
-                            <property name="halign">start</property>
-                            <property name="label" translatable="yes">Global template file path</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">0</property>
-                            <property name="top-attach">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="halign">start</property>
-                            <property name="label" translatable="yes">The following strings will be substituted in the global template file when running the LaTeX tool:</property>
-                            <property name="wrap">True</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">0</property>
-                            <property name="top-attach">1</property>
-                            <property name="width">2</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="halign">start</property>
-                            <property name="label" translatable="yes">%%XPP_TOOL_INPUT%%</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">0</property>
-                            <property name="top-attach">2</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="halign">start</property>
-                            <property name="label" translatable="yes">The math mode formula typed in the LaTeX tool.</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">1</property>
-                            <property name="top-attach">2</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkFileChooserButton" id="latexSettingsTemplateFile">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="hexpand">True</property>
-                            <property name="filter">filefilter1</property>
-                            <property name="title" translatable="yes">Choose a global LaTeX template file</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">1</property>
-                            <property name="top-attach">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="halign">start</property>
-                            <property name="label" translatable="yes">%%XPP_TEXT_COLOR%%</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">0</property>
-                            <property name="top-attach">4</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="halign">start</property>
-                            <property name="label" translatable="yes">The current color of the Text Tool, in hex RGB format.</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">1</property>
-                            <property name="top-attach">4</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
+                        <property name="tooltip-text" translatable="yes">The LaTeX file to use as a template for the LaTeX tool.</property>
+                        <property name="halign">start</property>
+                        <property name="label" translatable="yes">Global template file path</property>
                       </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="label" translatable="yes">The following strings will be substituted in the global template file when running the LaTeX tool:</property>
+                        <property name="wrap">True</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">1</property>
+                        <property name="width">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="label" translatable="yes">%%XPP_TOOL_INPUT%%</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="label" translatable="yes">The math mode formula typed in the LaTeX tool.</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkFileChooserButton" id="latexSettingsTemplateFile">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="hexpand">True</property>
+                        <property name="filter">filefilter1</property>
+                        <property name="title" translatable="yes">Choose a global LaTeX template file</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="label" translatable="yes">%%XPP_TEXT_COLOR%%</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">3</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="label" translatable="yes">The current color of the Text Tool, in hex RGB format.</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">3</property>
+                      </packing>
                     </child>
                   </object>
                 </child>
@@ -278,72 +205,53 @@
                 <property name="can-focus">False</property>
                 <property name="label-xalign">0.009999999776482582</property>
                 <child>
-                  <object class="GtkAlignment">
+                  <!-- n-columns=2 n-rows=2 -->
+                  <object class="GtkGrid">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="bottom-padding">8</property>
-                    <property name="left-padding">12</property>
-                    <property name="right-padding">12</property>
+                    <property name="margin-start">12</property>
+                    <property name="margin-end">12</property>
+                    <property name="margin-bottom">8</property>
                     <child>
-                      <!-- n-columns=3 n-rows=3 -->
-                      <object class="GtkGrid">
+                      <object class="GtkLabel">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="halign">start</property>
-                            <property name="label" translatable="yes">LaTeX generation command</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">0</property>
-                            <property name="top-attach">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkEntry" id="latexSettingsGenCmd">
-                            <property name="visible">True</property>
-                            <property name="can-focus">True</property>
-                            <property name="hexpand">True</property>
-                            <property name="input-purpose">terminal</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">1</property>
-                            <property name="top-attach">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkButton" id="latexSettingsTestBtn">
-                            <property name="label" translatable="yes">Test configuration</property>
-                            <property name="visible">True</property>
-                            <property name="can-focus">True</property>
-                            <property name="receives-default">True</property>
-                            <property name="tooltip-text" translatable="yes">Test if the current configuration is valid by running the LaTeX generation command on the global template file with a test formula.</property>
-                            <property name="halign">end</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">0</property>
-                            <property name="top-attach">1</property>
-                            <property name="width">2</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
+                        <property name="halign">start</property>
+                        <property name="margin-end">6</property>
+                        <property name="label" translatable="yes">LaTeX generation command</property>
                       </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkEntry" id="latexSettingsGenCmd">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="hexpand">True</property>
+                        <property name="input-purpose">terminal</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="latexSettingsTestBtn">
+                        <property name="label" translatable="yes">Test configuration</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
+                        <property name="tooltip-text" translatable="yes">Test if the current configuration is valid by running the LaTeX generation command on the global template file with a test formula.</property>
+                        <property name="halign">end</property>
+                        <property name="margin-top">2</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">1</property>
+                        <property name="width">2</property>
+                      </packing>
                     </child>
                   </object>
                 </child>
@@ -367,54 +275,28 @@
                 <property name="can-focus">False</property>
                 <property name="label-xalign">0.009999999776482582</property>
                 <child>
-                  <object class="GtkAlignment" id="alignmentSourceViewSettings">
+                  <object class="GtkBox" id="bxSourceViewSettingsRootContainer">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="bottom-padding">8</property>
-                    <property name="left-padding">12</property>
-                    <property name="right-padding">12</property>
+                    <property name="margin-start">12</property>
+                    <property name="margin-end">12</property>
+                    <property name="margin-bottom">8</property>
+                    <property name="orientation">vertical</property>
                     <child>
-                      <object class="GtkBox" id="bxSourceViewSettingsRootContainer">
+                      <object class="GtkBox" id="bxGtkSourceviewSettings">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="orientation">vertical</property>
                         <child>
-                          <object class="GtkBox" id="bxGtkSourceviewSettings">
+                          <object class="GtkBox" id="bxGtkSourceviewDescription">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
-                            <property name="orientation">vertical</property>
                             <child>
-                              <object class="GtkBox" id="bxGtkSourceviewDescription">
+                              <object class="GtkLabel" id="lbSourceviewSettingsDescription">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
-                                <child>
-                                  <object class="GtkLabel" id="lbSourceviewSettingsDescription">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="halign">start</property>
-                                    <property name="xpad">5</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkBox" id="bxThemeSelectionContainer">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="orientation">vertical</property>
-                                    <child>
-                                      <placeholder/>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
+                                <property name="halign">start</property>
+                                <property name="xpad">5</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -423,52 +305,12 @@
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkBox" id="bxGtkSourceviewMainSettings">
+                              <object class="GtkBox" id="bxThemeSelectionContainer">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
-                                <property name="no-show-all">True</property>
                                 <property name="orientation">vertical</property>
                                 <child>
-                                  <object class="GtkCheckButton" id="cbShowLineNumbers">
-                                    <property name="label" translatable="yes">Line numbers</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">False</property>
-                                    <property name="draw-indicator">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkCheckButton" id="cbAutoIndent">
-                                    <property name="label" translatable="yes">Auto-indent</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">False</property>
-                                    <property name="draw-indicator">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkCheckButton" id="cbSyntaxHighlight">
-                                    <property name="label" translatable="yes">Syntax highlighting</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">False</property>
-                                    <property name="draw-indicator">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">2</property>
-                                  </packing>
+                                  <placeholder/>
                                 </child>
                               </object>
                               <packing>
@@ -485,12 +327,14 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkBox" id="bxEditorWordWrapSetting">
+                          <object class="GtkBox" id="bxGtkSourceviewMainSettings">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
+                            <property name="no-show-all">True</property>
+                            <property name="orientation">vertical</property>
                             <child>
-                              <object class="GtkCheckButton" id="cbWordWrap">
-                                <property name="label" translatable="yes">Wrap text</property>
+                              <object class="GtkCheckButton" id="cbShowLineNumbers">
+                                <property name="label" translatable="yes">Line numbers</property>
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>
                                 <property name="receives-default">False</property>
@@ -502,6 +346,34 @@
                                 <property name="position">0</property>
                               </packing>
                             </child>
+                            <child>
+                              <object class="GtkCheckButton" id="cbAutoIndent">
+                                <property name="label" translatable="yes">Auto-indent</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="draw-indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkCheckButton" id="cbSyntaxHighlight">
+                                <property name="label" translatable="yes">Syntax highlighting</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="draw-indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">2</property>
+                              </packing>
+                            </child>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -509,93 +381,119 @@
                             <property name="position">1</property>
                           </packing>
                         </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="bxEditorWordWrapSetting">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <child>
-                          <object class="GtkFrame" id="frameEditorFontSettings">
+                          <object class="GtkCheckButton" id="cbWordWrap">
+                            <property name="label" translatable="yes">Wrap text</property>
                             <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="label-xalign">0.009999999776482582</property>
-                            <child>
-                              <object class="GtkAlignment">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="left-padding">12</property>
-                                <child>
-                                  <object class="GtkBox">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="orientation">vertical</property>
-                                    <child>
-                                      <object class="GtkCheckButton" id="cbUseSystemFont">
-                                        <property name="label" translatable="yes">Use font from system theme.</property>
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="draw-indicator">True</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">0</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkBox" id="boxCustomFontOptions">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <child>
-                                          <object class="GtkLabel" id="lbFontLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">Font: </property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkFontButton" id="selBtnEditorFont">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">True</property>
-                                            <property name="font">Sans 12</property>
-                                            <property name="preview-text"/>
-                                            <property name="title" translatable="yes">Pick the Editor's Font</property>
-                                            <property name="show-style">False</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">1</property>
-                                      </packing>
-                                    </child>
-                                  </object>
-                                </child>
-                              </object>
-                            </child>
-                            <child type="label">
-                              <object class="GtkLabel">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label" translatable="yes">Font</property>
-                              </object>
-                            </child>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="draw-indicator">True</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
                             <property name="fill">True</property>
-                            <property name="position">2</property>
+                            <property name="position">0</property>
                           </packing>
                         </child>
                       </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkFrame" id="frameEditorFontSettings">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label-xalign">0.009999999776482582</property>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="margin-start">12</property>
+                            <property name="margin-end">12</property>
+                            <property name="margin-bottom">4</property>
+                            <property name="orientation">vertical</property>
+                            <child>
+                              <object class="GtkCheckButton" id="cbUseSystemFont">
+                                <property name="label" translatable="yes">Use font from system theme.</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="draw-indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkBox" id="boxCustomFontOptions">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <child>
+                                  <object class="GtkLabel" id="lbFontLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">Font: </property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkFontButton" id="selBtnEditorFont">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">True</property>
+                                    <property name="font">Sans 12</property>
+                                    <property name="preview-text"/>
+                                    <property name="title" translatable="yes">Pick the Editor's Font</property>
+                                    <property name="show-style">False</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                        </child>
+                        <child type="label">
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">Font</property>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">2</property>
+                      </packing>
                     </child>
                   </object>
                 </child>

--- a/ui/plugin.glade
+++ b/ui/plugin.glade
@@ -1,143 +1,138 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
-  <requires lib="gtk+" version="3.0"/>
+  <requires lib="gtk+" version="3.16"/>
   <object class="GtkAdjustment" id="adjustment1">
     <property name="upper">100</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">1</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">1</property>
   </object>
-  <object class="GtkDialog" id="pluginDialog">
-    <property name="name">pluginDialog</property>
-    <property name="can_focus">False</property>
-    <property name="border_width">5</property>
-    <property name="title" translatable="yes">Plugin Manager</property>
+  <object class="GtkImage" id="iconCancel">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">dialog-cancel</property>
+  </object>
+  <object class="GtkImage" id="iconOk">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">dialog-ok</property>
+  </object>
+  <object class="GtkWindow" id="pluginDialog">
+    <property name="can-focus">False</property>
+    <property name="title" translatable="yes">Plugins</property>
     <property name="modal">True</property>
-    <property name="destroy_with_parent">True</property>
-    <property name="type_hint">dialog</property>
+    <property name="destroy-with-parent">True</property>
+    <property name="skip-taskbar-hint">True</property>
+    <property name="skip-pager-hint">True</property>
     <child>
-      <placeholder/>
-    </child>
-    <child internal-child="vbox">
-      <object class="GtkBox" id="dialog-vbox2">
+      <object class="GtkBox" id="dialog-main-box">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
+        <property name="margin-start">10</property>
+        <property name="margin-end">10</property>
+        <property name="margin-top">10</property>
+        <property name="margin-bottom">10</property>
         <property name="orientation">vertical</property>
         <property name="spacing">2</property>
-        <child internal-child="action_area">
-          <object class="GtkButtonBox" id="dialog-action_area2">
-            <property name="name">dialog-action_area2</property>
+        <child>
+          <object class="GtkScrolledWindow">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
+            <property name="can-focus">True</property>
+            <property name="shadow-type">in</property>
+            <property name="min-content-width">400</property>
+            <property name="min-content-height">300</property>
             <child>
-              <object class="GtkButton" id="button1">
-                <property name="label">gtk-close</property>
-                <property name="use_action_appearance">False</property>
+              <object class="GtkViewport">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
+                <property name="can-focus">False</property>
+                <child>
+                  <object class="GtkBox" id="pluginBox">
+                    <property name="name">pluginBox</property>
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="margin-top">5</property>
+            <property name="margin-bottom">5</property>
+            <property name="label" translatable="yes">Plugin changes are only applied after Xournal++ is restarted</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">end</property>
+            <property name="spacing">4</property>
+            <property name="homogeneous">True</property>
+            <child>
+              <object class="GtkButton" id="btCancel">
+                <property name="label" translatable="yes">Cancel</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="can-default">True</property>
+                <property name="receives-default">True</property>
+                <property name="image">iconCancel</property>
+                <accelerator key="Escape" signal="clicked"/>
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
               </packing>
             </child>
             <child>
-              <object class="GtkButton" id="button2">
-                <property name="label">gtk-ok</property>
-                <property name="use_action_appearance">False</property>
+              <object class="GtkButton" id="btOk">
+                <property name="label" translatable="yes">Ok</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
-                <accelerator key="Return" signal="activate"/>
+                <property name="can-focus">True</property>
+                <property name="has-focus">True</property>
+                <property name="can-default">True</property>
+                <property name="has-default">True</property>
+                <property name="receives-default">True</property>
+                <property name="image">iconOk</property>
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
               </packing>
             </child>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="pack_type">end</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="orientation">vertical</property>
-            <child>
-              <object class="GtkScrolledWindow">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="shadow_type">in</property>
-                <property name="min_content_width">400</property>
-                <property name="min_content_height">300</property>
-                <child>
-                  <object class="GtkViewport">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <child>
-                      <object class="GtkBox" id="pluginBox">
-                        <property name="name">pluginBox</property>
-                        <property name="name">pluginBox</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="orientation">vertical</property>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_top">5</property>
-                <property name="margin_bottom">5</property>
-                <property name="label" translatable="yes">Plugin changes are only applied after Xournal++ is restarted</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="position">3</property>
           </packing>
         </child>
       </object>
     </child>
-    <action-widgets>
-      <action-widget response="1">button1</action-widget>
-      <action-widget response="2">button2</action-widget>
-    </action-widgets>
   </object>
 </interface>

--- a/ui/pluginEntry.glade
+++ b/ui/pluginEntry.glade
@@ -1,28 +1,53 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
-  <object class="GtkOffscreenWindow" id="offscreenwindow">
-    <property name="name">offscreenwindow</property>
-    <property name="can_focus">False</property>
+  <object class="GtkBox" id="pluginMainBox">
+    <property name="name">pluginMainBox</property>
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="orientation">vertical</property>
     <child>
-      <placeholder/>
+      <object class="GtkLabel" id="pluginName">
+        <property name="name">pluginName</property>
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="label">pluginName</property>
+        <attributes>
+          <attribute name="weight" value="bold"/>
+        </attributes>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">0</property>
+      </packing>
     </child>
     <child>
-      <object class="GtkBox" id="pluginMainBox">
-        <property name="name">pluginMainBox</property>
+      <object class="GtkLabel" id="lbDescription">
+        <property name="name">lbDescription</property>
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="orientation">vertical</property>
+        <property name="can-focus">False</property>
+        <property name="margin-bottom">10</property>
+        <property name="label">Description</property>
+        <property name="selectable">True</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">1</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="halign">center</property>
         <child>
-          <object class="GtkLabel" id="pluginName">
-            <property name="name">pluginName</property>
+          <object class="GtkLabel">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="label">pluginName</property>
-            <attributes>
-              <attribute name="weight" value="bold"/>
-            </attributes>
+            <property name="can-focus">False</property>
+            <property name="label" translatable="yes">Author: </property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -31,13 +56,11 @@
           </packing>
         </child>
         <child>
-          <object class="GtkLabel" id="lbDescription">
-            <property name="name">lbDescription</property>
+          <object class="GtkLabel" id="lbAuthor">
+            <property name="name">lbAuthor</property>
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="margin_bottom">10</property>
-            <property name="label">Description</property>
-            <property name="selectable">True</property>
+            <property name="can-focus">False</property>
+            <property name="label">Author</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -45,170 +68,136 @@
             <property name="position">1</property>
           </packing>
         </child>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">False</property>
+        <property name="position">2</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="halign">center</property>
         <child>
-          <object class="GtkBox">
+          <object class="GtkLabel">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="halign">center</property>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Author: </property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="lbAuthor">
-                <property name="name">lbAuthor</property>
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label">Author</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">2</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="halign">center</property>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Path: </property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="lbPath">
-                <property name="name">lbPath</property>
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label"></property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">3</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="halign">center</property>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Version: </property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="lbVersion">
-                <property name="name">lbVersion</property>
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label">1.2.3</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">4</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="halign">center</property>
-            <child>
-              <object class="GtkCheckButton" id="cbEnabled">
-                <property name="name">cbEnabled</property>
-                <property name="label" translatable="yes">enabled,</property>
-                <property name="name">cbEnabled</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="draw_indicator">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="lbDefaultText">
-                <property name="name">lbDefaultText</property>
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label">default enabled / disabled</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">5</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkSeparator">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
+            <property name="label" translatable="yes">Path: </property>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">6</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="lbPath">
+            <property name="name">lbPath</property>
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
           </packing>
         </child>
       </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">False</property>
+        <property name="position">3</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="halign">center</property>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="label" translatable="yes">Version: </property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="lbVersion">
+            <property name="name">lbVersion</property>
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="label">1.2.3</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">False</property>
+        <property name="position">4</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="halign">center</property>
+        <child>
+          <object class="GtkCheckButton" id="cbEnabled">
+            <property name="label" translatable="yes">enabled,</property>
+            <property name="name">cbEnabled</property>
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">False</property>
+            <property name="draw-indicator">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="lbDefaultText">
+            <property name="name">lbDefaultText</property>
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="label">default enabled / disabled</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">False</property>
+        <property name="position">5</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkSeparator">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">6</property>
+      </packing>
     </child>
   </object>
 </interface>

--- a/ui/renameLayerDialog.glade
+++ b/ui/renameLayerDialog.glade
@@ -1,33 +1,64 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.36.0 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.24"/>
-  <object class="GtkDialog" id="renameLayerDialog">
-    <property name="name">renameLayerDialog</property>
-    <property name="can_focus">False</property>
+  <object class="GtkImage" id="iconCancel">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">dialog-cancel</property>
+  </object>
+  <object class="GtkImage" id="iconOk">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">dialog-ok</property>
+  </object>
+  <object class="GtkWindow" id="renameLayerDialog">
+    <property name="can-focus">False</property>
     <property name="title" translatable="yes">Rename selected layer</property>
-    <property name="destroy_with_parent">True</property>
-    <property name="type_hint">dialog</property>
-    <child internal-child="vbox">
-      <object class="GtkBox" id="box1">
-        <property name="can_focus">False</property>
-        <property name="margin_start">5</property>
-        <property name="margin_end">5</property>
-        <property name="margin_top">5</property>
-        <property name="margin_bottom">5</property>
+    <property name="modal">True</property>
+    <property name="destroy-with-parent">True</property>
+    <property name="skip-taskbar-hint">True</property>
+    <property name="skip-pager-hint">True</property>
+    <child>
+      <object class="GtkBox" id="dialog-main-box">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="margin-start">10</property>
+        <property name="margin-end">10</property>
+        <property name="margin-top">10</property>
+        <property name="margin-bottom">10</property>
         <property name="orientation">vertical</property>
-        <property name="spacing">14</property>
-        <child internal-child="action_area">
-          <object class="GtkButtonBox">
-            <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
+        <property name="spacing">4</property>
+        <child>
+          <object class="GtkEntry" id="layerNameEntry">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="has-focus">True</property>
+            <property name="activates-default">True</property>
+            <property name="text" translatable="yes">Sample layer name</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">end</property>
+            <property name="spacing">4</property>
+            <property name="homogeneous">True</property>
             <child>
-              <object class="GtkButton" id="cancelButton">
-                <property name="label">gtk-close</property>
+              <object class="GtkButton" id="btCancel">
+                <property name="label" translatable="yes">Cancel</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
+                <property name="can-focus">True</property>
+                <property name="can-default">True</property>
+                <property name="receives-default">True</property>
+                <property name="image">iconCancel</property>
+                <accelerator key="Escape" signal="clicked"/>
               </object>
               <packing>
                 <property name="expand">True</property>
@@ -36,14 +67,14 @@
               </packing>
             </child>
             <child>
-              <object class="GtkButton" id="renameButton">
-                <property name="label">gtk-ok</property>
+              <object class="GtkButton" id="btOk">
+                <property name="label" translatable="yes">Ok</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
-                <property name="image_position">right</property>
-                <accelerator key="Return" signal="clicked"/>
+                <property name="can-focus">True</property>
+                <property name="can-default">True</property>
+                <property name="has-default">True</property>
+                <property name="receives-default">True</property>
+                <property name="image">iconOk</property>
               </object>
               <packing>
                 <property name="expand">True</property>
@@ -54,26 +85,11 @@
           </object>
           <packing>
             <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkEntry" id="layerNameEntry">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="text" translatable="yes">Sample layer name</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">1</property>
           </packing>
         </child>
       </object>
-    </child>
-    <child type="titlebar">
-      <placeholder/>
     </child>
   </object>
 </interface>

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.40.0 -->
 <interface>
-  <requires lib="gtk+" version="3.18"/>
+  <requires lib="gtk+" version="3.20"/>
   <object class="GtkAdjustment" id="adjustmentAudioGain">
     <property name="upper">10</property>
     <property name="value">1</property>
@@ -1536,7 +1536,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                                 <property name="left-padding">12</property>
                                                 <property name="right-padding">12</property>
                                                 <child>
-                                                  <object class="GtkBox" id="hboxMidleMouse">
+                                                  <object class="GtkBox" id="hboxMiddleMouse">
                                                     <property name="name">hboxMidleMouse</property>
                                                     <property name="visible">True</property>
                                                     <property name="can-focus">False</property>

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.40.0 -->
 <interface>
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.24"/>
   <object class="GtkAdjustment" id="adjustmentAudioGain">
     <property name="upper">10</property>
     <property name="value">1</property>
@@ -273,6 +273,7 @@
     <property name="width-request">1024</property>
     <property name="height-request">740</property>
     <property name="can-focus">False</property>
+    <property name="title" translatable="yes">Xournal++ Preferences</property>
     <property name="modal">True</property>
     <property name="destroy-with-parent">True</property>
     <property name="skip-taskbar-hint">True</property>
@@ -298,7 +299,7 @@
                 <property name="name">saveLoadTabBox</property>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="margin-left">5</property>
+                <property name="margin-start">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid01">
@@ -322,27 +323,41 @@
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
                                 <child>
-                                  <object class="GtkAlignment" id="sid05">
+                                  <object class="GtkBox" id="sid06">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">8</property>
+                                    <property name="orientation">vertical</property>
                                     <child>
-                                      <object class="GtkBox" id="sid06">
+                                      <object class="GtkLabel" id="label28">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="orientation">vertical</property>
-                                        <child>
-                                          <object class="GtkLabel" id="label28">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">&lt;i&gt;If the document already was saved you can find it in the same folder with the extension .autosave.xoj
+                                        <property name="label" translatable="yes">&lt;i&gt;If the document already was saved you can find it in the same folder with the extension .autosave.xoj
 If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
-                                            <property name="wrap">True</property>
-                                            <property name="max-width-chars">85</property>
-                                            <property name="xalign">0</property>
+                                        <property name="use-markup">True</property>
+                                        <property name="wrap">True</property>
+                                        <property name="max-width-chars">85</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkBox" id="sid07">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <child>
+                                          <object class="GtkCheckButton" id="cbAutosave">
+                                            <property name="label" translatable="yes">Enable Autosaving</property>
+                                            <property name="name">cbAutosave</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -351,18 +366,16 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkBox" id="sid07">
+                                          <object class="GtkBox" id="boxAutosave">
+                                            <property name="name">boxAutosave</property>
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
                                             <child>
-                                              <object class="GtkCheckButton" id="cbAutosave">
-                                                <property name="label" translatable="yes">Enable Autosaving</property>
-                                                <property name="name">cbAutosave</property>
+                                              <object class="GtkLabel" id="lbAutosaveTimeout1">
+                                                <property name="name">lbAutosaveTimeout1</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="receives-default">False</property>
-                                                <property name="xalign">0</property>
-                                                <property name="draw-indicator">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">every</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
@@ -371,55 +384,30 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                               </packing>
                                             </child>
                                             <child>
-                                              <object class="GtkBox" id="boxAutosave">
-                                                <property name="name">boxAutosave</property>
+                                              <object class="GtkSpinButton" id="spAutosaveTimeout">
+                                                <property name="name">spAutosaveTimeout</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <child>
-                                                  <object class="GtkLabel" id="lbAutosaveTimeout1">
-                                                    <property name="name">lbAutosaveTimeout1</property>
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
-                                                    <property name="label" translatable="yes">every</property>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="expand">False</property>
-                                                    <property name="fill">True</property>
-                                                    <property name="position">0</property>
-                                                  </packing>
-                                                </child>
-                                                <child>
-                                                  <object class="GtkSpinButton" id="spAutosaveTimeout">
-                                                    <property name="name">spAutosaveTimeout</property>
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">True</property>
-                                                    <property name="adjustment">adjustmentTimeout</property>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="expand">False</property>
-                                                    <property name="fill">True</property>
-                                                    <property name="padding">10</property>
-                                                    <property name="position">1</property>
-                                                  </packing>
-                                                </child>
-                                                <child>
-                                                  <object class="GtkLabel" id="lbAutosaveTimeout2">
-                                                    <property name="name">lbAutosaveTimeout2</property>
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
-                                                    <property name="label" translatable="yes">minutes</property>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="expand">False</property>
-                                                    <property name="fill">True</property>
-                                                    <property name="position">2</property>
-                                                  </packing>
-                                                </child>
+                                                <property name="can-focus">True</property>
+                                                <property name="adjustment">adjustmentTimeout</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
                                                 <property name="fill">True</property>
+                                                <property name="padding">10</property>
                                                 <property name="position">1</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel" id="lbAutosaveTimeout2">
+                                                <property name="name">lbAutosaveTimeout2</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">minutes</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">2</property>
                                               </packing>
                                             </child>
                                           </object>
@@ -430,6 +418,11 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                           </packing>
                                         </child>
                                       </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
                                     </child>
                                   </object>
                                 </child>
@@ -453,25 +446,50 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
                                 <child>
-                                  <object class="GtkAlignment" id="sid10">
+                                  <object class="GtkBox" id="vbox3">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="orientation">vertical</property>
                                     <child>
-                                      <object class="GtkBox" id="vbox3">
+                                      <object class="GtkLabel" id="label30">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="orientation">vertical</property>
+                                        <property name="label" translatable="yes">&lt;i&gt;This name will be proposed if you save a new document.&lt;/i&gt;</property>
+                                        <property name="use-markup">True</property>
+                                        <property name="wrap">True</property>
+                                        <property name="max-width-chars">85</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkEntry" id="txtDefaultSaveName">
+                                        <property name="name">txtDefaultSaveName</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="placeholder-text">%F-Note-%H-%M</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkBox" id="box14">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
                                         <child>
-                                          <object class="GtkLabel" id="label30">
+                                          <object class="GtkLabel" id="label31">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">&lt;i&gt;This name will be proposed if you save a new document.&lt;/i&gt;</property>
+                                            <property name="label" translatable="yes">Default name: </property>
                                             <property name="use-markup">True</property>
-                                            <property name="wrap">True</property>
-                                            <property name="max-width-chars">85</property>
-                                            <property name="xalign">0</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -480,11 +498,11 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkEntry" id="txtDefaultSaveName">
-                                            <property name="name">txtDefaultSaveName</property>
+                                          <object class="GtkLabel" id="lbDefaultSavename">
+                                            <property name="name">lbDefaultSavename</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="placeholder-text">%F-Note-%H-%M</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label">%F-Note-%H-%M</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -492,54 +510,24 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                             <property name="position">1</property>
                                           </packing>
                                         </child>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkExpander" id="expander1">
+                                        <property name="name">expander1</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
                                         <child>
-                                          <object class="GtkBox" id="box14">
+                                          <object class="GtkLabel" id="label33">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
-                                            <child>
-                                              <object class="GtkLabel" id="label31">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">Default name: </property>
-                                                <property name="use-markup">True</property>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">True</property>
-                                                <property name="position">0</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkLabel" id="lbDefaultSavename">
-                                                <property name="name">lbDefaultSavename</property>
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label">%F-Note-%H-%M</property>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">True</property>
-                                                <property name="position">1</property>
-                                              </packing>
-                                            </child>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">2</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkExpander" id="expander1">
-                                            <property name="name">expander1</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <child>
-                                              <object class="GtkLabel" id="label33">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="margin-left">20</property>
-                                                <property name="label" translatable="yes">%a		Abbreviated weekday name (e.g. Thu)
+                                            <property name="margin-start">20</property>
+                                            <property name="label" translatable="yes">%a		Abbreviated weekday name (e.g. Thu)
 %A		Full weekday name (e.g. Thursday)
 %b		Abbreviated month name (e.g. Aug)
 %B		Full month name (e.g. August)
@@ -562,49 +550,46 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
 %Y		Year (e.g. 2001)
 %Z		Timezone name or abbreviation (e.g. CDT)
 %%	A % sign</property>
-                                                <property name="xalign">0</property>
-                                              </object>
-                                            </child>
-                                            <child type="label">
-                                              <object class="GtkBox" id="box15">
+                                          </object>
+                                        </child>
+                                        <child type="label">
+                                          <object class="GtkBox" id="box15">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <child>
+                                              <object class="GtkImage" id="image1">
                                                 <property name="visible">True</property>
                                                 <property name="can-focus">False</property>
-                                                <child>
-                                                  <object class="GtkImage" id="image1">
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
-                                                    <property name="icon-name">dialog-information</property>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="expand">False</property>
-                                                    <property name="fill">True</property>
-                                                    <property name="position">0</property>
-                                                  </packing>
-                                                </child>
-                                                <child>
-                                                  <object class="GtkLabel" id="label32">
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
-                                                    <property name="margin-left">3</property>
-                                                    <property name="label" translatable="yes">Available Placeholders</property>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="expand">False</property>
-                                                    <property name="fill">True</property>
-                                                    <property name="position">1</property>
-                                                  </packing>
-                                                </child>
+                                                <property name="icon-name">dialog-information</property>
                                               </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel" id="label32">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="margin-start">3</property>
+                                                <property name="label" translatable="yes">Available Placeholders</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">1</property>
+                                              </packing>
                                             </child>
                                           </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="padding">10</property>
-                                            <property name="position">3</property>
-                                          </packing>
                                         </child>
                                       </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="padding">10</property>
+                                        <property name="position">3</property>
+                                      </packing>
                                     </child>
                                   </object>
                                 </child>
@@ -796,52 +781,44 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
                                 <child>
-                                  <object class="GtkAlignment" id="sid13">
+                                  <object class="GtkBox" id="sid14">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">8</property>
+                                    <property name="orientation">vertical</property>
                                     <child>
-                                      <object class="GtkBox" id="sid14">
+                                      <object class="GtkCheckButton" id="cbAutoloadXoj">
+                                        <property name="label" translatable="yes">Enable Autoloading of Journals</property>
+                                        <property name="name">cbAutoloadXoj</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="orientation">vertical</property>
-                                        <child>
-                                          <object class="GtkCheckButton" id="cbAutoloadXoj">
-                                            <property name="label" translatable="yes">Enable Autoloading of Journals</property>
-                                            <property name="name">cbAutoloadXoj</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="tooltip-text" translatable="yes">If you open a PDF and there is a Xournal file with the same name it will open the xoj file.</property>
-                                            <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkCheckButton" id="cbAutoloadMostRecent">
-                                            <property name="label" translatable="yes">Enable autoloading of most recent file on application startup</property>
-                                            <property name="name">cbAutoloadMostRecent</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="tooltip-text" translatable="yes">If enabled Xournal++ will open the most recent document automatically that you can continue editing your last saved document.</property>
-                                            <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="tooltip-text" translatable="yes">If you open a PDF and there is a Xournal file with the same name it will open the xoj file.</property>
+                                        <property name="draw-indicator">True</property>
                                       </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="cbAutoloadMostRecent">
+                                        <property name="label" translatable="yes">Enable autoloading of most recent file on application startup</property>
+                                        <property name="name">cbAutoloadMostRecent</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="tooltip-text" translatable="yes">If enabled Xournal++ will open the most recent document automatically that you can continue editing your last saved document.</property>
+                                        <property name="draw-indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
                                     </child>
                                   </object>
                                 </child>
@@ -888,7 +865,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                 <property name="name">inputTabBox</property>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="margin-left">5</property>
+                <property name="margin-start">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="swInputTab">
@@ -912,50 +889,43 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
                                 <child>
-                                  <object class="GtkAlignment" id="sid85">
+                                  <object class="GtkBox">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">8</property>
+                                    <property name="orientation">vertical</property>
                                     <child>
-                                      <object class="GtkBox">
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">&lt;i&gt;Assign device classes to each input device of your system. Only change these values if your devices are not correctly matched. (e.g. your pen shows up as touchscreen)&lt;/i&gt;</property>
+                                        <property name="use-markup">True</property>
+                                        <property name="wrap">True</property>
+                                        <property name="max-width-chars">85</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkBox" id="hboxInputDeviceClasses">
+                                        <property name="name">hboxInputDeviceClasses</property>
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">&lt;i&gt;Assign device classes to each input device of your system. Only change these values if your devices are not correctly matched. (e.g. your pen shows up as touchscreen)&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
-                                            <property name="wrap">True</property>
-                                            <property name="max-width-chars">85</property>
-                                            <property name="xalign">0</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkBox" id="hboxInputDeviceClasses">
-                                            <property name="name">hboxInputDeviceClasses</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="orientation">vertical</property>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
+                                          <placeholder/>
                                         </child>
                                       </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
                                     </child>
                                   </object>
                                 </child>
@@ -979,103 +949,91 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
                                 <child>
-                                  <object class="GtkAlignment" id="sid89">
+                                  <object class="GtkBox" id="sid90">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">8</property>
+                                    <property name="orientation">vertical</property>
                                     <child>
-                                      <object class="GtkBox" id="sid90">
+                                      <object class="GtkCheckButton" id="cbInputSystemDrawOutsideWindow">
+                                        <property name="name">cbInputSystemDrawOutsideWindow</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="orientation">vertical</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="draw-indicator">True</property>
                                         <child>
-                                          <object class="GtkCheckButton" id="cbInputSystemDrawOutsideWindow">
-                                            <property name="name">cbInputSystemDrawOutsideWindow</property>
+                                          <object class="GtkLabel" id="sid92">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="xalign">0.5</property>
-                                            <property name="draw-indicator">True</property>
-                                            <child>
-                                              <object class="GtkLabel" id="sid92">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">Enable drawing outside of window &lt;i&gt;(Drawing will not stop at the border of the window)&lt;/i&gt;</property>
-                                                <property name="use-markup">True</property>
-                                                <property name="wrap">True</property>
-                                                <property name="xalign">0</property>
-                                              </object>
-                                            </child>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">Enable drawing outside of window &lt;i&gt;(Drawing will not stop at the border of the window)&lt;/i&gt;</property>
+                                            <property name="use-markup">True</property>
+                                            <property name="wrap">True</property>
                                           </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
                                         </child>
-                                        <child>
-                                          <object class="GtkCheckButton" id="cbInputSystemTPCButton">
-                                            <property name="name">cbInputSystemTPCButton</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="tooltip-markup" translatable="yes">Drag LEFT from start point acts like shift key is being held.
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="cbInputSystemTPCButton">
+                                        <property name="name">cbInputSystemTPCButton</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="tooltip-markup" translatable="yes">Drag LEFT from start point acts like shift key is being held.
 	    Drag UP acts as if Control key is being held.
 
             Determination Radius: Radius at which modifiers will lock in until finished drawing.
 
 	    &lt;i&gt;Useful for operating without keyboard.&lt;/i&gt;</property>
-                                            <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
-                                            <child>
-                                              <object class="GtkLabel" id="sid93">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">Merge button events with stylus tip events
-	    &lt;i&gt;(Check this if&lt;/i&gt; "&lt;tt&gt;xsetwacom get *deviceId* TabletPCButton&lt;/tt&gt;" &lt;i&gt;returns&lt;/i&gt; "&lt;tt&gt;on&lt;/tt&gt;"&lt;i&gt;)&lt;/i&gt;</property>
-                                                <property name="use-markup">True</property>
-                                                <property name="wrap">True</property>
-                                                <property name="xalign">0</property>
-                                              </object>
-                                            </child>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">2</property>
-                                          </packing>
-                                        </child>
+                                        <property name="draw-indicator">True</property>
                                         <child>
-                                          <object class="GtkCheckButton" id="cbEnablePressureInference">
-                                            <property name="name">cbEnablePressureInference</property>
+                                          <object class="GtkLabel" id="sid93">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="tooltip-markup" translatable="yes">Slower strokes are assigned a greater pressure than faster strokes, if pressure information is absent.
-
-&lt;i&gt;This feature may be useful for devices that lack pressure sensitivity. For example, a mouse or touchscreen.&lt;/i&gt;</property>
-                                            <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
-                                            <child>
-                                              <object class="GtkLabel" id="sid201">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">Enable Pressure Inference &lt;i&gt;(Guess pressure from drawing speed when device-supplied pressure is not available)&lt;/i&gt;</property>
-                                                <property name="use-markup">True</property>
-                                                <property name="wrap">True</property>
-                                                <property name="xalign">0</property>
-                                              </object>
-                                            </child>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">Merge button events with stylus tip events
+	    &lt;i&gt;(Check this if&lt;/i&gt; "&lt;tt&gt;xsetwacom get *deviceId* TabletPCButton&lt;/tt&gt;" &lt;i&gt;returns&lt;/i&gt; "&lt;tt&gt;on&lt;/tt&gt;"&lt;i&gt;)&lt;/i&gt;</property>
+                                            <property name="use-markup">True</property>
+                                            <property name="wrap">True</property>
                                           </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">3</property>
-                                          </packing>
                                         </child>
                                       </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="cbEnablePressureInference">
+                                        <property name="name">cbEnablePressureInference</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="tooltip-markup" translatable="yes">Slower strokes are assigned a greater pressure than faster strokes, if pressure information is absent.
+
+&lt;i&gt;This feature may be useful for devices that lack pressure sensitivity. For example, a mouse or touchscreen.&lt;/i&gt;</property>
+                                        <property name="draw-indicator">True</property>
+                                        <child>
+                                          <object class="GtkLabel" id="sid201">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">Enable Pressure Inference &lt;i&gt;(Guess pressure from drawing speed when device-supplied pressure is not available)&lt;/i&gt;</property>
+                                            <property name="use-markup">True</property>
+                                            <property name="wrap">True</property>
+                                          </object>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">3</property>
+                                      </packing>
                                     </child>
                                   </object>
                                 </child>
@@ -1099,297 +1057,290 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
                                 <child>
-                                  <object class="GtkAlignment" id="alignmentStabilizer">
+                                  <!-- n-columns=4 n-rows=4 -->
+                                  <object class="GtkGrid" id="gridStabilizer">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="bottom-padding">12</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">12</property>
+                                    <property name="column-spacing">10</property>
                                     <child>
-                                      <!-- n-columns=4 n-rows=4 -->
-                                      <object class="GtkGrid" id="gridStabilizer">
+                                      <object class="GtkLabel" id="lbStabilizerAveragingMethod">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="column-spacing">10</property>
+                                        <property name="halign">start</property>
+                                        <property name="margin-start">16</property>
+                                        <property name="label" translatable="yes">Averaging method</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">0</property>
+                                        <property name="top-attach">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkComboBox" id="cbStabilizerAveragingMethods">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="hexpand">True</property>
+                                        <property name="model">listStabilizerAveragingMethods</property>
+                                        <property name="active">0</property>
+                                        <property name="id-column">0</property>
+                                        <property name="active-id">0</property>
                                         <child>
-                                          <object class="GtkLabel" id="lbStabilizerAveragingMethod">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="halign">start</property>
-                                            <property name="margin-start">16</property>
-                                            <property name="label" translatable="yes">Averaging method</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkComboBox" id="cbStabilizerAveragingMethods">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="hexpand">True</property>
-                                            <property name="model">listStabilizerAveragingMethods</property>
-                                            <property name="active">0</property>
-                                            <property name="id-column">0</property>
-                                            <property name="active-id">0</property>
-                                            <child>
-                                              <object class="GtkCellRendererText"/>
-                                              <attributes>
-                                                <attribute name="markup">0</attribute>
-                                                <attribute name="text">0</attribute>
-                                              </attributes>
-                                            </child>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">1</property>
-                                            <property name="top-attach">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkLabel" id="lbStabilizerDescription">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">&lt;i&gt;Pick an input stabilization algorithm and its parameters&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
-                                            <property name="wrap">True</property>
-                                            <property name="width-chars">85</property>
-                                            <property name="max-width-chars">85</property>
-                                            <property name="xalign">0</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">0</property>
-                                            <property name="width">4</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkLabel" id="lbStabilizerBuffersize">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">Buffersize</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">2</property>
-                                            <property name="top-attach">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSpinButton" id="sbStabilizerBuffersize">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="hexpand">True</property>
-                                            <property name="text" translatable="yes">20</property>
-                                            <property name="input-purpose">number</property>
-                                            <property name="adjustment">adjustmentStabilizingBuffersize</property>
-                                            <property name="climb-rate">1</property>
-                                            <property name="snap-to-ticks">True</property>
-                                            <property name="numeric">True</property>
-                                            <property name="value">20</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">3</property>
-                                            <property name="top-attach">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkLabel" id="lbStabilizerDeadzoneRadius">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">Deadzone radius</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">2</property>
-                                            <property name="top-attach">2</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSpinButton" id="sbStabilizerDeadzoneRadius">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="hexpand">True</property>
-                                            <property name="text" translatable="yes">1,30</property>
-                                            <property name="input-purpose">number</property>
-                                            <property name="adjustment">adjustmentStabilizerDeadzoneRadius</property>
-                                            <property name="climb-rate">2</property>
-                                            <property name="digits">2</property>
-                                            <property name="snap-to-ticks">True</property>
-                                            <property name="numeric">True</property>
-                                            <property name="value">1.3</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">3</property>
-                                            <property name="top-attach">2</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkLabel" id="lbStabilizerDrag">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="tooltip-text" translatable="yes">Drag: If the value is too small, unwanted oscillations may appear. If the value is too high, there will be no stabilization.</property>
-                                            <property name="label" translatable="yes">Drag</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">2</property>
-                                            <property name="top-attach">2</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSpinButton" id="sbStabilizerDrag">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="tooltip-text" translatable="yes">Drag: If the value is too small, unwanted oscillations may appear. If the value is too high, there will be no stabilization.</property>
-                                            <property name="hexpand">True</property>
-                                            <property name="text" translatable="yes">0,4</property>
-                                            <property name="input-purpose">number</property>
-                                            <property name="adjustment">adjustmentStabilizerDrag</property>
-                                            <property name="climb-rate">2</property>
-                                            <property name="digits">2</property>
-                                            <property name="snap-to-ticks">True</property>
-                                            <property name="numeric">True</property>
-                                            <property name="value">0.40</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">3</property>
-                                            <property name="top-attach">2</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkLabel" id="lbStabilizerMass">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="tooltip-text" translatable="yes">Mass: the higher the mass, the more inertia and the more stabilization</property>
-                                            <property name="label" translatable="yes">Mass</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">2</property>
-                                            <property name="top-attach">3</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSpinButton" id="sbStabilizerMass">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="tooltip-text" translatable="yes">Mass: the higher the mass, the more inertia and the more stabilization</property>
-                                            <property name="hexpand">True</property>
-                                            <property name="text" translatable="yes">5</property>
-                                            <property name="input-purpose">number</property>
-                                            <property name="adjustment">adjustmentStabilizerMass</property>
-                                            <property name="climb-rate">2</property>
-                                            <property name="digits">2</property>
-                                            <property name="snap-to-ticks">True</property>
-                                            <property name="numeric">True</property>
-                                            <property name="value">5</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">3</property>
-                                            <property name="top-attach">3</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSpinButton" id="sbStabilizerSigma">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="tooltip-text" translatable="yes">Gaussian parameter: the higher, the more stabilization and the more lag between your cursor and the painting tip.</property>
-                                            <property name="hexpand">True</property>
-                                            <property name="text" translatable="yes">0,50</property>
-                                            <property name="input-purpose">number</property>
-                                            <property name="adjustment">adjustmentStabilizerSigma</property>
-                                            <property name="climb-rate">0.99999999977648257</property>
-                                            <property name="digits">2</property>
-                                            <property name="snap-to-ticks">True</property>
-                                            <property name="numeric">True</property>
-                                            <property name="value">0.5</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">3</property>
-                                            <property name="top-attach">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkLabel" id="lbStabilizerSigma">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="tooltip-text" translatable="yes">Gaussian parameter: the higher, the more stabilization and the more lag between your cursor and the painting tip.</property>
-                                            <property name="label">σ</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">2</property>
-                                            <property name="top-attach">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkLabel" id="lbStabilizerPreprocessor">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="halign">start</property>
-                                            <property name="margin-start">15</property>
-                                            <property name="label" translatable="yes">Preprocessor</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">2</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkComboBox" id="cbStabilizerPreprocessors">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="hexpand">True</property>
-                                            <property name="model">listStabilizerPreprocessors</property>
-                                            <property name="active">0</property>
-                                            <property name="id-column">0</property>
-                                            <property name="active-id">0</property>
-                                            <child>
-                                              <object class="GtkCellRendererText"/>
-                                              <attributes>
-                                                <attribute name="markup">0</attribute>
-                                                <attribute name="text">0</attribute>
-                                              </attributes>
-                                            </child>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">1</property>
-                                            <property name="top-attach">2</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkCheckButton" id="cbStabilizerEnableCuspDetection">
-                                            <property name="label" translatable="yes">Cusp detection</property>
-                                            <property name="name">cbStabilizerEnableCuspDetection</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="halign">start</property>
-                                            <property name="active">True</property>
-                                            <property name="draw-indicator">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">2</property>
-                                            <property name="top-attach">3</property>
-                                            <property name="width">2</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkCheckButton" id="cbStabilizerEnableFinalizeStroke">
-                                            <property name="label" translatable="yes">Finalize the stroke</property>
-                                            <property name="name">cbStabilizerEnableFinalizeStroke</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="tooltip-text" translatable="yes">Input stabilization can create a gap at the end of your stroke. If enabled, this gap is filled.</property>
-                                            <property name="active">True</property>
-                                            <property name="draw-indicator">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">3</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
+                                          <object class="GtkCellRendererText"/>
+                                          <attributes>
+                                            <attribute name="markup">0</attribute>
+                                            <attribute name="text">0</attribute>
+                                          </attributes>
                                         </child>
                                       </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="top-attach">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="lbStabilizerDescription">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">&lt;i&gt;Pick an input stabilization algorithm and its parameters&lt;/i&gt;</property>
+                                        <property name="use-markup">True</property>
+                                        <property name="wrap">True</property>
+                                        <property name="width-chars">85</property>
+                                        <property name="max-width-chars">85</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">0</property>
+                                        <property name="top-attach">0</property>
+                                        <property name="width">4</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="lbStabilizerBuffersize">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">Buffersize</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">2</property>
+                                        <property name="top-attach">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSpinButton" id="sbStabilizerBuffersize">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="hexpand">True</property>
+                                        <property name="text" translatable="yes">20</property>
+                                        <property name="input-purpose">number</property>
+                                        <property name="adjustment">adjustmentStabilizingBuffersize</property>
+                                        <property name="climb-rate">1</property>
+                                        <property name="snap-to-ticks">True</property>
+                                        <property name="numeric">True</property>
+                                        <property name="value">20</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">3</property>
+                                        <property name="top-attach">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="lbStabilizerDeadzoneRadius">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">Deadzone radius</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">2</property>
+                                        <property name="top-attach">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSpinButton" id="sbStabilizerDeadzoneRadius">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="hexpand">True</property>
+                                        <property name="text" translatable="yes">1,30</property>
+                                        <property name="input-purpose">number</property>
+                                        <property name="adjustment">adjustmentStabilizerDeadzoneRadius</property>
+                                        <property name="climb-rate">2</property>
+                                        <property name="digits">2</property>
+                                        <property name="snap-to-ticks">True</property>
+                                        <property name="numeric">True</property>
+                                        <property name="value">1.3</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">3</property>
+                                        <property name="top-attach">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="lbStabilizerDrag">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="tooltip-text" translatable="yes">Drag: If the value is too small, unwanted oscillations may appear. If the value is too high, there will be no stabilization.</property>
+                                        <property name="label" translatable="yes">Drag</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">2</property>
+                                        <property name="top-attach">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSpinButton" id="sbStabilizerDrag">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="tooltip-text" translatable="yes">Drag: If the value is too small, unwanted oscillations may appear. If the value is too high, there will be no stabilization.</property>
+                                        <property name="hexpand">True</property>
+                                        <property name="text" translatable="yes">0,4</property>
+                                        <property name="input-purpose">number</property>
+                                        <property name="adjustment">adjustmentStabilizerDrag</property>
+                                        <property name="climb-rate">2</property>
+                                        <property name="digits">2</property>
+                                        <property name="snap-to-ticks">True</property>
+                                        <property name="numeric">True</property>
+                                        <property name="value">0.40</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">3</property>
+                                        <property name="top-attach">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="lbStabilizerMass">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="tooltip-text" translatable="yes">Mass: the higher the mass, the more inertia and the more stabilization</property>
+                                        <property name="label" translatable="yes">Mass</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">2</property>
+                                        <property name="top-attach">3</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSpinButton" id="sbStabilizerMass">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="tooltip-text" translatable="yes">Mass: the higher the mass, the more inertia and the more stabilization</property>
+                                        <property name="hexpand">True</property>
+                                        <property name="text" translatable="yes">5</property>
+                                        <property name="input-purpose">number</property>
+                                        <property name="adjustment">adjustmentStabilizerMass</property>
+                                        <property name="climb-rate">2</property>
+                                        <property name="digits">2</property>
+                                        <property name="snap-to-ticks">True</property>
+                                        <property name="numeric">True</property>
+                                        <property name="value">5</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">3</property>
+                                        <property name="top-attach">3</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSpinButton" id="sbStabilizerSigma">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="tooltip-text" translatable="yes">Gaussian parameter: the higher, the more stabilization and the more lag between your cursor and the painting tip.</property>
+                                        <property name="hexpand">True</property>
+                                        <property name="text" translatable="yes">0,50</property>
+                                        <property name="input-purpose">number</property>
+                                        <property name="adjustment">adjustmentStabilizerSigma</property>
+                                        <property name="climb-rate">0.99999999977648257</property>
+                                        <property name="digits">2</property>
+                                        <property name="snap-to-ticks">True</property>
+                                        <property name="numeric">True</property>
+                                        <property name="value">0.5</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">3</property>
+                                        <property name="top-attach">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="lbStabilizerSigma">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="tooltip-text" translatable="yes">Gaussian parameter: the higher, the more stabilization and the more lag between your cursor and the painting tip.</property>
+                                        <property name="label">σ</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">2</property>
+                                        <property name="top-attach">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="lbStabilizerPreprocessor">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">start</property>
+                                        <property name="margin-start">15</property>
+                                        <property name="label" translatable="yes">Preprocessor</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">0</property>
+                                        <property name="top-attach">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkComboBox" id="cbStabilizerPreprocessors">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="hexpand">True</property>
+                                        <property name="model">listStabilizerPreprocessors</property>
+                                        <property name="active">0</property>
+                                        <property name="id-column">0</property>
+                                        <property name="active-id">0</property>
+                                        <child>
+                                          <object class="GtkCellRendererText"/>
+                                          <attributes>
+                                            <attribute name="markup">0</attribute>
+                                            <attribute name="text">0</attribute>
+                                          </attributes>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="top-attach">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="cbStabilizerEnableCuspDetection">
+                                        <property name="label" translatable="yes">Cusp detection</property>
+                                        <property name="name">cbStabilizerEnableCuspDetection</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="halign">start</property>
+                                        <property name="active">True</property>
+                                        <property name="draw-indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">2</property>
+                                        <property name="top-attach">3</property>
+                                        <property name="width">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="cbStabilizerEnableFinalizeStroke">
+                                        <property name="label" translatable="yes">Finalize the stroke</property>
+                                        <property name="name">cbStabilizerEnableFinalizeStroke</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="tooltip-text" translatable="yes">Input stabilization can create a gap at the end of your stroke. If enabled, this gap is filled.</property>
+                                        <property name="active">True</property>
+                                        <property name="draw-indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">0</property>
+                                        <property name="top-attach">3</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <placeholder/>
                                     </child>
                                   </object>
                                 </child>
@@ -1440,7 +1391,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                 <property name="name">mouseTabBox</property>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="margin-left">5</property>
+                <property name="margin-start">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid17">
@@ -1462,110 +1413,91 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
                                 <child>
-                                  <object class="GtkAlignment" id="sid21">
+                                  <object class="GtkBox" id="sid22">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="bottom-padding">12</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">12</property>
+                                    <property name="orientation">vertical</property>
                                     <child>
-                                      <object class="GtkBox" id="sid22">
+                                      <object class="GtkLabel" id="label23">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="orientation">vertical</property>
+                                        <property name="label" translatable="yes">&lt;i&gt;Define which tools will be selected if you press a mouse button. After you release the button the previously selected tool will be selected.&lt;/i&gt;</property>
+                                        <property name="use-markup">True</property>
+                                        <property name="wrap">True</property>
+                                        <property name="max-width-chars">85</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkFrame" id="sid23">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label-xalign">0.009999999776482582</property>
                                         <child>
-                                          <object class="GtkLabel" id="label23">
+                                          <object class="GtkBox" id="hboxMiddleMouse">
+                                            <property name="name">hboxMidleMouse</property>
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">&lt;i&gt;Define which tools will be selected if you press a mouse button. After you release the button the previously selected tool will be selected.&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
-                                            <property name="wrap">True</property>
-                                            <property name="max-width-chars">85</property>
-                                            <property name="xalign">0</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkFrame" id="sid23">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label-xalign">0.009999999776482582</property>
+                                            <property name="margin-start">12</property>
+                                            <property name="margin-end">12</property>
+                                            <property name="margin-bottom">8</property>
                                             <child>
-                                              <object class="GtkAlignment" id="sid24">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="bottom-padding">8</property>
-                                                <property name="left-padding">12</property>
-                                                <property name="right-padding">12</property>
-                                                <child>
-                                                  <object class="GtkBox" id="hboxMiddleMouse">
-                                                    <property name="name">hboxMidleMouse</property>
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
-                                                    <child>
-                                                      <placeholder/>
-                                                    </child>
-                                                  </object>
-                                                </child>
-                                              </object>
-                                            </child>
-                                            <child type="label">
-                                              <object class="GtkLabel" id="sid25">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">Middle Mouse Button</property>
-                                              </object>
+                                              <placeholder/>
                                             </child>
                                           </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
                                         </child>
-                                        <child>
-                                          <object class="GtkFrame" id="sid26">
+                                        <child type="label">
+                                          <object class="GtkLabel" id="sid25">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
-                                            <property name="label-xalign">0.009999999776482582</property>
-                                            <child>
-                                              <object class="GtkAlignment" id="sid27">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="bottom-padding">8</property>
-                                                <property name="left-padding">12</property>
-                                                <property name="right-padding">12</property>
-                                                <child>
-                                                  <object class="GtkBox" id="hboxRightMouse">
-                                                    <property name="name">hboxRightMouse</property>
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
-                                                    <child>
-                                                      <placeholder/>
-                                                    </child>
-                                                  </object>
-                                                </child>
-                                              </object>
-                                            </child>
-                                            <child type="label">
-                                              <object class="GtkLabel" id="sid28">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">Right Mouse Button</property>
-                                              </object>
-                                            </child>
+                                            <property name="label" translatable="yes">Middle Mouse Button</property>
                                           </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">2</property>
-                                          </packing>
                                         </child>
                                       </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkFrame" id="sid26">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label-xalign">0.009999999776482582</property>
+                                        <child>
+                                          <object class="GtkBox" id="hboxRightMouse">
+                                            <property name="name">hboxRightMouse</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="margin-start">12</property>
+                                            <property name="margin-end">12</property>
+                                            <property name="margin-bottom">8</property>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                          </object>
+                                        </child>
+                                        <child type="label">
+                                          <object class="GtkLabel" id="sid28">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">Right Mouse Button</property>
+                                          </object>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">2</property>
+                                      </packing>
                                     </child>
                                   </object>
                                 </child>
@@ -1616,7 +1548,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                 <property name="name">stylusTabBox</property>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="margin-left">5</property>
+                <property name="margin-start">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid30">
@@ -1640,176 +1572,161 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
                                 <child>
-                                  <object class="GtkAlignment" id="sid34">
+                                  <object class="GtkBox" id="sid35">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">8</property>
+                                    <property name="orientation">vertical</property>
                                     <child>
-                                      <object class="GtkBox" id="sid35">
+                                      <object class="GtkLabel" id="sid36">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="orientation">vertical</property>
+                                        <property name="label" translatable="yes">&lt;i&gt;Pressure Sensitivity allows you to draw lines with different widths, depending on how much pressure you apply to the pen. If your tablet does not support this feature this setting has no effect.&lt;/i&gt;</property>
+                                        <property name="use-markup">True</property>
+                                        <property name="wrap">True</property>
+                                        <property name="max-width-chars">85</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="cbSettingPresureSensitivity">
+                                        <property name="label" translatable="yes">Enable Pressure Sensitivity</property>
+                                        <property name="name">cbSettingPresureSensitivity</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="draw-indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkFrame" id="framePressureSensitivityScale">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label-xalign">0.009999999776482582</property>
                                         <child>
-                                          <object class="GtkLabel" id="sid36">
+                                          <object class="GtkBox" id="boxSensitivityScaleOptions">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">&lt;i&gt;Pressure Sensitivity allows you to draw lines with different widths, depending on how much pressure you apply to the pen. If your tablet does not support this feature this setting has no effect.&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
-                                            <property name="wrap">True</property>
-                                            <property name="max-width-chars">85</property>
-                                            <property name="xalign">0</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkCheckButton" id="cbSettingPresureSensitivity">
-                                            <property name="label" translatable="yes">Enable Pressure Sensitivity</property>
-                                            <property name="name">cbSettingPresureSensitivity</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkFrame" id="framePressureSensitivityScale">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label-xalign">0.009999999776482582</property>
+                                            <property name="margin-start">12</property>
+                                            <property name="margin-end">12</property>
+                                            <property name="margin-bottom">8</property>
+                                            <property name="orientation">vertical</property>
                                             <child>
-                                              <object class="GtkAlignment" id="alignSensitivityScale">
+                                              <object class="GtkLabel" id="lbSensitivityScaleDescription">
                                                 <property name="visible">True</property>
                                                 <property name="can-focus">False</property>
-                                                <property name="bottom-padding">8</property>
-                                                <property name="left-padding">12</property>
-                                                <property name="right-padding">12</property>
+                                                <property name="label" translatable="yes">&lt;i&gt;Some devices report unexpectedly small or large pressures. This can be fixed by setting a minimum pressure or scaling the pressure reported by the device.&lt;/i&gt;</property>
+                                                <property name="use-markup">True</property>
+                                                <property name="wrap">True</property>
+                                                <property name="max-width-chars">85</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <!-- n-columns=3 n-rows=3 -->
+                                              <object class="GtkGrid" id="gridPressureSensitivityOptions">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="column-spacing">5</property>
+                                                <property name="column-homogeneous">True</property>
                                                 <child>
-                                                  <object class="GtkBox" id="boxSensitivityScaleOptions">
+                                                  <object class="GtkLabel">
                                                     <property name="visible">True</property>
                                                     <property name="can-focus">False</property>
-                                                    <property name="orientation">vertical</property>
-                                                    <child>
-                                                      <object class="GtkLabel" id="lbSensitivityScaleDescription">
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="label" translatable="yes">&lt;i&gt;Some devices report unexpectedly small or large pressures. This can be fixed by setting a minimum pressure or scaling the pressure reported by the device.&lt;/i&gt;</property>
-                                                        <property name="use-markup">True</property>
-                                                        <property name="wrap">True</property>
-                                                        <property name="max-width-chars">85</property>
-                                                        <property name="xalign">0</property>
-                                                      </object>
-                                                      <packing>
-                                                        <property name="expand">False</property>
-                                                        <property name="fill">True</property>
-                                                        <property name="position">0</property>
-                                                      </packing>
-                                                    </child>
-                                                    <child>
-                                                      <!-- n-columns=3 n-rows=3 -->
-                                                      <object class="GtkGrid" id="gridPressureSensitivityOptions">
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="column-spacing">5</property>
-                                                        <property name="column-homogeneous">True</property>
-                                                        <child>
-                                                          <object class="GtkLabel">
-                                                            <property name="visible">True</property>
-                                                            <property name="can-focus">False</property>
-                                                            <property name="label" translatable="yes">Minimum Pressure:</property>
-                                                          </object>
-                                                          <packing>
-                                                            <property name="left-attach">0</property>
-                                                            <property name="top-attach">0</property>
-                                                          </packing>
-                                                        </child>
-                                                        <child>
-                                                          <object class="GtkLabel">
-                                                            <property name="visible">True</property>
-                                                            <property name="can-focus">False</property>
-                                                            <property name="label" translatable="yes">Pressure Multiplier: </property>
-                                                          </object>
-                                                          <packing>
-                                                            <property name="left-attach">0</property>
-                                                            <property name="top-attach">1</property>
-                                                          </packing>
-                                                        </child>
-                                                        <child>
-                                                          <object class="GtkScale" id="scaleMinimumPressure">
-                                                            <property name="visible">True</property>
-                                                            <property name="can-focus">True</property>
-                                                            <property name="adjustment">adjustmentMinimumPressure</property>
-                                                            <property name="round-digits">1</property>
-                                                            <property name="digits">2</property>
-                                                            <property name="value-pos">right</property>
-                                                          </object>
-                                                          <packing>
-                                                            <property name="left-attach">1</property>
-                                                            <property name="top-attach">0</property>
-                                                            <property name="width">2</property>
-                                                          </packing>
-                                                        </child>
-                                                        <child>
-                                                          <object class="GtkScale" id="scalePressureMultiplier">
-                                                            <property name="visible">True</property>
-                                                            <property name="can-focus">True</property>
-                                                            <property name="adjustment">adjustmentPressureMultiplier</property>
-                                                            <property name="round-digits">1</property>
-                                                            <property name="digits">2</property>
-                                                            <property name="value-pos">right</property>
-                                                          </object>
-                                                          <packing>
-                                                            <property name="left-attach">1</property>
-                                                            <property name="top-attach">1</property>
-                                                            <property name="width">2</property>
-                                                          </packing>
-                                                        </child>
-                                                        <child>
-                                                          <placeholder/>
-                                                        </child>
-                                                        <child>
-                                                          <placeholder/>
-                                                        </child>
-                                                        <child>
-                                                          <placeholder/>
-                                                        </child>
-                                                      </object>
-                                                      <packing>
-                                                        <property name="expand">True</property>
-                                                        <property name="fill">True</property>
-                                                        <property name="position">2</property>
-                                                      </packing>
-                                                    </child>
+                                                    <property name="label" translatable="yes">Minimum Pressure:</property>
                                                   </object>
+                                                  <packing>
+                                                    <property name="left-attach">0</property>
+                                                    <property name="top-attach">0</property>
+                                                  </packing>
+                                                </child>
+                                                <child>
+                                                  <object class="GtkLabel">
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">False</property>
+                                                    <property name="label" translatable="yes">Pressure Multiplier: </property>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="left-attach">0</property>
+                                                    <property name="top-attach">1</property>
+                                                  </packing>
+                                                </child>
+                                                <child>
+                                                  <object class="GtkScale" id="scaleMinimumPressure">
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">True</property>
+                                                    <property name="adjustment">adjustmentMinimumPressure</property>
+                                                    <property name="round-digits">1</property>
+                                                    <property name="digits">2</property>
+                                                    <property name="value-pos">right</property>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="left-attach">1</property>
+                                                    <property name="top-attach">0</property>
+                                                    <property name="width">2</property>
+                                                  </packing>
+                                                </child>
+                                                <child>
+                                                  <object class="GtkScale" id="scalePressureMultiplier">
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">True</property>
+                                                    <property name="adjustment">adjustmentPressureMultiplier</property>
+                                                    <property name="round-digits">1</property>
+                                                    <property name="digits">2</property>
+                                                    <property name="value-pos">right</property>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="left-attach">1</property>
+                                                    <property name="top-attach">1</property>
+                                                    <property name="width">2</property>
+                                                  </packing>
+                                                </child>
+                                                <child>
+                                                  <placeholder/>
+                                                </child>
+                                                <child>
+                                                  <placeholder/>
+                                                </child>
+                                                <child>
+                                                  <placeholder/>
                                                 </child>
                                               </object>
-                                            </child>
-                                            <child type="label">
-                                              <object class="GtkLabel" id="lbSensitivityScaleHeader">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">Sensitivity Scale</property>
-                                              </object>
+                                              <packing>
+                                                <property name="expand">True</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">2</property>
+                                              </packing>
                                             </child>
                                           </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">2</property>
-                                          </packing>
+                                        </child>
+                                        <child type="label">
+                                          <object class="GtkLabel" id="lbSensitivityScaleHeader">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">Sensitivity Scale</property>
+                                          </object>
                                         </child>
                                       </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">2</property>
+                                      </packing>
                                     </child>
                                   </object>
                                 </child>
@@ -1833,26 +1750,37 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
                                 <child>
-                                  <object class="GtkAlignment" id="sid184">
+                                  <object class="GtkBox" id="sid185">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="orientation">vertical</property>
                                     <child>
-                                      <object class="GtkBox" id="sid185">
+                                      <object class="GtkLabel" id="sid186">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="orientation">vertical</property>
+                                        <property name="label" translatable="yes">&lt;i&gt;With some setup, pen strokes have artifacts at their beginning. This can be avoided by ignoring the first few events/stroke-points when the pen touches the screen.&lt;/i&gt;</property>
+                                        <property name="use-markup">True</property>
+                                        <property name="wrap">True</property>
+                                        <property name="max-width-chars">85</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkBox" id="sid187">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
                                         <child>
-                                          <object class="GtkLabel" id="sid186">
+                                          <object class="GtkCheckButton" id="cbIgnoreFirstStylusEvents">
+                                            <property name="label" translatable="yes">Ignore the first</property>
+                                            <property name="name">cbSettingIgnoreFirstStylusEvents</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">&lt;i&gt;With some setup, pen strokes have artifacts at their beginning. This can be avoided by ignoring the first few events/stroke-points when the pen touches the screen.&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
-                                            <property name="wrap">True</property>
-                                            <property name="max-width-chars">85</property>
-                                            <property name="xalign">0</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -1861,62 +1789,40 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkBox" id="sid187">
+                                          <object class="GtkSpinButton" id="spNumIgnoredStylusEvents">
+                                            <property name="name">spNrOfIgnoredFirstStylusEvents</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <child>
-                                              <object class="GtkCheckButton" id="cbIgnoreFirstStylusEvents">
-                                                <property name="label" translatable="yes">Ignore the first</property>
-                                                <property name="name">cbSettingIgnoreFirstStylusEvents</property>
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="receives-default">False</property>
-                                                <property name="xalign">0</property>
-                                                <property name="draw-indicator">True</property>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">True</property>
-                                                <property name="position">0</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkSpinButton" id="spNumIgnoredStylusEvents">
-                                                <property name="name">spNrOfIgnoredFirstStylusEvents</property>
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="text" translatable="yes">1</property>
-                                                <property name="adjustment">adjustmentIgnoreStylusEvents</property>
-                                                <property name="value">1</property>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">True</property>
-                                                <property name="padding">10</property>
-                                                <property name="position">1</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkLabel" id="lbIgnoreFirstStylusEvents">
-                                                <property name="name">lbIgnoreFirstStylusEvents</property>
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">events</property>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">True</property>
-                                                <property name="position">2</property>
-                                              </packing>
-                                            </child>
+                                            <property name="can-focus">True</property>
+                                            <property name="text" translatable="yes">1</property>
+                                            <property name="adjustment">adjustmentIgnoreStylusEvents</property>
+                                            <property name="value">1</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
                                             <property name="fill">True</property>
+                                            <property name="padding">10</property>
                                             <property name="position">1</property>
                                           </packing>
                                         </child>
+                                        <child>
+                                          <object class="GtkLabel" id="lbIgnoreFirstStylusEvents">
+                                            <property name="name">lbIgnoreFirstStylusEvents</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">events</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">2</property>
+                                          </packing>
+                                        </child>
                                       </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
                                     </child>
                                   </object>
                                 </child>
@@ -1940,148 +1846,123 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
                                 <child>
-                                  <object class="GtkAlignment" id="sid39">
+                                  <object class="GtkBox" id="sid40">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="bottom-padding">12</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">12</property>
+                                    <property name="orientation">vertical</property>
                                     <child>
-                                      <object class="GtkBox" id="sid40">
+                                      <object class="GtkLabel" id="sid41">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="orientation">vertical</property>
+                                        <property name="label" translatable="yes">&lt;i&gt;Specify the tools that will be selected if a button of the stylus is pressed or the eraser is used. After releasing the button, the previous tool will be selected.&lt;/i&gt;</property>
+                                        <property name="use-markup">True</property>
+                                        <property name="wrap">True</property>
+                                        <property name="max-width-chars">85</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkFrame" id="sid42">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label-xalign">0.009999999776482582</property>
                                         <child>
-                                          <object class="GtkLabel" id="sid41">
+                                          <object class="GtkBox" id="hboxPenButton1">
+                                            <property name="name">hboxPenButton1</property>
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">&lt;i&gt;Specify the tools that will be selected if a button of the stylus is pressed or the eraser is used. After releasing the button, the previous tool will be selected.&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
-                                            <property name="wrap">True</property>
-                                            <property name="max-width-chars">85</property>
-                                            <property name="xalign">0</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkFrame" id="sid42">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label-xalign">0.009999999776482582</property>
+                                            <property name="margin-start">12</property>
+                                            <property name="margin-end">12</property>
+                                            <property name="margin-bottom">8</property>
                                             <child>
-                                              <object class="GtkAlignment" id="sid43">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="bottom-padding">8</property>
-                                                <property name="left-padding">12</property>
-                                                <property name="right-padding">12</property>
-                                                <child>
-                                                  <object class="GtkBox" id="hboxPenButton1">
-                                                    <property name="name">hboxPenButton1</property>
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
-                                                    <child>
-                                                      <placeholder/>
-                                                    </child>
-                                                  </object>
-                                                </child>
-                                              </object>
-                                            </child>
-                                            <child type="label">
-                                              <object class="GtkLabel" id="sid44">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">Button 1</property>
-                                              </object>
+                                              <placeholder/>
                                             </child>
                                           </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
                                         </child>
-                                        <child>
-                                          <object class="GtkFrame" id="sid45">
+                                        <child type="label">
+                                          <object class="GtkLabel" id="sid44">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
-                                            <property name="label-xalign">0.009999999776482582</property>
-                                            <child>
-                                              <object class="GtkAlignment" id="sid46">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="bottom-padding">8</property>
-                                                <property name="left-padding">12</property>
-                                                <property name="right-padding">12</property>
-                                                <child>
-                                                  <object class="GtkBox" id="hboxPenButton2">
-                                                    <property name="name">hboxPenButton2</property>
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
-                                                    <child>
-                                                      <placeholder/>
-                                                    </child>
-                                                  </object>
-                                                </child>
-                                              </object>
-                                            </child>
-                                            <child type="label">
-                                              <object class="GtkLabel" id="sid47">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">Button 2</property>
-                                              </object>
-                                            </child>
+                                            <property name="label" translatable="yes">Button 1</property>
                                           </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">2</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkFrame" id="sid48">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label-xalign">0.009999999776482582</property>
-                                            <child>
-                                              <object class="GtkAlignment" id="sid49">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="bottom-padding">8</property>
-                                                <property name="left-padding">12</property>
-                                                <property name="right-padding">12</property>
-                                                <child>
-                                                  <object class="GtkBox" id="hboxEraser">
-                                                    <property name="name">hboxEraser</property>
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
-                                                    <child>
-                                                      <placeholder/>
-                                                    </child>
-                                                  </object>
-                                                </child>
-                                              </object>
-                                            </child>
-                                            <child type="label">
-                                              <object class="GtkLabel" id="sid50">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">Eraser</property>
-                                              </object>
-                                            </child>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">3</property>
-                                          </packing>
                                         </child>
                                       </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkFrame" id="sid45">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label-xalign">0.009999999776482582</property>
+                                        <child>
+                                          <object class="GtkBox" id="hboxPenButton2">
+                                            <property name="name">hboxPenButton2</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="margin-start">12</property>
+                                            <property name="margin-end">12</property>
+                                            <property name="margin-bottom">8</property>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                          </object>
+                                        </child>
+                                        <child type="label">
+                                          <object class="GtkLabel" id="sid47">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">Button 2</property>
+                                          </object>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkFrame" id="sid48">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label-xalign">0.009999999776482582</property>
+                                        <child>
+                                          <object class="GtkBox" id="hboxEraser">
+                                            <property name="name">hboxEraser</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="margin-start">12</property>
+                                            <property name="margin-end">12</property>
+                                            <property name="margin-bottom">8</property>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                          </object>
+                                        </child>
+                                        <child type="label">
+                                          <object class="GtkLabel" id="sid50">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">Eraser</property>
+                                          </object>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">3</property>
+                                      </packing>
                                     </child>
                                   </object>
                                 </child>
@@ -2105,62 +1986,55 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
                                 <child>
-                                  <object class="GtkAlignment" id="sid7">
+                                  <object class="GtkBox" id="sid8">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">8</property>
+                                    <property name="orientation">vertical</property>
                                     <child>
-                                      <object class="GtkBox" id="sid8">
+                                      <object class="GtkBox">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="orientation">vertical</property>
+                                        <property name="spacing">5</property>
                                         <child>
-                                          <object class="GtkBox">
+                                          <object class="GtkLabel">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
-                                            <property name="spacing">5</property>
-                                            <child>
-                                              <object class="GtkLabel">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">Stylus-based eraser is visible</property>
-                                                <property name="xalign">0</property>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">True</property>
-                                                <property name="position">0</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkComboBoxText" id="cbEraserVisibility">
-                                                <property name="name">cbEraserVisibility</property>
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="active">0</property>
-                                                <items>
-                                                  <item id="never" translatable="yes" context="eraser is never visible">Never</item>
-                                                  <item id="always" translatable="yes" context="eraser is always visible">Always</item>
-                                                  <item id="float" translatable="yes" context="eraser is only visible when floating">When floating</item>
-                                                  <item id="touch" translatable="yes" context="eraser is only visible when touching the screen">When touching</item>
-                                                </items>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">True</property>
-                                                <property name="position">1</property>
-                                              </packing>
-                                            </child>
+                                            <property name="label" translatable="yes">Stylus-based eraser is visible</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
                                             <property name="fill">True</property>
-                                            <property name="position">2</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkComboBoxText" id="cbEraserVisibility">
+                                            <property name="name">cbEraserVisibility</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="active">0</property>
+                                            <items>
+                                              <item id="never" translatable="yes" context="eraser is never visible">Never</item>
+                                              <item id="always" translatable="yes" context="eraser is always visible">Always</item>
+                                              <item id="float" translatable="yes" context="eraser is only visible when floating">When floating</item>
+                                              <item id="touch" translatable="yes" context="eraser is only visible when touching the screen">When touching</item>
+                                            </items>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
                                           </packing>
                                         </child>
                                       </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">2</property>
+                                      </packing>
                                     </child>
                                   </object>
                                 </child>
@@ -2211,7 +2085,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                 <property name="name">touchTabBox</property>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="margin-left">5</property>
+                <property name="margin-start">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid52">
@@ -2235,49 +2109,42 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
                                 <child>
-                                  <object class="GtkAlignment" id="sid56">
+                                  <object class="GtkBox" id="sid57">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">8</property>
+                                    <property name="orientation">vertical</property>
                                     <child>
-                                      <object class="GtkBox" id="sid57">
+                                      <object class="GtkLabel" id="sid58">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="orientation">vertical</property>
+                                        <property name="label" translatable="yes">&lt;i&gt;You can configure devices, not identified by GTK as touchscreen, to behave as if they were one.&lt;/i&gt;</property>
+                                        <property name="use-markup">True</property>
+                                        <property name="wrap">True</property>
+                                        <property name="max-width-chars">85</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkBox" id="hboxTouch">
+                                        <property name="name">hboxTouch</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
                                         <child>
-                                          <object class="GtkLabel" id="sid58">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">&lt;i&gt;You can configure devices, not identified by GTK as touchscreen, to behave as if they were one.&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
-                                            <property name="wrap">True</property>
-                                            <property name="max-width-chars">85</property>
-                                            <property name="xalign">0</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkBox" id="hboxTouch">
-                                            <property name="name">hboxTouch</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">True</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
+                                          <placeholder/>
                                         </child>
                                       </object>
+                                      <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
                                     </child>
                                   </object>
                                 </child>
@@ -2301,26 +2168,134 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
                                 <child>
-                                  <object class="GtkAlignment" id="sid61">
+                                  <object class="GtkBox" id="sid62">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">8</property>
+                                    <property name="orientation">vertical</property>
                                     <child>
-                                      <object class="GtkBox" id="sid62">
+                                      <object class="GtkLabel" id="sid63">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">&lt;i&gt;If your hardware does not support hand recognition, Xournal++ can disable your touchscreen when your pen is near the screen.&lt;/i&gt;</property>
+                                        <property name="use-markup">True</property>
+                                        <property name="wrap">True</property>
+                                        <property name="max-width-chars">85</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="cbDisableTouchOnPenNear">
+                                        <property name="label" translatable="yes">Enable internal Hand Recognition</property>
+                                        <property name="name">cbDisableTouchOnPenNear</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="draw-indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkBox" id="boxInternalHandRecognition">
+                                        <property name="name">boxInternalHandRecognition</property>
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
-                                          <object class="GtkLabel" id="sid63">
+                                          <!-- n-columns=3 n-rows=3 -->
+                                          <object class="GtkGrid" id="sid64">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">&lt;i&gt;If your hardware does not support hand recognition, Xournal++ can disable your touchscreen when your pen is near the screen.&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
-                                            <property name="wrap">True</property>
-                                            <property name="max-width-chars">85</property>
-                                            <property name="xalign">0</property>
+                                            <property name="row-spacing">5</property>
+                                            <property name="column-spacing">5</property>
+                                            <child>
+                                              <object class="GtkLabel" id="label50">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">Disabling Method</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel" id="label55">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">Timeout</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">1</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkComboBoxText" id="cbTouchDisableMethod">
+                                                <property name="name">cbTouchDisableMethod</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="active">0</property>
+                                                <items>
+                                                  <item translatable="yes">Autodetect</item>
+                                                  <item>X11</item>
+                                                  <item translatable="yes">Custom</item>
+                                                </items>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSpinButton" id="spTouchDisableTimeout">
+                                                <property name="name">spTouchDisableTimeout</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="adjustment">adjustmentTouchTImeout</property>
+                                                <property name="climb-rate">0.5</property>
+                                                <property name="digits">1</property>
+                                                <property name="value">1</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">1</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel" id="label56">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">s &lt;i&gt;(after which the touchscreen will be reactivated again)&lt;/i&gt;</property>
+                                                <property name="use-markup">True</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">2</property>
+                                                <property name="top-attach">1</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -2329,14 +2304,138 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkCheckButton" id="cbDisableTouchOnPenNear">
-                                            <property name="label" translatable="yes">Enable internal Hand Recognition</property>
-                                            <property name="name">cbDisableTouchOnPenNear</property>
+                                          <object class="GtkFrame" id="boxCustomTouchDisableSettings">
+                                            <property name="name">boxCustomTouchDisableSettings</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label-xalign">0.009999999776482582</property>
+                                            <child>
+                                              <object class="GtkBox" id="sid66">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="margin-start">12</property>
+                                                <property name="margin-end">12</property>
+                                                <property name="margin-bottom">8</property>
+                                                <property name="orientation">vertical</property>
+                                                <child>
+                                                  <object class="GtkLabel" id="label54">
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">False</property>
+                                                    <property name="label" translatable="yes">&lt;i&gt;Specify commands that are called once Hand Recognition triggers. The commands will be executed in the UI Thread, make sure they are not blocking!&lt;/i&gt;</property>
+                                                    <property name="use-markup">True</property>
+                                                    <property name="wrap">True</property>
+                                                    <property name="max-width-chars">85</property>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="expand">False</property>
+                                                    <property name="fill">True</property>
+                                                    <property name="position">0</property>
+                                                  </packing>
+                                                </child>
+                                                <child>
+                                                  <!-- n-columns=3 n-rows=3 -->
+                                                  <object class="GtkGrid" id="grid3">
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">False</property>
+                                                    <property name="row-spacing">5</property>
+                                                    <property name="column-spacing">5</property>
+                                                    <child>
+                                                      <object class="GtkLabel" id="label52">
+                                                        <property name="visible">True</property>
+                                                        <property name="can-focus">False</property>
+                                                        <property name="label" translatable="yes">Enable</property>
+                                                      </object>
+                                                      <packing>
+                                                        <property name="left-attach">0</property>
+                                                        <property name="top-attach">0</property>
+                                                      </packing>
+                                                    </child>
+                                                    <child>
+                                                      <object class="GtkLabel" id="label53">
+                                                        <property name="visible">True</property>
+                                                        <property name="can-focus">False</property>
+                                                        <property name="label" translatable="yes">Disable</property>
+                                                      </object>
+                                                      <packing>
+                                                        <property name="left-attach">0</property>
+                                                        <property name="top-attach">1</property>
+                                                      </packing>
+                                                    </child>
+                                                    <child>
+                                                      <object class="GtkEntry" id="txtEnableTouchCommand">
+                                                        <property name="name">txtEnableTouchCommand</property>
+                                                        <property name="visible">True</property>
+                                                        <property name="can-focus">True</property>
+                                                        <property name="hexpand">True</property>
+                                                      </object>
+                                                      <packing>
+                                                        <property name="left-attach">1</property>
+                                                        <property name="top-attach">0</property>
+                                                      </packing>
+                                                    </child>
+                                                    <child>
+                                                      <object class="GtkEntry" id="txtDisableTouchCommand">
+                                                        <property name="name">txtDisableTouchCommand</property>
+                                                        <property name="visible">True</property>
+                                                        <property name="can-focus">True</property>
+                                                        <property name="hexpand">True</property>
+                                                      </object>
+                                                      <packing>
+                                                        <property name="left-attach">1</property>
+                                                        <property name="top-attach">1</property>
+                                                      </packing>
+                                                    </child>
+                                                    <child>
+                                                      <object class="GtkButton" id="btTestEnable">
+                                                        <property name="label" translatable="yes">Test</property>
+                                                        <property name="name">btTestEnable</property>
+                                                        <property name="visible">True</property>
+                                                        <property name="can-focus">True</property>
+                                                        <property name="receives-default">True</property>
+                                                      </object>
+                                                      <packing>
+                                                        <property name="left-attach">2</property>
+                                                        <property name="top-attach">0</property>
+                                                      </packing>
+                                                    </child>
+                                                    <child>
+                                                      <object class="GtkButton" id="btTestDisable">
+                                                        <property name="label" translatable="yes">Test</property>
+                                                        <property name="name">btTestDisable</property>
+                                                        <property name="visible">True</property>
+                                                        <property name="can-focus">True</property>
+                                                        <property name="receives-default">True</property>
+                                                      </object>
+                                                      <packing>
+                                                        <property name="left-attach">2</property>
+                                                        <property name="top-attach">1</property>
+                                                      </packing>
+                                                    </child>
+                                                    <child>
+                                                      <placeholder/>
+                                                    </child>
+                                                    <child>
+                                                      <placeholder/>
+                                                    </child>
+                                                    <child>
+                                                      <placeholder/>
+                                                    </child>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="expand">False</property>
+                                                    <property name="fill">True</property>
+                                                    <property name="position">1</property>
+                                                  </packing>
+                                                </child>
+                                              </object>
+                                            </child>
+                                            <child type="label">
+                                              <object class="GtkLabel" id="sid67">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">Custom Commands (for Method "Custom")</property>
+                                              </object>
+                                            </child>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -2344,262 +2443,12 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                             <property name="position">1</property>
                                           </packing>
                                         </child>
-                                        <child>
-                                          <object class="GtkBox" id="boxInternalHandRecognition">
-                                            <property name="name">boxInternalHandRecognition</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="orientation">vertical</property>
-                                            <child>
-                                              <!-- n-columns=3 n-rows=3 -->
-                                              <object class="GtkGrid" id="sid64">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="row-spacing">5</property>
-                                                <property name="column-spacing">5</property>
-                                                <child>
-                                                  <object class="GtkLabel" id="label50">
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
-                                                    <property name="label" translatable="yes">Disabling Method</property>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="left-attach">0</property>
-                                                    <property name="top-attach">0</property>
-                                                  </packing>
-                                                </child>
-                                                <child>
-                                                  <object class="GtkLabel" id="label55">
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
-                                                    <property name="label" translatable="yes">Timeout</property>
-                                                    <property name="xalign">0</property>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="left-attach">0</property>
-                                                    <property name="top-attach">1</property>
-                                                  </packing>
-                                                </child>
-                                                <child>
-                                                  <object class="GtkComboBoxText" id="cbTouchDisableMethod">
-                                                    <property name="name">cbTouchDisableMethod</property>
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
-                                                    <property name="active">0</property>
-                                                    <items>
-                                                      <item translatable="yes">Autodetect</item>
-                                                      <item>X11</item>
-                                                      <item translatable="yes">Custom</item>
-                                                    </items>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="left-attach">1</property>
-                                                    <property name="top-attach">0</property>
-                                                  </packing>
-                                                </child>
-                                                <child>
-                                                  <object class="GtkSpinButton" id="spTouchDisableTimeout">
-                                                    <property name="name">spTouchDisableTimeout</property>
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">True</property>
-                                                    <property name="adjustment">adjustmentTouchTImeout</property>
-                                                    <property name="climb-rate">0.5</property>
-                                                    <property name="digits">1</property>
-                                                    <property name="value">1</property>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="left-attach">1</property>
-                                                    <property name="top-attach">1</property>
-                                                  </packing>
-                                                </child>
-                                                <child>
-                                                  <object class="GtkLabel" id="label56">
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
-                                                    <property name="label" translatable="yes">s &lt;i&gt;(after which the touchscreen will be reactivated again)&lt;/i&gt;</property>
-                                                    <property name="use-markup">True</property>
-                                                    <property name="xalign">0</property>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="left-attach">2</property>
-                                                    <property name="top-attach">1</property>
-                                                  </packing>
-                                                </child>
-                                                <child>
-                                                  <placeholder/>
-                                                </child>
-                                                <child>
-                                                  <placeholder/>
-                                                </child>
-                                                <child>
-                                                  <placeholder/>
-                                                </child>
-                                                <child>
-                                                  <placeholder/>
-                                                </child>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">True</property>
-                                                <property name="position">0</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkFrame" id="boxCustomTouchDisableSettings">
-                                                <property name="name">boxCustomTouchDisableSettings</property>
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label-xalign">0.009999999776482582</property>
-                                                <child>
-                                                  <object class="GtkAlignment" id="sid65">
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
-                                                    <property name="bottom-padding">8</property>
-                                                    <property name="left-padding">12</property>
-                                                    <property name="right-padding">12</property>
-                                                    <child>
-                                                      <object class="GtkBox" id="sid66">
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="orientation">vertical</property>
-                                                        <child>
-                                                          <object class="GtkLabel" id="label54">
-                                                            <property name="visible">True</property>
-                                                            <property name="can-focus">False</property>
-                                                            <property name="label" translatable="yes">&lt;i&gt;Specify commands that are called once Hand Recognition triggers. The commands will be executed in the UI Thread, make sure they are not blocking!&lt;/i&gt;</property>
-                                                            <property name="use-markup">True</property>
-                                                            <property name="wrap">True</property>
-                                                            <property name="max-width-chars">85</property>
-                                                            <property name="xalign">0</property>
-                                                          </object>
-                                                          <packing>
-                                                            <property name="expand">False</property>
-                                                            <property name="fill">True</property>
-                                                            <property name="position">0</property>
-                                                          </packing>
-                                                        </child>
-                                                        <child>
-                                                          <!-- n-columns=3 n-rows=3 -->
-                                                          <object class="GtkGrid" id="grid3">
-                                                            <property name="visible">True</property>
-                                                            <property name="can-focus">False</property>
-                                                            <property name="row-spacing">5</property>
-                                                            <property name="column-spacing">5</property>
-                                                            <child>
-                                                            <object class="GtkLabel" id="label52">
-                                                            <property name="visible">True</property>
-                                                            <property name="can-focus">False</property>
-                                                            <property name="label" translatable="yes">Enable</property>
-                                                            <property name="xalign">0</property>
-                                                            </object>
-                                                            <packing>
-                                                            <property name="left-attach">0</property>
-                                                            <property name="top-attach">0</property>
-                                                            </packing>
-                                                            </child>
-                                                            <child>
-                                                            <object class="GtkLabel" id="label53">
-                                                            <property name="visible">True</property>
-                                                            <property name="can-focus">False</property>
-                                                            <property name="label" translatable="yes">Disable</property>
-                                                            </object>
-                                                            <packing>
-                                                            <property name="left-attach">0</property>
-                                                            <property name="top-attach">1</property>
-                                                            </packing>
-                                                            </child>
-                                                            <child>
-                                                            <object class="GtkEntry" id="txtEnableTouchCommand">
-                                                            <property name="name">txtEnableTouchCommand</property>
-                                                            <property name="visible">True</property>
-                                                            <property name="can-focus">True</property>
-                                                            <property name="hexpand">True</property>
-                                                            </object>
-                                                            <packing>
-                                                            <property name="left-attach">1</property>
-                                                            <property name="top-attach">0</property>
-                                                            </packing>
-                                                            </child>
-                                                            <child>
-                                                            <object class="GtkEntry" id="txtDisableTouchCommand">
-                                                            <property name="name">txtDisableTouchCommand</property>
-                                                            <property name="visible">True</property>
-                                                            <property name="can-focus">True</property>
-                                                            <property name="hexpand">True</property>
-                                                            </object>
-                                                            <packing>
-                                                            <property name="left-attach">1</property>
-                                                            <property name="top-attach">1</property>
-                                                            </packing>
-                                                            </child>
-                                                            <child>
-                                                            <object class="GtkButton" id="btTestEnable">
-                                                            <property name="label" translatable="yes">Test</property>
-                                                            <property name="name">btTestEnable</property>
-                                                            <property name="visible">True</property>
-                                                            <property name="can-focus">True</property>
-                                                            <property name="receives-default">True</property>
-                                                            </object>
-                                                            <packing>
-                                                            <property name="left-attach">2</property>
-                                                            <property name="top-attach">0</property>
-                                                            </packing>
-                                                            </child>
-                                                            <child>
-                                                            <object class="GtkButton" id="btTestDisable">
-                                                            <property name="label" translatable="yes">Test</property>
-                                                            <property name="name">btTestDisable</property>
-                                                            <property name="visible">True</property>
-                                                            <property name="can-focus">True</property>
-                                                            <property name="receives-default">True</property>
-                                                            </object>
-                                                            <packing>
-                                                            <property name="left-attach">2</property>
-                                                            <property name="top-attach">1</property>
-                                                            </packing>
-                                                            </child>
-                                                            <child>
-                                                            <placeholder/>
-                                                            </child>
-                                                            <child>
-                                                            <placeholder/>
-                                                            </child>
-                                                            <child>
-                                                            <placeholder/>
-                                                            </child>
-                                                          </object>
-                                                          <packing>
-                                                            <property name="expand">False</property>
-                                                            <property name="fill">True</property>
-                                                            <property name="position">1</property>
-                                                          </packing>
-                                                        </child>
-                                                      </object>
-                                                    </child>
-                                                  </object>
-                                                </child>
-                                                <child type="label">
-                                                  <object class="GtkLabel" id="sid67">
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
-                                                    <property name="label" translatable="yes">Custom Commands (for Method "Custom")</property>
-                                                  </object>
-                                                </child>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">True</property>
-                                                <property name="position">1</property>
-                                              </packing>
-                                            </child>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">2</property>
-                                          </packing>
-                                        </child>
                                       </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">2</property>
+                                      </packing>
                                     </child>
                                   </object>
                                 </child>
@@ -2623,118 +2472,110 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
                                 <child>
-                                  <object class="GtkAlignment" id="sid70">
+                                  <object class="GtkBox" id="sid71">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">8</property>
+                                    <property name="orientation">vertical</property>
                                     <child>
-                                      <object class="GtkBox" id="sid71">
+                                      <object class="GtkLabel" id="sid72">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="orientation">vertical</property>
+                                        <property name="label" translatable="yes">&lt;i&gt;Use pinch gestures to zoom journal pages.&lt;/i&gt;</property>
+                                        <property name="use-markup">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="cbEnableZoomGestures">
+                                        <property name="label" translatable="yes">Enable zoom gestures (requires restart)</property>
+                                        <property name="name">cbEnableZoomGestures</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="draw-indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <!-- n-columns=3 n-rows=3 -->
+                                      <object class="GtkGrid" id="gdStartZoomAtSetting">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="tooltip-text" translatable="yes">When drawing with touch, two-finger gestures intended to pan the view can instead cause it to zoom, causing performance issues.
+This setting can make it easier to draw with touch. </property>
                                         <child>
-                                          <object class="GtkLabel" id="sid72">
+                                          <object class="GtkLabel" id="label2">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">&lt;i&gt;Use pinch gestures to zoom journal pages.&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
-                                            <property name="xalign">0</property>
+                                            <property name="label" translatable="yes">Start zooming after a distance </property>
                                           </object>
                                           <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkCheckButton" id="cbEnableZoomGestures">
-                                            <property name="label" translatable="yes">Enable zoom gestures (requires restart)</property>
-                                            <property name="name">cbEnableZoomGestures</property>
+                                          <object class="GtkSpinButton" id="spTouchZoomStartThreshold">
+                                            <property name="name">spTouchDisableTimeout</property>
                                             <property name="visible">True</property>
                                             <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
+                                            <property name="text" translatable="yes">1.0</property>
+                                            <property name="adjustment">adjustmentZoomStartThreshold</property>
+                                            <property name="climb-rate">0.5</property>
+                                            <property name="digits">1</property>
+                                            <property name="value">1</property>
                                           </object>
                                           <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
-                                          <!-- n-columns=3 n-rows=3 -->
-                                          <object class="GtkGrid" id="gdStartZoomAtSetting">
+                                          <object class="GtkLabel" id="label4">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
-                                            <property name="tooltip-text" translatable="yes">When drawing with touch, two-finger gestures intended to pan the view can instead cause it to zoom, causing performance issues.
-This setting can make it easier to draw with touch. </property>
-                                            <child>
-                                              <object class="GtkLabel" id="label2">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">Start zooming after a distance </property>
-                                              </object>
-                                              <packing>
-                                                <property name="left-attach">0</property>
-                                                <property name="top-attach">0</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkSpinButton" id="spTouchZoomStartThreshold">
-                                                <property name="name">spTouchDisableTimeout</property>
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="text" translatable="yes">1.0</property>
-                                                <property name="adjustment">adjustmentZoomStartThreshold</property>
-                                                <property name="climb-rate">0.5</property>
-                                                <property name="digits">1</property>
-                                                <property name="value">1</property>
-                                              </object>
-                                              <packing>
-                                                <property name="left-attach">1</property>
-                                                <property name="top-attach">0</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkLabel" id="label4">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">% greater than the initial distance between the two touches.</property>
-                                              </object>
-                                              <packing>
-                                                <property name="left-attach">2</property>
-                                                <property name="top-attach">0</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
+                                            <property name="label" translatable="yes">% greater than the initial distance between the two touches.</property>
                                           </object>
                                           <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">2</property>
+                                            <property name="left-attach">2</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
                                         </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
                                       </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">2</property>
+                                      </packing>
                                     </child>
                                   </object>
                                 </child>
@@ -2758,51 +2599,43 @@ This setting can make it easier to draw with touch. </property>
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
                                 <child>
-                                  <object class="GtkAlignment" id="touchDrawingFrameAlignment">
+                                  <object class="GtkBox" id="boxTouchDrawing">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">8</property>
+                                    <property name="orientation">vertical</property>
                                     <child>
-                                      <object class="GtkBox" id="boxTouchDrawing">
+                                      <object class="GtkLabel" id="lblTouchDrawingDescription">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="orientation">vertical</property>
-                                        <child>
-                                          <object class="GtkLabel" id="lblTouchDrawingDescription">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">&lt;i&gt;Use the touchscreen like a multi-touch-aware pen.&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
-                                            <property name="wrap">True</property>
-                                            <property name="max-width-chars">85</property>
-                                            <property name="xalign">0</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkCheckButton" id="cbTouchDrawing">
-                                            <property name="label" translatable="yes">Enable touch drawing</property>
-                                            <property name="name">cbTouchDrawing</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="tooltip-text" translatable="yes">Use two fingers to pan/zoom and one finger to use the selected tool.</property>
-                                            <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
+                                        <property name="label" translatable="yes">&lt;i&gt;Use the touchscreen like a multi-touch-aware pen.&lt;/i&gt;</property>
+                                        <property name="use-markup">True</property>
+                                        <property name="wrap">True</property>
+                                        <property name="max-width-chars">85</property>
                                       </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="cbTouchDrawing">
+                                        <property name="label" translatable="yes">Enable touch drawing</property>
+                                        <property name="name">cbTouchDrawing</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="tooltip-text" translatable="yes">Use two fingers to pan/zoom and one finger to use the selected tool.</property>
+                                        <property name="draw-indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
                                     </child>
                                   </object>
                                 </child>
@@ -2826,51 +2659,43 @@ This setting can make it easier to draw with touch. </property>
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
                                 <child>
-                                  <object class="GtkAlignment" id="touchScrollingFrameAlignment">
+                                  <object class="GtkBox" id="boxTouchScrolling">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">8</property>
+                                    <property name="orientation">vertical</property>
                                     <child>
-                                      <object class="GtkBox" id="boxTouchScrolling">
+                                      <object class="GtkLabel" id="lblTouchKineticScrollDisableDescription">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="orientation">vertical</property>
-                                        <child>
-                                          <object class="GtkLabel" id="lblTouchKineticScrollDisableDescription">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">&lt;i&gt;Disabling GTK's built-in touchscreen scrolling can work around scrolling bugs on some platforms. Consider changing this setting if you experience jumps/sudden changes in scroll position when attempting to scroll with a touchscreen.&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
-                                            <property name="wrap">True</property>
-                                            <property name="max-width-chars">85</property>
-                                            <property name="xalign">0</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkCheckButton" id="cbDisableGtkInertialScroll">
-                                            <property name="label" translatable="yes">Disable GTK's built-in inertial scroll functionality (requires restart).</property>
-                                            <property name="name">cbTouchDrawing</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="tooltip-text" translatable="yes">Use two fingers to pan/zoom and one finger to use the selected tool.</property>
-                                            <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
+                                        <property name="label" translatable="yes">&lt;i&gt;Disabling GTK's built-in touchscreen scrolling can work around scrolling bugs on some platforms. Consider changing this setting if you experience jumps/sudden changes in scroll position when attempting to scroll with a touchscreen.&lt;/i&gt;</property>
+                                        <property name="use-markup">True</property>
+                                        <property name="wrap">True</property>
+                                        <property name="max-width-chars">85</property>
                                       </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="cbDisableGtkInertialScroll">
+                                        <property name="label" translatable="yes">Disable GTK's built-in inertial scroll functionality (requires restart).</property>
+                                        <property name="name">cbTouchDrawing</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="tooltip-text" translatable="yes">Use two fingers to pan/zoom and one finger to use the selected tool.</property>
+                                        <property name="draw-indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
                                     </child>
                                   </object>
                                 </child>
@@ -2921,7 +2746,7 @@ This setting can make it easier to draw with touch. </property>
                 <property name="name">viewTabBox</property>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="margin-left">5</property>
+                <property name="margin-start">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid95">
@@ -2945,58 +2770,32 @@ This setting can make it easier to draw with touch. </property>
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
                                 <child>
-                                  <object class="GtkAlignment" id="sid99">
+                                  <object class="GtkBox" id="sid100">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="bottom-padding">12</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">12</property>
+                                    <property name="orientation">vertical</property>
                                     <child>
-                                      <object class="GtkBox" id="sid100">
+                                      <object class="GtkBox" id="vbox6">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
+                                        <property name="halign">start</property>
                                         <property name="orientation">vertical</property>
                                         <child>
-                                          <object class="GtkBox" id="vbox6">
+                                          <object class="GtkBox" id="vbox7">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
                                             <property name="halign">start</property>
-                                            <property name="orientation">vertical</property>
                                             <child>
-                                              <object class="GtkBox" id="vbox7">
+                                              <object class="GtkCheckButton" id="cbHideMenubarStartup">
+                                                <property name="label" translatable="yes">Show Menubar on Startup</property>
+                                                <property name="name">cbHideMenubarStartup</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="halign">start</property>
-                                                <child>
-                                                  <object class="GtkCheckButton" id="cbHideMenubarStartup">
-                                                    <property name="label" translatable="yes">Show Menubar on Startup</property>
-                                                    <property name="name">cbHideMenubarStartup</property>
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">True</property>
-                                                    <property name="receives-default">False</property>
-                                                    <property name="xalign">0</property>
-                                                    <property name="draw-indicator">True</property>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="expand">False</property>
-                                                    <property name="fill">True</property>
-                                                    <property name="position">0</property>
-                                                  </packing>
-                                                </child>
-                                                <child>
-                                                  <object class="GtkLabel" id="sid101">
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
-                                                    <property name="margin-left">5</property>
-                                                    <property name="label" translatable="yes">&lt;i&gt;Toggle visibility of menubar with F10&lt;/i&gt;</property>
-                                                    <property name="use-markup">True</property>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="expand">False</property>
-                                                    <property name="fill">True</property>
-                                                    <property name="position">1</property>
-                                                  </packing>
-                                                </child>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">False</property>
+                                                <property name="draw-indicator">True</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
@@ -3005,35 +2804,17 @@ This setting can make it easier to draw with touch. </property>
                                               </packing>
                                             </child>
                                             <child>
-                                              <object class="GtkCheckButton" id="cbShowFilepathInTitlebar">
-                                                <property name="label" translatable="yes">Show filepath in title bar</property>
-                                                <property name="name">cbShowFilepathInTitlebar</property>
+                                              <object class="GtkLabel" id="sid101">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="receives-default">False</property>
-                                                <property name="xalign">0</property>
-                                                <property name="draw-indicator">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="margin-start">5</property>
+                                                <property name="label" translatable="yes">&lt;i&gt;Toggle visibility of menubar with F10&lt;/i&gt;</property>
+                                                <property name="use-markup">True</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
                                                 <property name="fill">True</property>
-                                                <property name="position">2</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkCheckButton" id="cbShowPageNumberInTitlebar">
-                                                <property name="label" translatable="yes">Show page number in title bar</property>
-                                                <property name="name">cbShowPageNumberInTitlebar</property>
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="receives-default">False</property>
-                                                <property name="xalign">0</property>
-                                                <property name="draw-indicator">True</property>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">True</property>
-                                                <property name="position">2</property>
+                                                <property name="position">1</property>
                                               </packing>
                                             </child>
                                           </object>
@@ -3044,239 +2825,13 @@ This setting can make it easier to draw with touch. </property>
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkFrame" id="colorsFrame">
-                                            <property name="name">colorsFrame</property>
+                                          <object class="GtkCheckButton" id="cbShowFilepathInTitlebar">
+                                            <property name="label" translatable="yes">Show filepath in title bar</property>
+                                            <property name="name">cbShowFilepathInTitlebar</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label-xalign">0.009999999776482582</property>
-                                            <child>
-                                              <object class="GtkAlignment" id="sid102">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="bottom-padding">8</property>
-                                                <property name="left-padding">12</property>
-                                                <property name="right-padding">12</property>
-                                                <child>
-                                                  <!-- n-columns=3 n-rows=6 -->
-                                                  <object class="GtkGrid" id="grid2">
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
-                                                    <child>
-                                                      <object class="GtkLabel" id="label10">
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="hexpand">True</property>
-                                                        <property name="label" translatable="yes">Border color for current page and other selections</property>
-                                                        <property name="justify">right</property>
-                                                        <property name="xalign">0</property>
-                                                      </object>
-                                                      <packing>
-                                                        <property name="left-attach">0</property>
-                                                        <property name="top-attach">0</property>
-                                                      </packing>
-                                                    </child>
-                                                    <child>
-                                                      <object class="GtkColorButton" id="colorBorder">
-                                                        <property name="name">colorBorder</property>
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">True</property>
-                                                        <property name="receives-default">True</property>
-                                                        <property name="title" translatable="yes">Border color</property>
-                                                      </object>
-                                                      <packing>
-                                                        <property name="left-attach">1</property>
-                                                        <property name="top-attach">0</property>
-                                                      </packing>
-                                                    </child>
-                                                    <child>
-                                                      <object class="GtkLabel" id="label13">
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="label" translatable="yes">Background color between pages</property>
-                                                        <property name="xalign">0</property>
-                                                      </object>
-                                                      <packing>
-                                                        <property name="left-attach">0</property>
-                                                        <property name="top-attach">1</property>
-                                                      </packing>
-                                                    </child>
-                                                    <child>
-                                                      <object class="GtkColorButton" id="colorBackground">
-                                                        <property name="name">colorBackground</property>
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">True</property>
-                                                        <property name="receives-default">True</property>
-                                                        <property name="margin-top">5</property>
-                                                      </object>
-                                                      <packing>
-                                                        <property name="left-attach">1</property>
-                                                        <property name="top-attach">1</property>
-                                                      </packing>
-                                                    </child>
-                                                    <child>
-                                                      <object class="GtkLabel" id="label57">
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="label" translatable="yes">Selection Color (Text, Stroke Selection etc.)</property>
-                                                        <property name="xalign">0</property>
-                                                      </object>
-                                                      <packing>
-                                                        <property name="left-attach">0</property>
-                                                        <property name="top-attach">2</property>
-                                                      </packing>
-                                                    </child>
-                                                    <child>
-                                                      <object class="GtkColorButton" id="colorSelection">
-                                                        <property name="name">colorSelection</property>
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">True</property>
-                                                        <property name="receives-default">True</property>
-                                                        <property name="margin-top">5</property>
-                                                      </object>
-                                                      <packing>
-                                                        <property name="left-attach">1</property>
-                                                        <property name="top-attach">2</property>
-                                                      </packing>
-                                                    </child>
-                                                    <child>
-                                                      <object class="GtkLabel">
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="label" translatable="yes">Active Selection Color (Search Results etc.)</property>
-                                                        <property name="xalign">0</property>
-                                                      </object>
-                                                      <packing>
-                                                        <property name="left-attach">0</property>
-                                                        <property name="top-attach">3</property>
-                                                      </packing>
-                                                    </child>
-                                                    <child>
-                                                      <object class="GtkColorButton" id="colorSelectionActive">
-                                                        <property name="name">colorSelectionActive</property>
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">True</property>
-                                                        <property name="receives-default">True</property>
-                                                        <property name="margin-top">5</property>
-                                                      </object>
-                                                      <packing>
-                                                        <property name="left-attach">1</property>
-                                                        <property name="top-attach">3</property>
-                                                      </packing>
-                                                    </child>
-                                                    <child>
-                                                      <object class="GtkBox">
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <child>
-                                                          <object class="GtkLabel">
-                                                            <property name="visible">True</property>
-                                                            <property name="can-focus">False</property>
-                                                            <property name="label" translatable="yes">Icon Theme</property>
-                                                            <property name="xalign">0</property>
-                                                          </object>
-                                                          <packing>
-                                                            <property name="expand">False</property>
-                                                            <property name="fill">True</property>
-                                                            <property name="position">0</property>
-                                                          </packing>
-                                                        </child>
-                                                        <child>
-                                                          <object class="GtkComboBoxText" id="cbIconTheme">
-                                                            <property name="name">cbIconTheme</property>
-                                                            <property name="visible">True</property>
-                                                            <property name="can-focus">False</property>
-                                                            <property name="active">0</property>
-                                                            <items>
-                                                            <item id="iconsColor" translatable="yes">Color</item>
-                                                            <item id="iconsLucide" translatable="yes">Lucide</item>
-                                                            </items>
-                                                          </object>
-                                                          <packing>
-                                                            <property name="expand">False</property>
-                                                            <property name="fill">True</property>
-                                                            <property name="position">1</property>
-                                                          </packing>
-                                                        </child>
-                                                        <child>
-                                                          <object class="GtkLabel">
-                                                            <property name="visible">True</property>
-                                                            <property name="can-focus">False</property>
-                                                            <property name="label" translatable="yes">(requires restart)</property>
-                                                          </object>
-                                                          <packing>
-                                                            <property name="expand">False</property>
-                                                            <property name="fill">True</property>
-                                                            <property name="position">2</property>
-                                                          </packing>
-                                                        </child>
-                                                      </object>
-                                                      <packing>
-                                                        <property name="left-attach">0</property>
-                                                        <property name="top-attach">4</property>
-                                                        <property name="width">2</property>
-                                                      </packing>
-                                                    </child>
-                                                    <child>
-                                                      <object class="GtkCheckButton" id="cbDarkTheme">
-                                                        <property name="label" translatable="yes">Dark Theme (requires restart)</property>
-                                                        <property name="name">cbDarkTheme</property>
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">True</property>
-                                                        <property name="receives-default">False</property>
-                                                        <property name="xalign">0</property>
-                                                        <property name="draw-indicator">True</property>
-                                                      </object>
-                                                      <packing>
-                                                        <property name="left-attach">0</property>
-                                                        <property name="top-attach">5</property>
-                                                        <property name="width">2</property>
-                                                      </packing>
-                                                    </child>
-                                                    <child>
-                                                      <object class="GtkCheckButton" id="cbStockIcons">
-                                                        <property name="label" translatable="yes">Use available Stock Icons (requires restart)</property>
-                                                        <property name="name">cbStockIcons</property>
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">True</property>
-                                                        <property name="receives-default">False</property>
-                                                        <property name="xalign">0</property>
-                                                        <property name="draw-indicator">True</property>
-                                                      </object>
-                                                      <packing>
-                                                        <property name="left-attach">0</property>
-                                                        <property name="top-attach">6</property>
-                                                        <property name="width">2</property>
-                                                      </packing>
-                                                    </child>
-                                                    <child>
-                                                      <placeholder/>
-                                                    </child>
-                                                    <child>
-                                                      <placeholder/>
-                                                    </child>
-                                                    <child>
-                                                      <placeholder/>
-                                                    </child>
-                                                    <child>
-                                                      <placeholder/>
-                                                    </child>
-                                                    <child>
-                                                      <placeholder/>
-                                                    </child>
-                                                    <child>
-                                                      <placeholder/>
-                                                    </child>
-                                                  </object>
-                                                </child>
-                                              </object>
-                                            </child>
-                                            <child type="label">
-                                              <object class="GtkLabel" id="sid103">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">Colors</property>
-                                              </object>
-                                            </child>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="draw-indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -3284,7 +2839,244 @@ This setting can make it easier to draw with touch. </property>
                                             <property name="position">1</property>
                                           </packing>
                                         </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="cbShowPageNumberInTitlebar">
+                                            <property name="label" translatable="yes">Show page number in title bar</property>
+                                            <property name="name">cbShowPageNumberInTitlebar</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="draw-indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">2</property>
+                                          </packing>
+                                        </child>
                                       </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkFrame" id="colorsFrame">
+                                        <property name="name">colorsFrame</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label-xalign">0.009999999776482582</property>
+                                        <child>
+                                          <!-- n-columns=2 n-rows=7 -->
+                                          <object class="GtkGrid" id="grid2">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="margin-start">12</property>
+                                            <property name="margin-end">12</property>
+                                            <property name="margin-bottom">8</property>
+                                            <child>
+                                              <object class="GtkLabel" id="label10">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="halign">start</property>
+                                                <property name="hexpand">True</property>
+                                                <property name="label" translatable="yes">Border color for current page and other selections</property>
+                                                <property name="justify">right</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkColorButton" id="colorBorder">
+                                                <property name="name">colorBorder</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">True</property>
+                                                <property name="title" translatable="yes">Border color</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel" id="label13">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="halign">start</property>
+                                                <property name="hexpand">False</property>
+                                                <property name="label" translatable="yes">Background color between pages</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">1</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkColorButton" id="colorBackground">
+                                                <property name="name">colorBackground</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">True</property>
+                                                <property name="margin-top">5</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">1</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel" id="label57">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="halign">start</property>
+                                                <property name="hexpand">True</property>
+                                                <property name="label" translatable="yes">Selection Color (Text, Stroke Selection etc.)</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">2</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkColorButton" id="colorSelection">
+                                                <property name="name">colorSelection</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">True</property>
+                                                <property name="margin-top">5</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">2</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="halign">start</property>
+                                                <property name="hexpand">True</property>
+                                                <property name="label" translatable="yes">Active Selection Color (Search Results etc.)</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">3</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkColorButton" id="colorSelectionActive">
+                                                <property name="name">colorSelectionActive</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">True</property>
+                                                <property name="margin-top">5</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">3</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkCheckButton" id="cbDarkTheme">
+                                                <property name="label" translatable="yes">Dark Theme (requires restart)</property>
+                                                <property name="name">cbDarkTheme</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">False</property>
+                                                <property name="draw-indicator">True</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">5</property>
+                                                <property name="width">2</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkCheckButton" id="cbStockIcons">
+                                                <property name="label" translatable="yes">Use available Stock Icons (requires restart)</property>
+                                                <property name="name">cbStockIcons</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">False</property>
+                                                <property name="draw-indicator">True</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">6</property>
+                                                <property name="width">2</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkBox">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <child>
+                                                  <object class="GtkLabel">
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">False</property>
+                                                    <property name="label" translatable="yes">Icon Theme</property>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="expand">False</property>
+                                                    <property name="fill">True</property>
+                                                    <property name="position">0</property>
+                                                  </packing>
+                                                </child>
+                                                <child>
+                                                  <object class="GtkComboBoxText" id="cbIconTheme">
+                                                    <property name="name">cbIconTheme</property>
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">False</property>
+                                                    <property name="active">0</property>
+                                                    <items>
+                                                      <item id="iconsColor" translatable="yes">Color</item>
+                                                      <item id="iconsLucide" translatable="yes">Lucide</item>
+                                                    </items>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="expand">False</property>
+                                                    <property name="fill">True</property>
+                                                    <property name="position">1</property>
+                                                  </packing>
+                                                </child>
+                                                <child>
+                                                  <object class="GtkLabel">
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">False</property>
+                                                    <property name="label" translatable="yes">(requires restart)</property>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="expand">False</property>
+                                                    <property name="fill">True</property>
+                                                    <property name="position">2</property>
+                                                  </packing>
+                                                </child>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">4</property>
+                                                <property name="width">2</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                        </child>
+                                        <child type="label">
+                                          <object class="GtkLabel" id="sid103">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">Colors</property>
+                                          </object>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
                                     </child>
                                   </object>
                                 </child>
@@ -3309,54 +3101,23 @@ This setting can make it easier to draw with touch. </property>
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
                                 <child>
-                                  <object class="GtkAlignment" id="sid106">
+                                  <object class="GtkBox" id="vbox15">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">8</property>
+                                    <property name="orientation">vertical</property>
                                     <child>
-                                      <object class="GtkBox" id="vbox15">
+                                      <object class="GtkBox">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="orientation">vertical</property>
+                                        <property name="spacing">5</property>
                                         <child>
-                                          <object class="GtkBox">
+                                          <object class="GtkLabel">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
-                                            <property name="spacing">5</property>
-                                            <child>
-                                              <object class="GtkLabel">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">Cursor icon for pen</property>
-                                                <property name="xalign">0</property>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">True</property>
-                                                <property name="position">0</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkComboBoxText" id="cbStylusCursorType">
-                                                <property name="name">cbStylusCursorType</property>
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="active">0</property>
-                                                <items>
-                                                  <item id="none" translatable="yes" context="stylus cursor uses no icon">No icon</item>
-                                                  <item id="dot" translatable="yes" context="stylus cursor uses a small dot">Small dot icon</item>
-                                                  <item id="big" translatable="yes" context="stylus cursor uses a big pen icon">Big pen icon</item>
-                                                  <item id="arrow" translatable="yes" context="stylus cursor uses system cursor">System cursor</item>
-                                                </items>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">True</property>
-                                                <property name="position">1</property>
-                                              </packing>
-                                            </child>
+                                            <property name="label" translatable="yes">Cursor icon for pen</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -3365,221 +3126,17 @@ This setting can make it easier to draw with touch. </property>
                                           </packing>
                                         </child>
                                         <child>
-                                          <!-- n-columns=3 n-rows=3 -->
-                                          <object class="GtkGrid" id="highlightCursorGrid">
+                                          <object class="GtkComboBoxText" id="cbStylusCursorType">
+                                            <property name="name">cbStylusCursorType</property>
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
-                                            <property name="column-homogeneous">True</property>
-                                            <child>
-                                              <object class="GtkCheckButton" id="cbHighlightPosition">
-                                                <property name="label" translatable="yes">Highlight cursor position</property>
-                                                <property name="name">cbHighlightPosition</property>
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="receives-default">False</property>
-                                                <property name="tooltip-text" translatable="yes">Draw a transparent circle around the cursor</property>
-                                                <property name="draw-indicator">True</property>
-                                              </object>
-                                              <packing>
-                                                <property name="left-attach">0</property>
-                                                <property name="top-attach">0</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkBox">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <child>
-                                                  <object class="GtkColorButton" id="cursorHighlightColor">
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">True</property>
-                                                    <property name="receives-default">True</property>
-                                                    <property name="use-alpha">True</property>
-                                                    <property name="title" translatable="yes">Choose the color to use for "Highlight cursor position"</property>
-                                                    <property name="show-editor">True</property>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="expand">False</property>
-                                                    <property name="fill">True</property>
-                                                    <property name="pack-type">end</property>
-                                                    <property name="position">0</property>
-                                                  </packing>
-                                                </child>
-                                                <child>
-                                                  <object class="GtkLabel">
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
-                                                    <property name="label" translatable="yes">Circle Color</property>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="expand">False</property>
-                                                    <property name="fill">True</property>
-                                                    <property name="padding">10</property>
-                                                    <property name="pack-type">end</property>
-                                                    <property name="position">1</property>
-                                                  </packing>
-                                                </child>
-                                              </object>
-                                              <packing>
-                                                <property name="left-attach">1</property>
-                                                <property name="top-attach">1</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkBox">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <child>
-                                                  <object class="GtkLabel">
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
-                                                    <property name="label" translatable="yes">pixels</property>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="expand">False</property>
-                                                    <property name="fill">True</property>
-                                                    <property name="pack-type">end</property>
-                                                    <property name="position">0</property>
-                                                  </packing>
-                                                </child>
-                                                <child>
-                                                  <object class="GtkSpinButton" id="cursorHighlightRadius">
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">True</property>
-                                                    <property name="input-purpose">number</property>
-                                                    <property name="adjustment">adjustmentCursorHighlightRadius</property>
-                                                    <property name="numeric">True</property>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="expand">False</property>
-                                                    <property name="fill">True</property>
-                                                    <property name="pack-type">end</property>
-                                                    <property name="position">1</property>
-                                                  </packing>
-                                                </child>
-                                                <child>
-                                                  <object class="GtkLabel">
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
-                                                    <property name="label" translatable="yes">Radius</property>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="expand">False</property>
-                                                    <property name="fill">True</property>
-                                                    <property name="pack-type">end</property>
-                                                    <property name="position">3</property>
-                                                  </packing>
-                                                </child>
-                                              </object>
-                                              <packing>
-                                                <property name="left-attach">0</property>
-                                                <property name="top-attach">1</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkBox">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <child>
-                                                  <object class="GtkLabel">
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
-                                                    <property name="label" translatable="yes">pixels</property>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="expand">False</property>
-                                                    <property name="fill">True</property>
-                                                    <property name="pack-type">end</property>
-                                                    <property name="position">0</property>
-                                                  </packing>
-                                                </child>
-                                                <child>
-                                                  <object class="GtkSpinButton" id="cursorHighlightBorderWidth">
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">True</property>
-                                                    <property name="text" translatable="yes">30</property>
-                                                    <property name="input-purpose">number</property>
-                                                    <property name="adjustment">adjustmentCursorHighlightBorderWidth</property>
-                                                    <property name="numeric">True</property>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="expand">False</property>
-                                                    <property name="fill">True</property>
-                                                    <property name="pack-type">end</property>
-                                                    <property name="position">1</property>
-                                                  </packing>
-                                                </child>
-                                                <child>
-                                                  <object class="GtkLabel">
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
-                                                    <property name="label" translatable="yes">Border Width</property>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="expand">False</property>
-                                                    <property name="fill">True</property>
-                                                    <property name="pack-type">end</property>
-                                                    <property name="position">3</property>
-                                                  </packing>
-                                                </child>
-                                              </object>
-                                              <packing>
-                                                <property name="left-attach">0</property>
-                                                <property name="top-attach">2</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkBox">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <child>
-                                                  <object class="GtkColorButton" id="cursorHighlightBorderColor">
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">True</property>
-                                                    <property name="receives-default">True</property>
-                                                    <property name="use-alpha">True</property>
-                                                    <property name="title" translatable="yes">Choose the color to use for "Highlight cursor position"</property>
-                                                    <property name="show-editor">True</property>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="expand">False</property>
-                                                    <property name="fill">True</property>
-                                                    <property name="pack-type">end</property>
-                                                    <property name="position">0</property>
-                                                  </packing>
-                                                </child>
-                                                <child>
-                                                  <object class="GtkLabel">
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
-                                                    <property name="label" translatable="yes">Border Color</property>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="expand">False</property>
-                                                    <property name="fill">True</property>
-                                                    <property name="padding">10</property>
-                                                    <property name="pack-type">end</property>
-                                                    <property name="position">1</property>
-                                                  </packing>
-                                                </child>
-                                              </object>
-                                              <packing>
-                                                <property name="left-attach">1</property>
-                                                <property name="top-attach">2</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
+                                            <property name="active">0</property>
+                                            <items>
+                                              <item id="none" translatable="yes" context="stylus cursor uses no icon">No icon</item>
+                                              <item id="dot" translatable="yes" context="stylus cursor uses a small dot">Small dot icon</item>
+                                              <item id="big" translatable="yes" context="stylus cursor uses a big pen icon">Big pen icon</item>
+                                              <item id="arrow" translatable="yes" context="stylus cursor uses system cursor">System cursor</item>
+                                            </items>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -3588,6 +3145,226 @@ This setting can make it easier to draw with touch. </property>
                                           </packing>
                                         </child>
                                       </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <!-- n-columns=2 n-rows=3 -->
+                                      <object class="GtkGrid" id="highlightCursorGrid">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">start</property>
+                                        <property name="column-homogeneous">True</property>
+                                        <child>
+                                          <object class="GtkCheckButton" id="cbHighlightPosition">
+                                            <property name="label" translatable="yes">Highlight cursor position</property>
+                                            <property name="name">cbHighlightPosition</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="tooltip-text" translatable="yes">Draw a transparent circle around the cursor</property>
+                                            <property name="draw-indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkBox">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <child>
+                                              <object class="GtkColorButton" id="cursorHighlightColor">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">True</property>
+                                                <property name="use-alpha">True</property>
+                                                <property name="title" translatable="yes">Choose the color to use for "Highlight cursor position"</property>
+                                                <property name="show-editor">True</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="pack-type">end</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">Circle Color</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="padding">10</property>
+                                                <property name="pack-type">end</property>
+                                                <property name="position">1</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkBox">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">pixels</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="pack-type">end</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSpinButton" id="cursorHighlightRadius">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="input-purpose">number</property>
+                                                <property name="adjustment">adjustmentCursorHighlightRadius</property>
+                                                <property name="numeric">True</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="pack-type">end</property>
+                                                <property name="position">1</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">Radius</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="pack-type">end</property>
+                                                <property name="position">3</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkBox">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">pixels</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="pack-type">end</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSpinButton" id="cursorHighlightBorderWidth">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="text" translatable="yes">30</property>
+                                                <property name="input-purpose">number</property>
+                                                <property name="adjustment">adjustmentCursorHighlightBorderWidth</property>
+                                                <property name="numeric">True</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="pack-type">end</property>
+                                                <property name="position">1</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">Border Width</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="pack-type">end</property>
+                                                <property name="position">3</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">2</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkBox">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <child>
+                                              <object class="GtkColorButton" id="cursorHighlightBorderColor">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">True</property>
+                                                <property name="use-alpha">True</property>
+                                                <property name="title" translatable="yes">Choose the color to use for "Highlight cursor position"</property>
+                                                <property name="show-editor">True</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="pack-type">end</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">Border Color</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="padding">10</property>
+                                                <property name="pack-type">end</property>
+                                                <property name="position">1</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">2</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
                                     </child>
                                   </object>
                                 </child>
@@ -3611,50 +3388,42 @@ This setting can make it easier to draw with touch. </property>
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
                                 <child>
-                                  <object class="GtkAlignment" id="sid109">
+                                  <object class="GtkBox" id="box19">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">8</property>
+                                    <property name="orientation">vertical</property>
                                     <child>
-                                      <object class="GtkBox" id="box19">
+                                      <object class="GtkCheckButton" id="cbShowSidebarRight">
+                                        <property name="label" translatable="yes">Show sidebar on the right side</property>
+                                        <property name="name">cbShowSidebarRight</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="orientation">vertical</property>
-                                        <child>
-                                          <object class="GtkCheckButton" id="cbShowSidebarRight">
-                                            <property name="label" translatable="yes">Show sidebar on the right side</property>
-                                            <property name="name">cbShowSidebarRight</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkCheckButton" id="cbShowScrollbarLeft">
-                                            <property name="label" translatable="yes">Show vertical scrollbar on the left side</property>
-                                            <property name="name">cbShowScrollbarLeft</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="draw-indicator">True</property>
                                       </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="cbShowScrollbarLeft">
+                                        <property name="label" translatable="yes">Show vertical scrollbar on the left side</property>
+                                        <property name="name">cbShowScrollbarLeft</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="draw-indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
                                     </child>
                                   </object>
                                 </child>
@@ -3678,65 +3447,46 @@ This setting can make it easier to draw with touch. </property>
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0</property>
                                 <child>
-                                  <object class="GtkAlignment">
+                                  <object class="GtkBox">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="top-padding">2</property>
-                                    <property name="bottom-padding">6</property>
-                                    <property name="left-padding">12</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
                                     <child>
-                                      <object class="GtkBox">
+                                      <object class="GtkLabel">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="orientation">vertical</property>
-                                        <child>
-                                          <object class="GtkBox">
-                                            <property name="visible">True</property>
+                                        <property name="label" translatable="yes">Page numbering  </property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkComboBoxText" id="cbSidebarPageNumberStyle">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="active">0</property>
+                                        <property name="has-entry">True</property>
+                                        <items>
+                                          <item id="0" translatable="yes">None</item>
+                                          <item id="1" translatable="yes">Below preview</item>
+                                          <item id="2" translatable="yes">Circle background</item>
+                                          <item id="3" translatable="yes">Square background</item>
+                                        </items>
+                                        <child internal-child="entry">
+                                          <object class="GtkEntry">
                                             <property name="can-focus">False</property>
-                                            <child>
-                                              <object class="GtkLabel">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">Page numbering  </property>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">True</property>
-                                                <property name="position">0</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkComboBoxText" id="cbSidebarPageNumberStyle">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="active">0</property>
-                                                <property name="has-entry">True</property>
-                                                <items>
-                                                  <item id="0" translatable="yes">None</item>
-                                                  <item id="1" translatable="yes">Below preview</item>
-                                                  <item id="2" translatable="yes">Circle background</item>
-                                                  <item id="3" translatable="yes">Square background</item>
-                                                </items>
-                                                <child internal-child="entry">
-                                                  <object class="GtkEntry">
-                                                    <property name="can-focus">False</property>
-                                                  </object>
-                                                </child>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">True</property>
-                                                <property name="position">1</property>
-                                              </packing>
-                                            </child>
                                           </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
                                         </child>
                                       </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
                                     </child>
                                   </object>
                                 </child>
@@ -3761,62 +3511,56 @@ This setting can make it easier to draw with touch. </property>
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
                                 <child>
-                                  <object class="GtkAlignment" id="sid112">
+                                  <object class="GtkBox" id="box42">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">8</property>
+                                    <property name="orientation">vertical</property>
                                     <child>
-                                      <object class="GtkBox" id="box42">
+                                      <object class="GtkCheckButton" id="cbHideHorizontalScrollbar">
+                                        <property name="label" translatable="yes">Hide the horizontal scrollbar</property>
+                                        <property name="name">cbHideHorizontalScrollbar</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="orientation">vertical</property>
-                                        <child>
-                                          <object class="GtkCheckButton" id="cbHideHorizontalScrollbar">
-                                            <property name="label" translatable="yes">Hide the horizontal scrollbar</property>
-                                            <property name="name">cbHideHorizontalScrollbar</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="draw-indicator">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkCheckButton" id="cbHideVerticalScrollbar">
-                                            <property name="label" translatable="yes">Hide the vertical scrollbar</property>
-                                            <property name="name">cbHideVerticalScrollbar</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="draw-indicator">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkCheckButton" id="cbDisableScrollbarFadeout">
-                                            <property name="label" translatable="yes">Disable scrollbar fade out</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="draw-indicator">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">2</property>
-                                          </packing>
-                                        </child>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="draw-indicator">True</property>
                                       </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="cbHideVerticalScrollbar">
+                                        <property name="label" translatable="yes">Hide the vertical scrollbar</property>
+                                        <property name="name">cbHideVerticalScrollbar</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="draw-indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="cbDisableScrollbarFadeout">
+                                        <property name="label" translatable="yes">Disable scrollbar fade out</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="draw-indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">2</property>
+                                      </packing>
                                     </child>
                                   </object>
                                 </child>
@@ -3840,69 +3584,64 @@ This setting can make it easier to draw with touch. </property>
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0</property>
                                 <child>
-                                  <object class="GtkAlignment">
+                                  <!-- n-columns=2 n-rows=2 -->
+                                  <object class="GtkGrid">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">8</property>
                                     <child>
-                                      <!-- n-columns=2 n-rows=2 -->
-                                      <object class="GtkGrid">
+                                      <object class="GtkSpinButton" id="edgePanSpeed">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="input-purpose">number</property>
+                                        <property name="adjustment">adjustmentEdgePanSpeed</property>
+                                        <property name="numeric">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="top-attach">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSpinButton" id="edgePanMaxMult">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="input-purpose">number</property>
+                                        <property name="adjustment">adjustmentEdgePanMaxMult</property>
+                                        <property name="numeric">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="top-attach">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <child>
-                                          <object class="GtkSpinButton" id="edgePanSpeed">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="input-purpose">number</property>
-                                            <property name="adjustment">adjustmentEdgePanSpeed</property>
-                                            <property name="numeric">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">1</property>
-                                            <property name="top-attach">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSpinButton" id="edgePanMaxMult">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="input-purpose">number</property>
-                                            <property name="adjustment">adjustmentEdgePanMaxMult</property>
-                                            <property name="numeric">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">1</property>
-                                            <property name="top-attach">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="tooltip-text" translatable="yes">When an element is selected and moved past the visible portion of the canvas, pan the screen by an amount equal to this percentage of the visible part of the canvas. </property>
-                                            <property name="halign">start</property>
-                                            <property name="label" translatable="yes">Base speed</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="tooltip-text" translatable="yes">Multiply the panning speed by up to this amount, based on how much of the selected element is out of view.</property>
-                                            <property name="halign">start</property>
-                                            <property name="label" translatable="yes">Max multiplier</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">1</property>
-                                          </packing>
-                                        </child>
+                                        <property name="tooltip-text" translatable="yes">When an element is selected and moved past the visible portion of the canvas, pan the screen by an amount equal to this percentage of the visible part of the canvas. </property>
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">Base speed</property>
                                       </object>
+                                      <packing>
+                                        <property name="left-attach">0</property>
+                                        <property name="top-attach">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="tooltip-text" translatable="yes">Multiply the panning speed by up to this amount, based on how much of the selected element is out of view.</property>
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">Max multiplier</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">0</property>
+                                        <property name="top-attach">1</property>
+                                      </packing>
                                     </child>
                                   </object>
                                 </child>
@@ -3926,66 +3665,57 @@ This setting can make it easier to draw with touch. </property>
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
                                 <child>
-                                  <object class="GtkAlignment" id="sid115">
+                                  <object class="GtkBox" id="vbox9">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">8</property>
+                                    <property name="orientation">vertical</property>
                                     <child>
-                                      <object class="GtkBox" id="vbox9">
+                                      <object class="GtkCheckButton" id="cbShowFullscreenMenubar">
+                                        <property name="label" translatable="yes">Show Menubar</property>
+                                        <property name="name">cbShowFullscreenMenubar</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="orientation">vertical</property>
-                                        <child>
-                                          <object class="GtkCheckButton" id="cbShowFullscreenMenubar">
-                                            <property name="label" translatable="yes">Show Menubar</property>
-                                            <property name="name">cbShowFullscreenMenubar</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkCheckButton" id="cbShowFullscreenToolbar">
-                                            <property name="label" translatable="yes">Show Toolbar</property>
-                                            <property name="name">cbShowFullscreenToolbar</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkCheckButton" id="cbShowFullscreenSidebar">
-                                            <property name="label" translatable="yes">Show Sidebar</property>
-                                            <property name="name">cbShowFullscreenSidebar</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="draw-indicator">True</property>
                                       </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="cbShowFullscreenToolbar">
+                                        <property name="label" translatable="yes">Show Toolbar</property>
+                                        <property name="name">cbShowFullscreenToolbar</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="draw-indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="cbShowFullscreenSidebar">
+                                        <property name="label" translatable="yes">Show Sidebar</property>
+                                        <property name="name">cbShowFullscreenSidebar</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="draw-indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
                                     </child>
                                   </object>
                                 </child>
@@ -4009,116 +3739,106 @@ This setting can make it easier to draw with touch. </property>
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
                                 <child>
-                                  <object class="GtkAlignment" id="sid118">
+                                  <object class="GtkBox" id="vbox1">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">8</property>
+                                    <property name="orientation">vertical</property>
                                     <child>
-                                      <object class="GtkBox" id="vbox1">
+                                      <object class="GtkCheckButton" id="cbShowPresentationMenubar">
+                                        <property name="label" translatable="yes">Show Menubar</property>
+                                        <property name="name">cbShowPresentationMenubar</property>
                                         <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="draw-indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="cbShowPresentationToolbar">
+                                        <property name="label" translatable="yes">Show Toolbar</property>
+                                        <property name="name">cbShowPresentationToolbar</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="draw-indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="cbPresentationGoFullscreen">
+                                        <property name="label" translatable="yes">Go Fullscreen</property>
+                                        <property name="name">cbPresentationGoFullscreen</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="draw-indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="cbShowPresentationSidebar">
+                                        <property name="label" translatable="yes">Show Sidebar</property>
+                                        <property name="name">cbShowPresentationSidebar</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="draw-indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkBox" id="box8">
                                         <property name="can-focus">False</property>
-                                        <property name="orientation">vertical</property>
                                         <child>
-                                          <object class="GtkCheckButton" id="cbShowPresentationMenubar">
-                                            <property name="label" translatable="yes">Show Menubar</property>
-                                            <property name="name">cbShowPresentationMenubar</property>
+                                          <object class="GtkLabel" id="label16">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkCheckButton" id="cbShowPresentationToolbar">
-                                            <property name="label" translatable="yes">Show Toolbar</property>
-                                            <property name="name">cbShowPresentationToolbar</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkCheckButton" id="cbPresentationGoFullscreen">
-                                            <property name="label" translatable="yes">Go Fullscreen</property>
-                                            <property name="name">cbPresentationGoFullscreen</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkCheckButton" id="cbShowPresentationSidebar">
-                                            <property name="label" translatable="yes">Show Sidebar</property>
-                                            <property name="name">cbShowPresentationSidebar</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkBox" id="box8">
                                             <property name="can-focus">False</property>
-                                            <child>
-                                              <object class="GtkLabel" id="label16">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">Select toolbar:</property>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">True</property>
-                                                <property name="position">0</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkComboBoxText" id="comboboxtext1">
-                                                <property name="name">comboboxtext1</property>
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">True</property>
-                                                <property name="position">1</property>
-                                              </packing>
-                                            </child>
+                                            <property name="label" translatable="yes">Select toolbar:</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
                                             <property name="fill">True</property>
-                                            <property name="position">2</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkComboBoxText" id="comboboxtext1">
+                                            <property name="name">comboboxtext1</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
                                           </packing>
                                         </child>
                                       </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">2</property>
+                                      </packing>
                                     </child>
                                   </object>
                                 </child>
@@ -4142,92 +3862,88 @@ This setting can make it easier to draw with touch. </property>
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
                                 <child>
-                                  <object class="GtkAlignment">
+                                  <!-- n-columns=3 n-rows=3 -->
+                                  <object class="GtkGrid">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="left-padding">12</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">8</property>
+                                    <property name="column-spacing">10</property>
                                     <child>
-                                      <!-- n-columns=3 n-rows=3 -->
-                                      <object class="GtkGrid">
+                                      <object class="GtkLabel">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="column-spacing">10</property>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="halign">start</property>
-                                            <property name="label" translatable="yes">Pre-load pages before</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="halign">start</property>
-                                            <property name="label" translatable="yes">Pre-load pages after</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSpinButton" id="preloadPagesBefore">
-                                            <property name="name">preloadPagesBefore</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="input-purpose">number</property>
-                                            <property name="adjustment">adjustmentPreloadPagesBefore</property>
-                                            <property name="numeric">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">1</property>
-                                            <property name="top-attach">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSpinButton" id="preloadPagesAfter">
-                                            <property name="name">preloadPagesAfter</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="input-purpose">number</property>
-                                            <property name="adjustment">adjustmentPreloadPagesAfter</property>
-                                            <property name="numeric">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">1</property>
-                                            <property name="top-attach">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkCheckButton" id="cbEagerPageCleanup">
-                                            <property name="label" translatable="yes">Clear cached paged while scrolling</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="draw-indicator">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">2</property>
-                                            <property name="width">2</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">Pre-load pages before</property>
                                       </object>
+                                      <packing>
+                                        <property name="left-attach">0</property>
+                                        <property name="top-attach">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">Pre-load pages after</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">0</property>
+                                        <property name="top-attach">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSpinButton" id="preloadPagesBefore">
+                                        <property name="name">preloadPagesBefore</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="input-purpose">number</property>
+                                        <property name="adjustment">adjustmentPreloadPagesBefore</property>
+                                        <property name="numeric">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="top-attach">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSpinButton" id="preloadPagesAfter">
+                                        <property name="name">preloadPagesAfter</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="input-purpose">number</property>
+                                        <property name="adjustment">adjustmentPreloadPagesAfter</property>
+                                        <property name="numeric">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="top-attach">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="cbEagerPageCleanup">
+                                        <property name="label" translatable="yes">Clear cached paged while scrolling</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="draw-indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">0</property>
+                                        <property name="top-attach">2</property>
+                                        <property name="width">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <placeholder/>
+                                    </child>
+                                    <child>
+                                      <placeholder/>
+                                    </child>
+                                    <child>
+                                      <placeholder/>
                                     </child>
                                   </object>
                                 </child>
@@ -4278,7 +3994,7 @@ This setting can make it easier to draw with touch. </property>
                 <property name="name">zoomTabBox</property>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="margin-left">5</property>
+                <property name="margin-start">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid120">
@@ -4302,107 +4018,99 @@ This setting can make it easier to draw with touch. </property>
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
                                 <child>
-                                  <object class="GtkAlignment" id="sid124">
+                                  <!-- n-columns=3 n-rows=3 -->
+                                  <object class="GtkGrid" id="sid125">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">8</property>
+                                    <property name="column-spacing">5</property>
                                     <child>
-                                      <!-- n-columns=3 n-rows=3 -->
-                                      <object class="GtkGrid" id="sid125">
+                                      <object class="GtkLabel" id="settingZoomCtrlScrollSpeedLabel">
+                                        <property name="name">settingZoomCtrlScrollSpeedLabel</property>
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="column-spacing">5</property>
-                                        <child>
-                                          <object class="GtkLabel" id="settingZoomCtrlScrollSpeedLabel">
-                                            <property name="name">settingZoomCtrlScrollSpeedLabel</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">Speed for Ctrl + Scroll</property>
-                                            <property name="xalign">0</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSpinButton" id="spZoomStepScroll">
-                                            <property name="name">spZoomStepScroll</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="adjustment">adjustmentZoomStepScroll</property>
-                                            <property name="digits">1</property>
-                                            <property name="numeric">True</property>
-                                            <property name="value">2</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">1</property>
-                                            <property name="top-attach">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkLabel" id="settingZoomStepSpeedLabel">
-                                            <property name="name">settingZoomStepSpeedLabel</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">Speed for a Zoomstep</property>
-                                            <property name="xalign">0</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSpinButton" id="spZoomStep">
-                                            <property name="name">spZoomStep</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="margin-top">5</property>
-                                            <property name="adjustment">adjustmentZoomStep</property>
-                                            <property name="digits">1</property>
-                                            <property name="numeric">True</property>
-                                            <property name="value">10</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">1</property>
-                                            <property name="top-attach">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkLabel" id="sid126">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">%</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">2</property>
-                                            <property name="top-attach">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkLabel" id="sid127">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">%</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">2</property>
-                                            <property name="top-attach">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
+                                        <property name="label" translatable="yes">Speed for Ctrl + Scroll</property>
                                       </object>
+                                      <packing>
+                                        <property name="left-attach">0</property>
+                                        <property name="top-attach">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSpinButton" id="spZoomStepScroll">
+                                        <property name="name">spZoomStepScroll</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="adjustment">adjustmentZoomStepScroll</property>
+                                        <property name="digits">1</property>
+                                        <property name="numeric">True</property>
+                                        <property name="value">2</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="top-attach">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="settingZoomStepSpeedLabel">
+                                        <property name="name">settingZoomStepSpeedLabel</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">Speed for a Zoomstep</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">0</property>
+                                        <property name="top-attach">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSpinButton" id="spZoomStep">
+                                        <property name="name">spZoomStep</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="margin-top">5</property>
+                                        <property name="adjustment">adjustmentZoomStep</property>
+                                        <property name="digits">1</property>
+                                        <property name="numeric">True</property>
+                                        <property name="value">10</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="top-attach">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="sid126">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">%</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">2</property>
+                                        <property name="top-attach">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="sid127">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">%</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">2</property>
+                                        <property name="top-attach">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <placeholder/>
+                                    </child>
+                                    <child>
+                                      <placeholder/>
+                                    </child>
+                                    <child>
+                                      <placeholder/>
                                     </child>
                                   </object>
                                 </child>
@@ -4426,98 +4134,40 @@ This setting can make it easier to draw with touch. </property>
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
                                 <child>
-                                  <object class="GtkAlignment" id="sid130">
+                                  <object class="GtkBox" id="sid131">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">8</property>
+                                    <property name="orientation">vertical</property>
                                     <child>
-                                      <object class="GtkBox" id="sid131">
+                                      <object class="GtkLabel" id="sid132">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">&lt;i&gt;To make sure on 100% zoom the size of elements is natural. (requires restart)&lt;/i&gt;</property>
+                                        <property name="use-markup">True</property>
+                                        <property name="max-width-chars">85</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkBox" id="box5">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
-                                          <object class="GtkLabel" id="sid132">
+                                          <object class="GtkLabel" id="label21">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">&lt;i&gt;To make sure on 100% zoom the size of elements is natural. (requires restart)&lt;/i&gt;</property>
+                                            <property name="margin-top">5</property>
+                                            <property name="label" translatable="yes">&lt;i&gt;Put a ruler on your screen and move the slider until both rulers match.&lt;/i&gt;</property>
                                             <property name="use-markup">True</property>
                                             <property name="max-width-chars">85</property>
-                                            <property name="xalign">0</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkBox" id="box5">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="orientation">vertical</property>
-                                            <child>
-                                              <object class="GtkLabel" id="label21">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="margin-top">5</property>
-                                                <property name="label" translatable="yes">&lt;i&gt;Put a ruler on your screen and move the slider until both rulers match.&lt;/i&gt;</property>
-                                                <property name="use-markup">True</property>
-                                                <property name="max-width-chars">85</property>
-                                                <property name="xalign">0</property>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">True</property>
-                                                <property name="position">1</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkScale" id="zoomCallibSlider">
-                                                <property name="name">zoomCallibSlider</property>
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="margin-top">10</property>
-                                                <property name="margin-bottom">20</property>
-                                                <property name="adjustment">adjustmentZoom</property>
-                                                <property name="round-digits">0</property>
-                                                <property name="digits">0</property>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">True</property>
-                                                <property name="position">2</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkBox" id="zoomVBox">
-                                                <property name="name">zoomVBox</property>
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="orientation">vertical</property>
-                                                <child>
-                                                  <placeholder/>
-                                                </child>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">True</property>
-                                                <property name="position">3</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkLabel" id="label22">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">The unit of the ruler is cm</property>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">True</property>
-                                                <property name="position">4</property>
-                                              </packing>
-                                            </child>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -4525,7 +4175,57 @@ This setting can make it easier to draw with touch. </property>
                                             <property name="position">1</property>
                                           </packing>
                                         </child>
+                                        <child>
+                                          <object class="GtkScale" id="zoomCallibSlider">
+                                            <property name="name">zoomCallibSlider</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="margin-top">10</property>
+                                            <property name="margin-bottom">20</property>
+                                            <property name="adjustment">adjustmentZoom</property>
+                                            <property name="round-digits">0</property>
+                                            <property name="digits">0</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">2</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkBox" id="zoomVBox">
+                                            <property name="name">zoomVBox</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="orientation">vertical</property>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">3</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="label22">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">The unit of the ruler is cm</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">4</property>
+                                          </packing>
+                                        </child>
                                       </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
                                     </child>
                                   </object>
                                 </child>
@@ -4576,7 +4276,7 @@ This setting can make it easier to draw with touch. </property>
                 <property name="name">drawingAreaTabBox</property>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="margin-left">5</property>
+                <property name="margin-start">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid134">
@@ -4600,28 +4300,121 @@ This setting can make it easier to draw with touch. </property>
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
                                 <child>
-                                  <object class="GtkAlignment" id="sid138">
+                                  <object class="GtkBox" id="box41">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">8</property>
+                                    <property name="orientation">vertical</property>
+                                    <property name="spacing">8</property>
                                     <child>
-                                      <object class="GtkBox" id="box41">
+                                      <object class="GtkLabel" id="label37">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="orientation">vertical</property>
-                                        <property name="spacing">8</property>
+                                        <property name="ypad">2</property>
+                                        <property name="label" translatable="yes">&lt;i&gt;If you add additional space beside the pages you can choose the area of the screen you would like to work on.&lt;/i&gt;</property>
+                                        <property name="use-markup">True</property>
+                                        <property name="wrap">True</property>
+                                        <property name="max-width-chars">85</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkBox">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="spacing">20</property>
                                         <child>
-                                          <object class="GtkLabel" id="label37">
+                                          <!-- n-columns=3 n-rows=3 -->
+                                          <object class="GtkGrid">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
-                                            <property name="ypad">2</property>
-                                            <property name="label" translatable="yes">&lt;i&gt;If you add additional space beside the pages you can choose the area of the screen you would like to work on.&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
-                                            <property name="wrap">True</property>
-                                            <property name="max-width-chars">85</property>
-                                            <property name="xalign">0</property>
+                                            <property name="row-spacing">8</property>
+                                            <property name="column-spacing">5</property>
+                                            <child>
+                                              <object class="GtkSpinButton" id="spAddVerticalSpaceAbove">
+                                                <property name="name">spAddVerticalSpace</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">adjustmentVerticalSpaceAbove</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSpinButton" id="spAddHorizontalSpaceRight">
+                                                <property name="name">spAddHorizontalSpace</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">adjustmentHorizontalSpaceRight</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">2</property>
+                                                <property name="top-attach">1</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSpinButton" id="spAddVerticalSpaceBelow">
+                                                <property name="name">spAddHorizontalSpace</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">adjustmentVerticalSpaceBelow</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">2</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSpinButton" id="spAddHorizontalSpaceLeft">
+                                                <property name="name">spAddHorizontalSpace</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="valign">center</property>
+                                                <property name="adjustment">adjustmentHorizontalSpaceLeft</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">1</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkBox" id="pagePreviewImage">
+                                                <property name="name">imageBox</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="orientation">vertical</property>
+                                                <child>
+                                                  <placeholder/>
+                                                </child>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">1</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -4633,92 +4426,73 @@ This setting can make it easier to draw with touch. </property>
                                           <object class="GtkBox">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
-                                            <property name="spacing">20</property>
+                                            <property name="orientation">vertical</property>
                                             <child>
-                                              <!-- n-columns=3 n-rows=3 -->
-                                              <object class="GtkGrid">
+                                              <object class="GtkBox">
                                                 <property name="visible">True</property>
                                                 <property name="can-focus">False</property>
-                                                <property name="row-spacing">8</property>
-                                                <property name="column-spacing">5</property>
+                                                <property name="valign">start</property>
+                                                <property name="orientation">vertical</property>
                                                 <child>
-                                                  <object class="GtkSpinButton" id="spAddVerticalSpaceAbove">
-                                                    <property name="name">spAddVerticalSpace</property>
+                                                  <object class="GtkCheckButton" id="cbAddHorizontalSpace">
+                                                    <property name="label" translatable="yes">Add additional horizontal space</property>
+                                                    <property name="name">cbAddHorizontalSpace</property>
                                                     <property name="visible">True</property>
                                                     <property name="can-focus">True</property>
-                                                    <property name="valign">center</property>
-                                                    <property name="adjustment">adjustmentVerticalSpaceAbove</property>
+                                                    <property name="receives-default">False</property>
+                                                    <property name="draw-indicator">True</property>
                                                   </object>
                                                   <packing>
-                                                    <property name="left-attach">1</property>
-                                                    <property name="top-attach">0</property>
+                                                    <property name="expand">False</property>
+                                                    <property name="fill">True</property>
+                                                    <property name="padding">5</property>
+                                                    <property name="position">0</property>
                                                   </packing>
                                                 </child>
                                                 <child>
-                                                  <object class="GtkSpinButton" id="spAddHorizontalSpaceRight">
-                                                    <property name="name">spAddHorizontalSpace</property>
+                                                  <object class="GtkCheckButton" id="cbAddVerticalSpace">
+                                                    <property name="label" translatable="yes">Add additional vertical space</property>
+                                                    <property name="name">cbAddVerticalSpace</property>
                                                     <property name="visible">True</property>
                                                     <property name="can-focus">True</property>
-                                                    <property name="valign">center</property>
-                                                    <property name="adjustment">adjustmentHorizontalSpaceRight</property>
+                                                    <property name="receives-default">False</property>
+                                                    <property name="draw-indicator">True</property>
                                                   </object>
                                                   <packing>
-                                                    <property name="left-attach">2</property>
-                                                    <property name="top-attach">1</property>
+                                                    <property name="expand">False</property>
+                                                    <property name="fill">True</property>
+                                                    <property name="padding">5</property>
+                                                    <property name="position">1</property>
                                                   </packing>
                                                 </child>
                                                 <child>
-                                                  <object class="GtkSpinButton" id="spAddVerticalSpaceBelow">
-                                                    <property name="name">spAddHorizontalSpace</property>
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">True</property>
-                                                    <property name="valign">center</property>
-                                                    <property name="adjustment">adjustmentVerticalSpaceBelow</property>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="left-attach">1</property>
-                                                    <property name="top-attach">2</property>
-                                                  </packing>
-                                                </child>
-                                                <child>
-                                                  <object class="GtkSpinButton" id="spAddHorizontalSpaceLeft">
-                                                    <property name="name">spAddHorizontalSpace</property>
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">True</property>
-                                                    <property name="valign">center</property>
-                                                    <property name="adjustment">adjustmentHorizontalSpaceLeft</property>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="left-attach">0</property>
-                                                    <property name="top-attach">1</property>
-                                                  </packing>
-                                                </child>
-                                                <child>
-                                                  <object class="GtkBox" id="pagePreviewImage">
-                                                    <property name="name">imageBox</property>
+                                                  <object class="GtkLabel">
                                                     <property name="visible">True</property>
                                                     <property name="can-focus">False</property>
-                                                    <property name="orientation">vertical</property>
-                                                    <child>
-                                                      <placeholder/>
-                                                    </child>
+                                                    <property name="label" translatable="yes">&lt;i&gt;or&lt;/i&gt;</property>
+                                                    <property name="use-markup">True</property>
+                                                    <property name="xalign">0.029999999329447746</property>
                                                   </object>
                                                   <packing>
-                                                    <property name="left-attach">1</property>
-                                                    <property name="top-attach">1</property>
+                                                    <property name="expand">False</property>
+                                                    <property name="fill">True</property>
+                                                    <property name="position">2</property>
                                                   </packing>
                                                 </child>
                                                 <child>
-                                                  <placeholder/>
-                                                </child>
-                                                <child>
-                                                  <placeholder/>
-                                                </child>
-                                                <child>
-                                                  <placeholder/>
-                                                </child>
-                                                <child>
-                                                  <placeholder/>
+                                                  <object class="GtkCheckButton" id="cbUnlimitedScrolling">
+                                                    <property name="label" translatable="yes">Unlimited scrolling</property>
+                                                    <property name="name">cbUnlimitedScrolling</property>
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">True</property>
+                                                    <property name="receives-default">False</property>
+                                                    <property name="draw-indicator">True</property>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="expand">False</property>
+                                                    <property name="fill">True</property>
+                                                    <property name="position">3</property>
+                                                  </packing>
                                                 </child>
                                               </object>
                                               <packing>
@@ -4728,106 +4502,17 @@ This setting can make it easier to draw with touch. </property>
                                               </packing>
                                             </child>
                                             <child>
-                                              <object class="GtkBox">
+                                              <object class="GtkLabel">
                                                 <property name="visible">True</property>
                                                 <property name="can-focus">False</property>
-                                                <property name="orientation">vertical</property>
-                                                <child>
-                                                  <object class="GtkBox">
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
-                                                    <property name="valign">start</property>
-                                                    <property name="orientation">vertical</property>
-                                                    <child>
-                                                      <object class="GtkCheckButton" id="cbAddHorizontalSpace">
-                                                        <property name="label" translatable="yes">Add additional horizontal space</property>
-                                                        <property name="name">cbAddHorizontalSpace</property>
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">True</property>
-                                                        <property name="receives-default">False</property>
-                                                        <property name="xalign">0</property>
-                                                        <property name="draw-indicator">True</property>
-                                                      </object>
-                                                      <packing>
-                                                        <property name="expand">False</property>
-                                                        <property name="fill">True</property>
-                                                        <property name="padding">5</property>
-                                                        <property name="position">0</property>
-                                                      </packing>
-                                                    </child>
-                                                    <child>
-                                                      <object class="GtkCheckButton" id="cbAddVerticalSpace">
-                                                        <property name="label" translatable="yes">Add additional vertical space</property>
-                                                        <property name="name">cbAddVerticalSpace</property>
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">True</property>
-                                                        <property name="receives-default">False</property>
-                                                        <property name="xalign">0</property>
-                                                        <property name="draw-indicator">True</property>
-                                                      </object>
-                                                      <packing>
-                                                        <property name="expand">False</property>
-                                                        <property name="fill">True</property>
-                                                        <property name="padding">5</property>
-                                                        <property name="position">1</property>
-                                                      </packing>
-                                                    </child>
-                                                    <child>
-                                                      <object class="GtkLabel">
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="label" translatable="yes">&lt;i&gt;or&lt;/i&gt;</property>
-                                                        <property name="use-markup">True</property>
-                                                        <property name="xalign">0.029999999329447746</property>
-                                                      </object>
-                                                      <packing>
-                                                        <property name="expand">False</property>
-                                                        <property name="fill">True</property>
-                                                        <property name="position">2</property>
-                                                      </packing>
-                                                    </child>
-                                                    <child>
-                                                      <object class="GtkCheckButton" id="cbUnlimitedScrolling">
-                                                        <property name="label" translatable="yes">Unlimited scrolling</property>
-                                                        <property name="name">cbUnlimitedScrolling</property>
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">True</property>
-                                                        <property name="receives-default">False</property>
-                                                        <property name="draw-indicator">True</property>
-                                                      </object>
-                                                      <packing>
-                                                        <property name="expand">False</property>
-                                                        <property name="fill">True</property>
-                                                        <property name="position">3</property>
-                                                      </packing>
-                                                    </child>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="expand">False</property>
-                                                    <property name="fill">True</property>
-                                                    <property name="position">0</property>
-                                                  </packing>
-                                                </child>
-                                                <child>
-                                                  <object class="GtkLabel">
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
-                                                    <property name="label" translatable="yes">&lt;i&gt;The amount is specified in pixels.&lt;/i&gt;</property>
-                                                    <property name="use-markup">True</property>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="expand">False</property>
-                                                    <property name="fill">True</property>
-                                                    <property name="padding">2</property>
-                                                    <property name="pack-type">end</property>
-                                                    <property name="position">1</property>
-                                                  </packing>
-                                                </child>
+                                                <property name="label" translatable="yes">&lt;i&gt;The amount is specified in pixels.&lt;/i&gt;</property>
+                                                <property name="use-markup">True</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
                                                 <property name="fill">True</property>
-                                                <property name="padding">8</property>
+                                                <property name="padding">2</property>
+                                                <property name="pack-type">end</property>
                                                 <property name="position">1</property>
                                               </packing>
                                             </child>
@@ -4835,10 +4520,16 @@ This setting can make it easier to draw with touch. </property>
                                           <packing>
                                             <property name="expand">False</property>
                                             <property name="fill">True</property>
+                                            <property name="padding">8</property>
                                             <property name="position">1</property>
                                           </packing>
                                         </child>
                                       </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
                                     </child>
                                   </object>
                                 </child>
@@ -4862,70 +4553,43 @@ This setting can make it easier to draw with touch. </property>
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
                                 <child>
-                                  <object class="GtkAlignment" id="sid144">
+                                  <object class="GtkBox">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">8</property>
                                     <child>
-                                      <!-- n-columns=3 n-rows=3 -->
-                                      <object class="GtkGrid" id="grid4">
+                                      <object class="GtkLabel" id="label58a">
+                                        <property name="name">label58a</property>
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="column-spacing">5</property>
-                                        <child>
-                                          <object class="GtkLabel" id="label58a">
-                                            <property name="name">label58a</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="tooltip-markup" translatable="yes">Offset first page this many pages when &lt;b&gt;Pair Pages&lt;/b&gt; enabled</property>
-                                            <property name="label" translatable="yes">First Page Offset </property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSpinButton" id="spPairsOffset">
-                                            <property name="name">spPairsOffset</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="tooltip-text" translatable="yes">Usually 0 or 1</property>
-                                            <property name="valign">start</property>
-                                            <property name="max-width-chars">0</property>
-                                            <property name="adjustment">adjustmentPairsOffset</property>
-                                            <property name="numeric">True</property>
-                                            <property name="update-policy">if-valid</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">1</property>
-                                            <property name="top-attach">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
+                                        <property name="tooltip-markup" translatable="yes">Offset first page this many pages when &lt;b&gt;Pair Pages&lt;/b&gt; enabled</property>
+                                        <property name="label" translatable="yes">First Page Offset </property>
                                       </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSpinButton" id="spPairsOffset">
+                                        <property name="name">spPairsOffset</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="tooltip-text" translatable="yes">Usually 0 or 1</property>
+                                        <property name="valign">start</property>
+                                        <property name="max-width-chars">0</property>
+                                        <property name="adjustment">adjustmentPairsOffset</property>
+                                        <property name="numeric">True</property>
+                                        <property name="update-policy">if-valid</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
                                     </child>
                                   </object>
                                 </child>
@@ -4947,63 +4611,59 @@ This setting can make it easier to draw with touch. </property>
                               <object class="GtkFrame" id="sid198">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
-                                <property name="label-xalign">0</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
-                                  <object class="GtkAlignment" id="sid199">
+                                  <!-- n-columns=1 n-rows=3 -->
+                                  <object class="GtkGrid" id="grid7">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="left-padding">12</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">8</property>
+                                    <property name="orientation">vertical</property>
                                     <child>
-                                      <!-- n-columns=1 n-rows=3 -->
-                                      <object class="GtkGrid" id="grid7">
+                                      <object class="GtkRadioButton" id="rdLastPageAppendOnScrollToEndOfLastPage">
+                                        <property name="label" translatable="yes">when scrolling to end of last page</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="orientation">vertical</property>
-                                        <child>
-                                          <object class="GtkRadioButton" id="rdLastPageAppendOnScrollToEndOfLastPage">
-                                            <property name="label" translatable="yes">when scrolling to end of last page</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="active">True</property>
-                                            <property name="draw-indicator">True</property>
-                                            <property name="group">rdLastPageAppendDisabled</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">2</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkRadioButton" id="rdLastPageAppendOnDrawOfLastPage">
-                                            <property name="label" translatable="yes">when drawing on last page</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="active">True</property>
-                                            <property name="draw-indicator">True</property>
-                                            <property name="group">rdLastPageAppendDisabled</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkRadioButton" id="rdLastPageAppendDisabled">
-                                            <property name="label" translatable="yes">disabled</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="active">True</property>
-                                            <property name="draw-indicator">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">0</property>
-                                          </packing>
-                                        </child>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="active">True</property>
+                                        <property name="draw-indicator">True</property>
+                                        <property name="group">rdLastPageAppendDisabled</property>
                                       </object>
+                                      <packing>
+                                        <property name="left-attach">0</property>
+                                        <property name="top-attach">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkRadioButton" id="rdLastPageAppendOnDrawOfLastPage">
+                                        <property name="label" translatable="yes">when drawing on last page</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="active">True</property>
+                                        <property name="draw-indicator">True</property>
+                                        <property name="group">rdLastPageAppendDisabled</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">0</property>
+                                        <property name="top-attach">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkRadioButton" id="rdLastPageAppendDisabled">
+                                        <property name="label" translatable="yes">disabled</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="active">True</property>
+                                        <property name="draw-indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">0</property>
+                                        <property name="top-attach">0</property>
+                                      </packing>
                                     </child>
                                   </object>
                                 </child>
@@ -5027,86 +4687,62 @@ This setting can make it easier to draw with touch. </property>
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
                                 <child>
-                                  <object class="GtkAlignment" id="sid151">
+                                  <object class="GtkBox">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">8</property>
                                     <child>
-                                      <!-- n-columns=3 n-rows=3 -->
-                                      <object class="GtkGrid" id="grid6">
+                                      <object class="GtkCheckButton" id="cbDrawDirModsEnabled">
+                                        <property name="label" translatable="yes">Enable  with determination radius of </property>
+                                        <property name="name">cbDrawDirModsEnabled</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="column-spacing">5</property>
-                                        <child>
-                                          <object class="GtkCheckButton" id="cbDrawDirModsEnabled">
-                                            <property name="label" translatable="yes">Enable  with determination radius of </property>
-                                            <property name="name">cbDrawDirModsEnabled</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="tooltip-markup" translatable="yes">Drag LEFT from start point acts like shift key is being held.
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="tooltip-markup" translatable="yes">Drag LEFT from start point acts like shift key is being held.
 Drag UP acts as if Control key is being held.
 
 Determination Radius: Radius at which modifiers will lock in until finished drawing.
 
 &lt;i&gt;Useful for operating without keyboard.&lt;/i&gt;</property>
-                                            <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSpinButton" id="spDrawDirModsRadius">
-                                            <property name="name">spDrawDirModsRadius</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="valign">start</property>
-                                            <property name="max-width-chars">0</property>
-                                            <property name="adjustment">adjustmentDrawDirModRadius</property>
-                                            <property name="numeric">True</property>
-                                            <property name="update-policy">if-valid</property>
-                                            <property name="value">50</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">1</property>
-                                            <property name="top-attach">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkLabel" id="sid152">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">pixels</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">2</property>
-                                            <property name="top-attach">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
+                                        <property name="draw-indicator">True</property>
                                       </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSpinButton" id="spDrawDirModsRadius">
+                                        <property name="name">spDrawDirModsRadius</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="valign">start</property>
+                                        <property name="max-width-chars">0</property>
+                                        <property name="adjustment">adjustmentDrawDirModRadius</property>
+                                        <property name="numeric">True</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="value">50</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="sid152">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">pixels</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">2</property>
+                                      </packing>
                                     </child>
                                   </object>
                                 </child>
@@ -5130,58 +4766,17 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
                                 <child>
-                                  <object class="GtkAlignment">
+                                  <object class="GtkCheckButton" id="cbRestoreLineWidthEnabled">
+                                    <property name="label" translatable="yes">Preserve line width</property>
+                                    <property name="name">cbRestoreLineWidthEnabled</property>
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="left-padding">12</property>
-                                    <child>
-                                      <!-- n-columns=3 n-rows=3 -->
-                                      <object class="GtkGrid">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <child>
-                                          <object class="GtkCheckButton" id="cbRestoreLineWidthEnabled">
-                                            <property name="label" translatable="yes">Preserve line width</property>
-                                            <property name="name">cbRestoreLineWidthEnabled</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="tooltip-markup" translatable="yes">After resizing a selection, the line width of all strokes will be the same as before the resizing operation. </property>
-                                            <property name="margin-bottom">2</property>
-                                            <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                      </object>
-                                    </child>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-markup" translatable="yes">After resizing a selection, the line width of all strokes will be the same as before the resizing operation. </property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">8</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                 </child>
                                 <child type="label">
@@ -5204,142 +4799,123 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
                                 <child>
-                                  <object class="GtkAlignment" id="sid147">
+                                  <object class="GtkBox" id="box51">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">8</property>
+                                    <property name="orientation">vertical</property>
+                                    <property name="spacing">6</property>
                                     <child>
-                                      <object class="GtkBox" id="box51">
+                                      <!-- n-columns=2 n-rows=3 -->
+                                      <object class="GtkGrid" id="sid148">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="orientation">vertical</property>
-                                        <property name="spacing">6</property>
+                                        <property name="row-spacing">5</property>
+                                        <property name="column-spacing">5</property>
                                         <child>
-                                          <!-- n-columns=3 n-rows=3 -->
-                                          <object class="GtkGrid" id="sid148">
+                                          <object class="GtkLabel" id="lbSnapRotationTolerance">
+                                            <property name="name">lbSnapRotationTolerance</property>
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
-                                            <property name="row-spacing">5</property>
-                                            <property name="column-spacing">5</property>
-                                            <child>
-                                              <object class="GtkLabel" id="lbSnapRotationTolerance">
-                                                <property name="name">lbSnapRotationTolerance</property>
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">Rotation snapping tolerance</property>
-                                                <property name="xalign">0</property>
-                                              </object>
-                                              <packing>
-                                                <property name="left-attach">0</property>
-                                                <property name="top-attach">0</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkLabel" id="lbSnapGridTolerance">
-                                                <property name="name">lbSnapGridTolerance</property>
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">Grid snapping tolerance</property>
-                                                <property name="xalign">0</property>
-                                              </object>
-                                              <packing>
-                                                <property name="left-attach">0</property>
-                                                <property name="top-attach">1</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkSpinButton" id="spSnapRotationTolerance">
-                                                <property name="name">spSnapRotationTolerance</property>
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="adjustment">adjustmentSnapRotationTolerance</property>
-                                                <property name="climb-rate">0.05</property>
-                                                <property name="digits">2</property>
-                                                <property name="value">0.20</property>
-                                              </object>
-                                              <packing>
-                                                <property name="left-attach">1</property>
-                                                <property name="top-attach">0</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkSpinButton" id="spSnapGridTolerance">
-                                                <property name="name">spSnapGridTolerance</property>
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="adjustment">adjustmentSnapGridTolerance</property>
-                                                <property name="climb-rate">0.05</property>
-                                                <property name="digits">2</property>
-                                                <property name="value">0.25</property>
-                                              </object>
-                                              <packing>
-                                                <property name="left-attach">1</property>
-                                                <property name="top-attach">1</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkLabel" id="lbSnapGridSize">
-                                                <property name="name">lbSnapGridSize</property>
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">Grid size</property>
-                                                <property name="xalign">0</property>
-                                              </object>
-                                              <packing>
-                                                <property name="left-attach">0</property>
-                                                <property name="top-attach">2</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkSpinButton" id="spSnapGridSize">
-                                                <property name="name">spSnapGridSize</property>
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="adjustment">adjustmentSnapGridSize</property>
-                                                <property name="climb-rate">0.01</property>
-                                                <property name="digits">2</property>
-                                                <property name="value">1</property>
-                                              </object>
-                                              <packing>
-                                                <property name="left-attach">1</property>
-                                                <property name="top-attach">2</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
+                                            <property name="label" translatable="yes">Rotation snapping tolerance</property>
                                           </object>
                                           <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkCheckButton" id="cbSnapRecognizedShapesEnabled">
-                                            <property name="label" translatable="yes">Use snapping for recognized shapes</property>
+                                          <object class="GtkLabel" id="lbSnapGridTolerance">
+                                            <property name="name">lbSnapGridTolerance</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="tooltip-text" translatable="yes">If activated, shapes that have been recognized by the shape recognizer will be snapped to the grid automatically. This may lead to unexpected results if you have the shape recognizer turned on while writing.</property>
-                                            <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">Grid snapping tolerance</property>
                                           </object>
                                           <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSpinButton" id="spSnapRotationTolerance">
+                                            <property name="name">spSnapRotationTolerance</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="adjustment">adjustmentSnapRotationTolerance</property>
+                                            <property name="climb-rate">0.05</property>
+                                            <property name="digits">2</property>
+                                            <property name="value">0.20</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSpinButton" id="spSnapGridTolerance">
+                                            <property name="name">spSnapGridTolerance</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="adjustment">adjustmentSnapGridTolerance</property>
+                                            <property name="climb-rate">0.05</property>
+                                            <property name="digits">2</property>
+                                            <property name="value">0.25</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="lbSnapGridSize">
+                                            <property name="name">lbSnapGridSize</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">Grid size</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">2</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSpinButton" id="spSnapGridSize">
+                                            <property name="name">spSnapGridSize</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="adjustment">adjustmentSnapGridSize</property>
+                                            <property name="climb-rate">0.01</property>
+                                            <property name="digits">2</property>
+                                            <property name="value">1</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">2</property>
                                           </packing>
                                         </child>
                                       </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="cbSnapRecognizedShapesEnabled">
+                                        <property name="label" translatable="yes">Use snapping for recognized shapes</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="tooltip-text" translatable="yes">If activated, shapes that have been recognized by the shape recognizer will be snapped to the grid automatically. This may lead to unexpected results if you have the shape recognizer turned on while writing.</property>
+                                        <property name="draw-indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
                                     </child>
                                   </object>
                                 </child>
@@ -5361,63 +4937,43 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                               <object class="GtkFrame" id="strokeRecognizerFrrame">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
-                                <property name="label-xalign">0</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
-                                  <object class="GtkAlignment">
+                                  <object class="GtkBox">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="left-padding">12</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">8</property>
                                     <child>
-                                      <object class="GtkBox">
+                                      <object class="GtkLabel">
+                                        <property name="name">lbStrokeRecognizerMinSize</property>
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="orientation">vertical</property>
-                                        <child>
-                                          <!-- n-columns=3 n-rows=1 -->
-                                          <object class="GtkGrid" id="sid6">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="row-spacing">5</property>
-                                            <property name="column-spacing">5</property>
-                                            <child>
-                                              <object class="GtkLabel">
-                                                <property name="name">lbStrokeRecognizerMinSize</property>
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">Minimum Stroke Size</property>
-                                                <property name="xalign">0</property>
-                                              </object>
-                                              <packing>
-                                                <property name="left-attach">0</property>
-                                                <property name="top-attach">0</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkSpinButton" id="spStrokeRecognizerMinSize">
-                                                <property name="name">spStrokeRecognizerMinSize</property>
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="text" translatable="yes">0.20</property>
-                                                <property name="adjustment">adjustmentStrokeRecognizerMinSize</property>
-                                                <property name="climb-rate">2</property>
-                                                <property name="value">25</property>
-                                              </object>
-                                              <packing>
-                                                <property name="left-attach">1</property>
-                                                <property name="top-attach">0</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
+                                        <property name="margin-end">6</property>
+                                        <property name="label" translatable="yes">Minimum Stroke Size</property>
                                       </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSpinButton" id="spStrokeRecognizerMinSize">
+                                        <property name="name">spStrokeRecognizerMinSize</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="text" translatable="yes">0.20</property>
+                                        <property name="adjustment">adjustmentStrokeRecognizerMinSize</property>
+                                        <property name="climb-rate">2</property>
+                                        <property name="value">25</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
                                     </child>
                                   </object>
                                 </child>
@@ -5441,178 +4997,167 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
                                 <child>
-                                  <object class="GtkAlignment" id="sid155">
+                                  <!-- n-columns=4 n-rows=3 -->
+                                  <object class="GtkGrid" id="grid1">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">8</property>
+                                    <property name="column-spacing">5</property>
                                     <child>
-                                      <!-- n-columns=4 n-rows=3 -->
-                                      <object class="GtkGrid" id="grid1">
+                                      <object class="GtkCheckButton" id="cbStrokeFilterEnabled">
+                                        <property name="label" translatable="yes">Enable Tap action</property>
+                                        <property name="name">cbStrokeFilterEnabled</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="tooltip-markup" translatable="yes">Do not draw for inputs of short time and length unless it comes in short succession. Instead, show floating toolbox.</property>
+                                        <property name="draw-indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">0</property>
+                                        <property name="top-attach">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="sid156">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="column-spacing">5</property>
-                                        <child>
-                                          <object class="GtkCheckButton" id="cbStrokeFilterEnabled">
-                                            <property name="label" translatable="yes">Enable Tap action</property>
-                                            <property name="name">cbStrokeFilterEnabled</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="tooltip-markup" translatable="yes">Do not draw for inputs of short time and length unless it comes in short succession. Instead, show floating toolbox.</property>
-                                            <property name="xalign">0</property>
-                                            <property name="draw-indicator">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkLabel" id="sid156">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">Ignore Time (ms)</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">1</property>
-                                            <property name="top-attach">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSpinButton" id="spStrokeIgnoreTime">
-                                            <property name="name">spStrokeIgnoreTime</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="tooltip-markup" translatable="yes">How short (time)  AND...
+                                        <property name="label" translatable="yes">Ignore Time (ms)</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="top-attach">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSpinButton" id="spStrokeIgnoreTime">
+                                        <property name="name">spStrokeIgnoreTime</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="tooltip-markup" translatable="yes">How short (time)  AND...
 
 &lt;i&gt;Recommended: 150ms&lt;/i&gt;</property>
-                                            <property name="valign">start</property>
-                                            <property name="max-width-chars">0</property>
-                                            <property name="adjustment">adjustmentStrokeIgnoreTime</property>
-                                            <property name="numeric">True</property>
-                                            <property name="update-policy">if-valid</property>
-                                            <property name="value">150</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">1</property>
-                                            <property name="top-attach">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSpinButton" id="spStrokeIgnoreLength">
-                                            <property name="name">spStrokeIgnoreLength</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="tooltip-markup" translatable="yes">How short (screen mm)  of the stroke  AND...
+                                        <property name="valign">start</property>
+                                        <property name="max-width-chars">0</property>
+                                        <property name="adjustment">adjustmentStrokeIgnoreTime</property>
+                                        <property name="numeric">True</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="value">150</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="top-attach">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSpinButton" id="spStrokeIgnoreLength">
+                                        <property name="name">spStrokeIgnoreLength</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="tooltip-markup" translatable="yes">How short (screen mm)  of the stroke  AND...
 
 &lt;i&gt;Recommended: 1 mm&lt;/i&gt;</property>
-                                            <property name="valign">start</property>
-                                            <property name="max-width-chars">0</property>
-                                            <property name="adjustment">adjustmentStrokeIgnoreLength</property>
-                                            <property name="digits">2</property>
-                                            <property name="numeric">True</property>
-                                            <property name="update-policy">if-valid</property>
-                                            <property name="value">1</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">2</property>
-                                            <property name="top-attach">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkLabel" id="sid157">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">Max Length (mm)</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">2</property>
-                                            <property name="top-attach">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkLabel" id="sid158">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">Successive (ms)</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">3</property>
-                                            <property name="top-attach">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSpinButton" id="spStrokeSuccessiveTime">
-                                            <property name="name">spStrokeSuccessiveTime</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="tooltip-markup" translatable="yes">... AND How much time must have passed since last stroke.
+                                        <property name="valign">start</property>
+                                        <property name="max-width-chars">0</property>
+                                        <property name="adjustment">adjustmentStrokeIgnoreLength</property>
+                                        <property name="digits">2</property>
+                                        <property name="numeric">True</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="value">1</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">2</property>
+                                        <property name="top-attach">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="sid157">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">Max Length (mm)</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">2</property>
+                                        <property name="top-attach">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="sid158">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">Successive (ms)</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">3</property>
+                                        <property name="top-attach">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSpinButton" id="spStrokeSuccessiveTime">
+                                        <property name="name">spStrokeSuccessiveTime</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="tooltip-markup" translatable="yes">... AND How much time must have passed since last stroke.
 
 &lt;i&gt;Recommended: 500ms&lt;/i&gt;</property>
-                                            <property name="valign">start</property>
-                                            <property name="max-width-chars">0</property>
-                                            <property name="adjustment">adjustmentStrokeSuccessiveTime</property>
-                                            <property name="numeric">True</property>
-                                            <property name="update-policy">if-valid</property>
-                                            <property name="value">500</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">3</property>
-                                            <property name="top-attach">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkCheckButton" id="cbTrySelectOnStrokeFiltered">
-                                            <property name="label" translatable="yes">Try to select object first.</property>
-                                            <property name="name">cbTrySelectOnStrokeFiltered</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="tooltip-markup" translatable="yes">Try to select object first; if nothing selected then show floating toolbox if enabled.</property>
-                                            <property name="xalign">0</property>
-                                            <property name="yalign">0.4399999976158142</property>
-                                            <property name="draw-indicator">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">1</property>
-                                            <property name="top-attach">2</property>
-                                            <property name="width">3</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkLabel" id="label1">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="tooltip-text" translatable="yes">All three conditions must be met before stroke is ignored.
-It must be short in time and length and we can't have ignored another stroke recently.</property>
-                                            <property name="halign">end</property>
-                                            <property name="label" translatable="yes">Settings:</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkCheckButton" id="cbDoActionOnStrokeFiltered">
-                                            <property name="label" translatable="yes">Show Floating Toolbox</property>
-                                            <property name="name">cbDoActionOnStrokeFiltered</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="tooltip-markup" translatable="yes">Try to select object first; if nothing selected then show floating toolbox if enabled.</property>
-                                            <property name="xalign">0</property>
-                                            <property name="yalign">0.43000000715255737</property>
-                                            <property name="draw-indicator">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">2</property>
-                                          </packing>
-                                        </child>
+                                        <property name="valign">start</property>
+                                        <property name="max-width-chars">0</property>
+                                        <property name="adjustment">adjustmentStrokeSuccessiveTime</property>
+                                        <property name="numeric">True</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="value">500</property>
                                       </object>
+                                      <packing>
+                                        <property name="left-attach">3</property>
+                                        <property name="top-attach">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="cbTrySelectOnStrokeFiltered">
+                                        <property name="label" translatable="yes">Try to select object first.</property>
+                                        <property name="name">cbTrySelectOnStrokeFiltered</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="tooltip-markup" translatable="yes">Try to select object first; if nothing selected then show floating toolbox if enabled.</property>
+                                        <property name="draw-indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="top-attach">2</property>
+                                        <property name="width">3</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="label1">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="tooltip-text" translatable="yes">All three conditions must be met before stroke is ignored.
+It must be short in time and length and we can't have ignored another stroke recently.</property>
+                                        <property name="halign">end</property>
+                                        <property name="label" translatable="yes">Settings:</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">0</property>
+                                        <property name="top-attach">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="cbDoActionOnStrokeFiltered">
+                                        <property name="label" translatable="yes">Show Floating Toolbox</property>
+                                        <property name="name">cbDoActionOnStrokeFiltered</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="tooltip-markup" translatable="yes">Try to select object first; if nothing selected then show floating toolbox if enabled.</property>
+                                        <property name="draw-indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">0</property>
+                                        <property name="top-attach">2</property>
+                                      </packing>
                                     </child>
                                   </object>
                                 </child>
@@ -5636,27 +5181,43 @@ It must be short in time and length and we can't have ignored another stroke rec
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
                                 <child>
-                                  <object class="GtkAlignment" id="alignPDFCacheOptions">
+                                  <object class="GtkBox" id="boxReRenderSetting">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">8</property>
+                                    <property name="orientation">vertical</property>
                                     <child>
-                                      <object class="GtkBox" id="boxReRenderSetting">
+                                      <object class="GtkLabel" id="lblReRenderMoreOftenWhileZooming">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="orientation">vertical</property>
+                                        <property name="margin-bottom">2</property>
+                                        <property name="label" translatable="yes">&lt;i&gt;Re-render PDF backgrounds more often while zooming for better render quality.
+&lt;b&gt;Note:&lt;/b&gt; This should not affect print quality.&lt;/i&gt;</property>
+                                        <property name="use-markup">True</property>
+                                        <property name="wrap">True</property>
+                                        <property name="max-width-chars">85</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkBox">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
                                         <child>
-                                          <object class="GtkLabel" id="lblReRenderMoreOftenWhileZooming">
+                                          <object class="GtkLabel" id="lbReRenderThreshold">
+                                            <property name="name">lbSnapRotationTolerance</property>
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">&lt;i&gt;Re-render PDF backgrounds more often while zooming for better render quality.
-&lt;b&gt;Note:&lt;/b&gt; This should not affect print quality.&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
-                                            <property name="wrap">True</property>
-                                            <property name="max-width-chars">85</property>
-                                            <property name="xalign">0</property>
+                                            <property name="tooltip-text" translatable="yes">When zoomed in on a high-resolution PDF, each re-render can take a long time. Setting this to a large value causes these re-renders to happen less often.
+
+Set this to 0% to always re-render on zoom.</property>
+                                            <property name="label" translatable="yes">Re-render when the page's zoom changes by more than </property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -5665,75 +5226,15 @@ It must be short in time and length and we can't have ignored another stroke rec
                                           </packing>
                                         </child>
                                         <child>
-                                          <!-- n-columns=3 n-rows=3 -->
-                                          <object class="GtkGrid" id="gdRecacheOptions">
+                                          <object class="GtkSpinButton" id="spReRenderThreshold">
+                                            <property name="name">spSnapRotationTolerance</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="row-spacing">5</property>
-                                            <property name="column-spacing">5</property>
-                                            <child>
-                                              <object class="GtkLabel" id="lbReRenderThreshold">
-                                                <property name="name">lbSnapRotationTolerance</property>
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="tooltip-text" translatable="yes">When zoomed in on a high-resolution PDF, each re-render can take a long time. Setting this to a large value causes these re-renders to happen less often.
-
-Set this to 0% to always re-render on zoom.</property>
-                                                <property name="label" translatable="yes">Re-render when the page's zoom changes by more than </property>
-                                                <property name="xalign">0</property>
-                                              </object>
-                                              <packing>
-                                                <property name="left-attach">0</property>
-                                                <property name="top-attach">0</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkSpinButton" id="spReRenderThreshold">
-                                                <property name="name">spSnapRotationTolerance</property>
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="text" translatable="yes">0.00</property>
-                                                <property name="input-purpose">number</property>
-                                                <property name="adjustment">adjustmentReRenderThreshold</property>
-                                                <property name="climb-rate">2</property>
-                                                <property name="numeric">True</property>
-                                              </object>
-                                              <packing>
-                                                <property name="left-attach">1</property>
-                                                <property name="top-attach">0</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkLabel" id="lbReRenderThresholdEnding">
-                                                <property name="name">lbSnapRotationTolerance</property>
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">%.</property>
-                                                <property name="xalign">0</property>
-                                              </object>
-                                              <packing>
-                                                <property name="left-attach">2</property>
-                                                <property name="top-attach">0</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
+                                            <property name="can-focus">True</property>
+                                            <property name="text" translatable="yes">0.00</property>
+                                            <property name="input-purpose">number</property>
+                                            <property name="adjustment">adjustmentReRenderThreshold</property>
+                                            <property name="climb-rate">2</property>
+                                            <property name="numeric">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -5741,7 +5242,25 @@ Set this to 0% to always re-render on zoom.</property>
                                             <property name="position">1</property>
                                           </packing>
                                         </child>
+                                        <child>
+                                          <object class="GtkLabel" id="lbReRenderThresholdEnding">
+                                            <property name="name">lbSnapRotationTolerance</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">%.</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">2</property>
+                                          </packing>
+                                        </child>
                                       </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
                                     </child>
                                   </object>
                                 </child>
@@ -5792,7 +5311,7 @@ Set this to 0% to always re-render on zoom.</property>
                 <property name="name">defaultTabBox</property>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="margin-left">5</property>
+                <property name="margin-start">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid160">
@@ -5816,52 +5335,45 @@ Set this to 0% to always re-render on zoom.</property>
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
                                 <child>
-                                  <object class="GtkAlignment" id="sid164">
+                                  <object class="GtkBox" id="sid165">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">8</property>
+                                    <property name="orientation">vertical</property>
                                     <child>
-                                      <object class="GtkBox" id="sid165">
+                                      <object class="GtkLabel" id="label9">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="orientation">vertical</property>
-                                        <child>
-                                          <object class="GtkLabel" id="label9">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">&lt;i&gt;Select the tool and Settings if you press the Default Button.&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
-                                            <property name="max-width-chars">85</property>
-                                            <property name="xalign">0</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="padding">5</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkBox" id="hboxDefaultTool">
-                                            <property name="name">hboxDefaultTool</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
+                                        <property name="label" translatable="yes">&lt;i&gt;Select the tool and Settings if you press the Default Button.&lt;/i&gt;</property>
+                                        <property name="use-markup">True</property>
+                                        <property name="max-width-chars">85</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="padding">5</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkBox" id="hboxDefaultTool">
+                                        <property name="name">hboxDefaultTool</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
                                         <child>
                                           <placeholder/>
                                         </child>
                                       </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <placeholder/>
                                     </child>
                                   </object>
                                 </child>
@@ -5937,7 +5449,7 @@ Set this to 0% to always re-render on zoom.</property>
                 <property name="name">audioRecordingTabBox</property>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="margin-left">5</property>
+                <property name="margin-start">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid166">
@@ -5961,25 +5473,36 @@ Set this to 0% to always re-render on zoom.</property>
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
                                 <child>
-                                  <object class="GtkAlignment" id="sid170">
+                                  <object class="GtkBox" id="sid171">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">8</property>
+                                    <property name="orientation">vertical</property>
                                     <child>
-                                      <object class="GtkBox" id="sid171">
+                                      <object class="GtkLabel" id="label45">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="orientation">vertical</property>
+                                        <property name="label" translatable="yes">&lt;i&gt;Audio recordings are currently stored in a separate folder and referenced from the journal.&lt;/i&gt;</property>
+                                        <property name="use-markup">True</property>
+                                        <property name="max-width-chars">85</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkBox">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
                                         <child>
-                                          <object class="GtkLabel" id="label45">
+                                          <object class="GtkLabel" id="label46">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">&lt;i&gt;Audio recordings are currently stored in a separate folder and referenced from the journal.&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
-                                            <property name="max-width-chars">85</property>
-                                            <property name="xalign">0</property>
+                                            <property name="label" translatable="yes">Storage Folder</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -5988,59 +5511,13 @@ Set this to 0% to always re-render on zoom.</property>
                                           </packing>
                                         </child>
                                         <child>
-                                          <!-- n-columns=3 n-rows=3 -->
-                                          <object class="GtkGrid" id="grid5">
+                                          <object class="GtkFileChooserButton" id="fcAudioPath">
+                                            <property name="name">fcAudioPath</property>
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
-                                            <property name="row-spacing">10</property>
-                                            <property name="column-spacing">10</property>
-                                            <child>
-                                              <object class="GtkLabel" id="label46">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">Storage Folder</property>
-                                                <property name="xalign">0</property>
-                                              </object>
-                                              <packing>
-                                                <property name="left-attach">0</property>
-                                                <property name="top-attach">0</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkFileChooserButton" id="fcAudioPath">
-                                                <property name="name">fcAudioPath</property>
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="hexpand">True</property>
-                                                <property name="action">select-folder</property>
-                                                <property name="title" translatable="yes">Select Folder</property>
-                                              </object>
-                                              <packing>
-                                                <property name="left-attach">1</property>
-                                                <property name="top-attach">0</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
+                                            <property name="hexpand">True</property>
+                                            <property name="action">select-folder</property>
+                                            <property name="title" translatable="yes">Select Folder</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -6049,6 +5526,11 @@ Set this to 0% to always re-render on zoom.</property>
                                           </packing>
                                         </child>
                                       </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
                                     </child>
                                   </object>
                                 </child>
@@ -6072,110 +5554,86 @@ Set this to 0% to always re-render on zoom.</property>
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
                                 <child>
-                                  <object class="GtkAlignment" id="sid174">
+                                  <object class="GtkBox" id="sid175">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">8</property>
+                                    <property name="orientation">vertical</property>
                                     <child>
-                                      <object class="GtkBox" id="sid175">
+                                      <object class="GtkLabel" id="sid176">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="orientation">vertical</property>
+                                        <property name="label" translatable="yes">&lt;i&gt;Specify the audio devices used for recording and playback of audio attachments.
+If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as input / output device.&lt;/i&gt;</property>
+                                        <property name="use-markup">True</property>
+                                        <property name="wrap">True</property>
+                                        <property name="max-width-chars">85</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <!-- n-columns=2 n-rows=2 -->
+                                      <object class="GtkGrid" id="grid8">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="row-spacing">10</property>
+                                        <property name="column-spacing">10</property>
                                         <child>
-                                          <object class="GtkLabel" id="sid176">
+                                          <object class="GtkLabel" id="label36">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">&lt;i&gt;Specify the audio devices used for recording and playback of audio attachments.
-If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as input / output device.&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
-                                            <property name="wrap">True</property>
-                                            <property name="max-width-chars">85</property>
-                                            <property name="xalign">0</property>
+                                            <property name="label" translatable="yes">Input Device</property>
                                           </object>
                                           <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
-                                          <!-- n-columns=3 n-rows=3 -->
-                                          <object class="GtkGrid" id="grid8">
+                                          <object class="GtkComboBoxText" id="cbAudioInputDevice">
+                                            <property name="name">cbAudioInputDevice</property>
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
-                                            <property name="row-spacing">10</property>
-                                            <property name="column-spacing">10</property>
-                                            <child>
-                                              <object class="GtkLabel" id="label36">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">Input Device</property>
-                                                <property name="xalign">0</property>
-                                              </object>
-                                              <packing>
-                                                <property name="left-attach">0</property>
-                                                <property name="top-attach">0</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkComboBoxText" id="cbAudioInputDevice">
-                                                <property name="name">cbAudioInputDevice</property>
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                              </object>
-                                              <packing>
-                                                <property name="left-attach">1</property>
-                                                <property name="top-attach">0</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkLabel" id="label58">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">Output Device</property>
-                                                <property name="xalign">0</property>
-                                              </object>
-                                              <packing>
-                                                <property name="left-attach">0</property>
-                                                <property name="top-attach">1</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkComboBoxText" id="cbAudioOutputDevice">
-                                                <property name="name">cbAudioOutputDevice</property>
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                              </object>
-                                              <packing>
-                                                <property name="left-attach">1</property>
-                                                <property name="top-attach">1</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
                                           </object>
                                           <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="label58">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">Output Device</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkComboBoxText" id="cbAudioOutputDevice">
+                                            <property name="name">cbAudioOutputDevice</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">1</property>
                                           </packing>
                                         </child>
                                       </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
                                     </child>
                                   </object>
                                 </child>
@@ -6199,93 +5657,70 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
                                 <child>
-                                  <object class="GtkAlignment" id="sid179">
+                                  <!-- n-columns=2 n-rows=2 -->
+                                  <object class="GtkGrid" id="sid180">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">8</property>
+                                    <property name="row-spacing">10</property>
+                                    <property name="column-spacing">10</property>
                                     <child>
-                                      <!-- n-columns=3 n-rows=3 -->
-                                      <object class="GtkGrid" id="sid180">
+                                      <object class="GtkLabel" id="label59">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="row-spacing">10</property>
-                                        <property name="column-spacing">10</property>
-                                        <child>
-                                          <object class="GtkLabel" id="label59">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">Sample Rate</property>
-                                            <property name="xalign">0</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkLabel" id="label61">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">Gain</property>
-                                            <property name="xalign">0</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkComboBoxText" id="cbAudioSampleRate">
-                                            <property name="name">cbAudioSampleRate</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="active">0</property>
-                                            <items>
-                                              <item id="16000">16000 Hz</item>
-                                              <item id="44100">44100 Hz</item>
-                                              <item id="96000">96000 Hz</item>
-                                              <item id="192000">192000 Hz</item>
-                                            </items>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">1</property>
-                                            <property name="top-attach">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSpinButton" id="spAudioGain">
-                                            <property name="name">spAudioGain</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="adjustment">adjustmentAudioGain</property>
-                                            <property name="climb-rate">0.10</property>
-                                            <property name="digits">2</property>
-                                            <property name="numeric">True</property>
-                                            <property name="value">1</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">1</property>
-                                            <property name="top-attach">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
+                                        <property name="label" translatable="yes">Sample Rate</property>
                                       </object>
+                                      <packing>
+                                        <property name="left-attach">0</property>
+                                        <property name="top-attach">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="label61">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">Gain</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">0</property>
+                                        <property name="top-attach">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkComboBoxText" id="cbAudioSampleRate">
+                                        <property name="name">cbAudioSampleRate</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="active">0</property>
+                                        <items>
+                                          <item id="16000">16000 Hz</item>
+                                          <item id="44100">44100 Hz</item>
+                                          <item id="96000">96000 Hz</item>
+                                          <item id="192000">192000 Hz</item>
+                                        </items>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="top-attach">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSpinButton" id="spAudioGain">
+                                        <property name="name">spAudioGain</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="adjustment">adjustmentAudioGain</property>
+                                        <property name="climb-rate">0.10</property>
+                                        <property name="digits">2</property>
+                                        <property name="numeric">True</property>
+                                        <property name="value">1</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="top-attach">1</property>
+                                      </packing>
                                     </child>
                                   </object>
                                 </child>
@@ -6309,70 +5744,41 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
                                 <child>
-                                  <object class="GtkAlignment" id="sid2">
+                                  <object class="GtkBox">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="bottom-padding">8</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">8</property>
                                     <child>
-                                      <!-- n-columns=3 n-rows=3 -->
-                                      <object class="GtkGrid" id="sid3">
+                                      <object class="GtkLabel" id="label3">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="row-spacing">10</property>
-                                        <property name="column-spacing">10</property>
-                                        <child>
-                                          <object class="GtkLabel" id="label3">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">Default Seek Time (in seconds)</property>
-                                            <property name="xalign">0</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSpinButton" id="spDefaultSeekTime">
-                                            <property name="name">spAudioGain</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="text" translatable="yes">1,00</property>
-                                            <property name="adjustment">adjustmentSeekTime</property>
-                                            <property name="climb-rate">0.10</property>
-                                            <property name="digits">2</property>
-                                            <property name="numeric">True</property>
-                                            <property name="value">1</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">1</property>
-                                            <property name="top-attach">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
+                                        <property name="label" translatable="yes">Default Seek Time (in seconds)</property>
                                       </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSpinButton" id="spDefaultSeekTime">
+                                        <property name="name">spAudioGain</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="text" translatable="yes">1,00</property>
+                                        <property name="adjustment">adjustmentSeekTime</property>
+                                        <property name="climb-rate">0.10</property>
+                                        <property name="digits">2</property>
+                                        <property name="numeric">True</property>
+                                        <property name="value">1</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
                                     </child>
                                   </object>
                                 </child>
@@ -6397,7 +5803,6 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                 <property name="label" translatable="yes">&lt;i&gt;Changes take only effect on new recordings and playbacks.&lt;/i&gt;</property>
                                 <property name="use-markup">True</property>
                                 <property name="max-width-chars">85</property>
-                                <property name="xalign">0</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -6437,7 +5842,7 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
               <object class="GtkBox" id="latexTabBox">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="margin-left">5</property>
+                <property name="margin-start">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <placeholder/>
@@ -6462,7 +5867,7 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
               <object class="GtkBox" id="languageTabBox">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="margin-left">5</property>
+                <property name="margin-start">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid189">
@@ -6482,75 +5887,63 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                               <object class="GtkFrame" id="sid192">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
-                                <property name="margin-left">4</property>
+                                <property name="margin-start">4</property>
                                 <property name="margin-top">3</property>
                                 <property name="margin-bottom">3</property>
                                 <property name="border-width">2</property>
                                 <property name="label-xalign">0.009999999776482582</property>
                                 <child>
-                                  <object class="GtkAlignment" id="sid193">
+                                  <object class="GtkBox" id="sid194">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="bottom-padding">12</property>
-                                    <property name="left-padding">12</property>
-                                    <property name="right-padding">12</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">8</property>
+                                    <property name="orientation">vertical</property>
                                     <child>
-                                      <object class="GtkBox" id="sid194">
+                                      <object class="GtkLabel" id="label195">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="orientation">vertical</property>
+                                        <property name="label" translatable="yes">&lt;i&gt;Select language (requires restart)&lt;/i&gt;</property>
+                                        <property name="use-markup">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkFrame" id="sid195">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label-xalign">0.009999999776482582</property>
                                         <child>
-                                          <object class="GtkLabel" id="label195">
+                                          <object class="GtkBox" id="hboxLanguageSelect">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">&lt;i&gt;Select language (requires restart)&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkFrame" id="sid195">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label-xalign">0.009999999776482582</property>
+                                            <property name="margin-start">12</property>
+                                            <property name="margin-end">12</property>
+                                            <property name="margin-bottom">8</property>
+                                            <property name="orientation">vertical</property>
                                             <child>
-                                              <object class="GtkAlignment" id="sid196">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="bottom-padding">8</property>
-                                                <property name="left-padding">12</property>
-                                                <property name="right-padding">12</property>
-                                                <child>
-                                                  <object class="GtkBox" id="hboxLanguageSelect">
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
-                                                    <property name="orientation">vertical</property>
-                                                    <child>
-                                                      <placeholder/>
-                                                    </child>
-                                                  </object>
-                                                </child>
-                                              </object>
-                                            </child>
-                                            <child type="label">
-                                              <object class="GtkLabel" id="label196">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">Language</property>
-                                              </object>
+                                              <placeholder/>
                                             </child>
                                           </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
+                                        </child>
+                                        <child type="label">
+                                          <object class="GtkLabel" id="label196">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">Language</property>
+                                          </object>
                                         </child>
                                       </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
                                     </child>
                                   </object>
                                 </child>

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -225,6 +225,16 @@
     <property name="step-increment">0.5</property>
     <property name="page-increment">10</property>
   </object>
+  <object class="GtkImage" id="iconCancel">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">dialog-cancel</property>
+  </object>
+  <object class="GtkImage" id="iconOk">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">dialog-ok</property>
+  </object>
   <object class="GtkListStore" id="listStabilizerAveragingMethods">
     <columns>
       <!-- column-name Name -->
@@ -259,66 +269,22 @@
       </row>
     </data>
   </object>
-  <object class="GtkDialog" id="settingsDialog">
-    <property name="name">settingsDialog</property>
+  <object class="GtkWindow" id="settingsDialog">
+    <property name="width-request">1024</property>
+    <property name="height-request">740</property>
     <property name="can-focus">False</property>
-    <property name="border-width">5</property>
-    <property name="title" translatable="yes">Xournal++ Preferences</property>
-    <property name="window-position">center</property>
-    <property name="icon">pixmaps/com.github.xournalpp.xournalpp.svg</property>
-    <property name="type-hint">normal</property>
-    <property name="gravity">center</property>
-    <signal name="close" handler="gtk_widget_hide" swapped="no"/>
-    <child internal-child="vbox">
-      <object class="GtkBox" id="dialog-vbox3">
+    <property name="modal">True</property>
+    <property name="destroy-with-parent">True</property>
+    <property name="skip-taskbar-hint">True</property>
+    <child>
+      <object class="GtkBox" id="dialog-main-box">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
+        <property name="margin-start">10</property>
+        <property name="margin-end">10</property>
+        <property name="margin-top">10</property>
+        <property name="margin-bottom">10</property>
         <property name="orientation">vertical</property>
-        <property name="spacing">2</property>
-        <child internal-child="action_area">
-          <object class="GtkButtonBox" id="btSettingsButton">
-            <property name="name">btSettingsButton</property>
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="layout-style">end</property>
-            <child>
-              <object class="GtkButton" id="btSettingsCancel">
-                <property name="label">gtk-cancel</property>
-                <property name="name">btSettingsCancel</property>
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">True</property>
-                <property name="use-stock">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="btSettingsOk">
-                <property name="label">gtk-ok</property>
-                <property name="name">btSettingsOk</property>
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">True</property>
-                <property name="use-stock">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="pack-type">end</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
         <child>
           <object class="GtkNotebook" id="notebook1">
             <property name="name">notebook1</property>
@@ -2703,7 +2669,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                           <object class="GtkGrid" id="gdStartZoomAtSetting">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
-                                            <property name="tooltip-text" translatable="yes">When drawing with touch, two-finger gestures intended to pan the view can instead cause it to zoom, causing performance issues. 
+                                            <property name="tooltip-text" translatable="yes">When drawing with touch, two-finger gestures intended to pan the view can instead cause it to zoom, causing performance issues.
 This setting can make it easier to draw with touch. </property>
                                             <child>
                                               <object class="GtkLabel" id="label2">
@@ -5685,7 +5651,7 @@ It must be short in time and length and we can't have ignored another stroke rec
                                           <object class="GtkLabel" id="lblReRenderMoreOftenWhileZooming">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">&lt;i&gt;Re-render PDF backgrounds more often while zooming for better render quality. 
+                                            <property name="label" translatable="yes">&lt;i&gt;Re-render PDF backgrounds more often while zooming for better render quality.
 &lt;b&gt;Note:&lt;/b&gt; This should not affect print quality.&lt;/i&gt;</property>
                                             <property name="use-markup">True</property>
                                             <property name="wrap">True</property>
@@ -6633,14 +6599,56 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="buttonBox">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">end</property>
+            <property name="spacing">4</property>
+            <property name="homogeneous">True</property>
+            <child>
+              <object class="GtkButton" id="btCancel">
+                <property name="label" translatable="yes">Cancel</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="can-default">True</property>
+                <property name="receives-default">True</property>
+                <property name="image">iconCancel</property>
+                <accelerator key="Escape" signal="clicked"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="btOk">
+                <property name="label" translatable="yes">Ok</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="can-default">True</property>
+                <property name="has-default">True</property>
+                <property name="receives-default">True</property>
+                <property name="image">iconOk</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
           </packing>
         </child>
       </object>
     </child>
-    <action-widgets>
-      <action-widget response="0">btSettingsCancel</action-widget>
-      <action-widget response="1">btSettingsOk</action-widget>
-    </action-widgets>
   </object>
 </interface>

--- a/ui/settingsButtonConfig.glade
+++ b/ui/settingsButtonConfig.glade
@@ -1,67 +1,78 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.40.0 -->
 <interface>
-  <requires lib="gtk+" version="3.12"/>
-  <object class="GtkOffscreenWindow" id="offscreenwindow">
-    <property name="name">offscreenwindow</property>
+  <requires lib="gtk+" version="3.16"/>
+  <object class="GtkBox" id="mainBox">
+    <property name="visible">True</property>
     <property name="can-focus">False</property>
+    <property name="orientation">vertical</property>
     <child>
-      <!-- n-columns=3 n-rows=3 -->
-      <object class="GtkGrid" id="mainGrid">
-        <property name="name">mainGrid</property>
+      <object class="GtkBox" id="box1">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
         <property name="hexpand">True</property>
         <child>
-          <object class="GtkBox" id="box1">
+          <object class="GtkLabel" id="lbDevice">
+            <property name="name">lbDevice</property>
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="hexpand">True</property>
-            <child>
-              <object class="GtkLabel" id="lbDevice">
-                <property name="name">lbDevice</property>
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="hexpand">True</property>
-                <property name="label" translatable="yes">Device</property>
-                <property name="xalign">0</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkComboBoxText" id="labelDevice">
-                <property name="name">labelDevice</property>
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="hexpand">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkCheckButton" id="cbDisableDrawing">
-                <property name="label" translatable="yes">Disable drawing for this device</property>
-                <property name="name">cbDisableDrawing</property>
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">False</property>
-                <property name="hexpand">True</property>
-                <property name="xalign">0</property>
-                <property name="draw-indicator">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">2</property>
-              </packing>
-            </child>
+            <property name="label" translatable="yes">Device</property>
+            <property name="xalign">0</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkComboBoxText" id="labelDevice">
+            <property name="name">labelDevice</property>
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="hexpand">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkCheckButton" id="cbDisableDrawing">
+            <property name="label" translatable="yes">Disable drawing for this device</property>
+            <property name="name">cbDisableDrawing</property>
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">False</property>
+            <property name="hexpand">True</property>
+            <property name="draw-indicator">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">0</property>
+      </packing>
+    </child>
+    <child>
+      <!-- n-columns=3 n-rows=2 -->
+      <object class="GtkGrid" id="grid2">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <child>
+          <object class="GtkComboBox" id="cbTool">
+            <property name="name">cbTool</property>
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="hexpand">True</property>
           </object>
           <packing>
             <property name="left-attach">0</property>
@@ -69,102 +80,84 @@
           </packing>
         </child>
         <child>
-          <!-- n-columns=3 n-rows=3 -->
-          <object class="GtkGrid" id="grid2">
+          <object class="GtkComboBoxText" id="cbThickness">
+            <property name="name">cbThickness</property>
             <property name="visible">True</property>
             <property name="can-focus">False</property>
-            <child>
-              <object class="GtkComboBox" id="cbTool">
-                <property name="name">cbTool</property>
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="hexpand">True</property>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkComboBoxText" id="cbThickness">
-                <property name="name">cbThickness</property>
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="hexpand">True</property>
-              </object>
-              <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkColorButton" id="colorButton">
-                <property name="name">colorButton</property>
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">True</property>
-              </object>
-              <packing>
-                <property name="left-attach">2</property>
-                <property name="top-attach">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkComboBoxText" id="cbDrawingType">
-                <property name="name">cbDrawingType</property>
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="hexpand">True</property>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkComboBoxText" id="cbEraserType">
-                <property name="name">cbEraserType</property>
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="hexpand">True</property>
-                <items>
-                  <item translatable="yes">Eraser Type - don't change</item>
-                  <item translatable="yes">Standard</item>
-                  <item translatable="yes">Whiteout</item>
-                  <item translatable="yes">Delete stroke</item>
-                </items>
-              </object>
-              <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkComboBoxText" id="cbStrokeType">
-                <property name="name">cbStrokeType</property>
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="hexpand">True</property>
-                <items>
-                  <item translatable="yes">Stroke Type - don't change</item>
-                  <item translatable="yes">Standard</item>
-                  <item translatable="yes">Dashed</item>
-                  <item translatable="yes">Dash-dotted</item>
-                  <item translatable="yes">Dotted</item>
-                </items>
-              </object>
-              <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">2</property>
-              </packing>
-            </child>
+            <property name="hexpand">True</property>
+          </object>
+          <packing>
+            <property name="left-attach">1</property>
+            <property name="top-attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkColorButton" id="colorButton">
+            <property name="name">colorButton</property>
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+          </object>
+          <packing>
+            <property name="left-attach">2</property>
+            <property name="top-attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkComboBoxText" id="cbDrawingType">
+            <property name="name">cbDrawingType</property>
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="hexpand">True</property>
           </object>
           <packing>
             <property name="left-attach">0</property>
             <property name="top-attach">1</property>
           </packing>
         </child>
+        <child>
+          <object class="GtkComboBoxText" id="cbEraserType">
+            <property name="name">cbEraserType</property>
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="hexpand">True</property>
+            <items>
+              <item translatable="yes">Eraser Type - don't change</item>
+              <item translatable="yes">Standard</item>
+              <item translatable="yes">Whiteout</item>
+              <item translatable="yes">Delete stroke</item>
+            </items>
+          </object>
+          <packing>
+            <property name="left-attach">1</property>
+            <property name="top-attach">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkComboBoxText" id="cbStrokeType">
+            <property name="name">cbStrokeType</property>
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="hexpand">True</property>
+            <items>
+              <item translatable="yes">Stroke Type - don't change</item>
+              <item translatable="yes">Standard</item>
+              <item translatable="yes">Dashed</item>
+              <item translatable="yes">Dash-dotted</item>
+              <item translatable="yes">Dotted</item>
+            </items>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">2</property>
+          </packing>
+        </child>
       </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">1</property>
+      </packing>
     </child>
   </object>
 </interface>

--- a/ui/settingsDeviceClassConfig.glade
+++ b/ui/settingsDeviceClassConfig.glade
@@ -1,63 +1,49 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
-  <requires lib="gtk+" version="3.0"/>
-  <object class="GtkOffscreenWindow" id="offscreenwindow">
-    <property name="name">offscreenwindow</property>
-    <property name="can_focus">False</property>
+  <requires lib="gtk+" version="3.16"/>
+  <object class="GtkBox" id="deviceClassBox">
+    <property name="name">deviceClassGrid</property>
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="valign">start</property>
+    <property name="hexpand">True</property>
     <child>
-      <placeholder/>
+      <object class="GtkLabel" id="labelDevice">
+        <property name="name">labelDevice</property>
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="hexpand">True</property>
+        <property name="xalign">0</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">0</property>
+      </packing>
     </child>
     <child>
-      <object class="GtkBox" id="deviceClassGrid">
-        <property name="name">deviceClassGrid</property>
+      <object class="GtkComboBoxText" id="cbDeviceClass">
+        <property name="name">cbDeviceClass</property>
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="valign">start</property>
-        <property name="hexpand">True</property>
-        <child>
-          <object class="GtkLabel" id="labelDevice">
-            <property name="name">labelDevice</property>
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="hexpand">True</property>
-            <property name="xalign">0</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkComboBoxText" id="cbDeviceClass">
-            <property name="name">cbDeviceClass</property>
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="halign">end</property>
-            <property name="active">0</property>
-            <property name="has_entry">True</property>
-            <items>
-              <item id="0" translatable="yes">Disabled</item>
-              <item id="1" translatable="yes">Mouse</item>
-              <item id="5" translatable="yes">Mouse+Keyboard Combo</item>
-              <item id="2" translatable="yes">Pen</item>
-              <item id="3" translatable="yes">Eraser</item>
-              <item id="4" translatable="yes">Touchscreen</item>
-            </items>
-            <child internal-child="entry">
-              <object class="GtkEntry">
-                <property name="can_focus">False</property>
-              </object>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
+        <property name="can-focus">False</property>
+        <property name="halign">end</property>
+        <property name="active">0</property>
+        <property name="has-entry">True</property>
+        <items>
+          <item id="0" translatable="yes">Disabled</item>
+          <item id="1" translatable="yes">Mouse</item>
+          <item id="5" translatable="yes">Mouse+Keyboard Combo</item>
+          <item id="2" translatable="yes">Pen</item>
+          <item id="3" translatable="yes">Eraser</item>
+          <item id="4" translatable="yes">Touchscreen</item>
+        </items>
       </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">1</property>
+      </packing>
     </child>
   </object>
 </interface>

--- a/ui/texdialog.glade
+++ b/ui/texdialog.glade
@@ -1,66 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
-  <requires lib="gtk+" version="3.0"/>
-  <object class="GtkDialog" id="texDialog">
+  <requires lib="gtk+" version="3.16"/>
+  <object class="GtkImage" id="iconCancel">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">dialog-cancel</property>
+  </object>
+  <object class="GtkImage" id="iconOk">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">dialog-ok</property>
+  </object>
+  <object class="GtkWindow" id="texDialog">
     <property name="name">texDialog</property>
-    <property name="width-request">320</property>
     <property name="can-focus">False</property>
     <property name="title" translatable="yes">Insert Latex</property>
-    <property name="window-position">center</property>
-    <property name="icon-name">dialog-information</property>
-    <property name="type-hint">normal</property>
-    <property name="has-resize-grip">True</property>
-    <child internal-child="vbox">
-      <object class="GtkBox" id="dialog-vbox">
+    <property name="modal">True</property>
+    <property name="destroy-with-parent">True</property>
+    <property name="skip-taskbar-hint">True</property>
+    <property name="skip-pager-hint">True</property>
+    <child>
+      <object class="GtkBox">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
+        <property name="margin-start">10</property>
+        <property name="margin-end">10</property>
+        <property name="margin-top">10</property>
+        <property name="margin-bottom">10</property>
         <property name="orientation">vertical</property>
-        <child internal-child="action_area">
-          <object class="GtkButtonBox" id="dialog-action_area">
-            <property name="name">dialog-action_area2</property>
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="layout-style">end</property>
-            <child>
-              <object class="GtkButton" id="texcancelbutton">
-                <property name="label">gtk-cancel</property>
-                <property name="name">texcancelbutton</property>
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="texokbutton">
-                <property name="label">gtk-ok</property>
-                <property name="name">texokbutton</property>
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
-                <accelerator key="Return" signal="clicked" modifiers="GDK_CONTROL_MASK"/>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="pack-type">end</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
         <child>
           <object class="GtkLabel" id="labelTitle">
             <property name="name">labelTitle</property>
@@ -84,9 +52,14 @@
             <property name="orientation">vertical</property>
             <child>
               <object class="GtkDrawingArea" id="texImage">
+                <property name="name">texImage</property>
                 <property name="height-request">48</property>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
+                <property name="margin-start">4</property>
+                <property name="margin-end">4</property>
+                <property name="margin-top">4</property>
+                <property name="margin-bottom">4</property>
                 <property name="hexpand">True</property>
                 <property name="vexpand">True</property>
               </object>
@@ -179,13 +152,66 @@
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
-            <property name="position">2</property>
+            <property name="position">1</property>
           </packing>
         </child>
         <child>
           <object class="GtkLabel" id="texErrorLabel">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
+            <property name="opacity">0</property>
+            <property name="margin-start">4</property>
+            <property name="margin-end">4</property>
+            <property name="margin-top">4</property>
+            <property name="margin-bottom">4</property>
+            <property name="label">The formula is empty when rendered or invalid.</property>
+            <attributes>
+              <attribute name="foreground" value="#e0e01b1b2424"/>
+            </attributes>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">end</property>
+            <property name="margin-top">10</property>
+            <property name="spacing">4</property>
+            <property name="homogeneous">True</property>
+            <child>
+              <object class="GtkButton" id="btCancel">
+                <property name="label" translatable="yes">Cancel</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="image">iconCancel</property>
+                <accelerator key="Escape" signal="clicked"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="btOk">
+                <property name="label" translatable="yes">Ok</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="image">iconOk</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -195,9 +221,5 @@
         </child>
       </object>
     </child>
-    <action-widgets>
-      <action-widget response="-6">texcancelbutton</action-widget>
-      <action-widget response="-5">texokbutton</action-widget>
-    </action-widgets>
   </object>
 </interface>

--- a/ui/toolbarCustomizeDialog.glade
+++ b/ui/toolbarCustomizeDialog.glade
@@ -1,258 +1,231 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
-  <requires lib="gtk+" version="3.0"/>
-  <object class="GtkDialog" id="DialogCustomizeToolbar">
-    <property name="name">DialogCustomizeToolbar</property>
-    <property name="width_request">500</property>
-    <property name="height_request">400</property>
-    <property name="can_focus">False</property>
-    <property name="border_width">5</property>
+  <requires lib="gtk+" version="3.16"/>
+  <object class="GtkImage" id="iconClose">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">dialog-close</property>
+  </object>
+  <object class="GtkWindow" id="DialogCustomizeToolbar">
+    <property name="can-focus">False</property>
     <property name="title" translatable="yes">Customize Toolbars</property>
-    <property name="icon">pixmaps/com.github.xournalpp.xournalpp.svg</property>
-    <property name="type_hint">normal</property>
-    <child internal-child="vbox">
-      <object class="GtkBox" id="dialog-vbox1">
+    <property name="destroy-with-parent">True</property>
+    <property name="skip-taskbar-hint">True</property>
+    <property name="skip-pager-hint">True</property>
+    <child>
+      <object class="GtkBox" id="vbox1">
+        <property name="height-request">500</property>
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
+        <property name="margin-start">10</property>
+        <property name="margin-end">10</property>
+        <property name="margin-top">10</property>
+        <property name="margin-bottom">10</property>
         <property name="orientation">vertical</property>
-        <property name="spacing">2</property>
-        <child internal-child="action_area">
-          <object class="GtkButtonBox" id="dialog-action_area1">
-            <property name="name">dialog-action_area1</property>
+        <child>
+          <object class="GtkLabel" id="label1">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
-            <child>
-              <object class="GtkButton" id="button4">
-                <property name="label">gtk-close</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
+            <property name="can-focus">False</property>
+            <property name="label" translatable="yes">Drag and drop Components fom here to the toolbars and back.</property>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="pack_type">end</property>
             <property name="position">0</property>
           </packing>
         </child>
         <child>
-          <object class="GtkBox" id="vbox1">
+          <object class="GtkScrolledWindow" id="scrolledwindow1">
+            <property name="name">scrolledwindow1</property>
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="orientation">vertical</property>
+            <property name="can-focus">True</property>
+            <property name="shadow-type">in</property>
             <child>
-              <object class="GtkLabel" id="label1">
+              <object class="GtkViewport" id="viewport1">
+                <property name="name">viewport1</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Drag and drop Components fom here to the toolbars and back.</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkScrolledWindow" id="scrolledwindow1">
-                <property name="name">scrolledwindow1</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="shadow_type">in</property>
+                <property name="can-focus">False</property>
                 <child>
-                  <object class="GtkViewport" id="viewport1">
-                    <property name="name">viewport1</property>
+                  <object class="GtkBox" id="vbox2">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
+                    <property name="margin-start">4</property>
+                    <property name="margin-end">4</property>
+                    <property name="margin-top">4</property>
+                    <property name="margin-bottom">4</property>
+                    <property name="orientation">vertical</property>
                     <child>
-                      <object class="GtkBox" id="vbox2">
+                      <object class="GtkLabel" id="label2">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="orientation">vertical</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">&lt;b&gt;Default Tools&lt;/b&gt;</property>
+                        <property name="use-markup">True</property>
+                        <property name="xalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <!-- n-columns=3 n-rows=3 -->
+                      <object class="GtkGrid" id="tbDefaultTools">
+                        <property name="name">tbDefaultTools</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="row-spacing">5</property>
+                        <property name="column-spacing">5</property>
                         <child>
-                          <object class="GtkLabel" id="label2">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="xalign">0</property>
-                            <property name="label" translatable="yes">&lt;b&gt;Default Tools&lt;/b&gt;</property>
-                            <property name="use_markup">True</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
+                          <placeholder/>
                         </child>
                         <child>
-                          <object class="GtkGrid" id="tbDefaultTools">
-                            <property name="name">tbDefaultTools</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="row_spacing">5</property>
-                            <property name="column_spacing">5</property>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
-                          </packing>
+                          <placeholder/>
                         </child>
                         <child>
-                          <object class="GtkLabel" id="label3">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="xalign">0</property>
-                            <property name="label" translatable="yes">&lt;b&gt;Color&lt;/b&gt;</property>
-                            <property name="use_markup">True</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">2</property>
-                          </packing>
+                          <placeholder/>
                         </child>
                         <child>
-                          <object class="GtkGrid" id="tbColor">
-                            <property name="name">tbColor</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="row_spacing">5</property>
-                            <property name="column_spacing">5</property>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">3</property>
-                          </packing>
+                          <placeholder/>
                         </child>
                         <child>
-                          <object class="GtkLabel" id="label4">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="xalign">0</property>
-                            <property name="label" translatable="yes">&lt;b&gt;Separators&lt;/b&gt;</property>
-                            <property name="use_markup">True</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">4</property>
-                          </packing>
+                          <placeholder/>
                         </child>
                         <child>
-                          <object class="GtkGrid" id="tbSeparator">
-                            <property name="name">tbSeparator</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="row_spacing">5</property>
-                            <property name="column_spacing">5</property>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">5</property>
-                          </packing>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
                         </child>
                       </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label3">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">&lt;b&gt;Color&lt;/b&gt;</property>
+                        <property name="use-markup">True</property>
+                        <property name="xalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <!-- n-columns=3 n-rows=3 -->
+                      <object class="GtkGrid" id="tbColor">
+                        <property name="name">tbColor</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="row-spacing">5</property>
+                        <property name="column-spacing">5</property>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">3</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label4">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">&lt;b&gt;Separators&lt;/b&gt;</property>
+                        <property name="use-markup">True</property>
+                        <property name="xalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">4</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <!-- n-columns=3 n-rows=3 -->
+                      <object class="GtkGrid" id="tbSeparator">
+                        <property name="name">tbSeparator</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="row-spacing">5</property>
+                        <property name="column-spacing">5</property>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">5</property>
+                      </packing>
                     </child>
                   </object>
                 </child>
               </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
             </child>
           </object>
           <packing>
@@ -261,10 +234,24 @@
             <property name="position">1</property>
           </packing>
         </child>
+        <child>
+          <object class="GtkButton" id="btClose">
+            <property name="label" translatable="yes">Close</property>
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <property name="halign">end</property>
+            <property name="margin-top">4</property>
+            <property name="image">iconClose</property>
+            <accelerator key="Escape" signal="clicked"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
       </object>
     </child>
-    <action-widgets>
-      <action-widget response="0">button4</action-widget>
-    </action-widgets>
   </object>
 </interface>

--- a/ui/toolbarManageDialog.glade
+++ b/ui/toolbarManageDialog.glade
@@ -1,134 +1,57 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
-  <requires lib="gtk+" version="3.18"/>
-  <object class="GtkDialog" id="DialogManageToolbar">
+  <requires lib="gtk+" version="3.24"/>
+  <object class="GtkImage" id="iconClose">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">window-close</property>
+  </object>
+  <object class="GtkImage" id="iconCopy">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">edit-copy</property>
+  </object>
+  <object class="GtkImage" id="iconDelete">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">edit-delete</property>
+  </object>
+  <object class="GtkImage" id="iconNew">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">document-new</property>
+  </object>
+  <object class="GtkWindow" id="manageToolbarsDialog">
     <property name="name">DialogManageToolbar</property>
-    <property name="can_focus">False</property>
-    <property name="border_width">5</property>
+    <property name="can-focus">False</property>
     <property name="title" translatable="yes">Manage Toolbar</property>
-    <property name="icon">pixmaps/com.github.xournalpp.xournalpp.svg</property>
-    <property name="type_hint">normal</property>
+    <property name="modal">True</property>
+    <property name="destroy-with-parent">True</property>
+    <property name="skip-taskbar-hint">True</property>
+    <property name="skip-pager-hint">True</property>
     <child>
-      <placeholder/>
-    </child>
-    <child internal-child="vbox">
-      <object class="GtkBox" id="dialog-vbox1">
+      <object class="GtkBox">
+        <property name="name">dialog-main-box</property>
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
+        <property name="margin-start">10</property>
+        <property name="margin-end">10</property>
+        <property name="margin-top">10</property>
+        <property name="margin-bottom">10</property>
         <property name="orientation">vertical</property>
-        <property name="spacing">2</property>
-        <child internal-child="action_area">
-          <object class="GtkButtonBox" id="dialog-action_area1">
-            <property name="name">dialog-action_area1</property>
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
-            <child>
-              <object class="GtkButton" id="button4">
-                <property name="label">gtk-close</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="pack_type">end</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
+        <property name="spacing">4</property>
         <child>
-          <object class="GtkBox" id="vbox1">
+          <object class="GtkBox" id="hbox1">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="orientation">vertical</property>
+            <property name="can-focus">False</property>
             <child>
-              <object class="GtkBox" id="hbox1">
+              <object class="GtkTreeView" id="toolbarList">
+                <property name="name">toolbarList</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <child>
-                  <object class="GtkTreeView" id="toolbarList">
-                    <property name="name">toolbarList</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <child internal-child="selection">
-                      <object class="GtkTreeSelection" id="treeview-selection"/>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkBox" id="vbox2">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="orientation">vertical</property>
-                    <child>
-                      <object class="GtkButton" id="btCopy">
-                        <property name="label">gtk-copy</property>
-                        <property name="name">btCopy</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
-                        <property name="use_stock">True</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="padding">2</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkButton" id="btDelete">
-                        <property name="label">gtk-delete</property>
-                        <property name="name">btDelete</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
-                        <property name="use_stock">True</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="padding">3</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkButton" id="btNew">
-                        <property name="label">gtk-new</property>
-                        <property name="name">btNew</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
-                        <property name="use_stock">True</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="padding">2</property>
-                        <property name="position">2</property>
-                      </packing>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
+                <property name="can-focus">True</property>
+                <child internal-child="selection">
+                  <object class="GtkTreeSelection"/>
                 </child>
               </object>
               <packing>
@@ -138,22 +61,91 @@
               </packing>
             </child>
             <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
+              <object class="GtkBox" id="vbox2">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkButton" id="btCopy">
+                    <property name="label" translatable="yes">Copy</property>
+                    <property name="name">btCopy</property>
+                    <property name="visible">True</property>
+                    <property name="sensitive">False</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
+                    <property name="image">iconCopy</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="padding">2</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="btDelete">
+                    <property name="label" translatable="yes">Delete</property>
+                    <property name="name">btDelete</property>
+                    <property name="visible">True</property>
+                    <property name="sensitive">False</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
+                    <property name="image">iconDelete</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="padding">3</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="btNew">
+                    <property name="label" translatable="yes">New</property>
+                    <property name="name">btNew</property>
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
+                    <property name="image">iconNew</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="padding">2</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
             </child>
           </object>
           <packing>
-            <property name="expand">False</property>
+            <property name="expand">True</property>
             <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="btClose">
+            <property name="label" translatable="yes">Close</property>
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <property name="halign">end</property>
+            <property name="image">iconClose</property>
+            <accelerator key="Escape" signal="clicked"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
             <property name="position">1</property>
           </packing>
         </child>
       </object>
     </child>
-    <action-widgets>
-      <action-widget response="0">button4</action-widget>
-    </action-widgets>
   </object>
 </interface>


### PR DESCRIPTION
This follows #4763.
The structure set up in #4763 seems to fit all needs for now.

This PR can be split further down if need be (down to a per-dialog PR).
The diff is enormous, mainly because of Glade files changes (removing obsolete GtkAlignment makes huge changes mainly about indentation). Code changes are actually small (except SettingsDialog.cpp, but nothing complicated happened there either, just some renaming essentially).