### PR TITLE
Fix *.pdf filter for ExportAsPdf dialog

### DIFF
--- a/src/core/control/jobs/PdfExportJob.cpp
+++ b/src/core/control/jobs/PdfExportJob.cpp
@@ -16,9 +16,7 @@ PdfExportJob::PdfExportJob(Control* control): BaseExportJob(control, _("PDF Expo
 
 PdfExportJob::~PdfExportJob() = default;
 
-void PdfExportJob::addFilterToDialog() {
-     addFileFilterToDialog(_("PDF files"), ".pdf");
-}
+void PdfExportJob::addFilterToDialog() { addFileFilterToDialog(_("PDF files"), "*.pdf"); }
 
 auto PdfExportJob::testAndSetFilepath(const fs::path& file) -> bool {
     if (!BaseExportJob::testAndSetFilepath(file)) {


### PR DESCRIPTION
Fix *.pdf filter for ExportAsPdf dialog.

Note: we could also replace the pattern *.pdf by the MIME type application/pdf (so that the filter would match a pdf file without extension for instance)