### PR TITLE
Fix stroke replacement

### DIFF
--- a/src/core/view/overlays/StrokeToolView.cpp
+++ b/src/core/view/overlays/StrokeToolView.cpp
@@ -103,7 +103,10 @@ void StrokeToolView::deleteOn(StrokeToolView::CancellationRequest, const Range& 
 }
 
 void StrokeToolView::on(StrokeToolView::StrokeReplacementRequest, const Stroke& newStroke) {
-    this->mask.wipe();
+    if (this->mask.isInitialized()) {
+        // only wipe mask it actually exists (the view has already been drawn at least once)
+        this->mask.wipe();
+    }
     this->pointBuffer = newStroke.getPointVector();
     this->dashOffset = 0;
     this->strokeWidth = newStroke.getWidth();


### PR DESCRIPTION
Fixes #5362

I realized there is actually a very simple and logical fix for this issue.

While Xournal++ hangs, there are no calls to draw() so the mask never gets initialized. This means we need to check if the mask exists before resetting it.


This PR targets the release branch, since it's a simple bugfix. But I have already done this wrong a few times, so please tell me if it isn't right.