### PR TITLE
Fix "File bug report" dialog and more

### DIFF
--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -188,8 +188,8 @@ void Settings::loadDefault() {
     // clang-format on
 
     this->audioSampleRate = 44100.0;
-    this->audioInputDevice = -1;
-    this->audioOutputDevice = -1;
+    this->audioInputDevice = AUDIO_INPUT_SYSTEM_DEFAULT;
+    this->audioOutputDevice = AUDIO_OUTPUT_SYSTEM_DEFAULT;
     this->audioGain = 1.0;
     this->defaultSeekTime = 5;
 

--- a/src/core/control/settings/Settings.h
+++ b/src/core/control/settings/Settings.h
@@ -389,9 +389,11 @@ public:
     fs::path const& getAudioFolder() const;
     void setAudioFolder(fs::path audioFolder);
 
+    static constexpr PaDeviceIndex AUDIO_INPUT_SYSTEM_DEFAULT = -1;
     PaDeviceIndex getAudioInputDevice() const;
     void setAudioInputDevice(PaDeviceIndex deviceIndex);
 
+    static constexpr PaDeviceIndex AUDIO_OUTPUT_SYSTEM_DEFAULT = -1;
     PaDeviceIndex getAudioOutputDevice() const;
     void setAudioOutputDevice(PaDeviceIndex deviceIndex);
 

--- a/src/core/gui/dialog/SettingsDialog.cpp
+++ b/src/core/gui/dialog/SettingsDialog.cpp
@@ -909,14 +909,18 @@ void SettingsDialog::save() {
             static_cast<double>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spStrokeRecognizerMinSize")))));
 
     size_t selectedInputDeviceIndex =
-            static_cast<size_t>(gtk_combo_box_get_active(GTK_COMBO_BOX(get("cbAudioInputDevice")))) - 1;
-    if (selectedInputDeviceIndex < this->audioInputDevices.size()) {
-        settings->setAudioInputDevice(this->audioInputDevices[selectedInputDeviceIndex].getIndex());
+            static_cast<size_t>(gtk_combo_box_get_active(GTK_COMBO_BOX(get("cbAudioInputDevice"))));
+    if (selectedInputDeviceIndex == 0) {
+        settings->setAudioInputDevice(Settings::AUDIO_INPUT_SYSTEM_DEFAULT);
+    } else if (selectedInputDeviceIndex - 1 < this->audioInputDevices.size()) {
+        settings->setAudioInputDevice(this->audioInputDevices[selectedInputDeviceIndex - 1].getIndex());
     }
 
     size_t selectedOutputDeviceIndex =
-            static_cast<size_t>(gtk_combo_box_get_active(GTK_COMBO_BOX(get("cbAudioOutputDevice")))) - 1;
-    if (selectedOutputDeviceIndex < this->audioOutputDevices.size()) {
+            static_cast<size_t>(gtk_combo_box_get_active(GTK_COMBO_BOX(get("cbAudioOutputDevice"))));
+    if (selectedOutputDeviceIndex == 0) {
+        settings->setAudioOutputDevice(Settings::AUDIO_OUTPUT_SYSTEM_DEFAULT);
+    } else if (selectedOutputDeviceIndex < this->audioOutputDevices.size()) {
         settings->setAudioOutputDevice(this->audioOutputDevices[selectedOutputDeviceIndex].getIndex());
     }
 

--- a/src/core/gui/dialog/SettingsDialog.cpp
+++ b/src/core/gui/dialog/SettingsDialog.cpp
@@ -683,7 +683,8 @@ void SettingsDialog::save() {
             gtk_combo_box_get_active(GTK_COMBO_BOX(get("cbStabilizerAveragingMethods")))));
     settings->setStabilizerPreprocessor(static_cast<StrokeStabilizer::Preprocessor>(
             gtk_combo_box_get_active(GTK_COMBO_BOX(get("cbStabilizerPreprocessors")))));
-    settings->setStabilizerBuffersize(gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(get("sbStabilizerBuffersize"))));
+    settings->setStabilizerBuffersize(
+            static_cast<size_t>(gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(get("sbStabilizerBuffersize")))));
     settings->setStabilizerDeadzoneRadius(
             gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("sbStabilizerDeadzoneRadius"))));
     settings->setStabilizerDrag(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("sbStabilizerDrag"))));
