### PR TITLE
Fix memory management for PenInputHandler::sequenceStartPage

### DIFF
--- a/src/core/gui/Layout.h
+++ b/src/core/gui/Layout.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <cstddef>   // for size_t
+#include <memory>    // for shared_ptr, weak_ptr
 #include <mutex>     // for mutex
 #include <optional>  // for optional
 #include <vector>    // for vector
@@ -109,9 +110,19 @@ public:
     void updateVisibility();
 
     /**
-     * Return the pageview containing co-ordinates.
+     * Return the index of the page containing coordinates.
+     */
+    std::optional<size_t> getPageIndexAt(int x, int y);
+
+    /**
+     * Return the pageview containing coordinates.
      */
     XojPageView* getPageViewAt(int x, int y);
+
+    /**
+     * Return a shared reference to the pageview containing coordinates.
+     */
+    std::shared_ptr<XojPageView> getPageViewRefAt(int x, int y);
 
     /**
      * Return the page index found ( or std::nullopt if not found) at layout grid row,col

--- a/src/core/gui/XournalView.cpp
+++ b/src/core/gui/XournalView.cpp
@@ -624,7 +624,7 @@ auto XournalView::getCache() const -> PdfCache* { return this->cache.get(); }
 void XournalView::pageInserted(size_t page) {
     Document* doc = control->getDocument();
     doc->lock();
-    auto pageView = std::make_unique<XojPageView>(this, doc->getPage(page));
+    auto pageView = std::make_shared<XojPageView>(this, doc->getPage(page));
     doc->unlock();
 
     viewPages.insert(begin(viewPages) + as_signed(page), std::move(pageView));
@@ -791,7 +791,7 @@ void XournalView::documentChanged(DocumentChangeType type) {
     size_t pagecount = doc->getPageCount();
     viewPages.reserve(pagecount);
     for (size_t i = 0; i < pagecount; i++) {
-        viewPages.emplace_back(std::make_unique<XojPageView>(this, doc->getPage(i)));
+        viewPages.emplace_back(std::make_shared<XojPageView>(this, doc->getPage(i)));
     }
 
     doc->unlock();
@@ -844,7 +844,7 @@ auto XournalView::actionDelete() -> bool {
 
 auto XournalView::getDocument() const -> Document* { return control->getDocument(); }
 
-auto XournalView::getViewPages() const -> std::vector<std::unique_ptr<XojPageView>> const& { return viewPages; }
+auto XournalView::getViewPages() const -> std::vector<std::shared_ptr<XojPageView>> const& { return viewPages; }
 
 auto XournalView::getCursor() const -> XournalppCursor* { return control->getCursor(); }
 

--- a/src/core/gui/XournalView.h
+++ b/src/core/gui/XournalView.h
@@ -98,7 +98,7 @@ public:
     void repaintSelection(bool evenWithoutSelection = false);
 
     TextEditor* getTextEditor() const;
-    std::vector<std::unique_ptr<XojPageView>> const& getViewPages() const;
+    std::vector<std::shared_ptr<XojPageView>> const& getViewPages() const;
 
     Control* getControl() const;
     double getZoom() const;
@@ -166,7 +166,7 @@ private:
 
     GtkWidget* widget = nullptr;
 
-    std::vector<std::unique_ptr<XojPageView>> viewPages;
+    std::vector<std::shared_ptr<XojPageView>> viewPages;
 
     Control* control = nullptr;
 

--- a/src/core/gui/inputdevices/AbstractInputHandler.cpp
+++ b/src/core/gui/inputdevices/AbstractInputHandler.cpp
@@ -4,6 +4,7 @@
 
 #include "AbstractInputHandler.h"
 
+#include <memory>
 #include <string_view>
 
 #include <glib.h>  // for gdouble
@@ -64,6 +65,24 @@ auto AbstractInputHandler::getPageAtCurrentPosition(InputEvent const& event) con
     int y = round_cast<int>(event.relativeY);
 
     return xournal->layout->getPageViewAt(x, y);
+}
+
+/**
+ * Get weak_ptr to page view at current position
+ *
+ * @return pointer to page view (uninitialized if none)
+ */
+auto AbstractInputHandler::getPageViewRefAtCurrentPosition(InputEvent const& event) const -> std::shared_ptr<XojPageView> {
+    if (!event) {
+        return std::shared_ptr<XojPageView>();
+    }
+
+    GtkXournal* xournal = this->inputContext->getXournal();
+
+    int x = round_cast<int>(event.relativeX);
+    int y = round_cast<int>(event.relativeY);
+
+    return xournal->layout->getPageViewRefAt(x, y);
 }
 
 /**

--- a/src/core/gui/inputdevices/AbstractInputHandler.h
+++ b/src/core/gui/inputdevices/AbstractInputHandler.h
@@ -11,6 +11,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "PositionInputData.h"  // for PositionInputData
 
 class InputContext;
@@ -30,6 +32,7 @@ protected:
 
 protected:
     XojPageView* getPageAtCurrentPosition(InputEvent const& event) const;
+    std::shared_ptr<XojPageView> getPageViewRefAtCurrentPosition(InputEvent const& event) const;
     PositionInputData getInputDataRelativeToCurrentPage(XojPageView* page, InputEvent const& event) const;
 
 public:

--- a/src/core/gui/inputdevices/PenInputHandler.h
+++ b/src/core/gui/inputdevices/PenInputHandler.h
@@ -75,7 +75,7 @@ protected:
     /**
      * Page a selection started at as we require this for motion updates
      */
-    XojPageView* sequenceStartPage = nullptr;
+    std::weak_ptr<XojPageView> sequenceStartPage = {};
 
     /**
      * For tap event filtering. See Preferences->Drawing Area->Action on Tool Tap


### PR DESCRIPTION
Fixes #5400 

For now, this is just a patch that will prevent a very specific segmentation fault mentioned above from happening. It is only an addition to what already exists, and as such not a complete cure of the root cause. At least the bug described in the issue is solved. 

I do intend to look where there may be other places where we should use the new functions as well. 
Any comments welcome


But specifically, input on the following points would be appreciated:

- I created `std::shared_ptr<XojPageView> Layout::getPageViewRefAt()` alongside `XojPageView* Layout::getPageViewAt()`. Does that make sense ? Technically, I believe it would be possible at any time that the `XournalView` (which owns the page views) gets destroyed even if we had just requested the page view. But using a shared_ptr for everything doesn't seem right either. 
- Is it OK to pass just the raw pointer to called functions once it is properly locked in the parent? Some `const std::shared_ptr<XojPageView>&` would feel more appropriate, but would also require a ton of other changes and look very much out of place. 