### PR TITLE
Allow adding plugin strokes to selection

### DIFF
--- a/plugins/FitToContent/main.lua
+++ b/plugins/FitToContent/main.lua
@@ -17,6 +17,7 @@ local function fit_to_layer_or_selection(type)
     -- take the stroke width, or if set the pressure, into account hereby
     local mima    = {minX=100000, maxX=0, minY=100000, maxY=0}
     for _,stroke in ipairs(strokes) do
+        stroke.ref = nil
         if stroke.pressure then
             for i,x in ipairs(stroke.x) do
                 mima.maxX = math.max(mima.maxX, x + stroke.pressure[i]/2)

--- a/plugins/HighlightPosition/main.lua
+++ b/plugins/HighlightPosition/main.lua
@@ -2,7 +2,7 @@ function initUi()
   app.registerUi({["menu"] = "Toggle Highlight Position", ["callback"] = "laser", ["accelerator"] = "<Alt>x"});
 end
 
-local togglestate = false;
+local toggleState = false;
 
 function laser()
   toggleState = not toggleState

--- a/plugins/ImageActions/main.lua
+++ b/plugins/ImageActions/main.lua
@@ -63,10 +63,12 @@ function Cb(mode)
 
   local images = app.getImages("selection")
   local imdata = {}
+  local refs = {}
   for i = 1, #images do
     local im = images[i]
     local image = vips.Image.new_from_buffer(im["data"])
     local x, y, maxWidth, maxHeight = im["x"], im["y"], math.ceil(im["width"]), math.ceil(im["height"])
+    refs[i] = im.ref
     if mode == m.INVERT then
       image = image:invert()
     elseif mode == m.DOWNSCALE then
@@ -108,6 +110,8 @@ function Cb(mode)
       maxHeight = maxHeight
     })
   end
+  app.clearSelection()
+  app.addToSelection(refs)
   app.uiAction({ action = "ACTION_DELETE" })
   app.addImages({ images = imdata, allowUndoRedoAction = "grouped" })
 end
@@ -122,10 +126,12 @@ function Split(mode)
   local vertical = mode == m.SPLIT_V
   local images = app.getImages("selection")
   local imdata = {}
+  local refs = {}
   for i = 1, #images do
     local im = images[i]
     local image = vips.Image.new_from_buffer(im["data"])
     local x, y, maxWidth, maxHeight = im["x"], im["y"], math.ceil(im["width"]), math.ceil(im["height"])
+    refs[i] = im.ref
     -- find largest sequence of white or transparent pixel rows/columns
     local filter = image:colourspace("b-w") -- convert image to grayscale colour space
         :extract_band(0)                    -- ignore alpha channel if it exists
@@ -205,6 +211,8 @@ function Split(mode)
     end
     ::continue::
   end
+  app.clearSelection()
+  app.addToSelection(refs)
   app.uiAction({ action = "ACTION_DELETE" })
   app.addImages({ images = imdata, allowUndoRedoAction = "grouped" })
 end

--- a/plugins/luapi_application.def.lua
+++ b/plugins/luapi_application.def.lua
@@ -778,6 +778,7 @@ function app.openFile(path, pageNr, oldDocument) end
 --- 
 --- @param opts {images:{path:string, data:string, x:number, y:number, maxHeight:number, maxWidth:number,
 --- aspectRatio:boolean}[], allowUndoRedoAction:string}
+--- @return lightuserdata|string[]
 --- 
 --- Global parameters:
 ---  - images table: array of image-parameter-tables
@@ -806,15 +807,16 @@ function app.openFile(path, pageNr, oldDocument) end
 --- specified. Still, the scale parameter is applied after this width/height scaling and if after that the dimensions are
 --- too large for the page, the image still gets scaled down afterwards.
 --- 
---- Returns as many values as images were passed. A nil value represents success, while
---- on error the value corresponding to the image will be a string with the error message.
---- If the parameters don't fit at all, a real lua error might be thrown immediately.
+--- Returns a table with as many values as images were passed. A value of type lightuserdata represents the reference to
+--- the image, while on error the value corresponding to the image will be a string with the error message. If the
+--- parameters don't fit at all, a real lua error might be thrown immediately.
 --- 
