### PR TITLE
Check device hash for input sequences

### DIFF
--- a/src/core/gui/PageView.cpp
+++ b/src/core/gui/PageView.cpp
@@ -209,11 +209,11 @@ void XojPageView::endSpline() {
 }
 
 auto XojPageView::onButtonPressEvent(const PositionInputData& pos) -> bool {
-    if (currentSequenceDeviceHash) {
+    if (currentSequenceDeviceId) {
         // An input sequence is already under way from another device
         return false;
     }
-    currentSequenceDeviceHash = pos.deviceHash;
+    currentSequenceDeviceId = pos.deviceId;
 
     Control* control = xournal->getControl();
 
@@ -501,7 +501,7 @@ auto XojPageView::onButtonTriplePressEvent(const PositionInputData& pos) -> bool
 }
 
 auto XojPageView::onMotionNotifyEvent(const PositionInputData& pos) -> bool {
-    if (currentSequenceDeviceHash != pos.deviceHash) {
+    if (currentSequenceDeviceId != pos.deviceId) {
         // This motion event is not from the device which started the sequence: reject it
         return false;
     }
@@ -534,12 +534,12 @@ auto XojPageView::onMotionNotifyEvent(const PositionInputData& pos) -> bool {
     return false;
 }
 
-void XojPageView::onSequenceCancelEvent(size_t deviceHash) {
-    if (currentSequenceDeviceHash != deviceHash) {
+void XojPageView::onSequenceCancelEvent(DeviceId deviceId) {
+    if (currentSequenceDeviceId != deviceId) {
         // This motion event is not from the device which started the sequence: reject it
         return;
     }
-    currentSequenceDeviceHash = 0;
+    currentSequenceDeviceId.clear();
 
     if (this->inputHandler) {
         this->inputHandler->onSequenceCancelEvent();
@@ -615,11 +615,11 @@ void XojPageView::deleteView(xoj::view::OverlayView* view) {
 }
 
 auto XojPageView::onButtonReleaseEvent(const PositionInputData& pos) -> bool {
-    if (currentSequenceDeviceHash != pos.deviceHash) {
+    if (currentSequenceDeviceId != pos.deviceId) {
         // This event is not from the device which started the sequence: reject it
         return false;
     }
-    currentSequenceDeviceHash = 0;
+    currentSequenceDeviceId.clear();
 
     Control* control = xournal->getControl();
 

--- a/src/core/gui/PageView.cpp
+++ b/src/core/gui/PageView.cpp
@@ -209,6 +209,12 @@ void XojPageView::endSpline() {
 }
 
 auto XojPageView::onButtonPressEvent(const PositionInputData& pos) -> bool {
+    if (currentSequenceDeviceHash) {
+        // An input sequence is already under way from another device
+        return false;
+    }
+    currentSequenceDeviceHash = pos.deviceHash;
+
     Control* control = xournal->getControl();
 
     if (!this->selected) {
@@ -495,6 +501,11 @@ auto XojPageView::onButtonTriplePressEvent(const PositionInputData& pos) -> bool
 }
 
 auto XojPageView::onMotionNotifyEvent(const PositionInputData& pos) -> bool {
+    if (currentSequenceDeviceHash != pos.deviceHash) {
+        // This motion event is not from the device which started the sequence: reject it
+        return false;
+    }
+
     double zoom = xournal->getZoom();
     double x = pos.x / zoom;
     double y = pos.y / zoom;
@@ -523,7 +534,13 @@ auto XojPageView::onMotionNotifyEvent(const PositionInputData& pos) -> bool {
     return false;
 }
 
-void XojPageView::onSequenceCancelEvent() {
+void XojPageView::onSequenceCancelEvent(size_t deviceHash) {
+    if (currentSequenceDeviceHash != deviceHash) {
+        // This motion event is not from the device which started the sequence: reject it
+        return;
+    }
+    currentSequenceDeviceHash = 0;
+
     if (this->inputHandler) {
         this->inputHandler->onSequenceCancelEvent();
 
@@ -598,6 +615,12 @@ void XojPageView::deleteView(xoj::view::OverlayView* view) {
 }
 
 auto XojPageView::onButtonReleaseEvent(const PositionInputData& pos) -> bool {
+    if (currentSequenceDeviceHash != pos.deviceHash) {
+        // This event is not from the device which started the sequence: reject it
+        return false;
+    }
+    currentSequenceDeviceHash = 0;
+
     Control* control = xournal->getControl();
 
     if (this->inputHandler) {

--- a/src/core/gui/PageView.cpp
+++ b/src/core/gui/PageView.cpp
@@ -539,7 +539,7 @@ void XojPageView::onSequenceCancelEvent(DeviceId deviceId) {
         // This motion event is not from the device which started the sequence: reject it
         return;
     }
-    currentSequenceDeviceId.clear();
+    currentSequenceDeviceId.reset();
 
     if (this->inputHandler) {
         this->inputHandler->onSequenceCancelEvent();
@@ -619,7 +619,7 @@ auto XojPageView::onButtonReleaseEvent(const PositionInputData& pos) -> bool {
         // This event is not from the device which started the sequence: reject it
         return false;
     }
-    currentSequenceDeviceId.clear();
+    currentSequenceDeviceId.reset();
 
     Control* control = xournal->getControl();
 

--- a/src/core/gui/PageView.h
+++ b/src/core/gui/PageView.h
@@ -178,7 +178,7 @@ public:  // event handler
     bool onButtonDoublePressEvent(const PositionInputData& pos);
     bool onButtonTriplePressEvent(const PositionInputData& pos);
     bool onMotionNotifyEvent(const PositionInputData& pos);
-    void onSequenceCancelEvent();
+    void onSequenceCancelEvent(size_t deviceHash);
     void onTapEvent(const PositionInputData& pos);
 
     /**
@@ -294,6 +294,8 @@ private:
 
     int mappedRow{};
     int mappedCol{};
+
+    size_t currentSequenceDeviceHash = 0;
 
 
     friend class RenderJob;

--- a/src/core/gui/PageView.h
+++ b/src/core/gui/PageView.h
@@ -21,6 +21,7 @@
 #include <gdk/gdk.h>  // for GdkEventKey, GdkRGBA, GdkRectangle
 #include <gtk/gtk.h>  // for GtkWidget
 
+#include "gui/inputdevices/DeviceId.h"
 #include "model/PageListener.h"       // for PageListener
 #include "model/PageRef.h"            // for PageRef
 #include "util/Rectangle.h"           // for Rectangle
@@ -178,7 +179,7 @@ public:  // event handler
     bool onButtonDoublePressEvent(const PositionInputData& pos);
     bool onButtonTriplePressEvent(const PositionInputData& pos);
     bool onMotionNotifyEvent(const PositionInputData& pos);
-    void onSequenceCancelEvent(size_t deviceHash);
+    void onSequenceCancelEvent(DeviceId id);
     void onTapEvent(const PositionInputData& pos);
 
     /**
@@ -295,7 +296,7 @@ private:
     int mappedRow{};
     int mappedCol{};
 
-    size_t currentSequenceDeviceHash = 0;
+    DeviceId currentSequenceDeviceId;
 
 
     friend class RenderJob;

--- a/src/core/gui/inputdevices/AbstractInputHandler.cpp
+++ b/src/core/gui/inputdevices/AbstractInputHandler.cpp
@@ -5,6 +5,7 @@
 #include "AbstractInputHandler.h"
 
 #include <cmath>  // for round
+#include <string_view>
 
 #include <glib.h>  // for gdouble, g_assert
 
@@ -86,7 +87,13 @@ auto AbstractInputHandler::getInputDataRelativeToCurrentPage(XojPageView* page, 
     pos.state = this->inputContext->getModifierState();
     pos.timestamp = event.timestamp;
 
+    pos.deviceHash = computeDeviceHash(event);
+
     return pos;
+}
+
+size_t AbstractInputHandler::computeDeviceHash(const InputEvent& event) {
+    return std::hash<std::string_view>{}(event.deviceName) ^ (std::hash<size_t>{}(event.deviceClass) << 1);
 }
 
 void AbstractInputHandler::onBlock() {}

--- a/src/core/gui/inputdevices/AbstractInputHandler.cpp
+++ b/src/core/gui/inputdevices/AbstractInputHandler.cpp
@@ -87,13 +87,9 @@ auto AbstractInputHandler::getInputDataRelativeToCurrentPage(XojPageView* page, 
     pos.state = this->inputContext->getModifierState();
     pos.timestamp = event.timestamp;
 
-    pos.deviceHash = computeDeviceHash(event);
+    pos.deviceId = event.deviceId;
 
     return pos;
-}
-
-size_t AbstractInputHandler::computeDeviceHash(const InputEvent& event) {
-    return std::hash<std::string_view>{}(event.deviceName) ^ (std::hash<size_t>{}(event.deviceClass) << 1);
 }
 
 void AbstractInputHandler::onBlock() {}

--- a/src/core/gui/inputdevices/AbstractInputHandler.h
+++ b/src/core/gui/inputdevices/AbstractInputHandler.h
@@ -31,7 +31,6 @@ protected:
 protected:
     XojPageView* getPageAtCurrentPosition(InputEvent const& event);
     PositionInputData getInputDataRelativeToCurrentPage(XojPageView* page, InputEvent const& event);
-    static size_t computeDeviceHash(InputEvent const& event);
 
 public:
     explicit AbstractInputHandler(InputContext* inputContext);

--- a/src/core/gui/inputdevices/AbstractInputHandler.h
+++ b/src/core/gui/inputdevices/AbstractInputHandler.h
@@ -31,6 +31,7 @@ protected:
 protected:
     XojPageView* getPageAtCurrentPosition(InputEvent const& event);
     PositionInputData getInputDataRelativeToCurrentPage(XojPageView* page, InputEvent const& event);
+    static size_t computeDeviceHash(InputEvent const& event);
 
 public:
     explicit AbstractInputHandler(InputContext* inputContext);

--- a/src/core/gui/inputdevices/DeviceId.h
+++ b/src/core/gui/inputdevices/DeviceId.h
@@ -1,0 +1,22 @@
+/*
+ * Xournal++
+ *
+ * Device identifier
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+struct DeviceId {
+    DeviceId() = default;
+    explicit DeviceId(const void* id): id(id) {}
+    void clear() { id = nullptr; }
+    operator bool() const { return id != nullptr; }
+
+private:
+    const void* id = nullptr;
+};

--- a/src/core/gui/inputdevices/DeviceId.h
+++ b/src/core/gui/inputdevices/DeviceId.h
@@ -12,10 +12,12 @@
 #pragma once
 
 struct DeviceId {
-    DeviceId() = default;
-    explicit DeviceId(const void* id): id(id) {}
-    void clear() { id = nullptr; }
-    operator bool() const { return id != nullptr; }
+    constexpr DeviceId() = default;
+    explicit constexpr DeviceId(const void* id): id(id) {}
+    void reset(const void* id = nullptr) { this->id = id; }
+    explicit constexpr operator bool() const { return id != nullptr; }
+    constexpr bool operator==(const DeviceId& o) const { return id == o.id; }
+    constexpr bool operator!=(const DeviceId& o) const { return !(*this == o); }
 
 private:
     const void* id = nullptr;

--- a/src/core/gui/inputdevices/DeviceId.h
+++ b/src/core/gui/inputdevices/DeviceId.h
@@ -14,7 +14,7 @@
 struct DeviceId {
     constexpr DeviceId() = default;
     explicit constexpr DeviceId(const void* id): id(id) {}
-    void reset(const void* id = nullptr) { this->id = id; }
+    constexpr void reset(const void* id = nullptr) { this->id = id; }
     explicit constexpr operator bool() const { return id != nullptr; }
     constexpr bool operator==(const DeviceId& o) const { return id == o.id; }
     constexpr bool operator!=(const DeviceId& o) const { return !(*this == o); }

--- a/src/core/gui/inputdevices/InputEvents.cpp
+++ b/src/core/gui/inputdevices/InputEvents.cpp
@@ -87,7 +87,8 @@ auto InputEvents::translateEvent(GdkEvent* sourceEvent, Settings* settings) -> I
     GdkDevice* device = gdk_event_get_source_device(sourceEvent);
     targetEvent.deviceClass = translateDeviceType(device, settings);
 
-    targetEvent.deviceName = const_cast<gchar*>(gdk_device_get_name(device));
+    targetEvent.deviceName = gdk_device_get_name(device);
+    targetEvent.deviceId = DeviceId(device);
 
     // Copy both coordinates of the event
     gdk_event_get_root_coords(sourceEvent, &targetEvent.absoluteX, &targetEvent.absoluteY);

--- a/src/core/gui/inputdevices/InputEvents.h
+++ b/src/core/gui/inputdevices/InputEvents.h
@@ -19,6 +19,8 @@
 
 #include "model/Point.h"  // for Point, Point::NO_PRESSURE
 
+#include "DeviceId.h"
+
 class Settings;
 
 enum InputEventType {
@@ -74,7 +76,7 @@ struct InputEvent final {
 
     InputEventType type{UNKNOWN};
     InputDeviceClass deviceClass{INPUT_DEVICE_IGNORE};
-    gchar* deviceName{};
+    const gchar* deviceName{};
 
     gdouble absoluteX{0};
     gdouble absoluteY{0};
@@ -87,6 +89,8 @@ struct InputEvent final {
 
     GdkEventSequence* sequence{};
     guint32 timestamp{0};
+
+    DeviceId deviceId;
 };
 
 class InputEvents {

--- a/src/core/gui/inputdevices/PenInputHandler.cpp
+++ b/src/core/gui/inputdevices/PenInputHandler.cpp
@@ -372,8 +372,8 @@ auto PenInputHandler::actionEnd(InputEvent const& event) -> bool {
                 XojPageView* pageUnderTap =
                         this->sequenceStartPage ? this->sequenceStartPage : getPageAtCurrentPosition(event);
                 if (pageUnderTap) {
-                    pageUnderTap->onSequenceCancelEvent();
                     PositionInputData pos = getInputDataRelativeToCurrentPage(pageUnderTap, event);
+                    pageUnderTap->onSequenceCancelEvent(pos.deviceHash);
                     pageUnderTap->onTapEvent(pos);
                 }
                 this->sequenceStartPage = nullptr;

--- a/src/core/gui/inputdevices/PenInputHandler.cpp
+++ b/src/core/gui/inputdevices/PenInputHandler.cpp
@@ -373,7 +373,7 @@ auto PenInputHandler::actionEnd(InputEvent const& event) -> bool {
                         this->sequenceStartPage ? this->sequenceStartPage : getPageAtCurrentPosition(event);
                 if (pageUnderTap) {
                     PositionInputData pos = getInputDataRelativeToCurrentPage(pageUnderTap, event);
-                    pageUnderTap->onSequenceCancelEvent(pos.deviceHash);
+                    pageUnderTap->onSequenceCancelEvent(pos.deviceId);
                     pageUnderTap->onTapEvent(pos);
                 }
                 this->sequenceStartPage = nullptr;

--- a/src/core/gui/inputdevices/PositionInputData.h
+++ b/src/core/gui/inputdevices/PositionInputData.h
@@ -26,6 +26,7 @@ public:
     double y;
     double pressure;
     guint32 timestamp;
+    size_t deviceHash;
 
     /**
      * State flags from GDKevent (Shift down etc.)

--- a/src/core/gui/inputdevices/PositionInputData.h
+++ b/src/core/gui/inputdevices/PositionInputData.h
@@ -15,6 +15,8 @@
 #include <gdk/gdk.h>  // for GdkModifierType
 #include <glib.h>     // for guint32
 
+#include "DeviceId.h"
+
 class PositionInputData {
 public:
     bool isShiftDown() const;
@@ -26,7 +28,7 @@ public:
     double y;
     double pressure;
     guint32 timestamp;
-    size_t deviceHash;
+    DeviceId deviceId;
 
     /**
      * State flags from GDKevent (Shift down etc.)

--- a/src/core/gui/inputdevices/TouchDrawingInputHandler.cpp
+++ b/src/core/gui/inputdevices/TouchDrawingInputHandler.cpp
@@ -71,7 +71,7 @@ auto TouchDrawingInputHandler::handleImpl(InputEvent const& event) -> bool {
             XojPageView* currentPage = this->getPageAtCurrentPosition(event);
 
             if (currentPage) {
-                currentPage->onSequenceCancelEvent();
+                currentPage->onSequenceCancelEvent(computeDeviceHash(event));
             }
         }
 

--- a/src/core/gui/inputdevices/TouchDrawingInputHandler.cpp
+++ b/src/core/gui/inputdevices/TouchDrawingInputHandler.cpp
@@ -71,7 +71,7 @@ auto TouchDrawingInputHandler::handleImpl(InputEvent const& event) -> bool {
             XojPageView* currentPage = this->getPageAtCurrentPosition(event);
 
             if (currentPage) {
-                currentPage->onSequenceCancelEvent(computeDeviceHash(event));
+                currentPage->onSequenceCancelEvent(event.deviceId);
             }
         }
 


### PR DESCRIPTION
This PR adds a device hash and rejects input events that have not been issued by the pointing device that started a sequence.
Fixes #5116, possibly #5087 if this was the only source of negative pressure values.

This deserves some testing on various devices.