### PR TITLE
Cirrus pipeline task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -63,6 +63,8 @@ build_xournalpp_task:
     cmake .. -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo
     cmake --build .
     cmake --install . --prefix /opt/devroot/gtk/inst
+  pkgconf_symlink_script: | # used for gtk-mac-bundler
+    ln -sf $(which pkgconf) /opt/devroot/gtk/inst/bin/pkg-config
   package_script: |
     (cd mac-setup && bash build-app.sh ~/gtk && bash build-dmg.sh Xournal++.app Xournal++.dmg)
   xournalpp_artifacts:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 macos_instance:
-  image: ghcr.io/cirruslabs/macos-ventura-base:latest
+  image: ghcr.io/cirruslabs/macos-runner:sonoma
 
 # Need to override the user HOME so we can cache the jhbuild stuff.
 env:
@@ -32,7 +32,7 @@ build_binary_blob_task:
   upload_caches:
     - binary_blob
   upload_binary_blob_artifacts:
-    path: blobdir
+    path: "blobdir/*"
 
 build_xournalpp_task:
   << : *UNINSTALL_HOMEBREW

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,69 @@
+macos_instance:
+  image: ghcr.io/cirruslabs/macos-ventura-base:latest
+
+# Need to override the user HOME so we can cache the jhbuild stuff.
+env:
+  HOME: /opt/devroot
+
+# Define a template that is reused for both binary blob task & build task.
+binary_blob_cache_template: &BINARY_BLOB_CACHE_TEMPLATE
+  folder: blobdir
+  fingerprint_script: |
+    echo "$CIRRUS_OS"
+    cat mac-setup/jhbuild-version.lock
+    shasum -a 512256 mac-setup/xournalpp.modules | cut -f 1 -d' '
+
+uninstall_homebrew_template: &UNINSTALL_HOMEBREW
+  uninstall_homebrew_script: |
+    NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh)"
+    sudo rm -rf /opt/homebrew
+
+
+build_binary_blob_task:
+  << : *UNINSTALL_HOMEBREW
+  create_devroot_script: |
+    sudo mkdir -p /opt/devroot && sudo chown "$USER":admin /opt/devroot
+  binary_blob_cache:
+    << : *BINARY_BLOB_CACHE_TEMPLATE
+    populate_script: |
+      bash mac-setup/cirrus_jhbuild.sh
+      mkdir blobdir
+      mv xournalpp-binary-blob.tar.gz blobdir
+  upload_caches:
+    - binary_blob
+  upload_binary_blob_artifacts:
+    path: blobdir
+
+build_xournalpp_task:
+  << : *UNINSTALL_HOMEBREW
+  depends_on:
+    - build_binary_blob
+  env:
+    PATH: "/opt/devroot/.local/bin:/opt/devroot/gtk/inst/bin:${PATH}"
+    # Based on $PKG_CONFIG_PATH in the jhbuild shell
+    # There is also a pyenv Python pkgconfig path, but we don't need it...right?
+    PKG_CONFIG_PATH: "/opt/devroot/gtk/inst/lib/pkgconfig:/opt/devroot/gtk/inst/share/pkgconfig"
+    PREFIX: "/opt/devroot/gtk/inst"
+
+  create_devroot_script: |
+    sudo mkdir -p /opt/devroot && sudo chown "$USER":admin /opt/devroot
+  binary_blob_cache:
+    << : *BINARY_BLOB_CACHE_TEMPLATE
+  unpack_script: |
+    (cd /opt/devroot && tar xf "$CIRRUS_WORKING_DIR"/blobdir/xournalpp-binary-blob.tar.gz)
+    rm -rf blobdir
+  upload_caches: [] # do not upload any caches
+  install_ninja_script: |
+    curl -L -o ninja-mac.zip https://github.com/ninja-build/ninja/releases/download/v1.11.1/ninja-mac.zip
+    unzip ninja-mac.zip -d /opt/devroot/gtk/inst/bin
+    rm ninja-mac.zip
+  build_script: |
+    mkdir -p build
+    cd build
+    cmake .. -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo
+    cmake --build .
+    cmake --install . --prefix /opt/devroot/gtk/inst
+  package_script: |
+    (cd mac-setup && bash build-app.sh ~/gtk && bash build-dmg.sh Xournal++.app Xournal++.dmg)
+  xournalpp_artifacts:
+    path: mac-setup/Xournal++.dmg

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -58,12 +58,14 @@ build_xournalpp_for_macos_arm_task:
     curl -L -o ninja-mac.zip https://github.com/ninja-build/ninja/releases/download/v1.11.1/ninja-mac.zip
     unzip ninja-mac.zip -d /opt/devroot/gtk/inst/bin
     rm ninja-mac.zip
-  build_script: |
+  build_and_test_script: |
     mkdir -p build
     cd build
