### PR TITLE
Add image trimming and splitting

### DIFF
--- a/plugins/ImageActions/main.lua
+++ b/plugins/ImageActions/main.lua
@@ -144,7 +144,7 @@ function Split(mode)
     local currentLength = 0
     local n = 0
     for i = 1, last do
-      if sum[i] == maxSum then -- completely white row (or column)
+      if sum[i - 1] == maxSum then -- completely white row (or column)
         if currentLength > 0 then
           currentLength = currentLength + 1
         else

--- a/plugins/ImageActions/main.lua
+++ b/plugins/ImageActions/main.lua
@@ -1,4 +1,4 @@
-local Mode = {
+local m = {
   INVERT = 1,
   DOWNSCALE = 2,
   FLIP_H = 3,
@@ -12,35 +12,35 @@ local Mode = {
 }
 
 function initUi()
-  app.registerUi({ ["menu"] = "Invert selected images", ["callback"] = "cb", ["mode"] = Mode.INVERT })
+  app.registerUi({ ["menu"] = "Invert selected images", ["callback"] = "cb", ["mode"] = m.INVERT })
   app.registerUi({
     ["menu"] = "Downscale resolution of selected images by factor 0.5",
     ["callback"] = "cb",
-    ["mode"] = Mode.DOWNSCALE
+    ["mode"] = m.DOWNSCALE
   })
-  app.registerUi({ ["menu"] = "Flip selected images horizontally", ["callback"] = "cb", ["mode"] = Mode.FLIP_H })
-  app.registerUi({ ["menu"] = "Flip selected images vertically", ["callback"] = "cb", ["mode"] = Mode.FLIP_V })
+  app.registerUi({ ["menu"] = "Flip selected images horizontally", ["callback"] = "cb", ["mode"] = m.FLIP_H })
+  app.registerUi({ ["menu"] = "Flip selected images vertically", ["callback"] = "cb", ["mode"] = m.FLIP_V })
   app.registerUi({
     ["menu"] = "Rotate selected images 90 degree clockwise",
     ["callback"] = "cb",
-    ["mode"] = Mode.ROTATE_CW
+    ["mode"] = m.ROTATE_CW
   })
   app.registerUi({
     ["menu"] = "Rotate selected images 90 degree counterclockwise",
     ["callback"] = "cb",
-    ["mode"] = Mode.ROTATE_CCW
+    ["mode"] = m.ROTATE_CCW
   })
-  app.registerUi({ ["menu"] = "Make white pixels transparent", ["callback"] = "cb", ["mode"] = Mode.TRANSPARENT })
-  app.registerUi({ ["menu"] = "Trim selected images", ["callback"] = "cb", ["mode"] = Mode.TRIM })
+  app.registerUi({ ["menu"] = "Make white pixels transparent", ["callback"] = "cb", ["mode"] = m.TRANSPARENT })
+  app.registerUi({ ["menu"] = "Trim selected images", ["callback"] = "cb", ["mode"] = m.TRIM })
   app.registerUi({
     ["menu"] = "Split images vertically by largest white block",
     ["callback"] = "split",
-    ["mode"] = Mode.SPLIT_V
+    ["mode"] = m.SPLIT_V
   })
   app.registerUi({
     ["menu"] = "Split images horizontally by largest white block",
     ["callback"] = "split",
-    ["mode"] = Mode.SPLIT_H
+    ["mode"] = m.SPLIT_H
   })
 end
 
@@ -67,21 +67,21 @@ function cb(mode)
     local im = images[i]
     local image = vips.Image.new_from_buffer(im["data"])
     local x, y, maxWidth, maxHeight = im["x"], im["y"], math.ceil(im["width"]), math.ceil(im["height"])
-    if mode == Mode.INVERT then
+    if mode == m.INVERT then
       image = image:invert()
-    elseif mode == Mode.DOWNSCALE then
+    elseif mode == m.DOWNSCALE then
       image = image:resize(0.5)
-    elseif mode == Mode.FLIP_H then
+    elseif mode == m.FLIP_H then
       image = image:flip("horizontal")
-    elseif mode == Mode.FLIP_V then
+    elseif mode == m.FLIP_V then
       image = image:flip("vertical")
-    elseif mode == Mode.ROTATE_CW then
+    elseif mode == m.ROTATE_CW then
       image = image:rot("d90")
       maxWidth, maxHeight = maxHeight, maxWidth
-    elseif mode == Mode.ROTATE_CCW then
+    elseif mode == m.ROTATE_CCW then
       image = image:rot("d270")
       maxWidth, maxHeight = maxHeight, maxWidth
-    elseif mode == Mode.TRANSPARENT then
+    elseif mode == m.TRANSPARENT then
       if image:bands() == 3 then
         image = image:bandjoin(255)       -- add alpha channel
       end
@@ -92,7 +92,7 @@ function cb(mode)
       -- 255 (true) for white enough pixels,
       -- 0 (false) otherwise
       image = filter:ifthenelse(transparent, image) -- now white enough pixels become transparent, other are taken from image
-    elseif mode == Mode.TRIM then
+    elseif mode == m.TRIM then
       local width = image:width()
       local height = image:height()
       image = image:crop(image:find_trim())
@@ -119,7 +119,7 @@ function split(mode)
   local vips = checkVips()
   if not vips then return end
 
-  local vertical = mode == Mode.SPLIT_V
+  local vertical = mode == m.SPLIT_V
   local images = app.getImages("selection")
   local imdata = {}
   for i = 1, #images do

--- a/plugins/ImageActions/main.lua
+++ b/plugins/ImageActions/main.lua
@@ -164,32 +164,32 @@ function split(mode)
       goto continue
     end
 
-    local maxLength = 0
-    local index = 0
+    local maxBlockLength = 0
+    local endIndex = 0
     for i = 1, #whiteEnds do
-      if whiteLengths[i] > maxLength then
-        maxLength = whiteLengths[i]
-        index = whiteEnds[i]
+      if whiteLengths[i] > maxBlockLength then
+        maxBlockLength = whiteLengths[i]
+        endIndex = whiteEnds[i]
       end
     end
     if vertical then
-      local image1 = image:extract_area(0, 0, width, index - maxLength // 2)
-      local image2 = image:extract_area(0, index - maxLength // 2, width, height - index + maxLength // 2)
+      local image1 = image:extract_area(0, 0, width, endIndex - maxBlockLength // 2)
+      local image2 = image:extract_area(0, endIndex - maxBlockLength // 2, width, height - endIndex + maxBlockLength // 2)
       table.insert(imdata, { data = image1:write_to_buffer(".png"), x = x, y = y, maxWidth = maxWidth })
       table.insert(imdata, {
         data = image2:write_to_buffer(".png"),
         maxWidth = maxWidth,
         x = x,
-        y = y + index * maxHeight / height,
+        y = y + endIndex * maxHeight / height,
       })
     else
-      local image1 = image:extract_area(0, 0, index - maxLength // 2, height)
-      local image2 = image:extract_area(index - maxLength // 2, 0, width - index + maxLength // 2, height)
+      local image1 = image:extract_area(0, 0, endIndex - maxBlockLength // 2, height)
+      local image2 = image:extract_area(endIndex - maxBlockLength // 2, 0, width - endIndex + maxBlockLength // 2, height)
       table.insert(imdata, { data = image1:write_to_buffer(".png"), x = x, y = y, maxHeight = maxHeight })
       table.insert(imdata, {
         data = image2:write_to_buffer(".png"),
         maxHeight = maxHeight,
-        x = x + index * maxWidth / width,
+        x = x + endIndex * maxWidth / width,
         y = y,
       })
     end

--- a/plugins/ImageActions/main.lua
+++ b/plugins/ImageActions/main.lua
@@ -48,8 +48,8 @@ local function checkVips()
   local hasVips, vips = pcall(require, "vips")
   if not hasVips then
     app.openDialog(
-      "You need to have lua-vips and luaffifb installed and included in your Lua package path in order to use this plugin. \n" ..
-      "See https://github.com/rolandlo/lua-vips/tree/fix-lua-5.3#installation for installation instructions.\n\n",
+      "You need to have lua-vips installed and included in your Lua package path in order to use this plugin. \n" ..
+      "Use luarocks install lua-vips and see https://github.com/libvips/lua-vips for further information.\n\n",
       { "OK" },
       "", true)
     return nil

--- a/plugins/ImageActions/main.lua
+++ b/plugins/ImageActions/main.lua
@@ -1,29 +1,31 @@
 function initUi()
-  app.registerUi({["menu"] = "Invert selected images", ["callback"] = "cb", ["mode"] = 1})
-  app.registerUi({["menu"] = "Downscale resolution of selected images by factor 0.5", ["callback"] = "cb", ["mode"] = 2})
-  app.registerUi({["menu"] = "Flip selected images horizontally", ["callback"] = "cb", ["mode"] = 3})
-  app.registerUi({["menu"] = "Flip selected images vertically", ["callback"] = "cb", ["mode"] = 4})
-  app.registerUi({["menu"] = "Rotate selected images 90 degree clockwise", ["callback"] = "cb", ["mode"] = 5})
-  app.registerUi({["menu"] = "Rotate selected images 90 degree counterclockwise", ["callback"] = "cb", ["mode"] = 6})
-  app.registerUi({["menu"] = "Make white pixels transparent", ["callback"] = "cb", ["mode"] = 7})
-  app.registerUi({["menu"] = "Trim selected images", ["callback"] = "cb", ["mode"] = 8})
-  app.registerUi({["menu"] = "Split images vertically by largest white block", ["callback"] = "cb", ["mode"] = 9})
-  app.registerUi({["menu"] = "Split images horizontally by largest white block", ["callback"] = "cb", ["mode"] = 10})
+  app.registerUi({ ["menu"] = "Invert selected images", ["callback"] = "cb", ["mode"] = 1 })
+  app.registerUi({ ["menu"] = "Downscale resolution of selected images by factor 0.5", ["callback"] = "cb", ["mode"] = 2 })
+  app.registerUi({ ["menu"] = "Flip selected images horizontally", ["callback"] = "cb", ["mode"] = 3 })
+  app.registerUi({ ["menu"] = "Flip selected images vertically", ["callback"] = "cb", ["mode"] = 4 })
+  app.registerUi({ ["menu"] = "Rotate selected images 90 degree clockwise", ["callback"] = "cb", ["mode"] = 5 })
+  app.registerUi({ ["menu"] = "Rotate selected images 90 degree counterclockwise", ["callback"] = "cb", ["mode"] = 6 })
+  app.registerUi({ ["menu"] = "Make white pixels transparent", ["callback"] = "cb", ["mode"] = 7 })
+  app.registerUi({ ["menu"] = "Trim selected images", ["callback"] = "cb", ["mode"] = 8 })
+  app.registerUi({ ["menu"] = "Split images vertically by largest white block", ["callback"] = "cb", ["mode"] = 9 })
+  app.registerUi({ ["menu"] = "Split images horizontally by largest white block", ["callback"] = "cb", ["mode"] = 10 })
 end
 
 function cb(mode)
   local images = app.getImages("selection")
   local hasVips, vips = pcall(require, "vips")
   if not hasVips then
-    app.openDialog("You need to have lua-vips and luaffifb installed and included in your Lua package path in order to use this plugin. \n" .. 
-               "See https://github.com/rolandlo/lua-vips/tree/fix-lua-5.3#installation for installation instructions.\n\n", {"OK"}, "", true)
+    app.openDialog(
+      "You need to have lua-vips and luaffifb installed and included in your Lua package path in order to use this plugin. \n" ..
+      "See https://github.com/rolandlo/lua-vips/tree/fix-lua-5.3#installation for installation instructions.\n\n", { "OK" },
+      "", true)
     return
   end
   local imdata = {}
-  for i=1,#images do
+  for i = 1, #images do
     local im = images[i]
     local image = vips.Image.new_from_buffer(im["data"])
-    local x, y, maxWidth, maxHeight=im["x"], im["y"], math.ceil(im["width"]), math.ceil(im["height"])
+    local x, y, maxWidth, maxHeight = im["x"], im["y"], math.ceil(im["width"]), math.ceil(im["height"])
     if mode == 1 then
       image = image:invert()
     elseif mode == 2 then
@@ -39,11 +41,11 @@ function cb(mode)
       image = image:rot("d270")
       maxWidth, maxHeight = maxHeight, maxWidth
     elseif mode == 7 then
-      if image:bands()<4 then
-        image = image:bandjoin(255) -- add alpha channel
+      if image:bands() < 4 then
+        image = image:bandjoin(255)    -- add alpha channel
       end
-      local white = {240, 240, 240, 0} -- pixels are considered white, if its r,g,b values are >=240 and alpha is arbitrary
-      local transparent = {0, 0, 0, 0}
+      local white = { 240, 240, 240, 0 } -- pixels are considered white, if its r,g,b values are >=240 and alpha is arbitrary
+      local transparent = { 0, 0, 0, 0 }
       image = image:more(white):bandand():ifthenelse(transparent, image)
     elseif mode == 8 then
       local width = image:width()
@@ -54,8 +56,9 @@ function cb(mode)
       maxWidth, maxHeight = maxWidth * newWidth // width, maxHeight * newHeight // height
     end
 
-    if mode ~= 9 and mode ~=10 then
-      table.insert(imdata, {data = image:write_to_buffer(".png"), x=x, y=y, maxWidth=maxWidth, maxHeight=maxHeight})
+    if mode ~= 9 and mode ~= 10 then
+      table.insert(imdata, { data = image:write_to_buffer(".png"), x = x, y = y, maxWidth = maxWidth, maxHeight =
+      maxHeight })
     else
       local vertical = mode == 9
       -- find largest sequence of white or transparent pixel rows/columns
@@ -67,17 +70,17 @@ function cb(mode)
 
       for i = 0, last - 1 do
         if vertical then
-          isWhite[i+1] = filter:extract_area(0, i, width, 1):avg() > 254
+          isWhite[i + 1] = filter:extract_area(0, i, width, 1):avg() > 254
         else
-          isWhite[i+1] = filter:extract_area(i, 0, 1, height):avg() > 254
+          isWhite[i + 1] = filter:extract_area(i, 0, 1, height):avg() > 254
         end
       end
 
       if #isWhite == 0 then
-        word = vertical and "rows" or "columns"
-        print("There are no completely white " .. word .. " in this image. Skipping.") 
-        table.insert(imdata, {data = im["data"], x=x, y=y, maxHeight=maxHeight, maxWidth=maxWidth})
-        goto continue 
+        local word = vertical and "rows" or "columns"
+        print("There are no completely white " .. word .. " in this image. Skipping.")
+        table.insert(imdata, { data = im["data"], x = x, y = y, maxHeight = maxHeight, maxWidth = maxWidth })
+        goto continue
       end
 
       local whiteEnds = {}
@@ -89,11 +92,11 @@ function cb(mode)
         if isWhite[i] then
           if currentLength > 0 then
             currentLength = currentLength + 1
-          else 
+          else
             currentLength = 1
             firstAfter = true
           end
-        else 
+        else
           if firstAfter then
             whiteEnds[n] = i - 1
             whiteLengths[n] = currentLength
@@ -108,7 +111,7 @@ function cb(mode)
 
       if #whiteEnds == 0 then
         print("Could not find a split")
-        table.insert(imdata, {data = im["data"], x=x, y=y, maxHeight=maxHeight, maxWidth=maxWidth})
+        table.insert(imdata, { data = im["data"], x = x, y = y, maxHeight = maxHeight, maxWidth = maxWidth })
         goto continue
       end
 
@@ -123,17 +126,19 @@ function cb(mode)
       if vertical then
         local image1 = image:extract_area(0, 0, width, index - maxLength // 2)
         local image2 = image:extract_area(0, index - maxLength // 2, width, height - index + maxLength // 2)
-        table.insert(imdata, {data = image1:write_to_buffer(".png"), x=x, y=y, maxWidth=maxWidth})
-        table.insert(imdata, {data = image2:write_to_buffer(".png"), x=x, y=y+index*maxHeight/height, maxWidth=maxWidth})
-      else 
+        table.insert(imdata, { data = image1:write_to_buffer(".png"), x = x, y = y, maxWidth = maxWidth })
+        table.insert(imdata, { data = image2:write_to_buffer(".png"), x = x, y = y + index * maxHeight / height, maxWidth =
+        maxWidth })
+      else
         local image1 = image:extract_area(0, 0, index - maxLength // 2, height)
         local image2 = image:extract_area(index - maxLength // 2, 0, width - index + maxLength // 2, height)
-        table.insert(imdata, {data = image1:write_to_buffer(".png"), x=x, y=y, maxHeight=maxHeight})
-        table.insert(imdata, {data = image2:write_to_buffer(".png"), x=x+index*maxWidth/width, y=y, maxHeight=maxHeight})
+        table.insert(imdata, { data = image1:write_to_buffer(".png"), x = x, y = y, maxHeight = maxHeight })
+        table.insert(imdata, { data = image2:write_to_buffer(".png"), x = x + index * maxWidth / width, y = y, maxHeight =
+        maxHeight })
       end
       ::continue::
     end
   end
-  app.uiAction({action = "ACTION_DELETE"})
-  app.addImages({images=imdata, allowUndoRedoAction = "grouped"})
+  app.uiAction({ action = "ACTION_DELETE" })
+  app.addImages({ images = imdata, allowUndoRedoAction = "grouped" })
 end

--- a/plugins/ImageActions/main.lua
+++ b/plugins/ImageActions/main.lua
@@ -13,27 +13,55 @@ local Mode = {
 
 function initUi()
   app.registerUi({ ["menu"] = "Invert selected images", ["callback"] = "cb", ["mode"] = Mode.INVERT })
-  app.registerUi({ ["menu"] = "Downscale resolution of selected images by factor 0.5", ["callback"] = "cb", ["mode"] = Mode.DOWNSCALE })
+  app.registerUi({
+    ["menu"] = "Downscale resolution of selected images by factor 0.5",
+    ["callback"] = "cb",
+    ["mode"] = Mode.DOWNSCALE
+  })
   app.registerUi({ ["menu"] = "Flip selected images horizontally", ["callback"] = "cb", ["mode"] = Mode.FLIP_H })
   app.registerUi({ ["menu"] = "Flip selected images vertically", ["callback"] = "cb", ["mode"] = Mode.FLIP_V })
-  app.registerUi({ ["menu"] = "Rotate selected images 90 degree clockwise", ["callback"] = "cb", ["mode"] = Mode.ROTATE_CW })
-  app.registerUi({ ["menu"] = "Rotate selected images 90 degree counterclockwise", ["callback"] = "cb", ["mode"] = Mode.ROTATE_CCW })
+  app.registerUi({
+    ["menu"] = "Rotate selected images 90 degree clockwise",
+    ["callback"] = "cb",
+    ["mode"] = Mode.ROTATE_CW
+  })
+  app.registerUi({
+    ["menu"] = "Rotate selected images 90 degree counterclockwise",
+    ["callback"] = "cb",
+    ["mode"] = Mode.ROTATE_CCW
+  })
   app.registerUi({ ["menu"] = "Make white pixels transparent", ["callback"] = "cb", ["mode"] = Mode.TRANSPARENT })
   app.registerUi({ ["menu"] = "Trim selected images", ["callback"] = "cb", ["mode"] = Mode.TRIM })
-  app.registerUi({ ["menu"] = "Split images vertically by largest white block", ["callback"] = "cb", ["mode"] = Mode.SPLIT_V })
-  app.registerUi({ ["menu"] = "Split images horizontally by largest white block", ["callback"] = "cb", ["mode"] = Mode.SPLIT_H })
+  app.registerUi({
+    ["menu"] = "Split images vertically by largest white block",
+    ["callback"] = "split",
+    ["mode"] = Mode.SPLIT_V
+  })
+  app.registerUi({
+    ["menu"] = "Split images horizontally by largest white block",
+    ["callback"] = "split",
+    ["mode"] = Mode.SPLIT_H
+  })
 end
 
-function cb(mode)
-  local images = app.getImages("selection")
+local function checkVips()
   local hasVips, vips = pcall(require, "vips")
   if not hasVips then
     app.openDialog(
       "You need to have lua-vips and luaffifb installed and included in your Lua package path in order to use this plugin. \n" ..
-      "See https://github.com/rolandlo/lua-vips/tree/fix-lua-5.3#installation for installation instructions.\n\n", { "OK" },
+      "See https://github.com/rolandlo/lua-vips/tree/fix-lua-5.3#installation for installation instructions.\n\n",
+      { "OK" },
       "", true)
-    return
+    return nil
   end
+  return vips
+end
+
+function cb(mode)
+  local vips = checkVips()
+  if not vips then return end
+
+  local images = app.getImages("selection")
   local imdata = {}
   for i = 1, #images do
     local im = images[i]
@@ -55,7 +83,7 @@ function cb(mode)
       maxWidth, maxHeight = maxHeight, maxWidth
     elseif mode == Mode.TRANSPARENT then
       if image:bands() < 4 then
-        image = image:bandjoin(255)    -- add alpha channel
+        image = image:bandjoin(255)      -- add alpha channel
       end
       local white = { 240, 240, 240, 0 } -- pixels are considered white, if its r,g,b values are >=240 and alpha is arbitrary
       local transparent = { 0, 0, 0, 0 }
@@ -68,89 +96,112 @@ function cb(mode)
       local newHeight = image:height()
       maxWidth, maxHeight = maxWidth * newWidth // width, maxHeight * newHeight // height
     end
+    table.insert(imdata, {
+      data = image:write_to_buffer(".png"),
+      x = x,
+      y = y,
+      maxWidth = maxWidth,
+      maxHeight = maxHeight
+    })
+  end
+  app.uiAction({ action = "ACTION_DELETE" })
+  app.addImages({ images = imdata, allowUndoRedoAction = "grouped" })
+end
 
-    if mode ~= Mode.SPLIT_V and mode ~= Mode.SPLIT_H then
-      table.insert(imdata, { data = image:write_to_buffer(".png"), x = x, y = y, maxWidth = maxWidth, maxHeight =
-      maxHeight })
-    else
-      local vertical = mode == Mode.SPLIT_V
-      -- find largest sequence of white or transparent pixel rows/columns
-      local filter = image:colourspace("b-w"):extract_band(0):more(240)
-      local width = filter:width()
-      local height = filter:height()
-      local last = vertical and height or width
-      local isWhite = {}
+function split(mode)
+  local vips = checkVips()
+  if not vips then return end
 
-      for i = 0, last - 1 do
-        if vertical then
-          isWhite[i + 1] = filter:extract_area(0, i, width, 1):avg() > 254
-        else
-          isWhite[i + 1] = filter:extract_area(i, 0, 1, height):avg() > 254
-        end
-      end
+  local vertical = mode == Mode.SPLIT_V
+  local images = app.getImages("selection")
+  local imdata = {}
+  for i = 1, #images do
+    local im = images[i]
+    local image = vips.Image.new_from_buffer(im["data"])
+    local x, y, maxWidth, maxHeight = im["x"], im["y"], math.ceil(im["width"]), math.ceil(im["height"])
+    -- find largest sequence of white or transparent pixel rows/columns
+    local filter = image:colourspace("b-w"):extract_band(0):more(240)
+    local width, height = filter:width(), filter:height()
+    local last = vertical and height or width
+    local isWhite = {}
 
-      if #isWhite == 0 then
-        local word = vertical and "rows" or "columns"
-        print("There are no completely white " .. word .. " in this image. Skipping.")
-        table.insert(imdata, { data = im["data"], x = x, y = y, maxHeight = maxHeight, maxWidth = maxWidth })
-        goto continue
-      end
-
-      local whiteEnds = {}
-      local whiteLengths = {}
-      local firstAfter = false
-      local currentLength = 0
-      local n = 0
-      for i = 1, last do
-        if isWhite[i] then
-          if currentLength > 0 then
-            currentLength = currentLength + 1
-          else
-            currentLength = 1
-            firstAfter = true
-          end
-        else
-          if firstAfter then
-            whiteEnds[n] = i - 1
-            whiteLengths[n] = currentLength
-            n = n + 1
-            firstAfter = false
-            currentLength = 0
-          end
-        end
-      end
-      whiteEnds[0] = nil
-      whiteLengths[0] = nil
-
-      if #whiteEnds == 0 then
-        print("Could not find a split")
-        table.insert(imdata, { data = im["data"], x = x, y = y, maxHeight = maxHeight, maxWidth = maxWidth })
-        goto continue
-      end
-
-      local maxLength = 0
-      local index = 0
-      for i = 1, #whiteEnds do
-        if whiteLengths[i] > maxLength then
-          maxLength = whiteLengths[i]
-          index = whiteEnds[i]
-        end
-      end
+    for i = 0, last - 1 do
       if vertical then
-        local image1 = image:extract_area(0, 0, width, index - maxLength // 2)
-        local image2 = image:extract_area(0, index - maxLength // 2, width, height - index + maxLength // 2)
-        table.insert(imdata, { data = image1:write_to_buffer(".png"), x = x, y = y, maxWidth = maxWidth })
-        table.insert(imdata, { data = image2:write_to_buffer(".png"), x = x, y = y + index * maxHeight / height, maxWidth =
-        maxWidth })
+        isWhite[i + 1] = filter:extract_area(0, i, width, 1):avg() > 254
       else
-        local image1 = image:extract_area(0, 0, index - maxLength // 2, height)
-        local image2 = image:extract_area(index - maxLength // 2, 0, width - index + maxLength // 2, height)
-        table.insert(imdata, { data = image1:write_to_buffer(".png"), x = x, y = y, maxHeight = maxHeight })
-        table.insert(imdata, { data = image2:write_to_buffer(".png"), x = x + index * maxWidth / width, y = y, maxHeight =
-        maxHeight })
+        isWhite[i + 1] = filter:extract_area(i, 0, 1, height):avg() > 254
       end
-      ::continue::
     end
+
+    if #isWhite == 0 then
+      local word = vertical and "rows" or "columns"
+      print("There are no completely white " .. word .. " in this image. Skipping.")
+      table.insert(imdata, { data = im["data"], x = x, y = y, maxHeight = maxHeight, maxWidth = maxWidth })
+      goto continue
+    end
+
+    local whiteEnds = {}
+    local whiteLengths = {}
+    local firstAfter = false
+    local currentLength = 0
+    local n = 0
+    for i = 1, last do
+      if isWhite[i] then
+        if currentLength > 0 then
+          currentLength = currentLength + 1
+        else
+          currentLength = 1
+          firstAfter = true
+        end
+      else
+        if firstAfter then
+          whiteEnds[n] = i - 1
+          whiteLengths[n] = currentLength
+          n = n + 1
+          firstAfter = false
+          currentLength = 0
+        end
+      end
+    end
+    whiteEnds[0] = nil
+    whiteLengths[0] = nil
+
+    if #whiteEnds == 0 then
+      print("Could not find a split")
+      table.insert(imdata, { data = im["data"], x = x, y = y, maxHeight = maxHeight, maxWidth = maxWidth })
+      goto continue
+    end
+
+    local maxLength = 0
+    local index = 0
+    for i = 1, #whiteEnds do
+      if whiteLengths[i] > maxLength then
+        maxLength = whiteLengths[i]
+        index = whiteEnds[i]
+      end
+    end
+    if vertical then
+      local image1 = image:extract_area(0, 0, width, index - maxLength // 2)
+      local image2 = image:extract_area(0, index - maxLength // 2, width, height - index + maxLength // 2)
+      table.insert(imdata, { data = image1:write_to_buffer(".png"), x = x, y = y, maxWidth = maxWidth })
+      table.insert(imdata, {
+        data = image2:write_to_buffer(".png"),
+        maxWidth = maxWidth,
+        x = x,
+        y = y + index * maxHeight / height,
+      })
+    else
+      local image1 = image:extract_area(0, 0, index - maxLength // 2, height)
+      local image2 = image:extract_area(index - maxLength // 2, 0, width - index + maxLength // 2, height)
+      table.insert(imdata, { data = image1:write_to_buffer(".png"), x = x, y = y, maxHeight = maxHeight })
+      table.insert(imdata, {
+        data = image2:write_to_buffer(".png"),
+        maxHeight = maxHeight,
+        x = x + index * maxWidth / width,
+        y = y,
+      })
+    end
+    ::continue::
   end
   app.uiAction({ action = "ACTION_DELETE" })
   app.addImages({ images = imdata, allowUndoRedoAction = "grouped" })

--- a/plugins/ImageActions/main.lua
+++ b/plugins/ImageActions/main.lua
@@ -12,34 +12,34 @@ local m = {
 }
 
 function initUi()
-  app.registerUi({ ["menu"] = "Invert selected images", ["callback"] = "cb", ["mode"] = m.INVERT })
+  app.registerUi({ ["menu"] = "Invert selected images", ["callback"] = "Cb", ["mode"] = m.INVERT })
   app.registerUi({
     ["menu"] = "Downscale resolution of selected images by factor 0.5",
-    ["callback"] = "cb",
+    ["callback"] = "Cb",
     ["mode"] = m.DOWNSCALE
   })
-  app.registerUi({ ["menu"] = "Flip selected images horizontally", ["callback"] = "cb", ["mode"] = m.FLIP_H })
-  app.registerUi({ ["menu"] = "Flip selected images vertically", ["callback"] = "cb", ["mode"] = m.FLIP_V })
+  app.registerUi({ ["menu"] = "Flip selected images horizontally", ["callback"] = "Cb", ["mode"] = m.FLIP_H })
+  app.registerUi({ ["menu"] = "Flip selected images vertically", ["callback"] = "Cb", ["mode"] = m.FLIP_V })
   app.registerUi({
     ["menu"] = "Rotate selected images 90 degree clockwise",
-    ["callback"] = "cb",
+    ["callback"] = "Cb",
     ["mode"] = m.ROTATE_CW
   })
   app.registerUi({
     ["menu"] = "Rotate selected images 90 degree counterclockwise",
-    ["callback"] = "cb",
+    ["callback"] = "Cb",
     ["mode"] = m.ROTATE_CCW
   })
-  app.registerUi({ ["menu"] = "Make white pixels transparent", ["callback"] = "cb", ["mode"] = m.TRANSPARENT })
-  app.registerUi({ ["menu"] = "Trim selected images", ["callback"] = "cb", ["mode"] = m.TRIM })
+  app.registerUi({ ["menu"] = "Make white pixels transparent", ["callback"] = "Cb", ["mode"] = m.TRANSPARENT })
+  app.registerUi({ ["menu"] = "Trim selected images", ["callback"] = "Cb", ["mode"] = m.TRIM })
   app.registerUi({
     ["menu"] = "Split images vertically by largest white block",
-    ["callback"] = "split",
+    ["callback"] = "Split",
     ["mode"] = m.SPLIT_V
   })
   app.registerUi({
     ["menu"] = "Split images horizontally by largest white block",
-    ["callback"] = "split",
+    ["callback"] = "Split",
     ["mode"] = m.SPLIT_H
   })
 end
@@ -57,7 +57,7 @@ local function checkVips()
   return vips
 end
 
-function cb(mode)
+function Cb(mode)
   local vips = checkVips()
   if not vips then return end
 
@@ -112,7 +112,7 @@ function cb(mode)
   app.addImages({ images = imdata, allowUndoRedoAction = "grouped" })
 end
 
-function split(mode)
+function Split(mode)
   PADDING = 15 -- margin between image parts
 
   local ffi = require "ffi"

--- a/plugins/ImageActions/main.lua
+++ b/plugins/ImageActions/main.lua
@@ -6,6 +6,9 @@ function initUi()
   app.registerUi({["menu"] = "Rotate selected images 90 degree clockwise", ["callback"] = "cb", ["mode"] = 5})
   app.registerUi({["menu"] = "Rotate selected images 90 degree counterclockwise", ["callback"] = "cb", ["mode"] = 6})
   app.registerUi({["menu"] = "Make white pixels transparent", ["callback"] = "cb", ["mode"] = 7})
+  app.registerUi({["menu"] = "Trim selected images", ["callback"] = "cb", ["mode"] = 8})
+  app.registerUi({["menu"] = "Split images vertically by largest white block", ["callback"] = "cb", ["mode"] = 9})
+  app.registerUi({["menu"] = "Split images horizontally by largest white block", ["callback"] = "cb", ["mode"] = 10})
 end
 
 function cb(mode)
@@ -16,11 +19,11 @@ function cb(mode)
                "See https://github.com/rolandlo/lua-vips/tree/fix-lua-5.3#installation for installation instructions.\n\n", {"OK"}, "", true)
     return
   end
-  imdata = {}
+  local imdata = {}
   for i=1,#images do
-    im = images[i]
-    image = vips.Image.new_from_buffer(im["data"])
-    x, y, maxWidth, maxHeight=im["x"], im["y"], math.ceil(im["width"]), math.ceil(im["height"])
+    local im = images[i]
+    local image = vips.Image.new_from_buffer(im["data"])
+    local x, y, maxWidth, maxHeight=im["x"], im["y"], math.ceil(im["width"]), math.ceil(im["height"])
     if mode == 1 then
       image = image:invert()
     elseif mode == 2 then
@@ -39,11 +42,97 @@ function cb(mode)
       if image:bands()<4 then
         image = image:bandjoin(255) -- add alpha channel
       end
-      white = {240, 240, 240, 0} -- pixels are considered white, if its r,g,b values are >=240 and alpha is arbitrary
-      transparent = {0, 0, 0, 0}
+      local white = {240, 240, 240, 0} -- pixels are considered white, if its r,g,b values are >=240 and alpha is arbitrary
+      local transparent = {0, 0, 0, 0}
       image = image:more(white):bandand():ifthenelse(transparent, image)
+    elseif mode == 8 then
+      local width = image:width()
+      local height = image:height()
+      image = image:crop(image:find_trim())
+      local newWidth = image:width()
+      local newHeight = image:height()
+      maxWidth, maxHeight = maxWidth * newWidth // width, maxHeight * newHeight // height
     end
-    table.insert(imdata, {data = image:write_to_buffer(".png"), x=x, y=y, maxWidth=maxWidth, maxHeight=maxHeight})
+
+    if mode ~= 9 and mode ~=10 then
+      table.insert(imdata, {data = image:write_to_buffer(".png"), x=x, y=y, maxWidth=maxWidth, maxHeight=maxHeight})
+    else
+      local vertical = mode == 9
+      -- find largest sequence of white or transparent pixel rows/columns
+      local filter = image:colourspace("b-w"):extract_band(0):more(240)
+      local width = filter:width()
+      local height = filter:height()
+      local last = vertical and height or width
+      local isWhite = {}
+
+      for i = 0, last - 1 do
+        if vertical then
+          isWhite[i+1] = filter:extract_area(0, i, width, 1):avg() > 254
+        else
+          isWhite[i+1] = filter:extract_area(i, 0, 1, height):avg() > 254
+        end
+      end
+
+      if #isWhite == 0 then
+        word = vertical and "rows" or "columns"
+        print("There are no completely white " .. word .. " in this image. Skipping.") 
+        table.insert(imdata, {data = im["data"], x=x, y=y, maxHeight=maxHeight, maxWidth=maxWidth})
+        goto continue 
+      end
+
+      local whiteEnds = {}
+      local whiteLengths = {}
+      local firstAfter = false
+      local currentLength = 0
+      local n = 0
+      for i = 1, last do
+        if isWhite[i] then
+          if currentLength > 0 then
+            currentLength = currentLength + 1
+          else 
+            currentLength = 1
+            firstAfter = true
+          end
+        else 
+          if firstAfter then
+            whiteEnds[n] = i - 1
+            whiteLengths[n] = currentLength
+            n = n + 1
+            firstAfter = false
+            currentLength = 0
+          end
+        end
+      end
+      whiteEnds[0] = nil
+      whiteLengths[0] = nil
+
+      if #whiteEnds == 0 then
+        print("Could not find a split")
+        table.insert(imdata, {data = im["data"], x=x, y=y, maxHeight=maxHeight, maxWidth=maxWidth})
+        goto continue
+      end
+
+      local maxLength = 0
+      local index = 0
+      for i = 1, #whiteEnds do
+        if whiteLengths[i] > maxLength then
+          maxLength = whiteLengths[i]
+          index = whiteEnds[i]
+        end
+      end
+      if vertical then
+        local image1 = image:extract_area(0, 0, width, index - maxLength // 2)
+        local image2 = image:extract_area(0, index - maxLength // 2, width, height - index + maxLength // 2)
+        table.insert(imdata, {data = image1:write_to_buffer(".png"), x=x, y=y, maxWidth=maxWidth})
+        table.insert(imdata, {data = image2:write_to_buffer(".png"), x=x, y=y+index*maxHeight/height, maxWidth=maxWidth})
+      else 
+        local image1 = image:extract_area(0, 0, index - maxLength // 2, height)
+        local image2 = image:extract_area(index - maxLength // 2, 0, width - index + maxLength // 2, height)
+        table.insert(imdata, {data = image1:write_to_buffer(".png"), x=x, y=y, maxHeight=maxHeight})
+        table.insert(imdata, {data = image2:write_to_buffer(".png"), x=x+index*maxWidth/width, y=y, maxHeight=maxHeight})
+      end
+      ::continue::
+    end
   end
   app.uiAction({action = "ACTION_DELETE"})
   app.addImages({images=imdata, allowUndoRedoAction = "grouped"})


### PR DESCRIPTION
This PR adds image trimming and image splitting (vertically or horizontally) according to the largest block of white rows (or columns) to the ImageActions plugin.

