### PR TITLE
clang-format improvement,

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -48,6 +48,7 @@ BreakInheritanceList: AfterColon
 BreakBeforeTernaryOperators: false
 BreakConstructorInitializersBeforeComma: false
 BreakConstructorInitializers: AfterColon
+BreakAfterAttributes: Leave
 BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: true
 ColumnLimit: 120


### PR DESCRIPTION
Automatic handling of attributes may decrease readability: No good default, therefore using 'Leave'