### PR TITLE
Enhanced Image Adding & Image Frames

### DIFF
--- a/src/core/control/tools/ImageHandler.h
+++ b/src/core/control/tools/ImageHandler.h
@@ -26,15 +26,28 @@ public:
     virtual ~ImageHandler();
 
 public:
-    bool insertImage(double x, double y);
+    // todo p0mm documentation!
     // does the complete insertion based on create and add
-    bool insertImage(GFile* file, double x, double y);
+    bool insertImage(double x, double y);
     // creates the image and does automatic scaling of the image
+    std::tuple<Image*, int, int> createImage(double x, double y);
     std::tuple<Image*, int, int> createImage(GFile* file, double x, double y);
     bool addImageToDocument(Image* img, bool addUndoAction);
     // scale down (only if necessary) the image so that the it fits on the page
     // applies (potentially adjusted) width/height to the image
     void automaticScaling(Image* img, double x, double y, int width, int height);
+
+    /**
+     * inserts an image with predetermined size
+     */
+    bool insertImageWithSize(xoj::util::Rectangle<double> space);
+
+    /**
+     * scales image down to fit given space, without stretching the image
+     */
+    void scaleImageDown(Image* img, xoj::util::Rectangle<double> space);
+
+    void scaleImageUp(Image* img, xoj::util::Rectangle<double> space);
 
 private:
     Control* control;

--- a/src/core/control/tools/ImageSizeSelection.cpp
+++ b/src/core/control/tools/ImageSizeSelection.cpp
@@ -1,0 +1,20 @@
+#include "ImageSizeSelection.h"
+
+#include "util/Rectangle.h"  // for Rectangle
+
+using xoj::util::Rectangle;
+
+ImageSizeSelection::ImageSizeSelection(double x, double y): startX(x), startY(y), endX(x), endY(y) {}
+
+void ImageSizeSelection::updatePosition(double x, double y) {
+    this->endX = x;
+    this->endY = y;
+}
+
+auto ImageSizeSelection::getSelectedSpace() -> Rectangle<double> {
+    const double width = this->startX < this->endX ? this->endX - this->startX : this->startX - this->endX;
+    const double height = this->startY < this->endY ? this->endY - this->startY : this->startY - this->endY;
+    const double x = this->startX < this->endX ? this->startX : this->endX;
+    const double y = this->startY < this->endY ? this->startY : this->endY;
+    return {x, y, width, height};
+}

--- a/src/core/control/tools/ImageSizeSelection.h
+++ b/src/core/control/tools/ImageSizeSelection.h
@@ -1,0 +1,32 @@
+/*
+ * Xournal++
+ *
+ * Select a size before inserting an image
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+
+#include "model/Element.h"      // todo p0mm
+#include "model/OverlayBase.h"  // todo p0mm
+#include "util/Rectangle.h"     // for Rectangle
+
+class ImageSizeSelection: public OverlayBase {
+public:
+    ImageSizeSelection(double x, double y);
+
+    void updatePosition(double x, double y);
+
+    auto getSelectedSpace() -> xoj::util::Rectangle<double>;
+
+private:
+    double startX;
+    double startY;
+    double endX;
+    double endY;
+};

--- a/src/core/gui/PageView.h
+++ b/src/core/gui/PageView.h
@@ -32,6 +32,7 @@
 #include "LegacyRedrawable.h"  // for LegacyRedrawable
 
 class EraseHandler;
+class ImageSizeSelection;
 class InputHandler;
 class SearchControl;
 class Selection;
@@ -260,6 +261,11 @@ private:
      * The text editor
      */
     std::unique_ptr<TextEditor> textEditor;
+
+    /**
+     * For image insertion with size (selects the size)
+     */
+    std::unique_ptr<ImageSizeSelection> imageSizeSelection;
 
     /**
      * For keeping old text changes to undo!


### PR DESCRIPTION
this PR is a response to #4183!

## General Idea:
- define space image should take before choosing the image
- make adding multiple images easier to plan
- possibility to template?

## Plans:
- [ ] define space by dragging the mouse (click - drag - let go)
- [ ] have a nice visual to see what space you are choosing
- [ ] frame for image comes into existence
- [ ] its size can be adjusted
- [ ] it will remain if you save, close and open xournalpp again
- [ ] allow multiple image frames to coexist
- [ ] add image to the frame by clicking it
- [ ] give a visual so this mechanic is easily understandable (show pointer as tiny image icon while hovering over image frame)
- [ ] add image by dragging and dropping it into the frame
- [ ] give different options on whether the image is scaled up, down or stretches and fills the space
- [ ] have a default setting for these options available in the preferences 
- [ ] still keep a simple add image directly option easily available