### PR TITLE
Preliminary cleanup before porting PageType-related menus and dialogs to gtk4

### DIFF
--- a/src/core/control/pagetype/PageTypeMenu.cpp
+++ b/src/core/control/pagetype/PageTypeMenu.cpp
@@ -9,6 +9,7 @@
 
 #include "control/settings/PageTemplateSettings.h"  // for PageTemplateSettings
 #include "control/settings/Settings.h"              // for Settings
+#include "gui/CreatePreviewImage.h"                 // for CreatePreviewImage
 #include "util/Assert.h"                            // or xoj_assert
 #include "util/Color.h"                             // for Color
 #include "util/i18n.h"                              // for _
@@ -45,42 +46,13 @@ void PageTypeMenu::loadDefaultPage() {
     setSelected(model.getPageInsertType());
 }
 
-auto PageTypeMenu::createPreviewImage(const PageType& pt) -> cairo_surface_t* {
-    const int previewWidth = 100;
-    const int previewHeight = 141;
-    const double zoom = 0.5;
-
-    cairo_surface_t* surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, previewWidth, previewHeight);
-    cairo_t* cr = cairo_create(surface);
-    cairo_scale(cr, zoom, zoom);
-
-    auto bgView = xoj::view::BackgroundView::createRuled(previewWidth / zoom, previewHeight / zoom, Colors::white,
-                                                         pt, 2.0);
-    bgView->draw(cr);
-
-    cairo_identity_matrix(cr);
-
-    cairo_set_line_width(cr, 2);
-    cairo_set_source_rgb(cr, 0.8, 0.8, 0.8);
-    cairo_move_to(cr, 0, 0);
-    cairo_line_to(cr, previewWidth, 0);
-    cairo_line_to(cr, previewWidth, previewHeight);
-    cairo_line_to(cr, 0, previewHeight);
-    cairo_line_to(cr, 0, 0);
-    cairo_stroke(cr);
-
-    cairo_destroy(cr);
-    return surface;
-}
-
 void PageTypeMenu::addMenuEntry(const PageTypeInfo* t) {
     bool special = t == nullptr || t->page.isSpecial();
     bool showImg = !special && showPreview;
 
     GtkWidget* entry = nullptr;
     if (showImg) {
-        xoj::util::raii::CairoSurfaceSPtr img(createPreviewImage(t->page), xoj::util::adopt);
-        GtkWidget* preview = gtk_image_new_from_surface(img.get());
+        GtkWidget* preview = xoj::helper::createPreviewImage(t->page);
         entry = gtk_check_menu_item_new();
 
         GtkWidget* box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 6);

--- a/src/core/control/pagetype/PageTypeMenu.h
+++ b/src/core/control/pagetype/PageTypeMenu.h
@@ -66,11 +66,6 @@ public:
     void addApplyBackgroundButton(PageTypeApplyListener* pageTypeApplyListener, bool onlyAllMenu,
                                   ApplyPageTypeSource ptSource);
 
-    /**
-     * Create a small preview image of a specified page-type
-     */
-    static cairo_surface_t* createPreviewImage(const PageType& pt);
-
 private:
     static GtkWidget* createApplyMenuItem(const char* text);
     void initDefaultMenu();

--- a/src/core/gui/CreatePreviewImage.cpp
+++ b/src/core/gui/CreatePreviewImage.cpp
@@ -1,0 +1,39 @@
+#include "CreatePreviewImage.h"
+
+#include "model/PageType.h"  // for PageType
+#include "util/Color.h"      // for Color
+#include "util/raii/CairoWrappers.h"
+#include "util/raii/GObjectSPtr.h"
+#include "view/background/BackgroundView.h"  // for BackgroundView
+
+namespace xoj::helper {
+auto createPreviewImage(const PageType& pt) -> GtkWidget* {
+    const double zoom = 0.5;
+
+    xoj::util::CairoSurfaceSPtr surface(cairo_image_surface_create(CAIRO_FORMAT_ARGB32, PREVIEW_WIDTH, PREVIEW_HEIGHT),
+                                        xoj::util::adopt);
+    xoj::util::CairoSPtr crSPtr(cairo_create(surface.get()), xoj::util::adopt);
+    auto cr = crSPtr.get();
+
+    cairo_scale(cr, zoom, zoom);
+
+    auto bgView = xoj::view::BackgroundView::createRuled(PREVIEW_WIDTH / zoom, PREVIEW_HEIGHT / zoom, Colors::white, pt,
+                                                         1. / zoom);
+    bgView->draw(cr);
+
+    cairo_identity_matrix(cr);
+
+    cairo_set_line_width(cr, 2);
+    cairo_set_source_rgb(cr, 0.8, 0.8, 0.8);
+    cairo_move_to(cr, 0, 0);
+    cairo_line_to(cr, PREVIEW_WIDTH, 0);
+    cairo_line_to(cr, PREVIEW_WIDTH, PREVIEW_HEIGHT);
+    cairo_line_to(cr, 0, PREVIEW_HEIGHT);
+    cairo_line_to(cr, 0, 0);
+    cairo_stroke(cr);
+
+    xoj::util::GObjectSPtr<GdkPixbuf> pixbuf(
+            gdk_pixbuf_get_from_surface(surface.get(), 0, 0, PREVIEW_WIDTH, PREVIEW_HEIGHT), xoj::util::adopt);
+    return gtk_image_new_from_pixbuf(pixbuf.get());
+}
+};  // namespace xoj::helper

--- a/src/core/gui/CreatePreviewImage.h
+++ b/src/core/gui/CreatePreviewImage.h
@@ -1,0 +1,26 @@
+/*
+ * Xournal++
+ *
+ * Helper function
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+#include <gtk/gtk.h>  // for GtkWidget
+
+class PageType;
+
+namespace xoj::helper {
+constexpr auto PREVIEW_WIDTH = 100;
+constexpr auto PREVIEW_HEIGHT = 141;
+/**
+ * @brief Create a GtkImage containing a miniature of the given (standard) page type
+ *      The returned widget is a floating ref.
+ */
+auto createPreviewImage(const PageType& pt) -> GtkWidget*;
+};  // namespace xoj::helper

