### PR TITLE
Fix PROJECT_HOMEPAGE_URL

### DIFF
--- a/src/config.h.in
+++ b/src/config.h.in
@@ -36,7 +36,7 @@ constexpr auto PROJECT_STRING = "@PROJECT_NAME@ @PROJECT_VERSION@";
 /**
  * Project URL
  */
-constexpr auto PROJECT_URL = "@PROJECT_URL@";
+constexpr auto PROJECT_HOMEPAGE_URL = "@PROJECT_HOMEPAGE_URL@";
 
 /**
  * File format version

--- a/src/core/control/xojfile/SaveHandler.cpp
+++ b/src/core/control/xojfile/SaveHandler.cpp
@@ -78,7 +78,7 @@ void SaveHandler::prepareSave(Document* doc) {
 void SaveHandler::writeHeader() {
     this->root->setAttrib("creator", PROJECT_STRING);
     this->root->setAttrib("fileversion", FILE_FORMAT_VERSION);
-    this->root->addChild(new XmlTextNode("title", std::string{"Xournal++ document - see "} + PROJECT_URL));
+    this->root->addChild(new XmlTextNode("title", std::string{"Xournal++ document - see "} + PROJECT_HOMEPAGE_URL));
 }
 
 auto SaveHandler::getColorStr(Color c, unsigned char alpha) -> std::string {

--- a/src/core/control/xojfile/XojExportHandler.cpp
+++ b/src/core/control/xojfile/XojExportHandler.cpp
@@ -33,7 +33,7 @@ void XojExportHandler::writeHeader() {
     // Keep this version on 2, as this is anyway not read by Xournal
     this->root->setAttrib("fileversion", "2");
     this->root->addChild(
-            new XmlTextNode("title", std::string{"Xournal document (Compatibility) - see "} + PROJECT_URL));
+            new XmlTextNode("title", std::string{"Xournal document (Compatibility) - see "} + PROJECT_HOMEPAGE_URL));
 }
 
 void XojExportHandler::writeSolidBackground(XmlNode* background, PageRef p) {


### PR DESCRIPTION
Instead of
`<title>Xournal++ document - see https://xournalpp.github.io/</title>` we had
`<title>Xournal++ document - see </title>`
written into all xopp-files since 
#2570 (cmake scripts overhaul)