---- Example 1: app.addImages{images={{path="/media/data/myImg.png", x=10, y=20, scale=2},
+--- Example 1: local refs = app.addImages{images={{path="/media/data/myImg.png", x=10, y=20, scale=2},
 ---                                            {path="/media/data/myImg2.png", maxHeight=300, aspectRatio=true}},
 ---                                    allowUndoRedoAction="grouped",
 ---                                            }
---- Example 2: app.addImages{images={{data="<binary image data>", x=100, y=200, maxHeight=300, maxWidth=400}}}
+--- Example 2: local refs = app.addImages{images={{data="<binary image data>", x=100, y=200, maxHeight=300,
+--- maxWidth=400}}}
 function app.addImages(opts) end
 
 --- Puts a Lua Table of the Images (from the selection tool / selected layer) onto the stack.

--- a/plugins/luapi_application.def.lua
+++ b/plugins/luapi_application.def.lua
@@ -848,3 +848,21 @@ function app.addImages(opts) end
 --- }
 function app.getImages(type) end
 
+--- Clears a selection by releasing its elements to the current layer.
+--- 
+--- Example: app.clearSelection()
+--- 
+function app.clearSelection() end
+
+--- Adds those elements from the current layer to the current selection,
+--- whose addresses are in refs. If there is no selection create one.
+--- 
+--- @param refs lightuserdata[] references to elements from the current layer
+--- 
+--- Required argument: refs
+--- 
+--- Example: local refs = app.addStrokes( <some stroke data> )
+---          app.addToSelection(refs)
+--- 
+function app.addToSelection(refs) end
+

--- a/plugins/luapi_application.def.lua
+++ b/plugins/luapi_application.def.lua
@@ -165,6 +165,7 @@ function app.layerAction(action) end
 --- 
 --- @param opts {splines:{coordinates:number[], tool:string, width:number, color:integer, fill:number,
 --- linestyle:string}[], allowUndoRedoAction:string}
+--- @return lightuserdata[] references to the created strokes
 --- 
 --- Required Arguments: splines
 --- Optional Arguments: pressure, tool, width, color, fill, lineStyle
@@ -180,7 +181,7 @@ function app.layerAction(action) end
 --- The function checks that the length of the coordinate table is divisible by eight, and will throw
 --- an error if it is not.
 --- 
---- Example: app.addSplines({
+--- Example: local refs = app.addSplines({
 ---            ["splines"] = { -- The outer table is a table of strokes
 ---                ["coordinates"] = { -- Each inner table is a coord stream that represents SplineSegments that can be
 --- assembled into a stroke
@@ -213,6 +214,7 @@ function app.addSplines(opts) end
 --- 
 --- @param opts {strokes:{X:number[], Y:number[], pressure:number[], tool:string, width:number, color:integer,
 --- fill:number, linestyle:string}[], allowUndoRedoAction:string}
+--- @return lightuserdata[] references to the created strokes
 --- 
 --- Required Arguments: X, Y
 --- Optional Arguments: pressure, tool, width, color, fill, lineStyle
@@ -226,7 +228,7 @@ function app.addSplines(opts) end
 --- 
 --- Example:
 --- 
---- app.addStrokes({
+--- local refs = app.addStrokes({
 ---     ["strokes"] = { -- The outer table is a table of strokes
 ---         {   -- Inside a stroke are three tables of equivalent length that represent a series of points
 ---             ["x"]        = { [1] = 110.0, [2] = 120.0, [3] = 130.0, ... },
@@ -274,6 +276,7 @@ function app.addStrokes(opts) end
 --- 
 --- @param opts {texts:{text:string, font:{name:string, size:number}, color:integer, x:number, y:number}[],
 --- allowUndoRedoAction:string}
+--- @return lightuserdata[] references to the created text elements
 --- 
 --- Parameters per textbox:
 ---   - text string: content of the textbox (required)
@@ -284,7 +287,7 @@ function app.addStrokes(opts) end
 --- 
 --- Example:
 --- 
---- app.addTexts{texts={
+--- local refs = app.addTexts{texts={
 ---   {
 ---     text="Hello World",
 ---     font={name="Noto Sans Mono Medium", size=8.0},
@@ -307,7 +310,7 @@ function app.addTexts(opts) end
 --- 
 --- @param type string "selection" or "layer"
 --- @return {text:string, font:{name:string, size:number}, color:integer, x:number, y:number, width:number,
---- height:number}[] texts
+--- height:number, ref:lightuserdata}[] texts
 --- 
 --- Required argument: type ("selection" or "layer")
 --- 
@@ -326,6 +329,7 @@ function app.addTexts(opts) end
 ---     y = 70.0,
 ---     width = 55.0,
 ---     height = 23.0,
+---     ref = userdata: 0x5f644c0700d0
 ---   },
 ---   {
 ---     text = "Testing",
@@ -338,6 +342,7 @@ function app.addTexts(opts) end
 ---     y = 70.0,
 ---     width = 55.0,
 ---     height = 23.0,
+---     ref = userdata: 0x5f644c0701e8
 ---   },
 --- }
 --- 
@@ -348,7 +353,7 @@ function app.getTexts(type) end
 --- 
 --- @param type string "selection" or "layer"
 --- @return {x:number[], y:number[], pressure:number[], tool:string, width:number, color:integer, fill:number,
---- linestyle:string}[] strokes
+--- linestyle:string, ref:lightuserdata}[] strokes
 --- 
 --- Required argument: type ("selection" or "layer")
 --- 
@@ -367,6 +372,7 @@ function app.getTexts(type) end
 ---             ["color"] = 0xa000f0,
 ---             ["fill"] = 0,
 ---             ["lineStyle"] = "plain",
+---             ["ref"] = userdata: 0x5f644c02c538
 ---         },
 ---         {
 ---             ["x"]         = {207, 207.5, 315.2, 315.29, 207.5844},
@@ -376,6 +382,7 @@ function app.getTexts(type) end
 ---             ["color"]     = 16744448,
 ---             ["fill"]      = -1,
 ---             ["lineStyle"] = "plain",
+---             ["ref"] = userdata: 0x5f644c02d440
 ---         },
 ---         {
 ---             ["x"]         = {387.60, 387.6042, 500.879, 500.87, 387.604},
@@ -385,6 +392,7 @@ function app.getTexts(type) end
 ---             ["color"]     = 16744448,
 ---             ["fill"]      = -1,
 ---             ["lineStyle"] = "plain",
+---             ["ref"] = userdata: 0x5f644c0700d0
 ---         },
 --- }
 function app.getStrokes(type) end
@@ -814,7 +822,7 @@ function app.addImages(opts) end
 --- 
 --- @param type string "selection" or "layer"
 --- @return {x:number, y:number, width:number, height:number, data:string, format:string, imageWidth:number,
---- imageHeight:number}[] images
+--- imageHeight:number, ref:lightuserdata}[] images
 --- 
 --- Required argument: type ("selection" or "layer")
 --- 
@@ -831,6 +839,7 @@ function app.addImages(opts) end
 ---         ["format"] = string,
 ---         ["imageWidth"] = integer,
 ---         ["imageHeight"] = integer,
+---         ["ref"] = userdata: 0x5f644c0700d0
 ---     },
 ---     {
 ---         ...

--- a/src/core/plugin/luapi_application.h
+++ b/src/core/plugin/luapi_application.h
@@ -1632,7 +1632,6 @@ static int applib_getColorPalette(lua_State* L) {
     lua_settop(L, 0);
 
     Plugin* plugin = Plugin::getPluginFromLua(L);
-    Settings* settings = plugin->getControl()->getSettings();
     const Palette& palette = plugin->getControl()->getPalette();
 
 

--- a/src/core/plugin/luapi_application.h
+++ b/src/core/plugin/luapi_application.h
@@ -664,10 +664,15 @@ static int applib_layerAction(lua_State* L) {
  * - "grouped": the elements get a single undo-redo-action
  * - "individual" each of the elements get an own undo-redo-action
  * - "none": no undo-redo-action will be inserted
- * if an invalid value is being passed as allowUndoRedoAction this function errors
+ * If an invalid value is being passed as allowUndoRedoAction this function errors.
+ * If there are no elements emits a warning and does not add an UndoAction.
  */
 static int handleUndoRedoActionHelper(lua_State* L, Control* control, const char* allowUndoRedoAction,
                                       const std::vector<Element*>& elements) {
+    if (elements.empty()) {
+        g_warning("No elements, therefore not adding an undo action");
+        return 0;
+    }
     if (strcmp("grouped", allowUndoRedoAction) == 0) {
         PageRef const& page = control->getCurrentPage();
         Layer* layer = page->getSelectedLayer();


### PR DESCRIPTION
Closes #6028, #6002.

- [x] modify `app.getStrokes` by adding references to return value
- [x] modify `app.addStrokes` by adding return value
- [x] modify `app.addSplines` by adding return value
- [x] modify `app.getTexts` by adding references to return value
- [x] modify `app.addTexts` by adding return value
- [x] modify `app.getImages` by adding references to return value
- [x] modify `app.addImages` by adding replacing return values by a table and nil with a ref
- [x] add `app.addToSelection`
- [x] add `app.clearSelection`

**Edit:** Removed add `app.removeFromSelection`, since it can be achieved by a combination of the other API functions.