### PR TITLE
Fix wrongly sized loading pages

### DIFF
--- a/src/core/gui/PageView.cpp
+++ b/src/core/gui/PageView.cpp
@@ -871,15 +871,9 @@ auto XojPageView::actionDelete() -> bool {
 void XojPageView::drawLoadingPage(cairo_t* cr) {
     static const string txtLoading = _("Loading...");
 
-    double zoom = xournal->getZoom();
-    int dispWidth = getDisplayWidth();
-    int dispHeight = getDisplayHeight();
-
     cairo_set_source_rgb(cr, 1, 1, 1);
-    cairo_rectangle(cr, 0, 0, dispWidth, dispHeight);
+    cairo_rectangle(cr, 0, 0, page->getWidth(), page->getHeight());
     cairo_fill(cr);
-
-    cairo_scale(cr, zoom, zoom);
 
     cairo_set_source_rgb(cr, 0.5, 0.5, 0.5);
     cairo_select_font_face(cr, "Sans", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_BOLD);


### PR DESCRIPTION
The default "Loading..." pages that are displayed when pages aren't ready (rendered) at the time of painting are not sized correctly. The zoom was compensated for twice. This also led to some background regions not being redrawn properly afterwards.

To see the issue, zoom in or out quickly, especially with "Preferences -> View -> Clear cached pages while scrolling" checked.

Question to maintainers: should I always open an issue first, or is this fine?