### PR TITLE
Fix some Image import errors

### DIFF
--- a/src/core/control/tools/ImageHandler.cpp
+++ b/src/core/control/tools/ImageHandler.cpp
@@ -59,15 +59,19 @@ auto ImageHandler::createImage(GFile* file, double x, double y) -> std::tuple<Im
     }
 
     // Render the image.
-    // FIXME: this is horrible. We need an ImageView class...
-    (void)img->getImage();
+    if (auto opt = img->renderBuffer(); opt.has_value()) {
+        // An error occurred
+        delete img;
+        XojMsgBox::showErrorToUser(this->control->getGtkWindow(), opt.value());
+        return std::make_tuple(nullptr, 0, 0);
+    }
 
     const auto imgSize = img->getImageSize();
     auto [width, height] = imgSize;
     if (imgSize == Image::NOSIZE) {
         delete img;
-        XojMsgBox::showErrorToUser(this->control->getGtkWindow(),
-                                   _("Failed to load image, could not determine image size!"));
+        XojMsgBox::showErrorToUser(this->control->getGtkWindow(), std::string(_("Failed to load image")) + "\n" +
+                                                                          _("Could not determine image size!"));
         return std::make_tuple(nullptr, 0, 0);
     }
 

--- a/src/core/model/Image.cpp
+++ b/src/core/model/Image.cpp
@@ -2,15 +2,18 @@
 
 #include <algorithm>  // for min
 #include <array>      // for array
+#include <cmath>      // for sqrt
 #include <utility>    // for move, pair
 
-#include <cairo.h>        // for cairo_surface_destroy
-#include <gdk/gdk.h>      // for gdk_cairo_set_sourc...
-#include <glib.h>         // for g_assert, guchar
+#include <cairo.h>    // for cairo_surface_destroy
+#include <gdk/gdk.h>  // for gdk_cairo_set_sourc...
+#include <glib.h>     // for g_assert, guchar
 
-#include "model/Element.h"                        // for Element, ELEMENT_IMAGE
-#include "util/Rectangle.h"                       // for Rectangle
-#include "util/raii/GObjectSPtr.h"                // for GObjectSPtr
+#include "model/Element.h"   // for Element, ELEMENT_IMAGE
+#include "util/Rectangle.h"  // for Rectangle
+#include "util/i18n.h"
+#include "util/raii/GObjectSPtr.h"  // for GObjectSPtr
+#include "util/safe_casts.h"
 #include "util/serializing/ObjectInputStream.h"   // for ObjectInputStream
 #include "util/serializing/ObjectOutputStream.h"  // for ObjectOutputStream
 
@@ -127,34 +130,79 @@ void Image::setImage(cairo_surface_t* image) {
     data = std::move(closure_.buffer);
 }
 
