### PR TITLE
Update for new MacOS Gtk blob

### DIFF
--- a/azure-pipelines/steps/build_mac.yml
+++ b/azure-pipelines/steps/build_mac.yml
@@ -12,7 +12,7 @@ steps:
       sudo mkdir "${{parameters.generation_path}}"
       sudo chown $USER "${{parameters.generation_path}}"
       cd "${{parameters.generation_path}}"
-      curl -L -O https://github.com/xournalpp/xournalpp-pipeline-dependencies/raw/macos-10.15-jhbuild/gtk/gtk-bin.tar.gz.a[a-c]
+      curl -L -O https://github.com/xournalpp/xournalpp-pipeline-dependencies/raw/macos-10.15-jhbuild/gtk/gtk-bin.tar.gz.a[a-b]
       cat gtk-bin.tar.gz.* | tar -xz
     displayName: 'Unpack GTK'
   - bash: |


### PR DESCRIPTION
The new Gtk blob uses Gtk 3.24.37 and is split into only two files.