### PR TITLE
Keyboard Shortcuts: lay foundation for feature

### DIFF
--- a/src/core/control/settings/Settings.h
+++ b/src/core/control/settings/Settings.h
@@ -11,14 +11,14 @@
 
 #pragma once
 
-#include <array>    // for array
-#include <cstddef>  // for size_t
-#include <map>      // for map
-#include <memory>   // for make_shared, shared_ptr
-#include <string>   // for string, basic_string
-#include <utility>  // for pair
-#include <vector>   // for vector
-#include <optional> // for optional (retrieving keyboard shortcuts)
+#include <array>     // for array
+#include <cstddef>   // for size_t
+#include <map>       // for map
+#include <memory>    // for make_shared, shared_ptr
+#include <optional>  // for optional (retrieving keyboard shortcuts)
+#include <string>    // for string, basic_string
+#include <utility>   // for pair
+#include <vector>    // for vector
 
 #include <gdk/gdk.h>                      // for GdkInputSource, GdkD...
 #include <glib.h>                         // for gchar, gboolean, gint
@@ -579,8 +579,8 @@ public:
     bool getUseSpacesAsTab() const;
 
     /**
-     * @brief Set custom keyboard shortcut 
-     * 
+     * @brief Set custom keyboard shortcut
+     *
      * @param name shortcut name, e.g. pen
      * @param shortcut accelerator according to gtk syntax
      * @returns true if accelerator is valid and can the shortcut can be set
@@ -596,7 +596,7 @@ public:
 
     /**
      * @brief Get custom keyboard shortcut accelerator, if exists
-     * 
+     *
      * @param name shortcut name, e.g. pen
      * @return std::optional<const char> shortcut accel as cstring (to feed gtk), if exists, otherwise std::nullopt
      */

--- a/src/core/control/settings/Settings.h
+++ b/src/core/control/settings/Settings.h
@@ -18,6 +18,7 @@
 #include <string>   // for string, basic_string
 #include <utility>  // for pair
 #include <vector>   // for vector
+#include <optional> // for optional (retrieving keyboard shortcuts)
 
 #include <gdk/gdk.h>                      // for GdkInputSource, GdkD...
 #include <glib.h>                         // for gchar, gboolean, gint
@@ -576,6 +577,41 @@ public:
 
     void setUseSpacesAsTab(bool useSpaces);
     bool getUseSpacesAsTab() const;
+
+    /**
+     * @brief Set custom keyboard shortcut 
+     * 
+     * @param name shortcut name, e.g. pen
+     * @param shortcut accelerator according to gtk syntax
+     * @returns true if accelerator is valid and can the shortcut can be set
+     */
+    bool setKeyboardShortcut(const std::string& name, const std::string& shortcut) {
+        // FIXME: (keyboard shortcuts) parse and verify shortcut
+        customKeyboardShortcuts[name] = shortcut;
+        g_message("[Keyboard shortcuts] Set shortcut [%s] => '%s'", name.c_str(), shortcut.c_str());
+
+        // false if parsing failed
+        return true;
+    }
+
+    /**
+     * @brief Get custom keyboard shortcut accelerator, if exists
+     * 
+     * @param name shortcut name, e.g. pen
+     * @return std::optional<const char> shortcut accel as cstring (to feed gtk), if exists, otherwise std::nullopt
+     */
+    std::optional<const char*> getKeyboardShortcut(const std::string& name) {
+        auto result = customKeyboardShortcuts.find(name);
+
+        if (result != customKeyboardShortcuts.end()) {
+            g_message("[Keyboard shortcuts] Get shortcut [%s] => '%s'", name.c_str(), result->second.c_str());
+            return result->second.c_str();
+        }
+
+        g_warning("[Keyboard shortcuts] Could not get shortcut '%s'", name.c_str());
+        return std::nullopt;
+    }
+
 
 public:
     // Custom settings
@@ -1163,4 +1199,9 @@ private:
      */
     bool useSpacesForTab{};
     unsigned int numberOfSpacesForTab{};
+
+    /**
+     * Custom keyboard shortcuts hashmap
+     */
+    std::unordered_map<std::string, std::string> customKeyboardShortcuts{};
 };

--- a/src/core/gui/dialog/SettingsDialog.cpp
+++ b/src/core/gui/dialog/SettingsDialog.cpp
@@ -6,6 +6,7 @@
 
 #include <gdk/gdk.h>      // for GdkRGBA, GdkRectangle
 #include <glib-object.h>  // for G_CALLBACK, g_signal...
+#include <glib.h>         // for g_message
 
 #include "control/AudioController.h"             // for AudioController
 #include "control/Control.h"                     // for Control
@@ -674,6 +675,14 @@ void SettingsDialog::load() {
     }
 
     this->latexPanel.load(settings->latexSettings);
