### PR TITLE
Fix PDF page selection dialog OK button sensitivity

### DIFF
--- a/src/core/gui/dialog/backgroundSelect/PdfPagesDialog.cpp
+++ b/src/core/gui/dialog/backgroundSelect/PdfPagesDialog.cpp
@@ -29,9 +29,6 @@ PdfPagesDialog::PdfPagesDialog(GladeSearchpath* gladeSearchPath, Document* doc, 
         auto* pv = new PdfElementView(elements.size(), p, this);
         elements.push_back(pv);
     }
-    if (doc->getPdfPageCount() > 0) {
-        setSelected(0);
-    }
 
     for (size_t i = 0; i < doc->getPageCount(); i++) {
         PageRef p = doc->getPage(i);
@@ -44,7 +41,7 @@ PdfPagesDialog::PdfPagesDialog(GladeSearchpath* gladeSearchPath, Document* doc, 
         }
     }
 
-    updateOkButton();
+    gtk_widget_set_sensitive(get("buttonOk"), false);
 
     g_signal_connect(get("cbOnlyNotUsed"), "toggled", G_CALLBACK(onlyNotUsedCallback), this);
     g_signal_connect(get("buttonOk"), "clicked", G_CALLBACK(okButtonCallback), this);
@@ -103,4 +100,12 @@ void PdfPagesDialog::show(GtkWindow* parent) {
                                                        FC(_F("Show only not used pages ({1} unused pages)") % unused)));
 
     BackgroundSelectDialogBase::show(parent);
+}
+
+void PdfPagesDialog::setSelected(int selected) {
+    BackgroundSelectDialogBase::setSelected(selected);
+
+    if (selected < this->elements.size()) {
+        gtk_widget_set_sensitive(get("buttonOk"), true);
+    }
 }

--- a/src/core/gui/dialog/backgroundSelect/PdfPagesDialog.h
+++ b/src/core/gui/dialog/backgroundSelect/PdfPagesDialog.h
@@ -27,6 +27,7 @@ public:
 
 public:
     void show(GtkWindow* parent) override;
+    void setSelected(int selected) override;
     void updateOkButton();
     static double getZoom();
     int getSelectedPage();


### PR DESCRIPTION
Fixes issue reported here: https://github.com/xournalpp/xournalpp/issues/5436#issuecomment-1883815058

Second commit is some cleanup: `setSelected(0);` is already called by `BackgroundSelectDialogBase::show()`, which will now also set the button as sensitive if the PDF is not empty. But I'm not too sure about how pretty it really is though, since it requires setting the sensitivity to false at first. It's not a problem at all if you want to drop it. 