### PR TITLE
Improve arrow shape with respect to fill

### DIFF
--- a/src/core/control/tools/ArrowHandler.cpp
+++ b/src/core/control/tools/ArrowHandler.cpp
@@ -60,7 +60,7 @@ auto ArrowHandler::createShape(bool isAltDown, bool isShiftDown, bool isControlD
     std::pair<std::vector<Point>, Range> res; // members initialised below
     std::vector<Point>& shape = res.first;
 
-    shape.reserve(doubleEnded ? 9 : 5);
+    shape.reserve(doubleEnded ? 10 : 6);
 
     shape.emplace_back(this->startPoint);
 
@@ -77,6 +77,7 @@ auto ArrowHandler::createShape(bool isAltDown, bool isShiftDown, bool isControlD
     shape.emplace_back(c.x - arrowDist * cos(angle + delta), c.y - arrowDist * sin(angle + delta));
     shape.emplace_back(c);
     shape.emplace_back(c.x - arrowDist * cos(angle - delta), c.y - arrowDist * sin(angle - delta));
+    shape.emplace_back(c);
 
     auto [minX, maxX] = std::minmax_element(shape.begin(), shape.end(), [](auto& p, auto& q) { return p.x < q.x; });
     auto [minY, maxY] = std::minmax_element(shape.begin(), shape.end(), [](auto& p, auto& q) { return p.y < q.y; });


### PR DESCRIPTION
Filled arrows and double arrows currently look asymmetrical. This commit fixes that by adding an additional point. Instead of
`tail -> head -> side 1 of head -> head -> side 2 of head`
it's now
`tail -> head -> side 1 of head -> head -> side 2 of head -> head`

As a consequence filled and unfilled arrows looks pretty much the same (although they behave differently when something from the head is erased).