### PR TITLE
fix the casing of the parameters of getStrokes (2)

### DIFF
--- a/src/core/plugin/luapi_application.h
+++ b/src/core/plugin/luapi_application.h
@@ -909,7 +909,7 @@ static int applib_getStrokes(lua_State* L) {
     lua_settop(L, 1);
     luaL_checktype(L, 1, LUA_TSTRING);
 
-    if (type == "Layer") {
+    if (type == "layer") {
         auto sel = control->getWindow()->getXournal()->getSelection();
         if (sel) {
             control->clearSelection();  // otherwise strokes in the selection won't be recognized


### PR DESCRIPTION
Fix https://github.com/xournalpp/xournalpp/pull/4832 once again. Spelling mistake got reintroduced in https://github.com/xournalpp/xournalpp/pull/4837.

Especially for the PRs which branch of the master before this fixup got included, we need to be careful not to reintroduce this spelling mistake again. Namely these are (as far as I found some):
- https://github.com/xournalpp/xournalpp/pull/5029
- https://github.com/xournalpp/xournalpp/pull/4884