### PR TITLE
Make .deb package build in RelWithDebInfo

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -10,3 +10,6 @@ override_dh_auto_build:
 
 override_dh_dwz:
 	dh_dwz --no-dwz-multifile
+
+override_dh_auto_configure:
+    dh_auto_configure -- -DCMAKE_BUILD_TYPE=RelWithDebInfo


### PR DESCRIPTION
From the PPA buildlog it is visible that by default the `None` build type is used, which means that it is determined by the `CMAKE_CXX_FLAGS`. This PR overrides it with the `RelWithDebInfo` build type.

```term
dh_auto_configure
	cd obj-x86_64-linux-gnu && DEB_PYTHON_INSTALL_LAYOUT=deb cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=None -DCMAKE_INSTALL_SYSCONFDIR=/etc -DCMAKE_INSTALL_LOCALSTATEDIR=/var -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON 
```

