### PR TITLE
Fix Util::rgb_to_hex_string, thereby fixing the background color in the LaTeX editor

### DIFF
--- a/src/core/control/latex/LatexGenerator.cpp
+++ b/src/core/control/latex/LatexGenerator.cpp
@@ -1,8 +1,6 @@
 #include "LatexGenerator.h"
 
-#include <iomanip>  // for operator<<, setfill, setw
-#include <regex>    // for smatch, sregex_iterator
-#include <sstream>  // for ostringstream, basic_ost...
+#include <regex>  // for smatch, sregex_iterator
 
 #include <glib.h>     // for GError, gchar, g_error_free
 #include <poppler.h>  // for g_object_unref
@@ -15,7 +13,6 @@
 #include "util/raii/GLibGuards.h"            // for GErrorGuard, GStrvGuard
 #include "util/raii/GObjectSPtr.h"           // for GObjectSptr
 #include "util/safe_casts.h"                 // for as_signed
-#include "util/serdesstream.h"               // for serdes_stream
 
 
 using namespace xoj::util;
@@ -36,11 +33,7 @@ auto LatexGenerator::templateSub(const std::string& input, const std::string& te
         if (matchStr == "TOOL_INPUT") {
             repl = input;
         } else if (matchStr == "TEXT_COLOR") {
-            auto s = serdes_stream<std::ostringstream>();
-            auto tmp_color = textColor;
-            tmp_color.alpha = 0;
-            s << std::hex << std::setfill('0') << std::setw(6) << std::right << tmp_color;
-            repl = s.str();
+            repl = Util::rgb_to_hex_string(textColor).substr(1);
         }
         output.append(templ, templatePos, as_unsigned(match.position()) - templatePos);
         output.append(repl);

--- a/src/core/control/settings/PageTemplateSettings.cpp
+++ b/src/core/control/settings/PageTemplateSettings.cpp
@@ -1,9 +1,6 @@
 #include "PageTemplateSettings.h"
 
-#include <cinttypes>  // for PRIx32
-#include <cstdint>    // for uint32_t
-#include <cstdio>     // for snprintf, size_t
-#include <sstream>    // for basic_istream, strings...
+#include <sstream>  // for basic_istream, strings...
 
 #include "control/pagetype/PageTypeHandler.h"  // for PageTypeHandler
 
@@ -116,9 +113,7 @@ auto PageTemplateSettings::toString() const -> string {
         str += string("backgroundTypeConfig=") + backgroundType.config + "\n";
     }
 
-    char buffer[64];
-    snprintf(buffer, sizeof(buffer), "#%06" PRIx32, uint32_t{this->backgroundColor});
-    str += string("backgroundColor=") + buffer + "\n";
+    str += string("backgroundColor=") + Util::rgb_to_hex_string(this->backgroundColor) + "\n";
 
     return str;
 }

--- a/src/core/gui/toolbarMenubar/ColorToolItem.cpp
+++ b/src/core/gui/toolbarMenubar/ColorToolItem.cpp
@@ -1,7 +1,6 @@
 #include "ColorToolItem.h"
 
 #include <array>    // for array
-#include <cstdio>   // for snprintf, size_t
 #include <memory>   // for unique_ptr
 #include <sstream>  // for ostringstream
 #include <utility>  // for move

--- a/src/util/Color.cpp
+++ b/src/util/Color.cpp
@@ -2,8 +2,10 @@
 
 #include <algorithm>  // for max, min
 #include <cassert>    // for assert
-#include <cstdio>     // for snprintf
+#include <iomanip>    // for operator<<, setfill, setw
 #include <sstream>    // for operator<<, stringstream, basic_ostream, char_t...
+
+#include "util/serdesstream.h"  // for serdes_stream
 
 float Util::as_grayscale_color(Color color) {
     GdkRGBA components = rgb_to_GdkRGBA(color);
@@ -20,12 +22,10 @@ float Util::get_color_contrast(Color color1, Color color2) {
 }
 
 auto Util::rgb_to_hex_string(Color rgb) -> std::string {
-    char resultHex[7];
+    auto s = serdes_stream<std::ostringstream>();
+    auto tmp_color = rgb;
+    tmp_color.alpha = 0;
+    s << "#" << std::hex << std::setfill('0') << std::setw(6) << std::right << tmp_color;
 
-    // 06: Disregard alpha channel and pad with zeroes to a length of 6.
-    assert(std::snprintf(resultHex, 7, "%06x", uint32_t(rgb) & 0xffffff) > 0);
-
-    std::stringstream result;
-    result << "#" << resultHex;
-    return result.str();
+    return s.str();
 }


### PR DESCRIPTION
Fixes an issue with the background color of the latex editor remaining black discovered during the Gnome 45 upgrade for the [flatpak](https://github.com/flathub/com.github.xournalpp.xournalpp/pull/87#issuecomment-1731633491) and observed independently by a user in the [Matrix channel](https://matrix.to/#/!mIWOZbAzBNmtxiyIii:gitter.im/$K6ZyTBHRolhutu55TW3RB25-mHTLD--j6SHyBxL33YU?via=gitter.im&via=matrix.org&via=msrd0.de)

In the flatpak `Util::rgb_to_hex_string` returned unusable strings like `\xc5ס\xe1U`. The same issue would probably have appeared with page templates. 