### PR TITLE
Add undo touch gesture

### DIFF
--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -55,6 +55,7 @@ void Settings::loadDefault() {
     this->pressureMultiplier = 1.0;
     this->pressureGuessing = false;
     this->zoomGesturesEnabled = true;
+    this->undoGestureEnabled = false;
 
     this->maximized = false;
     this->showPairedPages = false;
@@ -382,6 +383,8 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur) {
         this->pressureMultiplier = g_ascii_strtod(reinterpret_cast<const char*>(value), nullptr);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("zoomGesturesEnabled")) == 0) {
         this->zoomGesturesEnabled = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("undoGestureEnabled")) == 0) {
+        this->undoGestureEnabled = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("selectedToolbar")) == 0) {
         this->selectedToolbar = reinterpret_cast<const char*>(value);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("lastSavePath")) == 0) {
@@ -950,6 +953,8 @@ void Settings::save() {
 
     SAVE_BOOL_PROP(zoomGesturesEnabled);
 
+    SAVE_BOOL_PROP(undoGestureEnabled);
+
     SAVE_STRING_PROP(selectedToolbar);
 
     auto lastSavePath = this->lastSavePath.u8string();
@@ -1238,6 +1243,16 @@ void Settings::setZoomGesturesEnabled(bool enable) {
         return;
     }
     this->zoomGesturesEnabled = enable;
+    save();
+}
+
+auto Settings::isUndoGestureEnabled() const -> bool { return this->undoGestureEnabled; }
+
+void Settings::setUndoGestureEnabled(bool enable) {
+    if (this->undoGestureEnabled == enable) {
+        return;
+    }
+    this->undoGestureEnabled = enable;
     save();
 }
 

--- a/src/core/control/settings/Settings.h
+++ b/src/core/control/settings/Settings.h
@@ -145,6 +145,12 @@ public:
     void setZoomGesturesEnabled(bool enable);
 
     /**
+     *  Undo Gesture getter and setter
+     */
+    bool isUndoGestureEnabled() const;
+    void setUndoGestureEnabled(bool enable);
+
+    /**
      * The last used font
      */
     XojFont& getFont();
@@ -617,6 +623,11 @@ private:
      * If the touch zoom gestures are enabled
      */
     bool zoomGesturesEnabled{};
+
+    /**
+     * If the touch undo gesture is enabled
+     */
+    bool undoGestureEnabled{};
 
     /**
      *  If fullscreen is active

--- a/src/core/gui/dialog/SettingsDialog.cpp
+++ b/src/core/gui/dialog/SettingsDialog.cpp
@@ -328,6 +328,7 @@ void SettingsDialog::showStabilizerPreprocessorOptions(StrokeStabilizer::Preproc
 void SettingsDialog::load() {
     loadCheckbox("cbSettingPresureSensitivity", settings->isPressureSensitivity());
     loadCheckbox("cbEnableZoomGestures", settings->isZoomGesturesEnabled());
+    loadCheckbox("cbUndoGesture", settings->isUndoGestureEnabled());
     loadCheckbox("cbShowSidebarRight", settings->isSidebarOnRight());
     loadCheckbox("cbShowScrollbarLeft", settings->isScrollbarOnLeft());
     loadCheckbox("cbAutoloadMostRecent", settings->isAutoloadMostRecent());
@@ -668,6 +669,7 @@ void SettingsDialog::save() {
     settings->setMinimumPressure(getSlider("scaleMinimumPressure"));
     settings->setPressureMultiplier(getSlider("scalePressureMultiplier"));
     settings->setZoomGesturesEnabled(getCheckbox("cbEnableZoomGestures"));
+    settings->setUndoGestureEnabled(getCheckbox("cbUndoGesture"));
     settings->setSidebarOnRight(getCheckbox("cbShowSidebarRight"));
     settings->setScrollbarOnLeft(getCheckbox("cbShowScrollbarLeft"));
     settings->setAutoloadMostRecent(getCheckbox("cbAutoloadMostRecent"));

--- a/src/core/gui/inputdevices/TouchInputHandler.cpp
+++ b/src/core/gui/inputdevices/TouchInputHandler.cpp
@@ -22,7 +22,7 @@ TouchInputHandler::TouchInputHandler(InputContext* inputContext): AbstractInputH
 
 auto TouchInputHandler::handleImpl(InputEvent const& event) -> bool {
     bool zoomGesturesEnabled = inputContext->getSettings()->isZoomGesturesEnabled();
-    bool undoGestureEnabled = true; // Set this to true until the setting is created
+    bool undoGestureEnabled = inputContext->getSettings()->isUndoGestureEnabled();
 
     // Don't handle more then 2 inputs
     if (this->primarySequence && this->primarySequence != event.sequence && this->secondarySequence &&

--- a/src/core/gui/inputdevices/TouchInputHandler.cpp
+++ b/src/core/gui/inputdevices/TouchInputHandler.cpp
@@ -22,7 +22,7 @@ TouchInputHandler::TouchInputHandler(InputContext* inputContext): AbstractInputH
 
 auto TouchInputHandler::handleImpl(InputEvent const& event) -> bool {
     bool zoomGesturesEnabled = inputContext->getSettings()->isZoomGesturesEnabled();
-    bool undoGestureEnabled = true; //Set this to true until the setting is created
+    bool undoGestureEnabled = true; // Set this to true until the setting is created
 
     // Don't handle more then 2 inputs
     if (this->primarySequence && this->primarySequence != event.sequence && this->secondarySequence &&
@@ -61,7 +61,7 @@ auto TouchInputHandler::handleImpl(InputEvent const& event) -> bool {
 
             // If undo gesture is enabled set variable accordingly
             if (undoGestureEnabled) {
-                detectingUndo = true; 
+                detectingUndo = true;
             }
         }
     }

--- a/src/core/gui/inputdevices/TouchInputHandler.cpp
+++ b/src/core/gui/inputdevices/TouchInputHandler.cpp
@@ -14,6 +14,7 @@
 #include "gui/XournalView.h"                        // for XournalView
 #include "gui/inputdevices/AbstractInputHandler.h"  // for AbstractInputHandler
 #include "gui/inputdevices/InputEvents.h"           // for InputEvent, BUTTO...
+#include "undo/UndoRedoHandler.h"                   // for UndoRedoHandler
 
 #include "InputContext.h"  // for InputContext
 
@@ -21,10 +22,17 @@ TouchInputHandler::TouchInputHandler(InputContext* inputContext): AbstractInputH
 
 auto TouchInputHandler::handleImpl(InputEvent const& event) -> bool {
     bool zoomGesturesEnabled = inputContext->getSettings()->isZoomGesturesEnabled();
+    bool undoGestureEnabled = true; //Set this to true until the setting is created
 
     // Don't handle more then 2 inputs
     if (this->primarySequence && this->primarySequence != event.sequence && this->secondarySequence &&
         this->secondarySequence != event.sequence) {
+
+        // If more than two inputs are detected cancel undo gesture
+        if (undoGestureEnabled && detectingUndo) {
+            detectingUndo = false;
+        }
+
         return false;
     }
 
@@ -36,7 +44,7 @@ auto TouchInputHandler::handleImpl(InputEvent const& event) -> bool {
             // Set sequence data
             sequenceStart(event);
         }
-        // Start zooming as soon as we have two sequences.
+        // Start zooming or checking for undo gesture as soon as we have two sequences.
         else if (this->primarySequence && this->primarySequence != event.sequence &&
                  this->secondarySequence == nullptr) {
             this->secondarySequence = event.sequence;
@@ -50,12 +58,23 @@ auto TouchInputHandler::handleImpl(InputEvent const& event) -> bool {
             if (zoomGesturesEnabled) {
                 zoomStart();
             }
+
+            // If undo gesture is enabled set variable accordingly
+            if (undoGestureEnabled) {
+                detectingUndo = true; 
+            }
         }
     }
 
     if (event.type == MOTION_EVENT && this->primarySequence) {
-        if (this->primarySequence && this->secondarySequence && zoomGesturesEnabled) {
-            zoomMotion(event);
+        if (this->primarySequence && this->secondarySequence) {
+            if (zoomGesturesEnabled) {
+                zoomMotion(event);
+            }
+
+            if (undoGestureEnabled && detectingUndo) {
+                detectingUndo = false;
+            }
         } else if (event.sequence == this->primarySequence) {
             scrollMotion(event);
         } else if (this->primarySequence && this->secondarySequence) {
@@ -64,9 +83,20 @@ auto TouchInputHandler::handleImpl(InputEvent const& event) -> bool {
     }
 
     if (event.type == BUTTON_RELEASE_EVENT) {
-        // Only stop zooing if both sequences were active (we were scrolling)
-        if (this->primarySequence != nullptr && this->secondarySequence != nullptr && zoomGesturesEnabled) {
-            zoomEnd();
+        // If both sequences were active check if zoom or undo gestures need to be handled
+        if (this->primarySequence != nullptr && this->secondarySequence != nullptr) {
+            if (zoomGesturesEnabled) {
+                zoomEnd();
+            }
+
+            if (undoGestureEnabled && detectingUndo) {
+                UndoRedoHandler* undoRedoHandler = this->inputContext->getView()->getControl()->getUndoRedoHandler();
+
+                // Undo only if undo is possible
+                if (undoRedoHandler->canUndo()) {
+                    undoRedoHandler->undo();
+                }
+            }
         }
 
         if (event.sequence == this->primarySequence) {

--- a/src/core/gui/inputdevices/TouchInputHandler.h
+++ b/src/core/gui/inputdevices/TouchInputHandler.h
@@ -36,6 +36,8 @@ private:
 
     bool canBlockZoom{false};
 
+    bool detectingUndo = false;
+
 private:
     void sequenceStart(InputEvent const& event);
     void scrollMotion(InputEvent const& event);

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -2686,7 +2686,7 @@ This setting can make it easier to draw with touch. </property>
                                       <object class="GtkLabel" id="lblUndoGestureDescription">
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
-                                        <property name="label" translatable="yes">&lt;i&gt;Quickly tap the touchscreen with to fingers to undo the last change.&lt;/i&gt;</property>
+                                        <property name="label" translatable="yes">&lt;i&gt;Quickly tap the touchscreen with two fingers to undo the last change.&lt;/i&gt;</property>
                                         <property name="use_markup">True</property>
                                         <property name="wrap">True</property>
                                         <property name="max_width_chars">85</property>
@@ -4784,64 +4784,6 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkFrame" id="strokeRecognizerFrrame">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label_xalign">0.0099999997764825821</property>
-                                <child>
-                                  <object class="GtkBox">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="margin_start">12</property>
-                                    <property name="margin_end">12</property>
-                                    <property name="margin_bottom">8</property>
-                                    <child>
-                                      <object class="GtkLabel">
-                                        <property name="name">lbStrokeRecognizerMinSize</property>
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="margin_end">6</property>
-                                        <property name="label" translatable="yes">Minimum Stroke Size</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">0</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkSpinButton" id="spStrokeRecognizerMinSize">
-                                        <property name="name">spStrokeRecognizerMinSize</property>
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="text" translatable="yes">0.20</property>
-                                        <property name="adjustment">adjustmentStrokeRecognizerMinSize</property>
-                                        <property name="climb_rate">2</property>
-                                        <property name="value">25</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">1</property>
-                                      </packing>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child type="label">
-                                  <object class="GtkLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="label" translatable="yes">Stroke Recognizer</property>
-                                  </object>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">5</property>
-                              </packing>
-                            </child>
-                            <child>
                               <object class="GtkFrame" id="sid146">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
@@ -4971,6 +4913,64 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Snapping</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">5</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkFrame" id="strokeRecognizerFrrame">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
+                                <child>
+                                  <object class="GtkBox">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
+                                    <property name="margin_bottom">8</property>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="name">lbStrokeRecognizerMinSize</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="margin_end">6</property>
+                                        <property name="label" translatable="yes">Minimum Stroke Size</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSpinButton" id="spStrokeRecognizerMinSize">
+                                        <property name="name">spStrokeRecognizerMinSize</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="text" translatable="yes">0.20</property>
+                                        <property name="adjustment">adjustmentStrokeRecognizerMinSize</property>
+                                        <property name="climb_rate">2</property>
+                                        <property name="value">25</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label">
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="label" translatable="yes">Stroke Recognizer</property>
                                   </object>
                                 </child>
                               </object>

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -1,240 +1,240 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.40.0 -->
+<!-- Generated with glade 3.22.2 -->
 <interface>
   <requires lib="gtk+" version="3.24"/>
   <object class="GtkAdjustment" id="adjustmentAudioGain">
     <property name="upper">10</property>
     <property name="value">1</property>
-    <property name="step-increment">0.10</property>
+    <property name="step_increment">0.10000000000000001</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentCursorHighlightBorderWidth">
     <property name="upper">30</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">10</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentCursorHighlightRadius">
     <property name="upper">30</property>
     <property name="value">30</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">5</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">5</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentDrawDirModRadius">
     <property name="lower">2</property>
     <property name="upper">1000</property>
     <property name="value">50</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">10</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentEdgePanMaxMult">
     <property name="upper">10</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">10</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentEdgePanSpeed">
     <property name="upper">100</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">10</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentHorizontalSpaceLeft">
     <property name="upper">2000</property>
     <property name="value">150</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">10</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentHorizontalSpaceRight">
     <property name="upper">2000</property>
     <property name="value">150</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">10</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentIgnoreStylusEvents">
     <property name="lower">1</property>
     <property name="upper">1000</property>
     <property name="value">1</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">10</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentMinimumPressure">
     <property name="lower">0.01</property>
     <property name="upper">1</property>
-    <property name="step-increment">0.01</property>
-    <property name="page-increment">0.5</property>
+    <property name="step_increment">0.01</property>
+    <property name="page_increment">0.5</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentPairsOffset">
     <property name="upper">100</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">1</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentPreloadPagesAfter">
     <property name="upper">99</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">10</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentPreloadPagesBefore">
     <property name="upper">99</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">10</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentPressureMultiplier">
     <property name="lower">0.5</property>
     <property name="upper">4</property>
     <property name="value">1</property>
-    <property name="step-increment">0.05</property>
-    <property name="page-increment">0.5</property>
+    <property name="step_increment">0.050000000000000003</property>
+    <property name="page_increment">0.5</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentReRenderThreshold">
     <property name="upper">900</property>
     <property name="value">10</property>
-    <property name="step-increment">5</property>
-    <property name="page-increment">100</property>
+    <property name="step_increment">5</property>
+    <property name="page_increment">100</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentSeekTime">
     <property name="lower">1</property>
     <property name="upper">90</property>
     <property name="value">5</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">10</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentSnapGridSize">
     <property name="lower">0.01</property>
     <property name="upper">20</property>
     <property name="value">1</property>
-    <property name="step-increment">0.01</property>
-    <property name="page-increment">10</property>
+    <property name="step_increment">0.01</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentSnapGridTolerance">
-    <property name="lower">0.10</property>
+    <property name="lower">0.10000000000000001</property>
     <property name="upper">1</property>
     <property name="value">0.5</property>
-    <property name="step-increment">0.05</property>
-    <property name="page-increment">10</property>
+    <property name="step_increment">0.050000000000000003</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentSnapRotationTolerance">
-    <property name="lower">0.10</property>
+    <property name="lower">0.10000000000000001</property>
     <property name="upper">1</property>
     <property name="value">0.29999999999999999</property>
-    <property name="step-increment">0.05</property>
-    <property name="page-increment">10</property>
+    <property name="step_increment">0.050000000000000003</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentStabilizerDeadzoneRadius">
-    <property name="lower">0.10</property>
+    <property name="lower">0.10000000000000001</property>
     <property name="upper">50</property>
     <property name="value">1.3</property>
-    <property name="step-increment">0.10</property>
-    <property name="page-increment">1</property>
+    <property name="step_increment">0.10000000000000001</property>
+    <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentStabilizerDrag">
     <property name="upper">1</property>
-    <property name="value">0.40</property>
-    <property name="step-increment">0.05</property>
-    <property name="page-increment">0.20</property>
+    <property name="value">0.40000000000000002</property>
+    <property name="step_increment">0.050000000000000003</property>
+    <property name="page_increment">0.20000000000000001</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentStabilizerMass">
     <property name="lower">1</property>
     <property name="upper">30</property>
     <property name="value">5</property>
-    <property name="step-increment">0.10</property>
-    <property name="page-increment">1</property>
+    <property name="step_increment">0.10000000000000001</property>
+    <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentStabilizerSigma">
-    <property name="lower">0.05</property>
+    <property name="lower">0.050000000000000003</property>
     <property name="upper">5</property>
     <property name="value">0.5</property>
-    <property name="step-increment">0.05</property>
-    <property name="page-increment">1</property>
+    <property name="step_increment">0.050000000000000003</property>
+    <property name="page_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentStabilizingBuffersize">
     <property name="lower">2</property>
     <property name="upper">100</property>
     <property name="value">20</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">10</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentStrokeIgnoreLength">
-    <property name="lower">0.01000000000000001</property>
+    <property name="lower">0.010000000000000011</property>
     <property name="upper">100</property>
     <property name="value">1</property>
-    <property name="step-increment">0.10</property>
-    <property name="page-increment">2</property>
+    <property name="step_increment">0.10000000000000001</property>
+    <property name="page_increment">2</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentStrokeIgnoreTime">
     <property name="upper">1000</property>
     <property name="value">150</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">10</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentStrokeRecognizerMinSize">
     <property name="lower">1</property>
     <property name="upper">200</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">10</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentStrokeSuccessiveTime">
     <property name="upper">1000</property>
     <property name="value">500</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">10</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentTimeout">
     <property name="lower">1</property>
     <property name="upper">100</property>
     <property name="value">1</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">10</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentTouchTImeout">
     <property name="lower">0.5</property>
     <property name="upper">10</property>
     <property name="value">1</property>
-    <property name="step-increment">0.10</property>
-    <property name="page-increment">10</property>
+    <property name="step_increment">0.10000000000000001</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentVerticalSpaceAbove">
     <property name="upper">2000</property>
     <property name="value">150</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">10</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentVerticalSpaceBelow">
     <property name="upper">2000</property>
     <property name="value">150</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">10</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentZoom">
     <property name="lower">50</property>
     <property name="upper">400</property>
     <property name="value">72</property>
-    <property name="step-increment">1</property>
+    <property name="step_increment">1</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentZoomStartThreshold">
     <property name="upper">100</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">10</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentZoomStep">
-    <property name="lower">0.10</property>
+    <property name="lower">0.10000000000000001</property>
     <property name="upper">50</property>
     <property name="value">10</property>
-    <property name="step-increment">0.5</property>
-    <property name="page-increment">10</property>
+    <property name="step_increment">0.5</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentZoomStepScroll">
-    <property name="lower">0.10</property>
+    <property name="lower">0.10000000000000001</property>
     <property name="upper">50</property>
     <property name="value">2</property>
-    <property name="step-increment">0.5</property>
-    <property name="page-increment">10</property>
+    <property name="step_increment">0.5</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkImage" id="iconCancel">
     <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="icon-name">dialog-cancel</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">dialog-cancel</property>
   </object>
   <object class="GtkImage" id="iconOk">
     <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="icon-name">dialog-ok</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">dialog-ok</property>
   </object>
   <object class="GtkListStore" id="listStabilizerAveragingMethods">
     <columns>
@@ -271,75 +271,78 @@
     </data>
   </object>
   <object class="GtkWindow" id="settingsDialog">
-    <property name="width-request">1024</property>
-    <property name="height-request">740</property>
-    <property name="can-focus">False</property>
+    <property name="width_request">1024</property>
+    <property name="height_request">740</property>
+    <property name="can_focus">False</property>
     <property name="title" translatable="yes">Xournal++ Preferences</property>
     <property name="modal">True</property>
-    <property name="destroy-with-parent">True</property>
-    <property name="skip-taskbar-hint">True</property>
+    <property name="destroy_with_parent">True</property>
+    <property name="skip_taskbar_hint">True</property>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
     <child>
       <object class="GtkBox" id="dialog-main-box">
         <property name="visible">True</property>
-        <property name="can-focus">False</property>
-        <property name="margin-start">10</property>
-        <property name="margin-end">10</property>
-        <property name="margin-top">10</property>
-        <property name="margin-bottom">10</property>
+        <property name="can_focus">False</property>
+        <property name="margin_start">10</property>
+        <property name="margin_end">10</property>
+        <property name="margin_top">10</property>
+        <property name="margin_bottom">10</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkNotebook" id="notebook1">
             <property name="name">notebook1</property>
             <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="tab-pos">left</property>
-            <property name="show-border">False</property>
+            <property name="can_focus">True</property>
+            <property name="tab_pos">left</property>
+            <property name="show_border">False</property>
             <property name="scrollable">True</property>
             <child>
               <object class="GtkBox" id="saveLoadTabBox">
                 <property name="name">saveLoadTabBox</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="margin-start">5</property>
+                <property name="can_focus">False</property>
+                <property name="margin_start">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid01">
                     <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="min-content-width">500</property>
-                    <property name="min-content-height">450</property>
+                    <property name="can_focus">True</property>
+                    <property name="min_content_width">500</property>
+                    <property name="min_content_height">450</property>
                     <child>
                       <object class="GtkViewport" id="sid02">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="shadow-type">none</property>
+                        <property name="can_focus">False</property>
+                        <property name="shadow_type">none</property>
                         <child>
                           <object class="GtkBox" id="sid03">
                             <property name="visible">True</property>
-                            <property name="can-focus">False</property>
+                            <property name="can_focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="sid04">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkBox" id="sid06">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
-                                    <property name="margin-bottom">8</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
+                                    <property name="margin_bottom">8</property>
                                     <property name="orientation">vertical</property>
                                     <child>
                                       <object class="GtkLabel" id="label28">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="label" translatable="yes">&lt;i&gt;If the document already was saved you can find it in the same folder with the extension .autosave.xoj
 If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt;/i&gt;</property>
-                                        <property name="use-markup">True</property>
+                                        <property name="use_markup">True</property>
                                         <property name="wrap">True</property>
-                                        <property name="max-width-chars">85</property>
+                                        <property name="max_width_chars">85</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -350,15 +353,15 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                     <child>
                                       <object class="GtkBox" id="sid07">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <child>
                                           <object class="GtkCheckButton" id="cbAutosave">
                                             <property name="label" translatable="yes">Enable Autosaving</property>
                                             <property name="name">cbAutosave</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="draw-indicator">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="draw_indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -370,12 +373,12 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                           <object class="GtkBox" id="boxAutosave">
                                             <property name="name">boxAutosave</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <child>
                                               <object class="GtkLabel" id="lbAutosaveTimeout1">
                                                 <property name="name">lbAutosaveTimeout1</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">every</property>
                                               </object>
                                               <packing>
@@ -388,7 +391,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                               <object class="GtkSpinButton" id="spAutosaveTimeout">
                                                 <property name="name">spAutosaveTimeout</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
+                                                <property name="can_focus">True</property>
                                                 <property name="adjustment">adjustmentTimeout</property>
                                               </object>
                                               <packing>
@@ -402,7 +405,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                               <object class="GtkLabel" id="lbAutosaveTimeout2">
                                                 <property name="name">lbAutosaveTimeout2</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">minutes</property>
                                               </object>
                                               <packing>
@@ -430,7 +433,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                 <child type="label">
                                   <object class="GtkLabel" id="sid08">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Autosaving</property>
                                   </object>
                                 </child>
@@ -444,23 +447,23 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                             <child>
                               <object class="GtkFrame" id="sid09">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkBox" id="vbox3">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
                                     <property name="orientation">vertical</property>
                                     <child>
                                       <object class="GtkLabel" id="label30">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="label" translatable="yes">&lt;i&gt;This name will be proposed if you save a new document.&lt;/i&gt;</property>
-                                        <property name="use-markup">True</property>
+                                        <property name="use_markup">True</property>
                                         <property name="wrap">True</property>
-                                        <property name="max-width-chars">85</property>
+                                        <property name="max_width_chars">85</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -472,8 +475,8 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                       <object class="GtkEntry" id="txtDefaultSaveName">
                                         <property name="name">txtDefaultSaveName</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="placeholder-text">%F-Note-%H-%M</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="placeholder_text">%F-Note-%H-%M</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -484,13 +487,13 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                     <child>
                                       <object class="GtkBox" id="box14">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <child>
                                           <object class="GtkLabel" id="label31">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Default name: </property>
-                                            <property name="use-markup">True</property>
+                                            <property name="use_markup">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -502,7 +505,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                           <object class="GtkLabel" id="lbDefaultSavename">
                                             <property name="name">lbDefaultSavename</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label">%F-Note-%H-%M</property>
                                           </object>
                                           <packing>
@@ -522,12 +525,12 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                       <object class="GtkExpander" id="expander1">
                                         <property name="name">expander1</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
+                                        <property name="can_focus">True</property>
                                         <child>
                                           <object class="GtkLabel" id="label33">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="margin-start">20</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="margin_start">20</property>
                                             <property name="label" translatable="yes">%a		Abbreviated weekday name (e.g. Thu)
 %A		Full weekday name (e.g. Thursday)
 %b		Abbreviated month name (e.g. Aug)
@@ -556,12 +559,12 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                         <child type="label">
                                           <object class="GtkBox" id="box15">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <child>
                                               <object class="GtkImage" id="image1">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="icon-name">dialog-information</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="icon_name">dialog-information</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
@@ -572,8 +575,8 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                             <child>
                                               <object class="GtkLabel" id="label32">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="margin-start">3</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="margin_start">3</property>
                                                 <property name="label" translatable="yes">Available Placeholders</property>
                                               </object>
                                               <packing>
@@ -597,7 +600,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                 <child type="label">
                                   <object class="GtkLabel" id="sid11">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Default Save Name</property>
                                   </object>
                                 </child>
@@ -611,23 +614,23 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                             <child>
                               <object class="GtkFrame" id="sid9">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkBox" id="vbox2">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
                                     <property name="orientation">vertical</property>
                                     <child>
                                       <object class="GtkLabel" id="label5">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="label" translatable="yes">&lt;i&gt;This name will be proposed if you export a document to PDF.&lt;/i&gt;</property>
-                                        <property name="use-markup">True</property>
+                                        <property name="use_markup">True</property>
                                         <property name="wrap">True</property>
-                                        <property name="max-width-chars">85</property>
+                                        <property name="max_width_chars">85</property>
                                         <property name="xalign">0</property>
                                       </object>
                                       <packing>
@@ -640,8 +643,8 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                       <object class="GtkEntry" id="txtDefaultPdfName">
                                         <property name="name">txtDefaultSaveName</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="placeholder-text">%{name}_annotated</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="placeholder_text">%{name}_annotated</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -652,13 +655,13 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                     <child>
                                       <object class="GtkBox" id="box2">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <child>
                                           <object class="GtkLabel" id="label6">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Default name: </property>
-                                            <property name="use-markup">True</property>
+                                            <property name="use_markup">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -670,7 +673,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                           <object class="GtkLabel" id="lbDefaultSavename1">
                                             <property name="name">lbDefaultSavename</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label">%{name}_annotated</property>
                                           </object>
                                           <packing>
@@ -690,11 +693,11 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                       <object class="GtkExpander" id="expander2">
                                         <property name="name">expander1</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
+                                        <property name="can_focus">True</property>
                                         <child>
                                           <object class="GtkLabel" id="label7">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">%{name}	The name of the exported document
 %a			Abbreviated weekday name (e.g. Thu)
 %A			Full weekday name (e.g. Thursday)
@@ -725,12 +728,12 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                         <child type="label">
                                           <object class="GtkBox" id="box3">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <child>
                                               <object class="GtkImage" id="image3">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="icon-name">dialog-information</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="icon_name">dialog-information</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
@@ -741,7 +744,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                             <child>
                                               <object class="GtkLabel" id="label11">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">Available Placeholders</property>
                                               </object>
                                               <packing>
@@ -765,7 +768,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                 <child type="label">
                                   <object class="GtkLabel" id="sid75">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Default Pdf export name</property>
                                   </object>
                                 </child>
@@ -779,25 +782,25 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                             <child>
                               <object class="GtkFrame" id="sid12">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkBox" id="sid14">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
-                                    <property name="margin-bottom">8</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
+                                    <property name="margin_bottom">8</property>
                                     <property name="orientation">vertical</property>
                                     <child>
                                       <object class="GtkCheckButton" id="cbAutoloadXoj">
                                         <property name="label" translatable="yes">Enable Autoloading of Journals</property>
                                         <property name="name">cbAutoloadXoj</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="tooltip-text" translatable="yes">If you open a PDF and there is a Xournal file with the same name it will open the xoj file.</property>
-                                        <property name="draw-indicator">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="tooltip_text" translatable="yes">If you open a PDF and there is a Xournal file with the same name it will open the xoj file.</property>
+                                        <property name="draw_indicator">True</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -810,10 +813,10 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                         <property name="label" translatable="yes">Enable autoloading of most recent file on application startup</property>
                                         <property name="name">cbAutoloadMostRecent</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="tooltip-text" translatable="yes">If enabled Xournal++ will open the most recent document automatically that you can continue editing your last saved document.</property>
-                                        <property name="draw-indicator">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="tooltip_text" translatable="yes">If enabled Xournal++ will open the most recent document automatically that you can continue editing your last saved document.</property>
+                                        <property name="draw_indicator">True</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -826,7 +829,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                 <child type="label">
                                   <object class="GtkLabel" id="sid16">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Autoloading</property>
                                   </object>
                                 </child>
@@ -854,57 +857,57 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
               <object class="GtkLabel" id="saveLoadTabLabel">
                 <property name="name">saveLoadTabLabel</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Load / Save</property>
               </object>
               <packing>
-                <property name="tab-fill">False</property>
+                <property name="tab_fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="inputTabBox">
                 <property name="name">inputTabBox</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="margin-start">5</property>
+                <property name="can_focus">False</property>
+                <property name="margin_start">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="swInputTab">
                     <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="min-content-width">500</property>
-                    <property name="min-content-height">450</property>
+                    <property name="can_focus">True</property>
+                    <property name="min_content_width">500</property>
+                    <property name="min_content_height">450</property>
                     <child>
                       <object class="GtkViewport" id="wpInputTab">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="shadow-type">none</property>
+                        <property name="can_focus">False</property>
+                        <property name="shadow_type">none</property>
                         <child>
                           <object class="GtkBox" id="bxInputTab">
                             <property name="visible">True</property>
-                            <property name="can-focus">False</property>
+                            <property name="can_focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="sid84">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkBox">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
-                                    <property name="margin-bottom">8</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
+                                    <property name="margin_bottom">8</property>
                                     <property name="orientation">vertical</property>
                                     <child>
                                       <object class="GtkLabel">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="label" translatable="yes">&lt;i&gt;Assign device classes to each input device of your system. Only change these values if your devices are not correctly matched. (e.g. your pen shows up as touchscreen)&lt;/i&gt;</property>
-                                        <property name="use-markup">True</property>
+                                        <property name="use_markup">True</property>
                                         <property name="wrap">True</property>
-                                        <property name="max-width-chars">85</property>
+                                        <property name="max_width_chars">85</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -916,7 +919,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                       <object class="GtkBox" id="hboxInputDeviceClasses">
                                         <property name="name">hboxInputDeviceClasses</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <placeholder/>
@@ -933,7 +936,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                 <child type="label">
                                   <object class="GtkLabel" id="sid87">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Input Devices</property>
                                   </object>
                                 </child>
@@ -947,29 +950,29 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                             <child>
                               <object class="GtkFrame" id="sid88">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkBox" id="sid90">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
-                                    <property name="margin-bottom">8</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
+                                    <property name="margin_bottom">8</property>
                                     <property name="orientation">vertical</property>
                                     <child>
                                       <object class="GtkCheckButton" id="cbInputSystemDrawOutsideWindow">
                                         <property name="name">cbInputSystemDrawOutsideWindow</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="draw-indicator">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="draw_indicator">True</property>
                                         <child>
                                           <object class="GtkLabel" id="sid92">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Enable drawing outside of window &lt;i&gt;(Drawing will not stop at the border of the window)&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
+                                            <property name="use_markup">True</property>
                                             <property name="wrap">True</property>
                                           </object>
                                         </child>
@@ -984,22 +987,22 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                       <object class="GtkCheckButton" id="cbInputSystemTPCButton">
                                         <property name="name">cbInputSystemTPCButton</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="tooltip-markup" translatable="yes">Drag LEFT from start point acts like shift key is being held.
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="tooltip_markup" translatable="yes">Drag LEFT from start point acts like shift key is being held.
 	    Drag UP acts as if Control key is being held.
 
             Determination Radius: Radius at which modifiers will lock in until finished drawing.
 
 	    &lt;i&gt;Useful for operating without keyboard.&lt;/i&gt;</property>
-                                        <property name="draw-indicator">True</property>
+                                        <property name="draw_indicator">True</property>
                                         <child>
                                           <object class="GtkLabel" id="sid93">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Merge button events with stylus tip events
 	    &lt;i&gt;(Check this if&lt;/i&gt; "&lt;tt&gt;xsetwacom get *deviceId* TabletPCButton&lt;/tt&gt;" &lt;i&gt;returns&lt;/i&gt; "&lt;tt&gt;on&lt;/tt&gt;"&lt;i&gt;)&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
+                                            <property name="use_markup">True</property>
                                             <property name="wrap">True</property>
                                           </object>
                                         </child>
@@ -1014,18 +1017,18 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                       <object class="GtkCheckButton" id="cbEnablePressureInference">
                                         <property name="name">cbEnablePressureInference</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="tooltip-markup" translatable="yes">Slower strokes are assigned a greater pressure than faster strokes, if pressure information is absent.
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="tooltip_markup" translatable="yes">Slower strokes are assigned a greater pressure than faster strokes, if pressure information is absent.
 
 &lt;i&gt;This feature may be useful for devices that lack pressure sensitivity. For example, a mouse or touchscreen.&lt;/i&gt;</property>
-                                        <property name="draw-indicator">True</property>
+                                        <property name="draw_indicator">True</property>
                                         <child>
                                           <object class="GtkLabel" id="sid201">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Enable Pressure Inference &lt;i&gt;(Guess pressure from drawing speed when device-supplied pressure is not available)&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
+                                            <property name="use_markup">True</property>
                                             <property name="wrap">True</property>
                                           </object>
                                         </child>
@@ -1041,7 +1044,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                 <child type="label">
                                   <object class="GtkLabel" id="sid94">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Options</property>
                                   </object>
                                 </child>
@@ -1055,39 +1058,38 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                             <child>
                               <object class="GtkFrame" id="frameStabilizerSettings">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
-                                  <!-- n-columns=4 n-rows=4 -->
                                   <object class="GtkGrid" id="gridStabilizer">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
-                                    <property name="margin-bottom">12</property>
-                                    <property name="column-spacing">10</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
+                                    <property name="margin_bottom">12</property>
+                                    <property name="column_spacing">10</property>
                                     <child>
                                       <object class="GtkLabel" id="lbStabilizerAveragingMethod">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="halign">start</property>
-                                        <property name="margin-start">16</property>
+                                        <property name="margin_start">16</property>
                                         <property name="label" translatable="yes">Averaging method</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">0</property>
-                                        <property name="top-attach">1</property>
+                                        <property name="left_attach">0</property>
+                                        <property name="top_attach">1</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkComboBox" id="cbStabilizerAveragingMethods">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="hexpand">True</property>
                                         <property name="model">listStabilizerAveragingMethods</property>
                                         <property name="active">0</property>
-                                        <property name="id-column">0</property>
-                                        <property name="active-id">0</property>
+                                        <property name="id_column">0</property>
+                                        <property name="active_id">0</property>
                                         <child>
                                           <object class="GtkCellRendererText"/>
                                           <attributes>
@@ -1097,203 +1099,203 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                         </child>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">1</property>
-                                        <property name="top-attach">1</property>
+                                        <property name="left_attach">1</property>
+                                        <property name="top_attach">1</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkLabel" id="lbStabilizerDescription">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="label" translatable="yes">&lt;i&gt;Pick an input stabilization algorithm and its parameters&lt;/i&gt;</property>
-                                        <property name="use-markup">True</property>
+                                        <property name="use_markup">True</property>
                                         <property name="wrap">True</property>
-                                        <property name="width-chars">85</property>
-                                        <property name="max-width-chars">85</property>
+                                        <property name="width_chars">85</property>
+                                        <property name="max_width_chars">85</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">0</property>
-                                        <property name="top-attach">0</property>
+                                        <property name="left_attach">0</property>
+                                        <property name="top_attach">0</property>
                                         <property name="width">4</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkLabel" id="lbStabilizerBuffersize">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="label" translatable="yes">Buffersize</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">2</property>
-                                        <property name="top-attach">1</property>
+                                        <property name="left_attach">2</property>
+                                        <property name="top_attach">1</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkSpinButton" id="sbStabilizerBuffersize">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
+                                        <property name="can_focus">True</property>
                                         <property name="hexpand">True</property>
                                         <property name="text" translatable="yes">20</property>
-                                        <property name="input-purpose">number</property>
+                                        <property name="input_purpose">number</property>
                                         <property name="adjustment">adjustmentStabilizingBuffersize</property>
-                                        <property name="climb-rate">1</property>
-                                        <property name="snap-to-ticks">True</property>
+                                        <property name="climb_rate">1</property>
+                                        <property name="snap_to_ticks">True</property>
                                         <property name="numeric">True</property>
                                         <property name="value">20</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">3</property>
-                                        <property name="top-attach">1</property>
+                                        <property name="left_attach">3</property>
+                                        <property name="top_attach">1</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkLabel" id="lbStabilizerDeadzoneRadius">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="label" translatable="yes">Deadzone radius</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">2</property>
-                                        <property name="top-attach">2</property>
+                                        <property name="left_attach">2</property>
+                                        <property name="top_attach">2</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkSpinButton" id="sbStabilizerDeadzoneRadius">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
+                                        <property name="can_focus">True</property>
                                         <property name="hexpand">True</property>
                                         <property name="text" translatable="yes">1,30</property>
-                                        <property name="input-purpose">number</property>
+                                        <property name="input_purpose">number</property>
                                         <property name="adjustment">adjustmentStabilizerDeadzoneRadius</property>
-                                        <property name="climb-rate">2</property>
+                                        <property name="climb_rate">2</property>
                                         <property name="digits">2</property>
-                                        <property name="snap-to-ticks">True</property>
+                                        <property name="snap_to_ticks">True</property>
                                         <property name="numeric">True</property>
                                         <property name="value">1.3</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">3</property>
-                                        <property name="top-attach">2</property>
+                                        <property name="left_attach">3</property>
+                                        <property name="top_attach">2</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkLabel" id="lbStabilizerDrag">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="tooltip-text" translatable="yes">Drag: If the value is too small, unwanted oscillations may appear. If the value is too high, there will be no stabilization.</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="tooltip_text" translatable="yes">Drag: If the value is too small, unwanted oscillations may appear. If the value is too high, there will be no stabilization.</property>
                                         <property name="label" translatable="yes">Drag</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">2</property>
-                                        <property name="top-attach">2</property>
+                                        <property name="left_attach">2</property>
+                                        <property name="top_attach">2</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkSpinButton" id="sbStabilizerDrag">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="tooltip-text" translatable="yes">Drag: If the value is too small, unwanted oscillations may appear. If the value is too high, there will be no stabilization.</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="tooltip_text" translatable="yes">Drag: If the value is too small, unwanted oscillations may appear. If the value is too high, there will be no stabilization.</property>
                                         <property name="hexpand">True</property>
                                         <property name="text" translatable="yes">0,4</property>
-                                        <property name="input-purpose">number</property>
+                                        <property name="input_purpose">number</property>
                                         <property name="adjustment">adjustmentStabilizerDrag</property>
-                                        <property name="climb-rate">2</property>
+                                        <property name="climb_rate">2</property>
                                         <property name="digits">2</property>
-                                        <property name="snap-to-ticks">True</property>
+                                        <property name="snap_to_ticks">True</property>
                                         <property name="numeric">True</property>
-                                        <property name="value">0.40</property>
+                                        <property name="value">0.40000000000000002</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">3</property>
-                                        <property name="top-attach">2</property>
+                                        <property name="left_attach">3</property>
+                                        <property name="top_attach">2</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkLabel" id="lbStabilizerMass">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="tooltip-text" translatable="yes">Mass: the higher the mass, the more inertia and the more stabilization</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="tooltip_text" translatable="yes">Mass: the higher the mass, the more inertia and the more stabilization</property>
                                         <property name="label" translatable="yes">Mass</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">2</property>
-                                        <property name="top-attach">3</property>
+                                        <property name="left_attach">2</property>
+                                        <property name="top_attach">3</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkSpinButton" id="sbStabilizerMass">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="tooltip-text" translatable="yes">Mass: the higher the mass, the more inertia and the more stabilization</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="tooltip_text" translatable="yes">Mass: the higher the mass, the more inertia and the more stabilization</property>
                                         <property name="hexpand">True</property>
                                         <property name="text" translatable="yes">5</property>
-                                        <property name="input-purpose">number</property>
+                                        <property name="input_purpose">number</property>
                                         <property name="adjustment">adjustmentStabilizerMass</property>
-                                        <property name="climb-rate">2</property>
+                                        <property name="climb_rate">2</property>
                                         <property name="digits">2</property>
-                                        <property name="snap-to-ticks">True</property>
+                                        <property name="snap_to_ticks">True</property>
                                         <property name="numeric">True</property>
                                         <property name="value">5</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">3</property>
-                                        <property name="top-attach">3</property>
+                                        <property name="left_attach">3</property>
+                                        <property name="top_attach">3</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkSpinButton" id="sbStabilizerSigma">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="tooltip-text" translatable="yes">Gaussian parameter: the higher, the more stabilization and the more lag between your cursor and the painting tip.</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="tooltip_text" translatable="yes">Gaussian parameter: the higher, the more stabilization and the more lag between your cursor and the painting tip.</property>
                                         <property name="hexpand">True</property>
                                         <property name="text" translatable="yes">0,50</property>
-                                        <property name="input-purpose">number</property>
+                                        <property name="input_purpose">number</property>
                                         <property name="adjustment">adjustmentStabilizerSigma</property>
-                                        <property name="climb-rate">0.99999999977648257</property>
+                                        <property name="climb_rate">0.99999999977648257</property>
                                         <property name="digits">2</property>
-                                        <property name="snap-to-ticks">True</property>
+                                        <property name="snap_to_ticks">True</property>
                                         <property name="numeric">True</property>
                                         <property name="value">0.5</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">3</property>
-                                        <property name="top-attach">1</property>
+                                        <property name="left_attach">3</property>
+                                        <property name="top_attach">1</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkLabel" id="lbStabilizerSigma">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="tooltip-text" translatable="yes">Gaussian parameter: the higher, the more stabilization and the more lag between your cursor and the painting tip.</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="tooltip_text" translatable="yes">Gaussian parameter: the higher, the more stabilization and the more lag between your cursor and the painting tip.</property>
                                         <property name="label">σ</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">2</property>
-                                        <property name="top-attach">1</property>
+                                        <property name="left_attach">2</property>
+                                        <property name="top_attach">1</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkLabel" id="lbStabilizerPreprocessor">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="halign">start</property>
-                                        <property name="margin-start">15</property>
+                                        <property name="margin_start">15</property>
                                         <property name="label" translatable="yes">Preprocessor</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">0</property>
-                                        <property name="top-attach">2</property>
+                                        <property name="left_attach">0</property>
+                                        <property name="top_attach">2</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkComboBox" id="cbStabilizerPreprocessors">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="hexpand">True</property>
                                         <property name="model">listStabilizerPreprocessors</property>
                                         <property name="active">0</property>
-                                        <property name="id-column">0</property>
-                                        <property name="active-id">0</property>
+                                        <property name="id_column">0</property>
+                                        <property name="active_id">0</property>
                                         <child>
                                           <object class="GtkCellRendererText"/>
                                           <attributes>
@@ -1303,8 +1305,8 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                         </child>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">1</property>
-                                        <property name="top-attach">2</property>
+                                        <property name="left_attach">1</property>
+                                        <property name="top_attach">2</property>
                                       </packing>
                                     </child>
                                     <child>
@@ -1312,15 +1314,15 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                         <property name="label" translatable="yes">Cusp detection</property>
                                         <property name="name">cbStabilizerEnableCuspDetection</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">False</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
                                         <property name="halign">start</property>
                                         <property name="active">True</property>
-                                        <property name="draw-indicator">True</property>
+                                        <property name="draw_indicator">True</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">2</property>
-                                        <property name="top-attach">3</property>
+                                        <property name="left_attach">2</property>
+                                        <property name="top_attach">3</property>
                                         <property name="width">2</property>
                                       </packing>
                                     </child>
@@ -1329,15 +1331,15 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                         <property name="label" translatable="yes">Finalize the stroke</property>
                                         <property name="name">cbStabilizerEnableFinalizeStroke</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="tooltip-text" translatable="yes">Input stabilization can create a gap at the end of your stroke. If enabled, this gap is filled.</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="tooltip_text" translatable="yes">Input stabilization can create a gap at the end of your stroke. If enabled, this gap is filled.</property>
                                         <property name="active">True</property>
-                                        <property name="draw-indicator">True</property>
+                                        <property name="draw_indicator">True</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">0</property>
-                                        <property name="top-attach">3</property>
+                                        <property name="left_attach">0</property>
+                                        <property name="top_attach">3</property>
                                       </packing>
                                     </child>
                                     <child>
@@ -1348,7 +1350,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                 <child type="label">
                                   <object class="GtkLabel" id="lbStabilizerSettings">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Input stabilization</property>
                                   </object>
                                 </child>
@@ -1379,56 +1381,56 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
               <object class="GtkLabel" id="inputTabLabel">
                 <property name="name">inputTabLabel</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Input System</property>
               </object>
               <packing>
                 <property name="position">1</property>
-                <property name="tab-fill">False</property>
+                <property name="tab_fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="mouseTabBox">
                 <property name="name">mouseTabBox</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="margin-start">5</property>
+                <property name="can_focus">False</property>
+                <property name="margin_start">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid17">
                     <property name="visible">True</property>
-                    <property name="can-focus">True</property>
+                    <property name="can_focus">True</property>
                     <child>
                       <object class="GtkViewport" id="sid18">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="shadow-type">none</property>
+                        <property name="can_focus">False</property>
+                        <property name="shadow_type">none</property>
                         <child>
                           <object class="GtkBox" id="sid19">
                             <property name="visible">True</property>
-                            <property name="can-focus">False</property>
+                            <property name="can_focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="sid20">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkBox" id="sid22">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
-                                    <property name="margin-bottom">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
+                                    <property name="margin_bottom">12</property>
                                     <property name="orientation">vertical</property>
                                     <child>
                                       <object class="GtkLabel" id="label23">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="label" translatable="yes">&lt;i&gt;Define which tools will be selected if you press a mouse button. After you release the button the previously selected tool will be selected.&lt;/i&gt;</property>
-                                        <property name="use-markup">True</property>
+                                        <property name="use_markup">True</property>
                                         <property name="wrap">True</property>
-                                        <property name="max-width-chars">85</property>
+                                        <property name="max_width_chars">85</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -1439,16 +1441,16 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                     <child>
                                       <object class="GtkFrame" id="sid23">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="label-xalign">0.009999999776482582</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="label_xalign">0.0099999997764825821</property>
                                         <child>
                                           <object class="GtkBox" id="hboxMiddleMouse">
                                             <property name="name">hboxMidleMouse</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="margin-start">12</property>
-                                            <property name="margin-end">12</property>
-                                            <property name="margin-bottom">8</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="margin_start">12</property>
+                                            <property name="margin_end">12</property>
+                                            <property name="margin_bottom">8</property>
                                             <child>
                                               <placeholder/>
                                             </child>
@@ -1457,7 +1459,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                         <child type="label">
                                           <object class="GtkLabel" id="sid25">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Middle Mouse Button</property>
                                           </object>
                                         </child>
@@ -1471,16 +1473,16 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                     <child>
                                       <object class="GtkFrame" id="sid26">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="label-xalign">0.009999999776482582</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="label_xalign">0.0099999997764825821</property>
                                         <child>
                                           <object class="GtkBox" id="hboxRightMouse">
                                             <property name="name">hboxRightMouse</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="margin-start">12</property>
-                                            <property name="margin-end">12</property>
-                                            <property name="margin-bottom">8</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="margin_start">12</property>
+                                            <property name="margin_end">12</property>
+                                            <property name="margin_bottom">8</property>
                                             <child>
                                               <placeholder/>
                                             </child>
@@ -1489,7 +1491,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                         <child type="label">
                                           <object class="GtkLabel" id="sid28">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Right Mouse Button</property>
                                           </object>
                                         </child>
@@ -1505,7 +1507,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                 <child type="label">
                                   <object class="GtkLabel" id="sid29">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Mouse Buttons</property>
                                   </object>
                                 </child>
@@ -1536,58 +1538,58 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
               <object class="GtkLabel" id="mouseTabLabel">
                 <property name="name">mouseTabLabel</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Mouse</property>
               </object>
               <packing>
                 <property name="position">2</property>
-                <property name="tab-fill">False</property>
+                <property name="tab_fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="stylusTabBox">
                 <property name="name">stylusTabBox</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="margin-start">5</property>
+                <property name="can_focus">False</property>
+                <property name="margin_start">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid30">
                     <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="min-content-width">500</property>
-                    <property name="min-content-height">450</property>
+                    <property name="can_focus">True</property>
+                    <property name="min_content_width">500</property>
+                    <property name="min_content_height">450</property>
                     <child>
                       <object class="GtkViewport" id="sid31">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="shadow-type">none</property>
+                        <property name="can_focus">False</property>
+                        <property name="shadow_type">none</property>
                         <child>
                           <object class="GtkBox" id="sid32">
                             <property name="visible">True</property>
-                            <property name="can-focus">False</property>
+                            <property name="can_focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="sid33">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkBox" id="sid35">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
-                                    <property name="margin-bottom">8</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
+                                    <property name="margin_bottom">8</property>
                                     <property name="orientation">vertical</property>
                                     <child>
                                       <object class="GtkLabel" id="sid36">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="label" translatable="yes">&lt;i&gt;Pressure Sensitivity allows you to draw lines with different widths, depending on how much pressure you apply to the pen. If your tablet does not support this feature this setting has no effect.&lt;/i&gt;</property>
-                                        <property name="use-markup">True</property>
+                                        <property name="use_markup">True</property>
                                         <property name="wrap">True</property>
-                                        <property name="max-width-chars">85</property>
+                                        <property name="max_width_chars">85</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -1600,9 +1602,9 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                         <property name="label" translatable="yes">Enable Pressure Sensitivity</property>
                                         <property name="name">cbSettingPresureSensitivity</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="draw-indicator">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="draw_indicator">True</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -1613,24 +1615,24 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                     <child>
                                       <object class="GtkFrame" id="framePressureSensitivityScale">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="label-xalign">0.009999999776482582</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="label_xalign">0.0099999997764825821</property>
                                         <child>
                                           <object class="GtkBox" id="boxSensitivityScaleOptions">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="margin-start">12</property>
-                                            <property name="margin-end">12</property>
-                                            <property name="margin-bottom">8</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="margin_start">12</property>
+                                            <property name="margin_end">12</property>
+                                            <property name="margin_bottom">8</property>
                                             <property name="orientation">vertical</property>
                                             <child>
                                               <object class="GtkLabel" id="lbSensitivityScaleDescription">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">&lt;i&gt;Some devices report unexpectedly small or large pressures. This can be fixed by setting a minimum pressure or scaling the pressure reported by the device.&lt;/i&gt;</property>
-                                                <property name="use-markup">True</property>
+                                                <property name="use_markup">True</property>
                                                 <property name="wrap">True</property>
-                                                <property name="max-width-chars">85</property>
+                                                <property name="max_width_chars">85</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
@@ -1639,72 +1641,62 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                               </packing>
                                             </child>
                                             <child>
-                                              <!-- n-columns=3 n-rows=3 -->
                                               <object class="GtkGrid" id="gridPressureSensitivityOptions">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="column-spacing">5</property>
-                                                <property name="column-homogeneous">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="column_spacing">5</property>
+                                                <property name="column_homogeneous">True</property>
                                                 <child>
                                                   <object class="GtkLabel">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
+                                                    <property name="can_focus">False</property>
                                                     <property name="label" translatable="yes">Minimum Pressure:</property>
                                                   </object>
                                                   <packing>
-                                                    <property name="left-attach">0</property>
-                                                    <property name="top-attach">0</property>
+                                                    <property name="left_attach">0</property>
+                                                    <property name="top_attach">0</property>
                                                   </packing>
                                                 </child>
                                                 <child>
                                                   <object class="GtkLabel">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
+                                                    <property name="can_focus">False</property>
                                                     <property name="label" translatable="yes">Pressure Multiplier: </property>
                                                   </object>
                                                   <packing>
-                                                    <property name="left-attach">0</property>
-                                                    <property name="top-attach">1</property>
+                                                    <property name="left_attach">0</property>
+                                                    <property name="top_attach">1</property>
                                                   </packing>
                                                 </child>
                                                 <child>
                                                   <object class="GtkScale" id="scaleMinimumPressure">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">True</property>
+                                                    <property name="can_focus">True</property>
                                                     <property name="adjustment">adjustmentMinimumPressure</property>
-                                                    <property name="round-digits">1</property>
+                                                    <property name="round_digits">1</property>
                                                     <property name="digits">2</property>
-                                                    <property name="value-pos">right</property>
+                                                    <property name="value_pos">right</property>
                                                   </object>
                                                   <packing>
-                                                    <property name="left-attach">1</property>
-                                                    <property name="top-attach">0</property>
+                                                    <property name="left_attach">1</property>
+                                                    <property name="top_attach">0</property>
                                                     <property name="width">2</property>
                                                   </packing>
                                                 </child>
                                                 <child>
                                                   <object class="GtkScale" id="scalePressureMultiplier">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">True</property>
+                                                    <property name="can_focus">True</property>
                                                     <property name="adjustment">adjustmentPressureMultiplier</property>
-                                                    <property name="round-digits">1</property>
+                                                    <property name="round_digits">1</property>
                                                     <property name="digits">2</property>
-                                                    <property name="value-pos">right</property>
+                                                    <property name="value_pos">right</property>
                                                   </object>
                                                   <packing>
-                                                    <property name="left-attach">1</property>
-                                                    <property name="top-attach">1</property>
+                                                    <property name="left_attach">1</property>
+                                                    <property name="top_attach">1</property>
                                                     <property name="width">2</property>
                                                   </packing>
-                                                </child>
-                                                <child>
-                                                  <placeholder/>
-                                                </child>
-                                                <child>
-                                                  <placeholder/>
-                                                </child>
-                                                <child>
-                                                  <placeholder/>
                                                 </child>
                                               </object>
                                               <packing>
@@ -1718,7 +1710,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                         <child type="label">
                                           <object class="GtkLabel" id="lbSensitivityScaleHeader">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Sensitivity Scale</property>
                                           </object>
                                         </child>
@@ -1734,7 +1726,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                 <child type="label">
                                   <object class="GtkLabel" id="sid37">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Pressure Sensitivity</property>
                                   </object>
                                 </child>
@@ -1748,21 +1740,21 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                             <child>
                               <object class="GtkFrame" id="sid183">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkBox" id="sid185">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="orientation">vertical</property>
                                     <child>
                                       <object class="GtkLabel" id="sid186">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="label" translatable="yes">&lt;i&gt;With some setup, pen strokes have artifacts at their beginning. This can be avoided by ignoring the first few events/stroke-points when the pen touches the screen.&lt;/i&gt;</property>
-                                        <property name="use-markup">True</property>
+                                        <property name="use_markup">True</property>
                                         <property name="wrap">True</property>
-                                        <property name="max-width-chars">85</property>
+                                        <property name="max_width_chars">85</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -1773,15 +1765,15 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                     <child>
                                       <object class="GtkBox" id="sid187">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <child>
                                           <object class="GtkCheckButton" id="cbIgnoreFirstStylusEvents">
                                             <property name="label" translatable="yes">Ignore the first</property>
                                             <property name="name">cbSettingIgnoreFirstStylusEvents</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="draw-indicator">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="draw_indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -1793,7 +1785,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                           <object class="GtkSpinButton" id="spNumIgnoredStylusEvents">
                                             <property name="name">spNrOfIgnoredFirstStylusEvents</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
+                                            <property name="can_focus">True</property>
                                             <property name="text" translatable="yes">1</property>
                                             <property name="adjustment">adjustmentIgnoreStylusEvents</property>
                                             <property name="value">1</property>
@@ -1809,7 +1801,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                           <object class="GtkLabel" id="lbIgnoreFirstStylusEvents">
                                             <property name="name">lbIgnoreFirstStylusEvents</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">events</property>
                                           </object>
                                           <packing>
@@ -1830,7 +1822,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                 <child type="label">
                                   <object class="GtkLabel" id="sid188">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Artifact workaround</property>
                                   </object>
                                 </child>
@@ -1844,24 +1836,24 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                             <child>
                               <object class="GtkFrame" id="sid38">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkBox" id="sid40">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
-                                    <property name="margin-bottom">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
+                                    <property name="margin_bottom">12</property>
                                     <property name="orientation">vertical</property>
                                     <child>
                                       <object class="GtkLabel" id="sid41">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="label" translatable="yes">&lt;i&gt;Specify the tools that will be selected if a button of the stylus is pressed or the eraser is used. After releasing the button, the previous tool will be selected.&lt;/i&gt;</property>
-                                        <property name="use-markup">True</property>
+                                        <property name="use_markup">True</property>
                                         <property name="wrap">True</property>
-                                        <property name="max-width-chars">85</property>
+                                        <property name="max_width_chars">85</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -1872,16 +1864,16 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                     <child>
                                       <object class="GtkFrame" id="sid42">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="label-xalign">0.009999999776482582</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="label_xalign">0.0099999997764825821</property>
                                         <child>
                                           <object class="GtkBox" id="hboxPenButton1">
                                             <property name="name">hboxPenButton1</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="margin-start">12</property>
-                                            <property name="margin-end">12</property>
-                                            <property name="margin-bottom">8</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="margin_start">12</property>
+                                            <property name="margin_end">12</property>
+                                            <property name="margin_bottom">8</property>
                                             <child>
                                               <placeholder/>
                                             </child>
@@ -1890,7 +1882,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                         <child type="label">
                                           <object class="GtkLabel" id="sid44">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Button 1</property>
                                           </object>
                                         </child>
@@ -1904,16 +1896,16 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                     <child>
                                       <object class="GtkFrame" id="sid45">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="label-xalign">0.009999999776482582</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="label_xalign">0.0099999997764825821</property>
                                         <child>
                                           <object class="GtkBox" id="hboxPenButton2">
                                             <property name="name">hboxPenButton2</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="margin-start">12</property>
-                                            <property name="margin-end">12</property>
-                                            <property name="margin-bottom">8</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="margin_start">12</property>
+                                            <property name="margin_end">12</property>
+                                            <property name="margin_bottom">8</property>
                                             <child>
                                               <placeholder/>
                                             </child>
@@ -1922,7 +1914,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                         <child type="label">
                                           <object class="GtkLabel" id="sid47">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Button 2</property>
                                           </object>
                                         </child>
@@ -1936,16 +1928,16 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                     <child>
                                       <object class="GtkFrame" id="sid48">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="label-xalign">0.009999999776482582</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="label_xalign">0.0099999997764825821</property>
                                         <child>
                                           <object class="GtkBox" id="hboxEraser">
                                             <property name="name">hboxEraser</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="margin-start">12</property>
-                                            <property name="margin-end">12</property>
-                                            <property name="margin-bottom">8</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="margin_start">12</property>
+                                            <property name="margin_end">12</property>
+                                            <property name="margin_bottom">8</property>
                                             <child>
                                               <placeholder/>
                                             </child>
@@ -1954,7 +1946,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                         <child type="label">
                                           <object class="GtkLabel" id="sid50">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Eraser</property>
                                           </object>
                                         </child>
@@ -1970,7 +1962,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                 <child type="label">
                                   <object class="GtkLabel" id="sid51">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Stylus Buttons</property>
                                   </object>
                                 </child>
@@ -1984,25 +1976,25 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                             <child>
                               <object class="GtkFrame" id="sid5">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkBox" id="sid8">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
-                                    <property name="margin-bottom">8</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
+                                    <property name="margin_bottom">8</property>
                                     <property name="orientation">vertical</property>
                                     <child>
                                       <object class="GtkBox">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="spacing">5</property>
                                         <child>
                                           <object class="GtkLabel">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Stylus-based eraser is visible</property>
                                           </object>
                                           <packing>
@@ -2015,7 +2007,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                           <object class="GtkComboBoxText" id="cbEraserVisibility">
                                             <property name="name">cbEraserVisibility</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="active">0</property>
                                             <items>
                                               <item id="never" translatable="yes" context="eraser is never visible">Never</item>
@@ -2042,7 +2034,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                 <child type="label">
                                   <object class="GtkLabel" id="sid74">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Eraser visibility</property>
                                   </object>
                                 </child>
@@ -2073,58 +2065,58 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
               <object class="GtkLabel" id="stylusTabLabel">
                 <property name="name">stylusTabLabel</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Stylus</property>
               </object>
               <packing>
                 <property name="position">3</property>
-                <property name="tab-fill">False</property>
+                <property name="tab_fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="touchTabBox">
                 <property name="name">touchTabBox</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="margin-start">5</property>
+                <property name="can_focus">False</property>
+                <property name="margin_start">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid52">
                     <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="min-content-width">500</property>
-                    <property name="min-content-height">450</property>
+                    <property name="can_focus">True</property>
+                    <property name="min_content_width">500</property>
+                    <property name="min_content_height">450</property>
                     <child>
                       <object class="GtkViewport" id="sid53">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="shadow-type">none</property>
+                        <property name="can_focus">False</property>
+                        <property name="shadow_type">none</property>
                         <child>
                           <object class="GtkBox" id="sid54">
                             <property name="visible">True</property>
-                            <property name="can-focus">False</property>
+                            <property name="can_focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="sid55">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkBox" id="sid57">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
-                                    <property name="margin-bottom">8</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
+                                    <property name="margin_bottom">8</property>
                                     <property name="orientation">vertical</property>
                                     <child>
                                       <object class="GtkLabel" id="sid58">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="label" translatable="yes">&lt;i&gt;You can configure devices, not identified by GTK as touchscreen, to behave as if they were one.&lt;/i&gt;</property>
-                                        <property name="use-markup">True</property>
+                                        <property name="use_markup">True</property>
                                         <property name="wrap">True</property>
-                                        <property name="max-width-chars">85</property>
+                                        <property name="max_width_chars">85</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -2136,7 +2128,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                       <object class="GtkBox" id="hboxTouch">
                                         <property name="name">hboxTouch</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <child>
                                           <placeholder/>
                                         </child>
@@ -2152,7 +2144,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                 <child type="label">
                                   <object class="GtkLabel" id="sid59">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Touchscreen</property>
                                   </object>
                                 </child>
@@ -2166,24 +2158,24 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                             <child>
                               <object class="GtkFrame" id="sid60">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkBox" id="sid62">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
-                                    <property name="margin-bottom">8</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
+                                    <property name="margin_bottom">8</property>
                                     <property name="orientation">vertical</property>
                                     <child>
                                       <object class="GtkLabel" id="sid63">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="label" translatable="yes">&lt;i&gt;If your hardware does not support hand recognition, Xournal++ can disable your touchscreen when your pen is near the screen.&lt;/i&gt;</property>
-                                        <property name="use-markup">True</property>
+                                        <property name="use_markup">True</property>
                                         <property name="wrap">True</property>
-                                        <property name="max-width-chars">85</property>
+                                        <property name="max_width_chars">85</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -2196,9 +2188,9 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                         <property name="label" translatable="yes">Enable internal Hand Recognition</property>
                                         <property name="name">cbDisableTouchOnPenNear</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="draw-indicator">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="draw_indicator">True</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -2210,42 +2202,41 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                       <object class="GtkBox" id="boxInternalHandRecognition">
                                         <property name="name">boxInternalHandRecognition</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
-                                          <!-- n-columns=3 n-rows=3 -->
                                           <object class="GtkGrid" id="sid64">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="row-spacing">5</property>
-                                            <property name="column-spacing">5</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="row_spacing">5</property>
+                                            <property name="column_spacing">5</property>
                                             <child>
                                               <object class="GtkLabel" id="label50">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">Disabling Method</property>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">0</property>
-                                                <property name="top-attach">0</property>
+                                                <property name="left_attach">0</property>
+                                                <property name="top_attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkLabel" id="label55">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">Timeout</property>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">0</property>
-                                                <property name="top-attach">1</property>
+                                                <property name="left_attach">0</property>
+                                                <property name="top_attach">1</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkComboBoxText" id="cbTouchDisableMethod">
                                                 <property name="name">cbTouchDisableMethod</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="active">0</property>
                                                 <items>
                                                   <item translatable="yes">Autodetect</item>
@@ -2254,45 +2245,36 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                                 </items>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">1</property>
-                                                <property name="top-attach">0</property>
+                                                <property name="left_attach">1</property>
+                                                <property name="top_attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkSpinButton" id="spTouchDisableTimeout">
                                                 <property name="name">spTouchDisableTimeout</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
+                                                <property name="can_focus">True</property>
                                                 <property name="adjustment">adjustmentTouchTImeout</property>
-                                                <property name="climb-rate">0.5</property>
+                                                <property name="climb_rate">0.5</property>
                                                 <property name="digits">1</property>
                                                 <property name="value">1</property>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">1</property>
-                                                <property name="top-attach">1</property>
+                                                <property name="left_attach">1</property>
+                                                <property name="top_attach">1</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkLabel" id="label56">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">s &lt;i&gt;(after which the touchscreen will be reactivated again)&lt;/i&gt;</property>
-                                                <property name="use-markup">True</property>
+                                                <property name="use_markup">True</property>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">2</property>
-                                                <property name="top-attach">1</property>
+                                                <property name="left_attach">2</property>
+                                                <property name="top_attach">1</property>
                                               </packing>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                            <child>
-                                              <placeholder/>
                                             </child>
                                             <child>
                                               <placeholder/>
@@ -2308,24 +2290,24 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                           <object class="GtkFrame" id="boxCustomTouchDisableSettings">
                                             <property name="name">boxCustomTouchDisableSettings</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label-xalign">0.009999999776482582</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="label_xalign">0.0099999997764825821</property>
                                             <child>
                                               <object class="GtkBox" id="sid66">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="margin-start">12</property>
-                                                <property name="margin-end">12</property>
-                                                <property name="margin-bottom">8</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="margin_start">12</property>
+                                                <property name="margin_end">12</property>
+                                                <property name="margin_bottom">8</property>
                                                 <property name="orientation">vertical</property>
                                                 <child>
                                                   <object class="GtkLabel" id="label54">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
+                                                    <property name="can_focus">False</property>
                                                     <property name="label" translatable="yes">&lt;i&gt;Specify commands that are called once Hand Recognition triggers. The commands will be executed in the UI Thread, make sure they are not blocking!&lt;/i&gt;</property>
-                                                    <property name="use-markup">True</property>
+                                                    <property name="use_markup">True</property>
                                                     <property name="wrap">True</property>
-                                                    <property name="max-width-chars">85</property>
+                                                    <property name="max_width_chars">85</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
@@ -2334,56 +2316,55 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                                   </packing>
                                                 </child>
                                                 <child>
-                                                  <!-- n-columns=3 n-rows=3 -->
                                                   <object class="GtkGrid" id="grid3">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
-                                                    <property name="row-spacing">5</property>
-                                                    <property name="column-spacing">5</property>
+                                                    <property name="can_focus">False</property>
+                                                    <property name="row_spacing">5</property>
+                                                    <property name="column_spacing">5</property>
                                                     <child>
                                                       <object class="GtkLabel" id="label52">
                                                         <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
+                                                        <property name="can_focus">False</property>
                                                         <property name="label" translatable="yes">Enable</property>
                                                       </object>
                                                       <packing>
-                                                        <property name="left-attach">0</property>
-                                                        <property name="top-attach">0</property>
+                                                        <property name="left_attach">0</property>
+                                                        <property name="top_attach">0</property>
                                                       </packing>
                                                     </child>
                                                     <child>
                                                       <object class="GtkLabel" id="label53">
                                                         <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
+                                                        <property name="can_focus">False</property>
                                                         <property name="label" translatable="yes">Disable</property>
                                                       </object>
                                                       <packing>
-                                                        <property name="left-attach">0</property>
-                                                        <property name="top-attach">1</property>
+                                                        <property name="left_attach">0</property>
+                                                        <property name="top_attach">1</property>
                                                       </packing>
                                                     </child>
                                                     <child>
                                                       <object class="GtkEntry" id="txtEnableTouchCommand">
                                                         <property name="name">txtEnableTouchCommand</property>
                                                         <property name="visible">True</property>
-                                                        <property name="can-focus">True</property>
+                                                        <property name="can_focus">True</property>
                                                         <property name="hexpand">True</property>
                                                       </object>
                                                       <packing>
-                                                        <property name="left-attach">1</property>
-                                                        <property name="top-attach">0</property>
+                                                        <property name="left_attach">1</property>
+                                                        <property name="top_attach">0</property>
                                                       </packing>
                                                     </child>
                                                     <child>
                                                       <object class="GtkEntry" id="txtDisableTouchCommand">
                                                         <property name="name">txtDisableTouchCommand</property>
                                                         <property name="visible">True</property>
-                                                        <property name="can-focus">True</property>
+                                                        <property name="can_focus">True</property>
                                                         <property name="hexpand">True</property>
                                                       </object>
                                                       <packing>
-                                                        <property name="left-attach">1</property>
-                                                        <property name="top-attach">1</property>
+                                                        <property name="left_attach">1</property>
+                                                        <property name="top_attach">1</property>
                                                       </packing>
                                                     </child>
                                                     <child>
@@ -2391,12 +2372,12 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                                         <property name="label" translatable="yes">Test</property>
                                                         <property name="name">btTestEnable</property>
                                                         <property name="visible">True</property>
-                                                        <property name="can-focus">True</property>
-                                                        <property name="receives-default">True</property>
+                                                        <property name="can_focus">True</property>
+                                                        <property name="receives_default">True</property>
                                                       </object>
                                                       <packing>
-                                                        <property name="left-attach">2</property>
-                                                        <property name="top-attach">0</property>
+                                                        <property name="left_attach">2</property>
+                                                        <property name="top_attach">0</property>
                                                       </packing>
                                                     </child>
                                                     <child>
@@ -2404,22 +2385,13 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                                         <property name="label" translatable="yes">Test</property>
                                                         <property name="name">btTestDisable</property>
                                                         <property name="visible">True</property>
-                                                        <property name="can-focus">True</property>
-                                                        <property name="receives-default">True</property>
+                                                        <property name="can_focus">True</property>
+                                                        <property name="receives_default">True</property>
                                                       </object>
                                                       <packing>
-                                                        <property name="left-attach">2</property>
-                                                        <property name="top-attach">1</property>
+                                                        <property name="left_attach">2</property>
+                                                        <property name="top_attach">1</property>
                                                       </packing>
-                                                    </child>
-                                                    <child>
-                                                      <placeholder/>
-                                                    </child>
-                                                    <child>
-                                                      <placeholder/>
-                                                    </child>
-                                                    <child>
-                                                      <placeholder/>
                                                     </child>
                                                   </object>
                                                   <packing>
@@ -2433,7 +2405,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                             <child type="label">
                                               <object class="GtkLabel" id="sid67">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">Custom Commands (for Method "Custom")</property>
                                               </object>
                                             </child>
@@ -2456,7 +2428,7 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                 <child type="label">
                                   <object class="GtkLabel" id="sid68">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Hand Recognition</property>
                                   </object>
                                 </child>
@@ -2470,22 +2442,22 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                             <child>
                               <object class="GtkFrame" id="sid69">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkBox" id="sid71">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
-                                    <property name="margin-bottom">8</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
+                                    <property name="margin_bottom">8</property>
                                     <property name="orientation">vertical</property>
                                     <child>
                                       <object class="GtkLabel" id="sid72">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="label" translatable="yes">&lt;i&gt;Use pinch gestures to zoom journal pages.&lt;/i&gt;</property>
-                                        <property name="use-markup">True</property>
+                                        <property name="use_markup">True</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -2498,9 +2470,9 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                         <property name="label" translatable="yes">Enable zoom gestures (requires restart)</property>
                                         <property name="name">cbEnableZoomGestures</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="draw-indicator">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="draw_indicator">True</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -2509,67 +2481,48 @@ If the file was not yet saved you can find it in ~/.cache/xournalpp/autosaves&lt
                                       </packing>
                                     </child>
                                     <child>
-                                      <!-- n-columns=3 n-rows=3 -->
                                       <object class="GtkGrid" id="gdStartZoomAtSetting">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="tooltip-text" translatable="yes">When drawing with touch, two-finger gestures intended to pan the view can instead cause it to zoom, causing performance issues.
+                                        <property name="can_focus">False</property>
+                                        <property name="tooltip_text" translatable="yes">When drawing with touch, two-finger gestures intended to pan the view can instead cause it to zoom, causing performance issues.
 This setting can make it easier to draw with touch. </property>
                                         <child>
                                           <object class="GtkLabel" id="label2">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Start zooming after a distance </property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">0</property>
+                                            <property name="left_attach">0</property>
+                                            <property name="top_attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkSpinButton" id="spTouchZoomStartThreshold">
                                             <property name="name">spTouchDisableTimeout</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
+                                            <property name="can_focus">True</property>
                                             <property name="text" translatable="yes">1.0</property>
                                             <property name="adjustment">adjustmentZoomStartThreshold</property>
-                                            <property name="climb-rate">0.5</property>
+                                            <property name="climb_rate">0.5</property>
                                             <property name="digits">1</property>
                                             <property name="value">1</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">1</property>
-                                            <property name="top-attach">0</property>
+                                            <property name="left_attach">1</property>
+                                            <property name="top_attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="label4">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">% greater than the initial distance between the two touches.</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">2</property>
-                                            <property name="top-attach">0</property>
+                                            <property name="left_attach">2</property>
+                                            <property name="top_attach">0</property>
                                           </packing>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                        <child>
-                                          <placeholder/>
                                         </child>
                                       </object>
                                       <packing>
@@ -2583,7 +2536,7 @@ This setting can make it easier to draw with touch. </property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid73">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Zoom Gestures</property>
                                   </object>
                                 </child>
@@ -2597,24 +2550,24 @@ This setting can make it easier to draw with touch. </property>
                             <child>
                               <object class="GtkFrame" id="frameTouchDrawing">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkBox" id="boxTouchDrawing">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
-                                    <property name="margin-bottom">8</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
+                                    <property name="margin_bottom">8</property>
                                     <property name="orientation">vertical</property>
                                     <child>
                                       <object class="GtkLabel" id="lblTouchDrawingDescription">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="label" translatable="yes">&lt;i&gt;Use the touchscreen like a multi-touch-aware pen.&lt;/i&gt;</property>
-                                        <property name="use-markup">True</property>
+                                        <property name="use_markup">True</property>
                                         <property name="wrap">True</property>
-                                        <property name="max-width-chars">85</property>
+                                        <property name="max_width_chars">85</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -2627,10 +2580,10 @@ This setting can make it easier to draw with touch. </property>
                                         <property name="label" translatable="yes">Enable touch drawing</property>
                                         <property name="name">cbTouchDrawing</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="tooltip-text" translatable="yes">Use two fingers to pan/zoom and one finger to use the selected tool.</property>
-                                        <property name="draw-indicator">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="tooltip_text" translatable="yes">Use two fingers to pan/zoom and one finger to use the selected tool.</property>
+                                        <property name="draw_indicator">True</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -2643,7 +2596,7 @@ This setting can make it easier to draw with touch. </property>
                                 <child type="label">
                                   <object class="GtkLabel" id="headerTouchDrawingFrame">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Touch Drawing</property>
                                   </object>
                                 </child>
@@ -2657,24 +2610,24 @@ This setting can make it easier to draw with touch. </property>
                             <child>
                               <object class="GtkFrame" id="frameTouchScrolling">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkBox" id="boxTouchScrolling">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
-                                    <property name="margin-bottom">8</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
+                                    <property name="margin_bottom">8</property>
                                     <property name="orientation">vertical</property>
                                     <child>
                                       <object class="GtkLabel" id="lblTouchKineticScrollDisableDescription">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="label" translatable="yes">&lt;i&gt;Disabling GTK's built-in touchscreen scrolling can work around scrolling bugs on some platforms. Consider changing this setting if you experience jumps/sudden changes in scroll position when attempting to scroll with a touchscreen.&lt;/i&gt;</property>
-                                        <property name="use-markup">True</property>
+                                        <property name="use_markup">True</property>
                                         <property name="wrap">True</property>
-                                        <property name="max-width-chars">85</property>
+                                        <property name="max_width_chars">85</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -2687,10 +2640,10 @@ This setting can make it easier to draw with touch. </property>
                                         <property name="label" translatable="yes">Disable GTK's built-in inertial scroll functionality (requires restart).</property>
                                         <property name="name">cbTouchDrawing</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="tooltip-text" translatable="yes">Use two fingers to pan/zoom and one finger to use the selected tool.</property>
-                                        <property name="draw-indicator">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="tooltip_text" translatable="yes">Use two fingers to pan/zoom and one finger to use the selected tool.</property>
+                                        <property name="draw_indicator">True</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -2703,7 +2656,7 @@ This setting can make it easier to draw with touch. </property>
                                 <child type="label">
                                   <object class="GtkLabel" id="headerTouchScrollingFrame">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Touch Scrolling</property>
                                   </object>
                                 </child>
@@ -2712,6 +2665,67 @@ This setting can make it easier to draw with touch. </property>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
                                 <property name="position">4</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkFrame" id="frameUndoGesture">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
+                                <child>
+                                  <object class="GtkBox" id="boxUndoGesture">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_left">12</property>
+                                    <property name="margin_right">12</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
+                                    <property name="margin_bottom">8</property>
+                                    <property name="orientation">vertical</property>
+                                    <child>
+                                      <object class="GtkLabel" id="lblUndoGestureDescription">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="label" translatable="yes">&lt;i&gt;Quickly tap the touchscreen with to fingers to undo the last change.&lt;/i&gt;</property>
+                                        <property name="use_markup">True</property>
+                                        <property name="wrap">True</property>
+                                        <property name="max_width_chars">85</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="cbUndoGesture">
+                                        <property name="label" translatable="yes">Enable undo gesture</property>
+                                        <property name="name">cbUndoGesture</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="draw_indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label">
+                                  <object class="GtkLabel" id="headerUndoGesture">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="label" translatable="yes">Undo Gesture</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">5</property>
                               </packing>
                             </child>
                           </object>
@@ -2734,69 +2748,69 @@ This setting can make it easier to draw with touch. </property>
               <object class="GtkLabel" id="touchTabLabel">
                 <property name="name">touchTabLabel</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Touchscreen</property>
               </object>
               <packing>
                 <property name="position">4</property>
-                <property name="tab-fill">False</property>
+                <property name="tab_fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="viewTabBox">
                 <property name="name">viewTabBox</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="margin-start">5</property>
+                <property name="can_focus">False</property>
+                <property name="margin_start">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid95">
                     <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="min-content-width">500</property>
-                    <property name="min-content-height">450</property>
+                    <property name="can_focus">True</property>
+                    <property name="min_content_width">500</property>
+                    <property name="min_content_height">450</property>
                     <child>
                       <object class="GtkViewport" id="sid96">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="shadow-type">none</property>
+                        <property name="can_focus">False</property>
+                        <property name="shadow_type">none</property>
                         <child>
                           <object class="GtkBox" id="sid97">
                             <property name="visible">True</property>
-                            <property name="can-focus">False</property>
+                            <property name="can_focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="sid98">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkBox" id="sid100">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
-                                    <property name="margin-bottom">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
+                                    <property name="margin_bottom">12</property>
                                     <property name="orientation">vertical</property>
                                     <child>
                                       <object class="GtkBox" id="vbox6">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="halign">start</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkBox" id="vbox7">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="halign">start</property>
                                             <child>
                                               <object class="GtkCheckButton" id="cbHideMenubarStartup">
                                                 <property name="label" translatable="yes">Show Menubar on Startup</property>
                                                 <property name="name">cbHideMenubarStartup</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="receives-default">False</property>
-                                                <property name="draw-indicator">True</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="receives_default">False</property>
+                                                <property name="draw_indicator">True</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
@@ -2807,10 +2821,10 @@ This setting can make it easier to draw with touch. </property>
                                             <child>
                                               <object class="GtkLabel" id="sid101">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
-                                                <property name="margin-start">5</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="margin_start">5</property>
                                                 <property name="label" translatable="yes">&lt;i&gt;Toggle visibility of menubar with F10&lt;/i&gt;</property>
-                                                <property name="use-markup">True</property>
+                                                <property name="use_markup">True</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
@@ -2830,9 +2844,9 @@ This setting can make it easier to draw with touch. </property>
                                             <property name="label" translatable="yes">Show filepath in title bar</property>
                                             <property name="name">cbShowFilepathInTitlebar</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="draw-indicator">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="draw_indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -2845,9 +2859,9 @@ This setting can make it easier to draw with touch. </property>
                                             <property name="label" translatable="yes">Show page number in title bar</property>
                                             <property name="name">cbShowPageNumberInTitlebar</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="draw-indicator">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="draw_indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -2866,119 +2880,118 @@ This setting can make it easier to draw with touch. </property>
                                       <object class="GtkFrame" id="colorsFrame">
                                         <property name="name">colorsFrame</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="label-xalign">0.009999999776482582</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="label_xalign">0.0099999997764825821</property>
                                         <child>
-                                          <!-- n-columns=2 n-rows=7 -->
                                           <object class="GtkGrid" id="grid2">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="margin-start">12</property>
-                                            <property name="margin-end">12</property>
-                                            <property name="margin-bottom">8</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="margin_start">12</property>
+                                            <property name="margin_end">12</property>
+                                            <property name="margin_bottom">8</property>
                                             <child>
                                               <object class="GtkLabel" id="label10">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="halign">start</property>
                                                 <property name="hexpand">True</property>
                                                 <property name="label" translatable="yes">Border color for current page and other selections</property>
                                                 <property name="justify">right</property>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">0</property>
-                                                <property name="top-attach">0</property>
+                                                <property name="left_attach">0</property>
+                                                <property name="top_attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkColorButton" id="colorBorder">
                                                 <property name="name">colorBorder</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="receives-default">True</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="receives_default">True</property>
                                                 <property name="title" translatable="yes">Border color</property>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">1</property>
-                                                <property name="top-attach">0</property>
+                                                <property name="left_attach">1</property>
+                                                <property name="top_attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkLabel" id="label13">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="halign">start</property>
                                                 <property name="hexpand">False</property>
                                                 <property name="label" translatable="yes">Background color between pages</property>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">0</property>
-                                                <property name="top-attach">1</property>
+                                                <property name="left_attach">0</property>
+                                                <property name="top_attach">1</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkColorButton" id="colorBackground">
                                                 <property name="name">colorBackground</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="receives-default">True</property>
-                                                <property name="margin-top">5</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="receives_default">True</property>
+                                                <property name="margin_top">5</property>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">1</property>
-                                                <property name="top-attach">1</property>
+                                                <property name="left_attach">1</property>
+                                                <property name="top_attach">1</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkLabel" id="label57">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="halign">start</property>
                                                 <property name="hexpand">True</property>
                                                 <property name="label" translatable="yes">Selection Color (Text, Stroke Selection etc.)</property>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">0</property>
-                                                <property name="top-attach">2</property>
+                                                <property name="left_attach">0</property>
+                                                <property name="top_attach">2</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkColorButton" id="colorSelection">
                                                 <property name="name">colorSelection</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="receives-default">True</property>
-                                                <property name="margin-top">5</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="receives_default">True</property>
+                                                <property name="margin_top">5</property>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">1</property>
-                                                <property name="top-attach">2</property>
+                                                <property name="left_attach">1</property>
+                                                <property name="top_attach">2</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="halign">start</property>
                                                 <property name="hexpand">True</property>
                                                 <property name="label" translatable="yes">Active Selection Color (Search Results etc.)</property>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">0</property>
-                                                <property name="top-attach">3</property>
+                                                <property name="left_attach">0</property>
+                                                <property name="top_attach">3</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkColorButton" id="colorSelectionActive">
                                                 <property name="name">colorSelectionActive</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="receives-default">True</property>
-                                                <property name="margin-top">5</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="receives_default">True</property>
+                                                <property name="margin_top">5</property>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">1</property>
-                                                <property name="top-attach">3</property>
+                                                <property name="left_attach">1</property>
+                                                <property name="top_attach">3</property>
                                               </packing>
                                             </child>
                                             <child>
@@ -2986,13 +2999,13 @@ This setting can make it easier to draw with touch. </property>
                                                 <property name="label" translatable="yes">Dark Theme (requires restart)</property>
                                                 <property name="name">cbDarkTheme</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="receives-default">False</property>
-                                                <property name="draw-indicator">True</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="receives_default">False</property>
+                                                <property name="draw_indicator">True</property>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">0</property>
-                                                <property name="top-attach">5</property>
+                                                <property name="left_attach">0</property>
+                                                <property name="top_attach">5</property>
                                                 <property name="width">2</property>
                                               </packing>
                                             </child>
@@ -3001,24 +3014,24 @@ This setting can make it easier to draw with touch. </property>
                                                 <property name="label" translatable="yes">Use available Stock Icons (requires restart)</property>
                                                 <property name="name">cbStockIcons</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="receives-default">False</property>
-                                                <property name="draw-indicator">True</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="receives_default">False</property>
+                                                <property name="draw_indicator">True</property>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">0</property>
-                                                <property name="top-attach">6</property>
+                                                <property name="left_attach">0</property>
+                                                <property name="top_attach">6</property>
                                                 <property name="width">2</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkBox">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <child>
                                                   <object class="GtkLabel">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
+                                                    <property name="can_focus">False</property>
                                                     <property name="label" translatable="yes">Icon Theme</property>
                                                   </object>
                                                   <packing>
@@ -3031,7 +3044,7 @@ This setting can make it easier to draw with touch. </property>
                                                   <object class="GtkComboBoxText" id="cbIconTheme">
                                                     <property name="name">cbIconTheme</property>
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
+                                                    <property name="can_focus">False</property>
                                                     <property name="active">0</property>
                                                     <items>
                                                       <item id="iconsColor" translatable="yes">Color</item>
@@ -3047,7 +3060,7 @@ This setting can make it easier to draw with touch. </property>
                                                 <child>
                                                   <object class="GtkLabel">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
+                                                    <property name="can_focus">False</property>
                                                     <property name="label" translatable="yes">(requires restart)</property>
                                                   </object>
                                                   <packing>
@@ -3058,8 +3071,8 @@ This setting can make it easier to draw with touch. </property>
                                                 </child>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">0</property>
-                                                <property name="top-attach">4</property>
+                                                <property name="left_attach">0</property>
+                                                <property name="top_attach">4</property>
                                                 <property name="width">2</property>
                                               </packing>
                                             </child>
@@ -3068,7 +3081,7 @@ This setting can make it easier to draw with touch. </property>
                                         <child type="label">
                                           <object class="GtkLabel" id="sid103">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Colors</property>
                                           </object>
                                         </child>
@@ -3084,9 +3097,9 @@ This setting can make it easier to draw with touch. </property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid104">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Global</property>
-                                    <property name="use-markup">True</property>
+                                    <property name="use_markup">True</property>
                                   </object>
                                 </child>
                               </object>
@@ -3099,25 +3112,25 @@ This setting can make it easier to draw with touch. </property>
                             <child>
                               <object class="GtkFrame" id="sid105">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkBox" id="vbox15">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
-                                    <property name="margin-bottom">8</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
+                                    <property name="margin_bottom">8</property>
                                     <property name="orientation">vertical</property>
                                     <child>
                                       <object class="GtkBox">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="spacing">5</property>
                                         <child>
                                           <object class="GtkLabel">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Cursor icon for pen</property>
                                           </object>
                                           <packing>
@@ -3130,7 +3143,7 @@ This setting can make it easier to draw with touch. </property>
                                           <object class="GtkComboBoxText" id="cbStylusCursorType">
                                             <property name="name">cbStylusCursorType</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="active">0</property>
                                             <items>
                                               <item id="none" translatable="yes" context="stylus cursor uses no icon">No icon</item>
@@ -3153,208 +3166,207 @@ This setting can make it easier to draw with touch. </property>
                                       </packing>
                                     </child>
                                     <child>
-                                      <!-- n-columns=2 n-rows=3 -->
                                       <object class="GtkGrid" id="highlightCursorGrid">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="halign">start</property>
-                                        <property name="column-homogeneous">True</property>
+                                        <property name="column_homogeneous">True</property>
                                         <child>
                                           <object class="GtkCheckButton" id="cbHighlightPosition">
                                             <property name="label" translatable="yes">Highlight cursor position</property>
                                             <property name="name">cbHighlightPosition</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">False</property>
-                                            <property name="tooltip-text" translatable="yes">Draw a transparent circle around the cursor</property>
-                                            <property name="draw-indicator">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="tooltip_text" translatable="yes">Draw a transparent circle around the cursor</property>
+                                            <property name="draw_indicator">True</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">0</property>
+                                            <property name="left_attach">0</property>
+                                            <property name="top_attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkBox">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <child>
                                               <object class="GtkColorButton" id="cursorHighlightColor">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="receives-default">True</property>
-                                                <property name="use-alpha">True</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="receives_default">True</property>
+                                                <property name="use_alpha">True</property>
                                                 <property name="title" translatable="yes">Choose the color to use for "Highlight cursor position"</property>
-                                                <property name="show-editor">True</property>
+                                                <property name="show_editor">True</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
                                                 <property name="fill">True</property>
-                                                <property name="pack-type">end</property>
+                                                <property name="pack_type">end</property>
                                                 <property name="position">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">Circle Color</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
                                                 <property name="fill">True</property>
                                                 <property name="padding">10</property>
-                                                <property name="pack-type">end</property>
+                                                <property name="pack_type">end</property>
                                                 <property name="position">1</property>
                                               </packing>
                                             </child>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">1</property>
-                                            <property name="top-attach">1</property>
+                                            <property name="left_attach">1</property>
+                                            <property name="top_attach">1</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkBox">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">pixels</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
                                                 <property name="fill">True</property>
-                                                <property name="pack-type">end</property>
+                                                <property name="pack_type">end</property>
                                                 <property name="position">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkSpinButton" id="cursorHighlightRadius">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="input-purpose">number</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="input_purpose">number</property>
                                                 <property name="adjustment">adjustmentCursorHighlightRadius</property>
                                                 <property name="numeric">True</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
                                                 <property name="fill">True</property>
-                                                <property name="pack-type">end</property>
+                                                <property name="pack_type">end</property>
                                                 <property name="position">1</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">Radius</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
                                                 <property name="fill">True</property>
-                                                <property name="pack-type">end</property>
+                                                <property name="pack_type">end</property>
                                                 <property name="position">3</property>
                                               </packing>
                                             </child>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">1</property>
+                                            <property name="left_attach">0</property>
+                                            <property name="top_attach">1</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkBox">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">pixels</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
                                                 <property name="fill">True</property>
-                                                <property name="pack-type">end</property>
+                                                <property name="pack_type">end</property>
                                                 <property name="position">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkSpinButton" id="cursorHighlightBorderWidth">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
+                                                <property name="can_focus">True</property>
                                                 <property name="text" translatable="yes">30</property>
-                                                <property name="input-purpose">number</property>
+                                                <property name="input_purpose">number</property>
                                                 <property name="adjustment">adjustmentCursorHighlightBorderWidth</property>
                                                 <property name="numeric">True</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
                                                 <property name="fill">True</property>
-                                                <property name="pack-type">end</property>
+                                                <property name="pack_type">end</property>
                                                 <property name="position">1</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">Border Width</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
                                                 <property name="fill">True</property>
-                                                <property name="pack-type">end</property>
+                                                <property name="pack_type">end</property>
                                                 <property name="position">3</property>
                                               </packing>
                                             </child>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">2</property>
+                                            <property name="left_attach">0</property>
+                                            <property name="top_attach">2</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkBox">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <child>
                                               <object class="GtkColorButton" id="cursorHighlightBorderColor">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="receives-default">True</property>
-                                                <property name="use-alpha">True</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="receives_default">True</property>
+                                                <property name="use_alpha">True</property>
                                                 <property name="title" translatable="yes">Choose the color to use for "Highlight cursor position"</property>
-                                                <property name="show-editor">True</property>
+                                                <property name="show_editor">True</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
                                                 <property name="fill">True</property>
-                                                <property name="pack-type">end</property>
+                                                <property name="pack_type">end</property>
                                                 <property name="position">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">Border Color</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
                                                 <property name="fill">True</property>
                                                 <property name="padding">10</property>
-                                                <property name="pack-type">end</property>
+                                                <property name="pack_type">end</property>
                                                 <property name="position">1</property>
                                               </packing>
                                             </child>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">1</property>
-                                            <property name="top-attach">2</property>
+                                            <property name="left_attach">1</property>
+                                            <property name="top_attach">2</property>
                                           </packing>
                                         </child>
                                         <child>
@@ -3372,7 +3384,7 @@ This setting can make it easier to draw with touch. </property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid107">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Cursor</property>
                                   </object>
                                 </child>
@@ -3386,24 +3398,24 @@ This setting can make it easier to draw with touch. </property>
                             <child>
                               <object class="GtkFrame" id="sid108">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkBox" id="box19">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
-                                    <property name="margin-bottom">8</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
+                                    <property name="margin_bottom">8</property>
                                     <property name="orientation">vertical</property>
                                     <child>
                                       <object class="GtkCheckButton" id="cbShowSidebarRight">
                                         <property name="label" translatable="yes">Show sidebar on the right side</property>
                                         <property name="name">cbShowSidebarRight</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="draw-indicator">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="draw_indicator">True</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -3416,9 +3428,9 @@ This setting can make it easier to draw with touch. </property>
                                         <property name="label" translatable="yes">Show vertical scrollbar on the left side</property>
                                         <property name="name">cbShowScrollbarLeft</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="draw-indicator">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="draw_indicator">True</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -3431,7 +3443,7 @@ This setting can make it easier to draw with touch. </property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid110">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Left / Right-Handed</property>
                                   </object>
                                 </child>
@@ -3445,18 +3457,18 @@ This setting can make it easier to draw with touch. </property>
                             <child>
                               <object class="GtkFrame" id="grpSidebarSettings">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0</property>
                                 <child>
                                   <object class="GtkBox">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
                                     <child>
                                       <object class="GtkLabel">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="label" translatable="yes">Page numbering  </property>
                                       </object>
                                       <packing>
@@ -3468,9 +3480,9 @@ This setting can make it easier to draw with touch. </property>
                                     <child>
                                       <object class="GtkComboBoxText" id="cbSidebarPageNumberStyle">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="active">0</property>
-                                        <property name="has-entry">True</property>
+                                        <property name="has_entry">True</property>
                                         <items>
                                           <item id="0" translatable="yes">None</item>
                                           <item id="1" translatable="yes">Below preview</item>
@@ -3479,7 +3491,7 @@ This setting can make it easier to draw with touch. </property>
                                         </items>
                                         <child internal-child="entry">
                                           <object class="GtkEntry">
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                           </object>
                                         </child>
                                       </object>
@@ -3494,7 +3506,7 @@ This setting can make it easier to draw with touch. </property>
                                 <child type="label">
                                   <object class="GtkLabel">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Sidebar</property>
                                   </object>
                                 </child>
@@ -3509,24 +3521,24 @@ This setting can make it easier to draw with touch. </property>
                             <child>
                               <object class="GtkFrame" id="sid111">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkBox" id="box42">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
-                                    <property name="margin-bottom">8</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
+                                    <property name="margin_bottom">8</property>
                                     <property name="orientation">vertical</property>
                                     <child>
                                       <object class="GtkCheckButton" id="cbHideHorizontalScrollbar">
                                         <property name="label" translatable="yes">Hide the horizontal scrollbar</property>
                                         <property name="name">cbHideHorizontalScrollbar</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="draw-indicator">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="draw_indicator">True</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -3539,9 +3551,9 @@ This setting can make it easier to draw with touch. </property>
                                         <property name="label" translatable="yes">Hide the vertical scrollbar</property>
                                         <property name="name">cbHideVerticalScrollbar</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="draw-indicator">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="draw_indicator">True</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -3553,9 +3565,9 @@ This setting can make it easier to draw with touch. </property>
                                       <object class="GtkCheckButton" id="cbDisableScrollbarFadeout">
                                         <property name="label" translatable="yes">Disable scrollbar fade out</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="draw-indicator">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="draw_indicator">True</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -3568,7 +3580,7 @@ This setting can make it easier to draw with touch. </property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid113">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Scrollbars</property>
                                   </object>
                                 </child>
@@ -3582,66 +3594,65 @@ This setting can make it easier to draw with touch. </property>
                             <child>
                               <object class="GtkFrame">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0</property>
                                 <child>
-                                  <!-- n-columns=2 n-rows=2 -->
                                   <object class="GtkGrid">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
-                                    <property name="margin-bottom">8</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
+                                    <property name="margin_bottom">8</property>
                                     <child>
                                       <object class="GtkSpinButton" id="edgePanSpeed">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="input-purpose">number</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="input_purpose">number</property>
                                         <property name="adjustment">adjustmentEdgePanSpeed</property>
                                         <property name="numeric">True</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">1</property>
-                                        <property name="top-attach">0</property>
+                                        <property name="left_attach">1</property>
+                                        <property name="top_attach">0</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkSpinButton" id="edgePanMaxMult">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="input-purpose">number</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="input_purpose">number</property>
                                         <property name="adjustment">adjustmentEdgePanMaxMult</property>
                                         <property name="numeric">True</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">1</property>
-                                        <property name="top-attach">1</property>
+                                        <property name="left_attach">1</property>
+                                        <property name="top_attach">1</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkLabel">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="tooltip-text" translatable="yes">When an element is selected and moved past the visible portion of the canvas, pan the screen by an amount equal to this percentage of the visible part of the canvas. </property>
+                                        <property name="can_focus">False</property>
+                                        <property name="tooltip_text" translatable="yes">When an element is selected and moved past the visible portion of the canvas, pan the screen by an amount equal to this percentage of the visible part of the canvas. </property>
                                         <property name="halign">start</property>
                                         <property name="label" translatable="yes">Base speed</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">0</property>
-                                        <property name="top-attach">0</property>
+                                        <property name="left_attach">0</property>
+                                        <property name="top_attach">0</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkLabel">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="tooltip-text" translatable="yes">Multiply the panning speed by up to this amount, based on how much of the selected element is out of view.</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="tooltip_text" translatable="yes">Multiply the panning speed by up to this amount, based on how much of the selected element is out of view.</property>
                                         <property name="halign">start</property>
                                         <property name="label" translatable="yes">Max multiplier</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">0</property>
-                                        <property name="top-attach">1</property>
+                                        <property name="left_attach">0</property>
+                                        <property name="top_attach">1</property>
                                       </packing>
                                     </child>
                                   </object>
@@ -3649,7 +3660,7 @@ This setting can make it easier to draw with touch. </property>
                                 <child type="label">
                                   <object class="GtkLabel">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Selection Edge Panning</property>
                                   </object>
                                 </child>
@@ -3663,24 +3674,24 @@ This setting can make it easier to draw with touch. </property>
                             <child>
                               <object class="GtkFrame" id="sid114">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkBox" id="vbox9">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
-                                    <property name="margin-bottom">8</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
+                                    <property name="margin_bottom">8</property>
                                     <property name="orientation">vertical</property>
                                     <child>
                                       <object class="GtkCheckButton" id="cbShowFullscreenMenubar">
                                         <property name="label" translatable="yes">Show Menubar</property>
                                         <property name="name">cbShowFullscreenMenubar</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="draw-indicator">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="draw_indicator">True</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -3693,9 +3704,9 @@ This setting can make it easier to draw with touch. </property>
                                         <property name="label" translatable="yes">Show Toolbar</property>
                                         <property name="name">cbShowFullscreenToolbar</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="draw-indicator">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="draw_indicator">True</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -3708,9 +3719,9 @@ This setting can make it easier to draw with touch. </property>
                                         <property name="label" translatable="yes">Show Sidebar</property>
                                         <property name="name">cbShowFullscreenSidebar</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="draw-indicator">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="draw_indicator">True</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -3723,7 +3734,7 @@ This setting can make it easier to draw with touch. </property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid116">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Fullscreen</property>
                                   </object>
                                 </child>
@@ -3737,24 +3748,24 @@ This setting can make it easier to draw with touch. </property>
                             <child>
                               <object class="GtkFrame" id="sid117">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkBox" id="vbox1">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
-                                    <property name="margin-bottom">8</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
+                                    <property name="margin_bottom">8</property>
                                     <property name="orientation">vertical</property>
                                     <child>
                                       <object class="GtkCheckButton" id="cbShowPresentationMenubar">
                                         <property name="label" translatable="yes">Show Menubar</property>
                                         <property name="name">cbShowPresentationMenubar</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="draw-indicator">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="draw_indicator">True</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -3767,9 +3778,9 @@ This setting can make it easier to draw with touch. </property>
                                         <property name="label" translatable="yes">Show Toolbar</property>
                                         <property name="name">cbShowPresentationToolbar</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="draw-indicator">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="draw_indicator">True</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -3782,9 +3793,9 @@ This setting can make it easier to draw with touch. </property>
                                         <property name="label" translatable="yes">Go Fullscreen</property>
                                         <property name="name">cbPresentationGoFullscreen</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="draw-indicator">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="draw_indicator">True</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -3797,9 +3808,9 @@ This setting can make it easier to draw with touch. </property>
                                         <property name="label" translatable="yes">Show Sidebar</property>
                                         <property name="name">cbShowPresentationSidebar</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="draw-indicator">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="draw_indicator">True</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -3809,11 +3820,11 @@ This setting can make it easier to draw with touch. </property>
                                     </child>
                                     <child>
                                       <object class="GtkBox" id="box8">
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <child>
                                           <object class="GtkLabel" id="label16">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Select toolbar:</property>
                                           </object>
                                           <packing>
@@ -3826,7 +3837,7 @@ This setting can make it easier to draw with touch. </property>
                                           <object class="GtkComboBoxText" id="comboboxtext1">
                                             <property name="name">comboboxtext1</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -3846,7 +3857,7 @@ This setting can make it easier to draw with touch. </property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid119">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Presentation Mode</property>
                                   </object>
                                 </child>
@@ -3860,98 +3871,88 @@ This setting can make it easier to draw with touch. </property>
                             <child>
                               <object class="GtkFrame">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
-                                  <!-- n-columns=3 n-rows=3 -->
                                   <object class="GtkGrid">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
-                                    <property name="margin-bottom">8</property>
-                                    <property name="column-spacing">10</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
+                                    <property name="margin_bottom">8</property>
+                                    <property name="column_spacing">10</property>
                                     <child>
                                       <object class="GtkLabel">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="halign">start</property>
                                         <property name="label" translatable="yes">Pre-load pages before</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">0</property>
-                                        <property name="top-attach">0</property>
+                                        <property name="left_attach">0</property>
+                                        <property name="top_attach">0</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkLabel">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="halign">start</property>
                                         <property name="label" translatable="yes">Pre-load pages after</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">0</property>
-                                        <property name="top-attach">1</property>
+                                        <property name="left_attach">0</property>
+                                        <property name="top_attach">1</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkSpinButton" id="preloadPagesBefore">
                                         <property name="name">preloadPagesBefore</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="input-purpose">number</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="input_purpose">number</property>
                                         <property name="adjustment">adjustmentPreloadPagesBefore</property>
                                         <property name="numeric">True</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">1</property>
-                                        <property name="top-attach">0</property>
+                                        <property name="left_attach">1</property>
+                                        <property name="top_attach">0</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkSpinButton" id="preloadPagesAfter">
                                         <property name="name">preloadPagesAfter</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="input-purpose">number</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="input_purpose">number</property>
                                         <property name="adjustment">adjustmentPreloadPagesAfter</property>
                                         <property name="numeric">True</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">1</property>
-                                        <property name="top-attach">1</property>
+                                        <property name="left_attach">1</property>
+                                        <property name="top_attach">1</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkCheckButton" id="cbEagerPageCleanup">
                                         <property name="label" translatable="yes">Clear cached paged while scrolling</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="draw-indicator">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="draw_indicator">True</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">0</property>
-                                        <property name="top-attach">2</property>
+                                        <property name="left_attach">0</property>
+                                        <property name="top_attach">2</property>
                                         <property name="width">2</property>
                                       </packing>
-                                    </child>
-                                    <child>
-                                      <placeholder/>
-                                    </child>
-                                    <child>
-                                      <placeholder/>
-                                    </child>
-                                    <child>
-                                      <placeholder/>
                                     </child>
                                   </object>
                                 </child>
                                 <child type="label">
                                   <object class="GtkLabel">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Performance</property>
                                   </object>
                                 </child>
@@ -3982,143 +3983,133 @@ This setting can make it easier to draw with touch. </property>
               <object class="GtkLabel" id="viewTabLabel">
                 <property name="name">viewTabLabel</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">View</property>
               </object>
               <packing>
                 <property name="position">5</property>
-                <property name="tab-fill">False</property>
+                <property name="tab_fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="zoomTabBox">
                 <property name="name">zoomTabBox</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="margin-start">5</property>
+                <property name="can_focus">False</property>
+                <property name="margin_start">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid120">
                     <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="min-content-width">500</property>
-                    <property name="min-content-height">450</property>
+                    <property name="can_focus">True</property>
+                    <property name="min_content_width">500</property>
+                    <property name="min_content_height">450</property>
                     <child>
                       <object class="GtkViewport" id="sid121">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="shadow-type">none</property>
+                        <property name="can_focus">False</property>
+                        <property name="shadow_type">none</property>
                         <child>
                           <object class="GtkBox" id="sid122">
                             <property name="visible">True</property>
-                            <property name="can-focus">False</property>
+                            <property name="can_focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="sid123">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
-                                  <!-- n-columns=3 n-rows=3 -->
                                   <object class="GtkGrid" id="sid125">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
-                                    <property name="margin-bottom">8</property>
-                                    <property name="column-spacing">5</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
+                                    <property name="margin_bottom">8</property>
+                                    <property name="column_spacing">5</property>
                                     <child>
                                       <object class="GtkLabel" id="settingZoomCtrlScrollSpeedLabel">
                                         <property name="name">settingZoomCtrlScrollSpeedLabel</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="label" translatable="yes">Speed for Ctrl + Scroll</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">0</property>
-                                        <property name="top-attach">0</property>
+                                        <property name="left_attach">0</property>
+                                        <property name="top_attach">0</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkSpinButton" id="spZoomStepScroll">
                                         <property name="name">spZoomStepScroll</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
+                                        <property name="can_focus">True</property>
                                         <property name="adjustment">adjustmentZoomStepScroll</property>
                                         <property name="digits">1</property>
                                         <property name="numeric">True</property>
                                         <property name="value">2</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">1</property>
-                                        <property name="top-attach">0</property>
+                                        <property name="left_attach">1</property>
+                                        <property name="top_attach">0</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkLabel" id="settingZoomStepSpeedLabel">
                                         <property name="name">settingZoomStepSpeedLabel</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="label" translatable="yes">Speed for a Zoomstep</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">0</property>
-                                        <property name="top-attach">1</property>
+                                        <property name="left_attach">0</property>
+                                        <property name="top_attach">1</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkSpinButton" id="spZoomStep">
                                         <property name="name">spZoomStep</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="margin-top">5</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="margin_top">5</property>
                                         <property name="adjustment">adjustmentZoomStep</property>
                                         <property name="digits">1</property>
                                         <property name="numeric">True</property>
                                         <property name="value">10</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">1</property>
-                                        <property name="top-attach">1</property>
+                                        <property name="left_attach">1</property>
+                                        <property name="top_attach">1</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkLabel" id="sid126">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="label" translatable="yes">%</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">2</property>
-                                        <property name="top-attach">0</property>
+                                        <property name="left_attach">2</property>
+                                        <property name="top_attach">0</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkLabel" id="sid127">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="label" translatable="yes">%</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">2</property>
-                                        <property name="top-attach">1</property>
+                                        <property name="left_attach">2</property>
+                                        <property name="top_attach">1</property>
                                       </packing>
-                                    </child>
-                                    <child>
-                                      <placeholder/>
-                                    </child>
-                                    <child>
-                                      <placeholder/>
-                                    </child>
-                                    <child>
-                                      <placeholder/>
                                     </child>
                                   </object>
                                 </child>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid128">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Zoom Speed</property>
                                   </object>
                                 </child>
@@ -4132,23 +4123,23 @@ This setting can make it easier to draw with touch. </property>
                             <child>
                               <object class="GtkFrame" id="sid129">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkBox" id="sid131">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
-                                    <property name="margin-bottom">8</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
+                                    <property name="margin_bottom">8</property>
                                     <property name="orientation">vertical</property>
                                     <child>
                                       <object class="GtkLabel" id="sid132">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="label" translatable="yes">&lt;i&gt;To make sure on 100% zoom the size of elements is natural. (requires restart)&lt;/i&gt;</property>
-                                        <property name="use-markup">True</property>
-                                        <property name="max-width-chars">85</property>
+                                        <property name="use_markup">True</property>
+                                        <property name="max_width_chars">85</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -4159,16 +4150,16 @@ This setting can make it easier to draw with touch. </property>
                                     <child>
                                       <object class="GtkBox" id="box5">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkLabel" id="label21">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="margin-top">5</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="margin_top">5</property>
                                             <property name="label" translatable="yes">&lt;i&gt;Put a ruler on your screen and move the slider until both rulers match.&lt;/i&gt;</property>
-                                            <property name="use-markup">True</property>
-                                            <property name="max-width-chars">85</property>
+                                            <property name="use_markup">True</property>
+                                            <property name="max_width_chars">85</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -4180,11 +4171,11 @@ This setting can make it easier to draw with touch. </property>
                                           <object class="GtkScale" id="zoomCallibSlider">
                                             <property name="name">zoomCallibSlider</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="margin-top">10</property>
-                                            <property name="margin-bottom">20</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="margin_top">10</property>
+                                            <property name="margin_bottom">20</property>
                                             <property name="adjustment">adjustmentZoom</property>
-                                            <property name="round-digits">0</property>
+                                            <property name="round_digits">0</property>
                                             <property name="digits">0</property>
                                           </object>
                                           <packing>
@@ -4197,7 +4188,7 @@ This setting can make it easier to draw with touch. </property>
                                           <object class="GtkBox" id="zoomVBox">
                                             <property name="name">zoomVBox</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="orientation">vertical</property>
                                             <child>
                                               <placeholder/>
@@ -4212,7 +4203,7 @@ This setting can make it easier to draw with touch. </property>
                                         <child>
                                           <object class="GtkLabel" id="label22">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">The unit of the ruler is cm</property>
                                           </object>
                                           <packing>
@@ -4233,7 +4224,7 @@ This setting can make it easier to draw with touch. </property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid133">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Display DPI Calibration</property>
                                   </object>
                                 </child>
@@ -4264,60 +4255,60 @@ This setting can make it easier to draw with touch. </property>
               <object class="GtkLabel" id="zoomTabLabel">
                 <property name="name">zoomTabLabel</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Zoom</property>
               </object>
               <packing>
                 <property name="position">6</property>
-                <property name="tab-fill">False</property>
+                <property name="tab_fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="drawingAreaTabBox">
                 <property name="name">drawingAreaTabBox</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="margin-start">5</property>
+                <property name="can_focus">False</property>
+                <property name="margin_start">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid134">
                     <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="min-content-width">500</property>
-                    <property name="min-content-height">450</property>
+                    <property name="can_focus">True</property>
+                    <property name="min_content_width">500</property>
+                    <property name="min_content_height">450</property>
                     <child>
                       <object class="GtkViewport" id="sid135">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="shadow-type">none</property>
+                        <property name="can_focus">False</property>
+                        <property name="shadow_type">none</property>
                         <child>
                           <object class="GtkBox" id="sid136">
                             <property name="visible">True</property>
-                            <property name="can-focus">False</property>
+                            <property name="can_focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="sid137">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkBox" id="box41">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
-                                    <property name="margin-bottom">8</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
+                                    <property name="margin_bottom">8</property>
                                     <property name="orientation">vertical</property>
                                     <property name="spacing">8</property>
                                     <child>
                                       <object class="GtkLabel" id="label37">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="ypad">2</property>
                                         <property name="label" translatable="yes">&lt;i&gt;If you add additional space beside the pages you can choose the area of the screen you would like to work on.&lt;/i&gt;</property>
-                                        <property name="use-markup">True</property>
+                                        <property name="use_markup">True</property>
                                         <property name="wrap">True</property>
-                                        <property name="max-width-chars">85</property>
+                                        <property name="max_width_chars">85</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -4328,80 +4319,79 @@ This setting can make it easier to draw with touch. </property>
                                     <child>
                                       <object class="GtkBox">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="spacing">20</property>
                                         <child>
-                                          <!-- n-columns=3 n-rows=3 -->
                                           <object class="GtkGrid">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="row-spacing">8</property>
-                                            <property name="column-spacing">5</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="row_spacing">8</property>
+                                            <property name="column_spacing">5</property>
                                             <child>
                                               <object class="GtkSpinButton" id="spAddVerticalSpaceAbove">
                                                 <property name="name">spAddVerticalSpace</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
+                                                <property name="can_focus">True</property>
                                                 <property name="valign">center</property>
                                                 <property name="adjustment">adjustmentVerticalSpaceAbove</property>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">1</property>
-                                                <property name="top-attach">0</property>
+                                                <property name="left_attach">1</property>
+                                                <property name="top_attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkSpinButton" id="spAddHorizontalSpaceRight">
                                                 <property name="name">spAddHorizontalSpace</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
+                                                <property name="can_focus">True</property>
                                                 <property name="valign">center</property>
                                                 <property name="adjustment">adjustmentHorizontalSpaceRight</property>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">2</property>
-                                                <property name="top-attach">1</property>
+                                                <property name="left_attach">2</property>
+                                                <property name="top_attach">1</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkSpinButton" id="spAddVerticalSpaceBelow">
                                                 <property name="name">spAddHorizontalSpace</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
+                                                <property name="can_focus">True</property>
                                                 <property name="valign">center</property>
                                                 <property name="adjustment">adjustmentVerticalSpaceBelow</property>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">1</property>
-                                                <property name="top-attach">2</property>
+                                                <property name="left_attach">1</property>
+                                                <property name="top_attach">2</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkSpinButton" id="spAddHorizontalSpaceLeft">
                                                 <property name="name">spAddHorizontalSpace</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
+                                                <property name="can_focus">True</property>
                                                 <property name="valign">center</property>
                                                 <property name="adjustment">adjustmentHorizontalSpaceLeft</property>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">0</property>
-                                                <property name="top-attach">1</property>
+                                                <property name="left_attach">0</property>
+                                                <property name="top_attach">1</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkBox" id="pagePreviewImage">
                                                 <property name="name">imageBox</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="orientation">vertical</property>
                                                 <child>
                                                   <placeholder/>
                                                 </child>
                                               </object>
                                               <packing>
-                                                <property name="left-attach">1</property>
-                                                <property name="top-attach">1</property>
+                                                <property name="left_attach">1</property>
+                                                <property name="top_attach">1</property>
                                               </packing>
                                             </child>
                                             <child>
@@ -4426,12 +4416,12 @@ This setting can make it easier to draw with touch. </property>
                                         <child>
                                           <object class="GtkBox">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="orientation">vertical</property>
                                             <child>
                                               <object class="GtkBox">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="valign">start</property>
                                                 <property name="orientation">vertical</property>
                                                 <child>
@@ -4439,9 +4429,9 @@ This setting can make it easier to draw with touch. </property>
                                                     <property name="label" translatable="yes">Add additional horizontal space</property>
                                                     <property name="name">cbAddHorizontalSpace</property>
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">True</property>
-                                                    <property name="receives-default">False</property>
-                                                    <property name="draw-indicator">True</property>
+                                                    <property name="can_focus">True</property>
+                                                    <property name="receives_default">False</property>
+                                                    <property name="draw_indicator">True</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
@@ -4455,9 +4445,9 @@ This setting can make it easier to draw with touch. </property>
                                                     <property name="label" translatable="yes">Add additional vertical space</property>
                                                     <property name="name">cbAddVerticalSpace</property>
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">True</property>
-                                                    <property name="receives-default">False</property>
-                                                    <property name="draw-indicator">True</property>
+                                                    <property name="can_focus">True</property>
+                                                    <property name="receives_default">False</property>
+                                                    <property name="draw_indicator">True</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
@@ -4469,9 +4459,9 @@ This setting can make it easier to draw with touch. </property>
                                                 <child>
                                                   <object class="GtkLabel">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
+                                                    <property name="can_focus">False</property>
                                                     <property name="label" translatable="yes">&lt;i&gt;or&lt;/i&gt;</property>
-                                                    <property name="use-markup">True</property>
+                                                    <property name="use_markup">True</property>
                                                     <property name="xalign">0.029999999329447746</property>
                                                   </object>
                                                   <packing>
@@ -4485,9 +4475,9 @@ This setting can make it easier to draw with touch. </property>
                                                     <property name="label" translatable="yes">Unlimited scrolling</property>
                                                     <property name="name">cbUnlimitedScrolling</property>
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">True</property>
-                                                    <property name="receives-default">False</property>
-                                                    <property name="draw-indicator">True</property>
+                                                    <property name="can_focus">True</property>
+                                                    <property name="receives_default">False</property>
+                                                    <property name="draw_indicator">True</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
@@ -4505,15 +4495,15 @@ This setting can make it easier to draw with touch. </property>
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">&lt;i&gt;The amount is specified in pixels.&lt;/i&gt;</property>
-                                                <property name="use-markup">True</property>
+                                                <property name="use_markup">True</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
                                                 <property name="fill">True</property>
                                                 <property name="padding">2</property>
-                                                <property name="pack-type">end</property>
+                                                <property name="pack_type">end</property>
                                                 <property name="position">1</property>
                                               </packing>
                                             </child>
@@ -4537,7 +4527,7 @@ This setting can make it easier to draw with touch. </property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid142">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Scrolling outside the page</property>
                                   </object>
                                 </child>
@@ -4551,21 +4541,21 @@ This setting can make it easier to draw with touch. </property>
                             <child>
                               <object class="GtkFrame" id="sid143">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkBox">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
-                                    <property name="margin-bottom">8</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
+                                    <property name="margin_bottom">8</property>
                                     <child>
                                       <object class="GtkLabel" id="label58a">
                                         <property name="name">label58a</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="tooltip-markup" translatable="yes">Offset first page this many pages when &lt;b&gt;Pair Pages&lt;/b&gt; enabled</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="tooltip_markup" translatable="yes">Offset first page this many pages when &lt;b&gt;Pair Pages&lt;/b&gt; enabled</property>
                                         <property name="label" translatable="yes">First Page Offset </property>
                                       </object>
                                       <packing>
@@ -4578,13 +4568,13 @@ This setting can make it easier to draw with touch. </property>
                                       <object class="GtkSpinButton" id="spPairsOffset">
                                         <property name="name">spPairsOffset</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="tooltip-text" translatable="yes">Usually 0 or 1</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="tooltip_text" translatable="yes">Usually 0 or 1</property>
                                         <property name="valign">start</property>
-                                        <property name="max-width-chars">0</property>
+                                        <property name="max_width_chars">0</property>
                                         <property name="adjustment">adjustmentPairsOffset</property>
                                         <property name="numeric">True</property>
-                                        <property name="update-policy">if-valid</property>
+                                        <property name="update_policy">if-valid</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -4597,7 +4587,7 @@ This setting can make it easier to draw with touch. </property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid145">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Paired Pages</property>
                                   </object>
                                 </child>
@@ -4611,59 +4601,58 @@ This setting can make it easier to draw with touch. </property>
                             <child>
                               <object class="GtkFrame" id="sid198">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
-                                  <!-- n-columns=1 n-rows=3 -->
                                   <object class="GtkGrid" id="grid7">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
-                                    <property name="margin-bottom">8</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
+                                    <property name="margin_bottom">8</property>
                                     <property name="orientation">vertical</property>
                                     <child>
                                       <object class="GtkRadioButton" id="rdLastPageAppendOnScrollToEndOfLastPage">
                                         <property name="label" translatable="yes">when scrolling to end of last page</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">False</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
                                         <property name="active">True</property>
-                                        <property name="draw-indicator">True</property>
+                                        <property name="draw_indicator">True</property>
                                         <property name="group">rdLastPageAppendDisabled</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">0</property>
-                                        <property name="top-attach">2</property>
+                                        <property name="left_attach">0</property>
+                                        <property name="top_attach">2</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkRadioButton" id="rdLastPageAppendOnDrawOfLastPage">
                                         <property name="label" translatable="yes">when drawing on last page</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">False</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
                                         <property name="active">True</property>
-                                        <property name="draw-indicator">True</property>
+                                        <property name="draw_indicator">True</property>
                                         <property name="group">rdLastPageAppendDisabled</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">0</property>
-                                        <property name="top-attach">1</property>
+                                        <property name="left_attach">0</property>
+                                        <property name="top_attach">1</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkRadioButton" id="rdLastPageAppendDisabled">
                                         <property name="label" translatable="yes">disabled</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">False</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
                                         <property name="active">True</property>
-                                        <property name="draw-indicator">True</property>
+                                        <property name="draw_indicator">True</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">0</property>
-                                        <property name="top-attach">0</property>
+                                        <property name="left_attach">0</property>
+                                        <property name="top_attach">0</property>
                                       </packing>
                                     </child>
                                   </object>
@@ -4671,7 +4660,7 @@ This setting can make it easier to draw with touch. </property>
                                 <child type="label">
                                   <object class="GtkLabel" id="sid197">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Automatically Add Empty Last Page (excluding PDFs)</property>
                                   </object>
                                 </child>
@@ -4685,29 +4674,29 @@ This setting can make it easier to draw with touch. </property>
                             <child>
                               <object class="GtkFrame" id="sid150">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkBox">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
-                                    <property name="margin-bottom">8</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
+                                    <property name="margin_bottom">8</property>
                                     <child>
                                       <object class="GtkCheckButton" id="cbDrawDirModsEnabled">
                                         <property name="label" translatable="yes">Enable  with determination radius of </property>
                                         <property name="name">cbDrawDirModsEnabled</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="tooltip-markup" translatable="yes">Drag LEFT from start point acts like shift key is being held.
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="tooltip_markup" translatable="yes">Drag LEFT from start point acts like shift key is being held.
 Drag UP acts as if Control key is being held.
 
 Determination Radius: Radius at which modifiers will lock in until finished drawing.
 
 &lt;i&gt;Useful for operating without keyboard.&lt;/i&gt;</property>
-                                        <property name="draw-indicator">True</property>
+                                        <property name="draw_indicator">True</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -4719,12 +4708,12 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                       <object class="GtkSpinButton" id="spDrawDirModsRadius">
                                         <property name="name">spDrawDirModsRadius</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
+                                        <property name="can_focus">True</property>
                                         <property name="valign">start</property>
-                                        <property name="max-width-chars">0</property>
+                                        <property name="max_width_chars">0</property>
                                         <property name="adjustment">adjustmentDrawDirModRadius</property>
                                         <property name="numeric">True</property>
-                                        <property name="update-policy">if-valid</property>
+                                        <property name="update_policy">if-valid</property>
                                         <property name="value">50</property>
                                       </object>
                                       <packing>
@@ -4736,7 +4725,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                     <child>
                                       <object class="GtkLabel" id="sid152">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="label" translatable="yes">pixels</property>
                                       </object>
                                       <packing>
@@ -4750,7 +4739,7 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                 <child type="label">
                                   <object class="GtkLabel" id="sid153">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Drawing Tools - Set Modifiers by Draw Direction (Experimental)</property>
                                   </object>
                                 </child>
@@ -4764,26 +4753,26 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                             <child>
                               <object class="GtkFrame" id="sid 155">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkCheckButton" id="cbRestoreLineWidthEnabled">
                                     <property name="label" translatable="yes">Preserve line width</property>
                                     <property name="name">cbRestoreLineWidthEnabled</property>
                                     <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">False</property>
-                                    <property name="tooltip-markup" translatable="yes">After resizing a selection, the line width of all strokes will be the same as before the resizing operation. </property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
-                                    <property name="margin-bottom">8</property>
-                                    <property name="draw-indicator">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="receives_default">False</property>
+                                    <property name="tooltip_markup" translatable="yes">After resizing a selection, the line width of all strokes will be the same as before the resizing operation. </property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
+                                    <property name="margin_bottom">8</property>
+                                    <property name="draw_indicator">True</property>
                                   </object>
                                 </child>
                                 <child type="label">
                                   <object class="GtkLabel">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Resizing</property>
                                   </object>
                                 </child>
@@ -4795,163 +4784,23 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkFrame" id="sid146">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
-                                <child>
-                                  <object class="GtkBox" id="box51">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
-                                    <property name="margin-bottom">8</property>
-                                    <property name="orientation">vertical</property>
-                                    <property name="spacing">6</property>
-                                    <child>
-                                      <!-- n-columns=2 n-rows=3 -->
-                                      <object class="GtkGrid" id="sid148">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="row-spacing">5</property>
-                                        <property name="column-spacing">5</property>
-                                        <child>
-                                          <object class="GtkLabel" id="lbSnapRotationTolerance">
-                                            <property name="name">lbSnapRotationTolerance</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">Rotation snapping tolerance</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkLabel" id="lbSnapGridTolerance">
-                                            <property name="name">lbSnapGridTolerance</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">Grid snapping tolerance</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSpinButton" id="spSnapRotationTolerance">
-                                            <property name="name">spSnapRotationTolerance</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="adjustment">adjustmentSnapRotationTolerance</property>
-                                            <property name="climb-rate">0.05</property>
-                                            <property name="digits">2</property>
-                                            <property name="value">0.20</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">1</property>
-                                            <property name="top-attach">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSpinButton" id="spSnapGridTolerance">
-                                            <property name="name">spSnapGridTolerance</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="adjustment">adjustmentSnapGridTolerance</property>
-                                            <property name="climb-rate">0.05</property>
-                                            <property name="digits">2</property>
-                                            <property name="value">0.25</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">1</property>
-                                            <property name="top-attach">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkLabel" id="lbSnapGridSize">
-                                            <property name="name">lbSnapGridSize</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">Grid size</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">2</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSpinButton" id="spSnapGridSize">
-                                            <property name="name">spSnapGridSize</property>
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="adjustment">adjustmentSnapGridSize</property>
-                                            <property name="climb-rate">0.01</property>
-                                            <property name="digits">2</property>
-                                            <property name="value">1</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left-attach">1</property>
-                                            <property name="top-attach">2</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">0</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkCheckButton" id="cbSnapRecognizedShapesEnabled">
-                                        <property name="label" translatable="yes">Use snapping for recognized shapes</property>
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="tooltip-text" translatable="yes">If activated, shapes that have been recognized by the shape recognizer will be snapped to the grid automatically. This may lead to unexpected results if you have the shape recognizer turned on while writing.</property>
-                                        <property name="draw-indicator">True</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">1</property>
-                                      </packing>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child type="label">
-                                  <object class="GtkLabel" id="sid149">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="label" translatable="yes">Snapping</property>
-                                  </object>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">5</property>
-                              </packing>
-                            </child>
-                            <child>
                               <object class="GtkFrame" id="strokeRecognizerFrrame">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkBox">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
-                                    <property name="margin-bottom">8</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
+                                    <property name="margin_bottom">8</property>
                                     <child>
                                       <object class="GtkLabel">
                                         <property name="name">lbStrokeRecognizerMinSize</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="margin-end">6</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="margin_end">6</property>
                                         <property name="label" translatable="yes">Minimum Stroke Size</property>
                                       </object>
                                       <packing>
@@ -4964,10 +4813,10 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                       <object class="GtkSpinButton" id="spStrokeRecognizerMinSize">
                                         <property name="name">spStrokeRecognizerMinSize</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
+                                        <property name="can_focus">True</property>
                                         <property name="text" translatable="yes">0.20</property>
                                         <property name="adjustment">adjustmentStrokeRecognizerMinSize</property>
-                                        <property name="climb-rate">2</property>
+                                        <property name="climb_rate">2</property>
                                         <property name="value">25</property>
                                       </object>
                                       <packing>
@@ -4981,8 +4830,147 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                 <child type="label">
                                   <object class="GtkLabel">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Stroke Recognizer</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">5</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkFrame" id="sid146">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
+                                <child>
+                                  <object class="GtkBox" id="box51">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
+                                    <property name="margin_bottom">8</property>
+                                    <property name="orientation">vertical</property>
+                                    <property name="spacing">6</property>
+                                    <child>
+                                      <object class="GtkGrid" id="sid148">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="row_spacing">5</property>
+                                        <property name="column_spacing">5</property>
+                                        <child>
+                                          <object class="GtkLabel" id="lbSnapRotationTolerance">
+                                            <property name="name">lbSnapRotationTolerance</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="label" translatable="yes">Rotation snapping tolerance</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">0</property>
+                                            <property name="top_attach">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="lbSnapGridTolerance">
+                                            <property name="name">lbSnapGridTolerance</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="label" translatable="yes">Grid snapping tolerance</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">0</property>
+                                            <property name="top_attach">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSpinButton" id="spSnapRotationTolerance">
+                                            <property name="name">spSnapRotationTolerance</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="adjustment">adjustmentSnapRotationTolerance</property>
+                                            <property name="climb_rate">0.050000000000000003</property>
+                                            <property name="digits">2</property>
+                                            <property name="value">0.20000000000000001</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">1</property>
+                                            <property name="top_attach">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSpinButton" id="spSnapGridTolerance">
+                                            <property name="name">spSnapGridTolerance</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="adjustment">adjustmentSnapGridTolerance</property>
+                                            <property name="climb_rate">0.050000000000000003</property>
+                                            <property name="digits">2</property>
+                                            <property name="value">0.25</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">1</property>
+                                            <property name="top_attach">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="lbSnapGridSize">
+                                            <property name="name">lbSnapGridSize</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="label" translatable="yes">Grid size</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">0</property>
+                                            <property name="top_attach">2</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSpinButton" id="spSnapGridSize">
+                                            <property name="name">spSnapGridSize</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="adjustment">adjustmentSnapGridSize</property>
+                                            <property name="climb_rate">0.01</property>
+                                            <property name="digits">2</property>
+                                            <property name="value">1</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">1</property>
+                                            <property name="top_attach">2</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="cbSnapRecognizedShapesEnabled">
+                                        <property name="label" translatable="yes">Use snapping for recognized shapes</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="tooltip_text" translatable="yes">If activated, shapes that have been recognized by the shape recognizer will be snapped to the grid automatically. This may lead to unexpected results if you have the shape recognizer turned on while writing.</property>
+                                        <property name="draw_indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label">
+                                  <object class="GtkLabel" id="sid149">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="label" translatable="yes">Snapping</property>
                                   </object>
                                 </child>
                               </object>
@@ -4995,124 +4983,123 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                             <child>
                               <object class="GtkFrame" id="sid154">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
-                                  <!-- n-columns=4 n-rows=3 -->
                                   <object class="GtkGrid" id="grid1">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
-                                    <property name="margin-bottom">8</property>
-                                    <property name="column-spacing">5</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
+                                    <property name="margin_bottom">8</property>
+                                    <property name="column_spacing">5</property>
                                     <child>
                                       <object class="GtkCheckButton" id="cbStrokeFilterEnabled">
                                         <property name="label" translatable="yes">Enable Tap action</property>
                                         <property name="name">cbStrokeFilterEnabled</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="tooltip-markup" translatable="yes">Do not draw for inputs of short time and length unless it comes in short succession. Instead, show floating toolbox.</property>
-                                        <property name="draw-indicator">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="tooltip_markup" translatable="yes">Do not draw for inputs of short time and length unless it comes in short succession. Instead, show floating toolbox.</property>
+                                        <property name="draw_indicator">True</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">0</property>
-                                        <property name="top-attach">0</property>
+                                        <property name="left_attach">0</property>
+                                        <property name="top_attach">0</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkLabel" id="sid156">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="label" translatable="yes">Ignore Time (ms)</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">1</property>
-                                        <property name="top-attach">0</property>
+                                        <property name="left_attach">1</property>
+                                        <property name="top_attach">0</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkSpinButton" id="spStrokeIgnoreTime">
                                         <property name="name">spStrokeIgnoreTime</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="tooltip-markup" translatable="yes">How short (time)  AND...
+                                        <property name="can_focus">True</property>
+                                        <property name="tooltip_markup" translatable="yes">How short (time)  AND...
 
 &lt;i&gt;Recommended: 150ms&lt;/i&gt;</property>
                                         <property name="valign">start</property>
-                                        <property name="max-width-chars">0</property>
+                                        <property name="max_width_chars">0</property>
                                         <property name="adjustment">adjustmentStrokeIgnoreTime</property>
                                         <property name="numeric">True</property>
-                                        <property name="update-policy">if-valid</property>
+                                        <property name="update_policy">if-valid</property>
                                         <property name="value">150</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">1</property>
-                                        <property name="top-attach">1</property>
+                                        <property name="left_attach">1</property>
+                                        <property name="top_attach">1</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkSpinButton" id="spStrokeIgnoreLength">
                                         <property name="name">spStrokeIgnoreLength</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="tooltip-markup" translatable="yes">How short (screen mm)  of the stroke  AND...
+                                        <property name="can_focus">True</property>
+                                        <property name="tooltip_markup" translatable="yes">How short (screen mm)  of the stroke  AND...
 
 &lt;i&gt;Recommended: 1 mm&lt;/i&gt;</property>
                                         <property name="valign">start</property>
-                                        <property name="max-width-chars">0</property>
+                                        <property name="max_width_chars">0</property>
                                         <property name="adjustment">adjustmentStrokeIgnoreLength</property>
                                         <property name="digits">2</property>
                                         <property name="numeric">True</property>
-                                        <property name="update-policy">if-valid</property>
+                                        <property name="update_policy">if-valid</property>
                                         <property name="value">1</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">2</property>
-                                        <property name="top-attach">1</property>
+                                        <property name="left_attach">2</property>
+                                        <property name="top_attach">1</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkLabel" id="sid157">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="label" translatable="yes">Max Length (mm)</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">2</property>
-                                        <property name="top-attach">0</property>
+                                        <property name="left_attach">2</property>
+                                        <property name="top_attach">0</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkLabel" id="sid158">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="label" translatable="yes">Successive (ms)</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">3</property>
-                                        <property name="top-attach">0</property>
+                                        <property name="left_attach">3</property>
+                                        <property name="top_attach">0</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkSpinButton" id="spStrokeSuccessiveTime">
                                         <property name="name">spStrokeSuccessiveTime</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="tooltip-markup" translatable="yes">... AND How much time must have passed since last stroke.
+                                        <property name="can_focus">True</property>
+                                        <property name="tooltip_markup" translatable="yes">... AND How much time must have passed since last stroke.
 
 &lt;i&gt;Recommended: 500ms&lt;/i&gt;</property>
                                         <property name="valign">start</property>
-                                        <property name="max-width-chars">0</property>
+                                        <property name="max_width_chars">0</property>
                                         <property name="adjustment">adjustmentStrokeSuccessiveTime</property>
                                         <property name="numeric">True</property>
-                                        <property name="update-policy">if-valid</property>
+                                        <property name="update_policy">if-valid</property>
                                         <property name="value">500</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">3</property>
-                                        <property name="top-attach">1</property>
+                                        <property name="left_attach">3</property>
+                                        <property name="top_attach">1</property>
                                       </packing>
                                     </child>
                                     <child>
@@ -5120,29 +5107,29 @@ Determination Radius: Radius at which modifiers will lock in until finished draw
                                         <property name="label" translatable="yes">Try to select object first.</property>
                                         <property name="name">cbTrySelectOnStrokeFiltered</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="tooltip-markup" translatable="yes">Try to select object first; if nothing selected then show floating toolbox if enabled.</property>
-                                        <property name="draw-indicator">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="tooltip_markup" translatable="yes">Try to select object first; if nothing selected then show floating toolbox if enabled.</property>
+                                        <property name="draw_indicator">True</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">1</property>
-                                        <property name="top-attach">2</property>
+                                        <property name="left_attach">1</property>
+                                        <property name="top_attach">2</property>
                                         <property name="width">3</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkLabel" id="label1">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="tooltip-text" translatable="yes">All three conditions must be met before stroke is ignored.
+                                        <property name="can_focus">False</property>
+                                        <property name="tooltip_text" translatable="yes">All three conditions must be met before stroke is ignored.
 It must be short in time and length and we can't have ignored another stroke recently.</property>
                                         <property name="halign">end</property>
                                         <property name="label" translatable="yes">Settings:</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">0</property>
-                                        <property name="top-attach">1</property>
+                                        <property name="left_attach">0</property>
+                                        <property name="top_attach">1</property>
                                       </packing>
                                     </child>
                                     <child>
@@ -5150,14 +5137,14 @@ It must be short in time and length and we can't have ignored another stroke rec
                                         <property name="label" translatable="yes">Show Floating Toolbox</property>
                                         <property name="name">cbDoActionOnStrokeFiltered</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="tooltip-markup" translatable="yes">Try to select object first; if nothing selected then show floating toolbox if enabled.</property>
-                                        <property name="draw-indicator">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="tooltip_markup" translatable="yes">Try to select object first; if nothing selected then show floating toolbox if enabled.</property>
+                                        <property name="draw_indicator">True</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">0</property>
-                                        <property name="top-attach">2</property>
+                                        <property name="left_attach">0</property>
+                                        <property name="top_attach">2</property>
                                       </packing>
                                     </child>
                                   </object>
@@ -5165,7 +5152,7 @@ It must be short in time and length and we can't have ignored another stroke rec
                                 <child type="label">
                                   <object class="GtkLabel" id="sid159">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Action on Tool Tap</property>
                                   </object>
                                 </child>
@@ -5179,26 +5166,26 @@ It must be short in time and length and we can't have ignored another stroke rec
                             <child>
                               <object class="GtkFrame" id="framePDFCacheOptions">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkBox" id="boxReRenderSetting">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
-                                    <property name="margin-bottom">8</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
+                                    <property name="margin_bottom">8</property>
                                     <property name="orientation">vertical</property>
                                     <child>
                                       <object class="GtkLabel" id="lblReRenderMoreOftenWhileZooming">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="margin-bottom">2</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="margin_bottom">2</property>
                                         <property name="label" translatable="yes">&lt;i&gt;Re-render PDF backgrounds more often while zooming for better render quality.
 &lt;b&gt;Note:&lt;/b&gt; This should not affect print quality.&lt;/i&gt;</property>
-                                        <property name="use-markup">True</property>
+                                        <property name="use_markup">True</property>
                                         <property name="wrap">True</property>
-                                        <property name="max-width-chars">85</property>
+                                        <property name="max_width_chars">85</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -5209,13 +5196,13 @@ It must be short in time and length and we can't have ignored another stroke rec
                                     <child>
                                       <object class="GtkBox">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <child>
                                           <object class="GtkLabel" id="lbReRenderThreshold">
                                             <property name="name">lbSnapRotationTolerance</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="tooltip-text" translatable="yes">When zoomed in on a high-resolution PDF, each re-render can take a long time. Setting this to a large value causes these re-renders to happen less often.
+                                            <property name="can_focus">False</property>
+                                            <property name="tooltip_text" translatable="yes">When zoomed in on a high-resolution PDF, each re-render can take a long time. Setting this to a large value causes these re-renders to happen less often.
 
 Set this to 0% to always re-render on zoom.</property>
                                             <property name="label" translatable="yes">Re-render when the page's zoom changes by more than </property>
@@ -5230,11 +5217,11 @@ Set this to 0% to always re-render on zoom.</property>
                                           <object class="GtkSpinButton" id="spReRenderThreshold">
                                             <property name="name">spSnapRotationTolerance</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
+                                            <property name="can_focus">True</property>
                                             <property name="text" translatable="yes">0.00</property>
-                                            <property name="input-purpose">number</property>
+                                            <property name="input_purpose">number</property>
                                             <property name="adjustment">adjustmentReRenderThreshold</property>
-                                            <property name="climb-rate">2</property>
+                                            <property name="climb_rate">2</property>
                                             <property name="numeric">True</property>
                                           </object>
                                           <packing>
@@ -5247,7 +5234,7 @@ Set this to 0% to always re-render on zoom.</property>
                                           <object class="GtkLabel" id="lbReRenderThresholdEnding">
                                             <property name="name">lbSnapRotationTolerance</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">%.</property>
                                           </object>
                                           <packing>
@@ -5268,7 +5255,7 @@ Set this to 0% to always re-render on zoom.</property>
                                 <child type="label">
                                   <object class="GtkLabel" id="headerPdfCaching">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">PDF Cache</property>
                                   </object>
                                 </child>
@@ -5299,57 +5286,57 @@ Set this to 0% to always re-render on zoom.</property>
               <object class="GtkLabel" id="drawingAreaTabLabel">
                 <property name="name">drawingAreaTabLabel</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Drawing Area</property>
               </object>
               <packing>
                 <property name="position">7</property>
-                <property name="tab-fill">False</property>
+                <property name="tab_fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="defaultTabBox">
                 <property name="name">defaultTabBox</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="margin-start">5</property>
+                <property name="can_focus">False</property>
+                <property name="margin_start">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid160">
                     <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="min-content-width">500</property>
-                    <property name="min-content-height">450</property>
+                    <property name="can_focus">True</property>
+                    <property name="min_content_width">500</property>
+                    <property name="min_content_height">450</property>
                     <child>
                       <object class="GtkViewport" id="sid161">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="shadow-type">none</property>
+                        <property name="can_focus">False</property>
+                        <property name="shadow_type">none</property>
                         <child>
                           <object class="GtkBox" id="sid162">
                             <property name="visible">True</property>
-                            <property name="can-focus">False</property>
+                            <property name="can_focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="sid163">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkBox" id="sid165">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
-                                    <property name="margin-bottom">8</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
+                                    <property name="margin_bottom">8</property>
                                     <property name="orientation">vertical</property>
                                     <child>
                                       <object class="GtkLabel" id="label9">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="label" translatable="yes">&lt;i&gt;Select the tool and Settings if you press the Default Button.&lt;/i&gt;</property>
-                                        <property name="use-markup">True</property>
-                                        <property name="max-width-chars">85</property>
+                                        <property name="use_markup">True</property>
+                                        <property name="max_width_chars">85</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -5362,7 +5349,7 @@ Set this to 0% to always re-render on zoom.</property>
                                       <object class="GtkBox" id="hboxDefaultTool">
                                         <property name="name">hboxDefaultTool</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <child>
                                           <placeholder/>
                                         </child>
@@ -5381,11 +5368,11 @@ Set this to 0% to always re-render on zoom.</property>
                                 <child type="label">
                                   <object class="GtkBox" id="box1">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <child>
                                       <object class="GtkImage" id="image2">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="pixbuf">iconsColor-dark/hicolor/scalable/actions/xopp-default.svg</property>
                                       </object>
                                       <packing>
@@ -5397,9 +5384,9 @@ Set this to 0% to always re-render on zoom.</property>
                                     <child>
                                       <object class="GtkLabel" id="label8">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="label" translatable="yes">&lt;b&gt;Default&lt;/b&gt;</property>
-                                        <property name="use-markup">True</property>
+                                        <property name="use_markup">True</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -5437,65 +5424,65 @@ Set this to 0% to always re-render on zoom.</property>
               <object class="GtkLabel" id="defaultTabLabel">
                 <property name="name">defaultTabLabel</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Defaults</property>
               </object>
               <packing>
                 <property name="position">8</property>
-                <property name="tab-fill">False</property>
+                <property name="tab_fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="audioRecordingTabBox">
                 <property name="name">audioRecordingTabBox</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="margin-start">5</property>
+                <property name="can_focus">False</property>
+                <property name="margin_start">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid166">
                     <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="min-content-width">500</property>
-                    <property name="min-content-height">450</property>
+                    <property name="can_focus">True</property>
+                    <property name="min_content_width">500</property>
+                    <property name="min_content_height">450</property>
                     <child>
                       <object class="GtkViewport" id="sid167">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="shadow-type">none</property>
+                        <property name="can_focus">False</property>
+                        <property name="shadow_type">none</property>
                         <child>
                           <object class="GtkBox" id="sid168">
                             <property name="visible">True</property>
-                            <property name="can-focus">False</property>
+                            <property name="can_focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="sid169">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkAlignment">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="left-padding">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="left_padding">12</property>
                                     <child>
                                       <object class="GtkAlignment">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <child>
                                           <object class="GtkBox">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="orientation">vertical</property>
                                             <child>
                                               <object class="GtkLabel">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="label" translatable="yes">&lt;i&gt;
 Using the checkbox the audio system can be disabled or enabled for future sessions (restart required).
 Disabling audio for a single session can be achieved using the &lt;tt&gt;--disable-audio&lt;/tt&gt; flag on the command line.
 &lt;/i&gt;</property>
-                                                <property name="use-markup">True</property>
+                                                <property name="use_markup">True</property>
                                                 <property name="wrap">True</property>
                                                 <property name="xalign">0</property>
                                               </object>
@@ -5509,9 +5496,9 @@ Disabling audio for a single session can be achieved using the &lt;tt&gt;--disab
                                               <object class="GtkCheckButton" id="cbDisableAudio">
                                                 <property name="label" translatable="yes">Disable Audio</property>
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="receives-default">False</property>
-                                                <property name="draw-indicator">True</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="receives_default">False</property>
+                                                <property name="draw_indicator">True</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
@@ -5528,7 +5515,7 @@ Disabling audio for a single session can be achieved using the &lt;tt&gt;--disab
                                 <child type="label">
                                   <object class="GtkLabel">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Enable or Disable Audio</property>
                                   </object>
                                 </child>
@@ -5542,23 +5529,23 @@ Disabling audio for a single session can be achieved using the &lt;tt&gt;--disab
                             <child>
                               <object class="GtkFrame" id="sidAudio1">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkBox" id="sid171">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
-                                    <property name="margin-bottom">8</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
+                                    <property name="margin_bottom">8</property>
                                     <property name="orientation">vertical</property>
                                     <child>
                                       <object class="GtkLabel" id="label45">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="label" translatable="yes">&lt;i&gt;Audio recordings are currently stored in a separate folder and referenced from the journal.&lt;/i&gt;</property>
-                                        <property name="use-markup">True</property>
-                                        <property name="max-width-chars">85</property>
+                                        <property name="use_markup">True</property>
+                                        <property name="max_width_chars">85</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -5569,11 +5556,11 @@ Disabling audio for a single session can be achieved using the &lt;tt&gt;--disab
                                     <child>
                                       <object class="GtkBox">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <child>
                                           <object class="GtkLabel" id="label46">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Storage Folder</property>
                                           </object>
                                           <packing>
@@ -5586,7 +5573,7 @@ Disabling audio for a single session can be achieved using the &lt;tt&gt;--disab
                                           <object class="GtkFileChooserButton" id="fcAudioPath">
                                             <property name="name">fcAudioPath</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="hexpand">True</property>
                                             <property name="action">select-folder</property>
                                             <property name="title" translatable="yes">Select Folder</property>
@@ -5609,7 +5596,7 @@ Disabling audio for a single session can be achieved using the &lt;tt&gt;--disab
                                 <child type="label">
                                   <object class="GtkLabel" id="sid172">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Storage Folder</property>
                                   </object>
                                 </child>
@@ -5623,25 +5610,25 @@ Disabling audio for a single session can be achieved using the &lt;tt&gt;--disab
                             <child>
                               <object class="GtkFrame" id="sidAudio2">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkBox" id="sid175">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
-                                    <property name="margin-bottom">8</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
+                                    <property name="margin_bottom">8</property>
                                     <property name="orientation">vertical</property>
                                     <child>
                                       <object class="GtkLabel" id="sid176">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="label" translatable="yes">&lt;i&gt;Specify the audio devices used for recording and playback of audio attachments.
 If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as input / output device.&lt;/i&gt;</property>
-                                        <property name="use-markup">True</property>
+                                        <property name="use_markup">True</property>
                                         <property name="wrap">True</property>
-                                        <property name="max-width-chars">85</property>
+                                        <property name="max_width_chars">85</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -5650,54 +5637,53 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                       </packing>
                                     </child>
                                     <child>
-                                      <!-- n-columns=2 n-rows=2 -->
                                       <object class="GtkGrid" id="grid8">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="row-spacing">10</property>
-                                        <property name="column-spacing">10</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="row_spacing">10</property>
+                                        <property name="column_spacing">10</property>
                                         <child>
                                           <object class="GtkLabel" id="label36">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Input Device</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">0</property>
+                                            <property name="left_attach">0</property>
+                                            <property name="top_attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkComboBoxText" id="cbAudioInputDevice">
                                             <property name="name">cbAudioInputDevice</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">1</property>
-                                            <property name="top-attach">0</property>
+                                            <property name="left_attach">1</property>
+                                            <property name="top_attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="label58">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Output Device</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">0</property>
-                                            <property name="top-attach">1</property>
+                                            <property name="left_attach">0</property>
+                                            <property name="top_attach">1</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkComboBoxText" id="cbAudioOutputDevice">
                                             <property name="name">cbAudioOutputDevice</property>
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                           </object>
                                           <packing>
-                                            <property name="left-attach">1</property>
-                                            <property name="top-attach">1</property>
+                                            <property name="left_attach">1</property>
+                                            <property name="top_attach">1</property>
                                           </packing>
                                         </child>
                                       </object>
@@ -5712,7 +5698,7 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                 <child type="label">
                                   <object class="GtkLabel" id="sid177">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Audio Devices</property>
                                   </object>
                                 </child>
@@ -5726,45 +5712,44 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                             <child>
                               <object class="GtkFrame" id="sidAudio3">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
-                                  <!-- n-columns=2 n-rows=2 -->
                                   <object class="GtkGrid" id="sid180">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
-                                    <property name="margin-bottom">8</property>
-                                    <property name="row-spacing">10</property>
-                                    <property name="column-spacing">10</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
+                                    <property name="margin_bottom">8</property>
+                                    <property name="row_spacing">10</property>
+                                    <property name="column_spacing">10</property>
                                     <child>
                                       <object class="GtkLabel" id="label59">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="label" translatable="yes">Sample Rate</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">0</property>
-                                        <property name="top-attach">0</property>
+                                        <property name="left_attach">0</property>
+                                        <property name="top_attach">0</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkLabel" id="label61">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="label" translatable="yes">Gain</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">0</property>
-                                        <property name="top-attach">1</property>
+                                        <property name="left_attach">0</property>
+                                        <property name="top_attach">1</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkComboBoxText" id="cbAudioSampleRate">
                                         <property name="name">cbAudioSampleRate</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="active">0</property>
                                         <items>
                                           <item id="16000">16000 Hz</item>
@@ -5774,24 +5759,24 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                         </items>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">1</property>
-                                        <property name="top-attach">0</property>
+                                        <property name="left_attach">1</property>
+                                        <property name="top_attach">0</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkSpinButton" id="spAudioGain">
                                         <property name="name">spAudioGain</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
+                                        <property name="can_focus">True</property>
                                         <property name="adjustment">adjustmentAudioGain</property>
-                                        <property name="climb-rate">0.10</property>
+                                        <property name="climb_rate">0.10000000000000001</property>
                                         <property name="digits">2</property>
                                         <property name="numeric">True</property>
                                         <property name="value">1</property>
                                       </object>
                                       <packing>
-                                        <property name="left-attach">1</property>
-                                        <property name="top-attach">1</property>
+                                        <property name="left_attach">1</property>
+                                        <property name="top_attach">1</property>
                                       </packing>
                                     </child>
                                   </object>
@@ -5799,7 +5784,7 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                 <child type="label">
                                   <object class="GtkLabel" id="sid181">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Recording Quality</property>
                                   </object>
                                 </child>
@@ -5813,19 +5798,19 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                             <child>
                               <object class="GtkFrame" id="sidAudio4">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkBox">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
-                                    <property name="margin-bottom">8</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
+                                    <property name="margin_bottom">8</property>
                                     <child>
                                       <object class="GtkLabel" id="label3">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="label" translatable="yes">Default Seek Time (in seconds)</property>
                                       </object>
                                       <packing>
@@ -5838,10 +5823,10 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                       <object class="GtkSpinButton" id="spDefaultSeekTime">
                                         <property name="name">spAudioGain</property>
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
+                                        <property name="can_focus">True</property>
                                         <property name="text" translatable="yes">1,00</property>
                                         <property name="adjustment">adjustmentSeekTime</property>
-                                        <property name="climb-rate">0.10</property>
+                                        <property name="climb_rate">0.10000000000000001</property>
                                         <property name="digits">2</property>
                                         <property name="numeric">True</property>
                                         <property name="value">1</property>
@@ -5857,7 +5842,7 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                 <child type="label">
                                   <object class="GtkLabel" id="sid4">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Playback Settings</property>
                                   </object>
                                 </child>
@@ -5871,10 +5856,10 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                             <child>
                               <object class="GtkLabel" id="sidAudioLbl">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
+                                <property name="can_focus">False</property>
                                 <property name="label" translatable="yes">&lt;i&gt;Changes take only effect on new recordings and playbacks.&lt;/i&gt;</property>
-                                <property name="use-markup">True</property>
-                                <property name="max-width-chars">85</property>
+                                <property name="use_markup">True</property>
+                                <property name="max_width_chars">85</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -5902,19 +5887,19 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
               <object class="GtkLabel" id="audioRecordingTabLabel">
                 <property name="name">audioRecordingTabLabel</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Audio Recording</property>
               </object>
               <packing>
                 <property name="position">9</property>
-                <property name="tab-fill">False</property>
+                <property name="tab_fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="latexTabBox">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="margin-start">5</property>
+                <property name="can_focus">False</property>
+                <property name="margin_start">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <placeholder/>
@@ -5927,57 +5912,57 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
             <child type="tab">
               <object class="GtkLabel" id="latexTabLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">LaTeX</property>
               </object>
               <packing>
                 <property name="position">11</property>
-                <property name="tab-fill">False</property>
+                <property name="tab_fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="languageTabBox">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="margin-start">5</property>
+                <property name="can_focus">False</property>
+                <property name="margin_start">5</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sid189">
                     <property name="visible">True</property>
-                    <property name="can-focus">True</property>
+                    <property name="can_focus">True</property>
                     <child>
                       <object class="GtkViewport" id="sid190">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="shadow-type">none</property>
+                        <property name="can_focus">False</property>
+                        <property name="shadow_type">none</property>
                         <child>
                           <object class="GtkBox" id="sid191">
                             <property name="visible">True</property>
-                            <property name="can-focus">False</property>
+                            <property name="can_focus">False</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkFrame" id="sid192">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="margin-start">4</property>
-                                <property name="margin-top">3</property>
-                                <property name="margin-bottom">3</property>
-                                <property name="border-width">2</property>
-                                <property name="label-xalign">0.009999999776482582</property>
+                                <property name="can_focus">False</property>
+                                <property name="margin_start">4</property>
+                                <property name="margin_top">3</property>
+                                <property name="margin_bottom">3</property>
+                                <property name="border_width">2</property>
+                                <property name="label_xalign">0.0099999997764825821</property>
                                 <child>
                                   <object class="GtkBox" id="sid194">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="margin-end">12</property>
-                                    <property name="margin-bottom">8</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
+                                    <property name="margin_bottom">8</property>
                                     <property name="orientation">vertical</property>
                                     <child>
                                       <object class="GtkLabel" id="label195">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="label" translatable="yes">&lt;i&gt;Select language (requires restart)&lt;/i&gt;</property>
-                                        <property name="use-markup">True</property>
+                                        <property name="use_markup">True</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -5988,15 +5973,15 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                     <child>
                                       <object class="GtkFrame" id="sid195">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="label-xalign">0.009999999776482582</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="label_xalign">0.0099999997764825821</property>
                                         <child>
                                           <object class="GtkBox" id="hboxLanguageSelect">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="margin-start">12</property>
-                                            <property name="margin-end">12</property>
-                                            <property name="margin-bottom">8</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="margin_start">12</property>
+                                            <property name="margin_end">12</property>
+                                            <property name="margin_bottom">8</property>
                                             <property name="orientation">vertical</property>
                                             <child>
                                               <placeholder/>
@@ -6006,7 +5991,7 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                         <child type="label">
                                           <object class="GtkLabel" id="label196">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Language</property>
                                           </object>
                                         </child>
@@ -6022,7 +6007,7 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                                 <child type="label">
                                   <object class="GtkLabel" id="label193">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Language Settings</property>
                                   </object>
                                 </child>
@@ -6052,12 +6037,12 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
             <child type="tab">
               <object class="GtkLabel" id="languageTabLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Language</property>
               </object>
               <packing>
                 <property name="position">11</property>
-                <property name="tab-fill">False</property>
+                <property name="tab_fill">False</property>
               </packing>
             </child>
           </object>
@@ -6070,7 +6055,7 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
         <child>
           <object class="GtkBox" id="buttonBox">
             <property name="visible">True</property>
-            <property name="can-focus">False</property>
+            <property name="can_focus">False</property>
             <property name="halign">end</property>
             <property name="spacing">4</property>
             <property name="homogeneous">True</property>
@@ -6078,9 +6063,9 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
               <object class="GtkButton" id="btCancel">
                 <property name="label" translatable="yes">Cancel</property>
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="can-default">True</property>
-                <property name="receives-default">True</property>
+                <property name="can_focus">True</property>
+                <property name="can_default">True</property>
+                <property name="receives_default">True</property>
                 <property name="image">iconCancel</property>
                 <accelerator key="Escape" signal="clicked"/>
               </object>
@@ -6094,10 +6079,10 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
               <object class="GtkButton" id="btOk">
                 <property name="label" translatable="yes">Ok</property>
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="can-default">True</property>
-                <property name="has-default">True</property>
-                <property name="receives-default">True</property>
+                <property name="can_focus">True</property>
+                <property name="can_default">True</property>
+                <property name="has_default">True</property>
+                <property name="receives_default">True</property>
                 <property name="image">iconOk</property>
               </object>
               <packing>


### PR DESCRIPTION
This PR adds an undo gesture - tapping the touchscreen with two fingers. If motion is detected during the touch it is rejected to not interfere with zooming or scrolling.
I also added a checkbox in the settings' Touchscreen tab to toggle it on or off.
I suggested this feature in #5023 