### PR TITLE
Refactor key event handling

### DIFF
--- a/src/core/gui/MainWindow.cpp
+++ b/src/core/gui/MainWindow.cpp
@@ -82,9 +82,9 @@ MainWindow::MainWindow(GladeSearchpath* gladeSearchPath, Control* control, GtkAp
 
     g_signal_connect(get("buttonCloseSidebar"), "clicked", G_CALLBACK(buttonCloseSidebarClicked), this);
 
-
-    // "watch over" all events
-    g_signal_connect(this->window, "key-press-event", G_CALLBACK(onKeyPressCallback), this);
+    // "watch over" all key events
+    g_signal_connect(this->window, "key-press-event", G_CALLBACK(gtk_window_propagate_key_event), nullptr);
+    g_signal_connect(this->window, "key-release-event", G_CALLBACK(gtk_window_propagate_key_event), nullptr);
 
     // need to create tool buttons registered in plugins, so they can be added to toolbars
     control->registerPluginToolButtons(this->toolbar.get());
@@ -450,33 +450,6 @@ void MainWindow::updateScrollbarSidebarPosition() {
 }
 
 void MainWindow::buttonCloseSidebarClicked(GtkButton* button, MainWindow* win) { win->setSidebarVisible(false); }
-
-auto MainWindow::onKeyPressCallback(GtkWidget* widget, GdkEventKey* event, MainWindow* win) -> bool {
-
-    if (win->getXournal()->getSelection()) {
-        // something is selected - give that control
-        return false;
-    }
-    if (win->getXournal()->getTextEditor()) {
-        // editing text - give that control
-        return false;
-    }
-    if (event->keyval == GDK_KEY_c && event->state & GDK_CONTROL_MASK) {
-        // Shortcut to get selected PDF text.
-        PdfFloatingToolbox* tool = win->getPdfToolbox();
-        if (tool->hasSelection()) {
-            tool->copyTextToClipboard();
-            return true;
-        }
-    }
-    if (event->keyval == GDK_KEY_Escape) {
-        win->getControl()->getSearchBar()->showSearchBar(false);
-        return true;
-    }
-
-
-    return false;
-}
 
 auto MainWindow::deleteEventCallback(GtkWidget* widget, GdkEvent* event, Control* control) -> bool {
     control->quit();

--- a/src/core/gui/MainWindow.h
+++ b/src/core/gui/MainWindow.h
@@ -156,11 +156,6 @@ private:
     static bool deleteEventCallback(GtkWidget* widget, GdkEvent* event, Control* control);
 
     /**
-     * Key is pressed
-     */
-    static bool onKeyPressCallback(GtkWidget* widget, GdkEventKey* event, MainWindow* win);
-
-    /**
      * Callback fro window states, we ned to know if the window is fullscreen
      */
     static bool windowStateEventCallback(GtkWidget* window, GdkEventWindowState* event, MainWindow* win);

--- a/src/core/gui/PageView.cpp
+++ b/src/core/gui/PageView.cpp
@@ -690,10 +690,6 @@ auto XojPageView::onKeyPressEvent(GdkEventKey* event) -> bool {
             endText();
             return true;
         }
-        if (xournal->getSelection()) {
-            xournal->clearSelection();
-            return true;
-        }
 
         return false;
     }

--- a/src/core/gui/SearchBar.cpp
+++ b/src/core/gui/SearchBar.cpp
@@ -34,12 +34,16 @@ SearchBar::SearchBar(Control* control): control(control) {
     g_signal_connect(searchTextField, "key-press-event",
                      G_CALLBACK(+[](GtkWidget* entry, GdkEventKey* event, SearchBar* self) {
                          if (event->keyval == GDK_KEY_Return) {
-                             if (event->state & GDK_SHIFT_MASK)
+                             if (event->state & GDK_SHIFT_MASK) {
                                  self->searchPrevious();
-                             else
+                             } else {
                                  self->searchNext();
+                             }
                              // Grab focus again since searching will take away focus
                              gtk_widget_grab_focus(entry);
+                             return true;
+                         } else if (event->keyval == GDK_KEY_Escape) {
+                             self->showSearchBar(false);
                              return true;
                          }
                          return false;

--- a/src/core/gui/XournalView.cpp
+++ b/src/core/gui/XournalView.cpp
@@ -128,6 +128,45 @@ auto XournalView::onKeyPressEvent(GdkEventKey* event) -> bool {
         }
     }
 
+    if (auto* tool = getControl()->getWindow()->getPdfToolbox(); tool->hasSelection()) {
+        if (event->keyval == GDK_KEY_c && event->state & GDK_CONTROL_MASK) {
+            // Shortcut to get selected PDF text.
+            tool->copyTextToClipboard();
+            return true;
+        }
+    }
+
+    if (auto* selection = getSelection(); selection) {
+        if (event->keyval == GDK_KEY_Escape) {
+            clearSelection();
+            return true;
+        }
+
+        int d = 3;
+        if (event->state & GDK_MOD1_MASK) {
+            d = 1;
+        } else if (event->state & GDK_SHIFT_MASK) {
+            d = 20;
+        }
+
+        int xdir = 0;
+        int ydir = 0;
+        if (event->keyval == GDK_KEY_Left) {
+            xdir = -1;
+        } else if (event->keyval == GDK_KEY_Up) {
+            ydir = -1;
+        } else if (event->keyval == GDK_KEY_Right) {
+            xdir = 1;
+        } else if (event->keyval == GDK_KEY_Down) {
+            ydir = 1;
+        }
+        if (xdir != 0 || ydir != 0) {
+            selection->moveSelection(d * xdir, d * ydir);
+            selection->ensureWithinVisibleArea();
+            return true;
+        }
+    }
+
     guint state = event->state & gtk_accelerator_get_default_mod_mask();
 
     Layout* layout = gtk_xournal_get_layout(this->widget);

--- a/src/core/gui/inputdevices/KeyboardInputHandler.cpp
+++ b/src/core/gui/inputdevices/KeyboardInputHandler.cpp
@@ -20,38 +20,11 @@ KeyboardInputHandler::KeyboardInputHandler(InputContext* inputContext): Abstract
 KeyboardInputHandler::~KeyboardInputHandler() = default;
 
 auto KeyboardInputHandler::handleImpl(InputEvent const& event) -> bool {
-    GtkXournal* xournal = inputContext->getXournal();
     GdkEvent* gdkEvent = event.sourceEvent;
 
     if (gdk_event_get_event_type(gdkEvent) == GDK_KEY_PRESS) {
         auto keyEvent = reinterpret_cast<GdkEventKey*>(gdkEvent);
-        EditSelection* selection = xournal->selection;
-        if (selection) {
-            int d = 3;
-            if (keyEvent->state & GDK_MOD1_MASK) {
-                d = 1;
-            } else if (keyEvent->state & GDK_SHIFT_MASK) {
-                d = 20;
-            }
-
-            int xdir = 0;
-            int ydir = 0;
-            if (keyEvent->keyval == GDK_KEY_Left) {
-                xdir = -1;
-            } else if (keyEvent->keyval == GDK_KEY_Up) {
-                ydir = -1;
-            } else if (keyEvent->keyval == GDK_KEY_Right) {
-                xdir = 1;
-            } else if (keyEvent->keyval == GDK_KEY_Down) {
-                ydir = 1;
-            }
-            if (xdir != 0 || ydir != 0) {
-                selection->moveSelection(d * xdir, d * ydir);
-                selection->ensureWithinVisibleArea();
-                return true;
-            }
-        }
-        return xournal->view->onKeyPressEvent(keyEvent);
+        return inputContext->getView()->onKeyPressEvent(keyEvent);
     } else if (gdk_event_get_event_type(gdkEvent) == GDK_KEY_RELEASE) {
         auto keyEvent = reinterpret_cast<GdkEventKey*>(gdkEvent);
         return inputContext->getView()->onKeyReleaseEvent(keyEvent);


### PR DESCRIPTION
Fixes #977 (comments in the discussion). Supersedes #4784 

- Let the key-press-event and key-release-event for the main window propogate the event to the focus widget and up the focus container chain until a widget handles the event
- Make the keyboard input handler only direct the GdkKeyEvents to the XournalView's handler
- Make the XournalView's handler first let the current page handle the key event for tools owned by the page
 (textEditor, inputHandler, verticalSpace) and then
handle selection, scrolling, page operations and color switching on its own

The main improvement relates to the fact that now keyboard accelerators can be used (for plugins and menus) that would otherwise make the text editor unfunctional.