### PR TITLE
Package lua-lgi for MacOS

### DIFF
--- a/mac-setup/Info.plist
+++ b/mac-setup/Info.plist
@@ -182,6 +182,12 @@
     <key>NSDownloadsUbiquitousContents</key>
     <true />
 
+    <key>LSEnvironment</key>
+    <dict>
+        <key>DYLD_FALLBACK_LIBRARY_PATH</key>
+        <string>/Applications/Xournal++.app/Contents/Resources/lib</string>
+    </dict>
+
     <key>NSHighResolutionCapable</key>
     <true />
     <key>NSRequiresAquaSystemAppearance</key>

--- a/mac-setup/jhbuild-version.lock
+++ b/mac-setup/jhbuild-version.lock
@@ -1,2 +1,2 @@
-gtk-osx=8c5052f4a57d5ec54d74bf13aaa1e1aeccad75f1
-xournalpp-pipeline-dependencies=5fb1da3de6ef84f129071d828ec99025ffa83894
+gtk-osx=6b8603cd4a40a54cbac9a1b8e722aadec1c3022f
+xournalpp-pipeline-dependencies=0ba50861b076ae472a69fb9335193aa8ce683c4d

--- a/mac-setup/xournalpp.bundle
+++ b/mac-setup/xournalpp.bundle
@@ -40,7 +40,7 @@
 
   <!-- Poppler -->
   <binary>
-    ${prefix}/lib/libpoppler-glib*.dynlib
+    ${prefix}/lib/libpoppler-glib*.dylib
   </binary>
 
   <!-- Translation filenames, one for each program or library that you
@@ -67,10 +67,10 @@
   </data -->
 
   <!--
-    Infos on how to structure the .app-file can be found on 
+    Infos on how to structure the .app-file can be found on
     https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFBundles/BundleTypes/BundleTypes.html#//apple_ref/doc/uid/20001119-110730
   -->
-   
+
   <!-- Copy in the themes data. You may want to trim this to save space
        in your bundle. -->
   <data>

--- a/mac-setup/xournalpp.bundle
+++ b/mac-setup/xournalpp.bundle
@@ -43,6 +43,26 @@
     ${prefix}/lib/libpoppler-glib*.dylib
   </binary>
 
