### PR TITLE
Add methods app.getZoom and app.setZoom to plugin api.

### DIFF
--- a/plugins/luapi_application.def.lua
+++ b/plugins/luapi_application.def.lua
@@ -710,6 +710,21 @@ function app.scaleTextElements(factor) end
 --- Example: app.getDisplayDpi()
 function app.getDisplayDpi() end
 
+--- Gets the current zoom.
+--- 
+--- @return double current zoom level
+--- 
+--- Example: app.getZoom()
+function app.getZoom() end
+
+--- Sets the current zoom.
+--- 
+--- @param zoom number
+--- 
+--- Example: app.setZoom(2.5)
+--- Changes zoom level to 2.5
+function app.setZoom(zoom) end
+
 --- Exports the current document as a pdf or as a svg or png image
 --- 
 --- @param opts {outputFile:string, range:string, background:string, progressiveMode: boolean}

--- a/src/core/plugin/luapi_application.h
+++ b/src/core/plugin/luapi_application.h
@@ -29,6 +29,7 @@
 #include "control/settings/Settings.h"
 #include "control/tools/EditSelection.h"
 #include "control/tools/ImageHandler.h"
+#include "control/zoom/ZoomControl.h"
 #include "enums/Action.enum.h"
 #include "gui/Layout.h"
 #include "gui/MainWindow.h"
@@ -2507,6 +2508,46 @@ static int applib_getDisplayDpi(lua_State* L) {
 
 
 /**
+ * Gets the current zoom.
+ *
+ * @return double current zoom level
+ *
+ * Example: app.getZoom()
+ **/
+static int applib_getZoom(lua_State* L) {
+    Plugin* plugin = Plugin::getPluginFromLua(L);
+    Control* control = plugin->getControl();
+    double zoom = control->getZoomControl()->getZoomReal();
+    lua_pushnumber(L, zoom);
+
+    return 1;
+}
+
+
+/**
+ * Sets the current zoom.
+ *
+ * @param zoom number
+ *
+ * Example: app.setZoom(2.5)
+ * Changes zoom level to 2.5
+ **/
+static int applib_setZoom(lua_State* L) {
+    Plugin* plugin = Plugin::getPluginFromLua(L);
+    Control* control = plugin->getControl();
+    ZoomControl* zoomControl = control->getZoomControl();
+
+    double newZoom = luaL_checknumber(L, 1) * zoomControl->getZoom100Value();
+    zoomControl->setZoomFitMode(false);
+    zoomControl->startZoomSequence();
+    zoomControl->zoomSequenceChange(newZoom, false);
+    zoomControl->endZoomSequence();
+
+    return 0;
+}
+
+
+/**
  * Exports the current document as a pdf or as a svg or png image
  *
  * @param opts {outputFile:string, range:string, background:string, progressiveMode: boolean}
@@ -2950,6 +2991,8 @@ static const luaL_Reg applib[] = {{"msgbox", applib_msgbox},  // Todo(gtk4) remo
                                   {"setBackgroundName", applib_setBackgroundName},
                                   {"scaleTextElements", applib_scaleTextElements},
                                   {"getDisplayDpi", applib_getDisplayDpi},
+                                  {"getZoom", applib_getZoom},
+                                  {"setZoom", applib_setZoom},
                                   {"export", applib_export},
                                   {"addStrokes", applib_addStrokes},
                                   {"addSplines", applib_addSplines},


### PR DESCRIPTION
I noticed that while you could zoom in and out using the actions, you couldn't set the zoom to a specific level or get the current zoom level using the plugin api.
In this pull request I added the methods `app.getZoom` and `app.setZoom` to the `luapi_application.h` file.
The `app.getZoom` method calls `ZoomControl::getZoomReal` and returns it as a number, the `app.setZoom` calls the same methods to set the zoom level that are also used in [ActionProperties.h](https://github.com/xournalpp/xournalpp/blob/2e9c84a88271d18e64ca64e293a6521f13bb2c3c/src/core/control/actions/ActionProperties.h#L430) (this also means first multiplying the supplied zoom level by the `zoom100Value` which means that you set the real zoom value using the api, which corresponds to getting the real zoom value with `app.getZoom`)

I hope I did everything correctly concerning the code style etc., this is my first time with Lua and C++ :sweat_smile: 