### PR TITLE
Ghost page

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -1444,8 +1444,8 @@ void Control::duplicatePage() {
     insertPage(pageCopy, getCurrentPageNo() + 1);
 }
 
-void Control::insertNewPage(size_t position, bool shouldScrollToPage) {
-    pageBackgroundChangeController->insertNewPage(position, shouldScrollToPage);
+void Control::insertNewPage(size_t position, bool ghostPage) {
+    pageBackgroundChangeController->insertNewPage(position, ghostPage);
 }
 
 void Control::appendNewPdfPages() {
@@ -1562,8 +1562,13 @@ void Control::paperFormat() {
 
     if (width > 0) {
         this->doc->lock();
-        Document::setPageSize(page, width, height);
+        page->setSize(width, height);
+        bool wasGhost = page->unghost();
         this->doc->unlock();
+
+        if (wasGhost) {
+            page->firePageUnghosted();
+        }
     }
 
     size_t pageNo = doc->indexOf(page);
@@ -2179,6 +2184,7 @@ void Control::showSettings() {
     StylusCursorType stylusCursorType = settings->getStylusCursorType();
     bool highlightPosition = settings->isHighlightPosition();
     SidebarNumberingStyle sidebarStyle = settings->getSidebarNumberingStyle();
+    bool ghostPage = settings->getGhostPage();
 
     auto dlg = SettingsDialog(this->gladeSearchPath, settings, this);
     dlg.show(GTK_WINDOW(this->win->getWindow()));
@@ -2214,6 +2220,23 @@ void Control::showSettings() {
 
     getWindow()->getXournal()->getHandRecognition()->reload();
     getWindow()->updateColorscheme();
+
+    if (ghostPage && !settings->getGhostPage()) {
+        // Remove the ghost page if any
+        doc->lock();
+        auto lastPageIndex = doc->getPageCount() - 1;
+        bool isGhost = doc->getPage(lastPageIndex)->isGhost();
+        doc->unlock();
+
+        if (isGhost) {
+            // first send event, then delete page...
+            firePageDeleted(lastPageIndex);
+
+            this->doc->lock();
+            doc->deletePage(lastPageIndex);
+            this->doc->unlock();
+        }
+    }
 }
 
 auto Control::newFile(string pageTemplate, fs::path filepath) -> bool {

--- a/src/core/control/Control.h
+++ b/src/core/control/Control.h
@@ -210,7 +210,7 @@ public:
 
     void addDefaultPage(std::string pageTemplate);
     void duplicatePage();
-    void insertNewPage(size_t position, bool shouldScrollToPage = true);
+    void insertNewPage(size_t position, bool ghostPage = false);
     void appendNewPdfPages();
     void insertPage(const PageRef& page, size_t position, bool shouldScrollToPage = true);
     void deletePage();

--- a/src/core/control/GeometryToolController.cpp
+++ b/src/core/control/GeometryToolController.cpp
@@ -59,34 +59,23 @@ void GeometryToolController::markPoint(double x, double y) {
     cross->addPoint(Point(x + MARK_SIZE, y - MARK_SIZE));
     cross->addPoint(Point(x - MARK_SIZE, y + MARK_SIZE));
 
-    const auto doc = control->getDocument();
     const auto page = view->getPage();
-    doc->lock();
-    const auto layer = page->getSelectedLayer();
-    layer->addElement(cross);
-    doc->unlock();
+    page->safeAddElementToActiveLayer(control->getDocument(), cross);
 
     const auto undo = control->getUndoRedoHandler();
-    undo->addUndoAction(std::make_unique<InsertUndoAction>(page, layer, cross));
-
-    const Rectangle<double> rect{cross->getX(), cross->getY(), cross->getElementWidth(), cross->getElementHeight()};
-    view->rerenderRect(rect.x, rect.y, rect.width, rect.height);
+    undo->addUndoAction(std::make_unique<InsertUndoAction>(page, page->getSelectedLayer(), cross));
 }
 
 void GeometryToolController::addStrokeToLayer() {
     const auto xournal = view->getXournal();
     const auto control = xournal->getControl();
-    const auto doc = control->getDocument();
     const auto page = view->getPage();
 
-    doc->lock();
-    const auto layer = page->getSelectedLayer();
-    layer->addElement(stroke.get());
-    doc->unlock();
+    page->safeAddElementToActiveLayer(control->getDocument(), stroke.get());
+
     const auto undo = control->getUndoRedoHandler();
-    undo->addUndoAction(std::make_unique<InsertUndoAction>(page, layer, stroke.get()));
-    const Rectangle<double> rect{stroke->getX(), stroke->getY(), stroke->getElementWidth(), stroke->getElementHeight()};
-    view->rerenderRect(rect.x, rect.y, rect.width, rect.height);
+    undo->addUndoAction(std::make_unique<InsertUndoAction>(page, page->getSelectedLayer(), stroke.get()));
+
     stroke.release();
     geometryTool->setStroke(nullptr);
     xournal->getCursor()->updateCursor();

--- a/src/core/control/PageBackgroundChangeController.h
+++ b/src/core/control/PageBackgroundChangeController.h
@@ -38,7 +38,7 @@ public:
     virtual void changeCurrentPageBackground(PageType& pageType);
     void changeCurrentPageBackground(PageTypeInfo* info) override;
     void changeAllPagesBackground(const PageType& pt);
-    void insertNewPage(size_t position, bool shouldScrollToPage = true);
+    void insertNewPage(size_t position, bool ghostPage = false);
     GtkWidget* getMenu();
 
     // DocumentListener

--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -69,7 +69,7 @@ void Settings::loadDefault() {
 
     this->numPairsOffset = 1;
 
-    this->emptyLastPageAppend = EmptyLastPageAppendType::Disabled;
+    this->ghostPage = true;
 
     this->edgePanSpeed = 20.0;
     this->edgePanMaxMult = 5.0;
@@ -564,8 +564,8 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur) {
         this->inputSystemTPCButton = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("inputSystemDrawOutsideWindow")) == 0) {
         this->inputSystemDrawOutsideWindow = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
-    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("emptyLastPageAppend")) == 0) {
-        this->emptyLastPageAppend = emptyLastPageAppendFromString(reinterpret_cast<char*>(value));
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("ghostPage")) == 0) {
+        this->ghostPage = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("strokeFilterIgnoreTime")) == 0) {
         this->strokeFilterIgnoreTime = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("strokeFilterIgnoreLength")) == 0) {
@@ -941,8 +941,7 @@ void Settings::save() {
     SAVE_BOOL_PROP(layoutRightToLeft);
     SAVE_BOOL_PROP(layoutBottomToTop);
     SAVE_INT_PROP(numPairsOffset);
-    xmlNode = saveProperty("emptyLastPageAppend", emptyLastPageAppendToString(this->emptyLastPageAppend), root);
-    ATTACH_COMMENT("The icon theme, allowed values are \"disabled\", \"onDrawOfLastPage\", and \"onScrollOfLastPage\"");
+    SAVE_BOOL_PROP(ghostPage);
     SAVE_BOOL_PROP(presentationMode);
 
     auto defaultViewModeAttributes = viewModeToSettingsString(viewModes.at(PresetViewModeIds::VIEW_MODE_DEFAULT));
@@ -1663,16 +1662,16 @@ void Settings::setPairsOffset(int numOffset) {
 
 auto Settings::getPairsOffset() const -> int { return this->numPairsOffset; }
 
-void Settings::setEmptyLastPageAppend(EmptyLastPageAppendType emptyLastPageAppend) {
-    if (this->emptyLastPageAppend == emptyLastPageAppend) {
+void Settings::setGhostPage(bool ghostPage) {
+    if (this->ghostPage == ghostPage) {
         return;
     }
 
-    this->emptyLastPageAppend = emptyLastPageAppend;
+    this->ghostPage = ghostPage;
     save();
 }
 
-auto Settings::getEmptyLastPageAppend() const -> EmptyLastPageAppendType { return this->emptyLastPageAppend; }
+auto Settings::getGhostPage() const -> bool { return this->ghostPage; }
 
 void Settings::setViewColumns(int numColumns) {
     if (this->numColumns == numColumns) {

--- a/src/core/control/settings/Settings.h
+++ b/src/core/control/settings/Settings.h
@@ -242,8 +242,8 @@ public:
     void setPairsOffset(int numOffset);
     int getPairsOffset() const;
 
-    void setEmptyLastPageAppend(EmptyLastPageAppendType emptyLastPageAppend);
-    EmptyLastPageAppendType getEmptyLastPageAppend() const;
+    void setGhostPage(bool ghostPage);
+    bool getGhostPage() const;
 
     void setViewColumns(int numColumns);
     int getViewColumns() const;
@@ -796,7 +796,7 @@ private:
     /**
      * Preference for appending an empty last page to the document
      */
-    EmptyLastPageAppendType emptyLastPageAppend{};
+    bool ghostPage{};
 
     /**
      *  Use when fixed number of columns

--- a/src/core/control/settings/SettingsEnums.cpp
+++ b/src/core/control/settings/SettingsEnums.cpp
@@ -46,18 +46,3 @@ auto iconThemeFromString(const std::string& iconThemeStr) -> IconTheme {
     g_warning("Settings::Unknown icon theme: %s\n", iconThemeStr.c_str());
     return ICON_THEME_COLOR;
 }
-
-auto emptyLastPageAppendFromString(const std::string& str) -> EmptyLastPageAppendType {
-    if (str == "disabled") {
-        return EmptyLastPageAppendType::Disabled;
-    }
-    if (str == "onDrawOfLastPage") {
-        return EmptyLastPageAppendType::OnDrawOfLastPage;
-    }
-    if (str == "onScrollOfLastPage") {
-        return EmptyLastPageAppendType::OnScrollToEndOfLastPage;
-    }
-
-    g_warning("Settings::Unknown empty last page append type: %s\n", str.c_str());
-    return EmptyLastPageAppendType::Disabled;
-}

--- a/src/core/control/settings/SettingsEnums.h
+++ b/src/core/control/settings/SettingsEnums.h
@@ -47,12 +47,6 @@ enum ScrollbarHideType {
     SCROLLBAR_HIDE_BOTH = SCROLLBAR_HIDE_HORIZONTAL | SCROLLBAR_HIDE_VERTICAL
 };
 
-enum class EmptyLastPageAppendType {
-    Disabled = 0,
-    OnDrawOfLastPage = 1,
-    OnScrollToEndOfLastPage = 2,
-};
-
 /**
  * The user-selectable device types
  */
@@ -165,20 +159,6 @@ constexpr auto iconThemeToString(IconTheme iconTheme) -> const char* {
     }
 }
 
-constexpr auto emptyLastPageAppendToString(EmptyLastPageAppendType appendType) -> const char* {
-    switch (appendType) {
-        case EmptyLastPageAppendType::Disabled:
-            return "disabled";
-        case EmptyLastPageAppendType::OnDrawOfLastPage:
-            return "onDrawOfLastPage";
-        case EmptyLastPageAppendType::OnScrollToEndOfLastPage:
-            return "onScrollOfLastPage";
-        default:
-            return "unknown";
-    }
-}
-
 StylusCursorType stylusCursorTypeFromString(const std::string& stylusCursorTypeStr);
 EraserVisibility eraserVisibilityFromString(const std::string& eraserVisibilityStr);
 IconTheme iconThemeFromString(const std::string& iconThemeStr);
-EmptyLastPageAppendType emptyLastPageAppendFromString(const std::string& str);

--- a/src/core/control/tools/BaseShapeHandler.cpp
+++ b/src/core/control/tools/BaseShapeHandler.cpp
@@ -98,8 +98,6 @@ void BaseShapeHandler::onButtonReleaseEvent(const PositionInputData& pos, double
         return;
     }
 
-    Layer* layer = page->getSelectedLayer();
-
     UndoRedoHandler* undo = control->getUndoRedoHandler();
 
     stroke->setPointVector(this->shape, &lastSnappingRange);
@@ -108,13 +106,9 @@ void BaseShapeHandler::onButtonReleaseEvent(const PositionInputData& pos, double
     repaintRange.addPadding(0.5 * this->stroke->getWidth());
     this->viewPool->dispatchAndClear(xoj::view::ShapeToolView::FINALIZATION_REQUEST, repaintRange);
 
-    undo->addUndoAction(std::make_unique<InsertUndoAction>(page, layer, stroke.get()));
+    undo->addUndoAction(std::make_unique<InsertUndoAction>(page, page->getSelectedLayer(), stroke.get()));
 
-    Document* doc = control->getDocument();
-    doc->lock();
-    layer->addElement(stroke.get());
-    doc->unlock();
-    page->fireElementChanged(stroke.get());
+    page->safeAddElementToActiveLayer(control->getDocument(), stroke.get());
     stroke.release();
 
     control->getCursor()->updateCursor();

--- a/src/core/control/tools/EditSelection.cpp
+++ b/src/core/control/tools/EditSelection.cpp
@@ -223,8 +223,8 @@ void EditSelection::finalizeSelection() {
 
     PageRef page = this->view->getPage();
     Layer* layer = page->getSelectedLayer();
-    this->contents->finalizeSelection(this->getRect(), this->snappedBounds, this->aspectRatio, layer, page, this->view,
-                                      this->undo);
+    this->contents->finalizeSelection(this->getRect(), this->snappedBounds, this->aspectRatio, layer, page,
+                                      this->view->getXournal()->getDocument());
 
 
     // Calculate new clip region delta due to rotation:

--- a/src/core/control/tools/EditSelectionContents.h
+++ b/src/core/control/tools/EditSelectionContents.h
@@ -28,6 +28,7 @@
 
 #include "CursorSelectionType.h"  // for CursorSelectionType
 
+class Document;
 class UndoRedoHandler;
 class Layer;
 class XojPageView;
@@ -114,8 +115,7 @@ public:
      * Finish the editing
      */
     void finalizeSelection(xoj::util::Rectangle<double> bounds, xoj::util::Rectangle<double> snappedBounds,
-                           bool aspectRatio, Layer* layer, const PageRef& targetPage, XojPageView* targetView,
-                           UndoRedoHandler* undo);
+                           bool aspectRatio, Layer* layer, const PageRef& targetPage, Document* doc);
 
     void updateContent(xoj::util::Rectangle<double> bounds, xoj::util::Rectangle<double> snappedBounds, double rotation,
                        bool aspectRatio, Layer* layer, const PageRef& targetPage, XojPageView* targetView,

--- a/src/core/control/tools/SplineHandler.cpp
+++ b/src/core/control/tools/SplineHandler.cpp
@@ -265,22 +265,16 @@ void SplineHandler::finalizeSpline() {
     stroke->setPointVector(linearizeSpline(data));
     stroke->freeUnusedPointItems();
 
-    Layer* layer = page->getSelectedLayer();
-
     UndoRedoHandler* undo = control->getUndoRedoHandler();
-    undo->addUndoAction(std::make_unique<InsertUndoAction>(page, layer, stroke.get()));
+    undo->addUndoAction(std::make_unique<InsertUndoAction>(page, page->getSelectedLayer(), stroke.get()));
 
-    Document* doc = control->getDocument();
-    doc->lock();
-    layer->addElement(stroke.get());
-    doc->unlock();
+    page->safeAddElementToActiveLayer(control->getDocument(), stroke.get());
 
     auto rg = this->computeTotalRepaintRange(data, stroke->getWidth());
     this->viewPool->dispatchAndClear(xoj::view::SplineToolView::FINALIZATION_REQUEST, rg);
 
     // Wait until this finishes before releasing `stroke`, so that PageView::elementChanged does not needlessly rerender
     // the stroke
-    this->page->fireElementChanged(stroke.get());
     stroke.release();
 
     control->getCursor()->updateCursor();

--- a/src/core/control/xojfile/LoadHandler.cpp
+++ b/src/core/control/xojfile/LoadHandler.cpp
@@ -324,7 +324,7 @@ void LoadHandler::parseContents() {
         double width = LoadHandlerHelper::getAttribDouble("width", this);
         double height = LoadHandlerHelper::getAttribDouble("height", this);
 
-        this->page = std::make_unique<XojPage>(width, height, /*suppressLayer*/true);
+        this->page = std::make_unique<XojPage>(width, height, /*ghostPage*/ false, /*suppressLayer*/ true);
 
         pages.push_back(this->page);
     } else if (strcmp(elementName, "audio") == 0) {

--- a/src/core/gui/Layout.h
+++ b/src/core/gui/Layout.h
@@ -150,7 +150,7 @@ protected:
 private:
     void recalculate_int() const;
 
-    void maybeAddLastPage(Layout* layout);
+    void maybeAddLastPage();
 
     // Todo(Fabian): move to ScrollHandling also it must not depend on Layout
     static void checkScroll(GtkAdjustment* adjustment, double& lastScroll);

--- a/src/core/gui/PageView.cpp
+++ b/src/core/gui/PageView.cpp
@@ -75,6 +75,7 @@
 #include "util/raii/CLibrariesSPtr.h"               // for adopt
 #include "util/serdesstream.h"                      // for serdes_stream
 #include "view/DebugShowRepaintBounds.h"            // for IF_DEBUG_REPAINT
+#include "view/background/BackgroundView.h"
 #include "view/overlays/OverlayView.h"              // for OverlayView, Tool...
 #include "view/overlays/PdfElementSelectionView.h"  // for PdfElementSelecti...
 #include "view/overlays/SearchResultView.h"         // for SearchResultView
@@ -848,15 +849,9 @@ auto XojPageView::actionDelete() -> bool {
 void XojPageView::drawLoadingPage(cairo_t* cr) {
     static const string txtLoading = _("Loading...");
 
-    double zoom = xournal->getZoom();
-    int dispWidth = getDisplayWidth();
-    int dispHeight = getDisplayHeight();
-
     cairo_set_source_rgb(cr, 1, 1, 1);
-    cairo_rectangle(cr, 0, 0, dispWidth, dispHeight);
+    cairo_rectangle(cr, 0, 0, page->getHeight(), page->getWidth());
     cairo_fill(cr);
-
-    cairo_scale(cr, zoom, zoom);
 
     cairo_set_source_rgb(cr, 0.5, 0.5, 0.5);
     cairo_select_font_face(cr, "Sans", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_BOLD);
@@ -958,6 +953,27 @@ GtkWidget* XojPageView::makePopover(const XojPdfRectangle& rect, GtkWidget* chil
     return popover;
 }
 
+static void drawGhostPage(const PageRef& page, cairo_t* cr) {
+    xoj::util::CairoSaveGuard saveguard(cr);
+    cairo_rectangle(cr, 0, 0, page->getWidth(), page->getHeight());
+    cairo_clip(cr);
+
+    static const string txtGhostPage = _("Write here to add a new page");
+    constexpr double TEXT_PERIOD = 300;
+
+    cairo_set_source_rgba(cr, 0.7, 0.7, 0.7, 0.5);
+    cairo_paint(cr);
+    cairo_set_source_rgb(cr, 0.3, 0.3, 0.3);
+    cairo_select_font_face(cr, "Sans", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_BOLD);
+    cairo_set_font_size(cr, 24.0);
+    cairo_text_extents_t ex;
+    cairo_text_extents(cr, txtGhostPage.c_str(), &ex);
+    for (double y = 0.5 * TEXT_PERIOD, maxY = page->getHeight() - y; y < maxY; y += TEXT_PERIOD) {
+        cairo_move_to(cr, (page->getWidth() - ex.width) / 2 - ex.x_bearing, y);
+        cairo_show_text(cr, txtGhostPage.c_str());
+    }
+}
+
 auto XojPageView::paintPage(cairo_t* cr, GdkRectangle* rect) -> bool {
 
     double zoom = xournal->getZoom();
@@ -967,6 +983,7 @@ auto XojPageView::paintPage(cairo_t* cr, GdkRectangle* rect) -> bool {
     {
         std::lock_guard lock(this->drawingMutex);  // Lock the mutex first
         xoj::util::CairoSaveGuard saveGuard(cr);   // see comment at the end of the scope
+
         if (!this->hasBuffer()) {
             drawLoadingPage(cr);
             return true;
@@ -979,6 +996,11 @@ auto XojPageView::paintPage(cairo_t* cr, GdkRectangle* rect) -> bool {
         this->buffer.paintTo(cr);
     }  // Restore the state of cr and then release the mutex
        // restoring the state of cr ensures this->buffer.surface is not longer referenced as the source in cr.
+
+    if (this->page->isGhost()) {
+        assert(!this->page->isAnnotated() && "Ghost page should be empty");
+        drawGhostPage(page, cr);
+    }
 
     /**
      * All the overlay painters below follow the assumption:
@@ -1080,6 +1102,8 @@ void XojPageView::rectChanged(Rectangle<double>& rect) { rerenderRect(rect.x, re
 void XojPageView::rangeChanged(Range& range) { rerenderRange(range); }
 
 void XojPageView::pageChanged() { rerenderPage(); }
+
+void XojPageView::pageUnghosted() { repaintPage(); }
 
 void XojPageView::elementChanged(Element* elem) {
     /*

--- a/src/core/gui/PageView.h
+++ b/src/core/gui/PageView.h
@@ -199,6 +199,7 @@ public:  // listener
     void pageChanged() override;
     void elementChanged(Element* elem) override;
     void elementsChanged(const std::vector<Element*>& elements, const Range& range) override;
+    void pageUnghosted() override;
 
 private:
     void startText(double x, double y);

--- a/src/core/gui/XournalView.cpp
+++ b/src/core/gui/XournalView.cpp
@@ -769,7 +769,7 @@ void XournalView::documentChanged(DocumentChangeType type) {
         this->cache = std::make_unique<PdfCache>(doc->getPdfDocument(), control->getSettings());
     }
 
-    size_t pagecount = doc->getPageCount();
+    size_t pagecount = doc->getVirtualPageCount();
     viewPages.reserve(pagecount);
     for (size_t i = 0; i < pagecount; i++) {
         viewPages.emplace_back(std::make_unique<XojPageView>(this, doc->getPage(i)));

--- a/src/core/gui/dialog/SettingsDialog.cpp
+++ b/src/core/gui/dialog/SettingsDialog.cpp
@@ -416,10 +416,7 @@ void SettingsDialog::load() {
     GtkWidget* spPairsOffset = get("spPairsOffset");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spPairsOffset), settings->getPairsOffset());
 
-    EmptyLastPageAppendType append = settings->getEmptyLastPageAppend();
-    loadCheckbox("rdLastPageAppendOnDrawOfLastPage", append == EmptyLastPageAppendType::OnDrawOfLastPage);
-    loadCheckbox("rdLastPageAppendOnScrollToEndOfLastPage", append == EmptyLastPageAppendType::OnScrollToEndOfLastPage);
-    loadCheckbox("rdLastPageAppendDisabled", append == EmptyLastPageAppendType::Disabled);
+    loadCheckbox("cbGhostPage", settings->getGhostPage());
 
     GtkWidget* spSnapRotationTolerance = get("spSnapRotationTolerance");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spSnapRotationTolerance), settings->getSnapRotationTolerance());
@@ -824,15 +821,7 @@ void SettingsDialog::save() {
     int numPairsOffset = static_cast<int>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(spPairsOffset)));
     settings->setPairsOffset(numPairsOffset);
 
-    if (getCheckbox("rdLastPageAppendDisabled")) {
-        settings->setEmptyLastPageAppend(EmptyLastPageAppendType::Disabled);
-    } else if (getCheckbox("rdLastPageAppendOnDrawOfLastPage")) {
-        settings->setEmptyLastPageAppend(EmptyLastPageAppendType::OnDrawOfLastPage);
-    } else if (getCheckbox("rdLastPageAppendOnScrollToEndOfLastPage")) {
-        settings->setEmptyLastPageAppend(EmptyLastPageAppendType::OnScrollToEndOfLastPage);
-    } else {
-        settings->setEmptyLastPageAppend(EmptyLastPageAppendType::Disabled);
-    }
+    settings->setGhostPage(getCheckbox("cbGhostPage"));
 
     settings->setEdgePanSpeed(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("edgePanSpeed"))));
     settings->setEdgePanMaxMult(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get("edgePanMaxMult"))));

--- a/src/core/model/Document.cpp
+++ b/src/core/model/Document.cpp
@@ -105,10 +105,11 @@ void Document::clearDocument(bool destroy) {
     this->pdfFilepath = fs::path{};
 }
 
-/**
- * Returns the pageCount, this call don't need to be synchronized (if it's not critical, you may get wrong data)
- */
-auto Document::getPageCount() const -> size_t { return this->pages.size(); }
+auto Document::getPageCount() const -> size_t {
+    return this->hasGhostPage() ? this->pages.size() - 1 : this->pages.size();
+}
+
+auto Document::getVirtualPageCount() const -> size_t { return this->pages.size(); }
 
 auto Document::getPdfPageCount() const -> size_t { return pdfDocument.getPageCount(); }
 
@@ -397,15 +398,14 @@ auto Document::indexOf(const PageRef& page) -> size_t {
 }
 
 auto Document::getPage(size_t page) const -> PageRef {
-    if (getPageCount() <= page) {
-        return nullptr;
-    }
-    if (page == npos) {
+    if (page >= pages.size()) {
         return nullptr;
     }
 
     return this->pages[page];
 }
+
+auto Document::hasGhostPage() const -> bool { return !pages.empty() && pages.back()->isGhost(); }
 
 auto Document::getPdfPage(size_t page) const -> XojPdfPageSPtr { return this->pdfDocument.getPage(page); }
 

--- a/src/core/model/Document.h
+++ b/src/core/model/Document.h
@@ -45,7 +45,11 @@ public:
     bool readPdf(const fs::path& filename, bool initPages, bool attachToDocument, gpointer data = nullptr,
                  gsize length = 0);
 
+    /// @brief Get the number of pages (possible ghost page excluded)
     size_t getPageCount() const;
+    /// @brief Get the number of pages including a possible ghost page
+    size_t getVirtualPageCount() const;
+
     size_t getPdfPageCount() const;
     XojPdfPageSPtr getPdfPage(size_t page) const;
     const XojPdfDocument& getPdfDocument() const;
@@ -56,6 +60,8 @@ public:
     void addPages(InputIter first, InputIter last);
     PageRef getPage(size_t page) const;
     void deletePage(size_t pNr);
+
+    bool hasGhostPage() const;
 
     static void setPageSize(PageRef p, double width, double height);
     static double getPageWidth(PageRef p);

--- a/src/core/model/PageHandler.cpp
+++ b/src/core/model/PageHandler.cpp
@@ -38,3 +38,9 @@ void PageHandler::fireElementsChanged(const std::vector<Element*>& elements, Ran
 void PageHandler::firePageChanged() {
     for (PageListener* pl: this->listeners) { pl->pageChanged(); }
 }
+
+void PageHandler::firePageUnghosted() const {
+    for (PageListener* pl: this->listeners) {
+        pl->pageUnghosted();
+    }
+}

--- a/src/core/model/PageHandler.h
+++ b/src/core/model/PageHandler.h
@@ -41,6 +41,8 @@ public:
     void fireElementsChanged(const std::vector<Element*>& elements, Range range = Range());
     void firePageChanged();
 
+    void firePageUnghosted() const;
+
 private:
     void addListener(PageListener* l);
     void removeListener(PageListener* l);

--- a/src/core/model/PageListener.h
+++ b/src/core/model/PageListener.h
@@ -36,6 +36,7 @@ public:
     virtual void elementChanged(Element* elem) {}
     virtual void elementsChanged(const std::vector<Element*>& elements, const Range& range) {}
     virtual void pageChanged() {}
+    virtual void pageUnghosted() {}
 
 private:
     std::weak_ptr<PageHandler> handler;

--- a/src/core/model/XojPage.h
+++ b/src/core/model/XojPage.h
@@ -24,9 +24,11 @@
 #include "PageHandler.h"      // for PageHandler
 #include "PageType.h"         // for PageType
 
+class Document;
+
 class XojPage: public PageHandler {
 public:
-    XojPage(double width, double height, bool suppressLayerCreation = false);
+    XojPage(double width, double height, bool ghost = false, bool suppressLayerCreation = false);
     ~XojPage() override;
     XojPage(const XojPage& page);
     void operator=(const XojPage& p) = delete;
@@ -81,6 +83,22 @@ public:
      */
     XojPage* clone();
 
+    /**
+     * @brief Returns true if the page is a ghost page (i.e. will not be saved)
+     * A page with elements on it should never be a ghost page
+     */
+    inline bool isGhost() const { return ghostPage; }
+
+    /**
+     * @brief Unghosts the page and returns true if the page was indeed a ghost page before
+     */
+    bool unghost();
+    /**
+     * @brief Lock the document and add the element to the page's active layer. Also Unghosts the page and calls
+     * firePageUnghosted() if needed
+     */
+    void safeAddElementToActiveLayer(Document* doc, Element* e);
+
 private:
     /**
      * The Background image if any
@@ -122,6 +140,11 @@ private:
      * Background visible
      */
     bool backgroundVisible = true;
+
+    /**
+     * @brief If true, the page is greyed out and not saved, until an element is added to it
+     */
+    bool ghostPage = false;
 
     /**
      * Background name

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -3865,9 +3865,9 @@ This setting can make it easier to draw with touch. </property>
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkCheckButton" id="cbShowPresentationSidebar">
-                                            <property name="label" translatable="yes">Show Sidebar</property>
-                                            <property name="name">cbShowPresentationSidebar</property>
+                                          <object class="GtkCheckButton" id="cbPresentationGoFullscreen">
+                                            <property name="label" translatable="yes">Go Fullscreen</property>
+                                            <property name="name">cbPresentationGoFullscreen</property>
                                             <property name="visible">True</property>
                                             <property name="can-focus">True</property>
                                             <property name="receives-default">False</property>
@@ -3881,9 +3881,9 @@ This setting can make it easier to draw with touch. </property>
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkCheckButton" id="cbPresentationGoFullscreen">
-                                            <property name="label" translatable="yes">Go Fullscreen</property>
-                                            <property name="name">cbPresentationGoFullscreen</property>
+                                          <object class="GtkCheckButton" id="cbShowPresentationSidebar">
+                                            <property name="label" translatable="yes">Show Sidebar</property>
+                                            <property name="name">cbShowPresentationSidebar</property>
                                             <property name="visible">True</property>
                                             <property name="can-focus">True</property>
                                             <property name="receives-default">False</property>
@@ -4662,71 +4662,25 @@ This setting can make it easier to draw with touch. </property>
                               <object class="GtkFrame" id="sid198">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
-                                <property name="label-xalign">0</property>
+                                <property name="label-xalign">0.009999999776482582</property>
                                 <child>
-                                  <object class="GtkAlignment" id="sid199">
+                                  <object class="GtkCheckButton" id="cbGhostPage">
+                                    <property name="label" translatable="yes">Show ghost page for easy page appending (excluding PDFs)</property>
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="left-padding">12</property>
-                                    <child>
-                                      <!-- n-columns=1 n-rows=3 -->
-                                      <object class="GtkGrid" id="grid7">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="orientation">vertical</property>
-                                        <child>
-                                          <object class="GtkRadioButton" id="rdLastPageAppendOnScrollToEndOfLastPage">
-                                            <property name="label" translatable="yes">when scrolling to end of last page</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="active">True</property>
-                                            <property name="draw-indicator">True</property>
-                                            <property name="group">rdLastPageAppendDisabled</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">2</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkRadioButton" id="rdLastPageAppendOnDrawOfLastPage">
-                                            <property name="label" translatable="yes">when drawing on last page</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="active">True</property>
-                                            <property name="draw-indicator">True</property>
-                                            <property name="group">rdLastPageAppendDisabled</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkRadioButton" id="rdLastPageAppendDisabled">
-                                            <property name="label" translatable="yes">disabled</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="active">True</property>
-                                            <property name="draw-indicator">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">0</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">4</property>
+                                    <property name="active">True</property>
+                                    <property name="draw-indicator">True</property>
                                   </object>
                                 </child>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid197">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="label" translatable="yes">Automatically Add Empty Last Page (excluding PDFs)</property>
+                                    <property name="label" translatable="yes">Ghost page</property>
                                   </object>
                                 </child>
                               </object>


### PR DESCRIPTION
Fix #4820

This PR is a proposal for more UX friendly automated page addition when reaching the end of a non-pdf document:

https://user-images.githubusercontent.com/17818041/234678823-2c88cea2-df3b-4768-86c4-7870779b4d8b.mp4

As you can see in the video: when scrolling to the bottom of the document, a greyed out page (ghost page) is added. This page:

- is not saved/exported/printed nor counted in the total number of pages.
- is unghosted as soon as anything is added to it (stroke or any other element(s)), or when it's size is changed -- but not when we change all the pages backgrounds at once.

The implementation is (amazingly) no very complicated: literally add a page to the document, flag it as a ghost page and ignore ghost pages in most places.
There is a small scrolling issue visible at the end of the video, as well as other bugs.  I'll try to fix them once people have given their opinion on the proposal.

@Photon89 @Technius @rolandlo (and anyone else who might have an opinion): what do you think?

- [ ] Fix sidebar preview
- [ ] Fix scrolling issue
- [ ] Test some more and fix the bugs encountered :-)