### PR TITLE
Add space between variable and "}}" for pipeline variables

### DIFF
--- a/azure-pipelines/steps/build_linux.yml
+++ b/azure-pipelines/steps/build_linux.yml
@@ -13,11 +13,11 @@ steps:
   - bash: |
       export CXX=g++-${{ parameters.gcc_version }}
       export CC=gcc-${{ parameters.gcc_version }}
-      cmake -GNinja .. -DCMAKE_BUILD_TYPE=${{ parameters.build_type}} ${{ parameters.cmake_flags }}
+      cmake -GNinja .. -DCMAKE_BUILD_TYPE=${{ parameters.build_type }} ${{ parameters.cmake_flags }}
       # Make sure pot is up to date with sources (maybe translation pipeline is currently running)
       cmake --build . --target pot
       cmake --build . --target translations
       # Build Xournal++
-      cmake --build . ${{ parameters.cmake_commands}}
+      cmake --build . ${{ parameters.cmake_commands }}
     workingDirectory: ./build
     displayName: 'Build Xournal++'


### PR DESCRIPTION
I don't know if this was the issue. `RelWithDebInfo` defines NDEBUG and I could not find code, which overrides this behavior.
