### PR TITLE
Fix-drawing-crash

### DIFF
--- a/src/core/control/tools/PdfElemSelection.h
+++ b/src/core/control/tools/PdfElemSelection.h
@@ -96,7 +96,7 @@ private:
     /// The PDF selection tool used for the selection.
     ToolType toolType;
 
-    long unsigned int selectionPageNr = npos;
+    size_t selectionPageNr = npos;
 
     /// The selection bounds. Note that this does not necessarily correspond to
     /// a rectangle--it may also indicate start and end positions of a linear

--- a/src/core/gui/PageView.cpp
+++ b/src/core/gui/PageView.cpp
@@ -765,7 +765,11 @@ void XojPageView::drawAndDeleteToolView(xoj::view::ToolView* v, const Range& rg)
         v->isViewOf(this->textEditor.get())) {
         // Draw the inputHandler's view onto the page buffer.
         std::lock_guard lock(this->drawingMutex);
-        v->drawWithoutDrawingAids(buffer.get());
+        if (auto cr = buffer.get(); cr) {
+            v->drawWithoutDrawingAids(cr);
+        } else {
+            rerenderPage();
+        }
     }
     this->deleteOverlayView(v, rg);
 }


### PR DESCRIPTION
fixes #5659

This introduces a SharedMask, which protects itself, holding a shared state to a Mask and a Mutex, protecting the Mask.
The solution might be a bit overkill, but it seems to be the easiest solution:

Mask in [PageView.h](https://github.com/xournalpp/xournalpp/pull/5662/files#diff-6379e23dd0c4d7ca42877da6ff49822c47025c346d45c2c27c4b3d97f1afb060) can be manipulated in 2 ways:
The Mask, holding its data and the cairo_mask can be replaced completely.
The data of the mask can be manipulated.

Both operations must be protected by a mutex, or they must be immutable.
The state may be shared and the removal / replacement must not happen in between.

