### PR TITLE
Clean up inheritance and constant declarations in menus

### DIFF
--- a/src/core/gui/menus/menubar/AbstractSubmenu.h
+++ b/src/core/gui/menus/menubar/AbstractSubmenu.h
@@ -16,9 +16,9 @@
 class MainWindow;
 
 class Submenu {
-public:
+protected:
     Submenu() = default;
-    virtual ~Submenu() noexcept = default;
+    ~Submenu() noexcept = default;
 
 public:
     virtual void setDisabled(bool disabled) = 0;

--- a/src/core/gui/menus/menubar/PageTypeSubmenu.h
+++ b/src/core/gui/menus/menubar/PageTypeSubmenu.h
@@ -22,11 +22,11 @@ class PageTypeHandler;
 class Settings;
 class PageBackgroundChangeController;
 
-class PageTypeSubmenu: public Submenu, public PageTypeSelectionMenuBase {
+class PageTypeSubmenu final: public Submenu, public PageTypeSelectionMenuBase {
 public:
     PageTypeSubmenu(PageTypeHandler* typesHandler, PageBackgroundChangeController* controller, const Settings* settings,
                     GtkApplicationWindow* win);
-    ~PageTypeSubmenu() override = default;
+    ~PageTypeSubmenu() = default;
 
     void setDisabled(bool disabled) override;
     void addToMenubar(MainWindow* win) override;

--- a/src/core/gui/menus/menubar/PluginsSubmenu.cpp
+++ b/src/core/gui/menus/menubar/PluginsSubmenu.cpp
@@ -3,6 +3,8 @@
 #include "gui/MainWindow.h"
 #include "plugin/PluginController.h"
 
+static constexpr auto SUBMENU_ID = "menuitemPlugin";
+
 PluginsSubmenu::PluginsSubmenu(PluginController* pluginController, GtkApplicationWindow* win) {
     sections = pluginController->createMenuSections(win);
 }
@@ -36,7 +38,7 @@ void PluginsSubmenu::addToMenubar(MainWindow* win) {
     if (sections.empty()) {
         return;
     }
-    GtkWidget* parent = win->get("menuitemPlugin");
+    GtkWidget* parent = win->get(SUBMENU_ID);
     GtkWidget* previousMenu = win->get("menuPlugin");
 
     xoj::util::GObjectSPtr<GMenu> submenu(g_menu_new(), xoj::util::adopt);

--- a/src/core/gui/menus/menubar/PluginsSubmenu.h
+++ b/src/core/gui/menus/menubar/PluginsSubmenu.h
@@ -20,10 +20,10 @@
 
 class PluginController;
 
-class PluginsSubmenu: public Submenu {
+class PluginsSubmenu final: public Submenu {
 public:
     PluginsSubmenu(PluginController* pluginController, GtkApplicationWindow* win);
-    virtual ~PluginsSubmenu() noexcept = default;
+    ~PluginsSubmenu() noexcept = default;
 
 public:
     void setDisabled(bool disabled) override;
@@ -32,7 +32,4 @@ public:
 private:
     PluginController* pluginController;
     std::vector<GMenuModel*> sections;
-
-private:
-    static constexpr auto SUBMENU_ID = "menuitemPlugin";
 };

--- a/src/core/gui/menus/menubar/RecentDocumentsSubmenu.cpp
+++ b/src/core/gui/menus/menubar/RecentDocumentsSubmenu.cpp
@@ -15,6 +15,16 @@
 #include "util/i18n.h"               // for FS, FORMAT_STR, C_F
 
 namespace {
+constexpr auto SUBMENU_ID = "menuFileRecent";
+constexpr auto G_ACTION_NAMESPACE = "win.";
+constexpr auto OPEN_ACTION_NAME = "open-file-at";
+
+/**
+ * @brief For a disable placeholder saying "No recent files"
+ *  To disable a GMenu entry, give it an action name that does not correspond to any GAction
+ */
+constexpr auto DISABLED_ACTION_NAME = "always-disabled-action";
+constexpr auto CLEAR_LIST_ACTION_NAME = "clear-recent-files";
 
 void recentManagerChangedCallback(GtkRecentManager* /*manager*/, RecentDocumentsSubmenu* recentDocsSubmenu) {
     recentDocsSubmenu->updateMenu();
@@ -29,8 +39,8 @@ auto createRecentMenuItem(const GtkRecentInfo* info, size_t i) {
     StringUtils::replaceAllChars(display_name, {replace_pair('_', "__")});
     std::string label = FS(FORMAT_STR("{1}. {2}") % (i + 1) % display_name);
 
-    std::string action = RecentDocumentsSubmenu::G_ACTION_NAMESPACE;
-    action += RecentDocumentsSubmenu::OPEN_ACTION_NAME;
+    std::string action = G_ACTION_NAMESPACE;
+    action += OPEN_ACTION_NAME;
     action += "(uint64 ";
     action += std::to_string(i);
     action += ")";
@@ -52,14 +62,14 @@ auto createRecentMenu(const container& recentFiles, size_t start_index) -> xoj::
 }
 
 auto createEmptyListPlaceholder() {
-    return xoj::util::GObjectSPtr<GMenuItem>(
-            g_menu_item_new(_("No recent files"), RecentDocumentsSubmenu::DISABLED_ACTION_NAME), xoj::util::adopt);
+    return xoj::util::GObjectSPtr<GMenuItem>(g_menu_item_new(_("No recent files"), DISABLED_ACTION_NAME),
+                                             xoj::util::adopt);
 }
 
 auto createClearListSection() {
     // Todo(cpp20): constexpr this concatenation
-    std::string action = RecentDocumentsSubmenu::G_ACTION_NAMESPACE;
-    action += RecentDocumentsSubmenu::CLEAR_LIST_ACTION_NAME;
+    std::string action = G_ACTION_NAMESPACE;
+    action += CLEAR_LIST_ACTION_NAME;
 
     GMenu* menu = g_menu_new();
     g_menu_append(menu, _("Clear list"), action.c_str());

--- a/src/core/gui/menus/menubar/RecentDocumentsSubmenu.h
+++ b/src/core/gui/menus/menubar/RecentDocumentsSubmenu.h
@@ -26,10 +26,10 @@ class Menubar;
 /**
  * @brief Handles the GtkMenu displaying the recent files
  */
-class RecentDocumentsSubmenu: public Submenu {
+class RecentDocumentsSubmenu final: public Submenu {
 public:
     RecentDocumentsSubmenu(Control* control, GtkApplicationWindow* win);
-    virtual ~RecentDocumentsSubmenu();
+    ~RecentDocumentsSubmenu();
 
     /**
      * Updates the menu of recent files
@@ -38,19 +38,6 @@ public:
 
     void setDisabled(bool disabled) override;
     void addToMenubar(MainWindow* win) override;
-
-    static constexpr auto SUBMENU_ID = "menuFileRecent";
-    static constexpr auto G_ACTION_NAMESPACE = "win.";
-
-    static constexpr auto OPEN_ACTION_NAME = "open-file-at";
-
-    /**
-     * @brief For a disable placeholder saying "No recent files"
-     *  To disable a GMenu entry, give it an action name that does not correspond to any GAction
-     */
-    static constexpr auto DISABLED_ACTION_NAME = "always-disabled-action";
-
-    static constexpr auto CLEAR_LIST_ACTION_NAME = "clear-recent-files";
 
 private:
     static void openFileCallback(GSimpleAction* ga, GVariant* parameter, RecentDocumentsSubmenu* self);

--- a/src/core/gui/menus/menubar/ToolbarSelectionSubmenu.cpp
+++ b/src/core/gui/menus/menubar/ToolbarSelectionSubmenu.cpp
@@ -15,10 +15,15 @@
 #include "Menubar.h"
 
 namespace {
+constexpr auto G_ACTION_NAMESPACE = "win.";
+constexpr auto G_ACTION_NAME = "select-toolbar";
+/// id from ui/mainmenubar.xml
+constexpr auto SUBMENU_ID = "menuViewToolbar";
+
 auto createToolbarSelectionMenuItem(const ToolbarData* toolbarData) {
 
-    std::string action = ToolbarSelectionSubmenu::G_ACTION_NAMESPACE;
-    action += ToolbarSelectionSubmenu::G_ACTION_NAME;
+    std::string action = G_ACTION_NAMESPACE;
+    action += G_ACTION_NAME;
     action += "('";
     action += toolbarData->getId();
     action += "')";

--- a/src/core/gui/menus/menubar/ToolbarSelectionSubmenu.h
+++ b/src/core/gui/menus/menubar/ToolbarSelectionSubmenu.h
@@ -20,10 +20,10 @@ class ToolMenuHandler;
 class ToolbarData;
 class MainWindow;
 
-class ToolbarSelectionSubmenu: public Submenu {
+class ToolbarSelectionSubmenu final: public Submenu {
 public:
     ToolbarSelectionSubmenu(MainWindow* win, Settings* settings, ToolMenuHandler* toolbar);
-    virtual ~ToolbarSelectionSubmenu();
+    ~ToolbarSelectionSubmenu();
 
 public:
     void update(ToolMenuHandler* toolbarHandler, const ToolbarData* selectedToolbar);
@@ -35,10 +35,4 @@ private:
     xoj::util::GObjectSPtr<GMenu> stockConfigurationsSection;
     xoj::util::GObjectSPtr<GMenu> customConfigurationsSection;
     xoj::util::GObjectSPtr<GSimpleAction> gAction;
-
-public:
-    static constexpr auto G_ACTION_NAMESPACE = "win.";
-    static constexpr auto G_ACTION_NAME = "select-toolbar";
-    /// id from ui/mainmenubar.xml
-    static constexpr auto SUBMENU_ID = "menuViewToolbar";
 };

--- a/src/core/gui/menus/popoverMenus/PageTypeSelectionPopover.h
+++ b/src/core/gui/menus/popoverMenus/PageTypeSelectionPopover.h
@@ -24,7 +24,7 @@ class PageTypeHandler;
 class PageTypeInfo;
 class Settings;
 
-class PageTypeSelectionPopover: public PageTypeSelectionMenuBase {
+class PageTypeSelectionPopover final: public PageTypeSelectionMenuBase {
 public:
     PageTypeSelectionPopover(PageTypeHandler* typesHandler, PageBackgroundChangeController* controller,
                              const Settings* settings, GtkApplicationWindow* win);

--- a/src/core/gui/menus/popoverMenus/PageTypeSelectionPopoverGridOnly.h
+++ b/src/core/gui/menus/popoverMenus/PageTypeSelectionPopoverGridOnly.h
@@ -24,7 +24,7 @@ class PageTypeHandler;
 class PageTypeInfo;
 class Settings;
 
-class PageTypeSelectionPopoverGridOnly: public PageTypeSelectionMenuBase {
+class PageTypeSelectionPopoverGridOnly final: public PageTypeSelectionMenuBase {
 public:
     PageTypeSelectionPopoverGridOnly(PageTypeHandler* typesHandler, const Settings* settings,
                                      PageTemplateDialog* parent);


### PR DESCRIPTION
Simple inocuous cleanup in GMenu-based dynamically generated submenus.
Merging as soon as the CI clears