### PR TITLE
Add timestamps to error logs

### DIFF
--- a/src/core/control/CrashHandlerUnix.h
+++ b/src/core/control/CrashHandlerUnix.h
@@ -32,6 +32,7 @@ constexpr GLogLevelFlags RECORDED_LOG_LEVELS = GLogLevelFlags(0xff);  //< Record
 static void log_handler(const gchar* log_domain, GLogLevelFlags log_level, const gchar* message,
                         std::stringstream* logBuffer) {
     if ((log_level & RECORDED_LOG_LEVELS) != 0) {
+        *logBuffer << g_get_monotonic_time() << "µs: ";
         if (log_level & G_LOG_FLAG_FATAL) {
             *logBuffer << "FATAL ";
         }


### PR DESCRIPTION
Just adds a timestamp to messages in the crash logs. It'll help disregarding messages from long before the crash.

Merging once the CI clears.