### PR TITLE
Check permissions to run \action create-installers CI

### DIFF
--- a/.github/workflows/trigger-create-installers-from-comment-on-pr.yml
+++ b/.github/workflows/trigger-create-installers-from-comment-on-pr.yml
@@ -61,12 +61,21 @@ jobs:
       checks: write         # To create the check in the PR
       pull-requests: write  # Write: To post a comment acknowledging the run + Read: To get the head_sha
     steps:
-      - name: 'Check permissions'
+      - name: 'Check user permission'
         # To circumvent a security issue, only members/owners of the xournalpp team can run this CI.
         uses: actions/github-script@v7
         with:
           script: |
-            if (context.payload.comment.author_association != "OWNER" && context.payload.comment.author_association != "MEMBER") {
+            const perm = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.payload.comment.user.login
+            })
+
+            if (!perm || !perm.data || !perm.data.permission) {
+              core.setFailed(`No user permission found in payload`)
+            }
+            if ( (perm.data.permission != 'write' && perm.data.permission != 'admin') || (context.payload.comment.author_association != "OWNER" && context.payload.comment.author_association != "MEMBER" && context.payload.comment.author_association != "COLLABORATOR" )) {
               core.setFailed('User ' + context.payload.comment.user.login + ' with author_association ' + context.payload.comment.author_association + ' is not allowed to run this CI')
             }
       - name: 'Get pull request HEAD_SHA'


### PR DESCRIPTION
We now check the user has (at least) write permissions to the repo when running \action create-installers