### PR TITLE
Optionally Display Current Page Number on the Titlebar

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -390,6 +390,7 @@ void Control::updatePageNumbers(size_t page, size_t pdfPage) {
     this->sidebar->selectPageNr(page, pdfPage);
 
     this->metadata->storeMetadata(this->doc->getEvMetadataFilename(), int(page), getZoomControl()->getZoomReal());
+    this->updateWindowTitle();
 
     auto current = getCurrentPageNo();
     auto count = this->doc->getPageCount();
@@ -2695,12 +2696,17 @@ void Control::updateWindowTitle() {
         if (doc->getPdfFilepath().empty()) {
             title = _("Unsaved Document");
         } else {
+            title += ("[" + 
+                std::to_string(getCurrentPageNo() + 1) + 
+                "/" + 
+                std::to_string(doc->getPageCount()) + 
+                "]  ");
             if (undoRedo->isChanged()) {
                 title += "*";
             }
 
             if (settings->isFilepathInTitlebarShown()) {
-                title += ("[" + doc->getPdfFilepath().parent_path().u8string() + "] - " +
+                title += ( + "[" + doc->getPdfFilepath().parent_path().u8string() + "] - " +
                           doc->getPdfFilepath().filename().u8string());
             } else {
                 title += doc->getPdfFilepath().filename().u8string();

--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -2696,25 +2696,24 @@ void Control::updateWindowTitle() {
         if (doc->getPdfFilepath().empty()) {
             title = _("Unsaved Document");
         } else {
-            if (settings->isPageNumberInTitlebarShown()){
-              title += ("[" + std::to_string(getCurrentPageNo() + 1) + "/" + 
-                        std::to_string(doc->getPageCount()) +  "]  ");
+            if (settings->isPageNumberInTitlebarShown()) {
+                title += ("[" + std::to_string(getCurrentPageNo() + 1) + "/" + std::to_string(doc->getPageCount()) +
+                          "]  ");
             }
             if (undoRedo->isChanged()) {
                 title += "*";
             }
 
             if (settings->isFilepathInTitlebarShown()) {
-                title += ( + "[" + doc->getPdfFilepath().parent_path().u8string() + "] - " +
+                title += (+"[" + doc->getPdfFilepath().parent_path().u8string() + "] - " +
                           doc->getPdfFilepath().filename().u8string());
             } else {
                 title += doc->getPdfFilepath().filename().u8string();
             }
         }
     } else {
-        if (settings->isPageNumberInTitlebarShown()){
-            title += ("[" + std::to_string(getCurrentPageNo() + 1) + "/" + 
-                      std::to_string(doc->getPageCount()) +  "]  ");
+        if (settings->isPageNumberInTitlebarShown()) {
+            title += ("[" + std::to_string(getCurrentPageNo() + 1) + "/" + std::to_string(doc->getPageCount()) + "]  ");
         }
         if (undoRedo->isChanged()) {
             title += "*";

--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -390,7 +390,9 @@ void Control::updatePageNumbers(size_t page, size_t pdfPage) {
     this->sidebar->selectPageNr(page, pdfPage);
 
     this->metadata->storeMetadata(this->doc->getEvMetadataFilename(), int(page), getZoomControl()->getZoomReal());
-    this->updateWindowTitle();
+    if (settings->isPageNumberInTitlebarShown()) {
+        this->updateWindowTitle();
+    }
 
     auto current = getCurrentPageNo();
     auto count = this->doc->getPageCount();

--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -2705,7 +2705,7 @@ void Control::updateWindowTitle() {
             }
 
             if (settings->isFilepathInTitlebarShown()) {
-                title += (+"[" + doc->getPdfFilepath().parent_path().u8string() + "] - " +
+                title += ("[" + doc->getPdfFilepath().parent_path().u8string() + "] - " +
                           doc->getPdfFilepath().filename().u8string());
             } else {
                 title += doc->getPdfFilepath().filename().u8string();

--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -2696,11 +2696,10 @@ void Control::updateWindowTitle() {
         if (doc->getPdfFilepath().empty()) {
             title = _("Unsaved Document");
         } else {
-            title += ("[" + 
-                std::to_string(getCurrentPageNo() + 1) + 
-                "/" + 
-                std::to_string(doc->getPageCount()) + 
-                "]  ");
+            if (settings->isPageNumberInTitlebarShown()){
+              title += ("[" + std::to_string(getCurrentPageNo() + 1) + "/" + 
+                        std::to_string(doc->getPageCount()) +  "]  ");
+            }
             if (undoRedo->isChanged()) {
                 title += "*";
             }
@@ -2713,6 +2712,10 @@ void Control::updateWindowTitle() {
             }
         }
     } else {
+        if (settings->isPageNumberInTitlebarShown()){
+            title += ("[" + std::to_string(getCurrentPageNo() + 1) + "/" + 
+                      std::to_string(doc->getPageCount()) +  "]  ");
+        }
         if (undoRedo->isChanged()) {
             title += "*";
         }

--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -401,6 +401,8 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur) {
         this->showToolbar = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("filepathShownInTitlebar")) == 0) {
         this->filepathShownInTitlebar = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("pageNumberShownInTitlebar")) == 0) {
+        this->pageNumberShownInTitlebar = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("showSidebar")) == 0) {
         this->showSidebar = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("sidebarNumberingStyle")) == 0) {
@@ -933,6 +935,7 @@ void Settings::save() {
     SAVE_BOOL_PROP(scrollbarOnLeft);
     SAVE_BOOL_PROP(menubarVisible);
     SAVE_BOOL_PROP(filepathShownInTitlebar);
+    SAVE_BOOL_PROP(pageNumberShownInTitlebar);
     SAVE_INT_PROP(numColumns);
     SAVE_INT_PROP(numRows);
     SAVE_BOOL_PROP(viewFixedRows);
@@ -1233,6 +1236,18 @@ void Settings::setFilepathInTitlebarShown(const bool shown) {
     }
 
     this->filepathShownInTitlebar = shown;
+
+    save();
+}
+
+const bool Settings::isPageNumberInTitlebarShown() const { return this->pageNumberShownInTitlebar; }
+
+void Settings::setPageNumberInTitlebarShown(const bool shown) {
+    if (this->pageNumberShownInTitlebar == shown) {
+        return;
+    }
+
+    this->pageNumberShownInTitlebar = shown;
 
     save();
 }

--- a/src/core/control/settings/Settings.h
+++ b/src/core/control/settings/Settings.h
@@ -233,6 +233,9 @@ public:
     const bool isFilepathInTitlebarShown() const;
     void setFilepathInTitlebarShown(const bool shown);
 
+    const bool isPageNumberInTitlebarShown() const;
+    void setPageNumberInTitlebarShown(const bool shown);
+
     void setShowPairedPages(bool showPairedPages);
     bool isShowPairedPages() const;
 
@@ -693,6 +696,11 @@ private:
      * If the filepath is shown in titlebar
      */
     bool filepathShownInTitlebar{};
+
+    /**
+     * If the page number is shown in titlebar
+     */
+    bool pageNumberShownInTitlebar{};
 
     /**
      *  Hide the scrollbar

--- a/src/core/gui/dialog/SettingsDialog.cpp
+++ b/src/core/gui/dialog/SettingsDialog.cpp
@@ -555,6 +555,7 @@ void SettingsDialog::load() {
     loadCheckbox("cbPresentationGoFullscreen", goPresentationFullscreen);
     loadCheckbox("cbHideMenubarStartup", settings->isMenubarVisible());
     loadCheckbox("cbShowFilepathInTitlebar", settings->isFilepathInTitlebarShown());
+    loadCheckbox("cbShowPageNumberInTitlebar", settings->isPageNumberInTitlebarShown());
 
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(get("preloadPagesBefore")),
                               static_cast<double>(settings->getPreloadPagesBefore()));
@@ -790,6 +791,7 @@ void SettingsDialog::save() {
 
     settings->setMenubarVisible(getCheckbox("cbHideMenubarStartup"));
     settings->setFilepathInTitlebarShown(getCheckbox("cbShowFilepathInTitlebar"));
+    settings->setPageNumberInTitlebarShown(getCheckbox("cbShowPageNumberInTitlebar"));
 
     constexpr auto spinAsUint = [&](GtkSpinButton* btn) {
         int v = gtk_spin_button_get_value_as_int(btn);

--- a/src/core/gui/dialog/SettingsDialog.cpp
+++ b/src/core/gui/dialog/SettingsDialog.cpp
@@ -178,7 +178,8 @@ void SettingsDialog::initLanguageSettings() {
 }
 
 void SettingsDialog::initMouseButtonEvents(const char* hbox, int button, bool withDevice) {
-    this->buttonConfigs.emplace_back(std::make_unique<ButtonConfigGui>(getGladeSearchPath(), get(hbox), settings, button, withDevice));
+    this->buttonConfigs.emplace_back(
+            std::make_unique<ButtonConfigGui>(getGladeSearchPath(), get(hbox), settings, button, withDevice));
 }
 
 void SettingsDialog::initMouseButtonEvents() {
@@ -375,7 +376,8 @@ void SettingsDialog::load() {
     loadCheckbox("cbStabilizerEnableFinalizeStroke", settings->getStabilizerFinalizeStroke());
 
     GtkWidget* sbStabilizerBuffersize = get("sbStabilizerBuffersize");
-    gtk_spin_button_set_value(GTK_SPIN_BUTTON(sbStabilizerBuffersize), static_cast<double>(settings->getStabilizerBuffersize()));
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(sbStabilizerBuffersize),
+                              static_cast<double>(settings->getStabilizerBuffersize()));
     GtkWidget* sbStabilizerDeadzoneRadius = get("sbStabilizerDeadzoneRadius");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(sbStabilizerDeadzoneRadius), settings->getStabilizerDeadzoneRadius());
     GtkWidget* sbStabilizerDrag = get("sbStabilizerDrag");
@@ -819,7 +821,8 @@ void SettingsDialog::save() {
 
     if (getCheckbox("cbIgnoreFirstStylusEvents")) {
         GtkWidget* spNumIgnoredStylusEvents = get("spNumIgnoredStylusEvents");
-        int numIgnoredStylusEvents = static_cast<int>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(spNumIgnoredStylusEvents)));
+        int numIgnoredStylusEvents =
+                static_cast<int>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(spNumIgnoredStylusEvents)));
         settings->setIgnoredStylusEvents(numIgnoredStylusEvents);
     } else {
         settings->setIgnoredStylusEvents(0);  // This means nothing will be ignored

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -3042,6 +3042,22 @@ This setting can make it easier to draw with touch. </property>
                                                 <property name="position">2</property>
                                               </packing>
                                             </child>
+                                            <child>
+                                              <object class="GtkCheckButton" id="cbShowPageNumberInTitlebar">
+                                                <property name="label" translatable="yes">Show page number in title bar</property>
+                                                <property name="name">cbShowPageNumberInTitlebar</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">False</property>
+                                                <property name="xalign">0</property>
+                                                <property name="draw-indicator">True</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">2</property>
+                                              </packing>
+                                            </child>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>


### PR DESCRIPTION
This feature can be enabled from `Edit>Preferences>View>Show page number in title bar`. It allows the user to see the current page number in the titlebar. This comes in handy when the user has toggled off `View>Show Toolbars`, but wish to see the current page number they are in, without having to go through the trouble of toggling toolbars back on.

MuPDF has it by default, and I thought it would be a nice little feature to incorporate into Xournal++ as well.

### Toggle option:
![image](https://github.com/xournalpp/xournalpp/assets/63693789/9bf1dad3-db2a-45c4-a4c2-5e1d1915b4fc)
### Example:
![image](https://github.com/xournalpp/xournalpp/assets/63693789/91564941-7beb-46d5-9a50-5b50e5ba74db)
