### PR TITLE
Fix cursor not immediately changing issue for vertical space tool

### DIFF
--- a/src/core/gui/XournalppCursor.cpp
+++ b/src/core/gui/XournalppCursor.cpp
@@ -307,9 +307,7 @@ void XournalppCursor::updateCursor() {
         } else if (type == TOOL_FLOATING_TOOLBOX) {
             setCursor(CRSR_DEFAULT);
         } else if (type == TOOL_VERTICAL_SPACE) {
-            if (this->mouseDown) {
-                setCursor(CRSR_SB_V_DOUBLE_ARROW);
-            }
+            setCursor(CRSR_SB_V_DOUBLE_ARROW);
         } else if (type == TOOL_SELECT_OBJECT) {
             setCursor(CRSR_DEFAULT);
         } else if (type == TOOL_PLAY_OBJECT) {


### PR DESCRIPTION
Don't know why it's needed to check if mouse button is pressed to change the cursor icon.

Fixes #4851  