### PR TITLE
Update gtk-osx and remove obsolete fixes

### DIFF
--- a/mac-setup/CI_jhbuild.sh
+++ b/mac-setup/CI_jhbuild.sh
@@ -7,8 +7,6 @@ set -o pipefail
 
 LOCKFILE="$(dirname "$0")"/jhbuild-version.lock
 MODULEFILE="$(dirname "$0")"/xournalpp.modules
-PATCHFILE_TIFF="$(dirname "$0")"/gtk-osx.patch
-PATCHFILE_FIND="$(dirname "$0")"/cmake-find.patch
 GTK_MODULES="meta-gtk-osx-gtk3 gtksourceview3"
 
 get_lockfile_entry() {
@@ -37,8 +35,6 @@ shallow_clone_into_commit() {
 
 download_jhbuild_sources() {
     shallow_clone_into_commit "https://gitlab.gnome.org/GNOME/gtk-osx.git" "gtk-osx" ~/gtk-osx-custom
-    (cd ~/gtk-osx-custom && patch -p1 -i "$PATCHFILE_TIFF")
-    (cd ~/gtk-osx-custom && patch -p1 -i "$PATCHFILE_FIND")
 
     # Make a shallow clone of jhbuild's sources. This way we detect if cloning fails and avoid the deep clone in gtk-osx-setup.sh
     JHBUILD_BRANCH=$(sed -e '/^JHBUILD_RELEASE_VERSION=/!d' -e 's/^[^=]*=//' ~/gtk-osx-custom/gtk-osx-setup.sh)

--- a/mac-setup/jhbuild-version.lock
+++ b/mac-setup/jhbuild-version.lock
@@ -1,2 +1,2 @@
-gtk-osx=8c5052f4a57d5ec54d74bf13aaa1e1aeccad75f1
+gtk-osx=7560afb065b7fc0b0c086f2c6d41c548fe64b79b
 xournalpp-pipeline-dependencies=5fb1da3de6ef84f129071d828ec99025ffa83894


### PR DESCRIPTION
The two fixes have been merged into gtk-osx. So I'm removing them here.