### PR TITLE
Enhances Scrolling outside the page

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -2174,6 +2174,7 @@ void Control::showSettings() {
     bool horizontalSpace = settings->getAddHorizontalSpace();
     int horizontalSpaceAmountRight = settings->getAddHorizontalSpaceAmountRight();
     int horizontalSpaceAmountLeft = settings->getAddHorizontalSpaceAmountLeft();
+    bool unlimitedScrolling = settings->getUnlimitedScrolling();
     StylusCursorType stylusCursorType = settings->getStylusCursorType();
     bool highlightPosition = settings->isHighlightPosition();
     SidebarNumberingStyle sidebarStyle = settings->getSidebarNumberingStyle();
@@ -2186,13 +2187,32 @@ void Control::showSettings() {
         win->getXournal()->forceUpdatePagenumbers();
     }
 
-    if (verticalSpace != settings->getAddVerticalSpace() || horizontalSpace != settings->getAddHorizontalSpace() ||
-        verticalSpaceAmountAbove != settings->getAddVerticalSpaceAmountAbove() ||
-        horizontalSpaceAmountRight != settings->getAddHorizontalSpaceAmountRight() ||
-        verticalSpaceAmountBelow != settings->getAddVerticalSpaceAmountBelow() ||
-        horizontalSpaceAmountLeft != settings->getAddHorizontalSpaceAmountLeft()) {
+    if (!settings->getUnlimitedScrolling() &&
+        (verticalSpace != settings->getAddVerticalSpace() || horizontalSpace != settings->getAddHorizontalSpace() ||
+         verticalSpaceAmountAbove != settings->getAddVerticalSpaceAmountAbove() ||
+         horizontalSpaceAmountRight != settings->getAddHorizontalSpaceAmountRight() ||
+         verticalSpaceAmountBelow != settings->getAddVerticalSpaceAmountBelow() ||
+         horizontalSpaceAmountLeft != settings->getAddHorizontalSpaceAmountLeft())) {
+
+        double const xChange = (settings->getAddHorizontalSpace() ? settings->getAddHorizontalSpaceAmountLeft() : 0) -
+                               (horizontalSpace ? horizontalSpaceAmountLeft : 0);
+        const double yChange = (settings->getAddVerticalSpace() ? settings->getAddVerticalSpaceAmountAbove() : 0) -
+                               (verticalSpace ? verticalSpaceAmountAbove : 0);
+
         win->getXournal()->layoutPages();
-        scrollHandler->scrollToPage(getCurrentPageNo());
+        win->getLayout()->scrollRelative(xChange, yChange);
+    }
+
+    if (unlimitedScrolling != settings->getUnlimitedScrolling()) {
+        const int xUnlimited = static_cast<int>(win->getLayout()->getVisibleRect().width);
+        const int yUnlimited = static_cast<int>(win->getLayout()->getVisibleRect().height);
+        const double xChange = unlimitedScrolling ? -xUnlimited + (horizontalSpace ? horizontalSpaceAmountLeft : 0) :
+                                                    xUnlimited - (horizontalSpace ? horizontalSpaceAmountLeft : 0);
+        const double yChange = unlimitedScrolling ? -yUnlimited + (verticalSpace ? verticalSpaceAmountAbove : 0) :
+                                                    yUnlimited - (verticalSpace ? verticalSpaceAmountAbove : 0);
+
+        win->getXournal()->layoutPages();
+        win->getLayout()->scrollRelative(xChange, yChange);
     }
 
     if (stylusCursorType != settings->getStylusCursorType() || highlightPosition != settings->isHighlightPosition()) {

--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -2172,6 +2172,10 @@ void Control::showSettings() {
     int verticalSpaceAmount = settings->getAddVerticalSpaceAmount();
     bool horizontalSpace = settings->getAddHorizontalSpace();
     int horizontalSpaceAmount = settings->getAddHorizontalSpaceAmount();
+    bool verticalSpaceBelow = settings->getAddVerticalSpaceBelow();
+    int verticalSpaceAmountBelow = settings->getAddVerticalSpaceAmountBelow();
+    bool horizontalSpaceLeft = settings->getAddHorizontalSpaceLeft();
+    int horizontalSpaceAmountLeft = settings->getAddHorizontalSpaceAmountLeft();
     StylusCursorType stylusCursorType = settings->getStylusCursorType();
     bool highlightPosition = settings->isHighlightPosition();
     SidebarNumberingStyle sidebarStyle = settings->getSidebarNumberingStyle();
@@ -2185,8 +2189,12 @@ void Control::showSettings() {
     }
 
     if (verticalSpace != settings->getAddVerticalSpace() || horizontalSpace != settings->getAddHorizontalSpace() ||
+        verticalSpaceBelow != settings->getAddVerticalSpaceBelow() ||
+        horizontalSpaceLeft != settings->getAddHorizontalSpaceLeft() ||
         verticalSpaceAmount != settings->getAddVerticalSpaceAmount() ||
-        horizontalSpaceAmount != settings->getAddHorizontalSpaceAmount()) {
+        horizontalSpaceAmount != settings->getAddHorizontalSpaceAmount() ||
+        verticalSpaceAmountBelow != settings->getAddVerticalSpaceAmountBelow() ||
+        horizontalSpaceAmountLeft != settings->getAddHorizontalSpaceAmountLeft()) {
         win->getXournal()->layoutPages();
         scrollHandler->scrollToPage(getCurrentPageNo());
     }

--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -2169,12 +2169,10 @@ void Control::showSettings() {
     // take note of some settings before to compare with after
     auto selectionColor = settings->getBorderColor();
     bool verticalSpace = settings->getAddVerticalSpace();
-    int verticalSpaceAmount = settings->getAddVerticalSpaceAmount();
-    bool horizontalSpace = settings->getAddHorizontalSpace();
-    int horizontalSpaceAmount = settings->getAddHorizontalSpaceAmount();
-    bool verticalSpaceBelow = settings->getAddVerticalSpaceBelow();
+    int verticalSpaceAmountAbove = settings->getAddVerticalSpaceAmountAbove();
     int verticalSpaceAmountBelow = settings->getAddVerticalSpaceAmountBelow();
-    bool horizontalSpaceLeft = settings->getAddHorizontalSpaceLeft();
+    bool horizontalSpace = settings->getAddHorizontalSpace();
+    int horizontalSpaceAmountRight = settings->getAddHorizontalSpaceAmountRight();
     int horizontalSpaceAmountLeft = settings->getAddHorizontalSpaceAmountLeft();
     StylusCursorType stylusCursorType = settings->getStylusCursorType();
     bool highlightPosition = settings->isHighlightPosition();
@@ -2189,10 +2187,8 @@ void Control::showSettings() {
     }
 
     if (verticalSpace != settings->getAddVerticalSpace() || horizontalSpace != settings->getAddHorizontalSpace() ||
-        verticalSpaceBelow != settings->getAddVerticalSpaceBelow() ||
-        horizontalSpaceLeft != settings->getAddHorizontalSpaceLeft() ||
-        verticalSpaceAmount != settings->getAddVerticalSpaceAmount() ||
-        horizontalSpaceAmount != settings->getAddHorizontalSpaceAmount() ||
+        verticalSpaceAmountAbove != settings->getAddVerticalSpaceAmountAbove() ||
+        horizontalSpaceAmountRight != settings->getAddHorizontalSpaceAmountRight() ||
         verticalSpaceAmountBelow != settings->getAddVerticalSpaceAmountBelow() ||
         horizontalSpaceAmountLeft != settings->getAddHorizontalSpaceAmountLeft()) {
         win->getXournal()->layoutPages();

--- a/src/core/control/pagetype/PageTypeMenu.h
+++ b/src/core/control/pagetype/PageTypeMenu.h
@@ -66,13 +66,17 @@ public:
     void addApplyBackgroundButton(PageTypeApplyListener* pageTypeApplyListener, bool onlyAllMenu,
                                   ApplyPageTypeSource ptSource);
 
+    /**
+     * Create a small preview image of a specified page-type
+     */
+    static cairo_surface_t* createPreviewImage(const PageType& pt);
+
 private:
     static GtkWidget* createApplyMenuItem(const char* text);
     void initDefaultMenu();
     void addMenuEntry(const PageTypeInfo* t);
     /// @brief Select the corresponding entry. If t == nullptr, the "Copy current page background" entry is selected.
     void entrySelected(const PageTypeInfo* t);
-    cairo_surface_t* createPreviewImage(const PageType& pt);
 
 private:
     bool showSpecial;

--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -126,6 +126,8 @@ void Settings::loadDefault() {
     this->addVerticalSpaceAmountAbove = 150;
     this->addVerticalSpaceAmountBelow = 150;
 
+    this->unlimitedScrolling = false;
+
     // Drawing direction emulates modifier keys
     this->drawDirModsRadius = 50;
     this->drawDirModsEnabled = false;
@@ -538,6 +540,8 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur) {
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("addVerticalSpaceAmountBelow")) == 0) {
         this->addVerticalSpaceAmountBelow =
                 static_cast<int>(g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10));
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("unlimitedScrolling")) == 0) {
+        this->unlimitedScrolling = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("drawDirModsEnabled")) == 0) {
         this->drawDirModsEnabled = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("drawDirModsRadius")) == 0) {
@@ -1039,6 +1043,8 @@ void Settings::save() {
     SAVE_INT_PROP(addVerticalSpaceAmountAbove);
     SAVE_INT_PROP(addVerticalSpaceAmountBelow);
 
+    SAVE_BOOL_PROP(unlimitedScrolling);
+
     SAVE_BOOL_PROP(drawDirModsEnabled);
     SAVE_INT_PROP(drawDirModsRadius);
 
@@ -1324,7 +1330,6 @@ void Settings::setAddVerticalSpaceAmountAbove(int pixels) {
     }
 
     this->addVerticalSpaceAmountAbove = pixels;
-    save();
 }
 
 auto Settings::getAddVerticalSpaceAmountBelow() const -> int { return this->addVerticalSpaceAmountBelow; }
@@ -1335,7 +1340,6 @@ void Settings::setAddVerticalSpaceAmountBelow(int pixels) {
     }
 
     this->addVerticalSpaceAmountBelow = pixels;
-    save();
 }
 
 
@@ -1351,7 +1355,6 @@ void Settings::setAddHorizontalSpaceAmountRight(int pixels) {
     }
 
     this->addHorizontalSpaceAmountRight = pixels;
-    save();
 }
 
 auto Settings::getAddHorizontalSpaceAmountLeft() const -> int { return this->addHorizontalSpaceAmountLeft; }
