### PR TITLE
Fix UB with GTK signals

### DIFF
--- a/src/core/gui/MainWindow.cpp
+++ b/src/core/gui/MainWindow.cpp
@@ -101,8 +101,11 @@ MainWindow::MainWindow(GladeSearchpath* gladeSearchPath, Control* control, GtkAp
                      this);
 
     // "watch over" all key events
-    g_signal_connect(this->window, "key-press-event", G_CALLBACK(gtk_window_propagate_key_event), nullptr);
-    g_signal_connect(this->window, "key-release-event", G_CALLBACK(gtk_window_propagate_key_event), nullptr);
+    auto keyPropagate = +[](GtkWidget* w, GdkEvent* e, gpointer) {
+        return gtk_window_propagate_key_event(GTK_WINDOW(w), (GdkEventKey*)(e));
+    };
+    g_signal_connect(this->window, "key-press-event", G_CALLBACK(keyPropagate), nullptr);
+    g_signal_connect(this->window, "key-release-event", G_CALLBACK(keyPropagate), nullptr);
 
     // need to create tool buttons registered in plugins, so they can be added to toolbars
     control->registerPluginToolButtons(this->toolbar.get());

--- a/src/core/gui/dialog/FillOpacityDialog.cpp
+++ b/src/core/gui/dialog/FillOpacityDialog.cpp
@@ -6,6 +6,8 @@
 #include <glib-object.h>  // for G_CALLBACK, g_signal_connect
 #include <glib.h>         // for gdouble
 
+#include "util/safe_casts.h"
+
 class GladeSearchpath;
 
 FillOpacityDialog::FillOpacityDialog(GladeSearchpath* gladeSearchPath, int alpha, bool pen):
