### PR TITLE
Prevent focus loss after save

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -1794,7 +1794,7 @@ auto Control::save(bool synchron) -> bool {
 
     auto v = win->getXournal()->getViewFor(getCurrentPageNo());
     auto edit = v->getTextEditor();
-    if(edit) {
+    if (edit) {
         PositionInputData pos = {};
         pos.x = edit->getTextElement()->getX() + edit->getCursorBox().getX();
         pos.y = edit->getTextElement()->getY() + edit->getCursorBox().getY() + edit->getCursorBox().getHeight();

--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -58,6 +58,7 @@
 #include "gui/inputdevices/CompassInputHandler.h"                // for Comp...
 #include "gui/inputdevices/GeometryToolInputHandler.h"           // for Geom...
 #include "gui/inputdevices/HandRecognition.h"                    // for Hand...
+#include "gui/inputdevices/PositionInputData.h"
 #include "gui/inputdevices/SetsquareInputHandler.h"              // for Sets...
 #include "gui/menus/menubar/Menubar.h"                           // for Menubar
 #include "gui/sidebar/Sidebar.h"                                 // for Sidebar
@@ -1789,7 +1790,20 @@ void Control::setCurrentState(size_t state) {
 
 auto Control::save(bool synchron) -> bool {
     // clear selection before saving
-    clearSelectionEndText();
+    clearSelection();
+
+    auto v = win->getXournal()->getViewFor(getCurrentPageNo());
+    auto edit = v->getTextEditor();
+    if(edit) {
+        PositionInputData pos = {};
+        pos.x = edit->getTextElement()->getX() + edit->getCursorBox().getX();
+        pos.y = edit->getTextElement()->getY() + edit->getCursorBox().getY() + edit->getCursorBox().getHeight();
+
+        v->endText();
+
+        v->onButtonPressEvent(pos);
+        v->onButtonReleaseEvent(pos);
+    }
 
     this->doc->lock();
     fs::path filepath = this->doc->getFilepath();


### PR DESCRIPTION
Fixes #5132

This commit changes `Control::save`. From now on, `Control::save` remembers cursor position, saves edition by exiting, then starts new edition on the same position.