### PR TITLE
Refactor EditSelection contructors

### DIFF
--- a/src/core/control/LatexController.cpp
+++ b/src/core/control/LatexController.cpp
@@ -277,8 +277,8 @@ void LatexController::updateStatus() { this->dlg->setCompilationStatus(isValidTe
 
 void LatexController::deleteOldImage() {
     if (this->selectedElem) {
-        EditSelection selection(control->getUndoRedoHandler(), selectedElem, view, page);
-        this->view->getXournal()->deleteSelection(&selection);
+        auto sel = SelectionFactory::createFromElementOnActiveLayer(control, page, view, selectedElem);
+        this->view->getXournal()->deleteSelection(sel.release());
         this->selectedElem = nullptr;
     }
 }
@@ -332,15 +332,11 @@ void LatexController::insertTexImage() {
     this->control->clearSelectionEndText();
     this->deleteOldImage();
 
-    doc->lock();
-    layer->addElement(img);
-    view->rerenderElement(img);
-    doc->unlock();
     control->getUndoRedoHandler()->addUndoAction(std::make_unique<InsertUndoAction>(page, layer, img));
 
     // Select element
-    auto* selection = new EditSelection(control->getUndoRedoHandler(), img, view, page);
-    view->getXournal()->setSelection(selection);
+    auto selection = SelectionFactory::createFromFloatingElement(control, page, layer, view, img);
+    view->getXournal()->setSelection(selection.release());
 }
 
 void LatexController::run(Control* ctrl) {

--- a/src/core/control/actions/ActionProperties.h
+++ b/src/core/control/actions/ActionProperties.h
@@ -130,10 +130,7 @@ struct ActionProperties<Action::UNDO> {
     static constexpr const char* accelerators[] = {"<Ctrl>Z", nullptr};
 #endif
     static bool initiallyEnabled(Control* ctrl) { return ctrl->undoRedo->canUndo(); }
-    static void callback(GSimpleAction*, GVariant*, Control* ctrl) {
-        ctrl->clearSelectionEndText();
-        UndoRedoController::undo(ctrl);
-    }
+    static void callback(GSimpleAction*, GVariant*, Control* ctrl) { UndoRedoController::undo(ctrl); }
 };
 template <>
 struct ActionProperties<Action::REDO> {

--- a/src/core/control/tools/EditSelection.h
+++ b/src/core/control/tools/EditSelection.h
@@ -12,7 +12,7 @@
 
 #pragma once
 
-#include <deque>    // for deque
+#include <memory>  // for unique_ptr
 #include <utility>  // for pair
 #include <vector>   // for vector
 
@@ -22,6 +22,7 @@
 #include "control/ToolEnums.h"              // for ToolSize
 #include "model/Element.h"                  // for Element, Element::Index
 #include "model/ElementContainer.h"         // for ElementContainer
+#include "model/ElementInsertionPosition.h"  // for InsertionOrder
 #include "model/PageRef.h"                  // for PageRef
 #include "undo/UndoAction.h"                // for UndoAction (ptr only)
 #include "util/Color.h"                     // for Color
@@ -41,26 +42,42 @@ class LineStyle;
 class ObjectInputStream;
 class ObjectOutputStream;
 class XojFont;
+class Document;
+class EditSelection;
+
+namespace SelectionFactory {
+std::unique_ptr<EditSelection> createFromFloatingElement(Control* ctrl, const PageRef& page, Layer* layer,
+                                                         XojPageView* view, Element* e);
+std::pair<std::unique_ptr<EditSelection>, Range> createFromFloatingElements(Control* ctrl, const PageRef& page,
+                                                                            Layer* layer, XojPageView* view,
+                                                                            InsertionOrder elts);
+std::unique_ptr<EditSelection> createFromElementOnActiveLayer(Control* ctrl, const PageRef& page, XojPageView* view,
+                                                              Element* e, Element::Index pos = Element::InvalidIndex);
+std::unique_ptr<EditSelection> createFromElementsOnActiveLayer(Control* ctrl, const PageRef& page, XojPageView* view,
+                                                               InsertionOrder elts);
+/**
+ * @brief Creates a new instance containing base->getElements() and *e. The content of *base is cleared but *base is not
+ * destroyed.
+ */
+std::unique_ptr<EditSelection> addElementFromActiveLayer(Control* ctrl, EditSelection* base, Element* e,
+                                                         Element::Index pos);
+/**
+ * @brief Creates a new instance containing base->getElements() and the content of elts. The content of *base is cleared
+ * but *base is not destroyed.
+ */
+std::unique_ptr<EditSelection> addElementsFromActiveLayer(Control* ctrl, EditSelection* base,
+                                                          const InsertionOrder& elts);
+};  // namespace SelectionFactory
 
 class EditSelection: public ElementContainer, public Serializable {
 public:
-    EditSelection(UndoRedoHandler* undo, const PageRef& page, XojPageView* view);
-    EditSelection(UndoRedoHandler* undo, Selection* selection, XojPageView* view);
-    EditSelection(UndoRedoHandler* undo, Element* e, XojPageView* view, const PageRef& page);
-    EditSelection(UndoRedoHandler* undo, const std::vector<Element*>& elements, XojPageView* view, const PageRef& page);
-    EditSelection(UndoRedoHandler* undo, XojPageView* view, const PageRef& page, Layer* layer);
+    EditSelection(Control* ctrl, InsertionOrder elts, const PageRef& page, Layer* layer, XojPageView* view,
+                  const Range& bounds, const Range& snappingBounds);
+
+    /// Construct an empty selection
+    EditSelection(Control* ctrl, const PageRef& page, Layer* layer, XojPageView* view);
+
     ~EditSelection() override;
-
-private:
-    /**
-     * Our internal constructor
-     */
-    void construct(UndoRedoHandler* undo, XojPageView* view, const PageRef& sourcePage);
-
-    /**
-     * Calculate the size from the element list
-     */
-    auto calcSizeFromElements(std::vector<Element*> elements) -> Range;
 
 public:
     /**
@@ -125,22 +142,24 @@ public:
     /**
      * Get the source page (where the selection was done)
      */
-    PageRef getSourcePage();
+    PageRef getSourcePage() const;
 
     /**
      * Get the source layer (form where the Elements come)
      */
-    Layer* getSourceLayer();
+    Layer* getSourceLayer() const;
 
     /**
      * Get the X coordinate in View coordinates (absolute)
      */
-    int getXOnViewAbsolute();
+    int getXOnViewAbsolute() const;
 
     /**
      * Get the Y coordinate in View coordinates (absolute)
      */
-    int getYOnViewAbsolute();
+    int getYOnViewAbsolute() const;
+
+    inline XojPageView* getView() const { return view; }
 
 public:
     /**
@@ -183,11 +202,10 @@ public:
 public:
     /**
      * Add an element to the this selection
-     * @param order: specifies the index of the element from the source layer,
+     * @param pos: specifies the index of the element from the source layer,
      * in case we want to replace it back where it came from.
-     * 'InvalidLayerIndex' is a special value that says it has no source layer index (e.g, from clipboard)
      */
-    void addElement(Element* e, Element::Index order = Element::InvalidIndex);
+    void addElement(Element* e, Element::Index pos);
 
     /**
      * Returns all containing elements of this selection
@@ -197,7 +215,7 @@ public:
     /**
      * Returns the insert order of this selection
      */
-    std::deque<std::pair<Element*, Element::Index>> const& getInsertOrder() const;
+    const InsertionOrder& getInsertOrder() const;
 
     enum class OrderChange {
         BringToFront,
@@ -270,6 +288,10 @@ public:
     void serialize(ObjectOutputStream& out) const override;
     void readSerialized(ObjectInputStream& in) override;
 
+
+    /// Applies the transformation to the selected elements, empties the selection and return the modified elements
+    InsertionOrder makeMoveEffective();
+
 private:
     /**
      * Draws an indicator where you can scale the selection
@@ -329,11 +351,6 @@ private:
 
 private:  // DATA
     /**
-     * Support rotation
-     */
-    bool supportRotation = true;
-
-    /**
      * The position (and rotation) relative to the current view
      */
     double x{};
@@ -346,7 +363,7 @@ private:  // DATA
     cairo_matrix_t cmatrix{};
 
     /**
-     * The size
+     * The size, including the padding and frame
      */
     double width{};
     double height{};
@@ -368,19 +385,23 @@ private:  // DATA
 
     /**
      * If both scale axes should have the same scale factor, e.g. for Text
-     * (we cannot only set the font size for text)
+     * (we can only set the font size for text)
      */
-    bool aspectRatio{};
+    bool preserveAspectRatio = false;
 
     /**
      * If mirrors are allowed e.g. for strokes
      */
-    bool mirror{};
+    bool supportMirroring = true;
+
+    /**
+     * Support rotation
+     */
+    bool supportRotation = true;
 
     /**
      * Size of the editing handles
      */
-
     int btnWidth{8};
 
     /**
@@ -396,7 +417,7 @@ private:  // DATA
     /**
      * The contents of the selection
      */
-    EditSelectionContents* contents{};
+    std::unique_ptr<EditSelectionContents> contents;
 
 private:  // HANDLER
     /**

--- a/src/core/control/tools/ImageHandler.cpp
+++ b/src/core/control/tools/ImageHandler.cpp
@@ -78,17 +78,14 @@ auto ImageHandler::createImageFromFile(GFile* file, double x, double y) -> std::
 
 auto ImageHandler::addImageToDocument(Image* img, bool addUndoAction) -> bool {
     PageRef const page = view->getPage();
-
-    page->getSelectedLayer()->addElement(img);
+    Layer* layer = page->getSelectedLayer();
 
     if (addUndoAction) {
-        control->getUndoRedoHandler()->addUndoAction(
-                std::make_unique<InsertUndoAction>(page, page->getSelectedLayer(), img));
+        control->getUndoRedoHandler()->addUndoAction(std::make_unique<InsertUndoAction>(page, layer, img));
     }
 
-    view->rerenderElement(img);
-    auto* selection = new EditSelection(control->getUndoRedoHandler(), img, view, page);
-    control->getWindow()->getXournal()->setSelection(selection);
+    auto sel = SelectionFactory::createFromFloatingElement(control, page, layer, view, img);
+    control->getWindow()->getXournal()->setSelection(sel.release());
 
     return true;
 }

--- a/src/core/control/tools/Selection.h
+++ b/src/core/control/tools/Selection.h
@@ -14,12 +14,15 @@
 #include <vector>  // for vector
 
 #include "model/Element.h"  // for Element (ptr only), ShapeContainer
+#include "model/ElementInsertionPosition.h"
 #include "model/OverlayBase.h"
 #include "model/PageRef.h"  // for PageRef
 #include "util/DispatchPool.h"
 #include "util/Point.h"
 #include "util/Range.h"
 #include "view/overlays/SelectionView.h"
+
+class Document;
 
 class Selection: public ShapeContainer, public OverlayBase {
 public:
@@ -32,7 +35,7 @@ public:
     /**
      * @return layerId of selected objects, 0 if there is nothing in RectSelection
     */
-    size_t finalize(PageRef page);
+    size_t finalize(PageRef page, bool disableMultilayer, Document* doc);
 
     virtual void currentPos(double x, double y) = 0;
     virtual bool userTapped(double zoom) const = 0;
@@ -43,7 +46,10 @@ public:
     }
 
     bool isMultiLayerSelection();
-    void addSelection(const std::vector<Element*>& elements);
+    /**
+     * Get the selected elements and clears them (std::move)
+     */
+    InsertionOrder releaseElements();
 
 private:
 protected:
@@ -51,7 +57,7 @@ protected:
 
     bool multiLayer;
 
-    std::vector<Element*> selectedElements;
+    InsertionOrder selectedElements;
     PageRef page;
 
     Range bbox;

--- a/src/core/model/ElementInsertionPosition.h
+++ b/src/core/model/ElementInsertionPosition.h
@@ -1,0 +1,28 @@
+/*
+ * Xournal++
+ *
+ * The position (depth) of an element
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+#include <limits>
+#include <vector>
+
+#include "Element.h"
+
+struct InsertionPosition {
+    InsertionPosition() = default;
+    explicit InsertionPosition(Element* e, Element::Index pos = std::numeric_limits<Element::Index>::max()):
+            e(e), pos(pos) {}
+    Element* e;
+    Element::Index pos;
+};
+using InsertionOrder = std::vector<InsertionPosition>;
+
+inline bool operator<(const InsertionPosition& p1, const InsertionPosition& p2) { return p1.pos < p2.pos; }

--- a/src/core/model/Layer.h
+++ b/src/core/model/Layer.h
@@ -17,6 +17,7 @@
 #include <vector>    // for vector
 
 #include "Element.h"  // for Element, Element::Index
+#include "ElementInsertionPosition.h"  // for InsertionOrder
 
 template <class T>
 using optional = std::optional<T>;
@@ -50,13 +51,26 @@ public:
 
     /**
      * Removes an Element from the Layer and optionally deletes it
+     * @return the position the element occupied
      */
     Element::Index removeElement(Element* e, bool free);
 
     /**
-     * Removes all Elements from the Layer *without freeing them*
+     * Removes the Element. If e is not at index pos, tries to find it elsewhere (this could happen is the layer was
+     * modified between now and when pos was computed)
+     * @return The actual position of the removed element
      */
-    void clearNoFree();
+    Element::Index removeElementAt(Element* e, Element::Index pos, bool free);
+
+    /**
+     * Removes the Elements. If an element cannot be found at its designated position, it is search through the layer
+     */
+    void removeElementsAt(const InsertionOrder& elts, bool free);
+
+    /**
+     * Removes all Elements from the Layer *without freeing them*. Returns the elements.
+     */
+    std::vector<Element*> clearNoFree();
 
     /**
      * Returns an iterator over the Element%s contained in this Layer

--- a/src/core/undo/ArrangeUndoAction.cpp
+++ b/src/core/undo/ArrangeUndoAction.cpp
@@ -9,9 +9,13 @@
 
 class Control;
 
-ArrangeUndoAction::ArrangeUndoAction(const PageRef& page, Layer* layer, std::string desc, InsertOrder oldOrder,
-                                     InsertOrder newOrder):
-        UndoAction("ArrangeUndoAction"), layer(layer), description(desc), oldOrder(oldOrder), newOrder(newOrder) {
+ArrangeUndoAction::ArrangeUndoAction(const PageRef& page, Layer* layer, std::string desc, InsertionOrder oldOrder,
+                                     InsertionOrder newOrder):
+        UndoAction("ArrangeUndoAction"),
+        layer(layer),
+        description(desc),
+        oldOrder(std::move(oldOrder)),
+        newOrder(std::move(newOrder)) {
     this->page = page;
 }
 

--- a/src/core/undo/ArrangeUndoAction.h
+++ b/src/core/undo/ArrangeUndoAction.h
@@ -17,6 +17,7 @@
 #include <vector>   // for vector
 
 #include "model/Element.h"  // for Element::Index, Element
+#include "model/ElementInsertionPosition.h"  // for InsertionOrder
 #include "model/PageRef.h"  // for PageRef
 
 #include "UndoAction.h"  // for UndoAction
@@ -26,9 +27,8 @@ class Layer;
 
 class ArrangeUndoAction: public UndoAction {
 public:
-    using InsertOrder = std::deque<std::pair<Element*, Element::Index>>;
-
-    ArrangeUndoAction(const PageRef& page, Layer* layer, std::string desc, InsertOrder oldOrder, InsertOrder newOrder);
+    ArrangeUndoAction(const PageRef& page, Layer* layer, std::string desc, InsertionOrder oldOrder,
+                      InsertionOrder newOrder);
     ~ArrangeUndoAction() override;
 
 public:
@@ -47,6 +47,6 @@ private:
     std::string description;
 
     // These track the ordering of elements
-    InsertOrder oldOrder;
-    InsertOrder newOrder;
+    InsertionOrder oldOrder;
+    InsertionOrder newOrder;
 };


### PR DESCRIPTION
This PR refactors the way selections are contructed, in order to remove some race conditions and optimize (quite a bit) the cost of selecting elements (in layers with a lot of elements). More specifically:
 - Properly lock the document mutex when needed (will surely help with #4917
 - Optimized out 2 out of 3 loops looking for elements in a layer
 - Avoid adding elements to the layer just before removing them for selection
 - Make SelectionFactory to have explicitly named "contructors"

I tested quite a bit, but there are many different ways of getting a selection: selection tools (+ shift to aggregate or multilayer), LaTex editor, Image insertion, switching from TextEditor to any selection tool, pasting from clipboard and others I may have forgotten. I possibly missed a couple of corner cases.

This is up for review.