### PR TITLE
Fix path separator for Windows

### DIFF
--- a/plugins/MigrateFontSizes/main.lua
+++ b/plugins/MigrateFontSizes/main.lua
@@ -3,7 +3,8 @@ function initUi()
   app.registerUi({["menu"] = "Migrate font sizes with factor displayDPI / 72", ["callback"] = "migrate"});
   app.registerUi({["menu"] = "Show font size migration dialog", ["callback"] = "showDialog"});
 
-  sourcePath = debug.getinfo(1).source:match("@?(.*/)")
+  local sep = package.config:sub(1, 1) -- path separator depends on OS
+  sourcePath = debug.getinfo(1).source:match("@?(.*" .. sep .. ")")
 end
 
 function migrate()


### PR DESCRIPTION
Now that `lgi` is shown to work on Windows (see installation instructions [here](https://github.com/xournalpp/xournalpp/discussions/4522#discussioncomment-4490657)) plugins must care about OS specific stuff like path separators.