### PR TITLE
Allow missing terminating newlines and empty lines in .gpl files

### DIFF
--- a/src/core/gui/toolbarMenubar/model/ColorPalette.cpp
+++ b/src/core/gui/toolbarMenubar/model/ColorPalette.cpp
@@ -32,9 +32,10 @@ void Palette::load() {
     // parse standard header line
     parseFirstGimpPaletteLine(line);
     // attempt parsing line by line as either header, color, or fallback
-    while (gplFile.peek() != EOF && getline(gplFile, line)) {
+    while (!gplFile.eof() && gplFile.peek() != EOF && getline(gplFile, line)) {
         lineNumber++;
-        parseCommentLine(line) || parseHeaderLine(line) || parseColorLine(line) || parseLineFallback(lineNumber);
+        parseCommentLine(line) || parseHeaderLine(line) || parseColorLine(line) || parseEmptyLine(line) ||
+                parseLineFallback(lineNumber);
     }
     if (namedColors.size() < 1) {
         throw std::invalid_argument("Your Palettefile has no parsable color. It needs at least one!");
@@ -82,6 +83,8 @@ auto Palette::parseColorLine(const std::string& line) -> bool {
 }
 
 auto Palette::parseCommentLine(const std::string& line) const -> bool { return line.front() == '#'; }
+
+auto Palette::parseEmptyLine(const std::string& line) const -> bool { return line.empty(); }
 
 auto Palette::parseLineFallback(int lineNumber) const -> const bool {
     throw std::invalid_argument(FS(FORMAT_STR("The line {1} is malformed.") % lineNumber));

--- a/src/core/gui/toolbarMenubar/model/ColorPalette.h
+++ b/src/core/gui/toolbarMenubar/model/ColorPalette.h
@@ -187,6 +187,16 @@ private:
     bool parseCommentLine(const std::string& line) const;
 
     /**
+     * @brief Parse an empty line
+     * Empty lines do not contain any characters and are ignored
+     *
+     * @param line
+     * @return true if line is empty
+     * @return false otherwise
+     */
+    bool parseEmptyLine(const std::string& line) const;
+
+    /**
      * @brief Fallback for line parsing
      * This function is the fallback in case no other parsing attempt works.
      * In this case this function throws an error containing the non-parseable line number


### PR DESCRIPTION
Fixes #5724 

In line with [the specification](https://developer.gimp.org/core/standards/gpl/), this will accept only actually empty lines. Allowing blank lines (with any kind of whitespaces) would be easily feasible with the following, if you think it's prefferable:
```c++
auto Palette::parseBlankLine(const std::string& line) const -> bool {
    return line.find_first_not_of(" \t\r\f\v") == std::string::npos;
}
```

PS: Hi it's me again. Haven't had much time lately... I'll try to work on my other open PRs, but I figured this small issue would be perfect to jump back in. 