### PR TITLE
Fix_chinese_locale

### DIFF
--- a/src/core/control/XournalMain.cpp
+++ b/src/core/control/XournalMain.cpp
@@ -84,7 +84,7 @@ void initCAndCoutLocales() {
 
 void initLocalisation() {
 #ifdef ENABLE_NLS
-    fs::path localeDir = Util::getGettextFilepath(Util::getLocalePath().u8string().c_str());
+    fs::path localeDir = Util::getGettextFilepath(Util::getLocalePath());
     bindtextdomain(GETTEXT_PACKAGE, localeDir.u8string().c_str());
     textdomain(GETTEXT_PACKAGE);
 

--- a/src/core/gui/dialog/LanguageConfigGui.cpp
+++ b/src/core/gui/dialog/LanguageConfigGui.cpp
@@ -27,9 +27,9 @@ LanguageConfigGui::LanguageConfigGui(GladeSearchpath* gladeSearchPath, GtkWidget
 
     // Fetch available locales
     try {
-        fs::path baseLocaleDir = Util::getGettextFilepath(Util::getLocalePath().u8string().c_str());
+        fs::path baseLocaleDir = Util::getGettextFilepath(Util::getLocalePath());
         for (auto const& d: fs::directory_iterator(baseLocaleDir)) {
-            if (fs::exists(d.path() / "LC_MESSAGES" / (std::string(GETTEXT_PACKAGE) + ".mo"))) {
+            if (auto mofile = (d.path() / "LC_MESSAGES" / GETTEXT_PACKAGE) += ".mo"; fs::exists(mofile)) {
                 availableLocales.push_back(d.path().filename().u8string());
             }
         }

--- a/src/util/PathUtil.cpp
+++ b/src/util/PathUtil.cpp
@@ -176,20 +176,22 @@ void Util::openFileWithDefaultApplication(const fs::path& filename) {
     }
 }
 
-auto Util::getGettextFilepath(const char* localeDir) -> fs::path {
+auto Util::getGettextFilepath(fs::path const& localeDir) -> fs::path {
+    /// documentation of g_getenv is wrong, its UTF-8, see #5640
     const char* gettextEnv = g_getenv("TEXTDOMAINDIR");
     // Only consider first path in environment variable
-    std::string directories;
+    std::string_view directories;
     if (gettextEnv) {
-        directories = std::string(gettextEnv);
+        directories = gettextEnv;
         size_t firstDot = directories.find(G_SEARCHPATH_SEPARATOR);
         if (firstDot != std::string::npos) {
             directories = directories.substr(0, firstDot);
         }
     }
-    const char* dir = (gettextEnv) ? directories.c_str() : localeDir;
-    g_debug("TEXTDOMAINDIR = %s, Platform-specific locale dir = %s, chosen directory = %s", gettextEnv, localeDir, dir);
-    return fs::path(dir);
+    auto dir = (gettextEnv) ? fs::u8path(directories) : localeDir;
+    g_debug("TEXTDOMAINDIR = %s, Platform-specific locale dir = %s, chosen directory = %s", gettextEnv,
+            localeDir.string().c_str(), dir.string().c_str());
+    return dir;
 }
 
 auto Util::getAutosaveFilepath() -> fs::path {

--- a/src/util/include/util/PathUtil.h
+++ b/src/util/include/util/PathUtil.h
@@ -137,7 +137,7 @@ auto system_single_byte_filename(const fs::path& path) -> std::string;
 [[maybe_unused]] [[nodiscard]] fs::path getCacheFile(const fs::path& relativeFileName = "");
 [[maybe_unused]] [[nodiscard]] fs::path getTmpDirSubfolder(const fs::path& subfolder = "");
 [[maybe_unused]] [[nodiscard]] fs::path getAutosaveFilepath();
-[[maybe_unused]] [[nodiscard]] fs::path getGettextFilepath(const char* localeDir);
+[[maybe_unused]] [[nodiscard]] fs::path getGettextFilepath(fs::path const& localeDir);
 [[maybe_unused]] [[nodiscard]] fs::path getDataPath();
 [[maybe_unused]] [[nodiscard]] fs::path getLocalePath();
 


### PR DESCRIPTION
Users of [auto Util::getGettextFilepath(fs::path const& localeDir) -> fs::path {](https://github.com/Febbe/xournalpp/blame/8dbb0cf81a0aecf2e5c1c47537f2654f62b72e94/src/util/PathUtil.cpp#L179C45-L179C45) used a utf8 encoded path, while `Util::getGettextFilepath` used system encoded paths. 

I changed the function, to use consistently `fs::path` and doing the encoding related parsing in this function.