### PR TITLE
Harden security in Github Workflow

### DIFF
--- a/.github/workflows/trigger-create-installers-from-comment-on-pr.yml
+++ b/.github/workflows/trigger-create-installers-from-comment-on-pr.yml
@@ -46,7 +46,11 @@ env:
 jobs:
   ack:
     name: Acknowledge order
-    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '\action create-installers')}}
+    # To circumvent a security issue, only members/owners of the xournalpp team can run this CI.
+    if: |
+      github.event.issue.pull_request &&
+      (github.event.comment.author_association == 'member' || github.event.comment.author_association == 'owner') &&
+      startsWith(github.event.comment.body, '\action create-installers')
     runs-on: ubuntu-latest
     outputs:
       head_sha: ${{ steps.get-sha.outputs.head_sha }}


### PR DESCRIPTION
This is a first PR to harden security in using `\action create-installers foo bar`.

It fixes two issues

- Prevents script injection in message body
- Prevents privilege escalation: if a user posts a PR where they modified (say) `.github/actions/install_deps_ubuntu/action.yml`, they now only have access to a very restrictive Github token (read content and that it). Without this, the user had essentially admin access to the entire repository.

Note that because the Github action trigger `issue_comment` (used to trigger this workflow) runs on the default branch (ie master), the files in .github/workflows/ called are all from the master branch. No attack possible there. Only .github/actions was exposed.
This also means that editing the .github/workflows/ files on a PR will not change the behaviour of `\action create-installers` (even in this PR comments) until the PR is merged.


There is still an issue with cache spoofing: by creating cache in say `.github/actions/install_deps_macos/action.yml`, the user could (via a PR) override our cached blobs with malicious binaries. They would be used in every other CI runs after that and could be shipped with releases...

This only happens because the Github action trigger `issue_comment` (used to trigger this workflow) runs on the master branch. Cache generated from such triggers is available to every other branch. I did not figure out a way to avoid that.