### PR TITLE
Add lgi and lua-vips modules for Windows

### DIFF
--- a/azure-pipelines/steps/build_windows.yml
+++ b/azure-pipelines/steps/build_windows.yml
@@ -11,12 +11,32 @@ steps:
       pacman --noconfirm -S mingw-w64-x86_64-imagemagick mingw-w64-x86_64-ninja mingw-w64-x86_64-poppler
       pacman --noconfirm -S mingw-w64-x86_64-gtk3 mingw-w64-x86_64-libsndfile mingw-w64-x86_64-libzip
       pacman --noconfirm -S mingw-w64-x86_64-lua mingw-w64-x86_64-portaudio mingw-w64-x86_64-gtksourceview4
+      pacman --noconfirm -S mingw-w64-x86_64-lua-luarocks mingw-w64-x86_64-gobject-introspection
     env:
       MSYS2_ARCH: x86_64
       MSYSTEM: MINGW64
       CHERE_INVOKING: yes
     displayName: 'Install dependencies on Windows'
   # End msys setup
+  - script: |
+      set PATH=C:\msys64\usr\bin;C:\msys64\mingw64\bin;%PATH%
+      C:\msys64\usr\bin\bash -lc "luarocks config --scope system lua_version 5.4"
+      C:\msys64\usr\bin\bash -lc "luarocks"
+      git clone https://github.com/lgi-devs/lgi.git
+      pushd lgi
+      C:\msys64\usr\bin\bash -lc "luarocks --tree $HOME/.luarocks make"
+      popd
+      C:\msys64\usr\bin\bash -lc "luarocks --tree $HOME/.luarocks install luaffi-tkl"
+      popd
+      git clone https://github.com/libvips/lua-vips.git
+      pushd lua-vips
+      C:\msys64\usr\bin\bash -lc "luarocks --tree $HOME/.luarocks make"
+      popd
+    env:
+      MSYS2_ARCH: x86_64
+      MSYSTEM: MINGW64
+      CHERE_INVOKING: yes
+    displayName: 'Make and install Lua modules'
   - script: |
       set PATH="C:\msys64\usr\bin;C:\msys64\mingw64\bin;%PATH%"
       C:\msys64\usr\bin\bash -lc "mkdir build"

--- a/windows-setup/package.sh
+++ b/windows-setup/package.sh
@@ -67,6 +67,14 @@ cp /mingw64/bin/gspawn-win64-helper-console.exe "$setup_dir"/bin
 echo "copy gdbus"
 cp /mingw64/bin/gdbus.exe "$setup_dir"/bin
 
+echo "copy Lua modules and gobject-introspection files"
+mkdir -p "$setup_dir"/share/lua/5.4
+cp -r $HOME/.luarocks/share/lua/5.4/ "$setup_dir"/share/lua
+mkdir -p "$setup_dir"/lib/lua/5.4
+cp -r $HOME/.luarocks/lib/lua/5.4/ "$setup_dir"/lib/lua
+mkdir -p "$setup_dir"/share/gir-1.0
+cp /mingw64/share/gir-1.0/*.gir "$setup_dir"/share/gir-1.0
+
 echo "create installer"
 bash make_version_nsh.sh
 "/c/Program Files (x86)/NSIS/Bin/makensis.exe" xournalpp.nsi


### PR DESCRIPTION
This PR adds the `lgi` module and the `lua-vips` module (together with its dependency `luaffi-tkl`) and gobject-introspection files for `lgi` to the Windows build. This allows to write plugins that create non-trivial GUI with Gtk (using `lgi`) or do image manipulations (using `lua-vips`). For Windows users it wasn't possible until now to install these useful modules without modifying the source code.