### PR TITLE
Add missing double arrow preference

### DIFF
--- a/src/core/gui/dialog/ButtonConfigGui.cpp
+++ b/src/core/gui/dialog/ButtonConfigGui.cpp
@@ -134,6 +134,8 @@ ButtonConfigGui::ButtonConfigGui(GladeSearchpath* gladeSearchPath, GtkWidget* w,
     gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(this->cbDrawingType), _("Draw Ellipse"));
     // DRAWING_TYPE_ARROW
     gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(this->cbDrawingType), _("Draw Arrow"));
+    // DRAWING_TYPE_DOUBLE_ARROW
+    gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(this->cbDrawingType), _("Draw Double Arrow"));
     // DRAWING_TYPE_COORDINATE_SYSTEM
     gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(this->cbDrawingType), _("Draw coordinate system"));
     // DRAWING_TYPE_STROKE_RECOGNIZER


### PR DESCRIPTION
This also fixes an inconsistency in the Edit → Preferences → Defaults dialog where the selected drawing type does not match the effective drawing type if something below "Draw Arrow" is selected.

This issue has been known since [at least May 31](https://github.com/xournalpp/xournalpp/pull/4828#pullrequestreview-1452167801), but it unfortunately wasn't fixed prior to the 1.2.0 release.

I've tested this PR and it indeed fixes the problem, but note that I'm not familiar with the codebase nor GTK nor C++.