### PR TITLE
Relax shape recognizer for rectangles

### DIFF
--- a/src/core/control/shaperecognizer/ShapeRecognizer.cpp
+++ b/src/core/control/shaperecognizer/ShapeRecognizer.cpp
@@ -127,7 +127,7 @@ auto ShapeRecognizer::findPolygonal(const Point* pt, int start, int end, int nsi
         i1 = start + (k * (end - start)) / nsides;
         i2 = start + ((k + 1) * (end - start)) / nsides;
         s.calc(pt, i1, i2);
-        if (s.det() < LINE_MAX_DET) {
+        if (s.det() < SEGMENT_MAX_DET) {
             break;
         }
     }
@@ -158,10 +158,10 @@ auto ShapeRecognizer::findPolygonal(const Point* pt, int start, int end, int nsi
             det2 = 1.0;
         }
 
-        if (det1 < det2 && det1 < LINE_MAX_DET) {
+        if (det1 < det2 && det1 < SEGMENT_MAX_DET) {
             i1--;
             s = s1;
-        } else if (det2 < det1 && det2 < LINE_MAX_DET) {
+        } else if (det2 < det1 && det2 < SEGMENT_MAX_DET) {
             i2++;
             s = s2;
         } else {
@@ -312,7 +312,7 @@ auto ShapeRecognizer::recognizePatterns(Stroke* stroke, double strokeMinSize) ->
 
         // Removed complicated recognition in commit 5494bd002050182cde3af70bd1924f4062579be5
 
-        if (n == 1)  // current stroke is a line
+        if (n == 1 && ss->det() < LINE_MAX_DET)  // current stroke is a line
         {
             bool aligned = true;
             if (fabs(rs->angle) < SLANT_TOLERANCE)  // nearly horizontal

--- a/src/core/control/shaperecognizer/ShapeRecognizerConfig.h
+++ b/src/core/control/shaperecognizer/ShapeRecognizerConfig.h
@@ -15,7 +15,8 @@
 
 #define MAX_POLYGON_SIDES 4
 
-#define LINE_MAX_DET 0.015                           // maximum score for line (ideal line = 0)
+#define SEGMENT_MAX_DET 0.045                        // maximum score for a polygon segment (ideal line = 0)
+#define LINE_MAX_DET 0.015                           // maximum score for single line, stricter than for polygons
 #define CIRCLE_MIN_DET 0.95                          // minimum det. score for circle (ideal circle = 1)
 #define CIRCLE_MAX_SCORE 0.10                        // max circle score for circle (ideal circle = 0)
 #define SLANT_TOLERANCE (5 * M_PI / 180)             // ignore slanting by +/- 5 degrees


### PR DESCRIPTION
Triggering shape recognition for rectangles is quite difficult currently. In fact, I didn't know it existed until I looked at the code, despite trying. 

This PR fixes this by initially allowing less precise lines to be considered as polygon segments. If we have only a single line, these are then excluded again. 

I acknowledge the risk of triggering false positives. At a first glance, it seems to be doing alright (haven't seen any yet). Anyhow, I will keep this as a draft PR for a few days and test it out. If I do not find any false positive until Wednesday evening, I will convert it to a normal PR. 