### PR TITLE
Fix crash whenentering presentation mode with tiny page size

### DIFF
--- a/src/core/control/zoom/ZoomControl.cpp
+++ b/src/core/control/zoom/ZoomControl.cpp
@@ -264,10 +264,11 @@ auto ZoomControl::getZoom() const -> double { return this->zoom; }
 auto ZoomControl::getZoomReal() const -> double { return this->zoom / this->zoom100Value; }
 
 void ZoomControl::setZoom(double zoomI) {
+    zoomI = std::clamp(zoomI, this->zoomMin, this->zoomMax);
     if (this->zoom == zoomI) {
         return;
     }
-    this->zoom = std::clamp(zoomI, this->zoomMin, this->zoomMax);
+    this->zoom = zoomI;
     fireZoomChanged();
 }
 
@@ -290,11 +291,8 @@ auto ZoomControl::updateZoomFitValue(size_t pageNo) -> bool {
 
     Rectangle widget_rect = getVisibleRect();
     double zoom_fit_width = widget_rect.width / (page->getWidth() + 20.0);
-    if (zoom_fit_width < this->zoomMin || zoom_fit_width > this->zoomMax) {
-        return false;
-    }
 
-    this->zoomFitValue = zoom_fit_width;
+    this->zoomFitValue = std::clamp(zoom_fit_width, this->zoomMin, this->zoomMax);
     fireZoomRangeValueChanged();
     if (this->isZoomFitMode() && !this->zoomPresentationMode) {
         this->zoomFit();
@@ -315,11 +313,8 @@ auto ZoomControl::updateZoomPresentationValue(size_t pageNo) -> bool {
     double zoom_fit_width = widget_rect.width / (page->getWidth() + 14.0);
     double zoom_fit_height = widget_rect.height / (page->getHeight() + 14.0);
     double zoom_presentation = zoom_fit_width < zoom_fit_height ? zoom_fit_width : zoom_fit_height;
-    if (zoom_presentation < this->zoomMin) {
-        return false;
-    }
 
-    this->zoomPresentationValue = zoom_presentation;
+    this->zoomPresentationValue = std::clamp(zoom_presentation, this->zoomMin, this->zoomMax);
     if (this->zoomPresentationMode) {
         this->zoomPresentation();
     }


### PR DESCRIPTION
Fix #2943 

The issue was: when entering presentation mode, if the required zoom value was bigger that the max (700%), we entered an infinite loop.