### PR TITLE
Add desktop file entry SingleMainWindow=false

### DIFF
--- a/desktop/com.github.xournalpp.xournalpp.desktop
+++ b/desktop/com.github.xournalpp.xournalpp.desktop
@@ -15,6 +15,7 @@ Keywords=tablet;Wacom;pen input;PDF Annotation;markup
 Keywords[hu]=táblagép;Wacom;tollas bevitel;PDF-megjegyzés;korrektúra
 
 Exec=xournalpp %f
+SingleMainWindow=false
 StartupWMClass=xournalpp
 Terminal=false
 StartupNotify=true


### PR DESCRIPTION
This allows creating a new window from Gnome dash
by middle-click or Ctrl+click or right-click -> "New Window". 
Compare [relevant Gnome shell code](https://github.com/GNOME/gnome-shell/blob/4b79eec45aba4755b4fb1be1b530552ac6e245cd/src/shell-app.c#L640-L714) and [desktop entry specification](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html)

Fixes #4759 
Supersedes #4764 which was not the correct solution.