### PR TITLE
Make ok button default in export dialog

### DIFF
--- a/ui/exportSettings.glade
+++ b/ui/exportSettings.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.16"/>
   <object class="GtkAdjustment" id="adjustmentDpi">
@@ -92,6 +92,8 @@
                 <property name="name">btOk</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
+                <property name="has-focus">True</property>
+                <property name="is-focus">True</property>
                 <property name="receives-default">True</property>
                 <property name="use-stock">True</property>
               </object>


### PR DESCRIPTION
Fix #5557 

Note: This is only required on the release branch: this was already fixed on master with the dialog refactor.