### PR TITLE
Inform windowing system of active text selections

### DIFF
--- a/src/core/control/tools/PdfElemSelection.cpp
+++ b/src/core/control/tools/PdfElemSelection.cpp
@@ -18,6 +18,7 @@
 #include "model/PageRef.h"        // for PageRef
 #include "model/XojPage.h"        // for XojPage
 #include "pdf/base/XojPdfPage.h"  // for XojPdfRectangle, XojPdfPageSelectio...
+#include "util/safe_casts.h"
 #include "view/overlays/PdfElementSelectionView.h"
 
 PdfElemSelection::PdfElemSelection(double x, double y, Control* control):
@@ -60,6 +61,9 @@ bool PdfElemSelection::finalizeSelection(XojPdfPageSelectionStyle style) {
     this->selectedTextRegion = std::move(selection.region);
     this->selectedTextRects = std::move(selection.rects);
     this->selectedText = this->pdf->selectText(this->bounds, style);
+    // Informs the windowing system of the selection -- i.e. for accessibility purposes
+    gtk_clipboard_set_text(gtk_clipboard_get(GDK_SELECTION_PRIMARY), this->selectedText.c_str(),
+                           strict_cast<gint>(this->selectedText.length()));
     return !this->selectedTextRects.empty();
 }
 

--- a/src/core/control/tools/TextEditor.cpp
+++ b/src/core/control/tools/TextEditor.cpp
@@ -126,6 +126,8 @@ TextEditor::TextEditor(Control* control, const PageRef& page, GtkWidget* xournal
         imContext(gtk_im_multicontext_new(), xoj::util::adopt),
         buffer(gtk_text_buffer_new(nullptr), xoj::util::adopt),
         viewPool(std::make_shared<xoj::util::DispatchPool<xoj::view::TextEditionView>>()) {
+    // Informs the windowing system of the selection -- i.e. for accessibility purposes
+    gtk_text_buffer_add_selection_clipboard(buffer.get(), gtk_clipboard_get(GDK_SELECTION_PRIMARY));
 
     this->initializeEditionAt(x, y);
 

--- a/src/core/gui/PdfFloatingToolbox.cpp
+++ b/src/core/gui/PdfFloatingToolbox.cpp
@@ -138,7 +138,7 @@ void PdfFloatingToolbox::show() {
 
 void PdfFloatingToolbox::copyTextToClipboard() {
     GtkClipboard* clipboard = gtk_widget_get_clipboard(this->theMainWindow->getWindow(), GDK_SELECTION_CLIPBOARD);
-    if (std::string text = this->pdfElemSelection->getSelectedText(); !text.empty()) {
+    if (const std::string& text = this->pdfElemSelection->getSelectedText(); !text.empty()) {
         gtk_clipboard_set_text(clipboard, text.c_str(), -1);
     }
 }


### PR DESCRIPTION
Exposes selected text (both when in a Text element and in a background PDF) to the windowing system.
With this fix, utilities like `xsel` (X11) or `wl-paste --primary` (Wayland) will print out the selected text.

This fixes half of #6215.