### PR TITLE
Fix Spline handler crash after hitting Escape and starting a new spline

### DIFF
--- a/src/core/control/tools/SplineHandler.cpp
+++ b/src/core/control/tools/SplineHandler.cpp
@@ -49,9 +49,9 @@ constexpr double MAX_TANGENT_LENGTH = 2000.0;
 constexpr double MIN_TANGENT_LENGTH = 1.0;
 
 auto SplineHandler::onKeyEvent(GdkEventKey* event) -> bool {
-    if (!stroke ||
-        (event->type != GDK_KEY_PRESS && event->keyval != GDK_KEY_Escape)) {  // except for escape key only act on key
-                                                                              // press event, not on key release event
+    if (!stroke || ((event->type != GDK_KEY_PRESS) ==
+                    (event->keyval != GDK_KEY_Escape))) {  // except for escape key only act on key
+                                                           // press event, not on key release event
         return false;
     }
 
@@ -65,7 +65,6 @@ auto SplineHandler::onKeyEvent(GdkEventKey* event) -> bool {
         }
         case GDK_KEY_BackSpace: {
             if (this->knots.size() == 1) {
-                this->finalizeSpline();
                 return true;
             }
             this->deleteLastKnotWithTangent();


### PR DESCRIPTION
superseeds #4824 
fixes #4822

Already discussed in #4824.
Merging in 24 hours.