### PR TITLE
Sink floating refs in PreviewEntry

### DIFF
--- a/src/core/gui/sidebar/previews/base/SidebarPreviewBaseEntry.cpp
+++ b/src/core/gui/sidebar/previews/base/SidebarPreviewBaseEntry.cpp
@@ -17,10 +17,8 @@
 
 SidebarPreviewBaseEntry::SidebarPreviewBaseEntry(SidebarPreviewBase* sidebar, const PageRef& page):
         sidebar(sidebar), page(page) {
-    this->widget = gtk_button_new();  // re: issue 1072
-
+    this->widget = GTK_WIDGET(g_object_ref_sink(gtk_button_new()));
     gtk_widget_show(this->widget);
-    g_object_ref(this->widget);
 
     updateSize();
     gtk_widget_set_events(widget, GDK_EXPOSURE_MASK);

--- a/src/core/gui/sidebar/previews/layer/SidebarPreviewLayerEntry.cpp
+++ b/src/core/gui/sidebar/previews/layer/SidebarPreviewLayerEntry.cpp
@@ -15,9 +15,8 @@ SidebarPreviewLayerEntry::SidebarPreviewLayerEntry(SidebarPreviewLayers* sidebar
         sidebar(sidebar),
         index(index),
         layerId(layerId),
-        box(gtk_box_new(GTK_ORIENTATION_VERTICAL, 2)),
+        box(GTK_WIDGET(g_object_ref_sink(gtk_box_new(GTK_ORIENTATION_VERTICAL, 2)))),
         stacked(stacked) {
-
     const auto clickCallback = G_CALLBACK(+[](GtkWidget* widget, GdkEvent* event, SidebarPreviewLayerEntry* self) {
         // Open context menu on right mouse click
         if (event->type == GDK_BUTTON_PRESS) {


### PR DESCRIPTION
Fixes #5074 

The issue was the following: by not sinking the widget's floating ref, the SidebarPreviewLayerEntry did not own a ref to the widget. The floating ref was then sunk by the parent container GtkLayout. So the widget has a ref-count of 1.
When calling `gtk_widget_destroy()` in `~SidebarPreviewLayerEntry()`, two things happen `gtk_container_remove()` is called on the GtkLayout and our widget **and** `g_object_unref()` is called.
As `gtk_container_remove()` also drops the ref-count by one (as the container releases its ref), we call `g_object_unref()` on an already destroyed object.