### PR TITLE
Add debug information for permissions when running \action

### DIFF
--- a/.github/workflows/trigger-create-installers-from-comment-on-pr.yml
+++ b/.github/workflows/trigger-create-installers-from-comment-on-pr.yml
@@ -46,10 +46,8 @@ env:
 jobs:
   ack:
     name: Acknowledge order
-    # To circumvent a security issue, only members/owners of the xournalpp team can run this CI.
     if: |
       github.event.issue.pull_request &&
-      (github.event.comment.author_association == 'member' || github.event.comment.author_association == 'owner') &&
       startsWith(github.event.comment.body, '\action create-installers')
     runs-on: ubuntu-latest
     outputs:
@@ -63,6 +61,14 @@ jobs:
       checks: write         # To create the check in the PR
       pull-requests: write  # Write: To post a comment acknowledging the run + Read: To get the head_sha
     steps:
+      - name: 'Check permissions'
+        # To circumvent a security issue, only members/owners of the xournalpp team can run this CI.
+        uses: actions/github-script@v7
+        with:
+          script: |
+            if (context.payload.comment.author_association != "OWNER" && context.payload.comment.author_association != "MEMBER") {
+              core.setFailed('User ' + context.payload.comment.user.login + ' with author_association ' + context.payload.comment.author_association + ' is not allowed to run this CI')
+            }
       - name: 'Get pull request HEAD_SHA'
         id: get-sha
         uses: actions/github-script@v7


### PR DESCRIPTION
create-installers from a PR