### PR TITLE
Fix header includes for GCC 13

### DIFF
--- a/src/core/control/ToolHandler.cpp
+++ b/src/core/control/ToolHandler.cpp
@@ -1,7 +1,7 @@
 #include "ToolHandler.h"
 
 #include <algorithm>  // for clamp
-#include <cinttypes>  // for uint32_t
+#include <cstdint>    // for uint32_t
 #include <cstdio>     // for size_t
 #include <optional>   // for nullopt, optional
 #include <string>     // for operator==, string, basic_string

--- a/src/core/control/jobs/Scheduler.cpp
+++ b/src/core/control/jobs/Scheduler.cpp
@@ -1,7 +1,8 @@
 #include "Scheduler.h"
 
 #include <cassert>    // for assert
-#include <cinttypes>  // for PRId64, uint64_t
+#include <cinttypes>  // for PRId64
+#include <cstdint>    // for uint64_t
 
 #include "control/jobs/Job.h"  // for Job, JOB_TYPE_RENDER
 

--- a/src/core/control/settings/PageTemplateSettings.cpp
+++ b/src/core/control/settings/PageTemplateSettings.cpp
@@ -1,6 +1,7 @@
 #include "PageTemplateSettings.h"
 
-#include <cinttypes>  // for PRIx32, uint32_t
+#include <cinttypes>  // for PRIx32
+#include <cstdint>    // for uint32_t
 #include <cstdio>     // for snprintf, size_t
 #include <sstream>    // for basic_istream, strings...
 

--- a/src/core/control/tools/PdfElemSelection.h
+++ b/src/core/control/tools/PdfElemSelection.h
@@ -10,7 +10,7 @@
  */
 #pragma once
 
-#include <cinttypes>  // for uint64_t
+#include <cstdint>    // for uint64_t
 #include <string>     // for string
 #include <vector>     // for vector
 

--- a/src/core/control/xojfile/LoadHandlerHelper.cpp
+++ b/src/core/control/xojfile/LoadHandlerHelper.cpp
@@ -10,7 +10,7 @@
  */
 #include "LoadHandlerHelper.h"
 
-#include <cinttypes>  // for uint32_t
+#include <cstdint>    // for uint32_t
 #include <cstdlib>    // for strtol, strtoull
 #include <cstring>    // for strcmp, size_t, strlen
 #include <string>     // for allocator, string

--- a/src/core/control/xojfile/SaveHandler.cpp
+++ b/src/core/control/xojfile/SaveHandler.cpp
@@ -1,6 +1,7 @@
 #include "SaveHandler.h"
 
-#include <cinttypes>   // for PRIx32, uint32_t
+#include <cinttypes>   // for PRIx32
+#include <cstdint>     // for uint32_t
 #include <cstdio>      // for sprintf, size_t
 #include <filesystem>  // for exists
 

--- a/src/core/gui/PageView.cpp
+++ b/src/core/gui/PageView.cpp
@@ -2,8 +2,8 @@
 
 #include <algorithm>  // for max, find_if
 #include <cassert>    // for assert
-#include <cinttypes>  // for int64_t
 #include <cmath>      // for lround
+#include <cstdint>    // for int64_t
 #include <cstdlib>    // for size_t
 #include <iomanip>    // for operator<<, quoted
 #include <memory>     // for unique_ptr, make_...

--- a/src/core/gui/PdfFloatingToolbox.h
+++ b/src/core/gui/PdfFloatingToolbox.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cinttypes>  // for uint8_t
+#include <cstdint>    // for uint8_t
 #include <memory>     // for unique_ptr
 
 #include <gdk/gdk.h>  // for GdkRectangle

--- a/src/core/gui/dialog/SelectBackgroundColorDialog.cpp
+++ b/src/core/gui/dialog/SelectBackgroundColorDialog.cpp
@@ -1,6 +1,6 @@
 #include "SelectBackgroundColorDialog.h"
 
-#include <cinttypes>  // for uint32_t
+#include <cstdint>    // for uint32_t
 #include <string>     // for allocator
 
 #include <glib.h>  // for g_free, g_strdup_printf

--- a/src/core/gui/sidebar/Sidebar.cpp
+++ b/src/core/gui/sidebar/Sidebar.cpp
@@ -1,7 +1,7 @@
 #include "Sidebar.h"
 
 #include <cassert>    // for assert
-#include <cinttypes>  // for int64_t
+#include <cstdint>    // for int64_t
 #include <memory>     // for make_shared
 #include <string>     // for string
 

--- a/src/core/gui/widgets/SpinPageAdapter.cpp
+++ b/src/core/gui/widgets/SpinPageAdapter.cpp
@@ -1,6 +1,6 @@
 #include "SpinPageAdapter.h"
 