+  <!-- Lua-lgi and GObject-introspection dependency -->
+  <binary>
+    ${prefix}/lib/lua/5.4/lgi/corelgilua51.so
+  </binary>
+  <binary>
+    ${prefix}/lib/libgirepository*.dylib
+  </binary>
+  <data>
+    ${prefix}/share/lua/5.4/lgi.lua
+  </data>
+  <data>
+    ${prefix}/share/lua/5.4/lgi/*.lua
+  </data>
+  <data>
+    ${prefix}/share/lua/5.4/lgi/override/*.lua
+  </data>
+  <data>
+    ${prefix}/lib/girepository-1.0/*.typelib
+  </data>
+
   <!-- Translation filenames, one for each program or library that you
        want to copy in to the bundle. The "dest" attribute is
        optional, as usual. Bundler will find all translations of that

--- a/mac-setup/xournalpp.modules
+++ b/mac-setup/xournalpp.modules
@@ -105,9 +105,36 @@
              makeinstallargs="INSTALL_TOP='$(DESTDIR)/${prefix}' install"
   >
     <branch repo="lua"
-            version="5.4.6"
-            module="lua-5.4.6.tar.gz"
-            checkoutdir="lua-5.4.6"/>
+            version="5.4.7"
+            module="lua-5.4.7.tar.gz"
+            checkoutdir="lua-5.4.7"/>
+  </autotools>
+
+  <autotools id="lua-lgi"
+             skip-autogen="true"
+             supports-non-srcdir-builds="no"
+             makeinstallargs='LUA_VERSION=5.4 PREFIX="${prefix}" install'
+  >
+    <branch repo="github-tarball"
+            module="lgi-devs/lgi/archive/refs/tags/0.9.2.tar.gz"
+            version="0.9.2"
+            checkoutdir="lgi-0.9.2">
+      <patch file="https://github.com/pavouk/lgi/pull/249.patch"
+            strip="1"
+      />
+      <patch file="https://github.com/pavouk/lgi/pull/331.patch"
+            strip="1"
+      />
+      <patch file="https://github.com/pavouk/lgi/pull/273.patch"
+            strip="1"
+      />
+      <patch file="https://github.com/pavouk/lgi/pull/313.patch"
+            strip="1"
+      />
+    </branch>
+    <dependencies>
+      <dep package="lua"/>
+    </dependencies>
   </autotools>
 
   <metamodule id="meta-xournalpp-deps">
@@ -116,7 +143,7 @@
       <dep package="libzip"/>
       <dep package="portaudio"/>
       <dep package="libsndfile"/>
-      <dep package="lua"/>
+      <dep package="lua-lgi"/>
     </dependencies>
   </metamodule>
 

--- a/src/exe/osx/setup-env.cpp
+++ b/src/exe/osx/setup-env.cpp
@@ -28,6 +28,11 @@ void setupEnvironment() {
     auto imModuleFile = libPath / "gtk-3.0" / "3.0.0" / "immodules.cache";
     auto pixbufModuleFile = libPath / "gdk-pixbuf-2.0" / "2.10.0" / "loaders.cache";
 
+    auto typelibPath = libPath / "girepository-1.0";
+
+    std::string luaPath = dataPath.string() + "/lua/5.4/?.lua";
+    std::string luaCPath = libPath.string() + "/lua/5.4/?.so";
+
     setenv("XDG_CONFIG_DIRS", xdgPath.string().c_str(), 1);
     setenv("XDG_DATA_DIRS", dataPath.string().c_str(), 1);
     setenv("GTK_DATA_PREFIX", base.string().c_str(), 1);
@@ -37,9 +42,25 @@ void setupEnvironment() {
     setenv("GTK_IM_MODULE_FILE", imModuleFile.string().c_str(), 0);
     setenv("GDK_PIXBUF_MODULE_FILE", pixbufModuleFile.string().c_str(), 0);
 
+    setenv("GI_TYPELIB_PATH", typelibPath.string().c_str(), 0);
+
+    setenv("LUA_PATH", luaPath.c_str(), 0);
+    setenv("LUA_CPATH", luaCPath.c_str(), 0);
+
     auto environ = g_get_environ();
     const char* usedPixbufModuleFile = g_environ_getenv(environ, "GDK_PIXBUF_MODULE_FILE");
-    g_message("Continue with GDK_PIXBUF_MODULE_FILE = %s", usedPixbufModuleFile);
+    const char* usedTypelibPath = g_environ_getenv(environ, "GI_TYPELIB_PATH");
+    // The DYLD_FALLBACK_LIBRARY_PATH is only read when the process is started, so it can't be set here. It is set in
+    // the Info.plist therefore, which only takes effect when running the App from Finder or using the "open" command.
+    const char* usedDYLDFallbackLibraryPath = g_environ_getenv(environ, "DYLD_FALLBACK_LIBRARY_PATH");
+    const char* usedLuaPath = g_environ_getenv(environ, "LUA_PATH");
+    const char* usedLuaCPath = g_environ_getenv(environ, "LUA_CPATH");
+    g_message("Continue with GDK_PIXBUF_MODULE_FILE = %s\n"
+              "GI_TYPELIB_PATH = %s\n"
+              "DYLD_FALLBACK_LIBRARY_PATH = %s\n"
+              "LUA_PATH = %s\n"
+              "LUA_CPATH = %s",
+              usedPixbufModuleFile, usedTypelibPath, usedDYLDFallbackLibraryPath, usedLuaPath, usedLuaCPath);
 
     /**
      * set LANG and LC_MESSAGES in order to detect the default language


### PR DESCRIPTION
This PR most notably packages `lua-lgi` on MacOS in the same spirit as #6158. That means `lua-lgi` will come bundled on all platforms where we provide bundled installations (Windows, MacOS, snap, flatpak), which makes it much easier for plugin authors that want to create some graphical user interface elements.

~While we already built Lua on MacOS as specified in `xournalpp.modules` and thus enabled plugins on MacOS, we somehow didn't package Lua on MacOS. This is fixed with this PR.~

I have also updated the Lua version from 5.4.6 to 5.4.7 (released in June 2024). 
There was a typo in `libpoppler-glib*.dylib`, which suggests that these lines could be omitted as well. I have just fixed the typo.

The assets will still need to be tested.

**Edit:** `liblua.a` is a static library and baked into the xournalpp executable, so it doesn't need packaging of course.