### PR TITLE
Do not export Pdf outline when only exporting part of the document

### DIFF
--- a/src/core/pdf/base/XojCairoPdfExport.h
+++ b/src/core/pdf/base/XojCairoPdfExport.h
@@ -42,19 +42,17 @@ public:
     void setExportBackground(ExportBackgroundType exportBackground) override;
 
 private:
-    bool startPdf(const fs::path& file);
+    bool startPdf(const fs::path& file, bool exportOutline);
 #if CAIRO_VERSION >= CAIRO_VERSION_ENCODE(1, 16, 0)
     /**
      * Populate the outline of the generated PDF using the outline of the
      * background PDF.
      *
      * This requires features available only in cairo 1.16 or newer.
-     *
-     * @param tocModel The Document's content model. Does nothing if set to null.
      */
-    void populatePdfOutline(GtkTreeModel* tocModel);
+    void populatePdfOutline();
 #endif
-    void endPdf();
+    bool endPdf();
     void exportPage(size_t page);
     /**
      * Export as a PDF document where each additional layer creates a


### PR DESCRIPTION
Fix #4897
The issue was: the cairo_pdf_surface was in failed state when cairo_surface_destroy() was calling (internally) cairo_surface_finish().
Indeed, if the outline has links pointing out of the document's bounds (e.g. to a page past the end of the document), then the surface enters a failed state upon cairo_surface_finish() (and not before, as it does not yet know the total number of pages...)

This PR:

1. Avoid exporting the outline when only exporting part of the document (via export as)
2. Calls cairo_surface_finish() by hand and checks for error, so that anything of the sort won't go undetected anymore.