### PR TITLE
Add Lua API for getting config, state and data folders of plugin

### DIFF
--- a/plugins/luapi_application.def.lua
+++ b/plugins/luapi_application.def.lua
@@ -850,6 +850,21 @@ function app.addImages(opts) end
 --- }
 function app.getImages(type) end
 
+--- Get the plugin's folder for writing one of
+--- - config files
+--- - data files
+--- - state files
+--- and forces it to exist.
+--- 
+--- @param type string "config", "data" or "state"
+--- @return string file path
+--- 
+--- Example 1: local configFolder = app.getFolder("config")
+--- 
+--- Example 2: local stateFolder = app.getFolder("state")
+--- 
+function app.getFolder(type) end
+
 --- Clears a selection by releasing its elements to the current layer.
 --- 
 --- Example: app.clearSelection()


### PR DESCRIPTION
Fixes #6060 
To keep it simple I didn't add an option to omit forcing existence of these folders. It could be added later if needed (with an optional argument).

Here's a sample callback in a plugin with name "Test" and sample output (on Linux):

```lua
function folder()
  print(app.getFolder("config"))
  print(app.getFolder("data"))
  print(app.getFolder("state"))
end
```

output:
```
/home/roland/.config/xournalpp/plugin-settings/Test
/home/roland/.local/share/xournalpp/plugin-data/Test
/home/roland/.local/state/xournalpp/plugin-state/Test
```

This still needs testing on various platforms.