### PR TITLE
Add preference settings for selection size

### DIFF
--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -76,6 +76,9 @@ void Settings::loadDefault() {
     this->edgePanSpeed = 20.0;
     this->edgePanMaxMult = 5.0;
 
+    this->selectPaddingMult = 1.0;
+    this->buttonSizeMult = 1.0;
+
     this->zoomStep = 10.0;
     this->zoomStepScroll = 2.0;
 
@@ -400,6 +403,10 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur) {
         this->edgePanSpeed = tempg_ascii_strtod(reinterpret_cast<const char*>(value), nullptr);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("edgePanMaxMult")) == 0) {
         this->edgePanMaxMult = tempg_ascii_strtod(reinterpret_cast<const char*>(value), nullptr);
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("selectPaddingMult")) == 0) {
+        this->selectPaddingMult = tempg_ascii_strtod(reinterpret_cast<const char*>(value), nullptr);
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("buttonSizeMult")) == 0) {
+        this->buttonSizeMult = tempg_ascii_strtod(reinterpret_cast<const char*>(value), nullptr);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("zoomStep")) == 0) {
         this->zoomStep = tempg_ascii_strtod(reinterpret_cast<const char*>(value), nullptr);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("zoomStepScroll")) == 0) {
@@ -978,6 +985,8 @@ void Settings::save() {
 
     SAVE_DOUBLE_PROP(edgePanSpeed);
     SAVE_DOUBLE_PROP(edgePanMaxMult);
+    SAVE_DOUBLE_PROP(selectPaddingMult);
+    SAVE_DOUBLE_PROP(buttonSizeMult);
     SAVE_DOUBLE_PROP(zoomStep);
     SAVE_DOUBLE_PROP(zoomStepScroll);
     SAVE_INT_PROP(displayDpi);
@@ -1925,6 +1934,26 @@ void Settings::setEdgePanMaxMult(double maxMult) {
 }
 
 auto Settings::getEdgePanMaxMult() const -> double { return this->edgePanMaxMult; }
+
+void Settings::setSelectPaddingMult(double mult) {
+    if (this->selectPaddingMult == mult) {
+        return;
+    }
+    this->selectPaddingMult = mult;
+    save();
+}
+
+auto Settings::getSelectPaddingMult() const -> double { return this->selectPaddingMult; }
+
+void Settings::setButtonSizeMult(double mult) {
+    if (this->buttonSizeMult == mult) {
+        return;
+    }
+    this->buttonSizeMult = mult;
+    save();
+}
+
+auto Settings::getButtonSizeMult() const -> double { return this->buttonSizeMult; }
 
 void Settings::setDisplayDpi(int dpi) {
     if (this->displayDpi == dpi) {

--- a/src/core/control/settings/Settings.h
+++ b/src/core/control/settings/Settings.h
@@ -164,6 +164,12 @@ public:
     void setEdgePanMaxMult(double mult);
     double getEdgePanMaxMult() const;
 
+    void setSelectPaddingMult(double mult);
+    double getSelectPaddingMult() const;
+
+    void setButtonSizeMult(double mult);
+    double getButtonSizeMult() const;
+
     /**
      * Set the Zoomstep for one step in percent
      */
@@ -774,6 +780,9 @@ private:
      * of view
      */
     double edgePanMaxMult{};
+
+    double selectPaddingMult{};
+    double buttonSizeMult{};
 
     /**
      * Zoomstep for one step

--- a/src/core/control/tools/EditSelection.cpp
+++ b/src/core/control/tools/EditSelection.cpp
@@ -212,17 +212,17 @@ auto addElementsFromActiveLayer(Control* ctrl, EditSelection* base, const Insert
 EditSelection::EditSelection(Control* ctrl, InsertionOrder elts, const PageRef& page, Layer* layer, XojPageView* view,
                              const Range& bounds, const Range& snappingBounds):
         snappedBounds(snappingBounds),
-        btnWidth(std::max(10, ctrl->getSettings()->getDisplayDpi() / 8)),
+        btnWidth(std::max(10, static_cast<int>(ctrl->getSettings()->getButtonSizeMult() * ctrl->getSettings()->getDisplayDpi() / 8))),
         sourcePage(page),
         sourceLayer(layer),
         view(view),
         undo(ctrl->getUndoRedoHandler()),
         snappingHandler(ctrl->getSettings()) {
     // make the visible bounding box large enough so that anchors do not collapse even for horizontal/vertical strokes
-    x = bounds.minX - 1.5 * this->btnWidth;
-    y = bounds.minY - 1.5 * this->btnWidth;
-    width = bounds.getWidth() + 3 * this->btnWidth;
-    height = bounds.getHeight() + 3 * this->btnWidth;
+    x = bounds.minX - ctrl->getSettings()->getSelectPaddingMult() * 1.5 * this->btnWidth;
+    y = bounds.minY - ctrl->getSettings()->getSelectPaddingMult() * 1.5 * this->btnWidth;
+    width = bounds.getWidth() + ctrl->getSettings()->getSelectPaddingMult() * 3 * this->btnWidth;
+    height = bounds.getHeight() + ctrl->getSettings()->getSelectPaddingMult() * 3 * this->btnWidth;
 
     this->contents = std::make_unique<EditSelectionContents>(this->getRect(), this->snappedBounds, this->sourcePage,
                                                              this->sourceLayer, this->view);
@@ -242,7 +242,7 @@ EditSelection::EditSelection(Control* ctrl, InsertionOrder elts, const PageRef& 
 
 EditSelection::EditSelection(Control* ctrl, const PageRef& page, Layer* layer, XojPageView* view):
         snappedBounds(Rectangle<double>{}),
-        btnWidth(std::max(10, ctrl->getSettings()->getDisplayDpi() / 8)),
+        btnWidth(std::max(10, static_cast<int>(ctrl->getSettings()->getButtonSizeMult() * ctrl->getSettings()->getDisplayDpi() / 8))),
         sourcePage(page),
         sourceLayer(layer),
         view(view),
@@ -866,6 +866,7 @@ bool EditSelection::handleEdgePan(EditSelection* self) {
         double mult = 0.0;
 
         // Calculate bonus scroll amount due to proportion of selection out of view.
+            // maybe introduce factor also here (since the selection side depends on multipliers...)
         const double maxMult = settings->getEdgePanMaxMult();
         int panDir = 0;
         if (aboveMax) {

--- a/src/core/gui/dialog/SettingsDialog.cpp
+++ b/src/core/gui/dialog/SettingsDialog.cpp
@@ -443,6 +443,9 @@ void SettingsDialog::load() {
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(builder.get("edgePanSpeed")), settings->getEdgePanSpeed());
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(builder.get("edgePanMaxMult")), settings->getEdgePanMaxMult());
 
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(builder.get("selectPaddingMult")), settings->getSelectPaddingMult());
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(builder.get("buttonSizeMult")), settings->getButtonSizeMult());
+
     GtkWidget* spZoomStep = builder.get("spZoomStep");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spZoomStep), settings->getZoomStep());
 
@@ -877,6 +880,9 @@ void SettingsDialog::save() {
 
     settings->setEdgePanSpeed(gtk_spin_button_get_value(GTK_SPIN_BUTTON(builder.get("edgePanSpeed"))));
     settings->setEdgePanMaxMult(gtk_spin_button_get_value(GTK_SPIN_BUTTON(builder.get("edgePanMaxMult"))));
+
+    settings->setSelectPaddingMult(gtk_spin_button_get_value(GTK_SPIN_BUTTON(builder.get("selectPaddingMult"))));
+    settings->setButtonSizeMult(gtk_spin_button_get_value(GTK_SPIN_BUTTON(builder.get("buttonSizeMult"))));
 
     GtkWidget* spZoomStep = builder.get("spZoomStep");
     double zoomStep = gtk_spin_button_get_value(GTK_SPIN_BUTTON(spZoomStep));

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -35,6 +35,18 @@
     <property name="step-increment">1</property>
     <property name="page-increment">10</property>
   </object>
+  <object class="GtkAdjustment" id="adjustmentSelectPaddingMult">
+    <property name="lower">0.1</property>
+    <property name="upper">3</property>
+    <property name="step-increment">0.1</property>
+    <property name="page-increment">1</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustmentButtonSizeMult">
+    <property name="lower">0.1</property>
+    <property name="upper">3</property>
+    <property name="step-increment">0.1</property>
+    <property name="page-increment">1</property>
+  </object>
   <object class="GtkAdjustment" id="adjustmentHorizontalSpaceLeft">
     <property name="upper">2000</property>
     <property name="value">150</property>
@@ -1388,7 +1400,7 @@ Illegal characters are replaced with "_"</property>
                                         <property name="row-homogeneous">True</property>
                                         <child>
                                           <object class="GtkCheckButton" id="cbUseSpacesAsTab">
-                                            <property name="label" translatable="yes">Indent using spaces</property> 
+                                            <property name="label" translatable="yes">Indent using spaces</property>
                                             <property name="visible">True</property>
                                             <property name="can-focus">True</property>
                                             <property name="receives-default">False</property>
@@ -3764,6 +3776,89 @@ This setting can make it easier to draw with touch. </property>
                               </packing>
                             </child>
                             <child>
+                              <object class="GtkFrame">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
+                                <child>
+                                  <!-- n-columns=2 n-rows=2 -->
+                                  <object class="GtkGrid">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">8</property>
+                                    <child>
+                                      <object class="GtkSpinButton" id="selectPaddingMult">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="input-purpose">number</property>
+                                        <property name="adjustment">adjustmentSelectPaddingMult</property>
+                                        <property name="digits">1</property>
+                                        <property name="numeric">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="top-attach">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSpinButton" id="buttonSizeMult">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="input-purpose">number</property>
+                                        <property name="adjustment">adjustmentButtonSizeMult</property>
+                                        <property name="digits">1</property>
+                                        <property name="numeric">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="top-attach">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="tooltip-text" translatable="yes">TODO</property>
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">Padding multiplier</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">0</property>
+                                        <property name="top-attach">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="tooltip-text" translatable="yes">TODO</property>
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">Button size multiplier</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">0</property>
+                                        <property name="top-attach">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label">
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">Selection Size</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">6</property>
+                              </packing>
+                            </child>
+                            <child>
                               <object class="GtkFrame" id="sid114">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
@@ -3834,7 +3929,7 @@ This setting can make it easier to draw with touch. </property>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">6</property>
+                                <property name="position">7</property>
                               </packing>
                             </child>
                             <child>
@@ -3957,7 +4052,7 @@ This setting can make it easier to draw with touch. </property>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">7</property>
+                                <property name="position">8</property>
                               </packing>
                             </child>
                             <child>
@@ -4062,7 +4157,7 @@ This setting can make it easier to draw with touch. </property>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">8</property>
+                                <property name="position">9</property>
                               </packing>
                             </child>
                           </object>


### PR DESCRIPTION
Problem:
Selection can be sometimes unnecessarily big (mainly when working zoomed in). It would be suitable to have a preference setting for selection padding, such that one can adjust it according to their workflow.

Two options added:
* SelectPaddingMult (to change selection padding)
* ButtonSizeMult (to change size of selection buttons)

This is still WIP (need to add some tooltips and other small tweaks), but overall it seems to work pretty well.
I will gladly hear your thoughts on this.