@@ -16,10 +18,9 @@ FillOpacityDialog::FillOpacityDialog(GladeSearchpath* gladeSearchPath, int alpha
 
     setPreviewImage(alpha);
 
-    g_signal_connect(scaleAlpha, "change-value",
-                     G_CALLBACK(+[](GtkRange* range, GtkScrollType scroll, gdouble value, FillOpacityDialog* self) {
-                         self->setPreviewImage((int)(value / 100 * 255));
-                         gtk_range_set_value(range, value);
+    g_signal_connect(scaleAlpha, "value-changed", G_CALLBACK(+[](GtkRange* range, gpointer self) {
+                         static_cast<FillOpacityDialog*>(self)->setPreviewImage(
+                                 round_cast<int>(gtk_range_get_value(range) * 2.55));
                      }),
                      this);
 }

--- a/src/core/gui/dialog/LatexDialog.h
+++ b/src/core/gui/dialog/LatexDialog.h
@@ -108,7 +108,7 @@ private:
      * @param cr is drawn to
      * @param self The LatexDialog that is the source and target of the callback.
      */
-    static void drawPreviewCallback(GtkWidget* widget, cairo_t* cr, LatexDialog* self);
+    static bool drawPreviewCallback(GtkWidget* widget, cairo_t* cr, LatexDialog* self);
 
 private:
     // Temporary render

--- a/src/core/gui/dialog/SettingsDialog.cpp
+++ b/src/core/gui/dialog/SettingsDialog.cpp
@@ -44,64 +44,72 @@ SettingsDialog::SettingsDialog(GladeSearchpath* gladeSearchPath, Settings* setti
 
     GtkWidget* zoomCalibSlider = get("zoomCallibSlider");
     g_return_if_fail(zoomCalibSlider != nullptr);
-    g_signal_connect(zoomCalibSlider, "change-value",
-                     G_CALLBACK(+[](GtkRange* range, GtkScrollType scroll, gdouble value, SettingsDialog* self) {
-                         self->setDpi((int)value);
+    g_signal_connect(GTK_RANGE(zoomCalibSlider), "value-changed", G_CALLBACK(+[](GtkRange* range, gpointer self) {
+                         static_cast<SettingsDialog*>(self)->setDpi(round_cast<int>(gtk_range_get_value(range)));
                      }),
                      this);
 
-    g_signal_connect(
-            get("cbEnablePressureInference"), "toggled",
-            G_CALLBACK(+[](GtkComboBox* comboBox, SettingsDialog* self) { self->updatePressureSensitivityOptions(); }),
-            this);
-
-    g_signal_connect(
-            get("cbSettingPresureSensitivity"), "toggled",
-            G_CALLBACK(+[](GtkComboBox* comboBox, SettingsDialog* self) { self->updatePressureSensitivityOptions(); }),
-            this);
-
-    g_signal_connect(get("cbAutosave"), "toggled", G_CALLBACK(+[](GtkToggleButton* togglebutton, SettingsDialog* self) {
-                         self->enableWithCheckbox("cbAutosave", "boxAutosave");
+    g_signal_connect(GTK_TOGGLE_BUTTON(get("cbEnablePressureInference")), "toggled",
+                     G_CALLBACK(+[](GtkToggleButton*, gpointer self) {
+                         static_cast<SettingsDialog*>(self)->updatePressureSensitivityOptions();
                      }),
                      this);
 
-    g_signal_connect(get("cbIgnoreFirstStylusEvents"), "toggled",
-                     G_CALLBACK(+[](GtkToggleButton* togglebutton, SettingsDialog* self) {
-                         self->enableWithCheckbox("cbIgnoreFirstStylusEvents", "spNumIgnoredStylusEvents");
+    g_signal_connect(GTK_TOGGLE_BUTTON(get("cbSettingPresureSensitivity")), "toggled",
+                     G_CALLBACK(+[](GtkToggleButton*, gpointer self) {
+                         static_cast<SettingsDialog*>(self)->updatePressureSensitivityOptions();
+                     }),
+                     this);
+
+    g_signal_connect(GTK_TOGGLE_BUTTON(get("cbAutosave")), "toggled", G_CALLBACK(+[](GtkToggleButton*, gpointer self) {
+                         static_cast<SettingsDialog*>(self)->enableWithCheckbox("cbAutosave", "boxAutosave");
+                     }),
+                     this);
+
+    g_signal_connect(GTK_TOGGLE_BUTTON(get("cbIgnoreFirstStylusEvents")), "toggled",
+                     G_CALLBACK(+[](GtkToggleButton*, gpointer self) {
+                         static_cast<SettingsDialog*>(self)->enableWithCheckbox("cbIgnoreFirstStylusEvents",
+                                                                                "spNumIgnoredStylusEvents");
                      }),
                      this);
 
 
-    g_signal_connect(get("btTestEnable"), "clicked", G_CALLBACK(+[](GtkButton* bt, SettingsDialog* self) {
-                         Util::systemWithMessage(gtk_entry_get_text(GTK_ENTRY(self->get("txtEnableTouchCommand"))));
+    g_signal_connect(GTK_BUTTON(get("btTestEnable")), "clicked", G_CALLBACK(+[](GtkButton*, gpointer self) {
+                         Util::systemWithMessage(gtk_entry_get_text(
+                                 GTK_ENTRY(static_cast<SettingsDialog*>(self)->get("txtEnableTouchCommand"))));
                      }),
                      this);
 
-    g_signal_connect(get("btTestDisable"), "clicked", G_CALLBACK(+[](GtkButton* bt, SettingsDialog* self) {
-                         Util::systemWithMessage(gtk_entry_get_text(GTK_ENTRY(self->get("txtDisableTouchCommand"))));
+    g_signal_connect(GTK_BUTTON(get("btTestDisable")), "clicked", G_CALLBACK(+[](GtkButton*, gpointer self) {
+                         Util::systemWithMessage(gtk_entry_get_text(
+                                 GTK_ENTRY(static_cast<SettingsDialog*>(self)->get("txtDisableTouchCommand"))));
                      }),
                      this);
 
-    g_signal_connect(get("cbAddVerticalSpace"), "toggled",
-                     G_CALLBACK(+[](GtkToggleButton* togglebutton, SettingsDialog* self) {
-                         self->enableWithCheckbox("cbAddVerticalSpace", "spAddVerticalSpace");
+    g_signal_connect(GTK_TOGGLE_BUTTON(get("cbAddVerticalSpace")), "toggled",
+                     G_CALLBACK(+[](GtkToggleButton* togglebutton, gpointer self) {
+                         static_cast<SettingsDialog*>(self)->enableWithCheckbox("cbAddVerticalSpace",
+                                                                                "spAddVerticalSpace");
                      }),
                      this);
 
-    g_signal_connect(get("cbAddHorizontalSpace"), "toggled",
-                     G_CALLBACK(+[](GtkToggleButton* togglebutton, SettingsDialog* self) {
-                         self->enableWithCheckbox("cbAddHorizontalSpace", "spAddHorizontalSpace");
+    g_signal_connect(GTK_TOGGLE_BUTTON(get("cbAddHorizontalSpace")), "toggled",
+                     G_CALLBACK(+[](GtkToggleButton* togglebutton, gpointer self) {
+                         static_cast<SettingsDialog*>(self)->enableWithCheckbox("cbAddHorizontalSpace",
+                                                                                "spAddHorizontalSpace");
                      }),
                      this);
 
-    g_signal_connect(get("cbDrawDirModsEnabled"), "toggled",
-                     G_CALLBACK(+[](GtkToggleButton* togglebutton, SettingsDialog* self) {
-                         self->enableWithCheckbox("cbDrawDirModsEnabled", "spDrawDirModsRadius");
+    g_signal_connect(GTK_TOGGLE_BUTTON(get("cbDrawDirModsEnabled")), "toggled",
+                     G_CALLBACK(+[](GtkToggleButton* togglebutton, gpointer self) {
+                         static_cast<SettingsDialog*>(self)->enableWithCheckbox("cbDrawDirModsEnabled",
+                                                                                "spDrawDirModsRadius");
                      }),
                      this);
 
-    g_signal_connect(get("cbStrokeFilterEnabled"), "toggled",
-                     G_CALLBACK(+[](GtkToggleButton* togglebutton, SettingsDialog* self) {
+    g_signal_connect(GTK_TOGGLE_BUTTON(get("cbStrokeFilterEnabled")), "toggled",
+                     G_CALLBACK(+[](GtkToggleButton* togglebutton, gpointer d) {
+                         auto* self = static_cast<SettingsDialog*>(d);
                          self->enableWithCheckbox("cbStrokeFilterEnabled", "spStrokeIgnoreTime");
                          self->enableWithCheckbox("cbStrokeFilterEnabled", "spStrokeIgnoreLength");
                          self->enableWithCheckbox("cbStrokeFilterEnabled", "spStrokeSuccessiveTime");
@@ -110,8 +118,9 @@ SettingsDialog::SettingsDialog(GladeSearchpath* gladeSearchPath, Settings* setti
                      }),
                      this);
 
-    g_signal_connect(get("cbDisableAudio"), "toggled",
-                     G_CALLBACK(+[](GtkToggleButton* togglebutton, SettingsDialog* self) {
+    g_signal_connect(GTK_TOGGLE_BUTTON(get("cbDisableAudio")), "toggled",
+                     G_CALLBACK(+[](GtkToggleButton* togglebutton, gpointer d) {
+                         auto* self = static_cast<SettingsDialog*>(d);
                          self->disableWithCheckbox("cbDisableAudio", "sidAudio1");
                          self->disableWithCheckbox("cbDisableAudio", "sidAudio2");
                          self->disableWithCheckbox("cbDisableAudio", "sidAudio3");
@@ -121,38 +130,41 @@ SettingsDialog::SettingsDialog(GladeSearchpath* gladeSearchPath, Settings* setti
                      this);
 
 
-    g_signal_connect(get("cbDisableTouchOnPenNear"), "toggled",
-                     G_CALLBACK(+[](GtkToggleButton* togglebutton, SettingsDialog* self) {
-                         self->enableWithCheckbox("cbDisableTouchOnPenNear", "boxInternalHandRecognition");
+    g_signal_connect(GTK_TOGGLE_BUTTON(get("cbDisableTouchOnPenNear")), "toggled",
+                     G_CALLBACK(+[](GtkToggleButton* togglebutton, gpointer self) {
+                         static_cast<SettingsDialog*>(self)->enableWithCheckbox("cbDisableTouchOnPenNear",
+                                                                                "boxInternalHandRecognition");
+                     }),
+                     this);
+
+    g_signal_connect(GTK_COMBO_BOX(get("cbTouchDisableMethod")), "changed",
+                     G_CALLBACK(+[](GtkComboBox* comboBox, gpointer self) {
+                         static_cast<SettingsDialog*>(self)->customHandRecognitionToggled();
                      }),
                      this);
 
     g_signal_connect(
-            get("cbTouchDisableMethod"), "changed",
-            G_CALLBACK(+[](GtkComboBox* comboBox, SettingsDialog* self) { self->customHandRecognitionToggled(); }),
+            GTK_TOGGLE_BUTTON(get("cbEnableZoomGestures")), "toggled", G_CALLBACK(+[](GtkToggleButton*, gpointer self) {
+                static_cast<SettingsDialog*>(self)->enableWithCheckbox("cbEnableZoomGestures", "gdStartZoomAtSetting");
+            }),
             this);
 
-    g_signal_connect(get("cbEnableZoomGestures"), "toggled",
-                     G_CALLBACK(+[](GtkComboBox* comboBox, SettingsDialog* self) {
-                         self->enableWithCheckbox("cbEnableZoomGestures", "gdStartZoomAtSetting");
+    g_signal_connect(GTK_COMBO_BOX(get("cbStylusCursorType")), "changed",
+                     G_CALLBACK(+[](GtkComboBox* comboBox, gpointer self) {
+                         static_cast<SettingsDialog*>(self)->customStylusIconTypeChanged();
                      }),
                      this);
 
-    g_signal_connect(get("cbStylusCursorType"), "changed", G_CALLBACK(+[](GtkComboBox* comboBox, SettingsDialog* self) {
-                         self->customStylusIconTypeChanged();
-                     }),
-                     this);
-
-    g_signal_connect(get("cbStabilizerAveragingMethods"), "changed",
-                     G_CALLBACK(+[](GtkComboBox* comboBox, SettingsDialog* self) {
-                         self->showStabilizerAvMethodOptions(
+    g_signal_connect(GTK_COMBO_BOX(get("cbStabilizerAveragingMethods")), "changed",
+                     G_CALLBACK(+[](GtkComboBox* comboBox, gpointer self) {
+                         static_cast<SettingsDialog*>(self)->showStabilizerAvMethodOptions(
                                  static_cast<StrokeStabilizer::AveragingMethod>(gtk_combo_box_get_active(comboBox)));
                      }),
                      this);
 
-    g_signal_connect(get("cbStabilizerPreprocessors"), "changed",
-                     G_CALLBACK(+[](GtkComboBox* comboBox, SettingsDialog* self) {
-                         self->showStabilizerPreprocessorOptions(
+    g_signal_connect(GTK_COMBO_BOX(get("cbStabilizerPreprocessors")), "changed",
+                     G_CALLBACK(+[](GtkComboBox* comboBox, gpointer self) {
+                         static_cast<SettingsDialog*>(self)->showStabilizerPreprocessorOptions(
                                  static_cast<StrokeStabilizer::Preprocessor>(gtk_combo_box_get_active(comboBox)));
                      }),
                      this);

--- a/src/core/gui/toolbarMenubar/icon/ColorSelectImage.cpp
+++ b/src/core/gui/toolbarMenubar/icon/ColorSelectImage.cpp
@@ -10,8 +10,10 @@ ColorSelectImage::ColorSelectImage(Color color, bool circle): color(color), circ
     widget = gtk_drawing_area_new();
     gtk_widget_set_size_request(widget, 16, 16);
 
-    g_signal_connect(widget, "draw",
-                     G_CALLBACK(+[](GtkWidget* widget, cairo_t* cr, ColorSelectImage* self) { self->drawWidget(cr); }),
+    g_signal_connect(widget, "draw", G_CALLBACK(+[](GtkWidget* widget, cairo_t* cr, gpointer self) -> gboolean {
+                         static_cast<ColorSelectImage*>(self)->drawWidget(cr);
+                         return true;
+                     }),
                      this);
 }
 

--- a/src/core/gui/widgets/gtkmenutooltogglebutton.cpp
+++ b/src/core/gui/widgets/gtkmenutooltogglebutton.cpp
@@ -41,7 +41,7 @@ struct _GtkMenuToolToggleButtonPrivate {
 
 static void gtk_menu_tool_toggle_button_dispose(GObject* object);
 
-static auto menu_deactivate_cb(GtkMenuShell* menu_shell, GtkMenuToolToggleButton* button) -> int;
+static void menu_deactivate_cb(GtkMenuShell* menu_shell, GtkMenuToolToggleButton* button);
 
 enum { SHOW_MENU, LAST_SIGNAL };
 
@@ -390,12 +390,10 @@ auto gtk_menu_tool_toggle_button_new_from_stock(const gchar* stock_id) -> GtkToo
  * This is used so that we unset the state of the toggle button
  * when the pop-up menu disappears.
  */
-static auto menu_deactivate_cb(GtkMenuShell* menu_shell, GtkMenuToolToggleButton* button) -> int {
+static void menu_deactivate_cb(GtkMenuShell* menu_shell, GtkMenuToolToggleButton* button) {
     GtkMenuToolToggleButtonPrivate* priv = button->priv;
 
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(priv->arrow_button), false);
-
-    return true;
 }
 
 static void menu_detacher(GtkWidget* widget, GtkMenu* menu) {


### PR DESCRIPTION
- Some callbacks were returning void while they should have returned gboolean, leading to inconsistent behaviour -- see for instance https://github.com/xournalpp/xournalpp/discussions/5842, but the UB was more spread than just there.
- GtkRange::change-value is also replaced by GtkRange::value-changed (which is more suited for our uses)

As a side note, I've been working on a way to enforce at compile time that the signals callbacks have the right type, but that'll be for the master branch.