### PR TITLE
Avoid using fs::equivalent on empty path

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -221,11 +221,12 @@ Control::~Control() {
 
 void Control::setLastAutosaveFile(fs::path newAutosaveFile) {
     try {
-        if (!fs::equivalent(newAutosaveFile, this->lastAutosaveFilename) && fs::exists(newAutosaveFile)) {
+        if (!this->lastAutosaveFilename.empty() && !fs::equivalent(newAutosaveFile, this->lastAutosaveFilename) &&
+            fs::exists(newAutosaveFile)) {
             deleteLastAutosaveFile();
         }
     } catch (const fs::filesystem_error& e) {
-        auto fmtstr = FS(_F("Filesystem error: {2}") % e.what());
+        auto fmtstr = FS(_F("Filesystem error: {1}") % e.what());
         Util::execInUiThread([fmtstr, win = getGtkWindow()]() { XojMsgBox::showErrorToUser(win, fmtstr); });
     }
     this->lastAutosaveFilename = std::move(newAutosaveFile);


### PR DESCRIPTION
Fixes two issues
- Filesystem error on MacOS when a document is autosaved the first time after startup
- Typo in error message displaying `{2}` instead of error message

The first issue was described in https://github.com/xournalpp/xournalpp/issues/5474#issue-2103370589