--- a/src/core/gui/dialog/SettingsDialog.cpp
+++ b/src/core/gui/dialog/SettingsDialog.cpp
@@ -10,10 +10,10 @@
 #include "control/AudioController.h"             // for AudioController
 #include "control/Control.h"                     // for Control
 #include "control/DeviceListHelper.h"            // for getDeviceList, Input...
-#include "control/pagetype/PageTypeMenu.h"       // for createPreviewImage
 #include "control/settings/Settings.h"           // for Settings, SElement
 #include "control/settings/SettingsEnums.h"      // for STYLUS_CURSOR_ARROW
 #include "control/tools/StrokeStabilizerEnum.h"  // for AveragingMethod, Pre...
+#include "gui/CreatePreviewImage.h"              // for createPreviewImage
 #include "gui/MainWindow.h"                      // for MainWindow
 #include "gui/XournalView.h"                     // for XournalView
 #include "gui/widgets/ZoomCallib.h"              // for zoomcallib_new, zoom...
@@ -54,9 +54,7 @@ SettingsDialog::SettingsDialog(GladeSearchpath* gladeSearchPath, Settings* setti
     gtk_box_append(GTK_BOX(builder.get("zoomVBox")), callib);
     gtk_widget_show(callib);
 
-    const xoj::util::raii::CairoSurfaceSPtr img(PageTypeMenu::createPreviewImage(PageType{PageTypeFormat::Lined}),
-                                                xoj::util::adopt);
-    GtkWidget* preview = gtk_image_new_from_surface(img.get());
+    GtkWidget* preview = xoj::helper::createPreviewImage(PageType{PageTypeFormat::Lined});
     gtk_box_append(GTK_BOX(builder.get("pagePreviewImage")), preview);
     gtk_widget_show(preview);
 

--- a/src/core/gui/toolbarMenubar/AbstractToolItem.cpp
+++ b/src/core/gui/toolbarMenubar/AbstractToolItem.cpp
@@ -12,13 +12,7 @@ class ActionHandler;
 AbstractToolItem::AbstractToolItem(std::string id, ActionHandler* handler, ActionType type, GtkWidget* menuitem):
         AbstractItem(std::move(id), handler, type, menuitem) {}
 
-AbstractToolItem::~AbstractToolItem() {
-    this->item = nullptr;
-    if (this->popupMenu) {
-        g_object_unref(G_OBJECT(this->popupMenu));
-        this->popupMenu = nullptr;
-    }
-}
+AbstractToolItem::~AbstractToolItem() = default;
 
 auto AbstractToolItem::getItem() const -> GtkToolItem* {
     return this->item;
@@ -87,16 +81,7 @@ auto AbstractToolItem::createTmpItem(bool horizontal) -> GtkToolItem* {
     return item;
 }
 
-void AbstractToolItem::setPopupMenu(GtkWidget* popupMenu) {
-    if (this->popupMenu) {
-        g_object_unref(this->popupMenu);
-    }
-    if (popupMenu) {
-        g_object_ref(popupMenu);
-    }
-
-    this->popupMenu = popupMenu;
-}
+void AbstractToolItem::setPopupMenu(GtkWidget* popupMenu) { this->popupMenu.reset(popupMenu, xoj::util::refsink); }
 
 auto AbstractToolItem::isUsed() const -> bool { return used; }
 

--- a/src/core/gui/toolbarMenubar/AbstractToolItem.h
+++ b/src/core/gui/toolbarMenubar/AbstractToolItem.h
@@ -18,6 +18,7 @@
 
 #include "enums/ActionGroup.enum.h"  // for ActionGroup
 #include "enums/ActionType.enum.h"   // for ActionType
+#include "util/raii/GObjectSPtr.h"
 
 #include "AbstractItem.h"  // for AbstractItem
 
@@ -75,7 +76,7 @@ protected:
 public:
 protected:
     GtkToolItem* item = nullptr;
-    GtkWidget* popupMenu = nullptr;
+    xoj::util::WidgetSPtr popupMenu;
 
     bool toolToggleButtonActive = false;
     bool toolToggleOnlyEnable = false;

--- a/src/core/gui/toolbarMenubar/ToolButton.cpp
+++ b/src/core/gui/toolbarMenubar/ToolButton.cpp
@@ -34,7 +34,7 @@ ToolButton::~ToolButton() = default;
  * @return The created menu item
  */
 auto ToolButton::registerPopupMenuEntry(const string& name, const string& iconName) -> GtkWidget* {
-    if (this->popupMenu == nullptr) {
+    if (!this->popupMenu) {
         setPopupMenu(gtk_menu_new());
     }
 
@@ -57,7 +57,7 @@ auto ToolButton::registerPopupMenuEntry(const string& name, const string& iconNa
 
     gtk_check_menu_item_set_draw_as_radio(GTK_CHECK_MENU_ITEM(menuItem), true);
     gtk_widget_show_all(menuItem);
-    gtk_container_add(GTK_CONTAINER(this->popupMenu), menuItem);
+    gtk_container_add(GTK_CONTAINER(this->popupMenu.get()), menuItem);
 
     return menuItem;
 }
@@ -77,7 +77,7 @@ auto ToolButton::newItem() -> GtkToolItem* {
         if (popupMenu) {
             it = gtk_menu_tool_toggle_button_new(
                     gtk_image_new_from_icon_name(iconName.c_str(), GTK_ICON_SIZE_SMALL_TOOLBAR), description.c_str());
-            gtk_menu_tool_toggle_button_set_menu(GTK_MENU_TOOL_TOGGLE_BUTTON(it), popupMenu);
+            gtk_menu_tool_toggle_button_set_menu(GTK_MENU_TOOL_TOGGLE_BUTTON(it), popupMenu.get());
         } else {
             it = gtk_toggle_tool_button_new();
             gtk_tool_button_set_icon_widget(
@@ -87,7 +87,7 @@ auto ToolButton::newItem() -> GtkToolItem* {
         if (popupMenu) {
             it = gtk_menu_tool_button_new(gtk_image_new_from_icon_name(iconName.c_str(), GTK_ICON_SIZE_SMALL_TOOLBAR),
                                           description.c_str());
-            gtk_menu_tool_button_set_menu(GTK_MENU_TOOL_BUTTON(it), popupMenu);
+            gtk_menu_tool_button_set_menu(GTK_MENU_TOOL_BUTTON(it), popupMenu.get());
         } else {
             it = gtk_tool_button_new(gtk_image_new_from_icon_name(iconName.c_str(), GTK_ICON_SIZE_SMALL_TOOLBAR),
                                      description.c_str());

--- a/src/core/gui/toolbarMenubar/ToolDrawCombocontrol.cpp
+++ b/src/core/gui/toolbarMenubar/ToolDrawCombocontrol.cpp
@@ -63,7 +63,7 @@ void ToolDrawCombocontrol::createMenuItem(const string& name, const string& icon
     gtk_container_add(GTK_CONTAINER(box), gtk_label_new(name.c_str()));
     gtk_container_add(GTK_CONTAINER(menuItem), box);
 
-    gtk_container_add(GTK_CONTAINER(popupMenu), menuItem);
+    gtk_container_add(GTK_CONTAINER(popupMenu.get()), menuItem);
     toolMenuHandler->registerMenupoint(menuItem, type, GROUP_RULER);
     gtk_widget_show_all(menuItem);
 }
@@ -102,6 +102,6 @@ auto ToolDrawCombocontrol::newItem() -> GtkToolItem* {
 
     GtkToolItem* it = gtk_menu_tool_toggle_button_new(iconWidget, _("Draw Rectangle"));
     gtk_tool_button_set_label_widget(GTK_TOOL_BUTTON(it), labelWidget);
-    gtk_menu_tool_toggle_button_set_menu(GTK_MENU_TOOL_TOGGLE_BUTTON(it), popupMenu);
+    gtk_menu_tool_toggle_button_set_menu(GTK_MENU_TOOL_TOGGLE_BUTTON(it), popupMenu.get());
     return it;
 }

--- a/src/core/gui/toolbarMenubar/ToolPdfCombocontrol.cpp
+++ b/src/core/gui/toolbarMenubar/ToolPdfCombocontrol.cpp
@@ -86,6 +86,6 @@ auto ToolPdfCombocontrol::newItem() -> GtkToolItem* {
 
     it = gtk_menu_tool_toggle_button_new(iconWidget, "test0");
     gtk_tool_button_set_label_widget(GTK_TOOL_BUTTON(it), labelWidget);
-    gtk_menu_tool_toggle_button_set_menu(GTK_MENU_TOOL_TOGGLE_BUTTON(it), popupMenu);
+    gtk_menu_tool_toggle_button_set_menu(GTK_MENU_TOOL_TOGGLE_BUTTON(it), popup);
     return it;
 }

--- a/src/core/gui/toolbarMenubar/ToolSelectCombocontrol.cpp
+++ b/src/core/gui/toolbarMenubar/ToolSelectCombocontrol.cpp
@@ -112,6 +112,6 @@ auto ToolSelectCombocontrol::newItem() -> GtkToolItem* {
 
     it = gtk_menu_tool_toggle_button_new(iconWidget, "test0");
     gtk_tool_button_set_label_widget(GTK_TOOL_BUTTON(it), labelWidget);
-    gtk_menu_tool_toggle_button_set_menu(GTK_MENU_TOOL_TOGGLE_BUTTON(it), popupMenu);
+    gtk_menu_tool_toggle_button_set_menu(GTK_MENU_TOOL_TOGGLE_BUTTON(it), popup);
     return it;
 }

--- a/src/util/gtk4_helper.cpp
+++ b/src/util/gtk4_helper.cpp
@@ -1,0 +1,96 @@
+#include "util/gtk4_helper.h"
+
+#include <gtk/gtk.h>
+
+#include "util/Assert.h"
+
+namespace {
+void set_child(GtkContainer* c, GtkWidget* child) {
+    gtk_container_foreach(
+            c, +[](GtkWidget* child, gpointer c) { gtk_container_remove(GTK_CONTAINER(c), child); }, c);
+    gtk_container_add(c, child);
+}
+};  // namespace
+
+/**** GtkBox ****/
+
+void gtk_box_append(GtkBox* box, GtkWidget* child) {
+    constexpr auto default_expand = false;
+    gtk_box_pack_start(GTK_BOX(box), child, default_expand, true, 0);
+}
+
+void gtk_box_remove(GtkBox* box, GtkWidget* child) { gtk_container_remove(GTK_CONTAINER(box), child); }
+
+/**** GtkWindow ****/
+
+void gtk_window_destroy(GtkWindow* win) { gtk_widget_destroy(GTK_WIDGET(win)); }
+
+/**** GtkWidget ****/
+
+void gtk_widget_add_css_class(GtkWidget* widget, const char* css_class) {
+    gtk_style_context_add_class(gtk_widget_get_style_context(widget), css_class);
+}
+
+void gtk_widget_remove_css_class(GtkWidget* widget, const char* css_class) {
+    gtk_style_context_remove_class(gtk_widget_get_style_context(widget), css_class);
+}
+
+/*** GtkDrawingArea ****/
+
+void gtk_drawing_area_set_draw_func(GtkDrawingArea* area, GtkDrawingAreaDrawFunc draw_func, gpointer user_data,
+                                    GDestroyNotify destroy) {
+    xoj_assert(draw_func != nullptr);
+    struct Data {
+        gpointer data;
+        GtkDrawingAreaDrawFunc draw_func;
+        GDestroyNotify destroy;
+    };
+    Data* data = new Data{user_data, draw_func, destroy};
+    g_signal_connect_data(area, "draw", G_CALLBACK(+[](GtkDrawingArea* self, cairo_t* cr, Data* d) {
+                              GtkAllocation alloc;
+                              gtk_widget_get_allocation(GTK_WIDGET(self), &alloc);
+                              d->draw_func(self, cr, alloc.width, alloc.height, d->data);
+                          }),
+                          data, GClosureNotify(+[](Data* d, GClosure*) {
+                              if (d && d->destroy) {
+                                  d->destroy(d->data);
+                              }
+                              delete d;
+                          }),
+                          GConnectFlags(0U));  // 0 = G_CONNECT_DEFAULT only introduced in GObject 2.74
+}
+
+/**** GtkScrolledWindow ****/
+
+void gtk_scrolled_window_set_child(GtkScrolledWindow* win, GtkWidget* child) { set_child(GTK_CONTAINER(win), child); }
+GtkWidget* gtk_scrolled_window_get_child(GtkScrolledWindow* win) { return gtk_bin_get_child(GTK_BIN(win)); }
+
+/**** GtkCheckButton ****/
+
+void gtk_check_button_set_child(GtkCheckButton* button, GtkWidget* child) { set_child(GTK_CONTAINER(button), child); }
+
+void gtk_check_button_set_label(GtkCheckButton* button, const char* label) {
+    gtk_check_button_set_child(GTK_CHECK_BUTTON(button), gtk_label_new(label));
+}
+
+bool gtk_check_button_get_active(GtkCheckButton* bt) { return gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(bt)); }
+
+void gtk_check_button_set_active(GtkCheckButton* bt, bool state) {
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bt), state);
+}
+
+/**** GtkButton ****/
+
+void gtk_button_set_child(GtkButton* button, GtkWidget* child) { set_child(GTK_CONTAINER(button), child); }
+GtkWidget* gtk_button_get_child(GtkButton* button) { return gtk_bin_get_child(GTK_BIN(button)); }
+
+/**** GtkPopover ****/
+
+GtkWidget* gtk_popover_new() { return gtk_popover_new(nullptr); }
+void gtk_popover_set_child(GtkPopover* popover, GtkWidget* child) { set_child(GTK_CONTAINER(popover), child); }
+
+/**** GtkLabel ****/
+void gtk_label_set_wrap(GtkLabel* label, gboolean wrap) { gtk_label_set_line_wrap(label, wrap); }
+void gtk_label_set_wrap_mode(GtkLabel* label, PangoWrapMode wrap_mode) {
+    gtk_label_set_line_wrap_mode(label, wrap_mode);
+}

--- a/src/util/include/util/GListView.h
+++ b/src/util/include/util/GListView.h
@@ -16,10 +16,15 @@
 
 #include <glib.h>
 
-template <typename T>
-
-struct GListView {
+template <class ListType, typename T>
+struct ListView {
     struct GListViewIter {
+        using iterator_category = std::forward_iterator_tag;
+        using value_type = T;
+        using pointer = T*;
+        using reference = T&;
+        using difference_type = std::ptrdiff_t;
+
         constexpr auto operator++() -> GListViewIter& {
             this->list = list->next;
             return *this;
@@ -32,9 +37,7 @@ struct GListView {
         }
 
         constexpr friend auto operator==(GListViewIter const& lhs, GListViewIter const& rhs) -> bool {
-            auto tier = [](GList const& list) { return std::tie(list.data, list.next, list.prev); };
-            return (lhs.list == rhs.list) ||
-                   (lhs.list != nullptr && rhs.list != nullptr && tier(*lhs.list) == tier(*rhs.list));
+            return lhs.list == rhs.list;
         }
 
         constexpr friend auto operator!=(GListViewIter const& lhs, GListViewIter const& rhs) -> bool {
@@ -45,7 +48,7 @@ struct GListView {
 
         constexpr T* operator->() { return static_cast<T*>(list->data); }
 
-        GList* list{};
+        ListType* list{};
     };
 
     struct GListViewSentinel {
@@ -63,7 +66,7 @@ struct GListView {
         }
     };
 
-    constexpr GListView(GList* list): list(list) {}
+    constexpr ListView(ListType* list): list(list) {}
 
     constexpr auto begin() -> GListViewIter { return {list}; }
     // /// Slow, iterates over all elements to find the end
@@ -73,8 +76,13 @@ struct GListView {
     // Todo(if required): constexpr auto rend() -> GListViewSentinel { return {}; }
 
     /// Convenient way to iterate over a GListView, DO NOT REVERSE IT
-    constexpr auto end_iter() -> GListViewIter { return nullptr; }
+    constexpr auto end_iter() -> GListViewIter { return {nullptr}; }
 
 private:
-    GList* list;
+    ListType* list;
 };
+
+template <typename T>
+using GListView = ListView<GList, T>;
+template <typename T>
+using GSListView = ListView<GSList, T>;

--- a/src/util/include/util/gtk4_helper.h
+++ b/src/util/include/util/gtk4_helper.h
@@ -14,69 +14,51 @@
 
 #include <gtk/gtk.h>
 
-#include "util/Assert.h"
+/**** GtkBox ****/
 
-inline void gtk_box_append(GtkBox* box, GtkWidget* child) {
-    constexpr auto default_expand = false;
-    gtk_box_pack_start(GTK_BOX(box), child, default_expand, true, 0);
-}
+void gtk_box_append(GtkBox* box, GtkWidget* child);
+void gtk_box_remove(GtkBox* box, GtkWidget* child);
 
-inline void gtk_box_remove(GtkBox* box, GtkWidget* child) { gtk_container_remove(GTK_CONTAINER(box), child); }
+/**** GtkWindow ****/
 
-inline void gtk_window_destroy(GtkWindow* win) { gtk_widget_destroy(GTK_WIDGET(win)); }
+void gtk_window_destroy(GtkWindow* win);
 
-inline bool gtk_check_button_get_active(GtkCheckButton* bt) {
-    return gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(bt));
-}
-inline void gtk_check_button_set_active(GtkCheckButton* bt, bool state) {
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(bt), state);
-}
+/**** GtkWidget ****/
 
-inline void gtk_widget_add_css_class(GtkWidget* widget, const char* css_class) {
-    gtk_style_context_add_class(gtk_widget_get_style_context(widget), css_class);
-}
+void gtk_widget_add_css_class(GtkWidget* widget, const char* css_class);
+void gtk_widget_remove_css_class(GtkWidget* widget, const char* css_class);
 
-inline void gtk_widget_remove_css_class(GtkWidget* widget, const char* css_class) {
-    gtk_style_context_remove_class(gtk_widget_get_style_context(widget), css_class);
-}
+/*** GtkDrawingArea ****/
 
 typedef void (*GtkDrawingAreaDrawFunc)(GtkDrawingArea* drawing_area, cairo_t* cr, int width, int height,
                                        gpointer user_data);
 /// WARNING: unsetting (via draw_func = nullptr) or replacing the function is not implemented here.
-inline void gtk_drawing_area_set_draw_func(GtkDrawingArea* area, GtkDrawingAreaDrawFunc draw_func, gpointer user_data,
-                                           GDestroyNotify destroy) {
-    xoj_assert(draw_func != nullptr);
-    struct Data {
-        gpointer data;
-        GtkDrawingAreaDrawFunc draw_func;
-        GDestroyNotify destroy;
-    };
-    Data* data = new Data{user_data, draw_func, destroy};
-    g_signal_connect_data(area, "draw", G_CALLBACK(+[](GtkDrawingArea* self, cairo_t* cr, Data* d) {
-                              GtkAllocation alloc;
-                              gtk_widget_get_allocation(GTK_WIDGET(self), &alloc);
-                              d->draw_func(self, cr, alloc.width, alloc.height, d->data);
-                          }),
-                          data, GClosureNotify(+[](Data* d, GClosure*) {
-                              if (d && d->destroy) {
-                                  d->destroy(d->data);
-                              }
-                              delete d;
-                          }),
-                          GConnectFlags(0U));  // 0 = G_CONNECT_DEFAULT only introduced in GObject 2.74
-}
+void gtk_drawing_area_set_draw_func(GtkDrawingArea* area, GtkDrawingAreaDrawFunc draw_func, gpointer user_data,
+                                    GDestroyNotify destroy);
 
-namespace gtk4_helper {
-template <class GtkBinType>
-static inline void set_child(GtkBinType* c, GtkWidget* child) {
-    gtk_container_foreach(
-            GTK_CONTAINER(c), +[](GtkWidget* child, gpointer c) { gtk_container_remove(GTK_CONTAINER(c), child); }, c);
-    gtk_container_add(GTK_CONTAINER(c), child);
-}
-template <class GtkBinType>
-static inline GtkWidget* get_child(GtkBinType* c) {
-    return gtk_bin_get_child(GTK_BIN(c));
-}
-};  // namespace gtk4_helper
-constexpr auto gtk_scrolled_window_set_child = gtk4_helper::set_child<GtkScrolledWindow>;
-constexpr auto gtk_scrolled_window_get_child = gtk4_helper::get_child<GtkScrolledWindow>;
+/**** GtkScrolledWindow ****/
+
+void gtk_scrolled_window_set_child(GtkScrolledWindow* win, GtkWidget* child);
+GtkWidget* gtk_scrolled_window_get_child(GtkScrolledWindow* win);
+
+/**** GtkCheckButton ****/
+
+void gtk_check_button_set_child(GtkCheckButton* button, GtkWidget* child);
+void gtk_check_button_set_label(GtkCheckButton* button, const char* label);
+
+bool gtk_check_button_get_active(GtkCheckButton* bt);
+void gtk_check_button_set_active(GtkCheckButton* bt, bool state);
+
+/**** GtkButton ****/
+
+void gtk_button_set_child(GtkButton* button, GtkWidget* child);
+GtkWidget* gtk_button_get_child(GtkButton* button);
+
+/**** GtkPopover ****/
+
+GtkWidget* gtk_popover_new();
+void gtk_popover_set_child(GtkPopover* popover, GtkWidget* child);
+
+/**** GtkLabel ****/
+void gtk_label_set_wrap(GtkLabel* label, gboolean wrap);
+void gtk_label_set_wrap_mode(GtkLabel* label, PangoWrapMode wrap_mode);


### PR DESCRIPTION
This was part of #4508, to ease the reviewing process.
This PR only contains cleanups and extension of classes in util/ needed for #4508.