### PR TITLE
Install libgtksourceview-4-dev on Azure pipelines

### DIFF
--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -69,7 +69,7 @@ stages:
                   ninja-build libgtk-3-dev libpoppler-glib-dev libxml2-dev \
                   portaudio19-dev libsndfile-dev liblua5.3-dev \
                   libzip-dev gettext lsb-release librsvg2-dev help2man \
-                  libgtest-dev
+                  libgtest-dev libgtksourceview-4-dev
             displayName: 'Install dependencies'
           - template: steps/build_linux.yml
             parameters:

--- a/azure-pipelines/steps/install_deps_ubuntu.yml
+++ b/azure-pipelines/steps/install_deps_ubuntu.yml
@@ -10,6 +10,6 @@ steps:
       sudo apt-get update
       sudo apt-get install -y librsvg2-dev gcc-${{ parameters.gcc_version }} g++-${{ parameters.gcc_version }} cmake ninja-build \
         libgtk-3-dev libpoppler-glib-dev portaudio19-dev libsndfile-dev \
-        liblua5.3-dev libzip-dev gettext help2man libgtest-dev
+        liblua5.3-dev libzip-dev gettext help2man libgtest-dev libgtksourceview-4-dev
       g++ --version
     displayName: 'Install dependencies'


### PR DESCRIPTION
The release builds on Ubuntu and Debian were compiled without gtksourceview. This PR fixes this problem for future releases.