-    cmake .. -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo
+    cmake .. -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_GTEST=ON -DDOWNLOAD_GTEST=on
     cmake --build .
     cmake --install . --prefix /opt/devroot/gtk/inst
+    cmake --build . --target test-units
+    CI=true ctest --verbose
   pkgconf_symlink_script: | # used for gtk-mac-bundler
     ln -sf $(which pkgconf) /opt/devroot/gtk/inst/bin/pkg-config
   package_script: |

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,7 +20,7 @@ uninstall_homebrew_template: &UNINSTALL_HOMEBREW
     sudo rm -rf /opt/homebrew
 
 
-build_binary_blob_task:
+build_binary_blob_for_macos_arm_task:
   << : *UNINSTALL_HOMEBREW
   create_devroot_script: |
     sudo mkdir -p /opt/devroot && sudo chown "$USER":admin /opt/devroot
@@ -35,10 +35,10 @@ build_binary_blob_task:
   upload_binary_blob_artifacts:
     path: "blobdir/*"
 
-build_xournalpp_task:
+build_xournalpp_for_macos_arm_task:
   << : *UNINSTALL_HOMEBREW
   depends_on:
-    - build_binary_blob
+    - build_binary_blob_for_macos_arm
   env:
     PATH: "/opt/devroot/.local/bin:/opt/devroot/gtk/inst/bin:${PATH}"
     # Based on $PKG_CONFIG_PATH in the jhbuild shell

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,6 +4,7 @@ macos_instance:
 # Need to override the user HOME so we can cache the jhbuild stuff.
 env:
   HOME: /opt/devroot
+  GITHUB_TOKEN: ENCRYPTED[efdc1b6215eedf2fceee15dbcf3bfd7919329028e8878dfa5df8a21d16e0ee3bdb7e6d96f30591cc8154573644c90d63]
 
 # Define a template that is reused for both binary blob task & build task.
 binary_blob_cache_template: &BINARY_BLOB_CACHE_TEMPLATE
@@ -69,3 +70,8 @@ build_xournalpp_task:
     (cd mac-setup && bash build-app.sh ~/gtk && bash build-dmg.sh Xournal++.app Xournal++.dmg)
   xournalpp_artifacts:
     path: mac-setup/Xournal++.dmg
+
+upload_task:
+  xournalpp_upload_script: |
+    bash mac-setup/upload-release.sh
+  only_if: $BRANCH =~ 'release-*' && "$CIRRUS_RELEASE" != ""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_policy(VERSION ${CMAKE_VERSION})
 ## The CMAKE_OSX_DEPLOYMENT_TARGET must be set before project(), so don't move the following line further down.
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "Minimum OS X deployment version" FORCE)
 
-if(NOT CMAKE_BUILD_TYPE) 
+if(NOT CMAKE_BUILD_TYPE)
     # set default build type to RelWithDebInfo, we never supported multi config generators, therefore this is fine
     set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel." FORCE)
 endif()
@@ -120,23 +120,6 @@ if (ENABLE_PROFILING)
 endif (ENABLE_PROFILING)
 
 pkg_check_modules(ExternalModules REQUIRED IMPORTED_TARGET ${pkg-module-spec})
