### PR TITLE
Remove PageTypeFormat::Copy

### DIFF
--- a/src/core/control/PageBackgroundChangeController.h
+++ b/src/core/control/PageBackgroundChangeController.h
@@ -35,8 +35,8 @@ public:
     ~PageBackgroundChangeController() override = default;
 
 public:
-    virtual void changeCurrentPageBackground(PageType& pageType);
-    void changeCurrentPageBackground(PageTypeInfo* info) override;
+    virtual void changeCurrentPageBackground(const PageType& pageType);
+    void changeCurrentPageBackground(const PageTypeInfo* info) override;
     void changeAllPagesBackground(const PageType& pt);
     void insertNewPage(size_t position, bool shouldScrollToPage = true);
     GtkWidget* getMenu();

--- a/src/core/control/pagetype/PageTypeHandler.h
+++ b/src/core/control/pagetype/PageTypeHandler.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <memory>
 #include <string>  // for string
 #include <vector>  // for vector
 
@@ -34,15 +35,17 @@ public:
     virtual ~PageTypeHandler();
 
 public:
-    std::vector<PageTypeInfo*>& getPageTypes();
+    const std::vector<std::unique_ptr<PageTypeInfo>>& getPageTypes();
+    const std::vector<std::unique_ptr<PageTypeInfo>>& getSpecialPageTypes();
     static PageTypeFormat getPageTypeFormatForString(const std::string& format);
     static std::string getStringForPageTypeFormat(const PageTypeFormat& format);
+    const PageTypeInfo* getInfoOn(const PageType& pt) const;
 
 private:
-    void addPageTypeInfo(std::string name, PageTypeFormat format, std::string config);
     bool parseIni(fs::path const& filepath);
     void loadFormat(GKeyFile* config, const char* group);
 
 private:
-    std::vector<PageTypeInfo*> types;
+    std::vector<std::unique_ptr<PageTypeInfo>> types;
+    std::vector<std::unique_ptr<PageTypeInfo>> specialTypes;
 };

--- a/src/core/control/pagetype/PageTypeMenu.h
+++ b/src/core/control/pagetype/PageTypeMenu.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <optional>
 #include <vector>  // for vector
 
 #include <cairo.h>    // for cairo_surface_t
