### PR TITLE
Refactor sidebar width control

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -1256,6 +1256,7 @@ void Control::showSettings() {
                     ctrl->getCursor()->updateCursor();
                 }
 
+                ctrl->getSidebar()->saveSize();
                 ctrl->win->updateScrollbarSidebarPosition();
                 ctrl->updateWindowTitle();
 

--- a/src/core/gui/MainWindow.h
+++ b/src/core/gui/MainWindow.h
@@ -69,8 +69,6 @@ public:
 
     void updatePageNumbers(size_t page, size_t pagecount, size_t pdfpage);
 
-    void saveSidebarSize();
-
     void setMaximized(bool maximized);
     bool isMaximized() const;
 
@@ -127,6 +125,19 @@ private:
     void initXournalWidget();
 
     void createToolbar();
+
+    /**
+     * Update the position of the separator in the paned container, adjusting it to the saved sidebar width.
+     * @param contentWidth should be the width of the paned container. The caller should retrieve the width
+     * of the container before any modifications to it, as that will reset its allocation.
+     */
+    void updatePanedPosition(int contentWidth);
+
+    /**
+     * Invert the position of the paned widget and disconnect from the signal.
+     * @param handlerId should be the ID of the signal handler that should be disconnected.
+     */
+    static void invertPanedPosition(GtkWidget* widget, GtkAllocation* allocation, gulong* handlerId);
 
     /**
      * Window close Button is pressed


### PR DESCRIPTION
There had been a couple of issues when having the sidebar on the right side: 
 * The width setting was not saving properly when the sidebar was closed.
 * The sidebar always had its minimal size when the app was launched with the sidebar visible.
 * When the sidebar was hidden on launch, setting the sidebar to visible would set the paned position wrong.

These issues have been around since pretty much forever. This PR aims to fix all these inconsistencies.

What I tested, for both left and right sidebar:
 * Sidebar width is always remembered, whether the sidebar is visible or not upon closing.
 * When the sidebar is shown on launch, it appears with the correct size.
 * When the sidebar is not shown on launch but made visible later, the size is correct as well.
 * Switching the sidebar side from the preferences keeps the same sidebar size, whether the sidebar is visible or not.