-
-if (#[[${CMAKE_VERSION} VERSION_LESS "3.18" AND]] ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    # bugfix for old pkg_config versions
-    get_target_property(libs PkgConfig::ExternalModules INTERFACE_LINK_LIBRARIES)
-    # message(STATUS "PkgConfig::ExternalModules::INTERFACE_LINK_LIBRARIES: ${libs}")
-    string(REPLACE "-framework;" "-framework " libs "${libs}")
-    # message(STATUS "PkgConfig::ExternalModules::INTERFACE_LINK_LIBRARIES fixed: ${libs}")
-    set_target_properties(PkgConfig::ExternalModules PROPERTIES INTERFACE_LINK_LIBRARIES "${libs}")
-
-
-    if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.13")
-        # fix broken framework flags from pkgconfig
-        get_target_property(opts PkgConfig::ExternalModules INTERFACE_LINK_OPTIONS)
-        string(REPLACE "-framework;" "SHELL:-framework " opts "${opts}")
-        set_target_properties(PkgConfig::ExternalModules PROPERTIES INTERFACE_LINK_OPTIONS "${opts}")
-    endif ()
-endif ()
 
 find_package(ZLIB REQUIRED)
 find_package(Threads REQUIRED)

--- a/mac-setup/cirrus_jhbuild.sh
+++ b/mac-setup/cirrus_jhbuild.sh
@@ -6,6 +6,8 @@ set -o pipefail
 ### Step 1: install jhbuild
 
 LOCKFILE="$(dirname "$0")"/jhbuild-version.lock
+MODULEFILE="$(dirname "$0")"/xournalpp.modules
+
 get_lockfile_entry() {
     local key="$1"
     # Print the value corresponding to the provided lockfile key to stdout
@@ -51,7 +53,7 @@ setup_custom_modulesets() {
     (cd ~/gtk-osx-custom && git checkout "$gtk_osx_commit")
 
     # Set osx deployment target
-    sed -i '' -e 's/^setup_sdk()/setup_sdk(target="10.15")/' ~/.config/jhbuildrc-custom
+    sed -i '' -e 's/^setup_sdk()/setup_sdk(target="11.7")/' ~/.config/jhbuildrc-custom
 
     # Enable custom jhbuild configuration
     cat <<EOF >> ~/.config/jhbuildrc-custom
@@ -86,6 +88,7 @@ setup_custom_modulesets
 build_gtk() {
     jhbuild bootstrap-gtk-osx
     jhbuild build meta-gtk-osx-gtk3 gtksourceview3
+    echo "Finished building gtk"
 }
 
 build_gtk
@@ -93,7 +96,7 @@ build_gtk
 ### Step 4: build xournalpp deps
 
 build_xournalpp_deps() {
-    jhbuild -m xournalpp.modules build meta-xournalpp-deps
+    jhbuild -m "$MODULEFILE" build meta-xournalpp-deps
 }
 
 build_xournalpp_deps

--- a/mac-setup/cirrus_jhbuild.sh
+++ b/mac-setup/cirrus_jhbuild.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+
+### Step 1: install jhbuild
+
+LOCKFILE="$(dirname "$0")"/jhbuild-version.lock
+get_lockfile_entry() {
+    local key="$1"
+    # Print the value corresponding to the provided lockfile key to stdout
+    sed -e "/$key/!d" -e 's/^[^=]*=//' "$LOCKFILE"
+}
+
+install_jhbuild() {
+    # Fetch the gtk-osx setup script
+    local gtk_osx_commit=$(get_lockfile_entry gtk-osx)
+    local gtk_osx_url=https://gitlab.gnome.org/GNOME/gtk-osx/raw/"$gtk_osx_commit"
+    curl -LR "$gtk_osx_url"/gtk-osx-setup.sh -o ~/gtk-osx-setup.sh
+
+    # Remove existing jhbuild
+    rm -rf ~/gtk ~/.new_local ~/.config/jhbuildrc ~/.config/jhbuildrc-custom ~/Source ~/.cache/jhbuild
+
+    # Build jhbuild
+    bash ~/gtk-osx-setup.sh
+
+    # Copy default jhbuild config files from the pinned commit
+    curl -ks "$gtk_osx_url"/jhbuildrc-gtk-osx -o ~/.config/jhbuildrc
+    curl -ks "$gtk_osx_url"/jhbuildrc-gtk-osx-custom-example -o ~/.config/jhbuildrc-custom
+}
+
+configure_jhbuild_envvars() {
+    if ! [ -f ~/.zshrc ] || ! grep '"$HOME"/.new_local/bin' ~/.zshrc; then
+        echo "Permanently adding jhbuild to path..."
+        echo 'export PATH="$HOME"/.new_local/bin:"$PATH"' >> ~/.zshrc
+    fi
+
+    # Add jhbuild to PATH for this shell
+    export PATH="$HOME"/.new_local/bin:"$PATH"
+}
+
+install_jhbuild
+configure_jhbuild_envvars
+
+### Step 2: set up custom modulesets
+
+setup_custom_modulesets() {
+    local gtk_osx_commit=$(get_lockfile_entry gtk-osx)
+    [ -d ~/gtk-osx-custom ] && rm -rf ~/gtk-osx-custom
+    git clone https://gitlab.gnome.org/GNOME/gtk-osx.git ~/gtk-osx-custom
+    (cd ~/gtk-osx-custom && git checkout "$gtk_osx_commit")
+
+    # Set osx deployment target
+    sed -i '' -e 's/^setup_sdk()/setup_sdk(target="10.15")/' ~/.config/jhbuildrc-custom
+
+    # Enable custom jhbuild configuration
+    cat <<EOF >> ~/.config/jhbuildrc-custom
+
+### BEGIN xournalpp macOS CI
+use_local_modulesets = True
+moduleset = "gtk-osx.modules"
+modulesets_dir = os.path.expanduser("~/gtk-osx-custom/modulesets-stable")
+
+# Workaround for https://gitlab.gnome.org/GNOME/glib/-/issues/2759
+module_mesonargs['glib'] = mesonargs + ' -Dobjc_args=-Wno-error=declaration-after-statement'
+
+# Fix freetype build finding brotli installed through brew or ports, causing the
+# harfbuzz build to fail when jhbuild's pkg-config cannot find brotli.
+module_cmakeargs['freetype-no-harfbuzz'] = ' -DFT_DISABLE_BROTLI=TRUE '
+module_cmakeargs['freetype'] = ' -DFT_DISABLE_BROTLI=TRUE '
+
+# portaudio may fail with parallel build, so disable parallel building.
+module_makeargs['portaudio'] = ' -j1 '
+
+### END
+EOF
+
+    # Fix broken arg overrides in jhbuildrc
+    sed -i '' -e 's/^\(module_cmakeargs\["freetype"\]\) =/module_cmakeargs.setdefault("freetype", ""); \1 +=/' ~/.config/jhbuildrc
+    sed -i '' -e 's/^\(module_cmakeargs\["freetype-no-harfbuzz"\]\) =/module_cmakeargs.setdefault("freetype-no-harfbuzz", ""); \1 +=/' ~/.config/jhbuildrc
+}
+
+setup_custom_modulesets
+
+### Step 3: build gtk (~15 minutes on a Mac Mini M1 w/ 8 cores)
+build_gtk() {
+    jhbuild bootstrap-gtk-osx
+    jhbuild build meta-gtk-osx-gtk3 gtksourceview3
+}
+
+build_gtk
+
+### Step 4: build xournalpp deps
+
+build_xournalpp_deps() {
+    jhbuild -m xournalpp.modules build meta-xournalpp-deps
+}
+
+build_xournalpp_deps
+
+### Step 5: build binary blob
+
+build_binary_blob() {
+    local pdeps_commit=$(get_lockfile_entry xournalpp-pipeline-dependencies)
+    [ -d ~/xournalpp-pipeline-dependencies ] && rm -rf ~/xournalpp-pipeline-dependencies
+    git clone https://github.com/xournalpp/xournalpp-pipeline-dependencies --depth 1 ~/xournalpp-pipeline-dependencies
+    (cd ~/xournalpp-pipeline-dependencies && git checkout "$pdeps_commit")
+    jhbuild run python3 ~/xournalpp-pipeline-dependencies/gtk/package-gtk-bin.py -o xournalpp-binary-blob.tar.gz
+}
+
+build_binary_blob

--- a/mac-setup/jhbuild-version.lock
+++ b/mac-setup/jhbuild-version.lock
@@ -1,0 +1,2 @@
+gtk-osx=c0bddb391f57df773e421907b390e54f59d9a72e
+xournalpp-pipeline-dependencies=c14f89055f9790390b71829c75a0932eb023792b

--- a/mac-setup/jhbuild-version.lock
+++ b/mac-setup/jhbuild-version.lock
@@ -1,2 +1,2 @@
-gtk-osx=c0bddb391f57df773e421907b390e54f59d9a72e
+gtk-osx=8c5052f4a57d5ec54d74bf13aaa1e1aeccad75f1
 xournalpp-pipeline-dependencies=c14f89055f9790390b71829c75a0932eb023792b

--- a/mac-setup/jhbuild-version.lock
+++ b/mac-setup/jhbuild-version.lock
@@ -1,2 +1,2 @@
 gtk-osx=8c5052f4a57d5ec54d74bf13aaa1e1aeccad75f1
-xournalpp-pipeline-dependencies=c14f89055f9790390b71829c75a0932eb023792b
+xournalpp-pipeline-dependencies=5fb1da3de6ef84f129071d828ec99025ffa83894

--- a/mac-setup/upload-release.sh
+++ b/mac-setup/upload-release.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# See https://cirrus-ci.org/examples/#release-assets
+
+if [[ "$CIRRUS_RELEASE" == "" ]]; then
+  echo "Not a release. No need to deploy!"
+  exit 0
+fi
+
+if [[ "$GITHUB_TOKEN" == "" ]]; then
+  echo "Please provide GitHub access token via GITHUB_TOKEN environment variable!"
+  exit 1
+fi
+
+file_content_type="application/octet-stream"
+asset_path=mac-setup/Xournal++.dmg  # relative path of asset to upload
+
+ver=$(cat build/VERSION | sed '1q;d')  # --> x.y.z
+name="xournalpp-$ver-macos_arm64.dmg"  # --> xournalpp-x.y.z-macos_arm64.dmg
+
+echo "Uploading $asset_path..."
+url_to_upload="https://uploads.github.com/repos/$CIRRUS_REPO_FULL_NAME/releases/$CIRRUS_RELEASE/assets?name=$name"
+curl -X POST \
+    --data-binary @$asset_path \
+    --header "Authorization: token $GITHUB_TOKEN" \
+    --header "Content-Type: $file_content_type" \
+    $url_to_upload


### PR DESCRIPTION
This PR is based on work of @Technius and adds a Cirrus configuration file and build task in order to create a MacOS ARM build. The task is executed on https://cirrus-ci.com/ and on a MacOS Ventura runner.

The lock file (and possibly GITHUB token) still need to be updated to the latest versions and tested.