### PR TITLE
Release of version 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.2.1~dev (Unreleased)
+## 1.2.1
 
 Bugfixes from various community contributors.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 1.2.2~dev (Unreleased)
+
 ## 1.2.1
 
 Bugfixes from various community contributors.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,13 +6,13 @@ set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "Minimum OS X deployment ve
 ## Project related Variables
 ## Also update changelog in debian folder!
 project(xournalpp
-        VERSION 1.2.1
+        VERSION 1.2.2
         DESCRIPTION "Xournal++ - Open source hand note-taking program"
         HOMEPAGE_URL "https://xournalpp.github.io/"
         LANGUAGES CXX C)
 # according to https://cmake.org/cmake/help/latest/command/project.html we must fix the suffix:
 # And https://gitlab.kitware.com/cmake/cmake/-/issues/16716 is still open:
-set(VERSION_SUFFIX "")
+set(VERSION_SUFFIX "~dev")
 set(PROJECT_VERSION "${PROJECT_VERSION}${VERSION_SUFFIX}")
 set(xournalpp_VERSION ${PROJECT_VERSION})
 set(CMAKE_PROJECT_VERSION ${PROJECT_VERSION})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ project(xournalpp
         LANGUAGES CXX C)
 # according to https://cmake.org/cmake/help/latest/command/project.html we must fix the suffix:
 # And https://gitlab.kitware.com/cmake/cmake/-/issues/16716 is still open:
-set(VERSION_SUFFIX "~dev")
+set(VERSION_SUFFIX "")
 set(PROJECT_VERSION "${PROJECT_VERSION}${VERSION_SUFFIX}")
 set(xournalpp_VERSION ${PROJECT_VERSION})
 set(CMAKE_PROJECT_VERSION ${PROJECT_VERSION})

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+xournalpp (1.2.2~dev-1) UNRELEASED; urgency=medium
+
+  * 
+
+ -- rolandlo <roland_loetscher@hotmail.com>  Thu, 24 Aug 2023 17:22:55 +0200
+
 xournalpp (1.2.1-1) unstable; urgency=medium
 
   * Added a default toolbar so that the app does not start without toolbar on new installations

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,11 @@
-xournalpp (1.2.1~dev-1) UNRELEASED; urgency=medium
+xournalpp (1.2.1-1) unstable; urgency=medium
 
-  * 
-
- -- Roland Lötscher <roland_loetscher@hotmail.com>  Sat, 29 Jul 2023 23:29:03 +0100
+  * Added a default toolbar so that the app does not start without toolbar on new installations
+  * Fixed some crashes and various issues with the crash log handling
+  * Added options to the command line and preferences to disable the audio system used for audio recording
+  * The official release builds are now all built with gtksourceview styling for the LaTeX tool and in "RelWithDeb" mode. Thus failing asserts do not result in a crash anymore.
+ 
+ -- rolandlo <roland_loetscher@hotmail.com>  Thu, 24 Aug 2023 17:22:54 +0200
 
 xournalpp (1.2.0-1) unstable; urgency=medium
 

--- a/desktop/com.github.xournalpp.xournalpp.appdata.xml
+++ b/desktop/com.github.xournalpp.xournalpp.appdata.xml
@@ -121,7 +121,7 @@
     <!-- Could be automated more:
 	 `git tag -l | grep "^[0-9]*\.[0-9]*\.[0-9]*$`"
     -->
-    <release date="2023-07-29" version="1.2.1~dev" />
+    <release date="2023-08-24" version="1.2.1" />
     <release date="2023-07-29" version="1.2.0" />
     <release date="2022-11-25" version="1.1.3" />
     <release date="2022-10-15" version="1.1.2" />

--- a/desktop/com.github.xournalpp.xournalpp.appdata.xml
+++ b/desktop/com.github.xournalpp.xournalpp.appdata.xml
@@ -121,6 +121,7 @@
     <!-- Could be automated more:
 	 `git tag -l | grep "^[0-9]*\.[0-9]*\.[0-9]*$`"
     -->
+    <release date="2023-08-24" version="1.2.2~dev" />
     <release date="2023-08-24" version="1.2.1" />
     <release date="2023-07-29" version="1.2.0" />
     <release date="2022-11-25" version="1.1.3" />

--- a/mac-setup/Info.plist
+++ b/mac-setup/Info.plist
@@ -16,9 +16,9 @@
     <string>Xournal++</string>
 
     <key>CFBundleShortVersionString</key>
-    <string>1.2.1</string>
+    <string>1.2.2~dev</string>
     <key>CFBundleVersion</key>
-    <string>1.2.1.0</string>
+    <string>1.2.2~dev.0</string>
     <key>CFBundleInfoDictionaryVersion</key>
     <string>6.0</string>
     <key>NSHumanReadableCopyright</key>

--- a/mac-setup/Info.plist
+++ b/mac-setup/Info.plist
@@ -16,9 +16,9 @@
     <string>Xournal++</string>
 
     <key>CFBundleShortVersionString</key>
-    <string>1.2.1~dev</string>
+    <string>1.2.1</string>
     <key>CFBundleVersion</key>
-    <string>1.2.1~dev.0</string>
+    <string>1.2.1.0</string>
     <key>CFBundleInfoDictionaryVersion</key>
     <string>6.0</string>
     <key>NSHumanReadableCopyright</key>

--- a/rpm/fedora/xournalpp.spec
+++ b/rpm/fedora/xournalpp.spec
@@ -4,7 +4,7 @@
 #This spec file is intended for daily development snapshot release
 %global	build_repo https://github.com/xournalpp/xournalpp/
 %global	build_branch master
-%global	version_string 1.2.1
+%global	version_string 1.2.2~dev
 %define	build_commit %(git ls-remote %{build_repo} | grep "refs/heads/%{build_branch}" | cut -c1-41)
 %define	build_shortcommit %(c=%{build_commit}; echo ${c:0:7})
 %global	build_timestamp %(date +"%Y%m%d")

--- a/rpm/fedora/xournalpp.spec
+++ b/rpm/fedora/xournalpp.spec
@@ -4,7 +4,7 @@
 #This spec file is intended for daily development snapshot release
 %global	build_repo https://github.com/xournalpp/xournalpp/
 %global	build_branch master
-%global	version_string 1.2.1~dev
+%global	version_string 1.2.1
 %define	build_commit %(git ls-remote %{build_repo} | grep "refs/heads/%{build_branch}" | cut -c1-41)
 %define	build_shortcommit %(c=%{build_commit}; echo ${c:0:7})
 %global	build_timestamp %(date +"%Y%m%d")


### PR DESCRIPTION
This is the release PR for version 1.2.1. The HEAD commit of the PR will be pushed directly to the `xournalpp` repo, not via Github's web interface.

@xournalpp/core Please check!