### PR TITLE
Add undo handler for missing PDF replacement

### DIFF
--- a/src/core/control/Control.h
+++ b/src/core/control/Control.h
@@ -37,6 +37,7 @@
 #include "ToolHandler.h"       // for ToolListener
 #include "filesystem.h"        // for path
 
+class LoadHandler;
 class GeometryToolController;
 class AudioController;
 class FullscreenHandler;
@@ -363,6 +364,11 @@ private:
     template <class ToolClass, class ViewClass, class ControllerClass, class InputHandlerClass, ActionType a>
     void makeGeometryTool();
     void resetGeometryTool();
+
+    /**
+     * Prompt the user that the PDF background is missing and offer solution options
+     */
+    void promptMissingPdf(LoadHandler& loadHandler, const fs::path& filepath);
 
     /**
      * "Closes" the document, preparing the editor for a new document.

--- a/src/core/control/PageBackgroundChangeController.h
+++ b/src/core/control/PageBackgroundChangeController.h
@@ -21,6 +21,8 @@
 #include "model/DocumentListener.h"         // for DocumentListener
 #include "model/PageRef.h"                  // for PageRef
 
+#include "filesystem.h"  // for path
+
 class Control;
 class UndoAction;
 class PageType;
@@ -38,6 +40,7 @@ public:
     virtual void changeCurrentPageBackground(PageType& pageType);
     void changeCurrentPageBackground(PageTypeInfo* info) override;
     void changeAllPagesBackground(const PageType& pt);
+    void changePdfPagesBackground(const fs::path& filepath, bool attachPdf);
     void insertNewPage(size_t position, bool shouldScrollToPage = true);
     GtkWidget* getMenu();
 

--- a/src/core/control/xojfile/LoadHandler.cpp
+++ b/src/core/control/xojfile/LoadHandler.cpp
@@ -52,8 +52,6 @@ namespace {
 
 LoadHandler::LoadHandler():
         attachedPdfMissing(false),
-        removePdfBackgroundFlag(false),
-        pdfReplacementAttach(false),
         pdfFilenameParsed(false),
         pos(PARSER_POS_NOT_STARTED),
         fileVersion(0),
@@ -113,13 +111,6 @@ auto LoadHandler::getLastError() -> string { return this->lastError; }
 auto LoadHandler::isAttachedPdfMissing() const -> bool { return this->attachedPdfMissing; }
 
 auto LoadHandler::getMissingPdfFilename() const -> string { return this->pdfMissing; }
-
-void LoadHandler::removePdfBackground() { this->removePdfBackgroundFlag = true; }
-
-void LoadHandler::setPdfReplacement(fs::path filepath, bool attachToDocument) {
-    this->pdfReplacementFilepath = std::move(filepath);
-    this->pdfReplacementAttach = attachToDocument;
-}
 
 auto LoadHandler::openFile(fs::path const& filepath) -> bool {
     this->filepath = filepath;
@@ -462,49 +453,44 @@ void LoadHandler::parseBgPdf() {
 
     if (!this->pdfFilenameParsed) {
 
-        if (this->pdfReplacementFilepath.empty()) {
-            const char* domain = LoadHandlerHelper::getAttrib("domain", false, this);
-            {
-                const char* sFilename = LoadHandlerHelper::getAttrib("filename", false, this);
-                if (sFilename == nullptr) {
-                    error("PDF Filename missing!");
-                    return;
-                }
-                pdfFilename = fs::u8path(sFilename);
+        const char* domain = LoadHandlerHelper::getAttrib("domain", false, this);
+        {
+            const char* sFilename = LoadHandlerHelper::getAttrib("filename", false, this);
+            if (sFilename == nullptr) {
+                error("PDF Filename missing!");
+                return;
             }
+            pdfFilename = fs::u8path(sFilename);
+        }
 
-            if (!strcmp("absolute", domain))  // Absolute OR relative path
-            {
-                if (pdfFilename.is_relative()) {
-                    pdfFilename = xournalFilepath.remove_filename() / pdfFilename;
-                }
-            } else if (!strcmp("attach", domain)) {
-                attachToDocument = true;
-                // Handle old format separately
-                if (this->isGzFile) {
-                    pdfFilename = (fs::path{xournalFilepath} += ".") += pdfFilename;
-                } else {
-                    auto readResult = readZipAttachment(pdfFilename);
-                    if (!readResult) {
-                        return;
-                    }
-                    std::string& pdfBytes = readResult.value();
-                    doc.readPdf(pdfFilename, false, attachToDocument, pdfBytes.data(), pdfBytes.size());
-
-                    if (!doc.getLastErrorMsg().empty()) {
-                        error("%s", FC(_F("Error reading PDF: {1}") % doc.getLastErrorMsg()));
-                    }
-
-                    this->pdfFilenameParsed = true;
+        if (!strcmp("absolute", domain))  // Absolute OR relative path
+        {
+            if (pdfFilename.is_relative()) {
+                pdfFilename = xournalFilepath.remove_filename() / pdfFilename;
+            }
+        } else if (!strcmp("attach", domain)) {
+            attachToDocument = true;
+            // Handle old format separately
+            if (this->isGzFile) {
+                pdfFilename = (fs::path{xournalFilepath} += ".") += pdfFilename;
+            } else {
+                auto readResult = readZipAttachment(pdfFilename);
+                if (!readResult) {
                     return;
                 }
-            } else {
-                error("%s", FC(_F("Unknown domain type: {1}") % domain));
+                std::string& pdfBytes = readResult.value();
+                doc.readPdf(pdfFilename, false, attachToDocument, pdfBytes.data(), pdfBytes.size());
+
+                if (!doc.getLastErrorMsg().empty()) {
+                    error("%s", FC(_F("Error reading PDF: {1}") % doc.getLastErrorMsg()));
+                }
+
+                this->pdfFilenameParsed = true;
                 return;
             }
         } else {
-            pdfFilename = this->pdfReplacementFilepath;
-            attachToDocument = this->pdfReplacementAttach;
+            error("%s", FC(_F("Unknown domain type: {1}") % domain));
+            return;
         }
 
         this->pdfFilenameParsed = true;
@@ -514,10 +500,13 @@ void LoadHandler::parseBgPdf() {
             if (!doc.getLastErrorMsg().empty()) {
                 error("%s", FC(_F("Error reading PDF: {1}") % doc.getLastErrorMsg()));
             }
-        } else if (attachToDocument) {
-            this->attachedPdfMissing = true;
         } else {
-            this->pdfMissing = pdfFilename.u8string();
+            doc.setPdfAttributes(pdfFilename, attachToDocument);
+            if (attachToDocument) {
+                this->attachedPdfMissing = true;
+            } else {
+                this->pdfMissing = pdfFilename.u8string();
+            }
         }
     }
 }
@@ -536,12 +525,7 @@ void LoadHandler::parsePage() {
         } else if (strcmp("pixmap", type) == 0) {
             parseBgPixmap();
         } else if (strcmp("pdf", type) == 0) {
-            if (this->removePdfBackgroundFlag) {
-                this->page->setBackgroundType(PageType(PageTypeFormat::Plain));
-                this->page->setBackgroundColor(Colors::white);
-            } else {
-                parseBgPdf();
-            }
+            parseBgPdf();
         } else {
             error("%s", FC(_F("Unknown background type: {1}") % type));
         }

--- a/src/core/control/xojfile/LoadHandler.h
+++ b/src/core/control/xojfile/LoadHandler.h
@@ -61,9 +61,6 @@ public:
     bool isAttachedPdfMissing() const;
     std::string getMissingPdfFilename() const;
 
-    void removePdfBackground();
-    void setPdfReplacement(fs::path filepath, bool attachToDocument);
-
     /** @return The version of the loaded file */
     int getFileVersion() const;
 
