### PR TITLE
Enhancement #4801: Integrated forcePresentation Option

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -302,7 +302,7 @@ void Control::saveSettings() {
     this->sidebar->saveSize();
 }
 
-void Control::initWindow(MainWindow* win) {
+void Control::initWindow(MainWindow* win, gboolean fP) {
     selectTool(toolHandler->getToolType());
     this->win = win;
     this->sidebar = new Sidebar(win, this);
@@ -318,7 +318,7 @@ void Control::initWindow(MainWindow* win) {
     // Disable undo buttons
     undoRedoChanged();
 
-    if (settings->isPresentationMode()) {
+    if (settings->isPresentationMode() || fP) {
         setViewPresentationMode(true);
     } else if (settings->isViewFixedRows()) {
         setViewRows(settings->getViewRows());

--- a/src/core/control/Control.h
+++ b/src/core/control/Control.h
@@ -82,7 +82,7 @@ public:
     auto operator=(Control&&) -> Control& = delete;
     ~Control() override;
 
-    void initWindow(MainWindow* win);
+    void initWindow(MainWindow* win, gboolean fP);
 
 public:
     // Menu File

--- a/src/core/control/XournalMain.cpp
+++ b/src/core/control/XournalMain.cpp
@@ -324,6 +324,7 @@ struct XournalMainPrivate {
     gchar* pdfFilename{};
     gchar* imgFilename{};
     gboolean showVersion = false;
+    gboolean forcePresentation = false;
     int openAtPageNumber = 0;  // when no --page is used, the document opens at the page specified in the metadata file
     gchar* exportRange{};
     gchar* exportLayerRange{};
@@ -483,7 +484,7 @@ void on_startup(GApplication* application, XMPtr app_data) {
 
     app_data->win = std::make_unique<MainWindow>(app_data->gladePath.get(), app_data->control.get(),
                                                  GTK_APPLICATION(application));
-    app_data->control->initWindow(app_data->win.get());
+    app_data->control->initWindow(app_data->win.get(), app_data->forcePresentation);
 
     if (migrateResult.status != MigrateStatus::NotNeeded) {
         Util::execInUiThread(
@@ -627,6 +628,8 @@ auto XournalMain::run(int argc, char** argv) -> int {
                                        "<input>", nullptr},
                           GOptionEntry{"version", 0, 0, G_OPTION_ARG_NONE, &app_data.showVersion,
                                        _("Get version of xournalpp"), nullptr},
+                          GOptionEntry{"presentation", 'p', 0, G_OPTION_ARG_NONE, &app_data.forcePresentation,
+                                       _("Force presentation mode at startup"), nullptr},
                           GOptionEntry{nullptr}};  // Must be terminated by a nullptr. See gtk doc
     g_application_add_main_option_entries(G_APPLICATION(app), options.data());
 


### PR DESCRIPTION
## Motivation
Issue #4801

## Changes
A command line option that toggles on a variable that now OR's with the set settings for presentation mode to force on presentation mode was added.

## Notes
It appears that for this new option (and perhaps future others pertaining to the view) the set value must be relayed as an argument to the initWindow function in order to work.