### PR TITLE
Fix #4822: Rerouted Esc and Backspace in Spline Handler to More Complete Spline Finish Functions.

### DIFF
--- a/src/core/control/tools/SplineHandler.cpp
+++ b/src/core/control/tools/SplineHandler.cpp
@@ -60,13 +60,11 @@ auto SplineHandler::onKeyEvent(GdkEventKey* event) -> bool {
 
     switch (event->keyval) {
         case GDK_KEY_Escape: {
-            this->finalizeSpline();
             return true;
         }
         case GDK_KEY_BackSpace: {
             if (this->knots.size() == 1) {
-                this->finalizeSpline();
-                return true;
+                return false;
             }
             this->deleteLastKnotWithTangent();
             assert(!this->knots.empty() && this->knots.size() == this->tangents.size());

--- a/src/core/gui/PageView.cpp
+++ b/src/core/gui/PageView.cpp
@@ -704,11 +704,8 @@ auto XojPageView::onKeyReleaseEvent(GdkEventKey* event) -> bool {
 
     if (this->inputHandler && this->inputHandler->onKeyEvent(event)) {
         DrawingType drawingType = this->xournal->getControl()->getToolHandler()->getDrawingType();
-        if (drawingType == DRAWING_TYPE_SPLINE) {  // Spline drawing has been finalized
-            if (this->inputHandler) {
-                assert(hasNoViewOf(overlayViews, inputHandler.get()));
-                this->inputHandler.reset();
-            }
+        if (drawingType == DRAWING_TYPE_SPLINE) {
+            endSpline();
         }
 
         return true;


### PR DESCRIPTION
## Reason
Issue #4822

## Description
Fixed the Esc and Backspace keys' links to end the spline by relinking them to a more complete spline ending function in XournalView. For this, the MainWindow and XournalView headers needed to be added.