### PR TITLE
Refactor sidebar to use vector+iterator instead of list+pointer

### DIFF
--- a/src/core/gui/sidebar/Sidebar.h
+++ b/src/core/gui/sidebar/Sidebar.h
@@ -12,7 +12,8 @@
 #pragma once
 
 #include <cstddef>  // for size_t
-#include <list>     // for list
+#include <memory>   // for unique_ptr
+#include <vector>   // for vector
 
 #include <gtk/gtk.h>  // for GtkWidget, Gtk...
 
@@ -32,7 +33,7 @@ public:
 
 private:
     void initPages(GtkWidget* sidebarContents, GladeGui* gui);
-    void addPage(AbstractSidebarPage* page);
+    void addPage(std::unique_ptr<AbstractSidebarPage> page);
 
     // SidebarToolbarActionListener
 public:
@@ -104,7 +105,7 @@ private:
     /**
      * The sidebar pages
      */
-    std::list<AbstractSidebarPage*> pages;
+    std::vector<std::unique_ptr<AbstractSidebarPage>> pages;
 
     /**
      * The Toolbar with the pages
@@ -124,7 +125,7 @@ private:
     /**
      * Current active page
      */
-    AbstractSidebarPage* currentPage = nullptr;
+    size_t currentPageIdx{0};
 
     /**
      * The sidebarContents widget


### PR DESCRIPTION
The advantage over the former approach of using a std::list is the random access and the fast calculation of indices. And using an iterator over a pointer is the more modern way of cpp for this case. We also can rapidly calculate the index of the current page via std::distance.

The downside of using a std::vector is that insertion might be slow (if the vector needs to be copied), but as there are only a few pages and we can preallocate space for the vector this should be no huge disadvantage.

The big downside of using an iterator over a pointer is iterator invalidation. But as pages isn't exposed to the outside, we can ensude in Sidebar.cpp that on each possible iterator invalidation, the iterator is refreshed.
Also when using a pointer we would need to refresh the pointer on e.g. insertion into the std::vector because probably the vector got copied to another location at this point.

See https://github.com/xournalpp/xournalpp/issues/4394 for the motivation behind this change (implement a `getSidebarPageNo`).

Please also consider the doubts in this [comment](https://github.com/xournalpp/xournalpp/issues/4394#issuecomment-1533196776) as well as my [response](https://github.com/xournalpp/xournalpp/issues/4394#issuecomment-1533575506) when reviewing this.