### PR TITLE
Use MultiUser.nsi for choosing between all users or current user install

### DIFF
--- a/windows-setup/package.sh
+++ b/windows-setup/package.sh
@@ -19,7 +19,7 @@ mkdir "$setup_dir"
 mkdir "$setup_dir"/lib
 
 echo "copy installed files"
-(cd ../build && cmake .. -DCMAKE_INSTALL_PREFIX= && DESTDIR=../windows-setup/"$setup_dir" cmake --build . --target install)
+(cd ../build && cmake --install . --prefix ../windows-setup/"$setup_dir")
 
 echo "copy libraries"
 ldd ../build/xournalpp.exe | grep '\/mingw.*\.dll' -o | sort -u | xargs -I{} cp "{}" "$setup_dir"/bin/


### PR DESCRIPTION
Remark: The MultiUser.nsi is preinstalled and suits our prupose:
        - In the GUI a admin can choose between installation for all users or current user
        - Silent mode installation works
	It has some limitations though, in particular
        - Privilige elevation is asked even if a user with admin priviliges wants to install
          for current user
        - To work around this issues the NsisMultiUser plugin on
          https://github.com/Drizin/NsisMultiUser could be used.
          It is not preinstalled though and would complicate the build process.

Some remarks about the changes:
- The custom page for choosing the install mode was replaced by the page MULTIUSER_PAGE_INSTALLMODE from the MultiUser plugin
- SetShellVarContext is handled by the MultiUser plugin.
- The RefreshShellIcons macro is already defined in the `FileFunc.nsh`  that is included via `MultiUser.nsh`.
