### PR TITLE
recolor: adjust pen coloring as well

### DIFF
--- a/src/core/gui/XournalppCursor.cpp
+++ b/src/core/gui/XournalppCursor.cpp
@@ -436,6 +436,9 @@ auto XournalppCursor::getPenCursor() -> GdkCursor* {
 
 auto XournalppCursor::createHighlighterOrPenCursor(double alpha) -> GdkCursor* {
     auto irgb = control->getToolHandler()->getColor();
+    if(control->getSettings()->getRecolorParameters().recolorizeMainView) {
+        irgb = control->getSettings()->getRecolorParameters().recolor.convertColor(irgb);
+    }
     auto drgb = Util::rgb_to_GdkRGBA(irgb);
     auto cursorType = control->getSettings()->getStylusCursorType();
     auto cursor = (cursorType == STYLUS_CURSOR_NONE) ? CRSR_BLANK_CURSOR : CRSR_PENORHIGHLIGHTER;


### PR DESCRIPTION
Like noted in https://github.com/xournalpp/xournalpp/issues/6165 we also want to adjust the coloring of the pen when the recolor feature is active.

This is a follow-up from https://github.com/xournalpp/xournalpp/pull/6090.

See these two examples:
![2025-01-12-111003_1920x1080_scrot](https://github.com/user-attachments/assets/53a21abf-ad34-4d56-bf73-8afe80f05a9c)
![2025-01-12-111016_1920x1080_scrot](https://github.com/user-attachments/assets/66c1aa31-4284-4458-8dfe-d8bdc078a4db)

Looking at the code, I would have expected I also need to adjust https://github.com/xournalpp/xournalpp/blob/b81bdc5a7312b5736dd3ebbb59ae28011a6f2d0c/src/core/gui/XournalppCursor.cpp#L497
but for me this was not needed. Can someone confirm this is true?

Also do you think we should obtain `Settings` once in `createHighlighterOrPenCursor` (instead of requesting it (now) 4 times via `control->getSettings()`? (probably doesn't change much)