### PR TITLE
Fix locale issue

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -2883,12 +2883,6 @@ void Control::applyPreferredLanguage() {
 #else
     setenv("LANGUAGE", lang.c_str(), 1);
 #endif
-    try {
-        auto glob = std::locale{std::locale(".UTF-8"), lang, std::locale::all};
-        std::locale::global(glob);
-    } catch (std::runtime_error const& e) {
-        g_warning("Failed to set locale %s: %s", lang.c_str(), e.what());
-    }
 }
 
 void Control::initButtonTool() {

--- a/src/core/control/XournalMain.cpp
+++ b/src/core/control/XournalMain.cpp
@@ -96,7 +96,7 @@ void initLocalisation() {
 
     // Not working on GNU g++(mingww) forWindows! Only working on Linux/macOS and with msvc
     try {
-        std::locale::global(std::locale(".UTF-8"));  // "" - system default locale
+        std::locale::global(std::locale(""));  // "" - system default locale
     } catch (const std::runtime_error& e) {
         g_warning("XournalMain: System default locale could not be set.\n - Caused by: %s\n - Note that it is not "
                   "supported to set the locale using mingw-w64 on windows.\n - This could be solved by compiling "


### PR DESCRIPTION
Applies default locale "", will be overriden later with userlang.UTF_8.

Fallback order: userlang.UTF_8 -> "" -> C 