### PR TITLE
Ensure repainted region is non-empty in PdfElemeSelection

### DIFF
--- a/src/core/control/tools/PdfElemSelection.cpp
+++ b/src/core/control/tools/PdfElemSelection.cpp
@@ -47,7 +47,9 @@ auto PdfElemSelection::finalizeSelectionAndRepaint(XojPdfPageSelectionStyle styl
     Range rg = getRegionBbox();
     bool result = this->finalizeSelection(style);
     rg = rg.unite(getRegionBbox());
-    this->viewPool->dispatch(xoj::view::PdfElementSelectionView::FLAG_DIRTY_REGION_REQUEST, rg);
+    if (!rg.empty()) {
+        this->viewPool->dispatch(xoj::view::PdfElementSelectionView::FLAG_DIRTY_REGION_REQUEST, rg);
+    }
     return result;
 }
 
@@ -110,7 +112,9 @@ void PdfElemSelection::currentPos(double x, double y, XojPdfPageSelectionStyle s
     g_assert(this->selectedTextRegion);
 
     rg = rg.unite(getRegionBbox());
-    this->viewPool->dispatch(xoj::view::PdfElementSelectionView::FLAG_DIRTY_REGION_REQUEST, rg);
+    if (!rg.empty()) {
+        this->viewPool->dispatch(xoj::view::PdfElementSelectionView::FLAG_DIRTY_REGION_REQUEST, rg);
+    }
 }
 
 auto PdfElemSelection::contains(double x, double y) -> bool {


### PR DESCRIPTION
Fix #5343 

This is a quick fix. Adding asserts in Range's member functions will come in a separate PR.