### PR TITLE
Use struct for forward declaration of Palette

### DIFF
--- a/src/core/gui/toolbarMenubar/ToolMenuHandler.h
+++ b/src/core/gui/toolbarMenubar/ToolMenuHandler.h
@@ -43,7 +43,7 @@ class ColorToolItem;
 struct ToolbarButtonEntry;
 class PageTypeSelectionPopover;
 class PageType;
-class Palette;
+struct Palette;
 class StylePopoverFactory;
 
 class ToolMenuHandler {


### PR DESCRIPTION
There's a few compilation warnings that pop up with clang:

warning: class 'Palette' was previously declared as a struct; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Wmismatched-tags]
warning: struct 'Palette' was previously declared as a class; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Wmismatched-tags]
warning: 'Palette' defined as a struct here but previously declared as a class; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Wmismatched-tags]

Very quick fix