### PR TITLE
Add wrapping for long labels in plugin manager

### DIFF
--- a/ui/plugin.glade
+++ b/ui/plugin.glade
@@ -118,6 +118,7 @@
                 <property name="can_focus">False</property>
                 <property name="margin_top">5</property>
                 <property name="margin_bottom">5</property>
+                <property name="wrap">true</property>
                 <property name="label" translatable="yes">Plugin changes are only applied after Xournal++ is restarted</property>
               </object>
               <packing>

--- a/ui/pluginEntry.glade
+++ b/ui/pluginEntry.glade
@@ -37,6 +37,7 @@
             <property name="can_focus">False</property>
             <property name="margin_bottom">10</property>
             <property name="label">Description</property>
+            <property name="wrap">True</property>
             <property name="selectable">True</property>
           </object>
           <packing>


### PR DESCRIPTION
The description of a plugin can be quite long. The whole dialog gets messed up when there is no wrapping. The line `Plugin changes are only applied after Xournal++ is restarted` is quite long as well.

The wrapping is already done on the GTK4 branch (.glade -> .ui conversion)