### PR TITLE
Add wildcard `file` when configuring the save filename

### DIFF
--- a/src/core/model/Document.cpp
+++ b/src/core/model/Document.cpp
@@ -152,9 +152,9 @@ auto Document::createSaveFilename(DocumentType type, const std::string& defaultS
             return p;
         }
     } else if (!pdfFilepath.empty()) {
-        wildcardString = SaveNameUtils::parseFilenameFromWildcardString(defaultPdfName, this->pdfFilepath.filename());
+        wildcardString = SaveNameUtils::parseFilenameFromWildcardString(defaultPdfName, this->pdfFilepath.filename(), this->filepath.filename());
     } else if (!filepath.empty()) {
-        wildcardString = SaveNameUtils::parseFilenameFromWildcardString(defaultPdfName, this->filepath.filename());
+        wildcardString = SaveNameUtils::parseFilenameFromWildcardString(defaultPdfName, this->filepath.filename(), this->filepath.filename());
     }
 
     auto format_str = wildcardString.empty() ? defaultSaveName : wildcardString;

--- a/src/util/SaveNameUtils.cpp
+++ b/src/util/SaveNameUtils.cpp
@@ -1,9 +1,10 @@
 #include "util/SaveNameUtils.h"
 
+#include "include/util/SaveNameUtils.h"
 #include "util/PathUtil.h"    // for clearExtensions
 
 
-auto SaveNameUtils::parseFilenameFromWildcardString(const std::string& wildcardString, const fs::path& defaultFilePath) -> std::string {
+auto SaveNameUtils::parseFilenameFromWildcardString(const std::string& wildcardString, const fs::path& PdfPath, const fs::path& FilePath) -> std::string {
     std::string saveString = wildcardString;
     size_t pos = saveString.find(DEFAULT_WILDCARD_START);
 
@@ -14,7 +15,7 @@ auto SaveNameUtils::parseFilenameFromWildcardString(const std::string& wildcardS
         if (endPos == std::string::npos) {
             break;
         }
-        std::string parsedWildcard = parseWildcard(saveString.substr(pos + wildcardStartLength, endPos - pos - wildcardStartLength), defaultFilePath);
+        std::string parsedWildcard = parseWildcard(saveString.substr(pos + wildcardStartLength, endPos - pos - wildcardStartLength), PdfPath, FilePath);
         saveString.replace(pos, endPos + 1 - pos, parsedWildcard);
         pos += parsedWildcard.size();
         pos = saveString.find(DEFAULT_WILDCARD_START, pos);
@@ -23,12 +24,19 @@ auto SaveNameUtils::parseFilenameFromWildcardString(const std::string& wildcardS
     return saveString;
 }
 
-auto SaveNameUtils::parseWildcard(const std::string& wildcard, const fs::path& defaultFilePath) -> std::string {
-    if (wildcard == WILDCARD_NAME) {
-        fs::path path = defaultFilePath;
+auto SaveNameUtils::parseWildcard(const std::string& wildcard, const fs::path& PdfPath, const fs::path& FilePath) -> std::string {
+    if (wildcard == WILDCARD_PDF_NAME) {
+        fs::path path = PdfPath;
         Util::clearExtensions(path, ".pdf");
         return path.u8string();
     }
+
+    if (wildcard == WILDCARD_FILE_NAME) {
+        fs::path path = FilePath;
+        Util::clearExtensions(path, "");
+        return path.u8string();
+    }
+
     if (wildcard == WILDCARD_DATE || wildcard == WILDCARD_TIME) {
         // Backwards compatibility: redirect to std::chrono placeholders
         return wildcard == WILDCARD_DATE ? "%F" : "%X";

--- a/src/util/include/util/SaveNameUtils.h
+++ b/src/util/include/util/SaveNameUtils.h
@@ -19,7 +19,10 @@ constexpr auto DEFAULT_WILDCARD_START = "%{";
 constexpr auto DEFAULT_WILDCARD_END = "}";
 
 // wildcard options
-constexpr auto WILDCARD_NAME = "name";  ///< default store name, e.g. original pdf name
+constexpr auto WILDCARD_PDF_NAME = "name";  ///< default store name, e.g. original pdf name
+
+constexpr auto  WILDCARD_FILE_NAME = "file";  ///< name of the file itself
+
 constexpr auto WILDCARD_DATE = "date";  ///< current date - Deprecated: prefer using %F instead of %{date}
 constexpr auto WILDCARD_TIME = "time";  ///< current time - Deprecated: prefer using %X instead of %{time}
 

--- a/test/unit_tests/util/SaveNameUtilsTest.cpp
+++ b/test/unit_tests/util/SaveNameUtilsTest.cpp
@@ -15,11 +15,11 @@
 #include "util/SaveNameUtils.h"
 
 TEST(SaveNameUtils, testWildcardExpansion) {
-    EXPECT_EQ(SaveNameUtils::parseFilenameFromWildcardString("", "defaultpath"), "");
-    EXPECT_EQ(SaveNameUtils::parseFilenameFromWildcardString("%{name}}%{name}", "x"), "x}x");
-    EXPECT_EQ(SaveNameUtils::parseFilenameFromWildcardString("%{name}", "defaultpath.pdf"), "defaultpath");
-    EXPECT_EQ(SaveNameUtils::parseFilenameFromWildcardString("%{", "defaultpath"), "%{");
-    EXPECT_EQ(SaveNameUtils::parseFilenameFromWildcardString("%{name%{name}}x", ""), "}x");
-    EXPECT_EQ(SaveNameUtils::parseFilenameFromWildcardString("\\%\\{name%{name}}x", ""), "\\%\\{name}x");
-    EXPECT_EQ(SaveNameUtils::parseFilenameFromWildcardString("%{name}", "      %{name}"), "      %{name}");
+    EXPECT_EQ(SaveNameUtils::parseFilenameFromWildcardString("", "defaultpath", ""), "");
+    EXPECT_EQ(SaveNameUtils::parseFilenameFromWildcardString("%{name}}%{name}", "x", ""), "x}x");
+    EXPECT_EQ(SaveNameUtils::parseFilenameFromWildcardString("%{name}", "defaultpath.pdf", ""), "defaultpath");
+    EXPECT_EQ(SaveNameUtils::parseFilenameFromWildcardString("%{", "defaultpath"), "%{", "");
+    EXPECT_EQ(SaveNameUtils::parseFilenameFromWildcardString("%{name%{name}}x", ""), "}x", "");
+    EXPECT_EQ(SaveNameUtils::parseFilenameFromWildcardString("\\%\\{name%{name}}x", "", ""), "\\%\\{name}x");
+    EXPECT_EQ(SaveNameUtils::parseFilenameFromWildcardString("%{name}", "      %{name}", ""), "      %{name}");
 }


### PR DESCRIPTION
`file` will use the filename of the file itself, instead of the name of the PDF background.