### PR TITLE
Fix errorlog opening

### DIFF
--- a/src/core/control/XournalMain.cpp
+++ b/src/core/control/XournalMain.cpp
@@ -197,7 +197,7 @@ void checkForErrorlog() {
     } else if (response == OPEN_FILE) {
         Util::openFileWithDefaultApplication(errorlogPath);
     } else if (response == OPEN_DIR) {
-        Util::openFileWithFilebrowser(errorlogPath.parent_path());
+        Util::openFileWithDefaultApplication(errorlogPath.parent_path());
     } else if (response == DELETE_FILE) {
         deleteFile(errorlogPath);
     }

--- a/src/util/PathUtil.cpp
+++ b/src/util/PathUtil.cpp
@@ -156,7 +156,11 @@ void Util::openFileWithDefaultApplication(const fs::path& filename) {
 #ifdef __APPLE__
     constexpr auto const OPEN_PATTERN = "open \"{1}\"";
 #elif _WIN32  // note the underscore: without it, it's not msdn official!
-    constexpr auto const OPEN_PATTERN = "start \"{1}\"";
+    constexpr auto const OPEN_PATTERN = "start \"\" \"{1}\"";
+    /**
+     * start command requires a (possibly empty) title when there are quotes around the command
+     * https://stackoverflow.com/questions/27261692/how-do-i-use-quotes-in-cmd-start
+     */
 #else         // linux, unix, ...
     constexpr auto const OPEN_PATTERN = "xdg-open \"{1}\"";
 #endif

--- a/src/util/PathUtil.cpp
+++ b/src/util/PathUtil.cpp
@@ -170,23 +170,6 @@ void Util::openFileWithDefaultApplication(const fs::path& filename) {
     }
 }
 
-void Util::openFileWithFilebrowser(const fs::path& filename) {
-#ifdef __APPLE__
-    constexpr auto const OPEN_PATTERN = "open \"{1}\"";
-#elif _WIN32
-    constexpr auto const OPEN_PATTERN = "explorer.exe /n,/e,\"{1}\"";
-#else  // linux, unix, ...
-    constexpr auto const OPEN_PATTERN = R"(nautilus "file://{1}" || dolphin "file://{1}" || konqueror "file://{1}" &)";
-#endif
-    std::string command = FS(FORMAT_STR(OPEN_PATTERN) % Util::getEscapedPath(filename));
-    if (system(command.c_str()) != 0) {
-        std::string msg = FS(_F("File couldn't be opened. You have to do it manually:\n"
-                                "URL: {1}") %
-                             filename.u8string());
-        XojMsgBox::showErrorToUser(nullptr, msg);
-    }
-}
-
 auto Util::getGettextFilepath(const char* localeDir) -> fs::path {
     const char* gettextEnv = g_getenv("TEXTDOMAINDIR");
     // Only consider first path in environment variable

--- a/src/util/include/util/PathUtil.h
+++ b/src/util/include/util/PathUtil.h
@@ -108,7 +108,6 @@ void clearExtensions(fs::path& path, const std::string& ext = "");
 
 
 void openFileWithDefaultApplication(const fs::path& filename);
-void openFileWithFilebrowser(const fs::path& filename);
 
 [[maybe_unused]] [[nodiscard]] bool isChildOrEquivalent(fs::path const& path, fs::path const& base);
 


### PR DESCRIPTION
This PR fixes the following problems that occur when an errorlog is present:
- The errorlogs directory doesn't open for the flatpak and snap package (since `nautilus`, `dolphin` and `konqueror` cannot be opened directly; rather `xdg-open` should be used)
- The errorlogs directory and errorlogs don't open on Windows (since the `start` command must use a title when there are quotes around the filename)