### PR TITLE
Fix crash when changing page type

### DIFF
--- a/src/core/control/PageBackgroundChangeController.cpp
+++ b/src/core/control/PageBackgroundChangeController.cpp
@@ -198,7 +198,7 @@ auto PageBackgroundChangeController::commitPageTypeChange(size_t pageNum, const 
     } else if (std::holds_alternative<size_t>(param)) {  // PDF background
         setPagePdfBackground(page, std::get<size_t>(param), doc);
     } else {
-        page->setBackgroundType(pageTypeForNewPages.value());
+        page->setBackgroundType(pageType);
     }
 
     return std::make_unique<PageBackgroundChangedUndoAction>(page, origType, origPdfPage, origBackgroundImage, origW,


### PR DESCRIPTION
This fixes a regression from #5630
The crash happens when using menu Journal > Page Background (e.g. changing from graph to lined). In that case `pageTypeForNewPages` may not hold a value.