### PR TITLE
Fix window maximized setting save

### DIFF
--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -1899,7 +1899,13 @@ auto Settings::getMainWndHeight() const -> int { return this->mainWndHeight; }
 
 auto Settings::isMainWndMaximized() const -> bool { return this->maximized; }
 
-void Settings::setMainWndMaximized(bool max) { this->maximized = max; }
+void Settings::setMainWndMaximized(bool max) {
+    if (this->maximized == max) {
+        return;
+    }
+    this->maximized = max;
+    save();
+}
 
 void Settings::setSelectedToolbar(const string& name) {
     if (this->selectedToolbar == name) {

--- a/src/core/gui/MainWindow.cpp
+++ b/src/core/gui/MainWindow.cpp
@@ -79,8 +79,13 @@ MainWindow::MainWindow(GladeSearchpath* gladeSearchPath, Control* control, GtkAp
     // Window handler
     g_signal_connect(this->window, "delete-event", xoj::util::wrap_for_g_callback_v<deleteEventCallback>,
                      this->control);
-    g_signal_connect(this->window, "window_state_event", xoj::util::wrap_for_g_callback_v<windowStateEventCallback>,
+#if GTK_MAJOR_VERSION == 3
+    g_signal_connect(this->window, "notify::is-maximized", xoj::util::wrap_for_g_callback_v<windowMaximizedCallback>,
                      this);
+#else
+    g_signal_connect(this->window, "notify::maximized", xoj::util::wrap_for_g_callback_v<windowMaximizedCallback>,
+                     this);
+#endif
 
     g_signal_connect(get("buttonCloseSidebar"), "clicked", xoj::util::wrap_for_g_callback_v<buttonCloseSidebarClicked>,
                      this);
@@ -535,10 +540,8 @@ auto MainWindow::isMaximized() const -> bool { return this->maximized; }
 
 auto MainWindow::getXournal() const -> XournalView* { return xournal.get(); }
 
-auto MainWindow::windowStateEventCallback(GtkWidget* window, GdkEventWindowState* event, MainWindow* win) -> bool {
+auto MainWindow::windowMaximizedCallback(GObject* window, GParamSpec*, MainWindow* win) -> void {
     win->setMaximized(gtk_window_is_maximized(GTK_WINDOW(window)));
-
-    return false;
 }
 
 void MainWindow::toolbarSelected(const std::string& id) {

--- a/src/core/gui/MainWindow.h
+++ b/src/core/gui/MainWindow.h
@@ -165,9 +165,9 @@ private:
     static bool deleteEventCallback(GtkWidget* widget, GdkEvent* event, Control* control);
 
     /**
-     * Callback fro window states, we ned to know if the window is fullscreen
+     * Window is maximized/minimized
      */
-    static bool windowStateEventCallback(GtkWidget* window, GdkEventWindowState* event, MainWindow* win);
+    static void windowMaximizedCallback(GObject* window, GParamSpec*, MainWindow* win);
 
     /**
      * Callback for drag & drop files


### PR DESCRIPTION
Fixes #5245

Includes a change to `MainWindow::windowStateEventCallback()` as `gtk_window_is_maximized()` isn't up-to-date yet when the callback is called, plus an additional `Control::save()` in `Settings::setMainWndMaximized()`. 

In general, I noticed there can be 3-5 calls to `Settings::save()` when closing Xournal++. Shouldn't we be able to optimize that somewhat? Right now it is being called once from `Control::quit()` (which is being called from `MainWindow::deleteEventCallback()`), and up to 4 times through `Control::saveSettings()`. 
Wouldn't a call to `Settings::save()`, in `Settings::transactionEnd()` and `Control::saveSettings()` be enough, and then remove them everywhere else?