### PR TITLE
Remove operator<<(const Rectangle&) declaration and fix compilation warnings

### DIFF
--- a/src/util/include/util/Rectangle.h
+++ b/src/util/include/util/Rectangle.h
@@ -83,8 +83,6 @@ public:
      */
     constexpr auto area() const -> T { return width * height; }
 
-    friend auto operator<<(std::ostream& os, Rectangle const& r) -> std::ostream&;
-
     T x{};
     T y{};
     T width{};


### PR DESCRIPTION
@Febbe You'll have to add back this declaration in #5601. For now, it clutters the compilation output so let's remove it.
@rolandlo, this'll remove the new warnings.

Merging once the CI clears.