### PR TITLE
Load plugins only from subfolders of plugin folder

### DIFF
--- a/src/core/plugin/PluginController.cpp
+++ b/src/core/plugin/PluginController.cpp
@@ -65,6 +65,9 @@ auto load_available_plugins_from(fs::path const& path, Control* control) -> std:
     std::vector<std::unique_ptr<Plugin>> returner;
     try {
         for (auto const& f: fs::directory_iterator(path)) {
+            if (!f.is_directory()) {
+                continue;
+            }
             const auto& pluginPath = f.path();
             try {
                 auto plugin = std::make_unique<Plugin>(control, pluginPath.filename().string(), pluginPath);


### PR DESCRIPTION
Currently the file plugins/luapi_application.def.lua raises a warning.

The warning only appears on master (since #5572), so I think it's enough to target it to the master branch.