+
+    //
+    // Load keyboard shortcuts from settings
+    // 
+
+    // TODO: make shortcut names (keys) constant
+    gtk_entry_set_text(GTK_ENTRY(builder.get("txtKeyboardShortcutPen")), settings->getKeyboardShortcut("pen").value_or("ERROR: pen unset"));
+
 }
 
 void SettingsDialog::save() {
@@ -1015,4 +1024,26 @@ void SettingsDialog::save() {
     this->control->getWindow()->setGtkTouchscreenScrollingForDeviceMapping();
     this->control->initButtonTool();
     this->control->getWindow()->getXournal()->onSettingsChanged();
+
+    //
+    // Save custom keyboard shortcuts
+    //
+
+    auto tryToGetGtkEntryText = [&](std::string entryName) -> const char* {
+        auto widgetPtr = builder.get(entryName);
+
+        if (widgetPtr == nullptr) {
+            return "[Keyboard Shortcuts] Error retrieving widget";
+        }
+
+        auto result = gtk_entry_get_text(GTK_ENTRY(widgetPtr));
+
+        if (result == nullptr) {
+            return "[Keyboard Shortcuts] Error retrieving name from text entry";
+        }
+
+        return result;
+    };
+
+    this->settings->setKeyboardShortcut("pen", tryToGetGtkEntryText("txtKeyboardShortcutPen"));
 }

--- a/src/core/gui/dialog/SettingsDialog.cpp
+++ b/src/core/gui/dialog/SettingsDialog.cpp
@@ -678,11 +678,11 @@ void SettingsDialog::load() {
 
     //
     // Load keyboard shortcuts from settings
-    // 
+    //
 
     // TODO: make shortcut names (keys) constant
-    gtk_entry_set_text(GTK_ENTRY(builder.get("txtKeyboardShortcutPen")), settings->getKeyboardShortcut("pen").value_or("ERROR: pen unset"));
-
+    gtk_entry_set_text(GTK_ENTRY(builder.get("txtKeyboardShortcutPen")),
+                       settings->getKeyboardShortcut("pen").value_or("ERROR: pen unset"));
 }
 
 void SettingsDialog::save() {

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -1379,16 +1379,17 @@ Illegal characters are replaced with "_"</property>
                                     <property name="can-focus">False</property>
                                     <property name="left-padding">12</property>
                                     <child>
+                                      <!-- n-columns=3 n-rows=3 -->
                                       <object class="GtkGrid" id="tabSettingsLayout">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
                                         <property name="margin-end">10</property>
                                         <property name="margin-bottom">10</property>
-                                        <property name="column-homogeneous">True</property>
                                         <property name="row-homogeneous">True</property>
+                                        <property name="column-homogeneous">True</property>
                                         <child>
                                           <object class="GtkCheckButton" id="cbUseSpacesAsTab">
-                                            <property name="label" translatable="yes">Indent using spaces</property> 
+                                            <property name="label" translatable="yes">Indent using spaces</property>
                                             <property name="visible">True</property>
                                             <property name="can-focus">True</property>
                                             <property name="receives-default">False</property>
@@ -1400,7 +1401,7 @@ Illegal characters are replaced with "_"</property>
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkBox" id ="numberOfSpacesContainer">
+                                          <object class="GtkBox" id="numberOfSpacesContainer">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
                                             <property name="spacing">14</property>
@@ -1428,7 +1429,6 @@ Illegal characters are replaced with "_"</property>
                                                 <property name="input-purpose">number</property>
                                                 <property name="adjustment">adjustmentNumberOfSpacesForTab</property>
                                                 <property name="climb-rate">2</property>
-                                                <property name="digits">0</property>
                                                 <property name="snap-to-ticks">True</property>
                                                 <property name="numeric">True</property>
                                                 <property name="value">5</property>
@@ -1444,6 +1444,27 @@ Illegal characters are replaced with "_"</property>
                                             <property name="left-attach">1</property>
                                             <property name="top-attach">0</property>
                                           </packing>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
                                         </child>
                                       </object>
                                     </child>
@@ -6024,7 +6045,7 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                 </child>
               </object>
               <packing>
-                <property name="position">11</property>
+                <property name="position">12</property>
               </packing>
             </child>
             <child type="tab">
@@ -6032,6 +6053,138 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="label" translatable="yes">LaTeX</property>
+              </object>
+              <packing>
+                <property name="position">12</property>
+                <property name="tab-fill">False</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkLabel" id="menushortcutsLabel">
+                    <property name="name">keyboardShortcutsLabel</property>
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="label" translatable="yes">Keyboard Shortcuts</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="padding">10</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkScrolledWindow">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="shadow-type">in</property>
+                    <child>
+                      <object class="GtkViewport">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="orientation">vertical</property>
+                            <child>
+                              <object class="GtkBox">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">Tools: Pen</property>
+                                    <property name="max-width-chars">128</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">True</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkEntry" id="txtKeyboardShortcutPen">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="text" translatable="yes">Default</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="position">11</property>
+              </packing>
+            </child>
+            <child type="tab">
+              <object class="GtkLabel" id="shortcutsTabLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Shortcuts</property>
               </object>
               <packing>
                 <property name="position">11</property>
@@ -6149,7 +6302,7 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                 </child>
               </object>
               <packing>
-                <property name="position">11</property>
+                <property name="position">12</property>
               </packing>
             </child>
             <child type="tab">
@@ -6159,7 +6312,7 @@ If available select &lt;small&gt;&lt;tt&gt;pulse&lt;/tt&gt;&lt;/small&gt; as inp
                 <property name="label" translatable="yes">Language</property>
               </object>
               <packing>
-                <property name="position">11</property>
+                <property name="position">12</property>
                 <property name="tab-fill">False</property>
               </packing>
             </child>


### PR DESCRIPTION
Lay the foundation for a standard way to configure user defined keyboard shortcuts. Added "Shortcuts" settings tab which can write and retreive gtk accelerator-strings from core::control::Settings

Shortcut key-values are stored as a std::unordered_map.

I did not add any modification to ActionDatabase yet, and would like to get community feedback before.

(second commit because I forgot to clang-format)

Refrences issue #919