-#include <cinttypes>  // for uint64_t
+#include <cstdint>  // for uint64_t
 
 #include <glib-object.h>  // for g_signal_handler_disconnect, G_CALLBACK
 

--- a/src/core/model/BackgroundConfig.h
+++ b/src/core/model/BackgroundConfig.h
@@ -11,7 +11,7 @@
 
 #pragma once
 
-#include <cinttypes>  // for uint32_t
+#include <cstdint>    // for uint32_t
 #include <map>        // for map
 #include <string>     // for string
 

--- a/src/core/model/Element.cpp
+++ b/src/core/model/Element.cpp
@@ -1,8 +1,8 @@
 #include "Element.h"
 
 #include <algorithm>  // for max, min
-#include <cinttypes>  // for uint32_t
 #include <cmath>      // for ceil, floor, NAN
+#include <cstdint>    // for uint32_t
 
 #include <glib.h>  // for gint
 

--- a/src/core/model/Stroke.cpp
+++ b/src/core/model/Stroke.cpp
@@ -2,8 +2,8 @@
 
 #include <algorithm>  // for min, max, copy
 #include <cassert>    // for assert
-#include <cinttypes>  // for uint64_t
 #include <cmath>      // for abs, hypot, sqrt
+#include <cstdint>    // for uint64_t
 #include <iterator>   // for back_insert_iterator
 #include <limits>     // for numeric_limits
 #include <numeric>    // for accumulate

--- a/src/core/pdf/base/XojPdfPage.h
+++ b/src/core/pdf/base/XojPdfPage.h
@@ -11,15 +11,16 @@
 
 #pragma once
 
-#include <cinttypes>  // for uint8_t
-#include <memory>     // for shared_ptr
-#include <string>     // for string
-#include <vector>     // for vector
+#include <cstdint>  // for uint8_t
+#include <memory>   // for shared_ptr
+#include <string>   // for string
+#include <vector>   // for vector
 
-#include <glib.h> // for GURI
 #include <cairo.h>  // for cairo_region_t, cairo_t
+#include <glib.h>   // for GURI
 
 #include "util/raii/CairoWrappers.h"
+
 #include "XojPdfAction.h"
 
 class XojPdfLink;

--- a/src/core/undo/UndoRedoHandler.cpp
+++ b/src/core/undo/UndoRedoHandler.cpp
@@ -1,7 +1,8 @@
 #include "UndoRedoHandler.h"
 
 #include <algorithm>  // for find_if
-#include <cinttypes>  // for PRIu64, uint64_t
+#include <cinttypes>  // for PRIu64
+#include <cstdint>    // for uint64_t
 #include <iterator>   // for end, begin
 #include <memory>     // for unique_ptr, allocator_traits<>::value_type
 #include <utility>    // for move

--- a/src/core/view/background/OneColorBackgroundView.cpp
+++ b/src/core/view/background/OneColorBackgroundView.cpp
@@ -1,6 +1,6 @@
 #include "OneColorBackgroundView.h"
 
-#include <cinttypes>  // for uint32_t
+#include <cstdint>  // for uint32_t
 
 #include "model/BackgroundConfig.h"               // for BackgroundConfig
 #include "view/background/BackgroundView.h"       // for view

--- a/src/util/include/util/PlaceholderString.h
+++ b/src/util/include/util/PlaceholderString.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include <cinttypes>  // for int64_t
+#include <cstdint>    // for int64_t
 #include <memory>     // for unique_ptr
 #include <ostream>    // for ostream
 #include <string>     // for string

--- a/src/util/serializing/HexObjectEncoding.cpp
+++ b/src/util/serializing/HexObjectEncoding.cpp
@@ -1,6 +1,7 @@
 #include "util/serializing/HexObjectEncoding.h"
 
-#include <cinttypes>  // for uint8_t, PRIx8
+#include <cinttypes>  // for PRIx8
+#include <cstdint>    // for uint8_t
 #include <cstdio>     // for sprintf
 
 #include <glib.h>  // for g_free, g_malloc, g_string_append_len

--- a/src/util/serializing/ObjectInputStream.cpp
+++ b/src/util/serializing/ObjectInputStream.cpp
@@ -1,6 +1,6 @@
 #include "util/serializing/ObjectInputStream.h"
 
-#include <cinttypes>  // for uint32_t
+#include <cstdint>  // for uint32_t
 
 #include <glib.h>  // for g_free, g_strdup_...
 


### PR DESCRIPTION
GCC 13 is much more strict about avoiding accidental inheritance of other headers

It's now necessary to include \<cstdint\> for uint*_t types, rather than \<cinttypes\>