### PR TITLE
Improve backtrace

### DIFF
--- a/src/core/control/CrashHandlerUnix.h
+++ b/src/core/control/CrashHandlerUnix.h
@@ -150,7 +150,7 @@ static void crashHandler(int sig) {
 
     free(messages);
 
-    fp << "\n\nTry to get a better stracktrace...\n";
+    fp << "\n\nTry to get a better stacktrace...\n";
 
     Stacktrace::printStracktrace(fp);
 

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -8,7 +8,7 @@ file(GLOB_RECURSE util_SOURCES *.cpp *.h)
 add_library(util STATIC ${util_SOURCES})
 add_dependencies(util std::filesystem)
 target_link_libraries(util
-        PUBLIC xoj::defaults xoj::external_modules std::filesystem cxx17
+        PUBLIC xoj::defaults xoj::external_modules std::filesystem cxx17 ${CMAKE_DL_LIBS}
         )
 target_compile_features(util PUBLIC ${PROJECT_CXX_FEATURES})
 target_include_directories(util PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)


### PR DESCRIPTION
I noticed that the "better stacktrace" in the error logs was just the same as the original one. I found out that the argument passed to `addr2line` wasn't correct (it expects the section offset, not the runtime function address). 

I used a regex to extract the section offset. 
I set `addr2line` to output demangled function names (`-fC` + `p` to write in on one line).
Even found a memory leak in the function, which I couldn't just let slide.

This will now print source files and line numbers for calls that are from within the xournalpp executable. I haven't found out how to add information for external libraries, should debug information be provided (or at least how to demangle the function names). 

I'm open to formatting changes. I didn't want to make too many changes, but if we have the source call location for a stack frame, I'd say we could drop the original message (which is still printed out in the log file anyways). 


I hope this can be useful!