### PR TITLE
QuickScreenshot: Do not block main thread while taking a screenshot with `maim`

### DIFF
--- a/plugins/QuickScreenshot/main.lua
+++ b/plugins/QuickScreenshot/main.lua
@@ -85,7 +85,7 @@ function Go()
   -- installed. Then a screenshot is made with maim and saved to the
   -- clipboard, skipping all other tools
   if existsUtility("maim") and existsUtility("xclip") then
-    os.execute("maim -s | xclip -selection clipboard -t image/png")
+    os.execute("maim -s | xclip -selection clipboard -t image/png &")
     return
   end
   -- This becomes true if at least one screenshot


### PR DESCRIPTION
The way it is written, the UI freezes every time a screenshot is taken using the plugin (on systems where `maim` is used). This makes the plugin unusable in Xorg systems. Once the screenshot border is drawn to the screen Xorg sends an Expose event to the window, but it is not handled since the thread is too busy waiting for `maim`, so the screenshot is just a bunch of frozen borders. Here is a screenshot taken with the plugin, the frozen menu can be seen behind the bars, hinting at the fact that the UI is taking a nap.

![image](https://github.com/user-attachments/assets/f9919872-d4d6-4030-ba83-cd7f054a1b68)

To be clear, the effect in the image happens when clicking on the plugin and then spanning a rectangle with the mouse. Just as I would do to take a screenshot of a region of the screen. It also only happens when taking a screenshot of `xournalpp` itself. And, yes, this is the only way my note taking workflow can work, I need to copy many small regions of annotated PDFs all the time.

I'm sure there are many solutions, but in my opinion the simplest one is to append `&` to the command that takes the screenshot so that it is run asynchronously. Since the plugin ends execution right after the command is run, there shouldn't be any issues.

I also have been running this fix for quite a while now without any issues. So I can confidently say that _it works on my machine_.