### PR TITLE
fix Debian build

### DIFF
--- a/src/core/enums/Action.enum.h
+++ b/src/core/enums/Action.enum.h
@@ -170,6 +170,5 @@ constexpr auto Action_fromString(const std::string_view value) -> Action {
             return static_cast<Action>(n);
         }
     }
-    g_warning("Invalid enum value for Action: \"%s\"", value.data());
     return Action::NEW_FILE;
 }


### PR DESCRIPTION
`g_warning` is not `constexpr` and the build fails on Debian

See also https://dev.azure.com/xournalpp/xournalpp/_build/results?buildId=28536&view=logs&j=30d9c38c-bfb1-5863-ddb1-d34ae18a0686&t=f29032be-d771-562d-9c95-a9db7f2cfcc4