### PR TITLE
Make MacOS Finder open xopp-files

### DIFF
--- a/mac-setup/Info.plist
+++ b/mac-setup/Info.plist
@@ -55,6 +55,26 @@
     <key>NSRemovableVolumesUsageDescription</key>
     <string>Required to enable the internal file chooser to choose files from removable devices.</string>
 
+    <key>CFBundleDocumentTypes</key>
+    <array>
+      <dict>
+        <key>CFBundleTypeExtensions</key>
+        <array>
+          <string>xopp</string>
+        </array>
+        <key>CFBundleTypeIconFile</key>
+	        <string>xournalpp.icns</string>
+        <key>CFBundleTypeName</key>
+        <string>Xournal++ Document</string>
+        <key>CFBundleTypeMIMETypes</key>
+        <array>
+          <string>application/x-xopp</string>
+        </array>
+        <key>CFBundleTypeRole</key>
+        <string>Editor</string>
+      </dict>
+    </array>
+
     <key>LSSupportsOpeningDocumentsInPlace</key>
     <true />
     <key>NSDownloadsUbiquitousContents</key>

--- a/src/core/control/XournalMain.cpp
+++ b/src/core/control/XournalMain.cpp
@@ -442,9 +442,10 @@ void on_open_files(GApplication* application, GFile** files, gint numFiles, gcha
             XojMsgBox::showErrorToUser(GTK_WINDOW(app_data->win->getWindow()), msg);
         }
     } catch (const fs::filesystem_error& e) {
-        const std::string msg = FS(_F("Sorry, Xournal++ cannot open remote files at the moment.\n"
-                                      "You have to copy the file to a local directory.") %
-                                   p.u8string() % e.what());
+        const std::string msg = FS(_F("Filesystem error: {1}\n"
+                                      "Sorry, Xournal++ cannot open the file: {2}\n"
+                                      "Consider copying the file to a local directory.") %
+                                   e.what() % p.u8string());
         XojMsgBox::showErrorToUser(GTK_WINDOW(app_data->win->getWindow()), msg);
     }
     gtk_window_present(GTK_WINDOW(app_data->win->getWindow()));
@@ -539,9 +540,10 @@ void on_startup(GApplication* application, XMPtr app_data) {
                 opened = app_data->control->newFile("", p);
             }
         } catch (const fs::filesystem_error& e) {
-            const std::string msg = FS(_F("Sorry, Xournal++ cannot open remote files at the moment.\n"
-                                          "You have to copy the file to a local directory.") %
-                                       p.u8string() % e.what());
+            const std::string msg = FS(_F("Filesystem error: {1}\n"
+                                          "Sorry, Xournal++ cannot open the file: {2}\n"
+                                          "Consider copying the file to a local directory.") %
+                                       e.what() % p.u8string());
             XojMsgBox::showErrorToUser(GTK_WINDOW(app_data->win->getWindow()), msg);
             opened = app_data->control->newFile("", p);
         }


### PR DESCRIPTION
Finder uses Launch Services to identify Xournal++ as the preferred app for xopp-files as declared in the Info.plist, to launch it and send it an "Open Documents" event. Gtk receives the event and uses g_application_open to make the handler for the "open" signal react to it. See gtkapplication-quartz.c.

Fixes #5229.