### PR TITLE
Feature lua add getSidebarPageNo/setSidebarPageNo

### DIFF
--- a/plugins/LayerActions/main.lua
+++ b/plugins/LayerActions/main.lua
@@ -16,7 +16,7 @@ function clone()
     app.msgbox("No next page. ", {[1] = "OK"})
     return
   end
-  
+
   local bgNextPage = docStructure["pages"][nextPage]["pageTypeFormat"]
   if bgNextPage ~= ":pdf" then
     app.msgbox("Next page has no pdf background. ", {[1] = "OK"})
@@ -32,11 +32,16 @@ function clone()
     if res == 1 then
       return
     end
-  end   
+  end
 
   -- Copy the page, change its background to the background of the next pdf page and delete the old page without cloned layers
+  local sidebarPage = app.getSidebarPageNo()
+  app.setSidebarPageNo(2)
   app.sidebarAction("COPY");
+  app.setSidebarPageNo(sidebarPage)
+
   app.changeBackgroundPdfPageNr(nextPdfPage, false);
+  app.refreshPage()
   app.uiAction({["action"]="ACTION_GOTO_NEXT"})
   app.uiAction({["action"]="ACTION_DELETE_PAGE"})
   if currentPage < numPages -1 then
@@ -53,7 +58,7 @@ function hide()
     app.setCurrentPage(i)
     app.setCurrentLayer(1, true)  -- makes background layer and layer 1 visible and all other layers invisible
   end
-  
+
   app.setCurrentPage(page)
 end
 
@@ -61,12 +66,12 @@ function add()
   local docStructure = app.getDocumentStructure()
   local numPages = #docStructure["pages"]
   local page = docStructure["currentPage"]
-  
+
   for i=1, numPages do
     app.setCurrentPage(i)
     app.layerAction("ACTION_GOTO_TOP_LAYER")
-    app.layerAction("ACTION_NEW_LAYER")  
+    app.layerAction("ACTION_NEW_LAYER")
   end
-  
+
   app.setCurrentPage(page)
 end

--- a/src/core/gui/sidebar/Sidebar.cpp
+++ b/src/core/gui/sidebar/Sidebar.cpp
@@ -140,6 +140,10 @@ void Sidebar::selectPageNr(size_t page, size_t pdfPage) {
     }
 }
 
+size_t Sidebar::getNumberOfPages() { return this->pages.size(); }
+
+size_t Sidebar::getSelectedPage() { return this->currentPageIdx; }
+
 void Sidebar::setSelectedPage(size_t page) {
     this->visiblePage = nullptr;
 

--- a/src/core/gui/sidebar/Sidebar.h
+++ b/src/core/gui/sidebar/Sidebar.h
@@ -48,7 +48,6 @@ public:
      */
     void layout();
 
-
     /**
      * A page was selected, so also select this page in the sidebar
      */
@@ -86,6 +85,16 @@ public:
      * should be added to the document.
      */
     void askInsertPdfPage(size_t pdfPage);
+
+    /**
+     * Get how many pages are contained in this sidebar
+     */
+    size_t getNumberOfPages();
+
+    /**
+     * Get index of the currently selected page
+     */
+    size_t getSelectedPage();
 
 public:
     // DocumentListener interface


### PR DESCRIPTION
Adds two lua api functions to set and get the index of the currently active page of the sidebar.  This now is possible due to #5030 and will fix #4394 since now we can
- obtain the currently active page
- set the sidebar into the state needed for the sidebar action
- reset the sidebar to the state it was before calling this function

Maybe it would be nice to be able to work with strings instead of just the indices, but I'm not sure about this (and it would make things much harder)

TODOs:
- [x] write api documentation in the comments