### PR TITLE
Add Lua API app.getImages and app.addImages

### DIFF
--- a/plugins/ImageActions/main.lua
+++ b/plugins/ImageActions/main.lua
@@ -12,8 +12,8 @@ function cb(mode)
   local images = app.getImages("selection")
   local hasVips, vips = pcall(require, "vips")
   if not hasVips then
-    app.msgbox("You need to have lua-vips and luaffifb installed and included in your Lua package path in order to use this plugin. \n" .. 
-               "See https://github.com/rolandlo/lua-vips/tree/fix-lua-5.3#installation for installation instructions.\n\n", {[1]="OK"})
+    app.openDialog("You need to have lua-vips and luaffifb installed and included in your Lua package path in order to use this plugin. \n" .. 
+               "See https://github.com/rolandlo/lua-vips/tree/fix-lua-5.3#installation for installation instructions.\n\n", {"OK"}, "", true)
     return
   end
   imdata = {}

--- a/plugins/ImageActions/main.lua
+++ b/plugins/ImageActions/main.lua
@@ -1,0 +1,50 @@
+function initUi()
+  app.registerUi({["menu"] = "Invert selected images", ["callback"] = "cb", ["mode"] = 1})
+  app.registerUi({["menu"] = "Downscale resolution of selected images by factor 0.5", ["callback"] = "cb", ["mode"] = 2})
+  app.registerUi({["menu"] = "Flip selected images horizontally", ["callback"] = "cb", ["mode"] = 3})
+  app.registerUi({["menu"] = "Flip selected images vertically", ["callback"] = "cb", ["mode"] = 4})
+  app.registerUi({["menu"] = "Rotate selected images 90 degree clockwise", ["callback"] = "cb", ["mode"] = 5})
+  app.registerUi({["menu"] = "Rotate selected images 90 degree counterclockwise", ["callback"] = "cb", ["mode"] = 6})
+  app.registerUi({["menu"] = "Make white pixels transparent", ["callback"] = "cb", ["mode"] = 7})
+end
+
+function cb(mode)
+  local images = app.getImages("selection")
+  local hasVips, vips = pcall(require, "vips")
+  if not hasVips then
+    app.msgbox("You need to have lua-vips and luaffifb installed and included in your Lua package path in order to use this plugin. \n" .. 
+               "See https://github.com/rolandlo/lua-vips/tree/fix-lua-5.3#installation for installation instructions.\n\n", {[1]="OK"})
+    return
+  end
+  imdata = {}
+  for i=1,#images do
+    im = images[i]
+    image = vips.Image.new_from_buffer(im["data"])
+    x, y, maxWidth, maxHeight=im["x"], im["y"], math.ceil(im["width"]), math.ceil(im["height"])
+    if mode == 1 then
+      image = image:invert()
+    elseif mode == 2 then
+      image = image:resize(0.5)
+    elseif mode == 3 then
+      image = image:flip("horizontal")
+    elseif mode == 4 then
+      image = image:flip("vertical")
+    elseif mode == 5 then
+      image = image:rot("d90")
+      maxWidth, maxHeight = maxHeight, maxWidth
+    elseif mode == 6 then
+      image = image:rot("d270")
+      maxWidth, maxHeight = maxHeight, maxWidth
+    elseif mode == 7 then
+      if image:bands()<4 then
+        image = image:bandjoin(255) -- add alpha channel
+      end
+      white = {240, 240, 240, 0} -- pixels are considered white, if its r,g,b values are >=240 and alpha is arbitrary
+      transparent = {0, 0, 0, 0}
+      image = image:more(white):bandand():ifthenelse(transparent, image)
+    end
+    table.insert(imdata, {data = image:write_to_buffer(".png"), x=x, y=y, maxWidth=maxWidth, maxHeight=maxHeight})
+  end
+  app.uiAction({action = "ACTION_DELETE"})
+  app.addImages({images=imdata, allowUndoRedoAction = "grouped"})
+end

--- a/plugins/ImageActions/plugin.ini
+++ b/plugins/ImageActions/plugin.ini
@@ -1,0 +1,15 @@
+[about]
+## Author / Copyright notice
+author=Roland Lötscher
+
+description=Provides different features using the Lua image API
+
+## If the plugin is packed with Xournal++, use
+## <xournalpp> then it gets the same version number
+version=<xournalpp>
+
+[default]
+enabled=false
+
+[plugin]
+mainfile=main.lua


### PR DESCRIPTION
This PR adds new API:
- app.getImages (for getting all info for the images contained either in the current layer or the current selection)
- app.addImages (for adding images to the current layer), extending upon functionality introduced in #4858

Combining these two functions it is possible to manipulate images contained in the document. In the test plugin for this PR it is currently possible to 
- invert
- downscale resolution
- flip horizontally/vertically
- rotate by 90 degrees clockwise/counterclockwise
all the images in the current selection.
- make white pixels transparent

In order to try it out, you should compile the PR (or use one of the [installers](https://github.com/xournalpp/xournalpp/pull/4884#issuecomment-1666423981) from this PR) and install the right versions of luaffifb and lua-vips as described [here](https://github.com/rolandlo/lua-vips/tree/fix-lua-5.3#installation).

*Edit*: Updated PR description (Aug 5)
*Edit*: Added make white pixels transparent