### PR TITLE
Fix some memory leaks

### DIFF
--- a/src/core/control/xml/XmlNode.cpp
+++ b/src/core/control/xml/XmlNode.cpp
@@ -37,9 +37,8 @@ void XmlNode::setAttrib(const char* attrib, size_t value) { putAttrib(new SizeTA
 /**
  * The double array is now owned by XmlNode and automatically deleted!
  */
-void XmlNode::setAttrib(const char* attrib, double* value, int count) {
-    putAttrib(new DoubleArrayAttribute(attrib, std::vector<double>{value, value + count}));
-    g_free(value);
+void XmlNode::setAttrib(const char* attrib, std::vector<double> values) {
+    putAttrib(new DoubleArrayAttribute(attrib, std::move(values)));
 }
 
 void XmlNode::writeOut(OutputStream* out, ProgressListener* listener) {

--- a/src/core/control/xml/XmlNode.h
+++ b/src/core/control/xml/XmlNode.h
@@ -32,11 +32,7 @@ public:
     void setAttrib(const char* attrib, double value);
     void setAttrib(const char* attrib, int value);
     void setAttrib(const char* attrib, size_t value);
-
-    /**
-     * The double array is now owned by XmlNode and automatically deleted!
-     */
-    void setAttrib(const char* attrib, double* value, int count);
+    void setAttrib(const char* attrib, std::vector<double> values);
 
     void writeOut(OutputStream* out, ProgressListener* _listener);
 

--- a/src/core/control/xml/XmlPointNode.cpp
+++ b/src/core/control/xml/XmlPointNode.cpp
@@ -9,7 +9,7 @@
 
 XmlPointNode::XmlPointNode(const char* tag): XmlAudioNode(tag) {}
 
-void XmlPointNode::addPoint(Point point) { points.emplace_back(std::move(point)); }
+void XmlPointNode::setPoints(std::vector<Point> pts) { this->points = std::move(pts); }
 
 void XmlPointNode::writeOut(OutputStream* out) {
     /** Write stroke and its attributes */

--- a/src/core/control/xml/XmlPointNode.h
+++ b/src/core/control/xml/XmlPointNode.h
@@ -24,7 +24,7 @@ public:
     XmlPointNode(const char* tag);
 
 public:
-    void addPoint(Point point);
+    void setPoints(std::vector<Point> points);
     void writeOut(OutputStream* out) override;
 
 private:

--- a/src/core/control/xojfile/SaveHandler.cpp
+++ b/src/core/control/xojfile/SaveHandler.cpp
@@ -114,20 +114,16 @@ void SaveHandler::visitStroke(XmlPointNode* stroke, Stroke* s) {
 
     stroke->setAttrib("color", getColorStr(s->getColor(), alpha).c_str());
 
-    int pointCount = s->getPointCount();
+    const auto& pts = s->getPointVector();
 
-    for (int i = 0; i < pointCount; i++) {
-        stroke->addPoint(s->getPoint(i));
-    }
+    stroke->setPoints(pts);
 
     if (s->hasPressure()) {
-        auto* values = new double[pointCount + 1];
-        values[0] = s->getWidth();
-        for (int i = 0; i < pointCount; i++) {
-            values[i + 1] = s->getPoint(i).z;
-        }
-
-        stroke->setAttrib("width", values, pointCount);
+        std::vector<double> values;
+        values.reserve(pts.size() + 1);
+        values.emplace_back(s->getWidth());
+        std::transform(pts.begin(), pts.end(), std::back_inserter(values), [](const Point& p) { return p.z; });
+        stroke->setAttrib("width", std::move(values));
     } else {
         stroke->setAttrib("width", s->getWidth());
     }

--- a/src/core/gui/sidebar/Sidebar.cpp
+++ b/src/core/gui/sidebar/Sidebar.cpp
@@ -22,6 +22,7 @@
 #include "previews/layer/SidebarPreviewLayers.h"      // for SidebarPreviewL...
 #include "previews/page/SidebarPreviewPages.h"        // for SidebarPreviewP...
 #include "util/Util.h"                                // for npos
+#include "util/glib_casts.h"                          // for closure_notify_cb
 #include "util/i18n.h"                                // for _, FC, _F
 
 Sidebar::Sidebar(GladeGui* gui, Control* control): control(control), gui(gui), toolbar(this, gui) {
@@ -51,7 +52,8 @@ void Sidebar::initPages(GtkWidget* sidebarContents, GladeGui* gui) {
 
         gtk_tool_button_set_icon_widget(GTK_TOOL_BUTTON(it), gtk_image_new_from_icon_name(p->getIconName().c_str(),
                                                                                           GTK_ICON_SIZE_SMALL_TOOLBAR));
-        g_signal_connect(it, "clicked", G_CALLBACK(&buttonClicked), new SidebarPageButton(this, i, p));
+        g_signal_connect_data(it, "clicked", G_CALLBACK(&buttonClicked), new SidebarPageButton(this, i, p),
+                              xoj::util::closure_notify_cb<SidebarPageButton>, GConnectFlags(0));
         gtk_tool_item_set_tooltip_text(it, p->getName().c_str());
         gtk_tool_button_set_label(GTK_TOOL_BUTTON(it), p->getName().c_str());
 

--- a/src/core/gui/sidebar/previews/base/SidebarLayout.cpp
+++ b/src/core/gui/sidebar/previews/base/SidebarLayout.cpp
@@ -80,7 +80,7 @@ void SidebarLayout::layout(SidebarPreviewBase* sidebar) {
 
     GtkAllocation alloc;
 
-    gtk_widget_get_allocation(sidebar->scrollPreview, &alloc);
+    gtk_widget_get_allocation(sidebar->scrollPreview.get(), &alloc);
 
     SidebarRow row(alloc.width);
 
@@ -88,7 +88,7 @@ void SidebarLayout::layout(SidebarPreviewBase* sidebar) {
         if (row.isSpaceFor(p.get())) {
             row.add(p.get());
         } else {
-            y += row.placeAt(y, GTK_LAYOUT(sidebar->iconViewPreview));
+            y += row.placeAt(y, GTK_LAYOUT(sidebar->iconViewPreview.get()));
 
             width = std::max(width, row.getWidth());
 
@@ -98,12 +98,12 @@ void SidebarLayout::layout(SidebarPreviewBase* sidebar) {
     }
 
     if (row.getCount() != 0) {
-        y += row.placeAt(y, GTK_LAYOUT(sidebar->iconViewPreview));
+        y += row.placeAt(y, GTK_LAYOUT(sidebar->iconViewPreview.get()));
 
         width = std::max(width, row.getWidth());
 
         row.clear();
     }
 
-    gtk_layout_set_size(GTK_LAYOUT(sidebar->iconViewPreview), width, y);
+    gtk_layout_set_size(GTK_LAYOUT(sidebar->iconViewPreview.get()), width, y);
 }

--- a/src/core/gui/sidebar/previews/base/SidebarPreviewBase.cpp
+++ b/src/core/gui/sidebar/previews/base/SidebarPreviewBase.cpp
@@ -19,7 +19,9 @@ class GladeGui;
 
 
 SidebarPreviewBase::SidebarPreviewBase(Control* control, GladeGui* gui, SidebarToolbar* toolbar):
-        AbstractSidebarPage(control, toolbar) {
+        AbstractSidebarPage(control, toolbar),
+        scrollPreview(gtk_scrolled_window_new(nullptr, nullptr), xoj::util::adopt),
+        iconViewPreview(gtk_layout_new(nullptr, nullptr), xoj::util::adopt) {
     this->layoutmanager = new SidebarLayout();
 
     Document* doc = this->control->getDocument();
@@ -29,37 +31,23 @@ SidebarPreviewBase::SidebarPreviewBase(Control* control, GladeGui* gui, SidebarT
     }
     doc->unlock();
 
-    this->iconViewPreview = gtk_layout_new(nullptr, nullptr);
-    g_object_ref(this->iconViewPreview);
-
-    this->scrollPreview = gtk_scrolled_window_new(nullptr, nullptr);
-    g_object_ref(this->scrollPreview);
-
-    gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(this->scrollPreview), GTK_POLICY_AUTOMATIC,
+    gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(this->scrollPreview.get()), GTK_POLICY_AUTOMATIC,
                                    GTK_POLICY_AUTOMATIC);
-    gtk_scrolled_window_set_shadow_type(GTK_SCROLLED_WINDOW(this->scrollPreview), GTK_SHADOW_IN);
+    gtk_scrolled_window_set_shadow_type(GTK_SCROLLED_WINDOW(this->scrollPreview.get()), GTK_SHADOW_IN);
 
-    gtk_container_add(GTK_CONTAINER(this->scrollPreview), this->iconViewPreview);
-    gtk_widget_show(this->scrollPreview);
-
-    gtk_widget_show(this->iconViewPreview);
+    gtk_container_add(GTK_CONTAINER(this->scrollPreview.get()), this->iconViewPreview.get());
 
     registerListener(this->control);
     this->control->addChangedDocumentListener(this);
 
-    g_signal_connect(this->scrollPreview, "size-allocate", G_CALLBACK(sizeChanged), this);
+    g_signal_connect(this->scrollPreview.get(), "size-allocate", G_CALLBACK(sizeChanged), this);
 
-    gtk_widget_show_all(this->scrollPreview);
+    gtk_widget_show_all(this->scrollPreview.get());
 }
 
 SidebarPreviewBase::~SidebarPreviewBase() {
-    gtk_widget_destroy(this->iconViewPreview);
-    this->iconViewPreview = nullptr;
-
     delete this->layoutmanager;
     this->layoutmanager = nullptr;
-
-    this->scrollPreview = nullptr;
 
     this->control->removeChangedDocumentListener(this);
 
@@ -91,7 +79,7 @@ void SidebarPreviewBase::layout() { SidebarLayout::layout(this); }
 
 auto SidebarPreviewBase::hasData() -> bool { return true; }
 
-auto SidebarPreviewBase::getWidget() -> GtkWidget* { return this->scrollPreview; }
+auto SidebarPreviewBase::getWidget() -> GtkWidget* { return this->scrollPreview.get(); }
 
 void SidebarPreviewBase::documentChanged(DocumentChangeType type) {
     if (type == DOCUMENT_CHANGE_COMPLETE || type == DOCUMENT_CHANGE_CLEARED) {
@@ -126,8 +114,8 @@ auto SidebarPreviewBase::scrollToPreview(SidebarPreviewBase* sidebar) -> bool {
         auto& p = sidebar->previews[sidebar->selectedEntry];
 
         // scroll to preview
-        GtkAdjustment* hadj = gtk_scrolled_window_get_hadjustment(GTK_SCROLLED_WINDOW(sidebar->scrollPreview));
-        GtkAdjustment* vadj = gtk_scrolled_window_get_vadjustment(GTK_SCROLLED_WINDOW(sidebar->scrollPreview));
+        GtkAdjustment* hadj = gtk_scrolled_window_get_hadjustment(GTK_SCROLLED_WINDOW(sidebar->scrollPreview.get()));
+        GtkAdjustment* vadj = gtk_scrolled_window_get_vadjustment(GTK_SCROLLED_WINDOW(sidebar->scrollPreview.get()));
         GtkWidget* widget = p->getWidget();
 
         GtkAllocation allocation;

--- a/src/core/gui/sidebar/previews/base/SidebarPreviewBase.h
+++ b/src/core/gui/sidebar/previews/base/SidebarPreviewBase.h
@@ -19,6 +19,7 @@
 
 #include "gui/sidebar/AbstractSidebarPage.h"  // for AbstractSidebarPage
 #include "model/DocumentChangeType.h"         // for DocumentChangeType
+#include "util/raii/GObjectSPtr.h"
 
 class PdfCache;
 class SidebarLayout;
@@ -93,7 +94,7 @@ private:
     /**
      * The scrollbar with the icons
      */
-    GtkWidget* scrollPreview = nullptr;
+    xoj::util::WidgetSPtr scrollPreview;
 
     /**
      * The Zoom of the previews
@@ -122,7 +123,7 @@ protected:
     /**
      * The widget within the scrollarea with the page icons
      */
-    GtkWidget* iconViewPreview = nullptr;
+    xoj::util::WidgetSPtr iconViewPreview;
 
     /**
      * The previews

--- a/src/core/gui/sidebar/previews/layer/SidebarPreviewLayers.cpp
+++ b/src/core/gui/sidebar/previews/layer/SidebarPreviewLayers.cpp
@@ -120,7 +120,7 @@ void SidebarPreviewLayers::updatePreviews() {
         --i;
         std::string name = lc->getLayerNameById(i);
         auto p = std::make_unique<SidebarPreviewLayerEntry>(this, page, i, name, index++, this->stacked);
-        gtk_layout_put(GTK_LAYOUT(this->iconViewPreview), p->getWidget(), 0, 0);
+        gtk_layout_put(GTK_LAYOUT(this->iconViewPreview.get()), p->getWidget(), 0, 0);
         this->previews.emplace_back(std::move(p));
     }
 

--- a/src/core/gui/sidebar/previews/page/SidebarPreviewPages.cpp
+++ b/src/core/gui/sidebar/previews/page/SidebarPreviewPages.cpp
@@ -183,7 +183,7 @@ void SidebarPreviewPages::updatePreviews() {
     size_t len = doc->getPageCount();
     for (size_t i = 0; i < len; i++) {
         auto p = std::make_unique<SidebarPreviewPageEntry>(this, doc->getPage(i), i);
-        gtk_layout_put(GTK_LAYOUT(this->iconViewPreview), p->getWidget(), 0, 0);
+        gtk_layout_put(GTK_LAYOUT(this->iconViewPreview.get()), p->getWidget(), 0, 0);
         this->previews.emplace_back(std::move(p));
     }
 
@@ -234,7 +234,7 @@ void SidebarPreviewPages::pageInserted(size_t page) {
 
     doc->unlock();
 
-    gtk_layout_put(GTK_LAYOUT(this->iconViewPreview), p->getWidget(), 0, 0);
+    gtk_layout_put(GTK_LAYOUT(this->iconViewPreview.get()), p->getWidget(), 0, 0);
     this->previews.insert(this->previews.begin() + page, std::move(p));
 
     // Unselect page, to prevent double selection displaying

--- a/src/core/model/Image.cpp
+++ b/src/core/model/Image.cpp
@@ -138,20 +138,19 @@ auto Image::getImage() const -> cairo_surface_t* {
 
         GdkPixbuf* tmp = gdk_pixbuf_loader_get_pixbuf(loader.get());
         g_assert(tmp != nullptr);
-        GdkPixbuf* pixbuf = gdk_pixbuf_apply_embedded_orientation(tmp);
+        xoj::util::GObjectSPtr<GdkPixbuf> pixbuf(gdk_pixbuf_apply_embedded_orientation(tmp), xoj::util::adopt);
 
-        this->imageSize = {gdk_pixbuf_get_width(pixbuf), gdk_pixbuf_get_height(pixbuf)};
+        this->imageSize = {gdk_pixbuf_get_width(pixbuf.get()), gdk_pixbuf_get_height(pixbuf.get())};
 
         // TODO: pass in window once this code is refactored into ImageView
-        this->image = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, gdk_pixbuf_get_width(pixbuf),
-                                                 gdk_pixbuf_get_height(pixbuf));
+        this->image = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, this->imageSize.first, this->imageSize.second);
         g_assert(this->image != nullptr);
 
         // Paint the pixbuf on to the surface
         // NOTE: we do this manually instead of using gdk_cairo_surface_create_from_pixbuf
         // since this does not work in CLI mode.
         cairo_t* cr = cairo_create(this->image);
-        gdk_cairo_set_source_pixbuf(cr, pixbuf, 0, 0);
+        gdk_cairo_set_source_pixbuf(cr, pixbuf.get(), 0, 0);
         cairo_paint(cr);
         cairo_destroy(cr);
     }

--- a/src/core/model/Stroke.cpp
+++ b/src/core/model/Stroke.cpp
@@ -196,11 +196,7 @@ void Stroke::readSerialized(ObjectInputStream& in) {
 
     this->capStyle = static_cast<StrokeCapStyle>(in.readInt());
 
-    Point* p{};
-    int count{};
-    in.readData(reinterpret_cast<void**>(&p), &count);
-    this->points = std::vector<Point>{p, p + count};
-    g_free(p);
+    in.readData(this->points);
     this->lineStyle.readSerialized(in);
 
     in.endObject();

--- a/src/core/model/TexImage.cpp
+++ b/src/core/model/TexImage.cpp
@@ -135,7 +135,7 @@ void TexImage::serialize(ObjectOutputStream& out) const {
     out.writeDouble(this->height);
     out.writeString(this->text);
 
-    out.writeData(this->binaryData.c_str(), this->binaryData.length(), 1);
+    out.writeString(this->binaryData);
 
     out.endObject();
 }
@@ -151,11 +151,8 @@ void TexImage::readSerialized(ObjectInputStream& in) {
 
     freeImageAndPdf();
 
-    char* data = nullptr;
-    int len = 0;
-    in.readData(reinterpret_cast<void**>(&data), &len);
-
-    this->loadData(std::string(data, len), nullptr);
+    std::string data = in.readString();
+    this->loadData(std::move(data), nullptr);
 
     in.endObject();
     this->calcSize();

--- a/src/util/include/util/glib_casts.h
+++ b/src/util/include/util/glib_casts.h
@@ -136,6 +136,11 @@ constexpr void destroy_cb(gpointer data) {
     delete static_cast<T*>(data);
 };
 
+template <typename T, std::enable_if_t<!std::is_same_v<T, void>, int> = 1>
+constexpr void closure_notify_cb(gpointer data, GClosure*) {
+    delete static_cast<T*>(data);
+};
+
 #ifndef NDEBUG
 constexpr auto tester1(int*, double*, char*) -> bool { return true; }
 constexpr auto tester2(int*, double*, char*) -> uint64_t { return 1; }

--- a/src/util/include/util/serializing/ObjectInputStream.h
+++ b/src/util/include/util/serializing/ObjectInputStream.h
@@ -16,6 +16,8 @@
 #include <string>   // for string
 #include <vector>   // for vector
 
+#include "InputStreamException.h"
+
 class ObjectInputStream {
 public:
     ObjectInputStream() = default;
@@ -34,7 +36,6 @@ public:
     size_t readSizeT();
     std::string readString();
 
-    void readData(void** data, int* len);
     template <typename T>
     void readData(std::vector<T>& data);
 
@@ -46,10 +47,42 @@ private:
 
     static std::string getType(char type);
 
+    template <class T>
+    T readType();
+
 private:
     std::istringstream istream;
     size_t pos();
     size_t len = 0;
 };
 
-extern template void ObjectInputStream::readData(std::vector<double>& data);
+extern template int ObjectInputStream::readType<int>();
+
+template <typename T>
+void ObjectInputStream::readData(std::vector<T>& data) {
+    checkType('b');
+
+    if (istream.str().size() < 2 * sizeof(int)) {
+        throw InputStreamException("End reached, but try to read data len and width", __FILE__, __LINE__);
+    }
+
+    int len = readType<int>();
+    int width = readType<int>();
+
+    if (width != sizeof(T)) {
+        throw InputStreamException("Data width mismatch requested type width", __FILE__, __LINE__);
+    }
+
+    if (len < 0) {
+        throw InputStreamException("Negative length of data array", __FILE__, __LINE__);
+    }
+
+    if (istream.str().size() < static_cast<size_t>(len * width)) {
+        throw InputStreamException("End reached, but try to read data", __FILE__, __LINE__);
+    }
+
+    if (len) {
+        data.resize(static_cast<size_t>(len));
+        istream.read((char*)data.data(), len * width);
+    }
+}

--- a/src/util/include/util/serializing/ObjectOutputStream.h
+++ b/src/util/include/util/serializing/ObjectOutputStream.h
@@ -49,4 +49,7 @@ private:
     ObjectEncoding* encoder = nullptr;
 };
 
-extern template void ObjectOutputStream::writeData(const std::vector<double>& data);
+template <typename T>
+void ObjectOutputStream::writeData(const std::vector<T>& data) {
+    writeData(data.data(), static_cast<int>(data.size()), sizeof(T));
+}

--- a/src/util/serializing/ObjectOutputStream.cpp
+++ b/src/util/serializing/ObjectOutputStream.cpp
@@ -5,8 +5,6 @@
 #include "util/serializing/ObjectEncoding.h"  // for ObjectEncoding
 #include "util/serializing/Serializable.h"    // for XML_VERSION_STR
 
-template void ObjectOutputStream::writeData(const std::vector<double>& data);
-
 ObjectOutputStream::ObjectOutputStream(ObjectEncoding* encoder) {
     g_assert(encoder != nullptr);
     this->encoder = encoder;
@@ -60,16 +58,6 @@ void ObjectOutputStream::writeData(const void* data, int len, int width) {
     if (data != nullptr) {
         this->encoder->addData(data, len * width);
     }
-}
-
-template <typename T>
-void ObjectOutputStream::writeData(const std::vector<T>& data) {
-    this->encoder->addStr("_b");
-    const int len = static_cast<int>(data.size());
-    const int width = sizeof(T);
-    this->encoder->addData(&len, sizeof(int));
-    this->encoder->addData(&width, sizeof(int));
-    this->encoder->addData(data.data(), static_cast<int>(data.size() * sizeof(T)));
 }
 
 void ObjectOutputStream::writeImage(const std::string_view& imgData) {

--- a/test/unit_tests/control/LoadHandlerTest.cpp
+++ b/test/unit_tests/control/LoadHandlerTest.cpp
@@ -366,7 +366,10 @@ void checkImageFormat(Image* img, const char* formatName) {
     ASSERT_TRUE(gdk_pixbuf_loader_close(imgLoader, nullptr));
     GdkPixbufFormat* format = gdk_pixbuf_loader_get_format(imgLoader);
     ASSERT_TRUE(format) << "could not determine image format";
-    EXPECT_STREQ(gdk_pixbuf_format_get_name(format), formatName);
+    auto gdkFormatName = gdk_pixbuf_format_get_name(format);
+    EXPECT_STREQ(gdkFormatName, formatName);
+    g_free(gdkFormatName);
+    g_object_unref(imgLoader);
 }
 }  // namespace
 

--- a/test/unit_tests/util/ObjectIOStreamTest.cpp
+++ b/test/unit_tests/util/ObjectIOStreamTest.cpp
@@ -19,7 +19,9 @@ std::string serializeDataVector(const std::vector<T>& data) {
     ObjectOutputStream outStream(new BinObjectEncoding);
     outStream.writeData(data);
     auto outStr = outStream.getStr();
-    return {outStr->str, outStr->len};
+    auto resStr = std::string{outStr->str, outStr->len};
+    g_string_free(outStr, true);
+    return resStr;
 }
 
 std::string serializeImage(cairo_surface_t* surf) {
@@ -27,42 +29,54 @@ std::string serializeImage(cairo_surface_t* surf) {
     std::string data{reinterpret_cast<char*>(cairo_image_surface_get_data(surf))};
     outStream.writeImage(data);
     auto outStr = outStream.getStr();
-    return {outStr->str, outStr->len};
+    auto resStr = std::string{outStr->str, outStr->len};
+    g_string_free(outStr, true);
+    return resStr;
 }
 
 std::string serializeString(const std::string& str) {
     ObjectOutputStream outStream(new BinObjectEncoding);
     outStream.writeString(str);
     auto outStr = outStream.getStr();
-    return {outStr->str, outStr->len};
+    auto resStr = std::string{outStr->str, outStr->len};
+    g_string_free(outStr, true);
+    return resStr;
 }
 
 std::string serializeSizeT(size_t x) {
     ObjectOutputStream outStream(new BinObjectEncoding);
     outStream.writeSizeT(x);
     auto outStr = outStream.getStr();
-    return {outStr->str, outStr->len};
+    auto resStr = std::string{outStr->str, outStr->len};
+    g_string_free(outStr, true);
+    return resStr;
 }
 
 std::string serializeDouble(double x) {
     ObjectOutputStream outStream(new BinObjectEncoding);
     outStream.writeDouble(x);
     auto outStr = outStream.getStr();
-    return {outStr->str, outStr->len};
+    auto resStr = std::string{outStr->str, outStr->len};
+    g_string_free(outStr, true);
+    return resStr;
 }
 
 std::string serializeInt(int x) {
     ObjectOutputStream outStream(new BinObjectEncoding);
     outStream.writeInt(x);
     auto outStr = outStream.getStr();
-    return {outStr->str, outStr->len};
+    auto resStr = std::string{outStr->str, outStr->len};
+    g_string_free(outStr, true);
+    return resStr;
 }
 
 std::string serializeStroke(Stroke& stroke) {
     ObjectOutputStream outStream(new BinObjectEncoding);
     stroke.serialize(outStream);
     auto outStr = outStream.getStr();
-    return {outStr->str, outStr->len};
+    auto resStr = std::string{outStr->str, outStr->len};
+    g_string_free(outStr, true);
+    return resStr;
 }
 
 template <typename T>
@@ -242,6 +256,7 @@ TEST(UtilObjectIOStream, testReadComplexObject) {
 
             auto gstr = outStream.getStr();
             std::string str(gstr->str, gstr->len);
+            g_string_free(gstr, true);
 
             ObjectInputStream stream;
             EXPECT_TRUE(stream.read(&str[0], (int)str.size() + 1));

--- a/test/unit_tests/util/ObjectIOStreamTest.cpp
+++ b/test/unit_tests/util/ObjectIOStreamTest.cpp
@@ -14,14 +14,6 @@
 #include "util/serializing/ObjectOutputStream.h"
 #include "util/serializing/Serializable.h"
 
-template <typename T, unsigned N>
-std::string serializeData(const std::array<T, N>& data) {
-    ObjectOutputStream outStream(new BinObjectEncoding);
-    outStream.writeData(&data[0], N, sizeof(T));
-    auto outStr = outStream.getStr();
-    return {outStr->str, outStr->len};
-}
-
 template <typename T>
 std::string serializeDataVector(const std::vector<T>& data) {
     ObjectOutputStream outStream(new BinObjectEncoding);
@@ -73,21 +65,6 @@ std::string serializeStroke(Stroke& stroke) {
     return {outStr->str, outStr->len};
 }
 
-template <typename T, unsigned int N>
-void testReadDataType(const std::array<T, N>& data) {
-    std::string str = serializeData<T, N>(data);
-
-    ObjectInputStream stream;
-    EXPECT_TRUE(stream.read(&str[0], (int)str.size() + 1));
-
-    int length = 0;
-    T* outputData = nullptr;
-    stream.readData((void**)&outputData, &length);
-    EXPECT_EQ(length, (int)N);
-
-    for (size_t i = 0; i < (size_t)length / sizeof(T); ++i) { EXPECT_EQ(outputData[i], data.at(i)); }
-}
-
 template <typename T>
 void testReadDataType(const std::vector<T>& data) {
     std::string str = serializeDataVector<T>(data);
@@ -102,12 +79,19 @@ void testReadDataType(const std::vector<T>& data) {
 
 
 TEST(UtilObjectIOStream, testReadData) {
-    testReadDataType<char, 3>(std::array<char, 3>{0, 42, -42});
-    testReadDataType<long, 3>(std::array<long, 3>{0, 42, -42});
-    testReadDataType<long long, 3>(std::array<long long, 3>{0, 420000000000, -42000000000});
-    testReadDataType<double, 3>(std::array<double, 3>{0, 42., -42.});
-    testReadDataType<float, 3>(std::array<float, 3>{0, 42., -42.});
-    testReadDataType<double>(std::vector<double>{0, 42., -42.});
+    testReadDataType(std::vector<char>{0, 42, -42});
+    testReadDataType(std::vector<long>{0, 42, -42});
+    testReadDataType(std::vector<long long>{0, 420000000000, -42000000000});
+    testReadDataType(std::vector<float>{0, 42., -42.});
+    testReadDataType(std::vector<double>{0, 42., -42.});
+
+    struct Data {
+        bool operator==(const Data& o) const { return s == o.s && f == o.f && b == o.b; }
+        size_t s;
+        float f;
+        bool b;
+    };
+    testReadDataType(std::vector<Data>{{243254, 0.4534314213f, true}, {2, -4243213.32f, false}});
 }
 
 TEST(UtilObjectIOStream, testReadImage) {


### PR DESCRIPTION
Fixes some memory leaks.
Some of the fixes are taken from #4613 (and flagged as coauthored with @jhilmer).


I also tried enabling `fsanitize=leak,address,undefined` to the tests' build env to implicitely add the test "no leaks in whatever the tests call". It detected some dataleaks in SaveHandler but I have not found the source of the leaks (yet).
I'll investigate and make a second PR once I found the issue.
