### PR TITLE
Replace file dialog plugin api

### DIFF
--- a/plugins/QuickScreenshot/main.lua
+++ b/plugins/QuickScreenshot/main.lua
@@ -16,7 +16,7 @@
 -- since the argument to popen is not sanitized.
 -- The programmer must ensure that the argument to
 -- existsUtility() is sanitized (not malicious).
-function existsUtility(utility)
+local function existsUtility(utility)
   if operatingSystem == "Windows" then
     -- Windows not supported yet.
   elseif operatingSystem == "Darwin" then
@@ -31,7 +31,7 @@ end
 
 -- Return one of "Windows", "Linux", "Darwin", "FreeBSD",
 -- "OpenBSD" or "NetBSD", etc.
-function findOS()
+local function findOS()
   if package.config:sub(1,1) == '\\' then
     return "Windows"
   else
@@ -44,18 +44,18 @@ end
 
 -- Register all Toolbar actions and intialize all UI stuff
 function initUi()
-  ref = app.registerUi({["menu"] = "QuickScreenshot", ["callback"] = "go", ["accelerator"] = "<Shift><Alt>t"});
-  operatingSystem = findOS() -- What's the operating system?
+  app.registerUi({ ["menu"] = "QuickScreenshot", ["callback"] = "Go", ["accelerator"] = "<Shift><Alt>t" });
+  OperatingSystem = findOS() -- What's the operating system?
 end
 
 -- This is the callback that gets executed when the user
 -- activates the plugin via the menu or hotkey.
 --
 -- This function executes a screenshot utility to capture
--- the region the user selects. Then, it calls 'app.saveAs'
+-- the region the user selects. Then, it calls 'app.fileDialogSave'
 -- to create a "Save As" dialog for the user to choose the
 -- filename where the image should reside.
-function go()
+function Go()
   local windowsUtilities = {} -- list of windows programs here
   local macUtilities = {} -- list of macOS programs here
   local elseUtilities = -- list of programs for other systems
@@ -71,12 +71,12 @@ function go()
 
   -- Different operating systems have different
   -- screenshot utilities, so we check the OS here
-  if operatingSystem == "Windows" then
+  if OperatingSystem == "Windows" then
     app.openDialog("Windows not supported yet.", {"OK"}, "", true)
     return
   end
 
-  if operatingSystem == "Darwin" then
+  if OperatingSystem == "Darwin" then
     app.openDialog("macOS not supported yet.", {"OK"}, "", true)
     return
   end
@@ -93,25 +93,15 @@ function go()
   local foundUtility = false
   -- Check utility availability and use it
   for i,command in ipairs(elseUtilities) do
-    utilityName = command:match("%S+")
+    local utilityName = command:match("%S+")
     if existsUtility(utilityName) then
-      local tmpFilename = os.tmpname() .. ".png"
+      foundUtility = true
+      TmpFilename = os.tmpname() .. ".png" -- global, because needed in Save callback
       -- The file extension is added in order to avoid the giblib error: no image grabbed
       -- see https://stackoverflow.com/questions/26326664/scrot-giblib-error-saving-to-file-failed
-      local runCommand = assert(io.popen(command .. tmpFilename .. " &"))
+      local runCommand = assert(io.popen(command .. TmpFilename .. " &"))
       runCommand:read('*all')
       runCommand:close()
-
-      -- Launch the "Save As" dialog
-      local filename = app.saveAs("Untitled.png")
-      if not filename then
-        os.remove(tmpFilename)
-        return
-      end
-
-      local res, msg = app.glib_rename(tmpFilename, filename)
-      if not res then print(msg) end
-      foundUtility = true
       break
     end
   end
@@ -123,5 +113,18 @@ function go()
       print(command:match("%S+"))
     end
     return
+  else
+    -- Launch the "Save As" dialog
+    app.fileDialogSave("Save", "Untitled.png")
   end
+end
+
+function Save(filename)
+  if not filename then
+    os.remove(TmpFilename)
+    return
+  end
+
+  local res, msg = app.glib_rename(TmpFilename, filename)
+  if not res then print(msg) end
 end

--- a/plugins/luapi_application.def.lua
+++ b/plugins/luapi_application.def.lua
@@ -17,10 +17,13 @@ app = {}
 --- Returns 1 on success, and (nil, message) on failure.
 function app.glib_rename(from, to) end
 
+--- THIS FUNCTION IS DEPRECATED AND WILL BE REMOVED SOON. Use applib_fileDialogSave() instead.
+--- 
+--- @deprecated
 --- Create a 'Save As' native dialog and return as a string
 --- the filepath of the location the user chose to save.
 --- 
---- @param filename string suggestion for a filename, defaults to "untitlted"
+--- @param filename string suggestion for a filename, defaults to "Untitled"
 --- @return string path of the selected location
 --- 
 --- Examples:
@@ -28,6 +31,22 @@ function app.glib_rename(from, to) end
 ---   local filename = app.saveAs("foo") -- suggests "foo" as filename
 function app.saveAs(filename) end
 
