### PR TITLE
Fix selection order bring forward action for plugins

### DIFF
--- a/src/core/plugin/ActionBackwardCompatibilityLayer.cpp
+++ b/src/core/plugin/ActionBackwardCompatibilityLayer.cpp
@@ -166,7 +166,7 @@ static const std::map<std::string_view, std::pair<Action, bool>> LAYOUT_MAP = {
 
 static const std::map<std::string_view, EditSelection::OrderChange> SELECTION_ORDER_ACTION_MAP = {
         {"ACTION_ARRANGE_BRING_TO_FRONT"sv, EditSelection::OrderChange::BringToFront},
-        {"ACTION_ARRANGE_BRING_TO_FRONT"sv, EditSelection::OrderChange::BringToFront},
+        {"ACTION_ARRANGE_BRING_FORWARD"sv, EditSelection::OrderChange::BringForward},
         {"ACTION_ARRANGE_SEND_BACKWARD"sv, EditSelection::OrderChange::SendBackward},
         {"ACTION_ARRANGE_SEND_TO_BACK"sv, EditSelection::OrderChange::SendToBack}};
 


### PR DESCRIPTION
In the file "ActionBackwardCompatibilityLayer.cpp" the action for bringing the selection to the front was duplicated instead of the second one being to bring the selection forward.