### PR TITLE
Disable antialias for the dots for better experience on Pinenote (Ein…

### DIFF
--- a/src/control/tools/StrokeHandler.cpp
+++ b/src/control/tools/StrokeHandler.cpp
@@ -403,6 +403,7 @@ void StrokeHandler::resetShapeRecognizer() {
 }
 
 void StrokeHandler::paintDot(const double x, const double y, const double width) const {
+    cairo_set_antialias(crMask, CAIRO_ANTIALIAS_NONE);
     cairo_set_line_cap(crMask, CAIRO_LINE_CAP_ROUND);
     cairo_set_operator(crMask, CAIRO_OPERATOR_OVER);
     cairo_set_source_rgba(crMask, 1, 1, 1, 1);


### PR DESCRIPTION
Hi,

this is a patch for use on [Pinenote EInk tablet](https://www.pine64.org/pinenote/).

It disables anti-aliasing as this degrades visual performance on EInk display which has lower refresh rate.