### PR TITLE
Make Mac version use Meta instead of Ctrl again

### DIFF
--- a/mac-setup/build-app.sh
+++ b/mac-setup/build-app.sh
@@ -78,8 +78,8 @@ export GTKDIR="$1/inst"
 
 "$GTK_MAC_BUNDLER" xournalpp.bundle
 
-echo "Replace GDK_CONTROL_MASK by GDK_META_MASK in main.glade"
-sed -i -e 's/GDK_CONTROL_MASK/GDK_META_MASK/g' ./Xournal++.app/Contents/Resources/ui/main.glade
+echo "Replace Ctrl by Meta in mainmenubar.xml"
+sed -i -e 's/Ctrl/Meta/g' ./Xournal++.app/Contents/Resources/ui/mainmenubar.xml
 
 echo "Create zip"
 zip --filesync -r Xournal++.zip Xournal++.app

--- a/src/core/control/actions/ActionProperties.h
+++ b/src/core/control/actions/ActionProperties.h
@@ -123,7 +123,11 @@ struct ActionProperties<Action::QUIT> {
 /** Edit Menu **/
 template <>
 struct ActionProperties<Action::UNDO> {
+#ifdef __APPLE__
+    static constexpr const char* accelerators[] = {"<Meta>Z", nullptr};
+#else
     static constexpr const char* accelerators[] = {"<Ctrl>Z", nullptr};
+#endif
     static bool initiallyEnabled(Control* ctrl) { return ctrl->undoRedo->canUndo(); }
     static void callback(GSimpleAction*, GVariant*, Control* ctrl) {
         ctrl->clearSelectionEndText();
@@ -132,7 +136,11 @@ struct ActionProperties<Action::UNDO> {
 };
 template <>
 struct ActionProperties<Action::REDO> {
+#ifdef __APPLE__
+    static constexpr const char* accelerators[] = {"<Meta><Shift>Z", "<Meta>Y", nullptr};
+#else
     static constexpr const char* accelerators[] = {"<Ctrl><Shift>Z", "<Ctrl>Y", nullptr};
+#endif
     static bool initiallyEnabled(Control* ctrl) { return ctrl->undoRedo->canRedo(); }
     static void callback(GSimpleAction*, GVariant*, Control* ctrl) {
         ctrl->clearSelectionEndText();


### PR DESCRIPTION
Fixes a regression from #4372 regarding accelerator modifiers, that are not defined in `main.glade` anymore, but in `mainmenubar.xml`.