@@ -1362,9 +1365,17 @@ void Settings::setAddHorizontalSpaceAmountLeft(int pixels) {
     }
 
     this->addHorizontalSpaceAmountLeft = pixels;
-    save();
 }
 
+auto Settings::getUnlimitedScrolling() const -> bool { return this->unlimitedScrolling; }
+
+void Settings::setUnlimitedScrolling(bool enable) {
+    if (enable == this->unlimitedScrolling) {
+        return;
+    }
+
+    this->unlimitedScrolling = enable;
+}
 
 auto Settings::getDrawDirModsEnabled() const -> bool { return this->drawDirModsEnabled; }
 

--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -120,12 +120,10 @@ void Settings::loadDefault() {
     this->autosaveEnabled = true;
 
     this->addHorizontalSpace = false;
-    this->addHorizontalSpaceAmount = 150;
-    this->addVerticalSpace = false;
-    this->addVerticalSpaceAmount = 150;
-    this->addHorizontalSpaceLeft = false;
+    this->addHorizontalSpaceAmountRight = 150;
     this->addHorizontalSpaceAmountLeft = 150;
-    this->addVerticalSpaceBelow = false;
+    this->addVerticalSpace = false;
+    this->addVerticalSpaceAmountAbove = 150;
     this->addVerticalSpaceAmountBelow = 150;
 
     // Drawing direction emulates modifier keys
@@ -517,19 +515,29 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur) {
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("addHorizontalSpace")) == 0) {
         this->addHorizontalSpace = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("addHorizontalSpaceAmount")) == 0) {
-        this->addHorizontalSpaceAmount = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
+        const int oldHorizontalAmount =
+                static_cast<int>(g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10));
+        this->addHorizontalSpaceAmountLeft = oldHorizontalAmount;
+        this->addHorizontalSpaceAmountRight = oldHorizontalAmount;
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("addHorizontalSpaceAmountRight")) == 0) {
+        this->addHorizontalSpaceAmountRight =
+                static_cast<int>(g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10));
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("addVerticalSpace")) == 0) {
         this->addVerticalSpace = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("addVerticalSpaceAmount")) == 0) {
-        this->addVerticalSpaceAmount = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
-    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("addHorizontalSpaceLeft")) == 0) {
-        this->addHorizontalSpaceLeft = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
+        const int oldVerticalAmount =
+                static_cast<int>(g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10));
+        this->addHorizontalSpaceAmountLeft = oldVerticalAmount;
+        this->addHorizontalSpaceAmountRight = oldVerticalAmount;
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("addVerticalSpaceAmountAbove")) == 0) {
+        this->addVerticalSpaceAmountAbove =
+                static_cast<int>(g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10));
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("addHorizontalSpaceAmountLeft")) == 0) {
-        this->addHorizontalSpaceAmountLeft = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
-    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("addVerticalSpaceBelow")) == 0) {
-        this->addVerticalSpaceBelow = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
+        this->addHorizontalSpaceAmountLeft =
+                static_cast<int>(g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10));
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("addVerticalSpaceAmountBelow")) == 0) {
-        this->addVerticalSpaceAmountBelow = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
+        this->addVerticalSpaceAmountBelow =
+                static_cast<int>(g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10));
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("drawDirModsEnabled")) == 0) {
         this->drawDirModsEnabled = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("drawDirModsRadius")) == 0) {
@@ -1025,12 +1033,10 @@ void Settings::save() {
     SAVE_INT_PROP(autosaveTimeout);
 
     SAVE_BOOL_PROP(addHorizontalSpace);
-    SAVE_INT_PROP(addHorizontalSpaceAmount);
-    SAVE_BOOL_PROP(addVerticalSpace);
-    SAVE_INT_PROP(addVerticalSpaceAmount);
-    SAVE_BOOL_PROP(addHorizontalSpaceLeft);
+    SAVE_INT_PROP(addHorizontalSpaceAmountRight);
     SAVE_INT_PROP(addHorizontalSpaceAmountLeft);
-    SAVE_BOOL_PROP(addVerticalSpaceBelow);
+    SAVE_BOOL_PROP(addVerticalSpace);
+    SAVE_INT_PROP(addVerticalSpaceAmountAbove);
     SAVE_INT_PROP(addVerticalSpaceAmountBelow);
 
     SAVE_BOOL_PROP(drawDirModsEnabled);
@@ -1310,20 +1316,16 @@ auto Settings::getAddVerticalSpace() const -> bool { return this->addVerticalSpa
 
 void Settings::setAddVerticalSpace(bool space) { this->addVerticalSpace = space; }
 
-auto Settings::getAddVerticalSpaceAmount() const -> int { return this->addVerticalSpaceAmount; }
+auto Settings::getAddVerticalSpaceAmountAbove() const -> int { return this->addVerticalSpaceAmountAbove; }
 
-void Settings::setAddVerticalSpaceAmount(int pixels) {
-    if (this->addVerticalSpaceAmount == pixels) {
+void Settings::setAddVerticalSpaceAmountAbove(int pixels) {
+    if (this->addVerticalSpaceAmountAbove == pixels) {
         return;
     }
 
-    this->addVerticalSpaceAmount = pixels;
+    this->addVerticalSpaceAmountAbove = pixels;
     save();
 }
-
-auto Settings::getAddVerticalSpaceBelow() const -> bool { return this->addVerticalSpaceBelow; }
-
-void Settings::setAddVerticalSpaceBelow(bool space) { this->addVerticalSpaceBelow = space; }
 
 auto Settings::getAddVerticalSpaceAmountBelow() const -> int { return this->addVerticalSpaceAmountBelow; }
 
@@ -1341,20 +1343,16 @@ auto Settings::getAddHorizontalSpace() const -> bool { return this->addHorizonta
 
 void Settings::setAddHorizontalSpace(bool space) { this->addHorizontalSpace = space; }
 
-auto Settings::getAddHorizontalSpaceAmount() const -> int { return this->addHorizontalSpaceAmount; }
+auto Settings::getAddHorizontalSpaceAmountRight() const -> int { return this->addHorizontalSpaceAmountRight; }
 
-void Settings::setAddHorizontalSpaceAmount(int pixels) {
-    if (this->addHorizontalSpaceAmount == pixels) {
+void Settings::setAddHorizontalSpaceAmountRight(int pixels) {
+    if (this->addHorizontalSpaceAmountRight == pixels) {
         return;
     }
 
-    this->addHorizontalSpaceAmount = pixels;
+    this->addHorizontalSpaceAmountRight = pixels;
     save();
 }
-
-auto Settings::getAddHorizontalSpaceLeft() const -> bool { return this->addHorizontalSpaceLeft; }
-
-void Settings::setAddHorizontalSpaceLeft(bool space) { this->addHorizontalSpaceLeft = space; }
 
 auto Settings::getAddHorizontalSpaceAmountLeft() const -> int { return this->addHorizontalSpaceAmountLeft; }
 

--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -123,6 +123,10 @@ void Settings::loadDefault() {
     this->addHorizontalSpaceAmount = 150;
     this->addVerticalSpace = false;
     this->addVerticalSpaceAmount = 150;
+    this->addHorizontalSpaceLeft = false;
+    this->addHorizontalSpaceAmountLeft = 150;
+    this->addVerticalSpaceBelow = false;
+    this->addVerticalSpaceAmountBelow = 150;
 
     // Drawing direction emulates modifier keys
     this->drawDirModsRadius = 50;
@@ -518,6 +522,14 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur) {
         this->addVerticalSpace = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("addVerticalSpaceAmount")) == 0) {
         this->addVerticalSpaceAmount = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("addHorizontalSpaceLeft")) == 0) {
+        this->addHorizontalSpaceLeft = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("addHorizontalSpaceAmountLeft")) == 0) {
+        this->addHorizontalSpaceAmountLeft = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("addVerticalSpaceBelow")) == 0) {
+        this->addVerticalSpaceBelow = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("addVerticalSpaceAmountBelow")) == 0) {
+        this->addVerticalSpaceAmountBelow = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("drawDirModsEnabled")) == 0) {
         this->drawDirModsEnabled = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("drawDirModsRadius")) == 0) {
@@ -1016,6 +1028,10 @@ void Settings::save() {
     SAVE_INT_PROP(addHorizontalSpaceAmount);
     SAVE_BOOL_PROP(addVerticalSpace);
     SAVE_INT_PROP(addVerticalSpaceAmount);
+    SAVE_BOOL_PROP(addHorizontalSpaceLeft);
+    SAVE_INT_PROP(addHorizontalSpaceAmountLeft);
+    SAVE_BOOL_PROP(addVerticalSpaceBelow);
+    SAVE_INT_PROP(addVerticalSpaceAmountBelow);
 
     SAVE_BOOL_PROP(drawDirModsEnabled);
     SAVE_INT_PROP(drawDirModsRadius);
@@ -1305,6 +1321,21 @@ void Settings::setAddVerticalSpaceAmount(int pixels) {
     save();
 }
 
+auto Settings::getAddVerticalSpaceBelow() const -> bool { return this->addVerticalSpaceBelow; }
+
+void Settings::setAddVerticalSpaceBelow(bool space) { this->addVerticalSpaceBelow = space; }
+
+auto Settings::getAddVerticalSpaceAmountBelow() const -> int { return this->addVerticalSpaceAmountBelow; }
+
+void Settings::setAddVerticalSpaceAmountBelow(int pixels) {
+    if (this->addVerticalSpaceAmountBelow == pixels) {
+        return;
+    }
+
+    this->addVerticalSpaceAmountBelow = pixels;
+    save();
+}
+
 
 auto Settings::getAddHorizontalSpace() const -> bool { return this->addHorizontalSpace; }
 
@@ -1318,6 +1349,21 @@ void Settings::setAddHorizontalSpaceAmount(int pixels) {
     }
 
     this->addHorizontalSpaceAmount = pixels;
+    save();
+}
+
+auto Settings::getAddHorizontalSpaceLeft() const -> bool { return this->addHorizontalSpaceLeft; }
+
+void Settings::setAddHorizontalSpaceLeft(bool space) { this->addHorizontalSpaceLeft = space; }
+
+auto Settings::getAddHorizontalSpaceAmountLeft() const -> int { return this->addHorizontalSpaceAmountLeft; }
+
+void Settings::setAddHorizontalSpaceAmountLeft(int pixels) {
+    if (this->addHorizontalSpaceAmountLeft == pixels) {
+        return;
+    }
+
+    this->addHorizontalSpaceAmountLeft = pixels;
     save();
 }
 

--- a/src/core/control/settings/Settings.h
+++ b/src/core/control/settings/Settings.h
@@ -279,21 +279,15 @@ public:
 
     bool getAddVerticalSpace() const;
     void setAddVerticalSpace(bool space);
-    int getAddVerticalSpaceAmount() const;
-    void setAddVerticalSpaceAmount(int pixels);
-
-    bool getAddHorizontalSpace() const;
-    void setAddHorizontalSpace(bool space);
-    int getAddHorizontalSpaceAmount() const;
-    void setAddHorizontalSpaceAmount(int pixels);
-
-    bool getAddVerticalSpaceBelow() const;
-    void setAddVerticalSpaceBelow(bool space);
+    int getAddVerticalSpaceAmountAbove() const;
+    void setAddVerticalSpaceAmountAbove(int pixels);
     int getAddVerticalSpaceAmountBelow() const;
     void setAddVerticalSpaceAmountBelow(int pixels);
 
-    bool getAddHorizontalSpaceLeft() const;
-    void setAddHorizontalSpaceLeft(bool space);
+    bool getAddHorizontalSpace() const;
+    void setAddHorizontalSpace(bool space);
+    int getAddHorizontalSpaceAmountRight() const;
+    void setAddHorizontalSpaceAmountRight(int pixels);
     int getAddHorizontalSpaceAmountLeft() const;
     void setAddHorizontalSpaceAmountLeft(int pixels);
 
@@ -869,28 +863,14 @@ private:
     bool autosaveEnabled{};
 
     /**
-     * Allow scroll outside the page display area (horizontal, right)
+     * Allow scroll outside the page display area (horizontal)
      */
     bool addHorizontalSpace{};
 
     /**
      * How much allowance to scroll outside the page display area on the right
      */
-    int addHorizontalSpaceAmount{};
-
-    /**
-     * Allow scroll outside the page display area (vertical, above)
-     */
-    bool addVerticalSpace{};
-
-    /** How much allowance to scroll outside the page display area above
-     */
-    int addVerticalSpaceAmount{};
-
-    /**
-     * Allow scroll outside the page display area (horizontal, left)
-     */
-    bool addHorizontalSpaceLeft{};
+    int addHorizontalSpaceAmountRight{};
 
     /**
      * How much allowance to scroll outside the page display area on the left
@@ -898,11 +878,17 @@ private:
     int addHorizontalSpaceAmountLeft{};
 
     /**
-     * Allow scroll outside the page display area (vertical, below)
+     * Allow scroll outside the page display area (vertical)
      */
-    bool addVerticalSpaceBelow{};
+    bool addVerticalSpace{};
 
-    /** How much allowance to scroll outside the page display area below
+    /**
+     * How much allowance to scroll outside the page display area above
+     */
+    int addVerticalSpaceAmountAbove{};
+
+    /**
+     * How much allowance to scroll outside the page display area below
      */
     int addVerticalSpaceAmountBelow{};
 

--- a/src/core/control/settings/Settings.h
+++ b/src/core/control/settings/Settings.h
@@ -291,6 +291,9 @@ public:
     int getAddHorizontalSpaceAmountLeft() const;
     void setAddHorizontalSpaceAmountLeft(int pixels);
 
+    bool getUnlimitedScrolling() const;
+    void setUnlimitedScrolling(bool enable);
+
     bool getDrawDirModsEnabled() const;
     void setDrawDirModsEnabled(bool enable);
     int getDrawDirModsRadius() const;
@@ -891,6 +894,11 @@ private:
      * How much allowance to scroll outside the page display area below
      */
     int addVerticalSpaceAmountBelow{};
+
+    /**
+     * Enables unlimited scrolling, which automatically adds maximum space to scroll outside the page
+     */
+    bool unlimitedScrolling{};
 
     /**
      * Emulate modifier keys based on initial direction of drawing tool ( for Rectangle, Ellipse etc. )

--- a/src/core/control/settings/Settings.h
+++ b/src/core/control/settings/Settings.h
@@ -287,6 +287,16 @@ public:
     int getAddHorizontalSpaceAmount() const;
     void setAddHorizontalSpaceAmount(int pixels);
 
+    bool getAddVerticalSpaceBelow() const;
+    void setAddVerticalSpaceBelow(bool space);
+    int getAddVerticalSpaceAmountBelow() const;
+    void setAddVerticalSpaceAmountBelow(int pixels);
+
+    bool getAddHorizontalSpaceLeft() const;
+    void setAddHorizontalSpaceLeft(bool space);
+    int getAddHorizontalSpaceAmountLeft() const;
+    void setAddHorizontalSpaceAmountLeft(int pixels);
+
     bool getDrawDirModsEnabled() const;
     void setDrawDirModsEnabled(bool enable);
     int getDrawDirModsRadius() const;
@@ -859,23 +869,42 @@ private:
     bool autosaveEnabled{};
 
     /**
-     * Allow scroll outside the page display area (horizontal)
+     * Allow scroll outside the page display area (horizontal, right)
      */
     bool addHorizontalSpace{};
 
     /**
-     * How much allowance to scroll outside the page display area (either side of )
+     * How much allowance to scroll outside the page display area on the right
      */
     int addHorizontalSpaceAmount{};
 
     /**
-     * Allow scroll outside the page display area (vertical)
+     * Allow scroll outside the page display area (vertical, above)
      */
     bool addVerticalSpace{};
 
-    /** How much allowance to scroll outside the page display area (above and below)
+    /** How much allowance to scroll outside the page display area above
      */
     int addVerticalSpaceAmount{};
+
+    /**
+     * Allow scroll outside the page display area (horizontal, left)
+     */
+    bool addHorizontalSpaceLeft{};
+
+    /**
+     * How much allowance to scroll outside the page display area on the left
+     */
+    int addHorizontalSpaceAmountLeft{};
+
+    /**
+     * Allow scroll outside the page display area (vertical, below)
+     */
+    bool addVerticalSpaceBelow{};
+
+    /** How much allowance to scroll outside the page display area below
+     */
+    int addVerticalSpaceAmountBelow{};
 
     /**
      * Emulate modifier keys based on initial direction of drawing tool ( for Rectangle, Ellipse etc. )

--- a/src/core/gui/Layout.cpp
+++ b/src/core/gui/Layout.cpp
@@ -184,13 +184,18 @@ void Layout::recalculate_int() const {
     }
 
     // add space around the entire page area to accommodate older Wacom tablets with limited sense area.
-    auto const vPadding = sumIf(2 * XOURNAL_PADDING,
-                                settings->getAddVerticalSpaceAmountAbove() + settings->getAddVerticalSpaceAmountBelow(),
-                                settings->getAddVerticalSpace());
+    auto const vPadding =
+            sumIf(sumIf(2 * XOURNAL_PADDING,
+                        settings->getAddVerticalSpaceAmountAbove() + settings->getAddVerticalSpaceAmountBelow(),
+                        settings->getAddVerticalSpace() && !settings->getUnlimitedScrolling()),
+                  2 * static_cast<int>(gtk_adjustment_get_page_size(scrollHandling->getVertical())),
+                  settings->getUnlimitedScrolling());
     auto const hPadding =
-            sumIf(2 * XOURNAL_PADDING,
-                  settings->getAddHorizontalSpaceAmountLeft() + settings->getAddHorizontalSpaceAmountRight(),
-                  settings->getAddHorizontalSpace());
+            sumIf(sumIf(2 * XOURNAL_PADDING,
+                        settings->getAddHorizontalSpaceAmountLeft() + settings->getAddHorizontalSpaceAmountRight(),
+                        settings->getAddHorizontalSpace() && !settings->getUnlimitedScrolling()),
+                  2 * static_cast<int>(gtk_adjustment_get_page_size(scrollHandling->getHorizontal())),
+                  settings->getUnlimitedScrolling());
 
     pc.minWidth = as_unsigned(hPadding + as_signed_strict((pc.widthCols.size() - 1) * XOURNAL_PADDING_BETWEEN));
     pc.minHeight = as_unsigned(vPadding + as_signed_strict((pc.heightRows.size() - 1) * XOURNAL_PADDING_BETWEEN));
@@ -225,10 +230,14 @@ void Layout::layoutPages(int width, int height) {
 
 
     // add space around the entire page area to accommodate older Wacom tablets with limited sense area.
-    auto const v_padding =
-            sumIf(XOURNAL_PADDING, settings->getAddVerticalSpaceAmountAbove(), settings->getAddVerticalSpace());
-    auto const h_padding =
-            sumIf(XOURNAL_PADDING, settings->getAddHorizontalSpaceAmountLeft(), settings->getAddHorizontalSpace());
+    auto const v_padding = sumIf(sumIf(XOURNAL_PADDING, settings->getAddVerticalSpaceAmountAbove(),
+                                       settings->getAddVerticalSpace() && !settings->getUnlimitedScrolling()),
+                                 static_cast<int>(gtk_adjustment_get_page_size(scrollHandling->getVertical())),
+                                 settings->getUnlimitedScrolling());
+    auto const h_padding = sumIf(sumIf(XOURNAL_PADDING, settings->getAddHorizontalSpaceAmountLeft(),
+                                       settings->getAddHorizontalSpace() && !settings->getUnlimitedScrolling()),
+                                 static_cast<int>(gtk_adjustment_get_page_size(scrollHandling->getHorizontal())),
+                                 settings->getUnlimitedScrolling());
 
     auto const centeringXBorder = (width - as_signed(pc.minWidth)) / 2;
     auto const centeringYBorder = (height - as_signed(pc.minHeight)) / 2;
@@ -314,8 +323,10 @@ auto Layout::getPaddingAbovePage(size_t pageIndex) const -> int {
     const Settings* settings = this->view->getControl()->getSettings();
 
     // User-configured padding above all pages.
-    auto const paddingAbove =
-            sumIf(XOURNAL_PADDING, settings->getAddVerticalSpaceAmountAbove(), settings->getAddVerticalSpace());
+    auto const paddingAbove = sumIf(sumIf(XOURNAL_PADDING, settings->getAddVerticalSpaceAmountAbove(),
+                                          settings->getAddVerticalSpace() && !settings->getUnlimitedScrolling()),
+                                    static_cast<int>(gtk_adjustment_get_page_size(scrollHandling->getVertical())),
+                                    settings->getUnlimitedScrolling());
 
     // (x, y) coordinate pair gives grid indicies. This handles paired pages
     // and different page layouts for us.
@@ -328,8 +339,10 @@ auto Layout::getPaddingLeftOfPage(size_t pageIndex) const -> int {
     bool isPairedPages = this->mapper.isPairedPages();
     const Settings* settings = this->view->getControl()->getSettings();
 
-    auto paddingBefore =
-            sumIf(XOURNAL_PADDING, settings->getAddHorizontalSpaceAmountLeft(), settings->getAddHorizontalSpace());
+    auto paddingBefore = sumIf(sumIf(XOURNAL_PADDING, settings->getAddHorizontalSpaceAmountLeft(),
+                                     settings->getAddHorizontalSpace() && !settings->getUnlimitedScrolling()),
+                               static_cast<int>(gtk_adjustment_get_page_size(scrollHandling->getHorizontal())),
+                               settings->getUnlimitedScrolling());
 
     auto const pageXLocation = as_signed(this->mapper.at(pageIndex).col);
 

--- a/src/core/gui/Layout.cpp
+++ b/src/core/gui/Layout.cpp
@@ -184,17 +184,16 @@ void Layout::recalculate_int() const {
     }
 
     // add space around the entire page area to accommodate older Wacom tablets with limited sense area.
-    auto const vPadding =
-            sumIf(XOURNAL_PADDING, settings->getAddVerticalSpaceAmount(), settings->getAddVerticalSpace());
-    auto const totalVPadding = sumIf(vPadding + XOURNAL_PADDING, settings->getAddVerticalSpaceAmountBelow(),
-                                     settings->getAddVerticalSpaceBelow());
+    auto const vPadding = sumIf(2 * XOURNAL_PADDING,
+                                settings->getAddVerticalSpaceAmountAbove() + settings->getAddVerticalSpaceAmountBelow(),
+                                settings->getAddVerticalSpace());
     auto const hPadding =
-            sumIf(XOURNAL_PADDING, settings->getAddHorizontalSpaceAmount(), settings->getAddHorizontalSpace());
-    auto const totalHPadding = sumIf(hPadding + XOURNAL_PADDING, settings->getAddHorizontalSpaceAmountLeft(),
-                                     settings->getAddHorizontalSpaceLeft());
+            sumIf(2 * XOURNAL_PADDING,
+                  settings->getAddHorizontalSpaceAmountLeft() + settings->getAddHorizontalSpaceAmountRight(),
+                  settings->getAddHorizontalSpace());
 
-    pc.minWidth = as_unsigned(totalHPadding + as_signed_strict((pc.widthCols.size() - 1) * XOURNAL_PADDING_BETWEEN));
-    pc.minHeight = as_unsigned(totalVPadding + as_signed_strict((pc.heightRows.size() - 1) * XOURNAL_PADDING_BETWEEN));
+    pc.minWidth = as_unsigned(hPadding + as_signed_strict((pc.widthCols.size() - 1) * XOURNAL_PADDING_BETWEEN));
+    pc.minHeight = as_unsigned(vPadding + as_signed_strict((pc.heightRows.size() - 1) * XOURNAL_PADDING_BETWEEN));
 
     pc.minWidth = floor_cast<size_t>(std::accumulate(begin(pc.widthCols), end(pc.widthCols), double(pc.minWidth)));
     pc.minHeight = floor_cast<size_t>(std::accumulate(begin(pc.heightRows), end(pc.heightRows), double(pc.minHeight)));
@@ -227,9 +226,9 @@ void Layout::layoutPages(int width, int height) {
 
     // add space around the entire page area to accommodate older Wacom tablets with limited sense area.
     auto const v_padding =
-            sumIf(XOURNAL_PADDING, settings->getAddVerticalSpaceAmount(), settings->getAddVerticalSpace());
+            sumIf(XOURNAL_PADDING, settings->getAddVerticalSpaceAmountAbove(), settings->getAddVerticalSpace());
     auto const h_padding =
-            sumIf(XOURNAL_PADDING, settings->getAddHorizontalSpaceAmount(), settings->getAddHorizontalSpace());
+            sumIf(XOURNAL_PADDING, settings->getAddHorizontalSpaceAmountLeft(), settings->getAddHorizontalSpace());
 
     auto const centeringXBorder = (width - as_signed(pc.minWidth)) / 2;
     auto const centeringYBorder = (height - as_signed(pc.minHeight)) / 2;
@@ -316,7 +315,7 @@ auto Layout::getPaddingAbovePage(size_t pageIndex) const -> int {
 
     // User-configured padding above all pages.
     auto const paddingAbove =
-            sumIf(XOURNAL_PADDING, settings->getAddVerticalSpaceAmount(), settings->getAddVerticalSpace());
+            sumIf(XOURNAL_PADDING, settings->getAddVerticalSpaceAmountAbove(), settings->getAddVerticalSpace());
 
     // (x, y) coordinate pair gives grid indicies. This handles paired pages
     // and different page layouts for us.
@@ -330,7 +329,7 @@ auto Layout::getPaddingLeftOfPage(size_t pageIndex) const -> int {
     const Settings* settings = this->view->getControl()->getSettings();
 
     auto paddingBefore =
-            sumIf(XOURNAL_PADDING, settings->getAddHorizontalSpaceAmount(), settings->getAddHorizontalSpace());
+            sumIf(XOURNAL_PADDING, settings->getAddHorizontalSpaceAmountLeft(), settings->getAddHorizontalSpace());
 
     auto const pageXLocation = as_signed(this->mapper.at(pageIndex).col);
 

--- a/src/core/gui/Layout.cpp
+++ b/src/core/gui/Layout.cpp
@@ -186,11 +186,15 @@ void Layout::recalculate_int() const {
     // add space around the entire page area to accommodate older Wacom tablets with limited sense area.
     auto const vPadding =
             sumIf(XOURNAL_PADDING, settings->getAddVerticalSpaceAmount(), settings->getAddVerticalSpace());
+    auto const totalVPadding = sumIf(vPadding + XOURNAL_PADDING, settings->getAddVerticalSpaceAmountBelow(),
+                                     settings->getAddVerticalSpaceBelow());
     auto const hPadding =
             sumIf(XOURNAL_PADDING, settings->getAddHorizontalSpaceAmount(), settings->getAddHorizontalSpace());
+    auto const totalHPadding = sumIf(hPadding + XOURNAL_PADDING, settings->getAddHorizontalSpaceAmountLeft(),
+                                     settings->getAddHorizontalSpaceLeft());
 
-    pc.minWidth = as_unsigned(2 * hPadding + as_signed_strict((pc.widthCols.size() - 1) * XOURNAL_PADDING_BETWEEN));
-    pc.minHeight = as_unsigned(2 * vPadding + as_signed_strict((pc.heightRows.size() - 1) * XOURNAL_PADDING_BETWEEN));
+    pc.minWidth = as_unsigned(totalHPadding + as_signed_strict((pc.widthCols.size() - 1) * XOURNAL_PADDING_BETWEEN));
+    pc.minHeight = as_unsigned(totalVPadding + as_signed_strict((pc.heightRows.size() - 1) * XOURNAL_PADDING_BETWEEN));
 
     pc.minWidth = floor_cast<size_t>(std::accumulate(begin(pc.widthCols), end(pc.widthCols), double(pc.minWidth)));
     pc.minHeight = floor_cast<size_t>(std::accumulate(begin(pc.heightRows), end(pc.heightRows), double(pc.minHeight)));

--- a/src/core/gui/dialog/SettingsDialog.cpp
+++ b/src/core/gui/dialog/SettingsDialog.cpp
@@ -94,6 +94,18 @@ SettingsDialog::SettingsDialog(GladeSearchpath* gladeSearchPath, Settings* setti
                      }),
                      this);
 
+    g_signal_connect(get("cbAddVerticalSpaceBelow"), "toggled",
+                     G_CALLBACK(+[](GtkToggleButton* togglebutton, SettingsDialog* self) {
+                         self->enableWithCheckbox("cbAddVerticalSpaceBelow", "spAddVerticalSpaceBelow");
+                     }),
+                     this);
+
+    g_signal_connect(get("cbAddHorizontalSpaceLeft"), "toggled",
+                     G_CALLBACK(+[](GtkToggleButton* togglebutton, SettingsDialog* self) {
+                         self->enableWithCheckbox("cbAddHorizontalSpaceLeft", "spAddHorizontalSpaceLeft");
+                     }),
+                     this);
+
     g_signal_connect(get("cbDrawDirModsEnabled"), "toggled",
                      G_CALLBACK(+[](GtkToggleButton* togglebutton, SettingsDialog* self) {
                          self->enableWithCheckbox("cbDrawDirModsEnabled", "spDrawDirModsRadius");
@@ -350,6 +362,8 @@ void SettingsDialog::load() {
     loadCheckbox("cbAutosave", settings->isAutosaveEnabled());
     loadCheckbox("cbAddVerticalSpace", settings->getAddVerticalSpace());
     loadCheckbox("cbAddHorizontalSpace", settings->getAddHorizontalSpace());
+    loadCheckbox("cbAddVerticalSpaceBelow", settings->getAddVerticalSpaceBelow());
+    loadCheckbox("cbAddHorizontalSpaceLeft", settings->getAddHorizontalSpaceLeft());
     loadCheckbox("cbDrawDirModsEnabled", settings->getDrawDirModsEnabled());
     loadCheckbox("cbStrokeFilterEnabled", settings->getStrokeFilterEnabled());
     loadCheckbox("cbDoActionOnStrokeFiltered", settings->getDoActionOnStrokeFiltered());
@@ -451,6 +465,12 @@ void SettingsDialog::load() {
 
     GtkWidget* spAddVerticalSpace = get("spAddVerticalSpace");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spAddVerticalSpace), settings->getAddVerticalSpaceAmount());
+
+    GtkWidget* spAddHorizontalSpaceLeft = get("spAddHorizontalSpaceLeft");
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(spAddHorizontalSpaceLeft), settings->getAddHorizontalSpaceAmountLeft());
+
+    GtkWidget* spAddVerticalSpaceBelow = get("spAddVerticalSpaceBelow");
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(spAddVerticalSpaceBelow), settings->getAddVerticalSpaceAmountBelow());
 
     GtkWidget* spDrawDirModsRadius = get("spDrawDirModsRadius");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spDrawDirModsRadius), settings->getDrawDirModsRadius());
@@ -571,6 +591,8 @@ void SettingsDialog::load() {
     enableWithCheckbox("cbIgnoreFirstStylusEvents", "spNumIgnoredStylusEvents");
     enableWithCheckbox("cbAddVerticalSpace", "spAddVerticalSpace");
     enableWithCheckbox("cbAddHorizontalSpace", "spAddHorizontalSpace");
+    enableWithCheckbox("cbAddVerticalSpaceBelow", "spAddVerticalSpaceBelow");
+    enableWithCheckbox("cbAddHorizontalSpaceLeft", "spAddHorizontalSpaceLeft");
     enableWithCheckbox("cbDrawDirModsEnabled", "spDrawDirModsRadius");
     enableWithCheckbox("cbStrokeFilterEnabled", "spStrokeIgnoreTime");
     enableWithCheckbox("cbStrokeFilterEnabled", "spStrokeIgnoreLength");
@@ -674,6 +696,8 @@ void SettingsDialog::save() {
     settings->setAutosaveEnabled(getCheckbox("cbAutosave"));
     settings->setAddVerticalSpace(getCheckbox("cbAddVerticalSpace"));
     settings->setAddHorizontalSpace(getCheckbox("cbAddHorizontalSpace"));
+    settings->setAddVerticalSpaceBelow(getCheckbox("cbAddVerticalSpaceBelow"));
+    settings->setAddHorizontalSpaceLeft(getCheckbox("cbAddHorizontalSpaceLeft"));
     settings->setDrawDirModsEnabled(getCheckbox("cbDrawDirModsEnabled"));
     settings->setStrokeFilterEnabled(getCheckbox("cbStrokeFilterEnabled"));
     settings->setDoActionOnStrokeFiltered(getCheckbox("cbDoActionOnStrokeFiltered"));
@@ -865,6 +889,17 @@ void SettingsDialog::save() {
     GtkWidget* spAddVerticalSpace = get("spAddVerticalSpace");
     int addVerticalSpaceAmount = static_cast<int>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(spAddVerticalSpace)));
     settings->setAddVerticalSpaceAmount(addVerticalSpaceAmount);
+
+    GtkWidget* spAddHorizontalSpaceLeft = get("spAddHorizontalSpaceLeft");
+    int addHorizontalSpaceAmountLeft =
+            static_cast<int>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(spAddHorizontalSpaceLeft)));
+    settings->setAddHorizontalSpaceAmountLeft(addHorizontalSpaceAmountLeft);
+
+    GtkWidget* spAddVerticalSpaceBelow = get("spAddVerticalSpaceBelow");
+    int addVerticalSpaceAmountBelow =
+            static_cast<int>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(spAddVerticalSpaceBelow)));
+    settings->setAddVerticalSpaceAmountBelow(addVerticalSpaceAmountBelow);
+
 
     GtkWidget* spDrawDirModsRadius = get("spDrawDirModsRadius");
     int drawDirModsRadius = static_cast<int>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(spDrawDirModsRadius)));

--- a/src/core/gui/dialog/SettingsDialog.h
+++ b/src/core/gui/dialog/SettingsDialog.h
@@ -47,7 +47,8 @@ public:
      * Set active regions
      */
     void enableWithCheckbox(const std::string& checkbox, const std::string& widget);
-    [[maybe_unused]] void disableWithCheckbox(const std::string& checkbox, const std::string& widget);
+    void disableWithCheckbox(const std::string& checkbox, const std::string& widget);
+    void enableWithEnabledCheckbox(const std::string& checkbox, const std::string& widget);
 
     /*
      * Listeners for changes to settings.

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -41,6 +41,12 @@
     <property name="step-increment">1</property>
     <property name="page-increment">10</property>
   </object>
+  <object class="GtkAdjustment" id="adjustmentHorizontalSpaceLeft">
+    <property name="upper">1000</property>
+    <property name="value">150</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
   <object class="GtkAdjustment" id="adjustmentIgnoreStylusEvents">
     <property name="lower">1</property>
     <property name="upper">1000</property>
@@ -183,6 +189,12 @@
     <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentVerticalSpace">
+    <property name="upper">1000</property>
+    <property name="value">150</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustmentVerticalSpaceBelow">
     <property name="upper">1000</property>
     <property name="value">150</property>
     <property name="step-increment">1</property>
@@ -4637,6 +4649,7 @@ This setting can make it easier to draw with touch. </property>
                                           <object class="GtkLabel" id="label37">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
+                                            <property name="ypad">2</property>
                                             <property name="label" translatable="yes">&lt;i&gt;If you add additional space beside the pages you can choose the area of the screen you would like to work on.&lt;/i&gt;</property>
                                             <property name="use-markup">True</property>
                                             <property name="wrap">True</property>
@@ -4650,7 +4663,7 @@ This setting can make it easier to draw with touch. </property>
                                           </packing>
                                         </child>
                                         <child>
-                                          <!-- n-columns=3 n-rows=3 -->
+                                          <!-- n-columns=3 n-rows=4 -->
                                           <object class="GtkGrid" id="sid139">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
@@ -4729,7 +4742,7 @@ This setting can make it easier to draw with touch. </property>
                                               <object class="GtkLabel" id="sid140">
                                                 <property name="visible">True</property>
                                                 <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">pixels</property>
+                                                <property name="label" translatable="yes">pixels above all pages</property>
                                               </object>
                                               <packing>
                                                 <property name="left-attach">2</property>
@@ -4740,7 +4753,8 @@ This setting can make it easier to draw with touch. </property>
                                               <object class="GtkLabel" id="sid141">
                                                 <property name="visible">True</property>
                                                 <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">pixels</property>
+                                                <property name="label" translatable="yes">pixels to the right</property>
+                                                <property name="xalign">2.2351741291171123e-10</property>
                                               </object>
                                               <packing>
                                                 <property name="left-attach">2</property>
@@ -4748,13 +4762,95 @@ This setting can make it easier to draw with touch. </property>
                                               </packing>
                                             </child>
                                             <child>
-                                              <placeholder/>
+                                              <object class="GtkCheckButton" id="cbAddVerticalSpaceBelow">
+                                                <property name="name">cbAddVerticalSpaceBelow</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">False</property>
+                                                <property name="xalign">0</property>
+                                                <property name="draw-indicator">True</property>
+                                                <child>
+                                                  <object class="GtkLabel" id="label5">
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">False</property>
+                                                    <property name="label" translatable="yes">Add additional vertical space of</property>
+                                                    <property name="use-markup">True</property>
+                                                  </object>
+                                                </child>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">2</property>
+                                              </packing>
                                             </child>
                                             <child>
-                                              <placeholder/>
+                                              <object class="GtkSpinButton" id="spAddVerticalSpaceBelow">
+                                                <property name="name">spAddHorizontalSpace</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="adjustment">adjustmentVerticalSpaceBelow</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">2</property>
+                                              </packing>
                                             </child>
                                             <child>
-                                              <placeholder/>
+                                              <object class="GtkSpinButton" id="spAddHorizontalSpaceLeft">
+                                                <property name="name">spAddHorizontalSpace</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="adjustment">adjustmentHorizontalSpaceLeft</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">3</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkCheckButton" id="cbAddHorizontalSpaceLeft">
+                                                <property name="name">cbAddHorizontalSpaceRight</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">False</property>
+                                                <property name="xalign">0</property>
+                                                <property name="draw-indicator">True</property>
+                                                <child>
+                                                  <object class="GtkLabel" id="label7">
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">False</property>
+                                                    <property name="label" translatable="yes">Add additional horizontal space of</property>
+                                                    <property name="use-markup">True</property>
+                                                  </object>
+                                                </child>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">3</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel" id="sid9">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">pixels to the left</property>
+                                                <property name="xalign">0</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">2</property>
+                                                <property name="top-attach">3</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel" id="sid15">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">pixels below all pages</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">2</property>
+                                                <property name="top-attach">2</property>
+                                              </packing>
                                             </child>
                                           </object>
                                           <packing>

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -35,14 +35,14 @@
     <property name="step-increment">1</property>
     <property name="page-increment">10</property>
   </object>
-  <object class="GtkAdjustment" id="adjustmentHorizontalSpace">
-    <property name="upper">1000</property>
+  <object class="GtkAdjustment" id="adjustmentHorizontalSpaceLeft">
+    <property name="upper">2000</property>
     <property name="value">150</property>
     <property name="step-increment">1</property>
     <property name="page-increment">10</property>
   </object>
-  <object class="GtkAdjustment" id="adjustmentHorizontalSpaceLeft">
-    <property name="upper">1000</property>
+  <object class="GtkAdjustment" id="adjustmentHorizontalSpaceRight">
+    <property name="upper">2000</property>
     <property name="value">150</property>
     <property name="step-increment">1</property>
     <property name="page-increment">10</property>
@@ -188,14 +188,14 @@
     <property name="step-increment">0.10</property>
     <property name="page-increment">10</property>
   </object>
-  <object class="GtkAdjustment" id="adjustmentVerticalSpace">
-    <property name="upper">1000</property>
+  <object class="GtkAdjustment" id="adjustmentVerticalSpaceAbove">
+    <property name="upper">2000</property>
     <property name="value">150</property>
     <property name="step-increment">1</property>
     <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentVerticalSpaceBelow">
-    <property name="upper">1000</property>
+    <property name="upper">2000</property>
     <property name="value">150</property>
     <property name="step-increment">1</property>
     <property name="page-increment">10</property>
@@ -4645,6 +4645,7 @@ This setting can make it easier to draw with touch. </property>
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
                                         <property name="orientation">vertical</property>
+                                        <property name="spacing">8</property>
                                         <child>
                                           <object class="GtkLabel" id="label37">
                                             <property name="visible">True</property>
@@ -4663,193 +4664,148 @@ This setting can make it easier to draw with touch. </property>
                                           </packing>
                                         </child>
                                         <child>
-                                          <!-- n-columns=3 n-rows=4 -->
-                                          <object class="GtkGrid" id="sid139">
+                                          <object class="GtkBox">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
-                                            <property name="row-spacing">5</property>
-                                            <property name="column-spacing">5</property>
+                                            <property name="spacing">20</property>
                                             <child>
-                                              <object class="GtkCheckButton" id="cbAddVerticalSpace">
-                                                <property name="name">cbAddVerticalSpace</property>
+                                              <!-- n-columns=3 n-rows=3 -->
+                                              <object class="GtkGrid">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="receives-default">False</property>
-                                                <property name="xalign">0</property>
-                                                <property name="draw-indicator">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="row-spacing">8</property>
+                                                <property name="column-spacing">5</property>
                                                 <child>
-                                                  <object class="GtkLabel" id="label38">
+                                                  <object class="GtkSpinButton" id="spAddVerticalSpaceAbove">
+                                                    <property name="name">spAddVerticalSpace</property>
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">True</property>
+                                                    <property name="valign">center</property>
+                                                    <property name="adjustment">adjustmentVerticalSpaceAbove</property>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="left-attach">1</property>
+                                                    <property name="top-attach">0</property>
+                                                  </packing>
+                                                </child>
+                                                <child>
+                                                  <object class="GtkSpinButton" id="spAddHorizontalSpaceRight">
+                                                    <property name="name">spAddHorizontalSpace</property>
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">True</property>
+                                                    <property name="valign">center</property>
+                                                    <property name="adjustment">adjustmentHorizontalSpaceRight</property>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="left-attach">2</property>
+                                                    <property name="top-attach">1</property>
+                                                  </packing>
+                                                </child>
+                                                <child>
+                                                  <object class="GtkSpinButton" id="spAddVerticalSpaceBelow">
+                                                    <property name="name">spAddHorizontalSpace</property>
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">True</property>
+                                                    <property name="valign">center</property>
+                                                    <property name="adjustment">adjustmentVerticalSpaceBelow</property>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="left-attach">1</property>
+                                                    <property name="top-attach">2</property>
+                                                  </packing>
+                                                </child>
+                                                <child>
+                                                  <object class="GtkSpinButton" id="spAddHorizontalSpaceLeft">
+                                                    <property name="name">spAddHorizontalSpace</property>
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">True</property>
+                                                    <property name="valign">center</property>
+                                                    <property name="adjustment">adjustmentHorizontalSpaceLeft</property>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="left-attach">0</property>
+                                                    <property name="top-attach">1</property>
+                                                  </packing>
+                                                </child>
+                                                <child>
+                                                  <object class="GtkBox" id="pagePreviewImage">
+                                                    <property name="name">imageBox</property>
                                                     <property name="visible">True</property>
                                                     <property name="can-focus">False</property>
-                                                    <property name="label" translatable="yes">Add additional vertical space of</property>
-                                                    <property name="use-markup">True</property>
+                                                    <property name="orientation">vertical</property>
+                                                    <child>
+                                                      <placeholder/>
+                                                    </child>
                                                   </object>
+                                                  <packing>
+                                                    <property name="left-attach">1</property>
+                                                    <property name="top-attach">1</property>
+                                                  </packing>
+                                                </child>
+                                                <child>
+                                                  <placeholder/>
+                                                </child>
+                                                <child>
+                                                  <placeholder/>
+                                                </child>
+                                                <child>
+                                                  <placeholder/>
+                                                </child>
+                                                <child>
+                                                  <placeholder/>
                                                 </child>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">0</property>
-                                                <property name="top-attach">0</property>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">0</property>
                                               </packing>
                                             </child>
                                             <child>
-                                              <object class="GtkCheckButton" id="cbAddHorizontalSpace">
-                                                <property name="name">cbAddHorizontalSpace</property>
+                                              <object class="GtkBox">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="receives-default">False</property>
-                                                <property name="xalign">0</property>
-                                                <property name="draw-indicator">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="orientation">vertical</property>
                                                 <child>
-                                                  <object class="GtkLabel" id="label39">
+                                                  <object class="GtkCheckButton" id="cbAddHorizontalSpace">
+                                                    <property name="label" translatable="yes">Add additional horizontal space</property>
+                                                    <property name="name">cbAddHorizontalSpace</property>
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
-                                                    <property name="label" translatable="yes">Add additional horizontal space of</property>
-                                                    <property name="use-markup">True</property>
-                                                    <property name="ellipsize">end</property>
+                                                    <property name="can-focus">True</property>
+                                                    <property name="receives-default">False</property>
+                                                    <property name="xalign">0</property>
+                                                    <property name="draw-indicator">True</property>
                                                   </object>
+                                                  <packing>
+                                                    <property name="expand">False</property>
+                                                    <property name="fill">True</property>
+                                                    <property name="padding">5</property>
+                                                    <property name="position">0</property>
+                                                  </packing>
+                                                </child>
+                                                <child>
+                                                  <object class="GtkCheckButton" id="cbAddVerticalSpace">
+                                                    <property name="label" translatable="yes">Add additional vertical space</property>
+                                                    <property name="name">cbAddVerticalSpace</property>
+                                                    <property name="visible">True</property>
+                                                    <property name="can-focus">True</property>
+                                                    <property name="receives-default">False</property>
+                                                    <property name="xalign">0</property>
+                                                    <property name="draw-indicator">True</property>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="expand">False</property>
+                                                    <property name="fill">True</property>
+                                                    <property name="padding">5</property>
+                                                    <property name="position">1</property>
+                                                  </packing>
                                                 </child>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">0</property>
-                                                <property name="top-attach">1</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkSpinButton" id="spAddVerticalSpace">
-                                                <property name="name">spAddVerticalSpace</property>
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="adjustment">adjustmentVerticalSpace</property>
-                                              </object>
-                                              <packing>
-                                                <property name="left-attach">1</property>
-                                                <property name="top-attach">0</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkSpinButton" id="spAddHorizontalSpace">
-                                                <property name="name">spAddHorizontalSpace</property>
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="adjustment">adjustmentHorizontalSpace</property>
-                                              </object>
-                                              <packing>
-                                                <property name="left-attach">1</property>
-                                                <property name="top-attach">1</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkLabel" id="sid140">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">pixels above all pages</property>
-                                              </object>
-                                              <packing>
-                                                <property name="left-attach">2</property>
-                                                <property name="top-attach">0</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkLabel" id="sid141">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">pixels to the right</property>
-                                                <property name="xalign">2.2351741291171123e-10</property>
-                                              </object>
-                                              <packing>
-                                                <property name="left-attach">2</property>
-                                                <property name="top-attach">1</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkCheckButton" id="cbAddVerticalSpaceBelow">
-                                                <property name="name">cbAddVerticalSpaceBelow</property>
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="receives-default">False</property>
-                                                <property name="xalign">0</property>
-                                                <property name="draw-indicator">True</property>
-                                                <child>
-                                                  <object class="GtkLabel" id="label5">
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
-                                                    <property name="label" translatable="yes">Add additional vertical space of</property>
-                                                    <property name="use-markup">True</property>
-                                                  </object>
-                                                </child>
-                                              </object>
-                                              <packing>
-                                                <property name="left-attach">0</property>
-                                                <property name="top-attach">2</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkSpinButton" id="spAddVerticalSpaceBelow">
-                                                <property name="name">spAddHorizontalSpace</property>
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="adjustment">adjustmentVerticalSpaceBelow</property>
-                                              </object>
-                                              <packing>
-                                                <property name="left-attach">1</property>
-                                                <property name="top-attach">2</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkSpinButton" id="spAddHorizontalSpaceLeft">
-                                                <property name="name">spAddHorizontalSpace</property>
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="adjustment">adjustmentHorizontalSpaceLeft</property>
-                                              </object>
-                                              <packing>
-                                                <property name="left-attach">1</property>
-                                                <property name="top-attach">3</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkCheckButton" id="cbAddHorizontalSpaceLeft">
-                                                <property name="name">cbAddHorizontalSpaceRight</property>
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="receives-default">False</property>
-                                                <property name="xalign">0</property>
-                                                <property name="draw-indicator">True</property>
-                                                <child>
-                                                  <object class="GtkLabel" id="label7">
-                                                    <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
-                                                    <property name="label" translatable="yes">Add additional horizontal space of</property>
-                                                    <property name="use-markup">True</property>
-                                                  </object>
-                                                </child>
-                                              </object>
-                                              <packing>
-                                                <property name="left-attach">0</property>
-                                                <property name="top-attach">3</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkLabel" id="sid9">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">pixels to the left</property>
-                                                <property name="xalign">0</property>
-                                              </object>
-                                              <packing>
-                                                <property name="left-attach">2</property>
-                                                <property name="top-attach">3</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkLabel" id="sid15">
-                                                <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="label" translatable="yes">pixels below all pages</property>
-                                              </object>
-                                              <packing>
-                                                <property name="left-attach">2</property>
-                                                <property name="top-attach">2</property>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="padding">8</property>
+                                                <property name="position">1</property>
                                               </packing>
                                             </child>
                                           </object>

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -4767,36 +4767,64 @@ This setting can make it easier to draw with touch. </property>
                                                 <property name="can-focus">False</property>
                                                 <property name="orientation">vertical</property>
                                                 <child>
-                                                  <object class="GtkCheckButton" id="cbAddHorizontalSpace">
-                                                    <property name="label" translatable="yes">Add additional horizontal space</property>
-                                                    <property name="name">cbAddHorizontalSpace</property>
+                                                  <object class="GtkBox">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">True</property>
-                                                    <property name="receives-default">False</property>
-                                                    <property name="xalign">0</property>
-                                                    <property name="draw-indicator">True</property>
+                                                    <property name="can-focus">False</property>
+                                                    <property name="valign">start</property>
+                                                    <property name="orientation">vertical</property>
+                                                    <child>
+                                                      <object class="GtkCheckButton" id="cbAddHorizontalSpace">
+                                                        <property name="label" translatable="yes">Add additional horizontal space</property>
+                                                        <property name="name">cbAddHorizontalSpace</property>
+                                                        <property name="visible">True</property>
+                                                        <property name="can-focus">True</property>
+                                                        <property name="receives-default">False</property>
+                                                        <property name="xalign">0</property>
+                                                        <property name="draw-indicator">True</property>
+                                                      </object>
+                                                      <packing>
+                                                        <property name="expand">False</property>
+                                                        <property name="fill">True</property>
+                                                        <property name="padding">5</property>
+                                                        <property name="position">0</property>
+                                                      </packing>
+                                                    </child>
+                                                    <child>
+                                                      <object class="GtkCheckButton" id="cbAddVerticalSpace">
+                                                        <property name="label" translatable="yes">Add additional vertical space</property>
+                                                        <property name="name">cbAddVerticalSpace</property>
+                                                        <property name="visible">True</property>
+                                                        <property name="can-focus">True</property>
+                                                        <property name="receives-default">False</property>
+                                                        <property name="xalign">0</property>
+                                                        <property name="draw-indicator">True</property>
+                                                      </object>
+                                                      <packing>
+                                                        <property name="expand">False</property>
+                                                        <property name="fill">True</property>
+                                                        <property name="padding">5</property>
+                                                        <property name="position">1</property>
+                                                      </packing>
+                                                    </child>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
                                                     <property name="fill">True</property>
-                                                    <property name="padding">5</property>
                                                     <property name="position">0</property>
                                                   </packing>
                                                 </child>
                                                 <child>
-                                                  <object class="GtkCheckButton" id="cbAddVerticalSpace">
-                                                    <property name="label" translatable="yes">Add additional vertical space</property>
-                                                    <property name="name">cbAddVerticalSpace</property>
+                                                  <object class="GtkLabel">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">True</property>
-                                                    <property name="receives-default">False</property>
-                                                    <property name="xalign">0</property>
-                                                    <property name="draw-indicator">True</property>
+                                                    <property name="can-focus">False</property>
+                                                    <property name="label" translatable="yes">&lt;i&gt;The amount is specified in pixels.&lt;/i&gt;</property>
+                                                    <property name="use-markup">True</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
                                                     <property name="fill">True</property>
-                                                    <property name="padding">5</property>
+                                                    <property name="padding">2</property>
+                                                    <property name="pack-type">end</property>
                                                     <property name="position">1</property>
                                                   </packing>
                                                 </child>

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -4806,6 +4806,35 @@ This setting can make it easier to draw with touch. </property>
                                                         <property name="position">1</property>
                                                       </packing>
                                                     </child>
+                                                    <child>
+                                                      <object class="GtkLabel">
+                                                        <property name="visible">True</property>
+                                                        <property name="can-focus">False</property>
+                                                        <property name="label" translatable="yes">&lt;i&gt;or&lt;/i&gt;</property>
+                                                        <property name="use-markup">True</property>
+                                                        <property name="xalign">0.029999999329447746</property>
+                                                      </object>
+                                                      <packing>
+                                                        <property name="expand">False</property>
+                                                        <property name="fill">True</property>
+                                                        <property name="position">2</property>
+                                                      </packing>
+                                                    </child>
+                                                    <child>
+                                                      <object class="GtkCheckButton" id="cbUnlimitedScrolling">
+                                                        <property name="label" translatable="yes">Unlimited scrolling</property>
+                                                        <property name="name">cbUnlimitedScrolling</property>
+                                                        <property name="visible">True</property>
+                                                        <property name="can-focus">True</property>
+                                                        <property name="receives-default">False</property>
+                                                        <property name="draw-indicator">True</property>
+                                                      </object>
+                                                      <packing>
+                                                        <property name="expand">False</property>
+                                                        <property name="fill">True</property>
+                                                        <property name="position">3</property>
+                                                      </packing>
+                                                    </child>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>


### PR DESCRIPTION
## Solution for FR #2300 
additional space left, right, above or below the pages can be added separately 
you can find this under 'Preferences -> Drawing Area -> Scrolling outside the page'

## this is a first trivial solution (first commit), i still plan to: 

- [x] make the user interface easier and more intuitive so that the user is able to understand the options available to them instantly
- [x] ensure adding horizontal/vertical space on both sides is still possible as easily as before 
- [x] make sure people don't need to change their settings if they have done this 
- [x] allow the user to add the space of one page (to imitate infinite scrolling) <- turned into an infinite scrolling option
- [x] ensure my logic is represented in the code and easily understandable

## main goals achieved (second commit):
- users who used the previous setting won't notice the change
- visually pleasing setting :)
 
![scroll_past_end_setting](https://github.com/xournalpp/xournalpp/assets/125290879/6aace7e9-923d-4392-8fe6-d6ba44ac19ca)

- it works really nice combined with automatically adding pages when scrolling past the last page, since you can have a lot of space there, without having to have the same space on top of all pages :D
[you don't have to try it yourself, you can watch this video!](https://github.com/xournalpp/xournalpp/assets/125290879/dcc1da68-0cbb-4bdd-a6e4-8b086bc89431)
