### PR TITLE
Add options to disable the audio system for audio recordings

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -109,7 +109,7 @@
 
 using std::string;
 
-Control::Control(GApplication* gtkApp, GladeSearchpath* gladeSearchPath): gtkApp(gtkApp) {
+Control::Control(GApplication* gtkApp, GladeSearchpath* gladeSearchPath, bool disableAudio): gtkApp(gtkApp) {
     this->undoRedo = new UndoRedoHandler(this);
     this->undoRedo->addUndoRedoListener(this);
     this->isBlocking = false;
@@ -132,7 +132,8 @@ Control::Control(GApplication* gtkApp, GladeSearchpath* gladeSearchPath): gtkApp
     this->pageTypes = new PageTypeHandler(gladeSearchPath);
     this->newPageType = std::make_unique<PageTypeMenu>(this->pageTypes, settings, true, true);
 
-    this->audioController = new AudioController(this->settings, this);
+    this->audioController =
+            (disableAudio || this->settings->isAudioDisabled()) ? nullptr : new AudioController(this->settings, this);
 
     this->scrollHandler = new ScrollHandler(this);
 
@@ -1001,6 +1002,10 @@ void Control::actionPerformed(ActionType type, ActionGroup group, GtkToolButton*
 
         case ACTION_AUDIO_RECORD: {
             bool result = false;
+            if (!audioController) {
+                g_warning("Audio has been disabled");
+                return;
+            }
             if (enabled) {
                 result = audioController->startRecording();
             } else {
@@ -1019,6 +1024,10 @@ void Control::actionPerformed(ActionType type, ActionGroup group, GtkToolButton*
         }
 
         case ACTION_AUDIO_PAUSE_PLAYBACK:
+            if (!audioController) {
+                g_warning("Audio has been disabled");
+                return;
+            }
             if (enabled) {
                 this->getAudioController()->pausePlayback();
             } else {
@@ -1027,14 +1036,29 @@ void Control::actionPerformed(ActionType type, ActionGroup group, GtkToolButton*
             break;
 
         case ACTION_AUDIO_SEEK_FORWARDS:
+            if (!audioController) {
+                g_warning("Audio has been disabled");
+                return;
+            }
+
             this->getAudioController()->seekForwards();
             break;
 
         case ACTION_AUDIO_SEEK_BACKWARDS:
+            if (!audioController) {
+                g_warning("Audio has been disabled");
+                return;
+            }
+
             this->getAudioController()->seekBackwards();
             break;
 
         case ACTION_AUDIO_STOP_PLAYBACK:
+            if (!audioController) {
+                g_warning("Audio has been disabled");
+                return;
+            }
+
             this->getAudioController()->stopPlayback();
             break;
 
@@ -2784,7 +2808,9 @@ void Control::quit(bool allowCancel) {
         return;
     }
 
-    audioController->stopRecording();
+    if (audioController) {
+        audioController->stopRecording();
+    }
     this->scheduler->lock();
     this->scheduler->removeAllJobs();
     this->scheduler->unlock();

--- a/src/core/control/Control.h
+++ b/src/core/control/Control.h
@@ -75,7 +75,7 @@ class Control:
         public ClipboardListener,
         public ProgressListener {
 public:
-    Control(GApplication* gtkApp, GladeSearchpath* gladeSearchPath);
+    Control(GApplication* gtkApp, GladeSearchpath* gladeSearchPath, bool disableAudio);
     Control(Control const&) = delete;
     Control(Control&&) = delete;
     auto operator=(Control const&) -> Control& = delete;

--- a/src/core/control/XournalMain.cpp
+++ b/src/core/control/XournalMain.cpp
@@ -346,6 +346,7 @@ struct XournalMainPrivate {
     gboolean exportNoBackground = false;
     gboolean exportNoRuling = false;
     gboolean progressiveMode = false;
+    gboolean disableAudio = false;
     std::unique_ptr<GladeSearchpath> gladePath;
     std::unique_ptr<Control> control;
     std::unique_ptr<MainWindow> win;
@@ -452,7 +453,7 @@ void on_startup(GApplication* application, XMPtr app_data) {
     initResourcePath(app_data->gladePath.get(), "ui/about.glade");
     initResourcePath(app_data->gladePath.get(), "ui/xournalpp.css", false);
 
-    app_data->control = std::make_unique<Control>(application, app_data->gladePath.get());
+    app_data->control = std::make_unique<Control>(application, app_data->gladePath.get(), app_data->disableAudio);
 
     // Set up icons
     {
@@ -641,6 +642,8 @@ auto XournalMain::run(int argc, char** argv) -> int {
                                        "<input>", nullptr},
                           GOptionEntry{"version", 0, 0, G_OPTION_ARG_NONE, &app_data.showVersion,
                                        _("Get version of xournalpp"), nullptr},
+                          GOptionEntry{"disable-audio", 0, 0, G_OPTION_ARG_NONE, &app_data.disableAudio,
+                                       _("Disable audio for this session"), nullptr},
                           GOptionEntry{nullptr}};  // Must be terminated by a nullptr. See gtk doc
     g_application_add_main_option_entries(G_APPLICATION(app), options.data());
 

--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -116,6 +116,7 @@ void Settings::loadDefault() {
     this->useStockIcons = false;
     this->scrollbarHideType = SCROLLBAR_HIDE_NONE;
     this->disableScrollbarFadeout = false;
+    this->disableAudio = false;
 
     // Set this for autosave frequency in minutes.
     this->autosaveTimeout = 3;
@@ -550,6 +551,8 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur) {
         }
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("disableScrollbarFadeout")) == 0) {
         this->disableScrollbarFadeout = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("disableAudio")) == 0) {
+        this->disableAudio = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("audioSampleRate")) == 0) {
         this->audioSampleRate = tempg_ascii_strtod(reinterpret_cast<const char*>(value), nullptr);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("audioGain")) == 0) {
@@ -978,6 +981,7 @@ void Settings::save() {
     SAVE_BOOL_PROP(useStockIcons);
 
     SAVE_BOOL_PROP(disableScrollbarFadeout);
+    SAVE_BOOL_PROP(disableAudio);
 
     if (this->scrollbarHideType == SCROLLBAR_HIDE_BOTH) {
         xmlNode = saveProperty("scrollbarHideType", "both", root);
@@ -2233,6 +2237,16 @@ void Settings::setScrollbarFadeoutDisabled(bool disable) {
         return;
     }
     disableScrollbarFadeout = disable;
+    save();
+}
+
+auto Settings::isAudioDisabled() const -> bool { return disableAudio; }
+
+void Settings::setAudioDisabled(bool disable) {
+    if (disableAudio == disable) {
+        return;
+    }
+    disableAudio = disable;
     save();
 }
 

--- a/src/core/control/settings/Settings.h
+++ b/src/core/control/settings/Settings.h
@@ -346,6 +346,9 @@ public:
     bool isScrollbarFadeoutDisabled() const;
     void setScrollbarFadeoutDisabled(bool disable);
 
+    bool isAudioDisabled() const;
+    void setAudioDisabled(bool disable);
+
     std::string const& getDefaultSaveName() const;
     void setDefaultSaveName(const std::string& name);
 
@@ -703,6 +706,11 @@ private:
      * Disable scrollbar fade out (overlay scrolling)
      */
     bool disableScrollbarFadeout{};
+
+    /**
+     * Disable the audio system
+     */
+    bool disableAudio{};
 
     /**
      *  The selected Toolbar name

--- a/src/core/control/tools/InputHandler.cpp
+++ b/src/core/control/tools/InputHandler.cpp
@@ -33,9 +33,9 @@ auto InputHandler::createStroke(Control* control) -> std::unique_ptr<Stroke> {
     if (h->getToolType() == TOOL_PEN) {
         s->setToolType(StrokeTool::PEN);
 
-        if (control->getAudioController()->isRecording()) {
-            fs::path audioFilename = control->getAudioController()->getAudioFilename();
-            size_t sttime = control->getAudioController()->getStartTime();
+        if (auto* audioController = control->getAudioController(); audioController && audioController->isRecording()) {
+            fs::path audioFilename = audioController->getAudioFilename();
+            size_t sttime = audioController->getStartTime();
             size_t milliseconds = ((g_get_monotonic_time() / 1000) - sttime);
             s->setTimestamp(milliseconds);
             s->setAudioFilename(audioFilename);

--- a/src/core/gui/MainWindow.cpp
+++ b/src/core/gui/MainWindow.cpp
@@ -605,7 +605,7 @@ void MainWindow::updateToolbarMenu() {
 void MainWindow::createToolbar() {
     toolbarSelected(control->getSettings()->getSelectedToolbar());
 
-    if (!this->control->getAudioController()->isPlaying()) {
+    if (auto* audioController = this->control->getAudioController(); audioController && !audioController->isPlaying()) {
         this->getToolMenuHandler()->disableAudioPlaybackButtons();
     }
 

--- a/src/core/gui/PageViewFindObjectHelper.h
+++ b/src/core/gui/PageViewFindObjectHelper.h
@@ -170,8 +170,12 @@ protected:
                     // Assume path exists
                     fn = path / fn;
                 }
-                auto* ac = view->getXournal()->getControl()->getAudioController();
-                bool success = ac->startPlayback(fn, (unsigned int)ts);
+                auto* audioController = view->getXournal()->getControl()->getAudioController();
+                if (!audioController) {
+                    g_warning("Audio has been disabled");
+                    return false;
+                }
+                bool success = audioController->startPlayback(fn, (unsigned int)ts);
                 playbackStatus = {success, std::move(fn)};
                 return success;
             }

--- a/src/core/gui/toolbarMenubar/ToolMenuHandler.cpp
+++ b/src/core/gui/toolbarMenubar/ToolMenuHandler.cpp
@@ -154,6 +154,12 @@ void ToolMenuHandler::load(ToolbarData* d, GtkWidget* toolbar, const char* toolb
                     name = "DRAW_ELLIPSE";
                 }
 
+                if (!this->control->getAudioController() &&
+                    (name == "AUDIO_RECORDING" || name == "AUDIO_SEEK_BACKWARDS" || name == "AUDIO_PAUSE_PLAYBACK" ||
+                     name == "AUDIO_STOP_PLAYBACK" || name == "AUDIO_SEEK_FORWARDS" || name == "PLAY_OBJECT")) {
+                    continue;
+                }
+
                 if (name == "SEPARATOR") {
                     GtkToolItem* it = gtk_separator_tool_item_new();
                     gtk_widget_show(GTK_WIDGET(it));
@@ -252,6 +258,10 @@ void ToolMenuHandler::load(ToolbarData* d, GtkWidget* toolbar, const char* toolb
         gtk_widget_hide(toolbar);
     } else {
         gtk_widget_show(toolbar);
+    }
+
+    if (!this->control->getAudioController()) {
+        hideAudioMenuItems();
     }
 }
 
@@ -597,8 +607,8 @@ void ToolMenuHandler::initToolItems() {
      * aka. COLOR_SELECT
      */
     addToolItem(new ColorToolItem(listener, toolHandler, this->parent, NamedColor{}, true));
-
-    addToolItem(new ToolSelectCombocontrol(this, listener, "SELECT"));
+    bool hideAudio = !this->control->getAudioController();
+    addToolItem(new ToolSelectCombocontrol(this, listener, "SELECT", hideAudio));
     addToolItem(new ToolDrawCombocontrol(this, listener, "DRAW"));
     addToolItem(new ToolPdfCombocontrol(this, listener, "PDF_TOOL"));
 
@@ -681,6 +691,15 @@ void ToolMenuHandler::enableAudioPlaybackButtons() {
     gtk_widget_set_sensitive(GTK_WIDGET(gui->get("menuAudioStopPlayback")), true);
     gtk_widget_set_sensitive(GTK_WIDGET(gui->get("menuAudioSeekForwards")), true);
     gtk_widget_set_sensitive(GTK_WIDGET(gui->get("menuAudioSeekBackwards")), true);
+}
+
+void ToolMenuHandler::hideAudioMenuItems() {
+    gtk_widget_hide(GTK_WIDGET(gui->get("menuAudioRecord")));
+    gtk_widget_hide(GTK_WIDGET(gui->get("menuAudioPausePlayback")));
+    gtk_widget_hide(GTK_WIDGET(gui->get("menuAudioStopPlayback")));
+    gtk_widget_hide(GTK_WIDGET(gui->get("menuAudioSeekForwards")));
+    gtk_widget_hide(GTK_WIDGET(gui->get("menuAudioSeekBackwards")));
+    gtk_widget_hide(GTK_WIDGET(gui->get("menuToolsPlayObject")));
 }
 
 void ToolMenuHandler::setAudioPlaybackPaused(bool paused) {

--- a/src/core/gui/toolbarMenubar/ToolMenuHandler.h
+++ b/src/core/gui/toolbarMenubar/ToolMenuHandler.h
@@ -102,6 +102,8 @@ public:
 
     void enableAudioPlaybackButtons();
 
+    void hideAudioMenuItems();
+
     void setAudioPlaybackPaused(bool paused);
     std::string iconName(const char* icon);
 

--- a/src/core/gui/toolbarMenubar/ToolSelectCombocontrol.cpp
+++ b/src/core/gui/toolbarMenubar/ToolSelectCombocontrol.cpp
@@ -14,7 +14,8 @@ class ActionHandler;
 
 using std::string;
 
-ToolSelectCombocontrol::ToolSelectCombocontrol(ToolMenuHandler* toolMenuHandler, ActionHandler* handler, string id):
+ToolSelectCombocontrol::ToolSelectCombocontrol(ToolMenuHandler* toolMenuHandler, ActionHandler* handler, string id,
+                                               bool hideAudio):
         ToolButton(handler, std::move(id), ACTION_TOOL_SELECT_RECT, GROUP_TOOL, true,
                    toolMenuHandler->iconName("combo-selection"), _("Selection Combo")),
         toolMenuHandler(toolMenuHandler),
@@ -24,8 +25,9 @@ ToolSelectCombocontrol::ToolSelectCombocontrol(ToolMenuHandler* toolMenuHandler,
     addMenuitem(_("Select Multi-Layer Rectangle"), toolMenuHandler->iconName("select-multilayer-rect"), ACTION_TOOL_SELECT_MULTILAYER_RECT, GROUP_TOOL);
     addMenuitem(_("Select Multi-Layer Region"), toolMenuHandler->iconName("select-multilayer-lasso"), ACTION_TOOL_SELECT_MULTILAYER_REGION, GROUP_TOOL);
     addMenuitem(_("Select Object"), toolMenuHandler->iconName("object-select"), ACTION_TOOL_SELECT_OBJECT, GROUP_TOOL);
-    addMenuitem(_("Play Object"), toolMenuHandler->iconName("object-play"), ACTION_TOOL_PLAY_OBJECT, GROUP_TOOL);
-
+    if (!hideAudio) {
+        addMenuitem(_("Play Object"), toolMenuHandler->iconName("object-play"), ACTION_TOOL_PLAY_OBJECT, GROUP_TOOL);
+    }
     setPopupMenu(popup);
 }
 

--- a/src/core/gui/toolbarMenubar/ToolSelectCombocontrol.h
+++ b/src/core/gui/toolbarMenubar/ToolSelectCombocontrol.h
@@ -25,7 +25,7 @@ class ActionHandler;
 
 class ToolSelectCombocontrol: public ToolButton {
 public:
-    ToolSelectCombocontrol(ToolMenuHandler* toolMenuHandler, ActionHandler* handler, std::string id);
+    ToolSelectCombocontrol(ToolMenuHandler* toolMenuHandler, ActionHandler* handler, std::string id, bool hideAudio);
     ~ToolSelectCombocontrol() override;
 
 public:

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -5846,6 +5846,77 @@ Set this to 0% to always re-render on zoom.</property>
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
                                 <child>
+                                  <object class="GtkAlignment">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="left-padding">12</property>
+                                    <child>
+                                      <object class="GtkAlignment">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <child>
+                                          <object class="GtkBox">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="orientation">vertical</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">&lt;i&gt;
+Using the checkbox the audio system can be disabled or enabled for future sessions (restart required). 
+Disabling audio for a single session can be achieved using the &lt;tt&gt;--disable-audio&lt;/tt&gt; flag on the command line.
+&lt;/i&gt;</property>
+                                                <property name="use-markup">True</property>
+                                                <property name="wrap">True</property>
+                                                <property name="xalign">0</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkCheckButton" id="cbDisableAudio">
+                                                <property name="label" translatable="yes">Disable Audio</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">False</property>
+                                                <property name="draw-indicator">True</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">1</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label">
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">Enable or Disable Audio</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkFrame" id="sidAudio1">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
+                                <child>
                                   <object class="GtkAlignment" id="sid170">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
@@ -5948,11 +6019,11 @@ Set this to 0% to always re-render on zoom.</property>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">0</property>
+                                <property name="position">1</property>
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkFrame" id="sid173">
+                              <object class="GtkFrame" id="sidAudio2">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
@@ -6075,11 +6146,11 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">1</property>
+                                <property name="position">2</property>
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkFrame" id="sid178">
+                              <object class="GtkFrame" id="sidAudio3">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
@@ -6185,11 +6256,11 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">2</property>
+                                <property name="position">3</property>
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkFrame" id="sid1">
+                              <object class="GtkFrame" id="sidAudio4">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.009999999776482582</property>
@@ -6272,11 +6343,11 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">3</property>
+                                <property name="position">4</property>
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkLabel" id="sid182">
+                              <object class="GtkLabel" id="sidAudioLbl">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
                                 <property name="label" translatable="yes">&lt;i&gt;Changes take only effect on new recordings and playbacks.&lt;/i&gt;</property>
@@ -6287,7 +6358,7 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">4</property>
+                                <property name="position">5</property>
                               </packing>
                             </child>
                           </object>


### PR DESCRIPTION
For one session the audio system can be disabled from the command line using the --disable-audio flag This option is particularly useful for troubleshooting crashes on startup. For future sessions the audio system can be disabled from the preferences by enabling the "Disable audio" checkbox.