### PR TITLE
Fix menubar visibility on startup

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -630,14 +630,6 @@ void Control::setShowToolbar(bool enabled) {
 void Control::setShowMenubar(bool enabled) {
     win->setMenubarVisible(enabled);
     actionDB->setActionState(Action::SHOW_MENUBAR, enabled);
-
-    if (settings->isMenubarVisible() != enabled &&
-        settings->getActiveViewMode() == PresetViewModeIds::VIEW_MODE_DEFAULT) {
-        settings->setMenubarVisible(enabled);
-        ViewMode viewMode = settings->getViewModes()[PresetViewModeIds::VIEW_MODE_DEFAULT];
-        viewMode.showMenubar = enabled;
-        settings->setViewMode(PresetViewModeIds::VIEW_MODE_DEFAULT, viewMode);
-    }
 }
 
 void Control::disableSidebarTmp(bool disabled) { this->sidebar->setTmpDisabled(disabled); }

--- a/src/core/gui/MainWindow.cpp
+++ b/src/core/gui/MainWindow.cpp
@@ -110,6 +110,11 @@ MainWindow::MainWindow(GladeSearchpath* gladeSearchPath, Control* control, GtkAp
         gtk_window_unmaximize(GTK_WINDOW(this->window));
     }
 
+    Util::execInUiThread([=]() {
+        // Execute after the window is visible, else the check won't work
+        control->setShowMenubar(control->getSettings()->isMenubarVisible());
+    });
+
     // Drag and Drop
     g_signal_connect(this->window, "drag-data-received", G_CALLBACK(dragDataRecived), this);
 


### PR DESCRIPTION
The menubar should be visible on startup iff the according checkbox in the View tab of the settings is enabled. Hitting F10 or using menu View > Show Menubar
should not change this setting.

This fixes a regression from #4372 and is only on master.