### PR TITLE
fix the casing of the parameters of getStrokes 

### DIFF
--- a/src/core/plugin/luapi_application.h
+++ b/src/core/plugin/luapi_application.h
@@ -859,7 +859,7 @@ static int applib_getStrokes(lua_State* L) {
     std::vector<Element*> elements = {};
     Control* control = plugin->getControl();
 
-    if (type == "Layer") {
+    if (type == "layer") {
         auto sel = control->getWindow()->getXournal()->getSelection();
         if (sel) {
             control->clearSelection();  // otherwise strokes in the selection won't be recognized


### PR DESCRIPTION
the type parameter of `applib_getStrokes` was documented as `layer` or `selection` but the implementation used `*L*ayer` and `selection` (see [#4528 (Comment)](https://github.com/xournalpp/xournalpp/pull/4528#issuecomment-1519088312)).
This PR fixes this inconsistency.