### PR TITLE
Rebased: Fix zoom jumping and zoom steps (Partial Zoom Refactor)

### DIFF
--- a/src/core/control/zoom/ZoomControl.cpp
+++ b/src/core/control/zoom/ZoomControl.cpp
@@ -32,7 +32,11 @@ auto onScrolledwindowMainScrollEvent(GtkWidget* widget, GdkEventScroll* event, Z
                 (event->direction == GDK_SCROLL_UP || (event->direction == GDK_SCROLL_SMOOTH && event->delta_y < 0)) ?
                         ZOOM_IN :
                         ZOOM_OUT;
-        zoom->zoomScroll(direction, {event->x, event->y});
+        // use screen pixel coordinates for the zoom center
+        // as relative coordinates depend on the changing zoom level
+        int rx, ry;
+        gdk_window_get_root_coords(gtk_widget_get_window(widget), 0, 0, &rx, &ry);
+        zoom->zoomScroll(direction, {event->x_root - rx, event->y_root - ry});
         return true;
     }
 
@@ -43,15 +47,16 @@ auto onScrolledwindowMainScrollEvent(GtkWidget* widget, GdkEventScroll* event, Z
 auto onTouchpadPinchEvent(GtkWidget* widget, GdkEventTouchpadPinch* event, ZoomControl* zoom) -> bool {
     if (event->type == GDK_TOUCHPAD_PINCH && event->n_fingers == 2) {
         utl::Point<double> center;
+        int rx, ry;
         switch (event->phase) {
             case GDK_TOUCHPAD_GESTURE_PHASE_BEGIN:
                 if (zoom->isZoomFitMode()) {
                     zoom->setZoomFitMode(false);
                 }
-                center = {event->x, event->y};
-                // Need to adjust the center because the event coordinates are relative
-                // to the widget, not to the zoomed (and translated) view
-                center += {zoom->getVisibleRect().x, zoom->getVisibleRect().y};
+                // use screen pixel coordinates for the zoom center
+                // as relative coordinates depend on the changing zoom level
+                gdk_window_get_root_coords(gtk_widget_get_window(widget), 0, 0, &rx, &ry);
+                center = {event->x_root - rx, event->y_root - ry};
                 zoom->startZoomSequence(center);
                 break;
             case GDK_TOUCHPAD_GESTURE_PHASE_UPDATE:
@@ -120,7 +125,7 @@ void ZoomControl::zoomOneStep(ZoomDirection direction, utl::Point<double> zoomCe
 
 void ZoomControl::zoomOneStep(ZoomDirection direction) {
     Rectangle rect = getVisibleRect();
-    zoomOneStep(direction, {rect.x + rect.width / 2.0, rect.y + rect.height / 2.0});
+    zoomOneStep(direction, {rect.width / 2.0, rect.height / 2.0});
 }
 
 
@@ -133,34 +138,60 @@ void ZoomControl::zoomScroll(ZoomDirection direction, utl::Point<double> zoomCen
         this->setZoomFitMode(false);
     }
 
-    if (this->zoomSequenceStart == -1 || scrollCursorPosition != zoomCenter) {
-        scrollCursorPosition = zoomCenter;
-        startZoomSequence(zoomCenter);
-    }
-
     double newZoom = this->withZoomStep(direction, this->zoomStepScroll);
+    startZoomSequence(zoomCenter);
     this->zoomSequenceChange(newZoom, false);
+    endZoomSequence();
 }
 
 void ZoomControl::startZoomSequence() {
     Rectangle rect = getVisibleRect();
-    startZoomSequence({rect.x + rect.width / 2.0, rect.y + rect.height / 2.0});
+    startZoomSequence({rect.width / 2.0, rect.height / 2.0});
 }
 
 void ZoomControl::startZoomSequence(utl::Point<double> zoomCenter) {
+    // * set zoom center and zoom startlevel
+    this->zoomWidgetPos = zoomCenter;  // window space coordinates of the zoomCenter!
+    this->zoomSequenceStart = this->zoom;
+
+    // * set unscaledPixels padding value
+    size_t currentPageIdx = this->view->getCurrentPage();
+
+    // To get the layout, we need to call view->getWidget(), which isn't const.
+    // As such, we get the view and determine `unscaledPixels` here, rather than
+    // in `getScrollPositionAfterZoom`.
+    GtkWidget* widget = view->getWidget();
+    Layout* layout = gtk_xournal_get_layout(widget);
+
+    // Not everything changes size as we zoom in/out. The padding, for example,
+    // remains constant! (changed when page changes, but the error stays small enough)
+    this->unscaledPixels = {static_cast<double>(layout->getPaddingLeftOfPage(currentPageIdx)),
+                            static_cast<double>(layout->getPaddingAbovePage(currentPageIdx))};
+
+    // * set initial scrollPosition value
     auto const& rect = getVisibleRect();
     auto const& view_pos = utl::Point{rect.x, rect.y};
 
-    this->zoomWidgetPos = zoomCenter - view_pos;
-    this->zoomSequenceStart = this->zoom;
-
-    setScrollPositionAfterZoom(view_pos);
+    // Use this->zoomWidgetPos to zoom into a location other than the top-left (e.g. where
+    // the user pinched).
+    this->scrollPosition = (view_pos + this->zoomWidgetPos - this->unscaledPixels) / this->zoom;
 }
 
 void ZoomControl::zoomSequenceChange(double zoom, bool relative) {
-    if (relative && this->zoomSequenceStart != -1) {
-        zoom *= zoomSequenceStart;
+    if (relative) {
+        zoom *= this->zoomSequenceStart != -1 ? zoomSequenceStart : this->zoom;
     }
+
+    setZoom(zoom);
+}
+
+void ZoomControl::zoomSequenceChange(double zoom, bool relative, utl::Point<double> scrollVector) {
+    if (relative) {
+        zoom *= this->zoomSequenceStart != -1 ? zoomSequenceStart : this->zoom;
+    }
+
+    // scroll update
+    this->zoomWidgetPos += scrollVector;
 
     setZoom(zoom);
 }
@@ -183,38 +214,17 @@ auto ZoomControl::getVisibleRect() -> Rectangle<double> {
     return layout->getVisibleRect();
 }
 
-void ZoomControl::setScrollPositionAfterZoom(utl::Point<double> scrollPos) {
-    size_t currentPageIdx = this->view->getCurrentPage();
-
-    // To get the layout, we need to call view->getWidget(), which isn't const.
-    // As such, we get the view and determine `unscaledPixels` here, rather than
-    // in `getScrollPositionAfterZoom`.
-    GtkWidget* widget = view->getWidget();
-    Layout* layout = gtk_xournal_get_layout(widget);
-
-    // TODO(personalizedrefrigerator) While this zooms in nearly where intended, it
-    //                                "jitters" while zooming if very far into the document.
-
-    // Not everything changes size as we zoom in/out. The padding, for example,
-    // remains constant!
-    this->unscaledPixels = {static_cast<double>(layout->getPaddingLeftOfPage(currentPageIdx)),
-                            static_cast<double>(layout->getPaddingAbovePage(currentPageIdx))};
-
-    // Use this->zoomWidgetPos to zoom into a location other than the top-left (e.g. where
-    // the user pinched).
-    this->scrollPosition = (scrollPos - this->unscaledPixels + this->zoomWidgetPos) / this->zoom;
-}
-
 auto ZoomControl::getScrollPositionAfterZoom() const -> utl::Point<double> {
     //  If we aren't in a zoomSequence, `unscaledPixels`, `scrollPosition`, and `zoomWidgetPos
     // can't be used to determine the scroll position! Return now.
+    // NOTE: this case should never happend currently.
+    //       getScrollPositionAfterZoom is called from XournalView after setZoom() fired the ZoomListeners
     if (this->zoomSequenceStart == -1) {
         return {-1, -1};
     }
 
-    return (this->scrollPosition * this->zoom) - this->zoomWidgetPos + this->unscaledPixels;
+    return this->scrollPosition * this->zoom - this->zoomWidgetPos + this->unscaledPixels;
 }
-
 
 void ZoomControl::addZoomListener(ZoomListener* l) { this->listener.emplace_back(l); }
 
@@ -235,15 +245,9 @@ void ZoomControl::initZoomHandler(GtkWidget* window, GtkWidget* widget, XournalV
 }
 
 void ZoomControl::fireZoomChanged() {
-    if (this->zoom < this->zoomMin) {
-        this->zoom = this->zoomMin;
+    for (ZoomListener* z: this->listener) {
+        z->zoomChanged();
     }
-
-    if (this->zoom > this->zoomMax) {
-        this->zoom = this->zoomMax;
-    }
-
-    for (ZoomListener* z: this->listener) { z->zoomChanged(); }
 }
 
 void ZoomControl::fireZoomRangeValueChanged() {
@@ -258,14 +262,12 @@ void ZoomControl::setZoom(double zoomI) {
     if (this->zoom == zoomI) {
         return;
     }
-    this->zoom = zoomI;
+    this->zoom = std::clamp(zoomI, this->zoomMin, this->zoomMax);
     fireZoomChanged();
 }
 
 void ZoomControl::setZoom100Value(double zoom100Val) {
     auto setWithRelZoom = [zoomOld = this->zoom100Value, zoom100Val](double& val) { val = val / zoomOld * zoom100Val; };
-    setWithRelZoom(this->zoomStep);
-    setWithRelZoom(this->zoomStepScroll);
     setWithRelZoom(this->zoomMax);
     setWithRelZoom(this->zoomMin);
     this->zoom100Value = zoom100Val;
@@ -390,9 +392,9 @@ void ZoomControl::setZoomPresentationMode(bool isZoomPresentationMode) {
 
 auto ZoomControl::isZoomPresentationMode() const -> bool { return this->zoomPresentationMode; }
 
-void ZoomControl::setZoomStep(double zoomStep) { this->zoomStep = zoomStep * this->zoom100Value; }
+void ZoomControl::setZoomStep(double zoomStep) { this->zoomStep = zoomStep; }
 
-void ZoomControl::setZoomStepScroll(double zoomStep) { this->zoomStepScroll = zoomStep * this->zoom100Value; }
+void ZoomControl::setZoomStepScroll(double zoomStep) { this->zoomStepScroll = zoomStep; }
 
 void ZoomControl::pageSizeChanged(size_t page) {
     updateZoomPresentationValue(page);

--- a/src/core/control/zoom/ZoomControl.h
+++ b/src/core/control/zoom/ZoomControl.h
@@ -143,6 +143,7 @@ public:
      * @param relative If the zoom is relative to the start value (for Gesture)
      */
     void zoomSequenceChange(double zoom, bool relative);
+
     /**
      * Change the zoom and zoomCenter within a Zoom sequence (startZoomSequence() / endZoomSequence())
      * Used while touch pinch event

--- a/src/core/control/zoom/ZoomControl.h
+++ b/src/core/control/zoom/ZoomControl.h
@@ -125,7 +125,7 @@ public:
     /**
      * Call this before any zoom is done, it saves the current page and position
      *
-     * @param zoomCenter position of zoom focus
+     * @param zoomCenter position of zoom focus in window coordinate space
      */
 
     void startZoomSequence(utl::Point<double> zoomCenter);
@@ -143,6 +143,15 @@ public:
      * @param relative If the zoom is relative to the start value (for Gesture)
      */
     void zoomSequenceChange(double zoom, bool relative);
+    /**
+     * Change the zoom and zoomCenter within a Zoom sequence (startZoomSequence() / endZoomSequence())
+     * Used while touch pinch event
+     *
+     * @param zoom Current zoom value
+     * @param relative If the zoom is relative to the start value (for Gesture)
+     * @param scrollVector relative zoom center movement in pixels since last call
+     */
+    void zoomSequenceChange(double zoom, bool relative, utl::Point<double> scrollVector);
 
     /// Clear all stored data from startZoomSequence()
     void endZoomSequence();
@@ -208,14 +217,11 @@ private:
     /// Base zoom on start, for relative zoom (Gesture)
     double zoomSequenceStart = -1;
 
-    /// Zoom center pos on view, will not be zoomed!
+    /// Zoom center position in window coordinate space, will not be zoomed!
     utl::Point<double> zoomWidgetPos;
 
     /// Scroll position (top left corner of view) to scale
     utl::Point<double> scrollPosition;
-
-    /// Cursorposition x for Ctrl + Scroll
-    utl::Point<double> scrollCursorPosition;
 
     /// Size {x, y} of the pixels before the current page that
     /// do not scale.

--- a/src/core/control/zoom/ZoomControl.h
+++ b/src/core/control/zoom/ZoomControl.h
@@ -125,9 +125,10 @@ public:
     /**
      * Call this before any zoom is done, it saves the current page and position
      *
-     * @param zoomCenter position of zoom focus in window coordinate space
+     * @param zoomCenter position of zoom focus in widget pixel coordinates. That
+     * is, absolute coordinates (not scaling with the document) translated to the
+     * top left corner of the drawing area.
      */
-
     void startZoomSequence(utl::Point<double> zoomCenter);
 
     /**
@@ -160,10 +161,13 @@ public:
     /// Revert and end the current zoom sequence
     void cancelZoomSequence();
 
-    /// Update the scroll position manually
-    void setScrollPositionAfterZoom(utl::Point<double> scrollPos);
+    /// Check if we are between calls to `startZoomSequence()` and `endZoomSequence()`
+    bool isZoomSequenceActive() const;
 
-    /// Zoom to correct position on zooming
+    /**
+     * Zoom to correct position on zooming.
+     * This function should only be called during a zoom sequence.
+     */
     utl::Point<double> getScrollPositionAfterZoom() const;
 
     /// Get visible rect on xournal view, for Zoom Gesture
@@ -218,7 +222,7 @@ private:
     /// Base zoom on start, for relative zoom (Gesture)
     double zoomSequenceStart = -1;
 
-    /// Zoom center position in window coordinate space, will not be zoomed!
+    /// Zoom center position in widget coordinate space, will not be zoomed!
     utl::Point<double> zoomWidgetPos;
 
     /// Scroll position (top left corner of view) to scale

--- a/src/core/gui/MainWindow.cpp
+++ b/src/core/gui/MainWindow.cpp
@@ -292,7 +292,9 @@ void MainWindow::initHideMenu() {
 
 auto MainWindow::getLayout() const -> Layout* { return gtk_xournal_get_layout(this->xournal->getWidget()); }
 
-auto MainWindow::getWinXournal() -> GtkWidget* { return this->winXournal; }
+auto MainWindow::getScreenPos() -> utl::Point<double> {
+    return Util::toScreenCoords(this->winXournal, utl::Point{0.0, 0.0});
+}
 
 auto cancellable_cancel(GCancellable* cancel) -> bool {
     g_cancellable_cancel(cancel);

--- a/src/core/gui/MainWindow.cpp
+++ b/src/core/gui/MainWindow.cpp
@@ -292,8 +292,8 @@ void MainWindow::initHideMenu() {
 
 auto MainWindow::getLayout() const -> Layout* { return gtk_xournal_get_layout(this->xournal->getWidget()); }
 
-auto MainWindow::getScreenPos() -> utl::Point<double> {
-    return Util::toScreenCoords(this->winXournal, utl::Point{0.0, 0.0});
+auto MainWindow::getNegativeXournalWidgetPos() const -> utl::Point<double> {
+    return Util::toWidgetCoords(this->winXournal, utl::Point{0.0, 0.0});
 }
 
 auto cancellable_cancel(GCancellable* cancel) -> bool {

--- a/src/core/gui/MainWindow.cpp
+++ b/src/core/gui/MainWindow.cpp
@@ -292,6 +292,8 @@ void MainWindow::initHideMenu() {
 
 auto MainWindow::getLayout() const -> Layout* { return gtk_xournal_get_layout(this->xournal->getWidget()); }
 
+auto MainWindow::getWinXournal() -> GtkWidget* { return this->winXournal; }
+
 auto cancellable_cancel(GCancellable* cancel) -> bool {
     g_cancellable_cancel(cancel);
 

--- a/src/core/gui/MainWindow.h
+++ b/src/core/gui/MainWindow.h
@@ -116,10 +116,12 @@ public:
     [[maybe_unused]] Menubar* getMenubar() const;
 
     /**
-     * Get the position of the top left corner of this window on the screen.
-     * @see gdk_window_get_root_origin
+     * Get the position of the top left corner of screen (X11) or the window (Wayland)
+     * relative to the Xournal Widget top left corner
+     *
+     * @see Util::toWidgetCoords()
      */
-    utl::Point<double> getScreenPos();
+    utl::Point<double> getNegativeXournalWidgetPos() const;
 
     /**
      * Disable kinetic scrolling if there is a touchscreen device that was manually mapped to another enabled input

--- a/src/core/gui/MainWindow.h
+++ b/src/core/gui/MainWindow.h
@@ -24,6 +24,7 @@
 
 #include "control/layer/LayerCtrlListener.h"  // for LayerCtrlListener
 #include "model/Font.h"                       // for XojFont
+#include "util/Point.h"
 #include "util/raii/GObjectSPtr.h"
 
 #include "GladeGui.h"            // for GladeGui
@@ -114,8 +115,11 @@ public:
 
     [[maybe_unused]] Menubar* getMenubar() const;
 
-    GtkWidget* getWinXournal();
-
+    /**
+     * Get the position of the top left corner of this window on the screen.
+     * @see gdk_window_get_root_origin
+     */
+    utl::Point<double> getScreenPos();
 
     /**
      * Disable kinetic scrolling if there is a touchscreen device that was manually mapped to another enabled input

--- a/src/core/gui/MainWindow.h
+++ b/src/core/gui/MainWindow.h
@@ -114,6 +114,9 @@ public:
 
     [[maybe_unused]] Menubar* getMenubar() const;
 
+    GtkWidget* getWinXournal();
+
+
     /**
      * Disable kinetic scrolling if there is a touchscreen device that was manually mapped to another enabled input
      * device class. This is required so the GtkScrolledWindow does not swallow all the events.

--- a/src/core/gui/XournalView.cpp
+++ b/src/core/gui/XournalView.cpp
@@ -541,12 +541,10 @@ void XournalView::zoomChanged() {
 
     if (zoom->isZoomPresentationMode() || zoom->isZoomFitMode()) {
         scrollTo(currentPage);
-    } else {
+    } else if (zoom->isZoomSequenceActive()) {
         auto pos = zoom->getScrollPositionAfterZoom();
-        if (pos.x != -1 && pos.y != -1) {
-            Layout* layout = gtk_xournal_get_layout(this->widget);
-            layout->scrollAbs(pos.x, pos.y);
-        }
+        Layout* layout = gtk_xournal_get_layout(this->widget);
+        layout->scrollAbs(pos.x, pos.y);
     }
 
     Document* doc = control->getDocument();

--- a/src/core/gui/inputdevices/TouchDrawingInputHandler.cpp
+++ b/src/core/gui/inputdevices/TouchDrawingInputHandler.cpp
@@ -59,12 +59,6 @@ auto TouchDrawingInputHandler::handleImpl(InputEvent const& event) -> bool {
         return false;
     }
 
-    // Don't handle more then 2 inputs
-    /*if (this->primarySequence && this->primarySequence != event.sequence && this->secondarySequence &&
-        this->secondarySequence != event.sequence) {
-        return false;
-    }*/
-
     // Multitouch
     if ((this->primarySequence && this->primarySequence != event.sequence) || this->secondarySequence) {
         if (!this->secondarySequence) {

--- a/src/core/gui/inputdevices/TouchDrawingInputHandler.cpp
+++ b/src/core/gui/inputdevices/TouchDrawingInputHandler.cpp
@@ -59,6 +59,12 @@ auto TouchDrawingInputHandler::handleImpl(InputEvent const& event) -> bool {
         return false;
     }
 
+    // Don't handle more then 2 inputs
+    /*if (this->primarySequence && this->primarySequence != event.sequence && this->secondarySequence &&
+        this->secondarySequence != event.sequence) {
+        return false;
+    }*/
+
     // Multitouch
     if ((this->primarySequence && this->primarySequence != event.sequence) || this->secondarySequence) {
         if (!this->secondarySequence) {

--- a/src/core/gui/inputdevices/TouchInputHandler.cpp
+++ b/src/core/gui/inputdevices/TouchInputHandler.cpp
@@ -146,16 +146,9 @@ void TouchInputHandler::zoomStart() {
     auto* mainWindow = inputContext->getView()->getControl()->getWindow();
     // use screen pixel coordinates for the zoom center
     // as relative coordinates depend on the changing zoom level
-    int rx, ry;
-    gdk_window_get_root_coords(gtk_widget_get_window(mainWindow->getWinXournal()), 0, 0, &rx, &ry);
-    center.x -= rx;
-    center.y -= ry;
-
-    // When not using touch drawing, we're using a different scrolling method.
-    // This requires different centering.
-    /*if (!mainWindow->getGtkTouchscreenScrollingEnabled()) {
-        center = (this->priLastRel + this->secLastRel) / 2.0;  // TODO check!
-    }*/
+    utl::Point<double> windowTopLeft = mainWindow->getScreenPos();
+    center.x -= windowTopLeft.x;
+    center.y -= windowTopLeft.y;
 
     zoomControl->startZoomSequence(center);
 

--- a/src/core/gui/inputdevices/TouchInputHandler.h
+++ b/src/core/gui/inputdevices/TouchInputHandler.h
@@ -34,7 +34,8 @@ private:
     utl::Point<double> priLastRel{-1.0, -1.0};
     utl::Point<double> secLastRel{-1.0, -1.0};
 
-    bool startZoomReady = false;
+    // True, if a zoom sequence may be started by a motion event.
+    bool startZoomReady{false};
 
     bool canBlockZoom{false};
 

--- a/src/core/gui/inputdevices/TouchInputHandler.h
+++ b/src/core/gui/inputdevices/TouchInputHandler.h
@@ -34,6 +34,8 @@ private:
     utl::Point<double> priLastRel{-1.0, -1.0};
     utl::Point<double> secLastRel{-1.0, -1.0};
 
+    bool startZoomReady = false;
+
     bool canBlockZoom{false};
 
 private:

--- a/src/util/Util.cpp
+++ b/src/util/Util.cpp
@@ -48,12 +48,14 @@ auto Util::paintBackgroundWhite(GtkWidget* widget, cairo_t* cr, void*) -> gboole
     return false;
 }
 
-utl::Point<double> Util::toScreenCoords(GtkWidget* widget, utl::Point<double> point) {
-    // use screen pixel coordinates for the zoom center
-    // as relative coordinates depend on the changing zoom level
+utl::Point<double> Util::toWidgetCoords(GtkWidget* widget, utl::Point<double> absolute_coords) {
     int rx, ry;
-    gdk_window_get_root_origin(gtk_widget_get_window(widget), &rx, &ry);
-    return utl::Point<double>{point.x - rx, point.y - ry};
+    // X11 uses absolute screen coordinates while Wayland uses absolute window coordinates.
+    // Converting them to widget-local coordinates will cancel out this difference.
+    // `gtk_widget_get_window` doesn't return the actual window, but the local widget-window.
+    // GTK4 renames `gdk_window_get_root_coords()` to `gdk_surface_get_root_coords()`
+    gdk_window_get_root_coords(gtk_widget_get_window(widget), 0, 0, &rx, &ry);
+    return utl::Point<double>{absolute_coords.x - rx, absolute_coords.y - ry};
 }
 
 void Util::cairo_set_dash_from_vector(cairo_t* cr, const std::vector<double>& dashes, double offset) {

--- a/src/util/Util.cpp
+++ b/src/util/Util.cpp
@@ -48,6 +48,14 @@ auto Util::paintBackgroundWhite(GtkWidget* widget, cairo_t* cr, void*) -> gboole
     return false;
 }
 
+utl::Point<double> Util::toScreenCoords(GtkWidget* widget, utl::Point<double> point) {
+    // use screen pixel coordinates for the zoom center
+    // as relative coordinates depend on the changing zoom level
+    int rx, ry;
+    gdk_window_get_root_origin(gtk_widget_get_window(widget), &rx, &ry);
+    return utl::Point<double>{point.x - rx, point.y - ry};
+}
+
 void Util::cairo_set_dash_from_vector(cairo_t* cr, const std::vector<double>& dashes, double offset) {
     cairo_set_dash(cr, dashes.data(), static_cast<int>(dashes.size()), offset);
 }

--- a/src/util/include/util/Util.h
+++ b/src/util/include/util/Util.h
@@ -22,6 +22,8 @@
 
 #include "util/glib_casts.h"
 
+#include "Point.h"
+
 class OutputStream;
 
 namespace Util {
@@ -66,6 +68,8 @@ void execInUiThread(Fun&& callback, gint priority = G_PRIORITY_DEFAULT_IDLE) {
 gboolean paintBackgroundWhite(GtkWidget* widget, cairo_t* cr, void* unused);
 
 void cairo_set_dash_from_vector(cairo_t* cr, const std::vector<double>& dashes, double offset);
+
+utl::Point<double> toScreenCoords(GtkWidget* widget, utl::Point<double> point);
 
 /**
  * Format coordinates to use 8 digits of precision https://m.xkcd.com/2170/

--- a/src/util/include/util/Util.h
+++ b/src/util/include/util/Util.h
@@ -69,7 +69,11 @@ gboolean paintBackgroundWhite(GtkWidget* widget, cairo_t* cr, void* unused);
 
 void cairo_set_dash_from_vector(cairo_t* cr, const std::vector<double>& dashes, double offset);
 
-utl::Point<double> toScreenCoords(GtkWidget* widget, utl::Point<double> point);
+/**
+ * Transform absolute coordinates into coordinates local to the specified widget.
+ * The top left corner of `widget` will have coordinates (0, 0).
+ */
+utl::Point<double> toWidgetCoords(GtkWidget* widget, utl::Point<double> absolute_coords);
 
 /**
  * Format coordinates to use 8 digits of precision https://m.xkcd.com/2170/


### PR DESCRIPTION
This PR rebases the stale PR #2837 onto the latest master in a hope to speed up fixing #4678.

When rebasing, I solved some emerging conflicts. I also applied the suggestions by @personalizedrefrigerator and @LittleHuba given in the original PR.

### Original PR description:

This is a splitup part of https://github.com/xournalpp/xournalpp/pull/2743 .
see https://github.com/xournalpp/xournalpp/pull/2743 for older comments.

This patch fixes the issues with zoom jumping to previous/different pages. It also changes zoom steps to be relative for a much better zooming experience.

Internally this is a change from local to global coordinates, because the local coordinates had weird position spikes in them. This is honestly mostly due to my missing understanding of where the local coordinates come from. I am sure that part of this patch can be done differently.

I have also simplified some of the logic to avoid addition/subtraction of large floating point values and simpler access of the zoom calls.