### PR TITLE
used deletion function in execInUiThread + c++17 comp. in CairoWrappers

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -69,7 +69,7 @@ endif()
 
 if (WIN32)
   # generate .ico from .png
-  find_package(ImageMagick REQUIRED COMPONENTS convert)
+  find_package(ImageMagick REQUIRED COMPONENTS magick)
   set (ICON_SIZES 16 32 48 256)
   foreach (SIZE IN LISTS ICON_SIZES)
     set (RESIZED_ICON ${PROJECT_BINARY_DIR}/xournalpp-icon-${SIZE}.png)
@@ -82,7 +82,7 @@ if (WIN32)
   endforeach()
   add_custom_command (
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/win32/xournalpp.ico
-                COMMAND convert ${ICON_DEPS} ${CMAKE_CURRENT_BINARY_DIR}/win32/xournalpp.ico
+                COMMAND magick convert ${ICON_DEPS} ${CMAKE_CURRENT_BINARY_DIR}/win32/xournalpp.ico
                 DEPENDS ${ICON_DEPS}
   )
   unset(ICON_SIZES)

--- a/src/util/Util.cpp
+++ b/src/util/Util.cpp
@@ -31,8 +31,6 @@ struct CallbackUiData {
  */
 static auto execInUiThreadCallback(CallbackUiData* cb) -> bool {
     cb->callback();
-
-    delete cb;
     // Do not call again
     return false;
 }
@@ -45,7 +43,8 @@ static auto execInUiThreadCallback(CallbackUiData* cb) -> bool {
 void Util::execInUiThread(std::function<void()>&& callback, gint priority) {
     // Note: nullptr = GDestroyNotify notify.
     gdk_threads_add_idle_full(priority, reinterpret_cast<GSourceFunc>(execInUiThreadCallback),
-                              new CallbackUiData(std::move(callback)), nullptr);
+                              new CallbackUiData(std::move(callback)),
+                              [](void* data) { delete static_cast<CallbackUiData*>(data); });
 }
 
 void Util::cairo_set_source_rgbi(cairo_t* cr, Color color, double alpha) {

--- a/src/util/include/util/raii/CairoWrappers.h
+++ b/src/util/include/util/raii/CairoWrappers.h
@@ -24,22 +24,22 @@ inline namespace raii {
 namespace specialization {
 class CairoHandler {
 public:
-    constexpr static auto ref = cairo_reference;
-    constexpr static auto unref = cairo_destroy;
+    constexpr static auto ref = [](cairo_t* cr) { return cairo_reference(cr); };
+    constexpr static auto unref = [](cairo_t* cr) { cairo_destroy(cr); };
     constexpr static auto adopt = identity<cairo_t>;
 };
 
 class CairoSurfaceHandler {
 public:
-    constexpr static auto ref = cairo_surface_reference;
-    constexpr static auto unref = cairo_surface_destroy;
+    constexpr static auto ref = [](cairo_surface_t* cs) { return cairo_surface_reference(cs); };
+    constexpr static auto unref = [](cairo_surface_t* cs) { cairo_surface_destroy(cs); };
     constexpr static auto adopt = identity<cairo_surface_t>;
 };
 
 class CairoRegionHandler {
 public:
-    constexpr static auto ref = cairo_region_reference;
-    constexpr static auto unref = cairo_region_destroy;
+    constexpr static auto ref = [](cairo_region_t* cr) { return cairo_region_reference(cr); };
+    constexpr static auto unref = [](cairo_region_t* cr) { cairo_region_destroy(cr); };
     constexpr static auto adopt = identity<cairo_region_t>;
 };
 };  // namespace specialization


### PR DESCRIPTION
 - `execInUiThread` was UB in case of MT (explicitly Windows+MSVC)
 - `CairoWrappers` specialisations were incompatible to c++17 (function pointers are not constexpr.)