@@ -123,10 +120,6 @@ private:
     std::string lastError;
     std::string pdfMissing;
     bool attachedPdfMissing;
-
-    bool removePdfBackgroundFlag;
-    fs::path pdfReplacementFilepath;
-    bool pdfReplacementAttach;
 
     fs::path filepath;
 

--- a/src/core/gui/XournalView.cpp
+++ b/src/core/gui/XournalView.cpp
@@ -509,6 +509,17 @@ auto XournalView::getVisibleRect(const XojPageView* redrawable) const -> Rectang
     return gtk_xournal_get_visible_area(this->widget, redrawable);
 }
 
+void XournalView::recreatePdfCache() {
+    this->cache.reset();
+
+    Document* doc = control->getDocument();
+    doc->lock();
+    if (doc->getPdfPageCount() != 0) {
+        this->cache = std::make_unique<PdfCache>(doc->getPdfDocument(), control->getSettings());
+    }
+    doc->unlock();
+}
+
 /**
  * @return Helper class for Touch specific fixes
  */
@@ -763,13 +774,10 @@ void XournalView::documentChanged(DocumentChangeType type) {
 
     viewPages.clear();
 
-    this->cache.reset();
+    recreatePdfCache();
 
     Document* doc = control->getDocument();
     doc->lock();
-    if (doc->getPdfPageCount() != 0) {
-        this->cache = std::make_unique<PdfCache>(doc->getPdfDocument(), control->getSettings());
-    }
 
     size_t pagecount = doc->getPageCount();
     viewPages.reserve(pagecount);

--- a/src/core/gui/XournalView.h
+++ b/src/core/gui/XournalView.h
@@ -109,6 +109,11 @@ public:
     xoj::util::Rectangle<double>* getVisibleRect(const XojPageView* redrawable) const;
 
     /**
+     * Recreate the PDF cache, for example after the underlying PDF file has changed
+     */
+    void recreatePdfCache();
+
+    /**
      * A pen action was detected now, therefore ignore touch events
      * for a short time
      */

--- a/src/core/model/Document.cpp
+++ b/src/core/model/Document.cpp
@@ -304,6 +304,11 @@ void Document::updateIndexPageNumbers() {
     }
 }
 
