### PR TITLE
Fix windows build because of missing libpng

### DIFF
--- a/azure-pipelines/steps/build_windows.yml
+++ b/azure-pipelines/steps/build_windows.yml
@@ -8,7 +8,7 @@ steps:
   # Copy of msys2-blob as a temporary fix for Windows CI
   - script: |
       set PATH=C:\msys64\usr\bin;C:\msys64\mingw64\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem
-      pacman --noconfirm -S mingw-w64-x86_64-imagemagick mingw-w64-x86_64-ninja mingw-w64-x86_64-poppler
+      pacman --noconfirm -S mingw-w64-x86_64-imagemagick mingw-w64-x86_64-ninja mingw-w64-x86_64-poppler mingw-w64-x86_64-libpng
       pacman --noconfirm -S mingw-w64-x86_64-gtk3 mingw-w64-x86_64-libsndfile mingw-w64-x86_64-libzip
       pacman --noconfirm -S mingw-w64-x86_64-lua mingw-w64-x86_64-portaudio mingw-w64-x86_64-gtksourceview4
     env:


### PR DESCRIPTION
Somehow, mingw-w64-x86_64-libpng is not a required dependency of ImageMagick. But we need it.