### PR TITLE
Restore selection box size as prior to 62ac7b6

### DIFF
--- a/src/core/control/tools/EditSelection.cpp
+++ b/src/core/control/tools/EditSelection.cpp
@@ -219,10 +219,11 @@ EditSelection::EditSelection(Control* ctrl, InsertionOrder elts, const PageRef& 
         undo(ctrl->getUndoRedoHandler()),
         snappingHandler(ctrl->getSettings()) {
     // make the visible bounding box large enough so that anchors do not collapse even for horizontal/vertical strokes
-    x = bounds.minX - 1.5 * this->btnWidth;
-    y = bounds.minY - 1.5 * this->btnWidth;
-    width = bounds.getWidth() + 3 * this->btnWidth;
-    height = bounds.getHeight() + 3 * this->btnWidth;
+    const double PADDING = 12.;
+    x = bounds.minX - PADDING;
+    y = bounds.minY - PADDING;
+    width = bounds.getWidth() + 2 * PADDING;
+    height = bounds.getHeight() + 2 * PADDING;
 
     this->contents = std::make_unique<EditSelectionContents>(this->getRect(), this->snappedBounds, this->sourcePage,
                                                              this->sourceLayer, this->view);


### PR DESCRIPTION
Fix #5542

This just restores the behaviour from before https://github.com/xournalpp/xournalpp/commit/62ac7b6df1a872ce7c34a988d883e58e50ac0195

This behaviour is not the best either, I'll make something better in a follow up PR.