### PR TITLE
Revisiting the `C` legacy ShapeRecognizer class 

### DIFF
--- a/src/core/control/shaperecognizer/Inertia.cpp
+++ b/src/core/control/shaperecognizer/Inertia.cpp
@@ -78,7 +78,7 @@ void Inertia::increase(Point p1, Point p2, int coef) {
     this->sxy += dm * p1.x * p1.y;
 }
 
-void Inertia::calc(const Point* pt, int start, int end) {
+void Inertia::calc(const std::vector<Point>& pt, int start, int end) {
     this->mass = this->sx = this->sy = this->sxx = this->sxy = this->syy = 0.;
     for (int i = start; i < end - 1; i++) { this->increase(pt[i], pt[i + 1], 1); }
 }

--- a/src/core/control/shaperecognizer/Inertia.h
+++ b/src/core/control/shaperecognizer/Inertia.h
@@ -10,6 +10,7 @@
  */
 
 #pragma once
+#include <vector>
 
 class Point;
 
@@ -34,13 +35,13 @@ public:
     double getMass() const;
 
     void increase(Point p1, Point p2, int coef);
-    void calc(const Point* pt, int start, int end);
+    void calc(const std::vector<Point>& pt, int start, int end);
 
 private:
     double mass{};
-    double sx{};
-    double sy{};
-    double sxx{};
-    double sxy{};
-    double syy{};
+    double sx{};    // sum of x
+    double sy{};    // sum of y
+    double sxx{};   // sum of x^2
+    double sxy{};   // sum of x*y
+    double syy{};   // sum of y^2
 };

