### PR TITLE
Add stroke type/line style to default tool settings

### DIFF
--- a/src/core/control/ToolEnums.cpp
+++ b/src/core/control/ToolEnums.cpp
@@ -1,5 +1,7 @@
 #include "ToolEnums.h"
 
+#include "model/StrokeStyle.h"
+
 auto toolSizeToString(ToolSize size) -> std::string {
     switch (size) {
         case TOOL_SIZE_NONE:
@@ -97,11 +99,8 @@ auto drawingTypeFromString(const std::string& type) -> DrawingType {
 }
 
 auto isSelectToolType(ToolType type) -> bool {
-    return type == TOOL_SELECT_RECT
-            || type == TOOL_SELECT_REGION
-            || type == TOOL_SELECT_MULTILAYER_RECT
-            || type == TOOL_SELECT_MULTILAYER_REGION
-            || type == TOOL_SELECT_OBJECT;
+    return type == TOOL_SELECT_RECT || type == TOOL_SELECT_REGION || type == TOOL_SELECT_MULTILAYER_RECT ||
+           type == TOOL_SELECT_MULTILAYER_REGION || type == TOOL_SELECT_OBJECT;
 }
 
 auto isSelectToolTypeSingleLayer(ToolType type) -> bool {
@@ -261,6 +260,20 @@ auto eraserTypeFromString(const std::string& type) -> EraserType {
     return ERASER_TYPE_NONE;
 }
 
+auto strokeTypeToLineStyle(StrokeType type) -> LineStyle {
+    switch (type) {
+        case STROKE_TYPE_STANDARD:
+            return {};
+        case STROKE_TYPE_DASHED:
+            return StrokeStyle::parseStyle("dash");
+        case STROKE_TYPE_DASHDOTTED:
+            return StrokeStyle::parseStyle("dashdot");
+        case STROKE_TYPE_DOTTED:
+            return StrokeStyle::parseStyle("dot");
+        default:
+            return {};
+    }
+}
 
 bool xoj::tool::isPdfSelectionTool(ToolType toolType) {
     return toolType == TOOL_SELECT_PDF_TEXT_LINEAR || toolType == TOOL_SELECT_PDF_TEXT_RECT;

--- a/src/core/control/ToolEnums.cpp
+++ b/src/core/control/ToolEnums.cpp
@@ -275,6 +275,35 @@ auto strokeTypeToLineStyle(StrokeType type) -> LineStyle {
     }
 }
 
+auto strokeTypeToString(StrokeType type) -> std::string {
+    switch (type) {
+        case STROKE_TYPE_NONE:
+            return "none";
+        case STROKE_TYPE_STANDARD:
+            return "standard";
+        case STROKE_TYPE_DASHED:
+            return "dash";
+        case STROKE_TYPE_DASHDOTTED:
+            return "dashdot";
+        case STROKE_TYPE_DOTTED:
+            return "dot";
+        default:
+            return "";
+    }
+}
+auto strokeTypeFromString(const std::string& type) -> StrokeType {
+    if (type == "standard")
+        return STROKE_TYPE_STANDARD;
+    if (type == "dash")
+        return STROKE_TYPE_DASHED;
+    if (type == "dashdot")
+        return STROKE_TYPE_DASHDOTTED;
+    if (type == "dot")
+        return STROKE_TYPE_DOTTED;
+
+    return STROKE_TYPE_NONE;
+}
+
 bool xoj::tool::isPdfSelectionTool(ToolType toolType) {
     return toolType == TOOL_SELECT_PDF_TEXT_LINEAR || toolType == TOOL_SELECT_PDF_TEXT_RECT;
 }

--- a/src/core/control/ToolEnums.h
+++ b/src/core/control/ToolEnums.h
@@ -13,6 +13,7 @@
 
 #include <string>  // for string
 
+#include "model/LineStyle.h"
 
 enum ToolSize {
     TOOL_SIZE_VERY_FINE = 0,
@@ -110,6 +111,15 @@ enum ToolCapabilities : unsigned int {
     TOOL_CAP_SPLINE = 1 << 11,
     TOOL_CAP_LINE_STYLE = 1 << 12
 };
+
+enum StrokeType {
+    STROKE_TYPE_NONE = 0,
+    STROKE_TYPE_STANDARD = 1,
+    STROKE_TYPE_DASHED = 2,
+    STROKE_TYPE_DASHDOTTED = 3,
+    STROKE_TYPE_DOTTED = 4
+};
+auto strokeTypeToLineStyle(StrokeType type) -> LineStyle;
 
 namespace xoj::tool {
 /// \return Whether the provided tool is used for selecting objects on a PDF.

--- a/src/core/control/ToolEnums.h
+++ b/src/core/control/ToolEnums.h
@@ -119,7 +119,9 @@ enum StrokeType {
     STROKE_TYPE_DASHDOTTED = 3,
     STROKE_TYPE_DOTTED = 4
 };
+auto strokeTypeFromString(const std::string& type) -> StrokeType;
 auto strokeTypeToLineStyle(StrokeType type) -> LineStyle;
+auto strokeTypeToString(StrokeType type) -> std::string;
 
 namespace xoj::tool {
 /// \return Whether the provided tool is used for selecting objects on a PDF.

--- a/src/core/control/ToolHandler.cpp
+++ b/src/core/control/ToolHandler.cpp
@@ -384,6 +384,15 @@ void ToolHandler::setButtonDrawingType(DrawingType drawingType, Button button) {
     tool->setDrawingType(drawingType);
 }
 
+void ToolHandler::setButtonStrokeType(StrokeType strokeType, Button button) {
+    this->setButtonStrokeType(strokeTypeToLineStyle(strokeType), button);
+}
+
+void ToolHandler::setButtonStrokeType(const LineStyle& lineStyle, Button button) {
+    Tool* tool = getButtonTool(button);
+    tool->setLineStyle(lineStyle);
+}
+
 auto ToolHandler::getTools() const -> std::array<std::unique_ptr<Tool>, TOOL_COUNT> const& { return tools; }
 
 void ToolHandler::saveSettings() const {

--- a/src/core/control/ToolHandler.h
+++ b/src/core/control/ToolHandler.h
@@ -148,6 +148,15 @@ public:
     void setButtonDrawingType(DrawingType drawingType, Button button);
 
     /**
+     * @brief Set the Stroke Type of a button tool
+     *
+     * @param strokeType The stroke type to apply
+     * @param button The button tool to change
+     */
+    void setButtonStrokeType(StrokeType strokeType, Button button);
+    void setButtonStrokeType(const LineStyle& lineStyle, Button button);
+
+    /**
      * @brief Get the Line Style of active tool
      *
      * @return const LineStyle&

--- a/src/core/control/settings/ButtonConfig.h
+++ b/src/core/control/settings/ButtonConfig.h
@@ -15,13 +15,15 @@
 
 #include "control/ToolEnums.h"               // for DrawingType, ToolType
 #include "control/settings/SettingsEnums.h"  // for Button
+#include "model/LineStyle.h"
 #include "util/Color.h"                      // for Color
 
 class ToolHandler;
 
 class ButtonConfig {
 public:
-    ButtonConfig(ToolType action, Color color, ToolSize size, DrawingType drawingType, EraserType eraserMode);
+    ButtonConfig(ToolType action, Color color, ToolSize size, DrawingType drawingType, EraserType eraserMode,
+                 StrokeType strokeType = STROKE_TYPE_NONE);
     virtual ~ButtonConfig();
 
 public:
@@ -67,6 +69,7 @@ private:
     ToolSize size;
     EraserType eraserMode;
     DrawingType drawingType;
+    StrokeType strokeType;
 
     bool disableDrawing;
 

--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -664,6 +664,12 @@ void Settings::loadButtonConfig() {
             ToolType type = toolTypeFromString(sType);
             cfg->action = type;
 
+            if (type == TOOL_PEN) {
+                string strokeType;
+                cfg->strokeType =
+                        e.getString("strokeType", strokeType) ? strokeTypeFromString(strokeType) : STROKE_TYPE_NONE;
+            }
+
             if (type == TOOL_PEN || type == TOOL_HIGHLIGHTER) {
                 string drawingType;
                 if (e.getString("drawingType", drawingType)) {
@@ -835,13 +841,17 @@ void Settings::saveButtonConfig() {
         SElement& e = s.child(buttonToString(static_cast<Button>(i)));
         const auto& cfg = buttonConfig[i];
 
-        ToolType type = cfg->action;
+        ToolType const type = cfg->action;
         e.setString("tool", toolTypeToString(type));
+
+        if (type == TOOL_PEN) {
+            e.setString("strokeType", strokeTypeToString(cfg->strokeType));
+        }
 
         if (type == TOOL_PEN || type == TOOL_HIGHLIGHTER) {
             e.setString("drawingType", drawingTypeToString(cfg->drawingType));
             e.setString("size", toolSizeToString(cfg->size));
-        }  // end if pen or highlighter
+        }
 
         if (type == TOOL_PEN || type == TOOL_HIGHLIGHTER || type == TOOL_TEXT) {
             e.setIntHex("color", int32_t(uint32_t(cfg->color)));

--- a/src/core/gui/dialog/ButtonConfigGui.cpp
+++ b/src/core/gui/dialog/ButtonConfigGui.cpp
@@ -145,6 +145,9 @@ ButtonConfigGui::ButtonConfigGui(GladeSearchpath* gladeSearchPath, GtkWidget* w,
     // Values in glade GUI!
     this->cbEraserType = get("cbEraserType");
 
+    // Possible values are defined in the .glade file
+    this->cbStrokeType = get("cbStrokeType");
+
     loadSettings();
 }
 
@@ -201,6 +204,8 @@ void ButtonConfigGui::loadSettings() {
     } else {
         gtk_combo_box_set_active(GTK_COMBO_BOX(cbEraserType), 0);
     }
+
+    gtk_combo_box_set_active(GTK_COMBO_BOX(cbStrokeType), cfg->strokeType);
 
     if (withDevice) {
         gtk_combo_box_set_active(GTK_COMBO_BOX(cbDevice), 0);
@@ -260,6 +265,8 @@ void ButtonConfigGui::saveSettings() {
         cfg->eraserMode = ERASER_TYPE_NONE;
     }
 
+    cfg->strokeType = static_cast<StrokeType>(gtk_combo_box_get_active(GTK_COMBO_BOX(this->cbStrokeType)));
+
     if (this->withDevice) {
         int dev = gtk_combo_box_get_active(GTK_COMBO_BOX(cbDevice)) - 1;
         cfg->device = (dev < 0 || this->deviceList.size() <= dev) ? "" : this->deviceList[dev].getName();
@@ -282,6 +289,12 @@ void ButtonConfigGui::enableDisableTools() {
 
     switch (action) {
         case TOOL_PEN:
+            gtk_widget_set_visible(cbThickness, true);
+            gtk_widget_set_visible(colorButton, true);
+            gtk_widget_set_visible(cbDrawingType, true);
+            gtk_widget_set_visible(cbEraserType, false);
+            gtk_widget_set_visible(cbStrokeType, true);
+            break;
         case TOOL_HIGHLIGHTER:
         case TOOL_SELECT_PDF_TEXT_LINEAR:
         case TOOL_SELECT_PDF_TEXT_RECT:
@@ -289,6 +302,7 @@ void ButtonConfigGui::enableDisableTools() {
             gtk_widget_set_visible(colorButton, true);
             gtk_widget_set_visible(cbDrawingType, true);
             gtk_widget_set_visible(cbEraserType, false);
+            gtk_widget_set_visible(cbStrokeType, false);
             break;
 
         case TOOL_ERASER:
@@ -296,6 +310,7 @@ void ButtonConfigGui::enableDisableTools() {
             gtk_widget_set_visible(colorButton, false);
             gtk_widget_set_visible(cbDrawingType, false);
             gtk_widget_set_visible(cbEraserType, true);
+            gtk_widget_set_visible(cbStrokeType, false);
             break;
 
         case TOOL_TEXT:
@@ -303,6 +318,7 @@ void ButtonConfigGui::enableDisableTools() {
             gtk_widget_set_visible(colorButton, true);
             gtk_widget_set_visible(cbDrawingType, false);
             gtk_widget_set_visible(cbEraserType, false);
+            gtk_widget_set_visible(cbStrokeType, false);
             break;
 
         case TOOL_NONE:
@@ -319,6 +335,7 @@ void ButtonConfigGui::enableDisableTools() {
             gtk_widget_set_visible(colorButton, false);
             gtk_widget_set_visible(cbDrawingType, false);
             gtk_widget_set_visible(cbEraserType, false);
+            gtk_widget_set_visible(cbStrokeType, false);
             break;
         default:
             break;

--- a/src/core/gui/dialog/ButtonConfigGui.h
+++ b/src/core/gui/dialog/ButtonConfigGui.h
@@ -53,6 +53,7 @@ private:
     GtkWidget* colorButton;
     GtkWidget* cbEraserType;
     GtkWidget* cbDrawingType;
+    GtkWidget* cbStrokeType;
 
     std::vector<InputDevice> deviceList;
 

--- a/ui/settingsButtonConfig.glade
+++ b/ui/settingsButtonConfig.glade
@@ -1,26 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.12"/>
   <object class="GtkOffscreenWindow" id="offscreenwindow">
     <property name="name">offscreenwindow</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <child>
+      <!-- n-columns=3 n-rows=3 -->
       <object class="GtkGrid" id="mainGrid">
         <property name="name">mainGrid</property>
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="hexpand">True</property>
         <child>
           <object class="GtkBox" id="box1">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="hexpand">True</property>
             <child>
               <object class="GtkLabel" id="lbDevice">
                 <property name="name">lbDevice</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="hexpand">True</property>
                 <property name="label" translatable="yes">Device</property>
                 <property name="xalign">0</property>
@@ -35,7 +36,7 @@
               <object class="GtkComboBoxText" id="labelDevice">
                 <property name="name">labelDevice</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="hexpand">True</property>
               </object>
               <packing>
@@ -46,14 +47,14 @@
             </child>
             <child>
               <object class="GtkCheckButton" id="cbDisableDrawing">
-                <property name="name">cbDisableDrawing</property>
                 <property name="label" translatable="yes">Disable drawing for this device</property>
+                <property name="name">cbDisableDrawing</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">False</property>
                 <property name="hexpand">True</property>
                 <property name="xalign">0</property>
-                <property name="draw_indicator">True</property>
+                <property name="draw-indicator">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -63,67 +64,68 @@
             </child>
           </object>
           <packing>
-            <property name="left_attach">0</property>
-            <property name="top_attach">0</property>
+            <property name="left-attach">0</property>
+            <property name="top-attach">0</property>
           </packing>
         </child>
         <child>
+          <!-- n-columns=3 n-rows=3 -->
           <object class="GtkGrid" id="grid2">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <child>
               <object class="GtkComboBox" id="cbTool">
                 <property name="name">cbTool</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="hexpand">True</property>
               </object>
               <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">0</property>
+                <property name="left-attach">0</property>
+                <property name="top-attach">0</property>
               </packing>
             </child>
             <child>
               <object class="GtkComboBoxText" id="cbThickness">
                 <property name="name">cbThickness</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="hexpand">True</property>
               </object>
               <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">0</property>
+                <property name="left-attach">1</property>
+                <property name="top-attach">0</property>
               </packing>
             </child>
             <child>
               <object class="GtkColorButton" id="colorButton">
                 <property name="name">colorButton</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
               </object>
               <packing>
-                <property name="left_attach">2</property>
-                <property name="top_attach">0</property>
+                <property name="left-attach">2</property>
+                <property name="top-attach">0</property>
               </packing>
             </child>
             <child>
               <object class="GtkComboBoxText" id="cbDrawingType">
                 <property name="name">cbDrawingType</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="hexpand">True</property>
               </object>
               <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">1</property>
+                <property name="left-attach">0</property>
+                <property name="top-attach">1</property>
               </packing>
             </child>
             <child>
               <object class="GtkComboBoxText" id="cbEraserType">
                 <property name="name">cbEraserType</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="hexpand">True</property>
                 <items>
                   <item translatable="yes">Eraser Type - don't change</item>
@@ -133,17 +135,33 @@
                 </items>
               </object>
               <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">1</property>
+                <property name="left-attach">1</property>
+                <property name="top-attach">1</property>
               </packing>
             </child>
             <child>
-              <placeholder/>
+              <object class="GtkComboBoxText" id="cbStrokeType">
+                <property name="name">cbStrokeType</property>
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="hexpand">True</property>
+                <items>
+                  <item translatable="yes">Stroke Type - don't change</item>
+                  <item translatable="yes">Standard</item>
+                  <item translatable="yes">Dashed</item>
+                  <item translatable="yes">Dash-dotted</item>
+                  <item translatable="yes">Dotted</item>
+                </items>
+              </object>
+              <packing>
+                <property name="left-attach">0</property>
+                <property name="top-attach">2</property>
+              </packing>
             </child>
           </object>
           <packing>
-            <property name="left_attach">0</property>
-            <property name="top_attach">1</property>
+            <property name="left-attach">0</property>
+            <property name="top-attach">1</property>
           </packing>
         </child>
       </object>


### PR DESCRIPTION
I've been sitting on this change for while. I saw that someone else requested this feature in #4815, so I decided to finally complete it.
Here's the preferences dialog with the new combobox. It will only show when "Pen" is selected as the default tool, since this is the only tool that supports different line styles AFAIK:
![image](https://user-images.githubusercontent.com/45766222/234014416-f7068ea0-9e19-4df5-9640-47f7479a62c1.png)

Suggestions/improvements welcome as this is my first PR on this project and I have limited C++ experience :smile: 
