### PR TITLE
Fix for scroll bug when undoing insert page

### DIFF
--- a/src/core/gui/XournalView.cpp
+++ b/src/core/gui/XournalView.cpp
@@ -579,12 +579,17 @@ void XournalView::pageChanged(size_t page) {
 }
 
 void XournalView::pageDeleted(size_t page) {
-    size_t currentPage = control->getCurrentPageNo();
+    const size_t currentPageNo = control->getCurrentPageNo();
 
-    viewPages.erase(begin(viewPages) + page);
+    viewPages.erase(begin(viewPages) + static_cast<long>(page));
 
     layoutPages();
-    control->getScrollHandler()->scrollToPage(currentPage);
+
+    if (currentPageNo > page) {
+        control->getScrollHandler()->scrollToPage(currentPageNo - 1);
+    } else {
+        control->getScrollHandler()->scrollToPage(currentPageNo);
+    }
 }
 
 auto XournalView::getTextEditor() const -> TextEditor* {


### PR DESCRIPTION
## Fix for Bug #2757 

In the case that you insert a page and then scroll further down and click undo, you will no longer be scrolled down an additional page. 
This occurred because the index of the current page decreased, since a page was deleted before it.
### Steps to reproduce old buggy behavior:
- have more then one page
- insert a page somewhere (not at the end)
- scroll to a page below the inserted page, that is not the end
- undo insert page

-> you are scrolled one page down / the page below the current page is selected
### What this Fix offers:
#### commit 1: Fix for scroll bug when undoing insert Page (fix)
- whatever page you scrolled to before undoing the inserted page is re-selected / scrolled to
- this means you are pulled to the top of whatever page you where viewing, since it is re-selected
- which was the previously intended behavior
#### commit 2: No movement when undoing insert page (improvement?)
- when undoing insert page while on another page your view doesn't change - no automatic scrolling
- (not implemented for paired pages as they shift sideways, no movement seemed more confusing)
- pro: no movement may be less intrusive and more desirable - as the user was probably viewing something on that page
- con: it is good to have some kind of way to recognize that something happened, should you somehow click the undo button without noticing 
