### PR TITLE
Fix crash when right clicking while left pressing

### DIFF
--- a/src/core/gui/inputdevices/MouseInputHandler.h
+++ b/src/core/gui/inputdevices/MouseInputHandler.h
@@ -11,6 +11,8 @@
 
 #pragma once
 
+#include <glib.h>  // for guint
+
 #include "PenInputHandler.h"  // for PenInputHandler
 
 class InputContext;
@@ -41,4 +43,9 @@ public:
      */
     bool changeTool(InputEvent const& event) override;
     void onBlock() override;
+
+private:
+    // see button member in https://docs.gtk.org/gdk3/struct.EventButton.html
+    static constexpr guint BUTTON_NONE = 0;
+    guint pressedButton = BUTTON_NONE;
 };


### PR DESCRIPTION
Make MouseInputEvent only consider one pressed button - discard any BUTTON_PRESS while the first button is not released.
Fix #5149 