### PR TITLE
Some const-correctness in SaveHandler

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -1986,7 +1986,7 @@ void Control::saveImpl(bool saveAs, std::function<void(bool)> callback) {
         // No need to backup the old saved file, as there is none
         this->doc->lock();
         this->doc->setCreateBackupOnSave(false);
-        auto suggestedPath = this->doc->createSaveFolder(this->settings->getLastSavePath());
+        auto suggestedPath = this->doc->createSaveFoldername(this->settings->getLastSavePath());
         suggestedPath /= this->doc->createSaveFilename(Document::XOPP, this->settings->getDefaultSaveName());
         this->doc->unlock();
         xoj::SaveExportDialog::showSaveFileDialog(getGtkWindow(), settings, std::move(suggestedPath),
@@ -2353,7 +2353,7 @@ void Control::moveSelectionToLayer(size_t layerNo) {
     }
 
     auto* oldLayer = currentP->getSelectedLayer();
-    auto* newLayer = currentP->getLayers()->at(layerNo);
+    auto* newLayer = currentP->getLayers().at(layerNo);
     auto moveSelUndo = std::make_unique<MoveSelectionToLayerUndoAction>(currentP, getLayerController(), oldLayer,
                                                                         currentP->getSelectedLayerId() - 1, layerNo);
     for (auto* e: selection->getElements()) {

--- a/src/core/control/SearchControl.cpp
+++ b/src/core/control/SearchControl.cpp
@@ -36,7 +36,7 @@ auto SearchControl::search(const std::string& text, size_t index, size_t* occurr
             this->results = this->pdf->findText(text);
         }
 
-        for (Layer* l: *this->page->getLayers()) {
+        for (Layer* l: this->page->getLayers()) {
             if (!l->isVisible()) {
                 continue;
             }

--- a/src/core/control/jobs/BaseExportJob.cpp
+++ b/src/core/control/jobs/BaseExportJob.cpp
@@ -54,7 +54,7 @@ void BaseExportJob::showFileChooser(std::function<void()> onFileSelected, std::f
     Settings* settings = control->getSettings();
     Document* doc = control->getDocument();
     doc->lock();
-    fs::path suggestedPath = doc->createSaveFolder(settings->getLastSavePath());
+    fs::path suggestedPath = doc->createSaveFoldername(settings->getLastSavePath());
     suggestedPath /=
             doc->createSaveFilename(Document::PDF, settings->getDefaultSaveName(), settings->getDefaultPdfExportName());
     doc->unlock();

--- a/src/core/control/jobs/PreviewJob.cpp
+++ b/src/core/control/jobs/PreviewJob.cpp
@@ -52,7 +52,7 @@ void PreviewJob::finishPaint() {
 }
 
 void PreviewJob::drawPage() {
-    PageRef page = this->sidebarPreview->page;
+    ConstPageRef page = this->sidebarPreview->page;
     Document* doc = this->sidebarPreview->sidebar->getControl()->getDocument();
     DocumentView view;
     view.setPdfCache(this->sidebarPreview->sidebar->getCache());
@@ -83,7 +83,7 @@ void PreviewJob::drawPage() {
                 view.drawBackground(flags);
             } else {
                 view.drawBackground(xoj::view::BACKGROUND_FORCE_PAINT_BACKGROUND_COLOR_ONLY);
-                Layer* drawLayer = (*page->getLayers())[layer - 1];
+                const Layer* drawLayer = page->getLayersView()[layer - 1];
                 xoj::view::LayerView layerView(drawLayer);
                 layerView.draw(context);
             }
@@ -96,8 +96,9 @@ void PreviewJob::drawPage() {
             auto flags = xoj::view::BACKGROUND_SHOW_ALL;
             flags.forceVisible = xoj::view::FORCE_VISIBLE;
             view.drawBackground(flags);
+            const auto layers = page->getLayersView();
             for (Layer::Index i = 0; i < layer; i++) {
-                Layer* drawLayer = (*page->getLayers())[i];
+                const Layer* drawLayer = layers[i];
                 xoj::view::LayerView layerView(drawLayer);
                 layerView.draw(context);
             }

--- a/src/core/control/layer/LayerController.cpp
+++ b/src/core/control/layer/LayerController.cpp
@@ -233,7 +233,7 @@ void LayerController::mergeCurrentLayerDown() {
      * the background is not in the vector, so layer 1 has index 0 and so on.
      */
     const Layer::Index layerBelowIndex = layerBelowID - 1;
-    Layer* layerBelow = (*page->getLayers())[layerBelowIndex];
+    Layer* layerBelow = page->getLayers()[layerBelowIndex];
 
     UndoActionPtr undo_redo_action =
             std::make_unique<MergeLayerDownUndoAction>(this, page, currentLayer, layerID - 1, layerBelow, pageID);

--- a/src/core/control/tools/Selection.cpp
+++ b/src/core/control/tools/Selection.cpp
@@ -23,7 +23,8 @@ auto Selection::finalize(PageRef page, bool disableMultilayer, Document* doc) ->
 
     if (multiLayer && !disableMultilayer) {
         std::lock_guard lock(*doc);
-        for (auto it = page->getLayers()->rbegin(); it != page->getLayers()->rend(); it++) {
+        const auto layers = page->getLayers();
+        for (auto it = layers.rbegin(); it != layers.rend(); it++) {
             Layer* l = *it;
             if (!l->isVisible()) {
                 continue;
@@ -38,7 +39,7 @@ auto Selection::finalize(PageRef page, bool disableMultilayer, Document* doc) ->
                 pos++;
             }
             if (selectionOnLayer) {
-                layerId = page->getLayers()->size() - as_unsigned(std::distance(page->getLayers()->rbegin(), it));
+                layerId = layers.size() - as_unsigned(std::distance(layers.rbegin(), it));
                 break;
             }
         }

--- a/src/core/control/xojfile/SaveHandler.cpp
+++ b/src/core/control/xojfile/SaveHandler.cpp
@@ -44,7 +44,7 @@ SaveHandler::SaveHandler() {
     this->attachBgId = 1;
 }
 
-void SaveHandler::prepareSave(Document* doc) {
+void SaveHandler::prepareSave(const Document* doc) {
     if (this->root) {
         // cleanup old data
         backgroundImages.clear();
@@ -88,7 +88,7 @@ auto SaveHandler::getColorStr(Color c, unsigned char alpha) -> std::string {
     return color;
 }
 
-void SaveHandler::writeTimestamp(AudioElement* audioElement, XmlAudioNode* xmlAudioNode) {
+void SaveHandler::writeTimestamp(XmlAudioNode* xmlAudioNode, const AudioElement* audioElement) {
     if (!audioElement->getAudioFilename().empty()) {
         /** set stroke timestamp value to the XmlPointNode */
         xmlAudioNode->setAttrib("ts", audioElement->getTimestamp());
@@ -96,14 +96,14 @@ void SaveHandler::writeTimestamp(AudioElement* audioElement, XmlAudioNode* xmlAu
     }
 }
 
-void SaveHandler::visitStroke(XmlPointNode* stroke, Stroke* s) {
+void SaveHandler::visitStroke(XmlPointNode* stroke, const Stroke* s) {
     StrokeTool t = s->getToolType();
 
     unsigned char alpha = 0xff;
 
     if (t == StrokeTool::PEN) {
         stroke->setAttrib("tool", "pen");
-        writeTimestamp(s, stroke);
+        writeTimestamp(stroke, s);
     } else if (t == StrokeTool::ERASER) {
         stroke->setAttrib("tool", "eraser");
     } else if (t == StrokeTool::HIGHLIGHTER) {
@@ -136,7 +136,7 @@ void SaveHandler::visitStroke(XmlPointNode* stroke, Stroke* s) {
 /**
  * Export the fill attributes
  */
-void SaveHandler::visitStrokeExtended(XmlPointNode* stroke, Stroke* s) {
+void SaveHandler::visitStrokeExtended(XmlPointNode* stroke, const Stroke* s) {
     if (s->getFill() != -1) {
         stroke->setAttrib("fill", s->getFill());
     }
@@ -158,7 +158,7 @@ void SaveHandler::visitStrokeExtended(XmlPointNode* stroke, Stroke* s) {
     }
 }
 
-void SaveHandler::visitLayer(XmlNode* page, Layer* l) {
+void SaveHandler::visitLayer(XmlNode* page, const Layer* l) {
     auto* layer = new XmlNode("layer");
     page->addChild(layer);
     if (l->hasName()) {
@@ -184,7 +184,7 @@ void SaveHandler::visitLayer(XmlNode* page, Layer* l) {
             text->setAttrib("y", t->getY());
             text->setAttrib("color", getColorStr(t->getColor()).c_str());
 
-            writeTimestamp(t, text);
+            writeTimestamp(text, t);
         } else if (e->getType() == ELEMENT_IMAGE) {
             auto* i = dynamic_cast<Image*>(e.get());
             auto* image = new XmlImageNode("image");
@@ -210,7 +210,7 @@ void SaveHandler::visitLayer(XmlNode* page, Layer* l) {
     }
 }
 
-void SaveHandler::visitPage(XmlNode* root, PageRef p, Document* doc, int id) {
+void SaveHandler::visitPage(XmlNode* root, ConstPageRef p, const Document* doc, int id) {
     auto* page = new XmlNode("page");
     root->addChild(page);
     page->setAttrib("width", p->getWidth());
@@ -271,33 +271,46 @@ void SaveHandler::visitPage(XmlNode* root, PageRef p, Document* doc, int id) {
             char* filename = g_strdup_printf("bg_%d.png", this->attachBgId++);
             background->setAttrib("domain", "attach");
             background->setAttrib("filename", filename);
-            p->getBackgroundImage().setFilepath(filename);
 
             backgroundImages.emplace_back(p->getBackgroundImage());
 
+            /*
+             * Because BackgroundImage is basically a wrapped pointer, the following lines actually modify
+             * *(p->getBackgroundImage().content) and thus the Document.
+             * TODO Find a better way
+             */
+            backgroundImages.back().setFilepath(filename);
+            backgroundImages.back().setCloneId(id);
+
             g_free(filename);
-            p->getBackgroundImage().setCloneId(id);
         } else {
             background->setAttrib("domain", "absolute");
             background->setAttrib("filename", p->getBackgroundImage().getFilepath().u8string());
-            p->getBackgroundImage().setCloneId(id);
+            BackgroundImage img = p->getBackgroundImage();
+
+            /*
+             * Because BackgroundImage is basically a wrapped pointer, the following line actually modifies
+             * *(p->getBackgroundImage().content) and thus the Document.
+             * TODO Find a better way
+             */
+            img.setCloneId(id);
         }
     } else {
         writeSolidBackground(background, p);
     }
 
     // no layer, but we need to write one layer, else the old Xournal cannot read the file
-    if (p->getLayers()->empty()) {
+    if (p->getLayerCount() == 0) {
         auto* layer = new XmlNode("layer");
         page->addChild(layer);
     }
 
-    for (Layer* l: *p->getLayers()) {
+    for (const Layer* l: p->getLayersView()) {
         visitLayer(page, l);
     }
 }
 
-void SaveHandler::writeSolidBackground(XmlNode* background, PageRef p) {
+void SaveHandler::writeSolidBackground(XmlNode* background, ConstPageRef p) {
     background->setAttrib("type", "solid");
     background->setAttrib("color", getColorStr(p->getBackgroundColor()));
     background->setAttrib("style", PageTypeHandler::getStringForPageTypeFormat(p->getBackgroundType().format));
@@ -309,7 +322,7 @@ void SaveHandler::writeSolidBackground(XmlNode* background, PageRef p) {
     }
 }
 
-void SaveHandler::writeBackgroundName(XmlNode* background, PageRef p) {
+void SaveHandler::writeBackgroundName(XmlNode* background, ConstPageRef p) {
     if (p->backgroundHasName()) {
         background->setAttrib("name", p->getBackgroundName());
     }
@@ -338,9 +351,11 @@ void SaveHandler::saveTo(OutputStream* out, const fs::path& filepath, ProgressLi
     out->write("<?xml version=\"1.0\" standalone=\"no\"?>\n");
     root->writeOut(out, listener);
 
-    for (BackgroundImage const& img: backgroundImages) {
+    for (const BackgroundImage& img: backgroundImages) {
         auto tmpfn = (fs::path(filepath) += ".") += img.getFilepath();
-        if (!gdk_pixbuf_save(img.getPixbuf(), tmpfn.u8string().c_str(), "png", nullptr, nullptr)) {
+        // Are we certain that does not modify the GdkPixbuf?
+        if (!gdk_pixbuf_save(const_cast<GdkPixbuf*>(img.getPixbuf()), tmpfn.u8string().c_str(), "png", nullptr,
+                             nullptr)) {
             if (!this->errorMessage.empty()) {
                 this->errorMessage += "\n";
             }
@@ -350,4 +365,4 @@ void SaveHandler::saveTo(OutputStream* out, const fs::path& filepath, ProgressLi
     }
 }
 
-auto SaveHandler::getErrorMessage() -> std::string { return this->errorMessage; }
+auto SaveHandler::getErrorMessage() -> const std::string& { return this->errorMessage; }

--- a/src/core/control/xojfile/SaveHandler.h
+++ b/src/core/control/xojfile/SaveHandler.h
@@ -36,27 +36,27 @@ public:
     SaveHandler();
 
 public:
-    void prepareSave(Document* doc);
+    void prepareSave(const Document* doc);
     void saveTo(const fs::path& filepath, ProgressListener* listener = nullptr);
     void saveTo(OutputStream* out, const fs::path& filepath, ProgressListener* listener = nullptr);
-    std::string getErrorMessage();
+    const std::string& getErrorMessage();
 
 protected:
     static std::string getColorStr(Color c, unsigned char alpha = 0xff);
 
-    virtual void visitPage(XmlNode* root, PageRef p, Document* doc, int id);
-    virtual void visitLayer(XmlNode* page, Layer* l);
-    virtual void visitStroke(XmlPointNode* stroke, Stroke* s);
+    virtual void visitPage(XmlNode* root, ConstPageRef p, const Document* doc, int id);
+    virtual void visitLayer(XmlNode* page, const Layer* l);
+    virtual void visitStroke(XmlPointNode* stroke, const Stroke* s);
 
     /**
      * Export the fill attributes
      */
-    virtual void visitStrokeExtended(XmlPointNode* stroke, Stroke* s);
+    virtual void visitStrokeExtended(XmlPointNode* stroke, const Stroke* s);
 
     virtual void writeHeader();
-    virtual void writeSolidBackground(XmlNode* background, PageRef p);
-    virtual void writeTimestamp(AudioElement* audioElement, XmlAudioNode* xmlAudioNode);
-    virtual void writeBackgroundName(XmlNode* background, PageRef p);
+    virtual void writeSolidBackground(XmlNode* background, ConstPageRef p);
+    virtual void writeTimestamp(XmlAudioNode* xmlAudioNode, const AudioElement* audioElement);
+    virtual void writeBackgroundName(XmlNode* background, ConstPageRef p);
 
 protected:
     std::unique_ptr<XmlNode> root{};

--- a/src/core/control/xojfile/XojExportHandler.cpp
+++ b/src/core/control/xojfile/XojExportHandler.cpp
@@ -23,7 +23,7 @@ XojExportHandler::~XojExportHandler() = default;
 /**
  * Export the fill attributes
  */
-void XojExportHandler::visitStrokeExtended(XmlPointNode* stroke, Stroke* s) {
+void XojExportHandler::visitStrokeExtended(XmlPointNode* stroke, const Stroke* s) {
     // Fill is not exported in .xoj
     // Line style is also not supported
 }
@@ -36,7 +36,7 @@ void XojExportHandler::writeHeader() {
             new XmlTextNode("title", std::string{"Xournal document (Compatibility) - see "} + PROJECT_HOMEPAGE_URL));
 }
 
-void XojExportHandler::writeSolidBackground(XmlNode* background, PageRef p) {
+void XojExportHandler::writeSolidBackground(XmlNode* background, ConstPageRef p) {
     background->setAttrib("type", "solid");
     background->setAttrib("color", getColorStr(p->getBackgroundColor()));
 
@@ -52,10 +52,10 @@ void XojExportHandler::writeSolidBackground(XmlNode* background, PageRef p) {
     background->setAttrib("style", format);
 }
 
-void XojExportHandler::writeTimestamp(AudioElement* audioElement, XmlAudioNode* xmlAudioNode) {
+void XojExportHandler::writeTimestamp(XmlAudioNode* xmlAudioNode, const AudioElement* audioElement) {
     // Do nothing since timestamp are not supported by Xournal
 }
 
-void XojExportHandler::writeBackgroundName(XmlNode* background, PageRef p) {
+void XojExportHandler::writeBackgroundName(XmlNode* background, ConstPageRef p) {
     // Do nothing since background name is not supported by Xournal
 }

--- a/src/core/control/xojfile/XojExportHandler.h
+++ b/src/core/control/xojfile/XojExportHandler.h
@@ -32,11 +32,11 @@ protected:
     /**
      * Export the fill attributes
      */
-    void visitStrokeExtended(XmlPointNode* stroke, Stroke* s) override;
+    void visitStrokeExtended(XmlPointNode* stroke, const Stroke* s) override;
     void writeHeader() override;
-    void writeSolidBackground(XmlNode* background, PageRef p) override;
-    void writeTimestamp(AudioElement* audioElement, XmlAudioNode* xmlAudioNode) override;
-    void writeBackgroundName(XmlNode* background, PageRef p) override;
+    void writeSolidBackground(XmlNode* background, ConstPageRef p) override;
+    void writeTimestamp(XmlAudioNode* xmlAudioNode, const AudioElement* audioElement) override;
+    void writeBackgroundName(XmlNode* background, ConstPageRef p) override;
 
 private:
 };

--- a/src/core/gui/PageViewFindObjectHelper.h
+++ b/src/core/gui/PageViewFindObjectHelper.h
@@ -48,17 +48,14 @@ public:
 
         std::lock_guard lock(*ctrl->getDocument());
         if (multiLayer) {
-            size_t initialLayer = this->view->getPage()->getSelectedLayerId();
-            auto* layers = this->view->getPage()->getLayers();
-            for (auto it = layers->rbegin(); it != layers->rend(); it++) {
-                Layer* layer = *it;
-                Layer::Index index = layers->size() - as_unsigned(std::distance(layers->rbegin(), it));
-                ctrl->getLayerController()->switchToLay(index);
-                if (checkLayer(layer)) {
+            const auto& layers = this->view->getPage()->getLayers();
+            size_t layerNo = layers.size();
+            for (auto l = layers.rbegin(); l != layers.rend(); l++, layerNo--) {
+                if (checkLayer(*l)) {
+                    ctrl->getLayerController()->switchToLay(as_unsigned(std::distance(l, layers.rend())));
                     return true;
                 }
             }
-            ctrl->getLayerController()->switchToLay(initialLayer);
             return false;
         } else {
             Layer* layer = this->view->getPage()->getSelectedLayer();
@@ -67,7 +64,7 @@ public:
     }
 
 protected:
-    bool checkLayer(Layer* l) {
+    bool checkLayer(const Layer* l) {
         /* Search for Element whose bounding box center is closest to the place (x,y) where the object is searched for.
          * Only those strokes are taken into account that pass the appropriate checkElement test.
          */

--- a/src/core/model/BackgroundImage.cpp
+++ b/src/core/model/BackgroundImage.cpp
@@ -59,7 +59,7 @@ void BackgroundImage::loadFile(GInputStream* stream, fs::path const& path, GErro
     this->img = std::make_shared<Content>(stream, path, error);
 }
 
-auto BackgroundImage::getCloneId() -> int { return this->img ? this->img->pageId : -1; }
+auto BackgroundImage::getCloneId() const -> int { return this->img ? this->img->pageId : -1; }
 
 void BackgroundImage::setCloneId(int id) {
     if (this->img) {
@@ -88,6 +88,7 @@ void BackgroundImage::setAttach(bool attach) {
     this->img->attach = attach;
 }
 
-auto BackgroundImage::getPixbuf() const -> GdkPixbuf* { return this->img ? this->img->pixbuf : nullptr; }
+auto BackgroundImage::getPixbuf() -> GdkPixbuf* { return this->img ? this->img->pixbuf : nullptr; }
+auto BackgroundImage::getPixbuf() const -> const GdkPixbuf* { return this->img ? this->img->pixbuf : nullptr; }
 
 auto BackgroundImage::isEmpty() const -> bool { return !this->img; }

--- a/src/core/model/BackgroundImage.h
+++ b/src/core/model/BackgroundImage.h
@@ -36,7 +36,7 @@ struct BackgroundImage {
     void loadFile(fs::path const& filepath, GError** error);
     void loadFile(GInputStream* stream, fs::path const& filepath, GError** error);
 
-    int getCloneId();
+    int getCloneId() const;
     void setCloneId(int id);
     void clearSaveState();
 
@@ -46,7 +46,8 @@ struct BackgroundImage {
     bool isAttached() const;
     void setAttach(bool attach);
 
-    GdkPixbuf* getPixbuf() const;
+    GdkPixbuf* getPixbuf();
+    const GdkPixbuf* getPixbuf() const;
 
     bool isEmpty() const;
 

--- a/src/core/model/Document.cpp
+++ b/src/core/model/Document.cpp
@@ -16,6 +16,7 @@
 #include "model/PageType.h"                   // for PageType
 #include "pdf/base/XojPdfAction.h"            // for XojPdfAction
 #include "pdf/base/XojPdfBookmarkIterator.h"  // for XojPdfBookmarkIterator
+#include "util/Assert.h"                      // for xoj_assert
 #include "util/PathUtil.h"                    // for clearExtensions
 #include "util/PlaceholderString.h"           // for PlaceholderString
 #include "util/SaveNameUtils.h"               // for parseFilename
@@ -123,7 +124,7 @@ auto Document::getFilepath() const -> fs::path { return filepath; }
 
 auto Document::getPdfFilepath() const -> fs::path { return pdfFilepath; }
 
-auto Document::createSaveFolder(fs::path lastSavePath) -> fs::path {
+auto Document::createSaveFoldername(const fs::path& lastSavePath) const -> fs::path {
     if (!filepath.empty()) {
         return filepath.parent_path();
     }
@@ -136,7 +137,7 @@ auto Document::createSaveFolder(fs::path lastSavePath) -> fs::path {
 }
 
 auto Document::createSaveFilename(DocumentType type, const std::string& defaultSaveName,
-                                  const std::string& defaultPdfName) -> fs::path {
+                                  const std::string& defaultPdfName) const -> fs::path {
     constexpr static std::wstring_view forbiddenChars = {L"\\/:*?\"<>|"};
     std::string wildcardString;
     if (type != Document::PDF) {
@@ -208,10 +209,9 @@ auto Document::getEvMetadataFilename() const -> fs::path {
 
 auto Document::isAttachPdf() const -> bool { return this->attachPdf; }
 
-auto Document::findPdfPage(size_t pdfPage) -> size_t {
+auto Document::findPdfPage(size_t pdfPage) const -> size_t {
     // Create a page index if not already indexed.
-    if (!this->pageIndex)
-        indexPdfPages();
+    xoj_assert(this->pageIndex);
     auto pos = this->pageIndex->find(pdfPage);
     if (pos == this->pageIndex->end()) {
         return npos;

--- a/src/core/model/Document.h
+++ b/src/core/model/Document.h
@@ -70,15 +70,16 @@ public:
      */
     std::string getLastErrorMsg() const;
 
-    size_t findPdfPage(size_t pdfPage);
+    size_t findPdfPage(size_t pdfPage) const;
 
     Document& operator=(const Document& doc);
 
     void setFilepath(fs::path filepath);
     fs::path getFilepath() const;
     fs::path getPdfFilepath() const;
-    fs::path createSaveFolder(fs::path lastSavePath);
-    fs::path createSaveFilename(DocumentType type, const std::string& defaultSaveName, const std::string& defaultPfdName = "");
+    fs::path createSaveFoldername(const fs::path& lastSavePath) const;
+    fs::path createSaveFilename(DocumentType type, const std::string& defaultSaveName,
+                                const std::string& defaultPfdName = "") const;
 
     fs::path getEvMetadataFilename() const;
 

--- a/src/core/model/PageRef.h
+++ b/src/core/model/PageRef.h
@@ -15,3 +15,4 @@
 class XojPage;
 
 using PageRef = std::shared_ptr<XojPage>;
+using ConstPageRef = std::shared_ptr<const XojPage>;

--- a/src/core/model/XojPage.cpp
+++ b/src/core/model/XojPage.cpp
@@ -67,7 +67,9 @@ void XojPage::removeLayer(Layer* l) {
 
 void XojPage::setSelectedLayerId(Layer::Index id) { this->currentLayer = id; }
 
-auto XojPage::getLayers() -> std::vector<Layer*>* { return &this->layer; }
+auto XojPage::getLayers() -> std::vector<Layer*>& { return this->layer; }
+
+auto XojPage::getLayersView() const -> xoj::util::PointerContainerView<std::vector<Layer*>> { return this->layer; }
 
 auto XojPage::getLayerCount() const -> Layer::Index { return this->layer.size(); }
 
@@ -150,9 +152,10 @@ void XojPage::setBackgroundType(const PageType& bgType) {
     }
 }
 
-auto XojPage::getBackgroundType() -> PageType { return this->bgType; }
+auto XojPage::getBackgroundType() const -> PageType { return this->bgType; }
 
 auto XojPage::getBackgroundImage() -> BackgroundImage& { return this->backgroundImage; }
+auto XojPage::getBackgroundImage() const -> const BackgroundImage& { return this->backgroundImage; }
 
 void XojPage::setBackgroundImage(BackgroundImage img) { this->backgroundImage = std::move(img); }
 

--- a/src/core/model/XojPage.h
+++ b/src/core/model/XojPage.h
@@ -17,7 +17,8 @@
 #include <vector>    // for vector
 
 #include "util/Color.h"  // for Color
-#include "util/Util.h"   // for npos
+#include "util/PointerContainerView.h"
+#include "util/Util.h"  // for npos
 
 #include "BackgroundImage.h"  // for BackgroundImage
 #include "Layer.h"            // for Layer, Layer::Index
@@ -44,7 +45,7 @@ public:
     void setBackgroundPdfPageNr(size_t page);
 
     void setBackgroundType(const PageType& bgType);
-    PageType getBackgroundType();
+    PageType getBackgroundType() const;
 
     /**
      * Do not call this, cal doc->setPageSize(Page * p, double width, double height);
@@ -61,7 +62,9 @@ public:
     void setBackgroundColor(Color color);
     Color getBackgroundColor() const;
 
-    std::vector<Layer*>* getLayers();
+    std::vector<Layer*>& getLayers();
+    xoj::util::PointerContainerView<std::vector<Layer*>> getLayersView() const;
+
     Layer::Index getLayerCount() const;
     Layer::Index getSelectedLayerId();
     void setSelectedLayerId(Layer::Index id);
@@ -70,6 +73,7 @@ public:
     Layer* getSelectedLayer();
 
     BackgroundImage& getBackgroundImage();
+    const BackgroundImage& getBackgroundImage() const;
     void setBackgroundImage(BackgroundImage img);
 
     std::string getBackgroundName() const;

--- a/src/core/pdf/base/XojCairoPdfExport.cpp
+++ b/src/core/pdf/base/XojCairoPdfExport.cpp
@@ -28,7 +28,7 @@
 #include "config.h"      // for PROJECT_STRING
 #include "filesystem.h"  // for path
 
-XojCairoPdfExport::XojCairoPdfExport(Document* doc, ProgressListener* progressListener):
+XojCairoPdfExport::XojCairoPdfExport(const Document* doc, ProgressListener* progressListener):
         doc(doc), progressListener(progressListener) {}
 
 XojCairoPdfExport::~XojCairoPdfExport() {
@@ -172,20 +172,20 @@ void XojCairoPdfExport::exportPageLayers(size_t page) {
 
     // We keep a copy of the layers initial Visible state
     std::map<Layer*, bool> initialVisibility;
-    for (const auto& layer: *p->getLayers()) {
+    for (const auto& layer: p->getLayers()) {
         initialVisibility[layer] = layer->isVisible();
         layer->setVisible(false);
     }
 
     // We draw as many pages as there are layers. The first page has
     // only Layer 1 visible, the last has all layers visible.
-    for (const auto& layer: *p->getLayers()) {
+    for (const auto& layer: p->getLayers()) {
         layer->setVisible(true);
         exportPage(page);
     }
 
     // We restore the initial visibilities
-    for (const auto& layer: *p->getLayers()) layer->setVisible(initialVisibility[layer]);
+    for (const auto& layer: p->getLayers()) layer->setVisible(initialVisibility[layer]);
 }
 
 auto XojCairoPdfExport::createPdf(fs::path const& file, const PageRangeVector& range, bool progressiveMode) -> bool {

--- a/src/core/pdf/base/XojCairoPdfExport.h
+++ b/src/core/pdf/base/XojCairoPdfExport.h
@@ -28,7 +28,7 @@ class ProgressListener;
 
 class XojCairoPdfExport: public XojPdfExport {
 public:
-    XojCairoPdfExport(Document* doc, ProgressListener* progressListener);
+    XojCairoPdfExport(const Document* doc, ProgressListener* progressListener);
     ~XojCairoPdfExport() override;
 
 public:
@@ -66,7 +66,7 @@ private:
     void setLayerRange(const char* rangeStr) override;
 
 private:
-    Document* doc = nullptr;
+    const Document* doc = nullptr;
     ProgressListener* progressListener = nullptr;
 
     cairo_surface_t* surface = nullptr;

--- a/src/core/pdf/base/XojPdfExportFactory.cpp
+++ b/src/core/pdf/base/XojPdfExportFactory.cpp
@@ -8,6 +8,7 @@ XojPdfExportFactory::XojPdfExportFactory() = default;
 
 XojPdfExportFactory::~XojPdfExportFactory() = default;
 
-auto XojPdfExportFactory::createExport(Document* doc, ProgressListener* listener) -> std::unique_ptr<XojPdfExport> {
+auto XojPdfExportFactory::createExport(const Document* doc, ProgressListener* listener)
+        -> std::unique_ptr<XojPdfExport> {
     return std::make_unique<XojCairoPdfExport>(doc, listener);
 }

--- a/src/core/pdf/base/XojPdfExportFactory.h
+++ b/src/core/pdf/base/XojPdfExportFactory.h
@@ -23,7 +23,7 @@ private:
     virtual ~XojPdfExportFactory();
 
 public:
-    static std::unique_ptr<XojPdfExport> createExport(Document* doc, ProgressListener* listener);
+    static std::unique_ptr<XojPdfExport> createExport(const Document* doc, ProgressListener* listener);
 
 private:
 };

--- a/src/core/plugin/luapi_application.h
+++ b/src/core/plugin/luapi_application.h
@@ -2222,7 +2222,7 @@ static int applib_getDocumentStructure(lua_State* L) {
         // add (non-background) layers
         int currLayer = 0;
 
-        for (auto l: *page->getLayers()) {
+        for (auto l: page->getLayers()) {
             lua_pushinteger(L, ++currLayer);  // key of the layer
             lua_newtable(L);                  // beginning of table for layer l
 

--- a/src/core/view/DocumentView.cpp
+++ b/src/core/view/DocumentView.cpp
@@ -26,7 +26,7 @@ void DocumentView::setPdfCache(PdfCache* cache) { pdfCache = cache; }
  * @param cr Draw to this context
  * @param dontRenderEditingStroke false to draw currently drawing stroke
  */
-void DocumentView::initDrawing(PageRef page, cairo_t* cr, bool dontRenderEditingStroke) {
+void DocumentView::initDrawing(ConstPageRef page, cairo_t* cr, bool dontRenderEditingStroke) {
     this->cr = cr;
     this->page = page;
     this->dontRenderEditingStroke = dontRenderEditingStroke;
@@ -65,14 +65,15 @@ void DocumentView::drawBackground(xoj::view::BackgroundFlags bgFlags) const {
     bgView->draw(cr);
 }
 
-void DocumentView::drawPage(PageRef page, cairo_t* cr, bool dontRenderEditingStroke, xoj::view::BackgroundFlags flags) {
+void DocumentView::drawPage(ConstPageRef page, cairo_t* cr, bool dontRenderEditingStroke,
+                            xoj::view::BackgroundFlags flags) {
     initDrawing(page, cr, dontRenderEditingStroke);
 
     drawBackground(flags);
 
     xoj::view::Context context{cr, (xoj::view::NonAudioTreatment)this->markAudioStroke,
                                (xoj::view::EditionTreatment) !this->dontRenderEditingStroke, xoj::view::NORMAL_COLOR};
-    for (Layer* layer: *page->getLayers()) {
+    for (const Layer* layer: page->getLayersView()) {
         if (layer->isVisible()) {
             xoj::view::LayerView layerView(layer);
             layerView.draw(context);
@@ -83,7 +84,7 @@ void DocumentView::drawPage(PageRef page, cairo_t* cr, bool dontRenderEditingStr
 }
 
 
-void DocumentView::drawLayersOfPage(const LayerRangeVector& layerRange, PageRef page, cairo_t* cr,
+void DocumentView::drawLayersOfPage(const LayerRangeVector& layerRange, ConstPageRef page, cairo_t* cr,
                                     bool dontRenderEditingStroke, xoj::view::BackgroundFlags flags) {
     initDrawing(page, cr, dontRenderEditingStroke);
 
@@ -105,7 +106,7 @@ void DocumentView::drawLayersOfPage(const LayerRangeVector& layerRange, PageRef 
     xoj::view::Context context{cr, (xoj::view::NonAudioTreatment)this->markAudioStroke,
                                (xoj::view::EditionTreatment) !this->dontRenderEditingStroke, xoj::view::NORMAL_COLOR};
     auto visibilityIt = visible.begin();
-    for (Layer* l: *page->getLayers()) {
+    for (const Layer* l: page->getLayersView()) {
         if (!*(visibilityIt++)) {
             continue;
         }

--- a/src/core/view/DocumentView.h
+++ b/src/core/view/DocumentView.h
@@ -13,7 +13,7 @@
 
 #include <cairo.h>  // for cairo_t
 
-#include "model/PageRef.h"  // for PageRef
+#include "model/PageRef.h"  // for ConstPageRef
 #include "util/ElementRange.h"
 #include "view/background/BackgroundFlags.h"
 
@@ -36,7 +36,7 @@ public:
      * @param dontRenderEditingStroke false to draw currently drawing stroke
      * @param flags show/hide various background components
      */
-    void drawPage(PageRef page, cairo_t* cr, bool dontRenderEditingStroke,
+    void drawPage(ConstPageRef page, cairo_t* cr, bool dontRenderEditingStroke,
                   xoj::view::BackgroundFlags flags = xoj::view::BACKGROUND_SHOW_ALL);
 
     /**
@@ -47,7 +47,8 @@ public:
      * @param dontRenderEditingStroke false to draw currently drawing stroke
      * @param flags show/hide various background components
      */
-    void drawLayersOfPage(const LayerRangeVector& layerRange, PageRef page, cairo_t* cr, bool dontRenderEditingStroke,
+    void drawLayersOfPage(const LayerRangeVector& layerRange, ConstPageRef page, cairo_t* cr,
+                          bool dontRenderEditingStroke,
                           xoj::view::BackgroundFlags flags = xoj::view::BACKGROUND_SHOW_ALL);
 
     /**
@@ -65,7 +66,7 @@ public:
      * @param cr Draw to thgis context
      * @param dontRenderEditingStroke false to draw currently drawing stroke
      */
-    void initDrawing(PageRef page, cairo_t* cr, bool dontRenderEditingStroke);
+    void initDrawing(ConstPageRef page, cairo_t* cr, bool dontRenderEditingStroke);
 
     /**
      * Draw the background
@@ -84,7 +85,7 @@ public:
 
 private:
     cairo_t* cr = nullptr;
-    PageRef page = nullptr;
+    ConstPageRef page = nullptr;
     PdfCache* pdfCache = nullptr;
     bool dontRenderEditingStroke = false;
     bool markAudioStroke = false;

--- a/src/core/view/background/BackgroundView.cpp
+++ b/src/core/view/background/BackgroundView.cpp
@@ -56,7 +56,7 @@ auto BackgroundView::createRuled(double width, double height, Color backgroundCo
     return res;
 }
 
-auto BackgroundView::createForPage(PageRef page, BackgroundFlags bgFlags, PdfCache* pdfCache)
+auto BackgroundView::createForPage(ConstPageRef page, BackgroundFlags bgFlags, PdfCache* pdfCache)
         -> std::unique_ptr<BackgroundView> {
     const double width = page->getWidth();
     const double height = page->getHeight();

--- a/src/core/view/background/BackgroundView.h
+++ b/src/core/view/background/BackgroundView.h
@@ -15,7 +15,7 @@
 
 #include <cairo.h>  // for cairo_t
 
-#include "model/PageRef.h"  // for PageRef
+#include "model/PageRef.h"  // for ConstPageRef
 #include "util/Color.h"     // for Color
 
 #include "BackgroundFlags.h"
@@ -40,7 +40,8 @@ public:
     [[nodiscard]] static std::unique_ptr<BackgroundView> createRuled(double width, double height, Color backgroundColor,
                                                                      const PageType& pt, double lineWidthFactor = 1.0);
 
-    [[nodiscard]] static std::unique_ptr<BackgroundView> createForPage(PageRef page, xoj::view::BackgroundFlags bgFlags,
+    [[nodiscard]] static std::unique_ptr<BackgroundView> createForPage(ConstPageRef page,
+                                                                       xoj::view::BackgroundFlags bgFlags,
                                                                        PdfCache* pdfCache = nullptr);
 
 protected:

--- a/src/core/view/background/ImageBackgroundView.cpp
+++ b/src/core/view/background/ImageBackgroundView.cpp
@@ -12,7 +12,7 @@ ImageBackgroundView::ImageBackgroundView(double pageWidth, double pageHeight, co
         BackgroundView(pageWidth, pageHeight), image(image) {}
 
 void ImageBackgroundView::draw(cairo_t* cr) const {
-    GdkPixbuf* pixbuff = this->image.getPixbuf();
+    const GdkPixbuf* pixbuff = this->image.getPixbuf();
     if (pixbuff) {
         cairo_matrix_t matrix = {0};
         cairo_get_matrix(cr, &matrix);

--- a/src/util/include/util/BasePointerIterator.h
+++ b/src/util/include/util/BasePointerIterator.h
@@ -64,7 +64,7 @@ public:
     BasePointerIterator operator-(difference_type n) const { return BasePointerIterator(p - n); }
     difference_type operator-(const BasePointerIterator& other) const { return p - other.p; }
 
-    reference operator[](difference_type n) { return *(p + n); }
+    reference operator[](difference_type n) const { return *(p + n); }
 
     bool operator==(const BasePointerIterator& other) const { return p == other.p; }
     bool operator!=(const BasePointerIterator& other) const { return p != other.p; }
@@ -74,7 +74,7 @@ public:
     bool operator<=(const BasePointerIterator& other) const { return !(other < *this); }
     bool operator>=(const BasePointerIterator& other) const { return !(*this < other); }
 
-    friend BasePointerIterator operator+(difference_type n, BasePointerIterator& it) { return it + n; }
+    friend BasePointerIterator operator+(difference_type n, const BasePointerIterator& it) { return it + n; }
 
 private:
     pointer p = nullptr;

--- a/src/util/include/util/PointerContainerView.h
+++ b/src/util/include/util/PointerContainerView.h
@@ -1,0 +1,96 @@
+/*
+ * Xournal++
+ *
+ * A C++20-style view for containers with values pointer
+ * Such a view is not allowed to modify the pointed objects.
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+#include <memory>
+#include <type_traits>
+
+#include "util/safe_casts.h"
+
+namespace xoj::util {
+
+// Todo(cpp20) use std::to_address instead
+template <typename T>
+T* to_address(T*& t) {
+    return t;
+}
+template <typename T>
+T* const to_address(T* const& t) {
+    return t;
+}
+
+template <typename T>
+T* to_address(std::unique_ptr<T>& t) {
+    return t.get();
+}
+
+template <typename T>
+const T* to_address(const std::unique_ptr<T>& t) {
+    return t.get();
+}
+
+template <typename container_type>
+class PointerContainerView {
+public:
+    using value_type = const typename std::pointer_traits<typename container_type::value_type>::element_type*;
+    class iterator;
+    using const_iterator = iterator;
+    using reference = const value_type&;
+    using pointer = const value_type*;
+    using difference_type = typename container_type::difference_type;
+    using size_type = typename container_type::size_type;
+
+    PointerContainerView(const container_type& container): b(container.cbegin()), e(container.cend()) {}
+
+    iterator begin() const { return b; }
+    iterator end() const { return e; }
+    std::reverse_iterator<iterator> rbegin() const { return std::reverse_iterator(e); }
+    std::reverse_iterator<iterator> rend() const { return std::reverse_iterator(b); }
+    value_type operator[](size_type n) const { return b[static_cast<typename iterator::difference_type>(n)]; }
+    value_type front() const { return *b; }
+    value_type back() const { return e[-1]; }
+
+    size_t size() const { return as_unsigned(std::distance(b, e)); }
+
+    /// Clones the view into a vector. The pointed elements are not cloned.
+    std::vector<value_type> clone() const { return {begin(), end()}; }
+
+private:
+    const iterator b;
+    const iterator e;
+};
+
+template <typename container_type>
+class PointerContainerView<container_type>::iterator: public container_type::const_iterator {
+public:
+    using value_type = const typename std::pointer_traits<typename container_type::value_type>::element_type*;
+    using reference = const value_type&;
+    using pointer = const value_type*;
+
+    iterator() = default;
+    ~iterator() = default;
+    iterator(typename container_type::const_iterator it): container_type::const_iterator(it) {}
+
+    value_type operator*() const { return to_address(container_type::const_iterator::operator*()); }
+    pointer operator->() const { return container_type::const_iterator::operator->(); }
+    value_type operator[](difference_type n) const { return to_address(container_type::const_iterator::operator[](n)); }
+};
+
+
+static_assert(std::is_same_v<PointerContainerView<std::vector<int*>>::value_type, const int*>);
+static_assert(std::is_same_v<PointerContainerView<std::vector<const int*>>::value_type, const int*>);
+static_assert(std::is_same_v<PointerContainerView<std::vector<std::unique_ptr<int>>>::value_type, const int*>);
+static_assert(std::is_same_v<PointerContainerView<std::vector<std::unique_ptr<const int>>>::value_type, const int*>);
+static_assert(std::is_same_v<PointerContainerView<std::vector<std::shared_ptr<int>>>::value_type, const int*>);
+static_assert(std::is_same_v<PointerContainerView<std::vector<std::shared_ptr<const int>>>::value_type, const int*>);
+}  // namespace xoj::util

--- a/test/gtk_tests/dialog/GtkTest.cpp
+++ b/test/gtk_tests/dialog/GtkTest.cpp
@@ -8,7 +8,7 @@
 void GtkTest::SetUp() {
     argn = 1;
     argv = new char*[2];
-    argv[0] = "xournalpp_test";
+    argv[0] = strdup("xournalpp_test");
     argv[1] = nullptr;
     app = gtk_application_new("com.github.xournalpp.xournalpp.test", G_APPLICATION_FLAGS_NONE);
     g_signal_connect(app, "activate", G_CALLBACK(applicationCallback), this);

--- a/test/unit_tests/control/LoadHandlerTest.cpp
+++ b/test/unit_tests/control/LoadHandlerTest.cpp
@@ -20,6 +20,7 @@
 #include "control/xojfile/SaveHandler.h"
 #include "model/Element.h"
 #include "model/Image.h"
+#include "model/PageRef.h"
 #include "model/Stroke.h"
 #include "model/Text.h"
 #include "model/XojPage.h"
@@ -39,10 +40,10 @@ using std::string;
 void testLoadStoreLoadHelper(const fs::path& filepath, double tol = 1e-8) {
     auto getElements = [](Document* doc) {
         EXPECT_EQ((size_t)1, doc->getPageCount());
-        PageRef page = doc->getPage(0);
+        ConstPageRef page = doc->getPage(0);
 
-        EXPECT_EQ((size_t)1, (*page).getLayerCount());
-        Layer* layer = (*(*page).getLayers())[0];
+        EXPECT_EQ((size_t)1, page->getLayerCount());
+        const Layer* layer = page->getLayersView()[0];
 
         const auto& elements = xoj::refElementContainer(layer->getElements());
         EXPECT_EQ(8, static_cast<int>(elements.size()));
@@ -137,8 +138,8 @@ void checkPageType(Document* doc, size_t pageIndex, string expectedText, PageTyp
     PageType bgType = page->getBackgroundType();
     EXPECT_TRUE(expectedBgType == bgType);
 
-    EXPECT_EQ((size_t)1, (*page).getLayerCount());
-    Layer* layer = (*(*page).getLayers())[0];
+    EXPECT_EQ((size_t)1, page->getLayerCount());
+    Layer* layer = page->getLayers()[0];
 
     auto&& element = layer->getElements().front();
     EXPECT_EQ(ELEMENT_TEXT, element->getType());
@@ -148,8 +149,8 @@ void checkPageType(Document* doc, size_t pageIndex, string expectedText, PageTyp
 }
 
 
-void checkLayer(PageRef page, size_t layerIndex, string expectedText) {
-    Layer* layer = (*(*page).getLayers())[layerIndex];
+void checkLayer(ConstPageRef page, size_t layerIndex, string expectedText) {
+    const Layer* layer = page->getLayersView()[layerIndex];
 
     auto&& element = layer->getElements().front();
 
@@ -166,8 +167,8 @@ TEST(ControlLoadHandler, testLoad) {
     EXPECT_EQ((size_t)1, doc->getPageCount());
     PageRef page = doc->getPage(0);
 
-    EXPECT_EQ((size_t)1, (*page).getLayerCount());
-    Layer* layer = (*(*page).getLayers())[0];
+    EXPECT_EQ((size_t)1, page->getLayerCount());
+    Layer* layer = page->getLayers()[0];
 
     auto&& element = layer->getElements().front();
     EXPECT_EQ(ELEMENT_TEXT, element->getType());
@@ -184,8 +185,8 @@ TEST(ControlLoadHandler, testLoadZipped) {
     EXPECT_EQ((size_t)1, doc->getPageCount());
     PageRef page = doc->getPage(0);
 
-    EXPECT_EQ((size_t)1, (*page).getLayerCount());
-    Layer* layer = (*(*page).getLayers())[0];
+    EXPECT_EQ((size_t)1, page->getLayerCount());
+    Layer* layer = page->getLayers()[0];
 
     auto&& element = layer->getElements().front();
     EXPECT_EQ(ELEMENT_TEXT, element->getType());
@@ -202,8 +203,8 @@ TEST(ControlLoadHandler, testLoadUnzipped) {
     EXPECT_EQ((size_t)1, doc->getPageCount());
     PageRef page = doc->getPage(0);
 
-    EXPECT_EQ((size_t)1, (*page).getLayerCount());
-    Layer* layer = (*(*page).getLayers())[0];
+    EXPECT_EQ((size_t)1, page->getLayerCount());
+    Layer* layer = page->getLayers()[0];
 
     auto&& element = layer->getElements().front();
     EXPECT_EQ(ELEMENT_TEXT, element->getType());
@@ -271,7 +272,7 @@ TEST(ControlLoadHandler, testLayer) {
     EXPECT_EQ((size_t)1, doc->getPageCount());
     PageRef page = doc->getPage(0);
 
-    EXPECT_EQ((size_t)3, (*page).getLayerCount());
+    EXPECT_EQ((size_t)3, page->getLayerCount());
     checkLayer(page, 0, "l1");
     checkLayer(page, 1, "l2");
     checkLayer(page, 2, "l3");
@@ -284,7 +285,7 @@ TEST(ControlLoadHandler, testLayerZipped) {
     EXPECT_EQ((size_t)1, doc->getPageCount());
     PageRef page = doc->getPage(0);
 
-    EXPECT_EQ((size_t)3, (*page).getLayerCount());
+    EXPECT_EQ((size_t)3, page->getLayerCount());
     checkLayer(page, 0, "l1");
     checkLayer(page, 1, "l2");
     checkLayer(page, 2, "l3");
@@ -297,8 +298,8 @@ TEST(ControlLoadHandler, testText) {
     EXPECT_EQ((size_t)1, doc->getPageCount());
     PageRef page = doc->getPage(0);
 
-    EXPECT_EQ((size_t)1, (*page).getLayerCount());
-    Layer* layer = (*(*page).getLayers())[0];
+    EXPECT_EQ((size_t)1, page->getLayerCount());
+    Layer* layer = page->getLayers()[0];
 
     Text* t1 = (Text*)layer->getElements()[0].get();
     EXPECT_EQ(ELEMENT_TEXT, t1->getType());
@@ -325,8 +326,8 @@ TEST(ControlLoadHandler, testTextZipped) {
     EXPECT_EQ((size_t)1, doc->getPageCount());
     PageRef page = doc->getPage(0);
 
-    EXPECT_EQ((size_t)1, (*page).getLayerCount());
-    Layer* layer = (*(*page).getLayers())[0];
+    EXPECT_EQ((size_t)1, page->getLayerCount());
+    Layer* layer = page->getLayers()[0];
 
     Text* t1 = (Text*)layer->getElements()[0].get();
     EXPECT_EQ(ELEMENT_TEXT, t1->getType());
@@ -353,7 +354,7 @@ TEST(ControlLoadHandler, testImageZipped) {
     EXPECT_EQ(1U, doc->getPageCount());
     PageRef page = doc->getPage(0);
     EXPECT_EQ(1U, page->getLayerCount());
-    Layer* layer = (*page->getLayers())[0];
+    Layer* layer = page->getLayers()[0];
     EXPECT_EQ(layer->getElements().size(), 1);
 
     Image* img = dynamic_cast<Image*>(layer->getElements()[0].get());
@@ -382,7 +383,7 @@ TEST(ControlLoadHandler, imageLoadJpeg) {
     ASSERT_EQ(1U, doc->getPageCount());
     PageRef page = doc->getPage(0);
     ASSERT_EQ(1U, page->getLayerCount());
-    Layer* layer = (*page->getLayers())[0];
+    Layer* layer = page->getLayers()[0];
     ASSERT_EQ(layer->getElements().size(), 1);
 
     Image* img = dynamic_cast<Image*>(layer->getElements()[0].get());
@@ -417,7 +418,7 @@ TEST(ControlLoadHandler, imageSaveJpegBackwardCompat) {
     ASSERT_EQ(1U, doc->getPageCount());
     PageRef page = doc->getPage(0);
     ASSERT_EQ(1U, page->getLayerCount());
-    Layer* layer = (*page->getLayers())[0];
+    Layer* layer = page->getLayers()[0];
     ASSERT_EQ(layer->getElements().size(), 1);
 
     Image* img = dynamic_cast<Image*>(layer->getElements()[0].get());
@@ -444,7 +445,7 @@ TEST(ControlLoadHandler, testStrokeWidthRecovery) {
 
     EXPECT_EQ((size_t)1, page->getLayerCount());
 
-    Layer* layer = (*(page->getLayers()))[0];
+    Layer* layer = page->getLayers()[0];
 
     EXPECT_EQ(9U, layer->getElements().size());
 
@@ -492,21 +493,21 @@ TEST(ControlLoadHandler, testStrokeWidthRecovery) {
 TEST(ControlLoadHandler, testLoadStoreCJK) {
     LoadHandler handler;
     auto filepath = string(GET_TESTFILE("cjk/测试.xopp"));
-    auto doc = handler.loadDocument(fs::u8path(filepath));
+    const auto doc = handler.loadDocument(fs::u8path(filepath));
     ASSERT_NE(doc.get(), nullptr);
 
     EXPECT_STREQ(doc->getPdfFilepath().filename().u8string().c_str(), u8"测试.pdf");
 
     EXPECT_EQ((size_t)2, doc->getPageCount());
-    const auto page = doc->getPage(0);
+    ConstPageRef page = doc->getPage(0);
 
     EXPECT_EQ((size_t)1, page->getLayerCount());
-    const auto* layer = (*page->getLayers())[0];
+    const auto* layer = page->getLayersView()[0];
 
     const auto& elements = layer->getElements();
     ASSERT_EQ((size_t)3, layer->getElements().size());
 
-    auto check_element = [&](int i, const char* answer) {
+    auto check_element = [&](size_t i, const char* answer) {
         EXPECT_EQ(ELEMENT_TEXT, elements[i]->getType());
         auto* text = dynamic_cast<Text*>(elements[i].get());
         ASSERT_NE(text, nullptr);


### PR DESCRIPTION
In order to cleanup the race conditions and add a shared_mutex for the Document (like in this attempt #3586), it'll be important to know when the document is accessed as read-only, or as read-write. All in all, we need better const-correctness (const Document gives const Page gives const Layer gives const Element).

This PR handle the use of Document* in SaveHandler to make it rely on a `const Document*`.