### PR TITLE
Unify Key handling accross tool handlers and use GtkEventControllerKey

### DIFF
--- a/src/core/control/tools/BaseShapeHandler.cpp
+++ b/src/core/control/tools/BaseShapeHandler.cpp
@@ -49,31 +49,29 @@ void BaseShapeHandler::cancelStroke() {
     this->lastSnappingRange = Range();
 }
 
-auto BaseShapeHandler::onKeyEvent(GdkEventKey* event) -> bool {
-    if (event->is_modifier) {
-        GdkModifierType state;
-        if (event->keyval == GDK_KEY_Shift_L || event->keyval == GDK_KEY_Shift_R) {
-            // event->state contains the modifiers' states BEFORE the current event
-            // We need a XOR to handler both keypress and keyrelease at once
-            state = static_cast<GdkModifierType>(event->state ^ GDK_SHIFT_MASK);
-        } else if (event->keyval == GDK_KEY_Control_L || event->keyval == GDK_KEY_Control_R) {
-            state = static_cast<GdkModifierType>(event->state ^ GDK_CONTROL_MASK);
-        } else if (event->keyval == GDK_KEY_Alt_L || event->keyval == GDK_KEY_Alt_R) {
-            state = static_cast<GdkModifierType>(event->state ^ GDK_MOD1_MASK);
-        } else {
-            return false;
-        }
-
-        bool isAltDown = state & GDK_MOD1_MASK;
-        bool isShiftDown = state & GDK_SHIFT_MASK;
-        bool isControlDown = state & GDK_CONTROL_MASK;
-
-        this->updateShape(isAltDown, isShiftDown, isControlDown);
-
-        return true;
+auto BaseShapeHandler::onKeyEvent(const KeyEvent& event, bool pressed) -> bool {
+    bool isAltDown = event.state & GDK_MOD1_MASK;
+    bool isShiftDown = event.state & GDK_SHIFT_MASK;
+    bool isControlDown = event.state & GDK_CONTROL_MASK;
+    // event->state contains the modifiers' states BEFORE the current event
+    if (event.keyval == GDK_KEY_Shift_L || event.keyval == GDK_KEY_Shift_R) {
+        isShiftDown = pressed;
+    } else if (event.keyval == GDK_KEY_Control_L || event.keyval == GDK_KEY_Control_R) {
+        isControlDown = pressed;
+    } else if (event.keyval == GDK_KEY_Alt_L || event.keyval == GDK_KEY_Alt_R) {
+        isAltDown = pressed;
+    } else {
+        return false;
     }
-    return false;
+    this->updateShape(isAltDown, isShiftDown, isControlDown);
+
+    return true;
 }
+
+auto BaseShapeHandler::onKeyPressEvent(const KeyEvent& event) -> bool { return onKeyEvent(event, true); }
+
+auto BaseShapeHandler::onKeyReleaseEvent(const KeyEvent& event) -> bool { return onKeyEvent(event, false); }
+
 
 auto BaseShapeHandler::onMotionNotifyEvent(const PositionInputData& pos, double zoom) -> bool {
     Point newPoint(pos.x / zoom, pos.y / zoom);

--- a/src/core/control/tools/BaseShapeHandler.h
+++ b/src/core/control/tools/BaseShapeHandler.h
@@ -51,7 +51,8 @@ public:
     void onButtonReleaseEvent(const PositionInputData& pos, double zoom) override;
     void onButtonPressEvent(const PositionInputData& pos, double zoom) override;
     void onButtonDoublePressEvent(const PositionInputData& pos, double zoom) override;
-    bool onKeyEvent(GdkEventKey* event) override;
+    bool onKeyPressEvent(const KeyEvent& event) override;
+    bool onKeyReleaseEvent(const KeyEvent& event) override;
 
     std::unique_ptr<xoj::view::OverlayView> createView(xoj::view::Repaintable* parent) const override;
 
@@ -80,6 +81,8 @@ private:
      * @brief Cancel the current shape creation: clears all data and wipes any drawing made
      */
     void cancelStroke();
+
+    bool onKeyEvent(const KeyEvent& event, bool pressed);
 
 protected:
     /**

--- a/src/core/control/tools/InputHandler.h
+++ b/src/core/control/tools/InputHandler.h
@@ -22,6 +22,7 @@ class Control;
 class Point;
 class Stroke;
 class PositionInputData;
+struct KeyEvent;
 
 namespace xoj::view {
 class OverlayView;
@@ -55,7 +56,8 @@ public:
      * It is used to update internal data structures and queue
      * repaints of the XojPageView if necessary.
      */
-    virtual bool onKeyEvent(GdkEventKey* event) = 0;
+    virtual bool onKeyPressEvent(const KeyEvent& event) = 0;
+    virtual bool onKeyReleaseEvent(const KeyEvent& event) = 0;
 
     /**
      * The current input device for stroken, do not react on other devices (linke mices)

--- a/src/core/control/tools/SplineHandler.h
+++ b/src/core/control/tools/SplineHandler.h
@@ -76,7 +76,8 @@ public:
     void onButtonReleaseEvent(const PositionInputData& pos, double zoom) override;
     void onButtonPressEvent(const PositionInputData& pos, double zoom) override;
     void onButtonDoublePressEvent(const PositionInputData& pos, double zoom) override;
-    bool onKeyEvent(GdkEventKey* event) override;
+    bool onKeyPressEvent(const KeyEvent& event) override;
+    bool onKeyReleaseEvent(const KeyEvent& event) override;
 
     void finalizeSpline();
 

--- a/src/core/control/tools/StrokeHandler.cpp
+++ b/src/core/control/tools/StrokeHandler.cpp
@@ -48,7 +48,8 @@ StrokeHandler::StrokeHandler(Control* control, const PageRef& page):
 
 StrokeHandler::~StrokeHandler() = default;
 
-auto StrokeHandler::onKeyEvent(GdkEventKey* event) -> bool { return false; }
+auto StrokeHandler::onKeyPressEvent(const KeyEvent&) -> bool { return false; }
+auto StrokeHandler::onKeyReleaseEvent(const KeyEvent&) -> bool { return false; }
 
 auto StrokeHandler::onMotionNotifyEvent(const PositionInputData& pos, double zoom) -> bool {
     if (!stroke) {

--- a/src/core/control/tools/StrokeHandler.h
+++ b/src/core/control/tools/StrokeHandler.h
@@ -61,7 +61,8 @@ public:
     void onButtonReleaseEvent(const PositionInputData& pos, double zoom) override;
     void onButtonPressEvent(const PositionInputData& pos, double zoom) override;
     void onButtonDoublePressEvent(const PositionInputData& pos, double zoom) override;
-    bool onKeyEvent(GdkEventKey* event) override;
+    bool onKeyPressEvent(const KeyEvent& event) override;
+    bool onKeyReleaseEvent(const KeyEvent& event) override;
 
     /**
      * @brief Add a straight line to the stroke (if the movement is valid).

--- a/src/core/control/tools/TextEditor.cpp
+++ b/src/core/control/tools/TextEditor.cpp
@@ -297,10 +297,11 @@ auto TextEditor::imDeleteSurroundingCallback(GtkIMContext* context, gint offset,
     return true;
 }
 
-auto TextEditor::onKeyPressEvent(GdkEventKey* event) -> bool {
+auto TextEditor::onKeyPressEvent(const KeyEvent& event) -> bool {
 
     // IME needs to handle the input first so the candidate window works correctly
-    if (gtk_im_context_filter_keypress(this->imContext.get(), event)) {
+    auto* e = (GdkEventKey*)(static_cast<GdkEvent*>(event.sourceEvent));
+    if (gtk_im_context_filter_keypress(this->imContext.get(), e)) {
         this->needImReset = true;
 
         GtkTextIter iter = getIteratorAtCursor(this->buffer.get());
@@ -314,13 +315,14 @@ auto TextEditor::onKeyPressEvent(GdkEventKey* event) -> bool {
         return true;
     }
 
-    return keyBindings.processEvent(this, (GdkEvent*)event);
+    return keyBindings.processEvent(this, event);
 }
 
-auto TextEditor::onKeyReleaseEvent(GdkEventKey* event) -> bool {
+auto TextEditor::onKeyReleaseEvent(const KeyEvent& event) -> bool {
     GtkTextIter iter = getIteratorAtCursor(this->buffer.get());
 
-    if (gtk_text_iter_can_insert(&iter, true) && gtk_im_context_filter_keypress(this->imContext.get(), event)) {
+    auto* e = (GdkEventKey*)(static_cast<GdkEvent*>(event.sourceEvent));
+    if (gtk_text_iter_can_insert(&iter, true) && gtk_im_context_filter_keypress(this->imContext.get(), e)) {
         this->needImReset = true;
         return true;
     }

--- a/src/core/control/tools/TextEditor.h
+++ b/src/core/control/tools/TextEditor.h
@@ -30,6 +30,7 @@ class Text;
 class XojFont;
 class Control;
 class TextEditorCallbacks;
+struct KeyEvent;
 
 namespace xoj::util {
 template <class T>
@@ -48,8 +49,8 @@ public:
     /** Represents the different kinds of text selection */
     enum class SelectType { WORD, PARAGRAPH, ALL };
 
-    bool onKeyPressEvent(GdkEventKey* event);
-    bool onKeyReleaseEvent(GdkEventKey* event);
+    bool onKeyPressEvent(const KeyEvent& event);
+    bool onKeyReleaseEvent(const KeyEvent& event);
     void mousePressed(double x, double y);
     void mouseMoved(double x, double y);
     void mouseReleased();

--- a/src/core/control/tools/VerticalToolHandler.cpp
+++ b/src/core/control/tools/VerticalToolHandler.cpp
@@ -8,6 +8,7 @@
 
 #include "control/tools/SnapToGridInputHandler.h"  // for SnapToGridInputHan...
 #include "gui/LegacyRedrawable.h"                  // for Redrawable
+#include "gui/inputdevices/InputEvents.h"          // for KeyEvent
 #include "model/Element.h"                         // for Element
 #include "model/Layer.h"                           // for Layer
 #include "model/XojPage.h"                         // for XojPage
@@ -66,9 +67,8 @@ void VerticalToolHandler::currentPos(double x, double y) {
     this->viewPool->dispatch(xoj::view::VerticalToolView::SET_VERTICAL_SHIFT_REQUEST, ySnapped);
 }
 
-bool VerticalToolHandler::onKeyPressEvent(GdkEventKey* event) {
-    if ((event->keyval == GDK_KEY_Control_L || event->keyval == GDK_KEY_Control_R) &&
-        this->spacingSide == Side::Below) {
+bool VerticalToolHandler::onKeyPressEvent(const KeyEvent& event) {
+    if ((event.keyval == GDK_KEY_Control_L || event.keyval == GDK_KEY_Control_R) && this->spacingSide == Side::Below) {
         this->adoptElements(Side::Above);
         this->viewPool->dispatch(xoj::view::VerticalToolView::SWITCH_DIRECTION_REQUEST);
         return true;
@@ -76,9 +76,8 @@ bool VerticalToolHandler::onKeyPressEvent(GdkEventKey* event) {
     return false;
 }
 
-bool VerticalToolHandler::onKeyReleaseEvent(GdkEventKey* event) {
-    if ((event->keyval == GDK_KEY_Control_L || event->keyval == GDK_KEY_Control_R) &&
-        this->spacingSide == Side::Above) {
+bool VerticalToolHandler::onKeyReleaseEvent(const KeyEvent& event) {
+    if ((event.keyval == GDK_KEY_Control_L || event.keyval == GDK_KEY_Control_R) && this->spacingSide == Side::Above) {
         this->adoptElements(Side::Below);
         this->viewPool->dispatch(xoj::view::VerticalToolView::SWITCH_DIRECTION_REQUEST);
         return true;

--- a/src/core/control/tools/VerticalToolHandler.h
+++ b/src/core/control/tools/VerticalToolHandler.h
@@ -14,8 +14,7 @@
 #include <memory>    // for unique_ptr
 #include <vector>    // for vector
 
-#include <cairo.h>    // for cairo_surface_t, cairo_t
-#include <gdk/gdk.h>  // for GdkEventKey, GdkWindow
+#include <cairo.h>  // for cairo_surface_t, cairo_t
 
 #include "model/ElementContainer.h"  // for ElementContainer
 #include "model/OverlayBase.h"
@@ -29,6 +28,7 @@ class Layer;
 class MoveUndoAction;
 class Settings;
 class ZoomControl;
+struct KeyEvent;
 
 using ElementPtr = std::unique_ptr<Element>;
 
@@ -59,13 +59,11 @@ public:
     VerticalToolHandler(VerticalToolHandler&&) = delete;
     VerticalToolHandler&& operator=(VerticalToolHandler&&) = delete;
 
-    void paint(cairo_t* cr);
-
     /** Update the tool state with the new spacing position */
     void currentPos(double x, double y);
 
-    bool onKeyPressEvent(GdkEventKey* event);
-    bool onKeyReleaseEvent(GdkEventKey* event);
+    bool onKeyPressEvent(const KeyEvent& event);
+    bool onKeyReleaseEvent(const KeyEvent& event);
 
     std::unique_ptr<MoveUndoAction> finalize();
 
@@ -114,7 +112,7 @@ private:
     Layer* layer;
     std::vector<ElementPtr> elements;
     /**
-     * @brief Stores the smallest box containing all the adopted elements. 
+     * @brief Stores the smallest box containing all the adopted elements.
      *     Used to only refresh the part of the screen that needs refreshing.
      */
     Range ownedElementsOriginalBoundingBox;

--- a/src/core/gui/PageView.cpp
+++ b/src/core/gui/PageView.cpp
@@ -738,13 +738,13 @@ auto XojPageView::onButtonReleaseEvent(const PositionInputData& pos) -> bool {
     return false;
 }
 
-auto XojPageView::onKeyPressEvent(GdkEventKey* event) -> bool {
+auto XojPageView::onKeyPressEvent(const KeyEvent& event) -> bool {
     if (this->textEditor) {
         if (this->textEditor->onKeyPressEvent(event)) {
             return true;
         }
     } else if (this->inputHandler) {
-        if (this->inputHandler->onKeyEvent(event)) {
+        if (this->inputHandler->onKeyPressEvent(event)) {
             return true;
         }
     } else if (this->verticalSpace) {
@@ -754,7 +754,7 @@ auto XojPageView::onKeyPressEvent(GdkEventKey* event) -> bool {
     }
 
     // Esc leaves text edition
-    if (event->keyval == GDK_KEY_Escape) {
+    if (event.keyval == GDK_KEY_Escape) {
         if (this->textEditor) {
             endText();
             return true;
@@ -766,12 +766,12 @@ auto XojPageView::onKeyPressEvent(GdkEventKey* event) -> bool {
     return false;
 }
 
-auto XojPageView::onKeyReleaseEvent(GdkEventKey* event) -> bool {
+auto XojPageView::onKeyReleaseEvent(const KeyEvent& event) -> bool {
     if (this->textEditor && this->textEditor->onKeyReleaseEvent(event)) {
         return true;
     }
 
-    if (this->inputHandler && this->inputHandler->onKeyEvent(event)) {
+    if (this->inputHandler && this->inputHandler->onKeyReleaseEvent(event)) {
         DrawingType drawingType = this->xournal->getControl()->getToolHandler()->getDrawingType();
         if (drawingType == DRAWING_TYPE_SPLINE) {  // Spline drawing has been finalized
             if (this->inputHandler) {

--- a/src/core/gui/PageView.h
+++ b/src/core/gui/PageView.h
@@ -22,6 +22,7 @@
 #include <gtk/gtk.h>  // for GtkWidget
 
 #include "gui/inputdevices/DeviceId.h"
+#include "gui/inputdevices/InputEvents.h"
 #include "model/PageListener.h"       // for PageListener
 #include "model/PageRef.h"            // for PageRef
 #include "util/Rectangle.h"           // for Rectangle
@@ -104,8 +105,8 @@ public:
 
     bool searchTextOnPage(const std::string& text, size_t index, size_t* occurrences, XojPdfRectangle* matchRect);
 
-    bool onKeyPressEvent(GdkEventKey* event);
-    bool onKeyReleaseEvent(GdkEventKey* event);
+    bool onKeyPressEvent(const KeyEvent& event);
+    bool onKeyReleaseEvent(const KeyEvent& event);
 
     bool cut();
     bool copy();

--- a/src/core/gui/XournalView.cpp
+++ b/src/core/gui/XournalView.cpp
@@ -124,7 +124,7 @@ auto XournalView::getCurrentPage() const -> size_t { return currentPage; }
 
 const int scrollKeySize = 30;
 
-auto XournalView::onKeyPressEvent(GdkEventKey* event) -> bool {
+auto XournalView::onKeyPressEvent(const KeyEvent& event) -> bool {
     size_t p = getCurrentPage();
     if (p != npos && p < this->viewPages.size()) {
         auto& v = this->viewPages[p];
@@ -133,20 +133,8 @@ auto XournalView::onKeyPressEvent(GdkEventKey* event) -> bool {
         }
     }
 
-    /*
-    According to https://docs.gtk.org/gdk3/method.Keymap.translate_keyboard_state.html
-    consumed modifiers should be masked out. For instance, on a US keyboard, the plus symbol is shifted, so when
-    comparing a key press to a <Control>plus accelerator <Shift> should be masked out.
-    */
-    GdkModifierType consumed;
-    gdk_keymap_translate_keyboard_state(gdk_keymap_get_for_display(gdk_display_get_default()), event->hardware_keycode,
-                                        static_cast<GdkModifierType>(event->state), event->group, nullptr, nullptr,
-                                        nullptr, &consumed);
-
-    // Todo(gtk4) there is no GdkEventKey. Use a GdkEventControllerKey and connect to its key-pressed signal
-    guint keyval = event->keyval;
-    auto state = static_cast<GdkModifierType>(event->state & gtk_accelerator_get_default_mod_mask() & ~consumed);
-
+    auto keyval = event.keyval;
+    auto state = event.state;
     if (auto* tool = getControl()->getWindow()->getPdfToolbox(); tool->hasSelection()) {
         if (keyval == GDK_KEY_c && state == GDK_CONTROL_MASK) {
             // Shortcut to get selected PDF text.
@@ -324,7 +312,7 @@ auto XournalView::onKeyPressEvent(GdkEventKey* event) -> bool {
 
 auto XournalView::getRepaintHandler() const -> RepaintHandler* { return this->repaintHandler.get(); }
 
-auto XournalView::onKeyReleaseEvent(GdkEventKey* event) -> bool {
+auto XournalView::onKeyReleaseEvent(const KeyEvent& event) -> bool {
     size_t p = getCurrentPage();
     if (p != npos && p < this->viewPages.size()) {
         auto& v = this->viewPages[p];

--- a/src/core/gui/XournalView.h
+++ b/src/core/gui/XournalView.h
@@ -22,11 +22,12 @@
 #include <glib.h>     // for gboolean
 #include <gtk/gtk.h>  // for GtkWidget, GtkAllocation
 
-#include "control/zoom/ZoomListener.h"  // for ZoomListener
-#include "model/DocumentChangeType.h"   // for DocumentChangeType
-#include "model/DocumentListener.h"     // for DocumentListener
-#include "pdf/base/XojPdfPage.h"        // for XojPdfRectangle
-#include "util/Util.h"                  // for npos
+#include "control/zoom/ZoomListener.h"     // for ZoomListener
+#include "gui/inputdevices/InputEvents.h"  // for KeyEvent
+#include "model/DocumentChangeType.h"      // for DocumentChangeType
+#include "model/DocumentListener.h"        // for DocumentListener
+#include "pdf/base/XojPdfPage.h"           // for XojPdfRectangle
+#include "util/Util.h"                     // for npos
 
 class Control;
 class XournalppCursor;
@@ -147,8 +148,8 @@ public:
     void documentChanged(DocumentChangeType type) override;
 
 public:
-    bool onKeyPressEvent(GdkEventKey* event);
-    bool onKeyReleaseEvent(GdkEventKey* event);
+    bool onKeyPressEvent(const KeyEvent& event);
+    bool onKeyReleaseEvent(const KeyEvent& event);
 
     static void onRealized(GtkWidget* widget, XournalView* view);
 

--- a/src/core/gui/inputdevices/GeometryToolInputHandler.h
+++ b/src/core/gui/inputdevices/GeometryToolInputHandler.h
@@ -24,6 +24,7 @@
 class Stroke;
 class GeometryToolController;
 struct InputEvent;
+struct KeyEvent;
 
 /**
  * @brief Input handler for the geometry tool
@@ -142,11 +143,6 @@ protected:
     bool handleTouchscreen(InputEvent const& event);
 
     /**
-     * @brief handles input from the keyboard for the geometry tool
-     */
-    bool handleKeyboard(InputEvent const& event);
-
-    /**
      * @brief handles input from mouse and stylus for the geometry tool
      */
     virtual bool handlePointer(InputEvent const& event) = 0;
@@ -168,6 +164,9 @@ public:
     bool handle(InputEvent const& event);
     void blockDevice(InputContext::DeviceType deviceType);
     void unblockDevice(InputContext::DeviceType deviceType);
+
+    bool keyPressed(KeyEvent const& event);
+    // bool keyReleased(KeyEvent const& event); // Implement if needed
 
     /**
      * Listener interface

--- a/src/core/gui/inputdevices/InputContext.h
+++ b/src/core/gui/inputdevices/InputContext.h
@@ -33,7 +33,7 @@ class TouchDrawingInputHandler;
 class TouchInputHandler;
 class XournalView;
 
-class InputContext {
+class InputContext final {
 
 private:
     gulong signal_id{0};
@@ -97,6 +97,7 @@ public:
     Settings* getSettings();
     ScrollHandling* getScrollHandling();
     void setGeometryToolInputHandler(std::unique_ptr<GeometryToolInputHandler> handler);
+    GeometryToolInputHandler* getGeometryToolInputHandler() const;
     void resetGeometryToolInputHandler();
 
     GdkModifierType getModifierState();

--- a/src/core/gui/inputdevices/InputEvents.cpp
+++ b/src/core/gui/inputdevices/InputEvents.cpp
@@ -6,6 +6,7 @@
 
 #include "control/settings/Settings.h"       // for Settings
 #include "control/settings/SettingsEnums.h"  // for InputDeviceTypeOption
+#include "util/gdk4_helper.h"
 
 auto InputEvents::translateEventType(GdkEventType type) -> InputEventType {
     switch (type) {
@@ -102,9 +103,9 @@ auto InputEvents::translateEvent(GdkEvent* sourceEvent, Settings* settings) -> I
         // As we only handle single finger events we can set the button statically to 1
         targetEvent.button = 1;
     }
-    gdk_event_get_state(sourceEvent, &targetEvent.state);
+    targetEvent.state = gdk_event_get_modifier_state(sourceEvent);
     if (targetEvent.deviceClass == INPUT_DEVICE_KEYBOARD) {
-        gdk_event_get_keyval(sourceEvent, &targetEvent.button);
+        targetEvent.button = gdk_key_event_get_keyval(sourceEvent);
     }
 
 

--- a/src/core/gui/inputdevices/InputEvents.h
+++ b/src/core/gui/inputdevices/InputEvents.h
@@ -93,6 +93,13 @@ struct InputEvent final {
     DeviceId deviceId;
 };
 
+struct KeyEvent final {
+    guint keyval{0};
+    GdkModifierType state{};  ///< Consumed modifiers have been masked out
+
+    GdkEventGuard sourceEvent;  ///< Original GdkEvent. Avoid using if possible.
+};
+
 class InputEvents {
 
     static InputEventType translateEventType(GdkEventType type);

--- a/src/core/gui/inputdevices/KeyboardInputHandler.cpp
+++ b/src/core/gui/inputdevices/KeyboardInputHandler.cpp
@@ -1,34 +1,18 @@
-//
-// Created by ulrich on 12.04.19.
-//
-
 #include "KeyboardInputHandler.h"
 
-#include <gdk/gdk.h>         // for _GdkEventKey, gdk...
-#include <gdk/gdkkeysyms.h>  // for GDK_KEY_Down, GDK...
-
-#include "control/tools/EditSelection.h"            // for EditSelection
 #include "gui/XournalView.h"                        // for XournalView
-#include "gui/inputdevices/AbstractInputHandler.h"  // for AbstractInputHandler
-#include "gui/inputdevices/InputEvents.h"           // for GdkEventGuard
-#include "gui/widgets/XournalWidget.h"              // for GtkXournal
+#include "gui/inputdevices/GeometryToolInputHandler.h"  // for GeometryToolInputHandler
 
 #include "InputContext.h"  // for InputContext
+#include "InputEvents.h"   // for KeyEvent
 
-KeyboardInputHandler::KeyboardInputHandler(InputContext* inputContext): AbstractInputHandler(inputContext) {}
+KeyboardInputHandler::KeyboardInputHandler(InputContext* inputContext): inputContext(inputContext) {}
 
 KeyboardInputHandler::~KeyboardInputHandler() = default;
 
-auto KeyboardInputHandler::handleImpl(InputEvent const& event) -> bool {
-    GdkEvent* gdkEvent = event.sourceEvent;
-
-    if (gdk_event_get_event_type(gdkEvent) == GDK_KEY_PRESS) {
-        auto keyEvent = reinterpret_cast<GdkEventKey*>(gdkEvent);
-        return inputContext->getView()->onKeyPressEvent(keyEvent);
-    } else if (gdk_event_get_event_type(gdkEvent) == GDK_KEY_RELEASE) {
-        auto keyEvent = reinterpret_cast<GdkEventKey*>(gdkEvent);
-        return inputContext->getView()->onKeyReleaseEvent(keyEvent);
-    }
-
-    return false;
+bool KeyboardInputHandler::keyPressed(KeyEvent e) const {
+    auto* geom = inputContext->getGeometryToolInputHandler();
+    return (geom && geom->keyPressed(e)) || inputContext->getView()->onKeyPressEvent(e);
 }
+
+bool KeyboardInputHandler::keyReleased(KeyEvent e) const { return inputContext->getView()->onKeyReleaseEvent(e); }

--- a/src/core/gui/inputdevices/KeyboardInputHandler.h
+++ b/src/core/gui/inputdevices/KeyboardInputHandler.h
@@ -11,16 +11,17 @@
 
 #pragma once
 
-#include "AbstractInputHandler.h"  // for AbstractInputHandler
-
 class InputContext;
-struct InputEvent;
+struct KeyEvent;
 
-
-class KeyboardInputHandler: public AbstractInputHandler {
+class KeyboardInputHandler final {
 private:
 public:
     explicit KeyboardInputHandler(InputContext* inputContext);
-    ~KeyboardInputHandler() override;
-    bool handleImpl(InputEvent const& event) override;
+    ~KeyboardInputHandler();
+    bool keyPressed(KeyEvent e) const;
+    bool keyReleased(KeyEvent e) const;
+
+private:
+    InputContext* inputContext;
 };

--- a/src/util/gtk4_helper.cpp
+++ b/src/util/gtk4_helper.cpp
@@ -166,3 +166,6 @@ gboolean gtk_file_chooser_set_current_folder(GtkFileChooser* chooser, GFile* fil
 void gtk_list_box_append(GtkListBox* box, GtkWidget* widget) { gtk_container_add(GTK_CONTAINER(box), widget); }
 void gtk_list_box_row_set_child(GtkListBoxRow* row, GtkWidget* w) { set_child(GTK_CONTAINER(row), w); }
 GtkWidget* gtk_list_box_row_get_child(GtkListBoxRow* row) { return gtk_bin_get_child(GTK_BIN(row)); }
+
+/**** GtkEventController ****/
+GdkEvent* gtk_event_controller_get_current_event(GtkEventController*) { return gtk_get_current_event(); }

--- a/src/util/include/util/gtk4_helper.h
+++ b/src/util/include/util/gtk4_helper.h
@@ -87,3 +87,6 @@ gboolean gtk_file_chooser_set_current_folder(GtkFileChooser* chooser, GFile* fil
 void gtk_list_box_append(GtkListBox* box, GtkWidget* widget);
 void gtk_list_box_row_set_child(GtkListBoxRow* row, GtkWidget* w);
 GtkWidget* gtk_list_box_row_get_child(GtkListBoxRow* row);
+
+/**** GtkEventController ****/
+GdkEvent* gtk_event_controller_get_current_event(GtkEventController*);


### PR DESCRIPTION
Again, a preliminary to gtk4. It removes direct access to GdkEvent's members.