@@ -25,7 +26,7 @@ class Settings;
 
 typedef struct {
     GtkWidget* entry;
-    PageTypeInfo* info;
+    const PageTypeInfo* info;
 } MenuCallbackInfo;
 
 enum class ApplyPageTypeSource {
@@ -37,7 +38,7 @@ enum class ApplyPageTypeSource {
 
 class PageTypeMenuChangeListener {
 public:
-    virtual void changeCurrentPageBackground(PageTypeInfo* info) = 0;
+    virtual void changeCurrentPageBackground(const PageTypeInfo* info) = 0;
     virtual ~PageTypeMenuChangeListener();
 };
 
@@ -52,10 +53,10 @@ public:
     PageTypeMenu(PageTypeHandler* types, Settings* settings, bool showPreview, bool showSpecial);
 
 public:
-    GtkWidget* getMenu();
-    PageType getSelected();
+    GtkWidget* getMenu() const;
+    const std::optional<PageType>& getSelected() const;
     void loadDefaultPage();
-    void setSelected(const PageType& selected);
+    void setSelected(std::optional<PageType> selected);
     void setListener(PageTypeMenuChangeListener* listener);
     void hideCopyPage();
 
@@ -68,8 +69,9 @@ public:
 private:
     static GtkWidget* createApplyMenuItem(const char* text);
     void initDefaultMenu();
-    void addMenuEntry(PageTypeInfo* t);
-    void entrySelected(PageTypeInfo* t);
+    void addMenuEntry(const PageTypeInfo* t);
+    /// @brief Select the corresponding entry. If t == nullptr, the "Copy current page background" entry is selected.
+    void entrySelected(const PageTypeInfo* t);
     cairo_surface_t* createPreviewImage(const PageType& pt);
 
 private:
@@ -80,8 +82,9 @@ private:
     Settings* settings;
 
     std::vector<MenuCallbackInfo> menuInfos;
+    GtkWidget* copyCurrentBackgroundMenuEntry = nullptr;
 
-    PageType selected;
+    std::optional<PageType> selected;
 
     bool ignoreEvents;
 

--- a/src/core/control/settings/PageTemplateSettings.cpp
+++ b/src/core/control/settings/PageTemplateSettings.cpp
@@ -45,9 +45,9 @@ void PageTemplateSettings::setBackgroundColor(Color backgroundColor) { this->bac
 
 auto PageTemplateSettings::getBackgroundType() -> PageType { return backgroundType; }
 
-auto PageTemplateSettings::getPageInsertType() -> PageType {
+auto PageTemplateSettings::getPageInsertType() -> std::optional<PageType> {
     if (copyLastPageSettings) {
-        return PageType(PageTypeFormat::Copy);
+        return std::nullopt;
     }
 
     return backgroundType;

--- a/src/core/control/settings/PageTemplateSettings.h
+++ b/src/core/control/settings/PageTemplateSettings.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <optional>
 #include <string>  // for string
 
 #include "model/PageType.h"  // for PageType
@@ -51,7 +52,7 @@ public:
     void setBackgroundColor(Color backgroundColor);
 
     PageType getBackgroundType();
-    PageType getPageInsertType();
+    std::optional<PageType> getPageInsertType();
     void setBackgroundType(const PageType& backgroundType);
 
 private:

--- a/src/core/control/xojfile/LoadHandler.cpp
+++ b/src/core/control/xojfile/LoadHandler.cpp
@@ -4,6 +4,7 @@
 #include <cmath>        // for isnan
 #include <cstdlib>      // for atoi, size_t
 #include <cstring>      // for strcmp, strlen
+#include <iterator>     // for back_inserter
 #include <memory>       // for __shared_ptr_access
 #include <regex>        // for regex_search, smatch
 #include <type_traits>  // for remove_reference<>::type
@@ -343,24 +344,6 @@ void LoadHandler::parseBgSolid() {
     const char* style = LoadHandlerHelper::getAttrib("style", false, this);
     if (style != nullptr) {
         bg.format = PageTypeHandler::getPageTypeFormatForString(style);
-    }
-
-    if (bg.format == PageTypeFormat::Copy) {
-        /*
-         * PageTypeFormat::Copy is just a placeholder for the various background related menus, indicating that the
-         * background should be copied from another page.
-         * IT SHOULD NEVER APPEAR IN AN ACTUAL PAGE MODEL OR A FORTIORI IN A SAVED FILE
-         *
-         * Due to several bugs (see e.g. https://github.com/xournalpp/xournalpp/issues/4142),
-         * it is possible for some older files to (incorrectly) contain pages with background type PageTypeFormat::Copy.
-         * Such pages were displayed as PageTypeFormat::Plain.
-         *
-         * This snippet is legacy code to recover said corrupted files.
-         */
-        g_warning("The opened page has background type PageTypeFormat::Copy, which should not happen. Converting to "
-                  "PageTypeFormat::Plain.");
-
-        bg.format = PageTypeFormat::Plain;
     }
 
     const char* config = LoadHandlerHelper::getAttrib("config", true, this);

--- a/src/core/control/xojfile/SaveHandler.cpp
+++ b/src/core/control/xojfile/SaveHandler.cpp
@@ -302,26 +302,7 @@ void SaveHandler::visitPage(XmlNode* root, PageRef p, Document* doc, int id) {
 void SaveHandler::writeSolidBackground(XmlNode* background, PageRef p) {
     background->setAttrib("type", "solid");
     background->setAttrib("color", getColorStr(p->getBackgroundColor()));
-
-    if (auto fmt = p->getBackgroundType().format; fmt == PageTypeFormat::Copy) {
-        /*
-         * PageTypeFormat::Copy is just a placeholder for the various background related menus, indicating that the
-         * background should be copied from another page.
-         * IT SHOULD NEVER APPEAR IN AN ACTUAL PAGE MODEL OR A FORTIORI IN A SAVED FILE
-         *
-         * A page with background type PageTypeFormat::Copy is unwanted.
-         * To avoid creating corrupted files, we replace the format with PageTypeFormat::Plain
-         */
-        if (!this->errorMessage.empty()) {
-            this->errorMessage += "\n";
-        }
-        this->errorMessage += _("Page type format is PageTypeFormat::Copy - converted to PageTypeFormat::Plain to "
-                                "avoid corrupted file");
-
-        background->setAttrib("style", PageTypeHandler::getStringForPageTypeFormat(PageTypeFormat::Plain));
-    } else {
-        background->setAttrib("style", PageTypeHandler::getStringForPageTypeFormat(fmt));
-    }
+    background->setAttrib("style", PageTypeHandler::getStringForPageTypeFormat(p->getBackgroundType().format));
 
     // Not compatible with Xournal, so the background needs
     // to be changed to a basic one!

--- a/src/core/gui/dialog/PageTemplateDialog.cpp
+++ b/src/core/gui/dialog/PageTemplateDialog.cpp
@@ -63,7 +63,7 @@ void PageTemplateDialog::updateDataFromModel() {
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(get("cbCopyLastPageSize")), model.isCopyLastPageSize());
 }
 
-void PageTemplateDialog::changeCurrentPageBackground(PageTypeInfo* info) {
+void PageTemplateDialog::changeCurrentPageBackground(const PageTypeInfo* info) {
     model.setBackgroundType(info->page);
 
     gtk_label_set_text(GTK_LABEL(get("lbBackgroundType")), info->name.c_str());

--- a/src/core/gui/dialog/PageTemplateDialog.h
+++ b/src/core/gui/dialog/PageTemplateDialog.h
@@ -42,7 +42,7 @@ public:
      */
     bool isSaved() const;
 
-    void changeCurrentPageBackground(PageTypeInfo* info) override;
+    void changeCurrentPageBackground(const PageTypeInfo* info) override;
 
 private:
     void showPageSizeDialog();

--- a/src/core/model/PageType.cpp
+++ b/src/core/model/PageType.cpp
@@ -17,6 +17,7 @@ PageType::~PageType() = default;
 auto PageType::operator==(const PageType& other) const -> bool {
     return this->config == other.config && this->format == other.format;
 }
+auto PageType::operator!=(const PageType& other) const -> bool { return !(*this == other); }
 
 /**
  * PDF background
@@ -32,6 +33,5 @@ auto PageType::isImagePage() const -> bool { return this->format == PageTypeForm
  * Special background
  */
 auto PageType::isSpecial() const -> bool {
-    return this->format == PageTypeFormat::Pdf || this->format == PageTypeFormat::Image ||
-           this->format == PageTypeFormat::Copy;
+    return this->format == PageTypeFormat::Pdf || this->format == PageTypeFormat::Image;
 }

--- a/src/core/model/PageType.h
+++ b/src/core/model/PageType.h
@@ -14,7 +14,7 @@
 #include <string>  // for string
 
 
-enum class PageTypeFormat { Plain, Ruled, Lined, Staves, Graph, Dotted, IsoDotted, IsoGraph, Pdf, Image, Copy };
+enum class PageTypeFormat { Plain, Ruled, Lined, Staves, Graph, Dotted, IsoDotted, IsoGraph, Pdf, Image };
 
 class PageType {
 public:
@@ -29,6 +29,7 @@ public:
      * Compare Operator
      */
     bool operator==(const PageType& other) const;
+    bool operator!=(const PageType& other) const;
 
     /**
      * PDF background

--- a/src/core/view/background/BackgroundView.cpp
+++ b/src/core/view/background/BackgroundView.cpp
@@ -77,9 +77,6 @@ auto BackgroundView::createForPage(PageRef page, BackgroundFlags bgFlags, PdfCac
                     return std::make_unique<PdfBackgroundView>(width, height, page->getPdfPageNr(), pdfCache);
                 }
                 break;
-            case PageTypeFormat::Copy:
-                g_warning("BackgroundView::createForPage for 'Copy' page type");
-                return nullptr;
             default:
                 g_warning("BackgroundView::createForPage unknown type: %d\n", static_cast<int>(pt.format));
                 return nullptr;


### PR DESCRIPTION
  This placeholder value was really just that. This PR replaces all
  occurences of a PageType instance with format ::Copy by an std::nullopt.
  In every place where a PageType could have format ::Copy, the PageType
  is replaced by an std::optional<PageType> (this only happens in
  dialogs and menus).

This was formerly part of #4508. It has been split of to ease the reviewing process.
This is ready for review.