--- a/src/core/control/shaperecognizer/RecoSegment.cpp
+++ b/src/core/control/shaperecognizer/RecoSegment.cpp
@@ -16,7 +16,7 @@ auto RecoSegment::calcEdgeIsect(RecoSegment* r2) const -> Point {
 /**
  * Find the geometry of a recognized segment
  */
-void RecoSegment::calcSegmentGeometry(const Point* pt, int start, int end, Inertia* s) {
+void RecoSegment::calcSegmentGeometry(const std::vector<Point>& pt, int start, int end, Inertia* s) {
     this->xcenter = s->centerX();
     this->ycenter = s->centerY();
     double a = s->xx();

--- a/src/core/control/shaperecognizer/RecoSegment.h
+++ b/src/core/control/shaperecognizer/RecoSegment.h
@@ -21,7 +21,7 @@ struct RecoSegment final {
     /**
      * Find the geometry of a recognized segment
      */
-    void calcSegmentGeometry(const Point* pt, int start, int end, Inertia* s);
+    void calcSegmentGeometry(const std::vector<Point>& pt, int start, int end, Inertia* s);
 
     Stroke* stroke{nullptr};
     int startpt{0};

--- a/src/core/control/shaperecognizer/ShapeRecognizer.cpp
+++ b/src/core/control/shaperecognizer/ShapeRecognizer.cpp
@@ -105,7 +105,7 @@ auto ShapeRecognizer::tryRectangle() -> std::unique_ptr<Stroke> {
 /*
  * check if something is a polygonal line with at most nsides sides
  */
-auto ShapeRecognizer::findPolygonal(const Point* pt, int start, int end, int nsides, int* breaks, Inertia* ss) -> int {
+auto ShapeRecognizer::findPolygonal(const std::vector<Point>& pt, int start, int end, int nsides, int* breaks, Inertia* ss) -> int {
     Inertia s;
     int i1 = 0, i2 = 0, n1 = 0, n2 = 0;
 
@@ -197,7 +197,7 @@ auto ShapeRecognizer::findPolygonal(const Point* pt, int start, int end, int nsi
 /**
  * Improve on the polygon found by find_polygonal()
  */
-void ShapeRecognizer::optimizePolygonal(const Point* pt, int nsides, int* breaks, Inertia* ss) {
+void ShapeRecognizer::optimizePolygonal(const std::vector<Point>& pt, int nsides, int* breaks, Inertia* ss) {
     for (int i = 1; i < nsides; i++) {
         // optimize break between sides i and i+1
         double cost = ss[i - 1].det() * ss[i - 1].det() + ss[i].det() * ss[i].det();

--- a/src/core/control/shaperecognizer/ShapeRecognizer.h
+++ b/src/core/control/shaperecognizer/ShapeRecognizer.h
@@ -34,9 +34,9 @@ private:
     auto tryRectangle() -> std::unique_ptr<Stroke>;
     // function Stroke* tryArrow(); removed after commit a3f7a251282dcfea8b4de695f28ce52bf2035da2
 
-    static void optimizePolygonal(const Point* pt, int nsides, int* breaks, Inertia* ss);
+    static void optimizePolygonal(const std::vector<Point>& pt, int nsides, int* breaks, Inertia* ss);
 
-    int findPolygonal(const Point* pt, int start, int end, int nsides, int* breaks, Inertia* ss);
+    int findPolygonal(const std::vector<Point>& pt, int start, int end, int nsides, int* breaks, Inertia* ss);
 
     static bool isStrokeLargeEnough(Stroke* stroke, double strokeMinSize);
 

--- a/src/core/model/Point.cpp
+++ b/src/core/model/Point.cpp
@@ -13,7 +13,7 @@ auto Point::lineLengthTo(const Point& p) const -> double { return std::hypot(thi
 auto Point::lineTo(const Point& p, double length) const -> Point { return relativeLineTo(p, length / lineLengthTo(p)); }
 
 auto Point::relativeLineTo(const Point& p, const double ratio) const -> Point {
-    return Point(x + ratio * (p.x - x), y + ratio * (p.y - y), z + ratio * (p.z - z));
+    return Point(x + ratio * (p.x - x), y + ratio * (p.y - y));
 }
 
 auto Point::equalsPos(const Point& p) const -> bool { return this->x == p.x && this->y == p.y; }

--- a/src/core/model/Point.h
+++ b/src/core/model/Point.h
@@ -10,7 +10,7 @@
  */
 
 #pragma once
-
+#include <vector>
 
 namespace xoj::util {
 template <class T>
@@ -53,7 +53,8 @@ public:
     double lineLengthTo(const Point& p) const;
 
     /**
-     * @brief Compute new Point in the direction from this to another Point.
+     * @brief Compute a new Point on the line between this Point and Point 
+     * \p p at a distance of length from this Point.
      * @param p The other Point.
      * @param length The line length or vector length.
      * @return The new Point.
@@ -61,7 +62,8 @@ public:
     Point lineTo(const Point& p, double length) const;
 
     /**
-     * @brief Compute new Point in the direction from this to another Point.
+     * @brief Compute a new Point on the line between this Point and Point 
+     * \p p that splits the line in the ratio of \p ratio.
      * @param p The other Point.
      * @param ratio The line length over the distance between this and the other Point p
      * @return The new Point.

--- a/src/core/model/Stroke.cpp
+++ b/src/core/model/Stroke.cpp
@@ -280,7 +280,7 @@ Point Stroke::getPoint(PathParameter parameter) const {
     return res;
 }
 
-auto Stroke::getPoints() const -> const Point* { return this->points.data(); }
+auto Stroke::getPoints() const -> const std::vector<Point>& { return this->points; }
 
 void Stroke::setPointVectorInternal(const Range* const snappingBox) {
     if (!snappingBox || this->points.empty() || this->points.front().z != Point::NO_PRESSURE) {

--- a/src/core/model/Stroke.h
+++ b/src/core/model/Stroke.h
@@ -115,7 +115,7 @@ public:
     std::vector<Point> const& getPointVector() const;
     Point getPoint(size_t index) const;
     Point getPoint(PathParameter parameter) const;
-    const Point* getPoints() const;
+    const std::vector<Point>& getPoints() const;
 
     /**
      * @brief Replace the stroke's points by the ones in the provided vector (they will be copied).


### PR DESCRIPTION
I am working on the code of ShapeRecognizer, SR for short, to make it more readable and modern so that it can be enhanced or replaced by a more robust ML model. I have always been fascinated by the ability of the SR of `Xournal++` knowing that it is a 17 YO, pure maths model introduced to `Xournal` by [Lukasz Kaiser](https://sourceforge.net/u/lukaszkaiser/profile/). Because it was first introduced to a `C` project it is still almost `C` code here too. I found the first appearance of SR to be in this `Xournal` [commit](https://sourceforge.net/p/xournal/patches/3/) on SourceForge. 

I am still struggling to wrap my head around this in-depth geometrical math model and am struggling with the missing build-time-made headers while I am browsing and editing. I seem to have made some progress in understanding the model but not making progress with the headers headache, so I stopped the analyzer and depended on the build process and testing the app.
