### PR TITLE
Fix rendering artefact with filled highlighter shapes

### DIFF
--- a/src/core/view/overlays/BaseShapeOrSplineToolView.cpp
+++ b/src/core/view/overlays/BaseShapeOrSplineToolView.cpp
@@ -10,6 +10,12 @@
 
 using namespace xoj::view;
 
+/**
+ * @brief To avoid rendering artefact (due to antialiasing?) we add a padding when clearing out the mask (for filled
+ * highlighter only)
+ */
+constexpr double MASK_CLEARANCE_PADDING = 1;
+
 static const Stroke& safeGetStroke(const InputHandler* h) {
     assert(h);
     assert(h->getStroke());
@@ -42,6 +48,7 @@ cairo_t* BaseShapeOrSplineToolView::prepareContext(cairo_t* cr) const {
             // operator is already set by createMask().
         } else {
             // Clear the mask
+            maskWipeExtent.addPadding(MASK_CLEARANCE_PADDING);
             mask.wipeRange(maskWipeExtent);
             maskWipeExtent = Range();
         }


### PR DESCRIPTION
Fix #4761
The only solution I could find was to add a small padding when wiping the mask.
I'm assuming the artefacts are due to some rounding errors and/or antialiasing, but I am not completely sure.