### PR TITLE
Move Point from `::utl::` to `xoj::util::`

### DIFF
--- a/src/core/control/CompassController.cpp
+++ b/src/core/control/CompassController.cpp
@@ -14,34 +14,34 @@ CompassController::~CompassController() = default;
 
 auto CompassController::getType() const -> GeometryToolType { return GeometryToolType::COMPASS; }
 
-auto CompassController::posRelToSide(double x, double y) const -> utl::Point<double> {
+auto CompassController::posRelToSide(double x, double y) const -> xoj::util::Point<double> {
     cairo_matrix_t inv = geometryTool->getMatrix();
     cairo_matrix_invert(&inv);
     cairo_matrix_transform_point(&inv, &x, &y);
-    return utl::Point<double>(x, -y);
+    return xoj::util::Point<double>(x, -y);
 }
 
 auto CompassController::isInsideGeometryTool(double x, double y, double border) const -> bool {
-    const utl::Point<double> p = posRelToSide(x, y);
+    const xoj::util::Point<double> p = posRelToSide(x, y);
     return std::hypot(p.x, p.y) <= geometryTool->getHeight() + border;
 }
 
-auto CompassController::getPointForAngle(double a) const -> utl::Point<double> {
+auto CompassController::getPointForAngle(double a) const -> xoj::util::Point<double> {
     cairo_matrix_t matrix = geometryTool->getMatrix();
     double x = geometryTool->getHeight() * std::cos(a);
     double y = geometryTool->getHeight() * std::sin(a);
     cairo_matrix_transform_point(&matrix, &x, &y);
 
-    return utl::Point<double>(x, y);
+    return xoj::util::Point<double>(x, y);
 }
 
-auto CompassController::getPointForRadius(double r) const -> utl::Point<double> {
+auto CompassController::getPointForRadius(double r) const -> xoj::util::Point<double> {
     cairo_matrix_t matrix = geometryTool->getMatrix();
     double x = r;
     double y = 0.;
     cairo_matrix_transform_point(&matrix, &x, &y);
 
-    return utl::Point<double>(x, y);
+    return xoj::util::Point<double>(x, y);
 }
 
 void CompassController::createOutlineStroke(double a) {
@@ -49,7 +49,7 @@ void CompassController::createOutlineStroke(double a) {
         angleMax = a;
         angleMin = a;
 
-        const utl::Point<double> p = this->getPointForAngle(a);
+        const xoj::util::Point<double> p = this->getPointForAngle(a);
         initializeStroke();
         stroke->addPoint(Point(p.x, p.y));
         stroke->addPoint(Point(p.x, p.y));  // doubled point
@@ -64,7 +64,7 @@ void CompassController::createRadialStroke(double x) {
         radiusMax = x;
         radiusMin = x;
 
-        const utl::Point<double> p = posRelToSide(x, 0.);
+        const xoj::util::Point<double> p = posRelToSide(x, 0.);
         initializeStroke();
         stroke->addPoint(Point(p.x, p.y));
         stroke->addPoint(Point(p.x, p.y));  // doubled point
@@ -80,13 +80,14 @@ void CompassController::updateOutlineStroke(double x) {
     stroke->deletePointsFrom(0);
     const auto h = view->getXournal()->getControl()->getToolHandler();
     const bool filled = (h->getFill() != -1);
-    const utl::Point<double> c = utl::Point<double>{geometryTool->getTranslationX(), geometryTool->getTranslationY()};
+    const xoj::util::Point<double> c =
+            xoj::util::Point<double>{geometryTool->getTranslationX(), geometryTool->getTranslationY()};
 
     if (filled && angleMax < angleMin + 2 * M_PI) {
         stroke->addPoint(Point(c.x, c.y));
     }
     for (auto i = 0; i <= 100; i++) {
-        const utl::Point<double> p =
+        const xoj::util::Point<double> p =
                 getPointForAngle(angleMin + static_cast<double>(i) / 100.0 * (angleMax - angleMin));
         stroke->addPoint(Point(p.x, p.y));
     }
@@ -100,8 +101,8 @@ void CompassController::updateRadialStroke(double x) {
     radiusMax = std::max(this->radiusMax, x);
     radiusMin = std::min(this->radiusMin, x);
     stroke->deletePointsFrom(0);
-    const utl::Point<double> p1 = getPointForRadius(radiusMin);
-    const utl::Point<double> p2 = getPointForRadius(radiusMax);
+    const xoj::util::Point<double> p1 = getPointForRadius(radiusMin);
+    const xoj::util::Point<double> p2 = getPointForRadius(radiusMax);
 
     stroke->addPoint(Point(p1.x, p1.y));
     stroke->addPoint(Point(p2.x, p2.y));

--- a/src/core/control/CompassController.h
+++ b/src/core/control/CompassController.h
@@ -47,7 +47,7 @@ public:
      * @param x the x-coordinate of the point (in document coordinates)
      * @param y the y-coordinate of the point (in document coordinates)
      */
-    utl::Point<double> posRelToSide(double x, double y) const;
+    xoj::util::Point<double> posRelToSide(double x, double y) const;
 
     /**
      * @brief checks whether a point with given coordinates lies in the geometry tool with an additional
@@ -62,14 +62,14 @@ public:
      * @brief the point (in document coordinates) for a given angle on the outline of the compass
      * @param a the angle with respect to the distinguished compass axis of the point
      */
-    utl::Point<double> getPointForAngle(double a) const;
+    xoj::util::Point<double> getPointForAngle(double a) const;
 
     /**
      * @brief the point (in document coordinates) for a given radius on the marked radius of the compass
      * @param r the x-coordinate with respect to a coordinate system, in which the positive x-axis
      * coincides with the marked radius and the origin lies in the center of the compass
      */
-    utl::Point<double> getPointForRadius(double r) const;
+    xoj::util::Point<double> getPointForRadius(double r) const;
 
     /**
      * @brief creates a stroke starting at the given angle of the outline of the compass

--- a/src/core/control/SetsquareController.cpp
+++ b/src/core/control/SetsquareController.cpp
@@ -16,17 +16,19 @@ SetsquareController::~SetsquareController() = default;
 
 auto SetsquareController::getType() const -> GeometryToolType { return GeometryToolType::SETSQUARE; }
 
-auto SetsquareController::posRelToSide(Leg leg, double x, double y) const -> utl::Point<double> {
+auto SetsquareController::posRelToSide(Leg leg, double x, double y) const -> xoj::util::Point<double> {
     cairo_matrix_t matrix = geometryTool->getMatrix();
     cairo_matrix_invert(&matrix);
     cairo_matrix_transform_point(&matrix, &x, &y);
     switch (leg) {
         case HYPOTENUSE:
-            return utl::Point<double>(x, -y);
+            return xoj::util::Point<double>(x, -y);
         case LEFT_LEG:
-            return utl::Point<double>((y + x) / std::sqrt(2.), (y - x - geometryTool->getHeight()) / std::sqrt(2.));
+            return xoj::util::Point<double>((y + x) / std::sqrt(2.),
+                                            (y - x - geometryTool->getHeight()) / std::sqrt(2.));
         case RIGHT_LEG:
-            return utl::Point<double>((y - x) / std::sqrt(2.), (y + x - geometryTool->getHeight()) / std::sqrt(2.));
+            return xoj::util::Point<double>((y - x) / std::sqrt(2.),
+                                            (y + x - geometryTool->getHeight()) / std::sqrt(2.));
         default:
             g_error("Invalid enum value: %d", leg);
     }
@@ -37,13 +39,13 @@ auto SetsquareController::isInsideGeometryTool(double x, double y, double border
            posRelToSide(RIGHT_LEG, x, y).y < border;
 }
 
-auto SetsquareController::getPointForPos(double xCoord) const -> utl::Point<double> {
+auto SetsquareController::getPointForPos(double xCoord) const -> xoj::util::Point<double> {
     double x = xCoord;
     double y = 0.0;
     cairo_matrix_t matrix = geometryTool->getMatrix();
     cairo_matrix_transform_point(&matrix, &x, &y);
 
-    return utl::Point<double>(x, y);
+    return xoj::util::Point<double>(x, y);
 }
 
 void SetsquareController::createEdgeStroke(double x) {

--- a/src/core/control/SetsquareController.h
+++ b/src/core/control/SetsquareController.h
@@ -49,7 +49,7 @@ public:
      * @param x the x-coordinate of the point (in document coordinates)
      * @param y the y-coordinate of the point (in document coordinates)
      */
-    utl::Point<double> posRelToSide(Leg leg, double x, double y) const;
+    xoj::util::Point<double> posRelToSide(Leg leg, double x, double y) const;
 
     /**
      * @brief checks whether a point with given coordinates lies in the setsquare with an additional border enlarging
@@ -64,7 +64,7 @@ public:
      * @brief the point (in document coordinates) for a given position on the longest side of the setsquare
      * @param x the x-coordinate of the point on the longest side of the setsquare (when unrotated and untranslated)
      */
-    utl::Point<double> getPointForPos(double x) const;
+    xoj::util::Point<double> getPointForPos(double x) const;
 
     /**
      * @brief creates a stroke starting at the given position of the longest side of the setsquare

--- a/src/core/control/tools/Selection.h
+++ b/src/core/control/tools/Selection.h
@@ -29,7 +29,7 @@ public:
     Selection(bool multiLayer);
     ~Selection() override;
 
-    using BoundaryPoint = utl::Point<double>;
+    using BoundaryPoint = xoj::util::Point<double>;
 
 public:
     /**

--- a/src/core/control/tools/StrokeHandler.cpp
+++ b/src/core/control/tools/StrokeHandler.cpp
@@ -38,7 +38,7 @@
 
 #include "StrokeStabilizer.h"  // for Base, get
 
-using namespace xoj::util;
+using xoj::util::Rectangle;
 
 StrokeHandler::StrokeHandler(Control* control, const PageRef& page):
         InputHandler(control, page),

--- a/src/core/control/zoom/ZoomControl.cpp
+++ b/src/core/control/zoom/ZoomControl.cpp
@@ -35,7 +35,7 @@ auto onScrolledwindowMainScrollEvent(GtkWidget* widget, GdkEventScroll* event, Z
                         ZOOM_IN :
                         ZOOM_OUT;
         // translate absolute window coordinates to the widget-local coordinates and start zooming
-        zoom->zoomScroll(direction, Util::toWidgetCoords(widget, utl::Point{event->x_root, event->y_root}));
+        zoom->zoomScroll(direction, Util::toWidgetCoords(widget, xoj::util::Point{event->x_root, event->y_root}));
         return true;
     }
 
@@ -51,7 +51,7 @@ auto onTouchpadPinchEvent(GtkWidget* widget, GdkEventTouchpadPinch* event, ZoomC
                     zoom->setZoomFitMode(false);
                 }
                 // translate absolute window coordinates to the widget-local coordinates and start zooming
-                zoom->startZoomSequence(Util::toWidgetCoords(widget, utl::Point{event->x_root, event->y_root}));
+                zoom->startZoomSequence(Util::toWidgetCoords(widget, xoj::util::Point{event->x_root, event->y_root}));
                 break;
             case GDK_TOUCHPAD_GESTURE_PHASE_UPDATE:
                 zoom->zoomSequenceChange(event->scale, true);
@@ -104,7 +104,7 @@ auto ZoomControl::withZoomStep(ZoomDirection direction, double zoomStep) const -
     return newZoom;
 }
 
-void ZoomControl::zoomOneStep(ZoomDirection direction, utl::Point<double> zoomCenter) {
+void ZoomControl::zoomOneStep(ZoomDirection direction, xoj::util::Point<double> zoomCenter) {
     if (this->zoomPresentationMode) {
         return;
     }
@@ -123,7 +123,7 @@ void ZoomControl::zoomOneStep(ZoomDirection direction) {
 }
 
 
-void ZoomControl::zoomScroll(ZoomDirection direction, utl::Point<double> zoomCenter) {
+void ZoomControl::zoomScroll(ZoomDirection direction, xoj::util::Point<double> zoomCenter) {
     if (this->zoomPresentationMode) {
         return;
     }
@@ -143,7 +143,7 @@ void ZoomControl::startZoomSequence() {
     startZoomSequence({rect.width / 2.0, rect.height / 2.0});
 }
 
-void ZoomControl::startZoomSequence(utl::Point<double> zoomCenter) {
+void ZoomControl::startZoomSequence(xoj::util::Point<double> zoomCenter) {
     // * set zoom center and zoom startlevel
     this->zoomWidgetPos = zoomCenter;  // widget space coordinates of the zoomCenter!
     this->zoomSequenceStart = this->zoom;
@@ -164,7 +164,7 @@ void ZoomControl::startZoomSequence(utl::Point<double> zoomCenter) {
 
     // * set initial scrollPosition value
     auto const& rect = getVisibleRect();
-    auto const& view_pos = utl::Point{rect.x, rect.y};
+    auto const& view_pos = xoj::util::Point{rect.x, rect.y};
 
     // Use this->zoomWidgetPos to zoom into a location other than the top-left (e.g. where
     // the user pinched).
@@ -183,7 +183,7 @@ void ZoomControl::zoomSequenceChange(double zoom, bool relative) {
     setZoom(zoom);
 }
 
-void ZoomControl::zoomSequenceChange(double zoom, bool relative, utl::Point<double> scrollVector) {
+void ZoomControl::zoomSequenceChange(double zoom, bool relative, xoj::util::Point<double> scrollVector) {
     if (relative) {
         if (isZoomSequenceActive()) {
             zoom *= zoomSequenceStart;
@@ -218,7 +218,7 @@ auto ZoomControl::getVisibleRect() -> Rectangle<double> {
     return layout->getVisibleRect();
 }
 
-auto ZoomControl::getScrollPositionAfterZoom() const -> utl::Point<double> {
+auto ZoomControl::getScrollPositionAfterZoom() const -> xoj::util::Point<double> {
     //  If we aren't in a zoomSequence, `unscaledPixels`, `scrollPosition`, and `zoomWidgetPos
     // can't be used to determine the scroll position! Return now.
     // NOTE: this case should never happen currently.

--- a/src/core/control/zoom/ZoomControl.h
+++ b/src/core/control/zoom/ZoomControl.h
@@ -43,7 +43,7 @@ public:
      * @param direction direction to zoom in or out
      * @param zoomCenter position of zoom focus
      */
-    void zoomOneStep(ZoomDirection direction, utl::Point<double> zoomCenter);
+    void zoomOneStep(ZoomDirection direction, xoj::util::Point<double> zoomCenter);
     void zoomOneStep(ZoomDirection direction);
 
     /**
@@ -52,7 +52,7 @@ public:
      * @param direction to zoom in or out
      * @param zoomCenter position of zoom focus
      */
-    void zoomScroll(ZoomDirection direction, utl::Point<double> zoomCenter);
+    void zoomScroll(ZoomDirection direction, xoj::util::Point<double> zoomCenter);
 
     /**
      * Zoom so that the page fits the current size of the window
@@ -129,7 +129,7 @@ public:
      * is, absolute coordinates (not scaling with the document) translated to the
      * top left corner of the drawing area.
      */
-    void startZoomSequence(utl::Point<double> zoomCenter);
+    void startZoomSequence(xoj::util::Point<double> zoomCenter);
 
     /**
      * Call this before any zoom is done, it saves the current page and position
@@ -153,7 +153,7 @@ public:
      * @param relative If the zoom is relative to the start value (for Gesture)
      * @param scrollVector relative zoom center movement in pixels since last call
      */
-    void zoomSequenceChange(double zoom, bool relative, utl::Point<double> scrollVector);
+    void zoomSequenceChange(double zoom, bool relative, xoj::util::Point<double> scrollVector);
 
     /// Clear all stored data from startZoomSequence()
     void endZoomSequence();
@@ -168,7 +168,7 @@ public:
      * Zoom to correct position on zooming.
      * This function should only be called during a zoom sequence.
      */
-    utl::Point<double> getScrollPositionAfterZoom() const;
+    xoj::util::Point<double> getScrollPositionAfterZoom() const;
 
     /// Get visible rect on xournal view, for Zoom Gesture
     xoj::util::Rectangle<double> getVisibleRect();
@@ -223,14 +223,14 @@ private:
     double zoomSequenceStart = -1;
 
     /// Zoom center position in widget coordinate space, will not be zoomed!
-    utl::Point<double> zoomWidgetPos;
+    xoj::util::Point<double> zoomWidgetPos;
 
     /// Scroll position (top left corner of view) to scale
-    utl::Point<double> scrollPosition;
+    xoj::util::Point<double> scrollPosition;
 
     /// Size {x, y} of the pixels before the current page that
     /// do not scale.
-    utl::Point<double> unscaledPixels;
+    xoj::util::Point<double> unscaledPixels;
 
     /**
      * Zoomstep value for Ctrl - and Zoom In and Out Button

--- a/src/core/gui/MainWindow.cpp
+++ b/src/core/gui/MainWindow.cpp
@@ -192,8 +192,8 @@ void MainWindow::setGtkTouchscreenScrollingEnabled(bool enabled) {
 
 auto MainWindow::getLayout() const -> Layout* { return gtk_xournal_get_layout(this->xournal->getWidget()); }
 
-auto MainWindow::getNegativeXournalWidgetPos() const -> utl::Point<double> {
-    return Util::toWidgetCoords(this->winXournal, utl::Point{0.0, 0.0});
+auto MainWindow::getNegativeXournalWidgetPos() const -> xoj::util::Point<double> {
+    return Util::toWidgetCoords(this->winXournal, xoj::util::Point{0.0, 0.0});
 }
 
 auto cancellable_cancel(GCancellable* cancel) -> bool {

--- a/src/core/gui/MainWindow.h
+++ b/src/core/gui/MainWindow.h
@@ -112,7 +112,7 @@ public:
      *
      * @see Util::toWidgetCoords()
      */
-    utl::Point<double> getNegativeXournalWidgetPos() const;
+    xoj::util::Point<double> getNegativeXournalWidgetPos() const;
 
     /**
      * Disable kinetic scrolling if there is a touchscreen device that was manually mapped to another enabled input

--- a/src/core/gui/inputdevices/GeometryToolInputHandler.cpp
+++ b/src/core/gui/inputdevices/GeometryToolInputHandler.cpp
@@ -82,7 +82,7 @@ auto GeometryToolInputHandler::handleTouchscreen(InputEvent const& event) -> boo
     if (event.type == BUTTON_PRESS_EVENT) {
         // Start scrolling when a sequence starts and we currently have none other
         if (this->primarySequence == nullptr && this->secondarySequence == nullptr) {
-            const utl::Point<double> coords = getCoords(event);
+            const xoj::util::Point<double> coords = getCoords(event);
 
             if (controller->isInsideGeometryTool(coords.x, coords.y, 0)) {
                 // Set sequence data
@@ -195,7 +195,7 @@ auto GeometryToolInputHandler::handleKeyboard(InputEvent const& event) -> bool {
             return true;
         }
 
-        auto p = utl::Point(translationX, translationY);
+        auto p = xoj::util::Point(translationX, translationY);
         if (angle != 0) {
             controller->rotate(angle, p.x, p.y);
             return true;
@@ -236,13 +236,13 @@ void GeometryToolInputHandler::sequenceStart(InputEvent const& event) {
 void GeometryToolInputHandler::scrollMotion(InputEvent const& event) {
     // Will only be called if there is a single sequence (rotation/zooming handles two sequences)
     auto offset = [&]() {
-        utl::Point<double> coords = this->getCoords(event);
+        xoj::util::Point<double> coords = this->getCoords(event);
         if (event.sequence == this->primarySequence) {
-            const utl::Point<double> offset = coords - this->priLastPageRel;
+            const xoj::util::Point<double> offset = coords - this->priLastPageRel;
             this->priLastPageRel = coords;
             return offset;
         } else {
-            const utl::Point<double> offset = coords - this->secLastPageRel;
+            const xoj::util::Point<double> offset = coords - this->secLastPageRel;
             this->secLastPageRel = coords;
             return offset;
         }
@@ -275,7 +275,7 @@ void GeometryToolInputHandler::rotateAndZoomStart() {
     this->canBlockZoom = true;
 
     this->lastZoomScrollCenter = (this->priLastPageRel + this->secLastPageRel) / 2.0;
-    const utl::Point<double> shift = this->secLastPageRel - this->priLastPageRel;
+    const xoj::util::Point<double> shift = this->secLastPageRel - this->priLastPageRel;
     this->lastAngle = atan2(shift.y, shift.x);
     this->lastDist = this->startZoomDistance;
 }
@@ -298,14 +298,14 @@ void GeometryToolInputHandler::rotateAndZoomMotion(InputEvent const& event) {
         this->canBlockZoom = false;
     }
 
-    const utl::Point<double> center = (this->priLastPageRel + this->secLastPageRel) / 2;
-    const utl::Point<double> shift = this->secLastPageRel - this->priLastPageRel;
+    const xoj::util::Point<double> center = (this->priLastPageRel + this->secLastPageRel) / 2;
+    const xoj::util::Point<double> shift = this->secLastPageRel - this->priLastPageRel;
     const double angle = atan2(shift.y, shift.x);
 
-    const utl::Point<double> offset = center - lastZoomScrollCenter;
+    const xoj::util::Point<double> offset = center - lastZoomScrollCenter;
     controller->translate(offset.x, offset.y);
     const double angleIncrease = angle - lastAngle;
-    const utl::Point<double> centerRel = (this->priLastPageRel + this->secLastPageRel) / 2.0;
+    const xoj::util::Point<double> centerRel = (this->priLastPageRel + this->secLastPageRel) / 2.0;
     if (controller->isInsideGeometryTool(secLastPageRel.x, secLastPageRel.y, 0.0)) {
         controller->rotate(angleIncrease, centerRel.x, centerRel.y);
     }  // allow moving without accidental rotation
@@ -321,12 +321,12 @@ void GeometryToolInputHandler::rotateAndZoomMotion(InputEvent const& event) {
     this->lastDist = dist;
 }
 
-auto GeometryToolInputHandler::getCoords(InputEvent const& event) -> utl::Point<double> {
+auto GeometryToolInputHandler::getCoords(InputEvent const& event) -> xoj::util::Point<double> {
     const double zoom = xournal->getZoom();
     const auto view = controller->getView();
     const double posX = event.relativeX - static_cast<double>(view->getX());
     const double posY = event.relativeY - static_cast<double>(view->getY());
-    return utl::Point<double>(posX / zoom, posY / zoom);
+    return xoj::util::Point<double>(posX / zoom, posY / zoom);
 }
 
 void GeometryToolInputHandler::blockDevice(InputContext::DeviceType deviceType) { isBlocked[deviceType] = true; }

--- a/src/core/gui/inputdevices/GeometryToolInputHandler.h
+++ b/src/core/gui/inputdevices/GeometryToolInputHandler.h
@@ -76,13 +76,13 @@ protected:
     /**
      * @brief the previous mid point between the two fingers in a zoom sequence
      */
-    utl::Point<double> lastZoomScrollCenter{};
+    xoj::util::Point<double> lastZoomScrollCenter{};
 
     /**
      * @brief The current positions of the first (primary) finger and second (secondary) finger in page coordinates
      */
-    utl::Point<double> priLastPageRel{-1.0, -1.0};
-    utl::Point<double> secLastPageRel{-1.0, -1.0};
+    xoj::util::Point<double> priLastPageRel{-1.0, -1.0};
+    xoj::util::Point<double> secLastPageRel{-1.0, -1.0};
 
     /**
      * @brief The previous angle between the line through the positions of the two fingers and the x-axis
@@ -155,7 +155,7 @@ protected:
      * @brief the document coordinates derived from an input event
      * @param event an input event
      */
-    utl::Point<double> getCoords(InputEvent const& event);
+    xoj::util::Point<double> getCoords(InputEvent const& event);
 
     virtual double getMinHeight() const = 0;
     virtual double getMaxHeight() const = 0;

--- a/src/core/gui/inputdevices/PenInputHandler.cpp
+++ b/src/core/gui/inputdevices/PenInputHandler.cpp
@@ -184,7 +184,7 @@ double PenInputHandler::inferPressureValue(PositionInputData const& pos, XojPage
     PositionInputData lastPos = getInputDataRelativeToCurrentPage(page, this->lastEvent);
 
     double dt = (pos.timestamp - lastPos.timestamp) / 10.0;
-    double distance = utl::Point<double>(pos.x, pos.y).distance(utl::Point<double>(lastPos.x, lastPos.y));
+    double distance = xoj::util::Point<double>(pos.x, pos.y).distance(xoj::util::Point<double>(lastPos.x, lastPos.y));
     double inverseSpeed = dt / (distance + 0.001);
 
     // This doesn't have to be exact. Arctan is used here for its sigmoid-like shape,

--- a/src/core/gui/inputdevices/PenInputHandler.h
+++ b/src/core/gui/inputdevices/PenInputHandler.h
@@ -82,7 +82,7 @@ protected:
      */
     guint32 lastActionEndTimeStamp = 0U;
     guint32 lastActionStartTimeStamp = 0U;
-    utl::Point<double> sequenceStartPosition;
+    xoj::util::Point<double> sequenceStartPosition;
 
 public:
     explicit PenInputHandler(InputContext* inputContext);

--- a/src/core/gui/inputdevices/TouchInputHandler.cpp
+++ b/src/core/gui/inputdevices/TouchInputHandler.cpp
@@ -103,7 +103,7 @@ void TouchInputHandler::sequenceStart(InputEvent const& event) {
 void TouchInputHandler::scrollMotion(InputEvent const& event) {
     // Will only be called if there is a single sequence (zooming handles two sequences)
     auto offset = [&]() {
-        auto absolutePoint = utl::Point{event.absoluteX, event.absoluteY};
+        auto absolutePoint = xoj::util::Point{event.absoluteX, event.absoluteY};
         if (event.sequence == this->primarySequence) {
             auto offset = absolutePoint - this->priLastAbs;
             this->priLastAbs = absolutePoint;

--- a/src/core/gui/inputdevices/TouchInputHandler.h
+++ b/src/core/gui/inputdevices/TouchInputHandler.h
@@ -26,13 +26,13 @@ private:
     GdkEventSequence* secondarySequence{};
 
     double startZoomDistance = 0.0;
-    utl::Point<double> lastZoomScrollCenter{};
+    xoj::util::Point<double> lastZoomScrollCenter{};
 
-    utl::Point<double> priLastAbs{-1.0, -1.0};
-    utl::Point<double> secLastAbs{-1.0, -1.0};
+    xoj::util::Point<double> priLastAbs{-1.0, -1.0};
+    xoj::util::Point<double> secLastAbs{-1.0, -1.0};
 
-    utl::Point<double> priLastRel{-1.0, -1.0};
-    utl::Point<double> secLastRel{-1.0, -1.0};
+    xoj::util::Point<double> priLastRel{-1.0, -1.0};
+    xoj::util::Point<double> secLastRel{-1.0, -1.0};
 
     // True, if a zoom sequence may be started by a motion event.
     bool startZoomReady{false};

--- a/src/core/view/overlays/StrokeToolFilledView.cpp
+++ b/src/core/view/overlays/StrokeToolFilledView.cpp
@@ -50,7 +50,7 @@ void StrokeToolFilledView::on(StrokeToolView::StrokeReplacementRequest, const St
     this->filling.contour = this->pointBuffer;
     if (!this->pointBuffer.empty()) {
         const Point& fp = this->pointBuffer.front();
-        this->filling.firstPoint = utl::Point<double>(fp.x, fp.y);
+        this->filling.firstPoint = xoj::util::Point<double>(fp.x, fp.y);
     }
 }
 

--- a/src/core/view/overlays/StrokeToolFilledView.h
+++ b/src/core/view/overlays/StrokeToolFilledView.h
@@ -43,7 +43,7 @@ protected:
         FillingData(double alpha, const Point& p): alpha(alpha), firstPoint(p.x, p.y), contour{p} {}
 
         const double alpha;
-        utl::Point<double> firstPoint;  // Store a copy for safe concurrent access
+        xoj::util::Point<double> firstPoint;  // Store a copy for safe concurrent access
 
 
         void appendSegments(const std::vector<Point>& pts);

--- a/src/util/Util.cpp
+++ b/src/util/Util.cpp
@@ -48,14 +48,14 @@ auto Util::paintBackgroundWhite(GtkWidget* widget, cairo_t* cr, void*) -> gboole
     return false;
 }
 
-utl::Point<double> Util::toWidgetCoords(GtkWidget* widget, utl::Point<double> absolute_coords) {
+xoj::util::Point<double> Util::toWidgetCoords(GtkWidget* widget, xoj::util::Point<double> absolute_coords) {
     int rx, ry;
     // X11 uses absolute screen coordinates while Wayland uses absolute window coordinates.
     // Converting them to widget-local coordinates will cancel out this difference.
     // `gtk_widget_get_window` doesn't return the actual window, but the local widget-window.
     // GTK4 renames `gdk_window_get_root_coords()` to `gdk_surface_get_root_coords()`
     gdk_window_get_root_coords(gtk_widget_get_window(widget), 0, 0, &rx, &ry);
-    return utl::Point<double>{absolute_coords.x - rx, absolute_coords.y - ry};
+    return xoj::util::Point<double>{absolute_coords.x - rx, absolute_coords.y - ry};
 }
 
 void Util::cairo_set_dash_from_vector(cairo_t* cr, const std::vector<double>& dashes, double offset) {

--- a/src/util/include/util/Point.h
+++ b/src/util/include/util/Point.h
@@ -14,35 +14,40 @@
 #include <cmath>
 #include <tuple>
 
-namespace utl {
+namespace xoj::util {
 
 template <typename T>
 struct Point {
 
-    Point() = default;
-    Point(T x, T y): x(x), y(y) {}
+    // Todo (c++20): remove constructors
+    constexpr Point() = default;
+    constexpr Point(T x, T y): x(x), y(y) {}
 
-    [[maybe_unused]] double distance(Point p) const { return std::hypot(p.x - this->x, p.y - this->y); }
+    [[maybe_unused]] constexpr auto distance(Point p) const -> double {
+        return std::hypot(p.x - this->x, p.y - this->y);
+    }
 
-    [[maybe_unused]] Point operator-(Point p) const { return {this->x - p.x, this->y - p.y}; }
-    [[maybe_unused]] Point& operator-=(Point p) { return *this = *this - p; }
+    [[maybe_unused]] constexpr auto operator-(Point p) const -> Point { return {this->x - p.x, this->y - p.y}; }
+    [[maybe_unused]] constexpr auto operator-=(Point p) -> Point& { return *this = *this - p; }
 
-    [[maybe_unused]] Point operator+(Point p) const { return {this->x + p.x, this->y + p.y}; }
-    [[maybe_unused]] Point& operator+=(Point p) { return *this = *this + p; }
+    [[maybe_unused]] constexpr auto operator+(Point p) const -> Point { return {this->x + p.x, this->y + p.y}; }
+    [[maybe_unused]] constexpr auto operator+=(Point p) -> Point& { return *this = *this + p; }
 
-    [[maybe_unused]] Point operator/(T k) const { return {this->x / k, this->y / k}; }
-    [[maybe_unused]] Point& operator/=(T k) { return *this = *this / k; }
+    [[maybe_unused]] constexpr auto operator/(T k) const -> Point { return {this->x / k, this->y / k}; }
+    [[maybe_unused]] constexpr auto operator/=(T k) -> Point& { return *this = *this / k; }
 
-    [[maybe_unused]] Point operator*(T k) const { return {this->x * k, this->y * k}; }
-    [[maybe_unused]] Point& operator*=(T k) { return *this = *this * k; }
+    [[maybe_unused]] constexpr auto operator*(T k) const -> Point { return {this->x * k, this->y * k}; }
+    [[maybe_unused]] constexpr auto operator*=(T k) -> Point& { return *this = *this * k; }
 
-    [[maybe_unused]] friend bool operator==(Point const& lhs, Point const& rhs) {
+    [[maybe_unused]] constexpr friend auto operator==(Point const& lhs, Point const& rhs) -> bool {
         return std::tie(lhs.x, lhs.y) == std::tie(rhs.x, rhs.y);
     }
 
-    [[maybe_unused]] friend bool operator!=(Point const& lhs, Point const& rhs) { return !(lhs == rhs); }
+    [[maybe_unused]] constexpr friend auto operator!=(Point const& lhs, Point const& rhs) -> bool {
+        return !(lhs == rhs);
+    }
 
     T x{};
     T y{};
 };
-}  // namespace utl
+}  // namespace xoj::util

--- a/src/util/include/util/Rectangle.h
+++ b/src/util/include/util/Rectangle.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <algorithm>
+#include <iosfwd>
 #include <optional>
 
 #include "util/Range.h"
@@ -21,17 +22,21 @@ namespace xoj::util {  // Rectangle is already defined in windows.h
 template <class T>
 class Rectangle final {
 public:
-    Rectangle() = default;
-    Rectangle(T x, T y, T width, T height): x(x), y(y), width(width), height(height) {}
-    explicit Rectangle(const Range& rect):
+    constexpr Rectangle() = default;
+    constexpr Rectangle(T x, T y, T width, T height): x(x), y(y), width(width), height(height) {}
+    constexpr explicit Rectangle(const Range& rect):
             x(rect.getX()), y(rect.getY()), width(rect.getWidth()), height(rect.getHeight()) {}
+
+    constexpr auto operator==(const Rectangle& other) const -> bool {
+        return x == other.x && y == other.y && width == other.width && height == other.height;
+    }
 
     /**
      * Returns whether this rectangle intersects another and the intersection
      * @param other the other rectangle
      * @return whether the rectangles intersect and if so, the intersection
      */
-    std::optional<Rectangle> intersects(const Rectangle& other) const {
+    constexpr auto intersects(const Rectangle& other) const -> std::optional<Rectangle> {
         auto x1 = std::max(this->x, other.x);
         auto y1 = std::max(this->y, other.y);
         auto x2 = std::min(this->x + this->width, other.x + other.width);
@@ -46,12 +51,14 @@ public:
      * Returns a new Rectangle with an offset specified
      * by the function arguments
      */
-    Rectangle translated(T dx, T dy) const { return Rectangle(this->x + dx, this->y + dy, this->width, this->height); }
+    constexpr auto translated(T dx, T dy) const -> Rectangle {
+        return Rectangle(this->x + dx, this->y + dy, this->width, this->height);
+    }
 
     /**
      * Computes the union of this and the other rectangle
      */
-    void unite(const Rectangle& other) {
+    constexpr void unite(const Rectangle& other) {
         this->width = std::max(this->x + this->width, other.x + other.width);
         this->height = std::max(this->y + this->height, other.y + other.height);
         this->x = std::min(this->x, other.x);
@@ -63,7 +70,7 @@ public:
     /**
      * Applies a scalar to this rectangle
      */
-    Rectangle& operator*=(T factor) {
+    constexpr auto operator*=(T factor) -> Rectangle& {
         x *= factor;
         y *= factor;
         width *= factor;
@@ -74,7 +81,9 @@ public:
     /**
      * Calculates the area
      */
-    T area() const { return width * height; }
+    constexpr auto area() const -> T { return width * height; }
+
+    friend auto operator<<(std::ostream& os, Rectangle const& r) -> std::ostream&;
 
     T x{};
     T y{};

--- a/src/util/include/util/Util.h
+++ b/src/util/include/util/Util.h
@@ -73,7 +73,7 @@ void cairo_set_dash_from_vector(cairo_t* cr, const std::vector<double>& dashes, 
  * Transform absolute coordinates into coordinates local to the specified widget.
  * The top left corner of `widget` will have coordinates (0, 0).
  */
-utl::Point<double> toWidgetCoords(GtkWidget* widget, utl::Point<double> absolute_coords);
+xoj::util::Point<double> toWidgetCoords(GtkWidget* widget, xoj::util::Point<double> absolute_coords);
 
 /**
  * Format coordinates to use 8 digits of precision https://m.xkcd.com/2170/

--- a/src/util/include/util/raii/CairoWrappers.h
+++ b/src/util/include/util/raii/CairoWrappers.h
@@ -54,7 +54,7 @@ using CairoRegionSPtr = CLibrariesSPtr<cairo_region_t, raii::specialization::Cai
 class CairoSaveGuard {
 public:
     CairoSaveGuard() = delete;
-    CairoSaveGuard(cairo_t* cr): cr(cr) { cairo_save(cr); }
+    [[nodiscard]] CairoSaveGuard(cairo_t* cr): cr(cr) { cairo_save(cr); }
     ~CairoSaveGuard() { cairo_restore(cr); }
 
     CairoSaveGuard(const CairoSaveGuard&) = delete;


### PR DESCRIPTION
 - added some constexpr to Rectangle and Point
 - made CairoWrapper `[[nodiscard]]`, its a guard and must not be discarded