### PR TITLE
Add uim-data to AppImage.

### DIFF
--- a/azure-pipelines/steps/install_deps_ubuntu.yml
+++ b/azure-pipelines/steps/install_deps_ubuntu.yml
@@ -10,7 +10,7 @@ steps:
       sudo apt-get update
       sudo apt-get install -y librsvg2-dev gcc-${{ parameters.gcc_version }} g++-${{ parameters.gcc_version }} cmake ninja-build \
         libgtk-3-dev libpoppler-glib-dev portaudio19-dev libsndfile-dev \
-        ibus-gtk3 fcitx-frontend-gtk3 fcitx5-frontend-gtk3 uim-gtk3-immodule gcin-gtk3-immodule \
+        ibus-gtk3 fcitx-frontend-gtk3 fcitx5-frontend-gtk3 uim-gtk3-immodule uim-data gcin-gtk3-immodule \
         liblua5.3-dev libzip-dev gettext help2man libgtest-dev libgtksourceview-4-dev
       g++ --version
     displayName: 'Install dependencies'


### PR DESCRIPTION
May fix #5493 and partially #5587.
This will install many `scheme` libraries for `uim` in the AppImage, and I don't think it appropriate.