### PR TITLE
Fix file open mode in readString

### DIFF
--- a/src/core/control/LatexController.cpp
+++ b/src/core/control/LatexController.cpp
@@ -322,7 +322,7 @@ auto LatexController::loadRendered(string renderedTex) -> std::unique_ptr<TexIma
     }
 
     fs::path pdfPath = texTmpDir / "tex.pdf";
-    auto contents = Util::readString(pdfPath, true);
+    auto contents = Util::readString(pdfPath, true, std::ios::binary);
     if (!contents) {
         return nullptr;
     }

--- a/src/util/PathUtil.cpp
+++ b/src/util/PathUtil.cpp
@@ -54,13 +54,15 @@ auto Util::getLongPath(const fs::path& path) -> fs::path { return path; }
  *
  * @param path Path to read
  * @param showErrorToUser Show an error to the user, if the file could not be read
+ * @param openmode Mode to open the file
  *
  * @return contents if the file was read, std::nullopt if not
  */
-auto Util::readString(fs::path const& path, bool showErrorToUser) -> std::optional<std::string> {
+auto Util::readString(fs::path const& path, bool showErrorToUser, std::ios_base::openmode openmode)
+        -> std::optional<std::string> {
     try {
         std::string s;
-        std::ifstream ifs{path};
+        std::ifstream ifs{path, openmode};
         s.resize(fs::file_size(path));
         ifs.read(s.data(), s.size());
         return {std::move(s)};

--- a/src/util/include/util/PathUtil.h
+++ b/src/util/include/util/PathUtil.h
@@ -29,10 +29,12 @@ namespace Util {
  *
  * @param path Path to read
  * @param showErrorToUser Show an error to the user, if the file could not be read
+ * @param openmode Mode to open the file
  *
  * @return contents if the file was read, std::nullopt if not
  */
-[[maybe_unused]] [[nodiscard]] std::optional<std::string> readString(fs::path const& path, bool showErrorToUser = true);
+[[maybe_unused]] [[nodiscard]] std::optional<std::string> readString(fs::path const& path, bool showErrorToUser = true,
+                                                                     std::ios_base::openmode openmode = std::ios::in);
 
 /**
  * Get escaped path, all " and \ are escaped


### PR DESCRIPTION
Fix issue with reading files by setting `std::ios::binary` flag when opening file stream. This corrects the file contents being read incorrectly.

For example, in the `LaTeX` preview dialog, `Util::readString` is used to read the generated PDF file. Without setting `std::ios::binary`, the PDF content was loaded incorrectly.

https://github.com/xournalpp/xournalpp/blob/718e57bd9c723723ddf0afdab486201248183125/src/core/control/LatexController.cpp#L318

Should fixes #4740 