+void Document::setPdfAttributes(const fs::path& filename, bool attachToDocument) {
+    this->pdfFilepath = filename;
+    this->attachPdf = attachToDocument;
+}
+
 auto Document::readPdf(const fs::path& filename, bool initPages, bool attachToDocument, gpointer data, gsize length)
         -> bool {
     GError* popplerError = nullptr;
@@ -358,6 +363,8 @@ auto Document::readPdf(const fs::path& filename, bool initPages, bool attachToDo
 
     return true;
 }
+
+void Document::resetPdf() { pdfDocument.reset(); }
 
 void Document::setPageSize(PageRef p, double width, double height) { p->setSize(width, height); }
 

--- a/src/core/model/Document.h
+++ b/src/core/model/Document.h
@@ -42,8 +42,10 @@ public:
 public:
     enum DocumentType { XOPP, XOJ, PDF };
 
+    void setPdfAttributes(const fs::path& filename, bool attachToDocument);
     bool readPdf(const fs::path& filename, bool initPages, bool attachToDocument, gpointer data = nullptr,
                  gsize length = 0);
+    void resetPdf();
 
     size_t getPageCount() const;
     size_t getPdfPageCount() const;

--- a/src/core/pdf/base/XojPdfDocument.cpp
+++ b/src/core/pdf/base/XojPdfDocument.cpp
@@ -42,6 +42,8 @@ auto XojPdfDocument::load(gpointer data, gsize length, std::string password, GEr
 
 auto XojPdfDocument::isLoaded() const -> bool { return doc->isLoaded(); }
 
+void XojPdfDocument::reset() { doc->reset(); }
+
 auto XojPdfDocument::getPage(size_t page) const -> XojPdfPageSPtr { return doc->getPage(page); }
 
 auto XojPdfDocument::getPageCount() const -> size_t { return doc->getPageCount(); }

--- a/src/core/pdf/base/XojPdfDocument.h
+++ b/src/core/pdf/base/XojPdfDocument.h
@@ -43,6 +43,7 @@ public:
     bool load(fs::path const& file, std::string password, GError** error) override;
     bool load(gpointer data, gsize length, std::string password, GError** error) override;
     bool isLoaded() const override;
+    void reset() override;
 
     XojPdfPageSPtr getPage(size_t page) const override;
     size_t getPageCount() const override;

--- a/src/core/pdf/base/XojPdfDocumentInterface.h
+++ b/src/core/pdf/base/XojPdfDocumentInterface.h
@@ -35,6 +35,7 @@ public:
     virtual bool load(fs::path const& file, std::string password, GError** error) = 0;
     virtual bool load(gpointer data, gsize length, std::string password, GError** error) = 0;
     virtual bool isLoaded() const = 0;
+    virtual void reset() = 0;
 
     virtual XojPdfPageSPtr getPage(size_t page) const = 0;
     virtual size_t getPageCount() const = 0;

--- a/src/core/pdf/popplerapi/PopplerGlibDocument.cpp
+++ b/src/core/pdf/popplerapi/PopplerGlibDocument.cpp
@@ -84,6 +84,13 @@ auto PopplerGlibDocument::load(gpointer data, gsize length, string password, GEr
 
 auto PopplerGlibDocument::isLoaded() const -> bool { return this->document != nullptr; }
 
+void PopplerGlibDocument::reset() {
+    if (document) {
+        g_object_unref(document);
+        document = nullptr;
+    }
+}
+
 auto PopplerGlibDocument::getPage(size_t page) const -> XojPdfPageSPtr {
     if (document == nullptr) {
         return nullptr;

--- a/src/core/pdf/popplerapi/PopplerGlibDocument.h
+++ b/src/core/pdf/popplerapi/PopplerGlibDocument.h
@@ -39,6 +39,7 @@ public:
     bool load(fs::path const& filepath, std::string password, GError** error) override;
     bool load(gpointer data, gsize length, std::string password, GError** error) override;
     bool isLoaded() const override;
+    void reset() override;
 
     XojPdfPageSPtr getPage(size_t page) const override;
     size_t getPageCount() const override;

--- a/src/core/undo/MissingPdfUndoAction.cpp
+++ b/src/core/undo/MissingPdfUndoAction.cpp
@@ -1,0 +1,66 @@
+#include "MissingPdfUndoAction.h"
+
+#include "control/Control.h"                         // for Control
+#include "control/PageBackgroundChangeController.h"  // for PageBackGroundChangeController
+#include "gui/MainWindow.h"                          // for MainWindow
+#include "gui/XournalView.h"                         // for XournalView
+#include "model/Document.h"                          // for Document
+#include "model/PageType.h"                          // for PageTypeFormat
+#include "model/XojPage.h"                           // for XojPage
+#include "undo/UndoAction.h"                         // for UndoAction
+#include "util/i18n.h"                               // for _
+
+MissingPdfUndoAction::MissingPdfUndoAction(const fs::path& oldFilepath, bool oldAttachPdf):
+        UndoAction("MissingPdfUndoAction"), filepath(oldFilepath), attachPdf(oldAttachPdf) {}
+
+MissingPdfUndoAction::~MissingPdfUndoAction() = default;
+
+auto MissingPdfUndoAction::undo(Control* control) -> bool {
+    Document* doc = control->getDocument();
+
+    fs::path redoFilepath = doc->getPdfFilepath();
+    bool redoAttachPdf = doc->isAttachPdf();
+
+    doc->resetPdf();
+    doc->setPdfAttributes(this->filepath, this->attachPdf);
+
+    doc->unlock();
+    control->getWindow()->getXournal()->recreatePdfCache();
+    doc->lock();
+
+    for (size_t p = 0; p < doc->getPageCount(); p++) {
+        if (doc->getPage(p)->getBackgroundType().format == PageTypeFormat::Pdf) {
+            control->firePageChanged(p);
+        }
+    }
+
+    this->filepath = std::move(redoFilepath);
+    this->attachPdf = redoAttachPdf;
+
+    return true;
+}
+
+auto MissingPdfUndoAction::redo(Control* control) -> bool {
+    Document* doc = control->getDocument();
+
+    fs::path undoFilepath = doc->getPdfFilepath();
+    bool undoAttachPdf = doc->isAttachPdf();
+
+    doc->unlock();
+    doc->readPdf(this->filepath, false, this->attachPdf);
+    control->getWindow()->getXournal()->recreatePdfCache();
+    doc->lock();
+
+    for (size_t p = 0; p < doc->getPageCount(); p++) {
+        if (doc->getPage(p)->getBackgroundType().format == PageTypeFormat::Pdf) {
+            control->firePageChanged(p);
+        }
+    }
+
+    this->filepath = std::move(undoFilepath);
+    this->attachPdf = undoAttachPdf;
+
+    return true;
+}
+
+auto MissingPdfUndoAction::getText() -> std::string { return _("Replace missing PDF"); }

--- a/src/core/undo/MissingPdfUndoAction.h
+++ b/src/core/undo/MissingPdfUndoAction.h
@@ -1,0 +1,33 @@
+/*
+ * Xournal++
+ *
+ * Undo action for replacing a missing PDF file
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+#include "UndoAction.h"  // for UndoAction
+#include "filesystem.h"  // for path
+
+class Control;
+
+class MissingPdfUndoAction: public UndoAction {
+public:
+    MissingPdfUndoAction(const fs::path& oldFilepath, bool oldAttachPdf);
+    ~MissingPdfUndoAction() override;
+
+public:
+    bool undo(Control* control) override;
+    bool redo(Control* control) override;
+
+    std::string getText() override;
+
+private:
+    fs::path filepath;
+    bool attachPdf;
+};


### PR DESCRIPTION
Fixes #5435

~~Undoing simply reopens the whole file.~~
Now involves a slight refactoring of how the page background is replaced.