### PR TITLE
Fix search box not able to receive user input when Windows IME is act…

### DIFF
--- a/src/core/gui/SearchBar.cpp
+++ b/src/core/gui/SearchBar.cpp
@@ -157,8 +157,8 @@ void SearchBar::showSearchBar(bool show) {
 
     if (show) {
         GtkWidget* searchTextField = win->get("searchTextField");
-        gtk_widget_grab_focus(searchTextField);
         gtk_widget_show_all(searchBar);
+        gtk_widget_grab_focus(searchTextField);
     } else {
         gtk_widget_hide(searchBar);
         for (int i = control->getDocument()->getPageCount() - 1; i >= 0; i--) {


### PR DESCRIPTION
Fix https://github.com/xournalpp/xournalpp/issues/4936

It turns out that making the focus before showing the widget will cause IME malfunctioning.