### PR TITLE
Add feature to remove individual entries from list of recent documents

### DIFF
--- a/src/core/control/RecentManager.h
+++ b/src/core/control/RecentManager.h
@@ -37,7 +37,7 @@ void addRecentFileFilename(const fs::path& filename);
 /**
  * Removes a file from the underlying GtkRecentManager
  */
-[[maybe_unused]] void removeRecentFileFilename(const fs::path& filename);
+void removeRecentFileFilename(const fs::path& filename);
 
 /**
  * Remove all supported files from the recent file list

--- a/src/core/gui/menus/menubar/RecentDocumentsSubmenu.h
+++ b/src/core/gui/menus/menubar/RecentDocumentsSubmenu.h
@@ -41,6 +41,7 @@ public:
 
 private:
     static void openFileCallback(GSimpleAction* ga, GVariant* parameter, RecentDocumentsSubmenu* self);
+    static void removeFileCallback(GSimpleAction* ga, GVariant* parameter, RecentDocumentsSubmenu* self);
 
     gulong recentHandlerId{};
 
@@ -69,4 +70,5 @@ private:
     xoj::util::GObjectSPtr<GMenu> menuPdfFiles;
     xoj::util::GObjectSPtr<GSimpleAction> openFileAction;
     xoj::util::GObjectSPtr<GSimpleAction> clearListAction;
+    xoj::util::GObjectSPtr<GSimpleAction> removeFileAction;
 };


### PR DESCRIPTION
Added submenu "Remove Recent Documents" under menu file -> recent documents. Clicking on files in this submenu remove individual recent files without the need of clearing the whole list.