### PR TITLE
Package lua-lgi and dependencies on Windows

### DIFF
--- a/.github/actions/install_deps_windows/action.yml
+++ b/.github/actions/install_deps_windows/action.yml
@@ -24,6 +24,7 @@ runs:
           mingw-w64-x86_64-lua
           mingw-w64-x86_64-gtksourceview4
           mingw-w64-x86_64-imagemagick
+          mingw-w64-x86_64-lua-lgi
     - shell: msys2 {0}
       # Apply https://gitlab.freedesktop.org/cairo/cairo/-/merge_requests/595 to cairo-1.18.2-1 to fix #6014
       # Can be removed if either msys' packages include that fix by hand or cairo-1.18.3 is released.

--- a/windows-setup/package.sh
+++ b/windows-setup/package.sh
@@ -69,6 +69,17 @@ cp /mingw64/bin/gspawn-win64-helper-console.exe "$setup_dir"/bin
 echo "copy gdbus"
 cp /mingw64/bin/gdbus.exe "$setup_dir"/bin
 
+echo "copy lua-lgi and dependencies"
+cp /mingw64/bin/libgirepository-1.0-1.dll "$setup_dir"/bin
+mkdir -p "$setup_dir"/lib/lua/5.4/lgi
+cp /mingw64/lib/lua/5.4/lgi/corelgilua51.dll "$setup_dir"/lib/lua/5.4/lgi
+cp /mingw64/lib/libgirepository-1.0.dll.a "$setup_dir"/lib
+mkdir "$setup_dir"/lib/girepository-1.0
+cp /mingw64/lib/girepository-1.0/*.typelib "$setup_dir"/lib/girepository-1.0
+mkdir -p "$setup_dir"/share/lua/5.4
+cp /mingw64/share/lua/5.4/lgi.lua "$setup_dir"/share/lua/5.4
+cp -r /mingw64/share/lua/5.4/lgi/ "$setup_dir"/share/lua/5.4
+
 echo "create installer"
 bash make_version_nsh.sh
 "/c/Program Files (x86)/NSIS/Bin/makensis.exe" xournalpp.nsi


### PR DESCRIPTION
Packaging `lua-lgi` and dependencies on Windows takes (only) roughly 4 MB when extracted.
- The .typelib files take 3.3 MB
- The libraries (libgirepository-1.0-1.dll, libgirepository-1.0.dll.a, corelgilua51.dll) take 0.5 MB
- The .lua files take 0.26 MB

It seems to work all fine (even without changing the lua package path or package cpath).