### PR TITLE
Bump MacOS pipeline image

### DIFF
--- a/azure-pipelines/continuous-integration.yml
+++ b/azure-pipelines/continuous-integration.yml
@@ -55,7 +55,7 @@ stages:
 
       - job: macOS
         pool:
-          vmImage: 'macOS-11'
+          vmImage: 'macOS-12'
         displayName: 'Test Xournal++ on MacOS'
         steps:
           - template: steps/build_mac.yml

--- a/azure-pipelines/create-installers.yml
+++ b/azure-pipelines/create-installers.yml
@@ -101,7 +101,7 @@ stages:
 
       - job: macOS
         pool:
-          vmImage: 'macOS-11'
+          vmImage: 'macOS-12'
         displayName: 'Build for macOS'
         steps:
           - template: steps/build_mac.yml

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -120,7 +120,7 @@ stages:
 
       - job: macOS
         pool:
-          vmImage: 'macOS-11'
+          vmImage: 'macOS-12'
         displayName: 'Build for macOS'
         steps:
           - template: steps/build_mac.yml


### PR DESCRIPTION
 - macOS-11 has been deprecated and removed
  - new versio macOS-12