### PR TITLE
Fix debian/rules indentation

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -12,4 +12,4 @@ override_dh_dwz:
 	dh_dwz --no-dwz-multifile
 
 override_dh_auto_configure:
-    dh_auto_configure -- -DCMAKE_BUILD_TYPE=RelWithDebInfo
+	dh_auto_configure -- -DCMAKE_BUILD_TYPE=RelWithDebInfo


### PR DESCRIPTION
Currently the Launchpad build (for the PPA) fails due to a separator issue:
```term
 dpkg-source -i -I.bzr -I.git --before-build .
 fakeroot debian/rules clean
debian/rules:15: *** missing separator.  Stop.
```

This is a regression from 1cbc67fe9531fca871b347c99d48b9b0bad6f7e0

It can be checked by running
```term
fakeroot debian/rules build
```
in the root directory that replacing the 4 spaces by tab makes all the difference.

See also https://www.debian.org/doc/manuals/maint-guide/dreq.en.html#customrules
> 4.4.1. Targets of the rules file

> Every rules file, like any other Makefile, consists of several rules, each of which defines a target and how it is carried out. [[37]](https://www.debian.org/doc/manuals/maint-guide/dreq.en.html#ftn.idm1517) A new rule begins with its target declaration in the first column. The following lines beginning with the TAB code (ASCII 9) specify the recipe for carrying out that target. Empty lines and lines beginning with # (hash) are treated as comments and ignored. [[38]](https://www.debian.org/doc/manuals/maint-guide/dreq.en.html#ftn.idm1525)