+--- Create a 'Save As' dialog and once the user has chosen the filepath of the location to save
+--- calls the specified callback function to which it passes the filepath or the empty string, if the
+--- operation was cancelled.
+--- 
+--- @param cb string name of the callback function(path:string) to call when a file has been chosen
+--- @param filename string suggestion for a filename, defaults to "Untitled"
+--- 
+--- Examples:
+---   app.fileDialogSave("cb") -- defaults to suggestion "Untitled" in current working directory
+---   app.fileDialogSave("cb", "foo") -- suggests "foo" as filename in current working directory
+---   app.fileDialogSave("cb", "/path/to/folder/bar.png") -- suggestes the given absolute path
+function app.fileDialogSave(cb, filename) end
+
+--- THIS FUNCTION IS DEPRECATED AND WILL BE REMOVED SOON. Use applib_fileDialogOpen() instead.
+--- 
+--- @deprecated
 --- Create a 'Open File' native dialog and return as a string
 --- the filepath the user chose to open.
 --- 
@@ -35,9 +54,20 @@ function app.saveAs(filename) end
 --- @returns string path of the selected location
 --- 
 --- Examples:
----   path = app.getFilePath()
+---   path = app.getFilePath({})
 ---   path = app.getFilePath({'*.bmp', '*.png'})
 function app.getFilePath(types) end
+
+--- Create an 'Open File' dialog and when the user has chosen a filepath
+--- call a callback function whose sole argument is the filepath.
+--- 
+--- @param cb string name of the callback function(path:string) to call when a file was chosen
+--- @param types string[] array of the different allowed extensions e.g. {'\*.bmp', '\*.png'}
+--- 
+--- Examples:
+---   app.fileDialogOpen("cb", {})
+---   app.fileDialogOpen("cb", {'*.bmp', '*.png'})
+function app.fileDialogOpen(cb, types) end
 
 --- THIS FUNCTION IS DEPRECATED AND WILL BE REMOVED SOON. Use applib_openDialog() instead.
 --- 

--- a/src/core/gui/dialog/XojOpenDlg.cpp
+++ b/src/core/gui/dialog/XojOpenDlg.cpp
@@ -191,3 +191,21 @@ void xoj::OpenDlg::showOpenImageDialog(GtkWindow* parent, Settings* settings,
 
     popup.show(parent);
 }
+
+void xoj::OpenDlg::showMultiFormatDialog(GtkWindow* parent, std::vector<std::string> formats,
+                                         std::function<void(fs::path)> callback) {
+    auto popup = xoj::popup::PopupWindowWrapper<FileDlg>(_("Open file"), std::move(callback));
+
+    auto* fc = GTK_FILE_CHOOSER(popup.getPopup()->getWindow());
+
+    if (formats.size() > 0) {
+        GtkFileFilter* filterSupported = gtk_file_filter_new();
+        gtk_file_filter_set_name(filterSupported, _("Supported files"));
+        for (std::string format: formats) {
+            gtk_file_filter_add_pattern(filterSupported, format.c_str());
+        }
+        gtk_file_chooser_add_filter(fc, filterSupported);
+    }
+
+    popup.show(parent);
+}

--- a/src/core/gui/dialog/XojOpenDlg.h
+++ b/src/core/gui/dialog/XojOpenDlg.h
@@ -27,4 +27,6 @@ void showOpenTemplateDialog(GtkWindow* parent, Settings* settings, std::function
 
 /// @param callback(path, attachImg)
 void showOpenImageDialog(GtkWindow* parent, Settings* settings, std::function<void(fs::path, bool)> callback);
+
+void showMultiFormatDialog(GtkWindow* parent, std::vector<std::string> formats, std::function<void(fs::path)> callback);
 };  // namespace xoj::OpenDlg

--- a/src/core/plugin/Plugin.cpp
+++ b/src/core/plugin/Plugin.cpp
@@ -296,6 +296,23 @@ auto Plugin::callFunction(const std::string& fnc, ptrdiff_t mode) -> bool {
     return true;
 }
 
+auto Plugin::callFunction(const std::string& fnc, const char* s) -> bool {
+    lua_getglobal(lua.get(), fnc.c_str());
+
+    lua_pushstring(lua.get(), s);
+
+    // Run the function
+    if (lua_pcall(lua.get(), 1, 0, 0)) {
+        const char* errMsg = lua_tostring(lua.get(), -1);
+        XojMsgBox::showPluginMessage(name, errMsg, true);
+
+        g_warning("Error in Plugin: \"%s\", error: \"%s\"", name.c_str(), errMsg);
+        return false;
+    }
+
+    return true;
+}
+
 auto Plugin::getName() const -> std::string const& { return name; }
 auto Plugin::getDescription() const -> std::string const& { return description; }
 auto Plugin::getAuthor() const -> std::string const& { return author; }

--- a/src/core/plugin/Plugin.h
+++ b/src/core/plugin/Plugin.h
@@ -167,6 +167,7 @@ public:
 
     /// Execute lua function
     auto callFunction(const std::string& fnc, ptrdiff_t mode = std::numeric_limits<ptrdiff_t>::max()) -> bool;
+    auto callFunction(const std::string& fnc, const char* s) -> bool;
 
 private:
     Control* control;                                      ///< The main controller


### PR DESCRIPTION
This PR deprecates the Lua plugin API app.saveAs app.getFilePath and replaces it by Gtk4 compatible versions. We wanted to do it before the Gtk4 switch, see https://github.com/xournalpp/xournalpp/pull/5615#issuecomment-2081171924

Maybe more customization should be introduced:
- custom file filter for save dialogs (currently all files are in the filter)
- custom window title for save dialogs

The QuickScreenshot plugin was adapted to use the new API. 