### PR TITLE
Plugin: Add pages for notes automatically

### DIFF
--- a/plugins/SpaceForNotes/main.lua
+++ b/plugins/SpaceForNotes/main.lua
@@ -1,0 +1,28 @@
+local m = {
+    NORMAL = 0,
+    FORCE = 1,
+}
+
+-- Register all Toolbar actions and intialize all UI stuff
+function initUi()
+  app.registerUi{menu="Add one empty pages after every pdf page once", callback="AddEmpty", mode=m.NORMAL}
+  app.registerUi{menu="Add empty pages after every page", callback="AddEmpty", mode=m.FORCE}
+end
+
+function AddEmpty(mode)
+    local struct = app.getDocumentStructure()
+    for p=#struct.pages,1,-1 do
+        local page = struct.pages[p]
+        local pred = true
+        if mode ~= m.FORCE then
+            local nextPage = struct.pages[p+1]
+            -- insert a new empty page if p is a pdf-page and succeeding page either does not exist or is also a pdf-page
+            pred = page.pdfBackgroundPageNo ~= 0 and (nextPage == nil or nextPage.pdfBackgroundPageNo ~= 0)
+        end
+        -- if mode is force => pred is set to true
+        if pred then
+            app.setCurrentPage(p)
+            app.uiAction{action="ACTION_NEW_PAGE_AFTER"}
+        end
+    end
+end

--- a/plugins/SpaceForNotes/plugin.ini
+++ b/plugins/SpaceForNotes/plugin.ini
@@ -1,0 +1,15 @@
+[about]
+## Author / Copyright notice
+author=Lukas Heindl
+
+description=Add empty pages to have space for notes
+
+## If the plugin is packed with Xournal++, use
+## <xournalpp> then it gets the same version number
+version=<xournalpp>
+
+[default]
+enabled=false
+
+[plugin]
+mainfile=main.lua


### PR DESCRIPTION
Adds a plugin which adds empty pages after each page showing a page from the pdf if the page is the last page of the document or the following page also shows a page from the pdf.

This rather complicated conditional makes the function idempotent, so executing it more than once won't do more changes.

To provide full flexibility to the user, there is also a `force` mode which simply skips the check and unconditionally adds an empty page after every page in the document.

Implements #5285.

After applying this, one can e.g. set the view to two-column mode so that one has always the pdf page on the left and have space on the right for notes.

---
Note: Initially I thought about naming the plugin `BatchChanges` as it allows us to apply one operation on the complete document. Also in the beginning I had functionalities like *change the background color of all pages* or so in mind (which I dropped for now because those functionalities would require more complex user input (-> lgi) which I have not really experience working with.

Just wanted to add this note so that you know I'm totally fine if you later decide to move the functionality of this plugin into another plugin if it fits.