### PR TITLE
Fix -Wreorder warning in RecognizerUndoAction

### DIFF
--- a/src/core/undo/RecognizerUndoAction.h
+++ b/src/core/undo/RecognizerUndoAction.h
@@ -37,8 +37,8 @@ public:
 
 private:
     Layer* layer;
-    Element* recognized;
     Element* original;
-    std::unique_ptr<Element> recognizedOwned;
     std::unique_ptr<Element> originalOwned;
+    Element* recognized;
+    std::unique_ptr<Element> recognizedOwned;
 };


### PR DESCRIPTION
Fixes this warning introduced in #5350:
```term
In file included from /home/roland/dev/xournalpp/src/core/undo/RecognizerUndoAction.cpp:1:
/home/roland/dev/xournalpp/src/core/undo/RecognizerUndoAction.h: In constructor ‘RecognizerUndoAction::RecognizerUndoAction(const PageRef&, Layer*, ElementPtr, Element*)’:
/home/roland/dev/xournalpp/src/core/undo/RecognizerUndoAction.h:42:30: warning: ‘RecognizerUndoAction::originalOwned’ will be initialized after [-Wreorder]
   42 |     std::unique_ptr<Element> originalOwned;
      |                              ^~~~~~~~~~~~~
/home/roland/dev/xournalpp/src/core/undo/RecognizerUndoAction.h:40:14: warning:   ‘Element* RecognizerUndoAction::recognized’ [-Wreorder]
   40 |     Element* recognized;
      |              ^~~~~~~~~~
/home/roland/dev/xournalpp/src/core/undo/RecognizerUndoAction.cpp:17:1: warning:   when initialized here [-Wreorder]
   17 | RecognizerUndoAction::RecognizerUndoAction(const PageRef& page, Layer* layer, ElementPtr original, Element* recognized):
      | ^~~~~~~~~~~~~~~~~~~~
```