-auto Image::getImage() const -> cairo_surface_t* {
+auto Image::renderBuffer() const -> std::optional<std::string> {
     g_assert(data.length() > 0 && "image has no data, cannot render it!");
-    if (this->image == nullptr) {
-        xoj::util::GObjectSPtr<GdkPixbufLoader> loader(gdk_pixbuf_loader_new(), xoj::util::adopt);
-        gdk_pixbuf_loader_write(loader.get(), reinterpret_cast<const guchar*>(this->data.c_str()), this->data.length(),
-                                nullptr);
-        bool success = gdk_pixbuf_loader_close(loader.get(), nullptr);
-        g_assert(success && "errors in loading image data!");
-
-        GdkPixbuf* tmp = gdk_pixbuf_loader_get_pixbuf(loader.get());
-        g_assert(tmp != nullptr);
-        xoj::util::GObjectSPtr<GdkPixbuf> pixbuf(gdk_pixbuf_apply_embedded_orientation(tmp), xoj::util::adopt);
-
-        this->imageSize = {gdk_pixbuf_get_width(pixbuf.get()), gdk_pixbuf_get_height(pixbuf.get())};
-
-        // TODO: pass in window once this code is refactored into ImageView
-        this->image = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, this->imageSize.first, this->imageSize.second);
-        g_assert(this->image != nullptr);
-
-        // Paint the pixbuf on to the surface
-        // NOTE: we do this manually instead of using gdk_cairo_surface_create_from_pixbuf
-        // since this does not work in CLI mode.
-        cairo_t* cr = cairo_create(this->image);
-        gdk_cairo_set_source_pixbuf(cr, pixbuf.get(), 0, 0);
-        cairo_paint(cr);
-        cairo_destroy(cr);
+    if (this->image) {
+        // Already rendered
+        return std::nullopt;
+    }
+    xoj::util::GObjectSPtr<GdkPixbufLoader> loader(gdk_pixbuf_loader_new(), xoj::util::adopt);
+    g_signal_connect(loader.get(), "size-prepared",
+                     G_CALLBACK(+[](GdkPixbufLoader* self, gint width, gint height, gpointer) {
+                         static constexpr uint64_t MAX_SIZE =
+                                 1 << 25;  ///< Max number of pixels: 32M = more than enough for A4 in 72pp
+                         if (width <= 0 || height <= 0) {
+                             g_warning("Image::renderBuffer(): non-positive width/height");
+                             return;
+                         }
+                         if (static_cast<uint64_t>(width) * static_cast<uint64_t>(height) > MAX_SIZE) {
+                             double ratio = static_cast<double>(width) / static_cast<double>(height);
+                             gint maxHeight = floor_cast<gint>(std::sqrt(MAX_SIZE / ratio));
+                             gint maxWidth = floor_cast<gint>(maxHeight * ratio);
+                             g_warning("Trying to open an image too big %d x %d. Resizing it to %d x %d", width, height,
+                                       maxWidth, maxHeight);
+                             gdk_pixbuf_loader_set_size(self, maxHeight, maxWidth);
+                         }
+                     }),
+                     nullptr);
+    GError* err = nullptr;
+    bool success = gdk_pixbuf_loader_write(loader.get(), reinterpret_cast<const guchar*>(this->data.c_str()),
+                                           this->data.length(), &err);
+    if (!success) {
+        if (err != nullptr) {
+            std::string msg = std::string(_("Failed to load image")) + "\n" + _("Error: ") + err->message;
+            g_free(err);
+            return msg;
+        } else {
+            return std::string(_("Failed to load image")) + "\n" + _("Unrecoverable error");
+        }
+    }
+    success = gdk_pixbuf_loader_close(loader.get(), &err);
+    if (!success) {
+        if (err != nullptr) {
+            std::string msg = std::string(_("Failed to close image stream")) + "\n" + _("Error: ") + err->message;
+            g_free(err);
+            return msg;
+        } else {
+            return std::string(_("Failed to close image stream")) + "\n" + _("Unrecoverable error");
+        }
     }
 
+    GdkPixbuf* tmp = gdk_pixbuf_loader_get_pixbuf(loader.get());
+    g_assert(tmp != nullptr);
+    xoj::util::GObjectSPtr<GdkPixbuf> pixbuf(gdk_pixbuf_apply_embedded_orientation(tmp), xoj::util::adopt);
+
+    this->imageSize = {gdk_pixbuf_get_width(pixbuf.get()), gdk_pixbuf_get_height(pixbuf.get())};
+
+    // TODO: pass in window once this code is refactored into ImageView
+    this->image = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, this->imageSize.first, this->imageSize.second);
+    g_assert(this->image != nullptr);
+
+    // Paint the pixbuf on to the surface
+    // NOTE: we do this manually instead of using gdk_cairo_surface_create_from_pixbuf
+    // since this does not work in CLI mode.
+    cairo_t* cr = cairo_create(this->image);
+    gdk_cairo_set_source_pixbuf(cr, pixbuf.get(), 0, 0);
+    cairo_paint(cr);
+    cairo_destroy(cr);
+    return std::nullopt;
+}
+
+auto Image::getImage() const -> cairo_surface_t* {
+    if (auto opt = renderBuffer(); opt.has_value()) {
+        // An error occurred
+        g_warning("%s", opt->c_str());
+    }
     return this->image;
 }
 

--- a/src/core/model/Image.h
+++ b/src/core/model/Image.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <cstddef>      // for size_t
+#include <optional>     // for optional
 #include <string>       // for string
 #include <string_view>  // for string_view
 #include <utility>      // for pair, make_pair
@@ -51,9 +52,11 @@ public:
     /// FIXME: remove this method. Currently, it is used by Control::clipboardPasteImage.
     [[deprecated]] void setImage(GdkPixbuf* img);
 
+    /// The image is rendered lazily by default; call this method to render it.
+    /// Returns std::nullopt on success, an error message on failure
+    std::optional<std::string> renderBuffer() const;
+
     /// Returns the internal surface that contains the rendered image data.
-    ///
-    /// Note that the image is rendered lazily by default; call this method to render it.
     cairo_surface_t* getImage() const;
 
     void scale(double x0, double y0, double fx, double fy, double rotation, bool restoreLineWidth) override;


### PR DESCRIPTION
Fixes the image import of either huge images or svg images with huge width and height parameters.
For SVG files, GdkPixbufLoader creates by default a pixbuf of the size the SVG's viewport. As an SVG's width and height parameters can be enormous, this causes crashes as in #6066.
This PR fixes that by capping the number of pixels to 32M - more than enough for A4 at 72pp.
It also adds error messages in case of loading error.