### PR TITLE
Improve CrashLog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,6 +222,7 @@ add_subdirectory(po)
 
 # Development options
 option(DEV_CALL_LOG "Call log" OFF)
+add_compile_definitions(G_LOG_DOMAIN="xopp")
 
 # Debug options
 option(DEBUG_INPUT "Input debugging, e.g. eraser events etc" OFF)

--- a/src/core/control/CrashHandler.cpp
+++ b/src/core/control/CrashHandler.cpp
@@ -1,5 +1,6 @@
 #include "CrashHandler.h"
 
+#include <sstream>
 #include <string>  // for string
 
 #include <glib.h>  // for g_warning, g_error
@@ -11,8 +12,10 @@
 #include "filesystem.h"  // for path
 
 static Document* document = nullptr;
+static std::stringstream logBuffer;
 
 void setEmergencyDocument(Document* doc) { document = doc; }
+static std::stringstream* getCrashHandlerLogBuffer() { return &logBuffer; }
 
 #ifdef _WIN32
 #include "CrashHandlerWindows.h"

--- a/src/core/control/CrashHandlerUnix.h
+++ b/src/core/control/CrashHandlerUnix.h
@@ -10,18 +10,61 @@
  */
 #pragma once
 
+#include <bitset>
 #include <fstream>  // std::ofstream
 
 #include <execinfo.h>
+#include <gtk/gtk.h>
 
 #include "util/PathUtil.h"
 #include "util/Stacktrace.h"
 
 #include "config-dev.h"
+#include "config-git.h"
+#include "config.h"
 
 static bool alreadyCrashed = false;
 
 static void crashHandler(int sig);
+
+constexpr GLogLevelFlags RECORDED_LOG_LEVELS = GLogLevelFlags(0xff);  //< Record all messages
+
+static void log_handler(const gchar* log_domain, GLogLevelFlags log_level, const gchar* message,
+                        std::stringstream* logBuffer) {
+    if ((log_level & RECORDED_LOG_LEVELS) != 0) {
+        if (log_level & G_LOG_FLAG_FATAL) {
+            *logBuffer << "FATAL ";
+        }
+        *logBuffer << std::setw(8) << std::left;
+        switch (log_level & G_LOG_LEVEL_MASK) {
+            case G_LOG_LEVEL_ERROR:
+                *logBuffer << "ERROR";
+                break;
+            case G_LOG_LEVEL_CRITICAL:
+                *logBuffer << "CRITICAL";
+                break;
+            case G_LOG_LEVEL_WARNING:
+                *logBuffer << "WARNING";
+                break;
+            case G_LOG_LEVEL_MESSAGE:
+                *logBuffer << "MESSAGE";
+                break;
+            case G_LOG_LEVEL_INFO:
+                *logBuffer << "INFO";
+                break;
+            case G_LOG_LEVEL_DEBUG:
+                *logBuffer << "DEBUG";
+                break;
+            default:
+                *logBuffer << std::bitset<8>(static_cast<unsigned int>(log_level));
+        }
+        *logBuffer << ": " << (log_domain ? log_domain : "--") << " :: " << (message ? message : "No message")
+                   << std::endl;
+    }
+
+    // Forward to stderr/stdout
+    g_log_default_handler(log_domain, log_level, message, nullptr);
+}
 
 void installCrashHandlers() {
     sigset_t mask;
@@ -49,6 +92,8 @@ void installCrashHandlers() {
 #endif
 
     sigprocmask(SIG_UNBLOCK, &mask, 0);
+
+    g_log_set_default_handler(GLogFunc(log_handler), getCrashHandlerLogBuffer());
 }
 
 /**
@@ -86,6 +131,15 @@ static void crashHandler(int sig) {
     fp << FORMAT_STR("Date: {1}") % ctime(&lt);
     fp << FORMAT_STR("Error: signal {1}") % sig;
     fp << "\n";
+    fp << "Xournal++ version " << PROJECT_VERSION << std::endl;
+
+    if (auto const gitCommitId = std::string{GIT_COMMIT_ID}; !gitCommitId.empty()) {
+        fp << "Git commit: " << gitCommitId << std::endl;
+    }
+
+    fp << "Gtk version " << gtk_get_major_version() << "." << gtk_get_minor_version() << "." << gtk_get_micro_version()
+       << std::endl
+       << std::endl;
 
     messages = backtrace_symbols(array, size);
 
@@ -99,6 +153,9 @@ static void crashHandler(int sig) {
     fp << "\n\nTry to get a better stracktrace...\n";
 
     Stacktrace::printStracktrace(fp);
+
+    fp << "\n\nExecution log:\n\n";
+    fp << getCrashHandlerLogBuffer()->str();
 
     if (fp) {
         fp.close();


### PR DESCRIPTION
This PR adds useful information to the CrashLog, to help with bug reports.

The added pieces of information are:

1. Xournal++ and Gtk versions
2. Every log message issued via g_message, g_critical, g_debug and so on

Implementing 1. was pretty straghtforward. Implementing 2. meant using g_log_set_default_handler() to record every such message.