### PR TITLE
TouchInputHandler: cancel on >2 finger touch

### DIFF
--- a/src/core/gui/inputdevices/TouchInputHandler.h
+++ b/src/core/gui/inputdevices/TouchInputHandler.h
@@ -22,6 +22,10 @@ struct InputEvent;
 
 class TouchInputHandler: public AbstractInputHandler {
 private:
+    int numTouches = 0;
+    bool valid = true;
+    bool zooming = false;
+
     GdkEventSequence* primarySequence{};
     GdkEventSequence* secondarySequence{};
 
@@ -48,5 +52,6 @@ public:
     ~TouchInputHandler() override = default;
 
     bool handleImpl(InputEvent const& event) override;
+    void onBlock() override;
     void onUnblock() override;
 };


### PR DESCRIPTION
Abort all touch input when more than two fingers are used simultaneously until all touch inputs are removed. Fixes #4850.

This might also fix an issue with zoom being active after 
1. activating zoom by pinching the touch screen
2. libinput cancelling the touch events, e.g. due to a stylus coming into range
3. a new single touch being accepted,

but I need to test said bug on a more recent version first.

A remaining issue I could find while briefly testing this is that the `GeometryToolInputHandler` might also handle up to two inputs, which would cause up to four touch inputs to be handled. For now I'll assume that the desired behaviour has not been defined yet and is therefore out of this PR's scope.