### PR TITLE
Ensure non-empty repaint ranges in SearchResultView and VerticalToolView

### DIFF
--- a/src/core/view/overlays/SearchResultView.cpp
+++ b/src/core/view/overlays/SearchResultView.cpp
@@ -31,5 +31,8 @@ void SearchResultView::draw(cairo_t* cr) const {
 bool SearchResultView::isViewOf(const OverlayBase* overlay) const { return overlay == this->searchControl; }
 
 void SearchResultView::on(SearchResultView::SearchChangedNotification) {
-    this->parent->flagDirtyRegion(this->parent->getVisiblePart());
+    Range rg = this->parent->getVisiblePart();
+    if (!rg.empty()) {
+        this->parent->flagDirtyRegion(this->parent->getVisiblePart());
+    }
 }

--- a/src/core/view/overlays/VerticalToolView.cpp
+++ b/src/core/view/overlays/VerticalToolView.cpp
@@ -63,9 +63,9 @@ void VerticalToolView::on(VerticalToolView::SetVerticalShiftRequest, double shif
     // Padding for taking into account the drawing aid line width
     const double padding = 0.5 * BORDER_WIDTH_IN_PIXELS / this->parent->getZoom();
     if (side == VerticalToolHandler::Side::Above) {
-        rg.maxY = std::min(std::max(shift, this->lastShift) + padding, rg.maxY);
+        rg.maxY = std::clamp(std::max(shift, this->lastShift) + padding, rg.minY, rg.maxY);
     } else {
-        rg.minY = std::max(std::min(shift, this->lastShift) - padding, rg.minY);
+        rg.minY = std::clamp(std::min(shift, this->lastShift) - padding, rg.minY, rg.maxY);
     }
     this->parent->flagDirtyRegion(rg);
     this->lastShift = shift;


### PR DESCRIPTION
When the search result is on a not currently visible page, we get an empty repaint range.
As in #5348 the repaint range must be non-empty, otherwise we get an assertion error (and hence a crash in Debug mode).

The repaint range in the vertical tool view was invalid when shifting below or above the visible part of the page. This could easily be reproduced (start with any document, switch to the vertical tool and move the mouse cursor below the visible part of the page). This lead to a `g-fatal-warning`, which is fixed now.