@@ -771,7 +772,7 @@ void SettingsDialog::save() {
     viewModeFullscreen.showToolbar = getCheckbox("cbShowFullscreenToolbar");
     viewModeFullscreen.showSidebar = getCheckbox("cbShowFullscreenSidebar");
     settings->setViewMode(PresetViewModeIds::VIEW_MODE_FULLSCREEN, viewModeFullscreen);
-    
+
     ViewMode viewModePresentation;
     viewModePresentation.showMenubar = getCheckbox("cbShowPresentationMenubar");
     viewModePresentation.showToolbar = getCheckbox("cbShowPresentationToolbar");
@@ -907,16 +908,16 @@ void SettingsDialog::save() {
     settings->setStrokeRecognizerMinSize(
             static_cast<double>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("spStrokeRecognizerMinSize")))));
 
-    int selectedInputDeviceIndex = gtk_combo_box_get_active(GTK_COMBO_BOX(get("cbAudioInputDevice"))) - 1;
-    if (selectedInputDeviceIndex >= 0 && selectedInputDeviceIndex < static_cast<int>(this->audioInputDevices.size())) {
-        settings->setAudioInputDevice(static_cast<int>(this->audioInputDevices[selectedInputDeviceIndex].getIndex()));
+    size_t selectedInputDeviceIndex =
+            static_cast<size_t>(gtk_combo_box_get_active(GTK_COMBO_BOX(get("cbAudioInputDevice")))) - 1;
+    if (selectedInputDeviceIndex < this->audioInputDevices.size()) {
+        settings->setAudioInputDevice(this->audioInputDevices[selectedInputDeviceIndex].getIndex());
     }
 
-    int selectedOutputDeviceIndex = gtk_combo_box_get_active(GTK_COMBO_BOX(get("cbAudioOutputDevice"))) - 1;
-    if (selectedOutputDeviceIndex >= 0 &&
-        selectedOutputDeviceIndex < static_cast<int>(this->audioOutputDevices.size())) {
-        settings->setAudioOutputDevice(
-                static_cast<int>(this->audioOutputDevices[selectedOutputDeviceIndex].getIndex()));
+    size_t selectedOutputDeviceIndex =
+            static_cast<size_t>(gtk_combo_box_get_active(GTK_COMBO_BOX(get("cbAudioOutputDevice")))) - 1;
+    if (selectedOutputDeviceIndex < this->audioOutputDevices.size()) {
+        settings->setAudioOutputDevice(this->audioOutputDevices[selectedOutputDeviceIndex].getIndex());
     }
 
     switch (gtk_combo_box_get_active(GTK_COMBO_BOX(get("cbAudioSampleRate")))) {

--- a/src/core/gui/sidebar/Sidebar.cpp
+++ b/src/core/gui/sidebar/Sidebar.cpp
@@ -98,7 +98,7 @@ void Sidebar::askInsertPdfPage(size_t pdfPage) {
     gtk_window_set_transient_for(GTK_WINDOW(dialog), control->getGtkWindow());
     int res = gtk_dialog_run(GTK_DIALOG(dialog));
     gtk_widget_destroy(dialog);
-    if (res == Responses::CANCEL) {
+    if (res != Responses::AFTER && res != Responses::END) {
         return;
     }
 
@@ -111,8 +111,6 @@ void Sidebar::askInsertPdfPage(size_t pdfPage) {
         position = control->getCurrentPageNo() + 1;
     } else if (res == Responses::END) {
         position = doc->getPageCount();
-    } else {
-        assert(false && "unhandled case");
     }
     XojPdfPageSPtr pdf = doc->getPdfPage(pdfPage);
     doc->unlock();


### PR DESCRIPTION
This PR fixes the "File bug report" dialog: it seems a dialog is supposed to pop-up on startup, when an errorlog is found.
This was broken (the errorlog files never matched the applied name filter, so the dialog never appeared).

This fixes that, as well as a couple of papercuts (encountered while working on #4796, but whose fix should be merged before that)

1. Failing assert when closing the Insert Pdf Page dialog via Escape, Alt+F4 or window-close icon.
2. Fix conversion warnings in Settings.cpp