### PR TITLE
Improved edge panning on large selections

### DIFF
--- a/src/core/control/tools/EditSelection.cpp
+++ b/src/core/control/tools/EditSelection.cpp
@@ -857,24 +857,40 @@ bool EditSelection::handleEdgePan(EditSelection* self) {
 
     // Helper function to compute scroll amount for a single dimension, based on visible region and selection bbox
     const auto computeScrollAmt = [&](double visMin, double visLen, double bboxMin, double bboxLen,
-                                      double layoutSize) -> double {
+                                      double layoutSize, double relMousePos) -> double {
         const bool belowMin = bboxMin < visMin;
         const bool aboveMax = bboxMin + bboxLen > visMin + visLen;
         const double visMax = visMin + visLen;
         const double bboxMax = bboxMin + bboxLen;
 
+        const bool isLargeSelection = bboxLen > visLen;
+        const auto centerVis = (visMin + visLen / 2);
+        const auto mouseDiff = (bboxMin + relMousePos * zoom - centerVis);
+
         // Scroll amount multiplier
         double mult = 0.0;
 
-        // Calculate bonus scroll amount due to proportion of selection out of view.
         const double maxMult = settings->getEdgePanMaxMult();
         int panDir = 0;
-        if (aboveMax) {
-            panDir = 1;
-            mult = maxMult * std::min(bboxLen, bboxMax - visMax) / bboxLen;
-        } else if (belowMin) {
-            panDir = -1;
-            mult = maxMult * std::min(bboxLen, visMin - bboxMin) / bboxLen;
+
+        // If the selection is larger than the view, scroll based on mouse position relative to the center of the visible view
+        // Otherwise calculate bonus scroll amount due to proportion of selection out of view.
+        if (isLargeSelection) {
+            mult = maxMult * std::abs(mouseDiff) / (visLen);
+            if (mouseDiff > 0.1 * visLen / 2.0) {
+                panDir = 1;
+            } else if (mouseDiff < -0.1 * visLen / 2.0) {
+                panDir = -1;
+            }
+        }
+        else {
+            if (aboveMax) {
+                panDir = 1;
+                mult = maxMult * std::min(bboxLen, bboxMax - visMax) / bboxLen;
+            } else if (belowMin) {
+                panDir = -1;
+                mult = maxMult * std::min(bboxLen, visMin - bboxMin) / bboxLen;
+            }
         }
 
         // Base amount to translate selection (in document coordinates) per timer tick
@@ -893,14 +909,13 @@ bool EditSelection::handleEdgePan(EditSelection* self) {
 
         return layoutScroll;
     };
-
     // Compute scroll (for layout) and translation (for selection) for x and y
     const int layoutWidth = layout->getMinimalWidth();
     const int layoutHeight = layout->getMinimalHeight();
     const auto visRect = layout->getVisibleRect();
     const auto bbox = self->getBoundingBoxInView();
-    const auto layoutScrollX = computeScrollAmt(visRect.x, visRect.width, bbox.x, bbox.width, layoutWidth);
-    const auto layoutScrollY = computeScrollAmt(visRect.y, visRect.height, bbox.y, bbox.height, layoutHeight);
+    const auto layoutScrollX = computeScrollAmt(visRect.x, visRect.width, bbox.x, bbox.width, layoutWidth, self->relMousePosX);
+    const auto layoutScrollY = computeScrollAmt(visRect.y, visRect.height, bbox.y, bbox.height, layoutHeight, self->relMousePosY);
     const auto translateX = layoutScrollX / zoom;
     const auto translateY = layoutScrollY / zoom;
 


### PR DESCRIPTION
This PR fixes issues mentioned in #4476 and #4172.

It can be difficult to move around selections larger than the view (in either dimension) due to the current edge pan handler only considering how far the selection is outside of the view.

 I fixed this by also considering (for only the large selections) how far the mouse position is from the center of the view, and then only panning if it's outside of a specified range from the middle (it feels nicer than if it were to just always move when you click on a selection).

I tried to fix this about a year ago in #4813 with a nearly identical solution but it was crashing for someone else in `PageView::getXournal()` (the backtrace can be seen in #4813). I have been unable to get it to crash in my testing and I'm unsure to why it was crashing with my previous additions at all.