### PR TITLE
Fix some undefined behaviour (and possible SegFaults) with GTK signals

### DIFF
--- a/src/core/control/XournalMain.cpp
+++ b/src/core/control/XournalMain.cpp
@@ -410,13 +410,18 @@ void initResourcePath(GladeSearchpath* gladePath, const gchar* relativePathAndFi
 
 void on_activate(GApplication*, XMPtr) {}
 
-void on_command_line(GApplication*, GApplicationCommandLine*, XMPtr) {
+gint on_command_line(GApplication*, GApplicationCommandLine*, XMPtr) {
     g_message("XournalMain::on_command_line: This should never happen, please file a bugreport with a detailed "
               "description how to reproduce this message");
     // Todo: implement this, if someone files the bug report
+    return 0;
 }
 
-void on_open_files(GApplication* application, GFile** files, gint numFiles, gchar* hint, XMPtr app_data) {
+void on_open_files(GApplication* application, gpointer f, gint numFiles, gchar* hint, XMPtr app_data) {
+    if (numFiles <= 0) {
+        return;
+    }
+    auto* files = (GFile**)f;
     if (numFiles != 1) {
         const std::string msg = _("Sorry, Xournal++ can only open one file at once.\n"
                                   "Others are ignored.");

--- a/src/core/gui/FloatingToolbox.cpp
+++ b/src/core/gui/FloatingToolbox.cpp
@@ -11,6 +11,7 @@
 #include "control/settings/ButtonConfig.h"   // for ButtonConfig
 #include "control/settings/Settings.h"       // for Settings
 #include "control/settings/SettingsEnums.h"  // for BUTTON_COUNT
+#include "util/glib_casts.h"
 
 #include "MainWindow.h"          // for MainWindow
 #include "ToolbarDefinitions.h"  // for ToolbarEntryDefintion
@@ -26,9 +27,10 @@ FloatingToolbox::FloatingToolbox(MainWindow* theMainWindow, GtkOverlay* overlay)
     gtk_overlay_add_overlay(overlay, this->floatingToolbox);
     gtk_overlay_set_overlay_pass_through(overlay, this->floatingToolbox, true);
     gtk_widget_add_events(this->floatingToolbox, GDK_LEAVE_NOTIFY_MASK);
-    g_signal_connect(this->floatingToolbox, "leave-notify-event", G_CALLBACK(handleLeaveFloatingToolbox), this);
+    g_signal_connect(this->floatingToolbox, "leave-notify-event",
+                     xoj::util::wrap_for_g_callback_v<handleLeaveFloatingToolbox>, this);
     // position overlay widgets
-    g_signal_connect(overlay, "get-child-position", G_CALLBACK(this->getOverlayPosition), this);
+    g_signal_connect(overlay, "get-child-position", xoj::util::wrap_for_g_callback_v<getOverlayPosition>, this);
 }
 
 
@@ -141,7 +143,7 @@ void FloatingToolbox::flagRecalculateSizeRequired() { this->floatingToolboxState
  *
  */
 auto FloatingToolbox::getOverlayPosition(GtkOverlay* overlay, GtkWidget* widget, GdkRectangle* allocation,
-                                         FloatingToolbox* self) -> gboolean {
+                                         FloatingToolbox* self) -> bool {
     if (widget == self->floatingToolbox) {
         gtk_widget_get_allocation(widget, allocation);  // get existing width and height
 
@@ -178,10 +180,12 @@ auto FloatingToolbox::getOverlayPosition(GtkOverlay* overlay, GtkWidget* widget,
 }
 
 
-void FloatingToolbox::handleLeaveFloatingToolbox(GtkWidget* floatingToolbox, GdkEvent* event, FloatingToolbox* self) {
+bool FloatingToolbox::handleLeaveFloatingToolbox(GtkWidget* floatingToolbox, GdkEvent* event, FloatingToolbox* self) {
     if (floatingToolbox == self->floatingToolbox) {
         if (self->floatingToolboxState != configuration) {
             self->hide();
         }
+        return true;
     }
+    return false;
 }

--- a/src/core/gui/FloatingToolbox.h
+++ b/src/core/gui/FloatingToolbox.h
@@ -56,13 +56,12 @@ private:
     /**
      * Callback for positioning overlayed floating menu
      */
-    static gboolean getOverlayPosition(GtkOverlay* overlay, GtkWidget* widget, GdkRectangle* allocation,
-                                       FloatingToolbox* self);
+    static bool getOverlayPosition(GtkOverlay* overlay, GtkWidget* widget, GdkRectangle* alloc, FloatingToolbox* self);
 
     /**
      * Callback to hide floating Toolbar when mouse leaves it
      */
-    static void handleLeaveFloatingToolbox(GtkWidget* floatingToolbox, GdkEvent* event, FloatingToolbox* self);
+    static bool handleLeaveFloatingToolbox(GtkWidget* floatingToolbox, GdkEvent* event, FloatingToolbox* self);
 
     /**
      * Show the Floating Toolbox

--- a/src/core/gui/SearchBar.cpp
+++ b/src/core/gui/SearchBar.cpp
@@ -32,7 +32,7 @@ SearchBar::SearchBar(Control* control): control(control) {
     g_signal_connect(searchTextField, "search-changed", G_CALLBACK(searchTextChangedCallback), this);
     // Enable next/previous search when pressing Enter / Shift+Enter
     g_signal_connect(searchTextField, "key-press-event",
-                     G_CALLBACK(+[](GtkWidget* entry, GdkEventKey* event, SearchBar* self) {
+                     G_CALLBACK(+[](GtkWidget* entry, GdkEventKey* event, SearchBar* self) -> gboolean {
                          if (event->keyval == GDK_KEY_Return) {
                              if (event->state & GDK_SHIFT_MASK) {
                                  self->searchPrevious();

--- a/src/core/gui/dialog/backgroundSelect/BackgroundSelectDialogBase.cpp
+++ b/src/core/gui/dialog/backgroundSelect/BackgroundSelectDialogBase.cpp
@@ -34,14 +34,12 @@ BackgroundSelectDialogBase::~BackgroundSelectDialogBase() {
     elements.clear();
 }
 
-void BackgroundSelectDialogBase::sizeAllocate(GtkWidget* widget, GtkRequisition* requisition,
+void BackgroundSelectDialogBase::sizeAllocate(GtkWidget* widget, GtkAllocation* alloc,
                                               BackgroundSelectDialogBase* dlg) {
-    GtkAllocation alloc = {0};
-    gtk_widget_get_allocation(dlg->scrollPreview, &alloc);
-    if (dlg->lastWidth == alloc.width) {
+    if (dlg->lastWidth == alloc->width) {
         return;
     }
-    dlg->lastWidth = alloc.width;
+    dlg->lastWidth = alloc->width;
     dlg->layout();
 }
 

--- a/src/core/gui/dialog/backgroundSelect/BackgroundSelectDialogBase.h
+++ b/src/core/gui/dialog/backgroundSelect/BackgroundSelectDialogBase.h
@@ -38,7 +38,7 @@ protected:
     void layout();
 
 private:
-    static void sizeAllocate(GtkWidget* widget, GtkRequisition* requisition, BackgroundSelectDialogBase* dlg);
+    static void sizeAllocate(GtkWidget* widget, GtkAllocation* alloc, BackgroundSelectDialogBase* dlg);
 
 private:
 protected:

--- a/src/core/gui/sidebar/indextree/SidebarIndexPage.cpp
+++ b/src/core/gui/sidebar/indextree/SidebarIndexPage.cpp
@@ -76,9 +76,9 @@ void SidebarIndexPage::disableSidebar() {
     // Nothing to do at the moment
 }
 
-auto SidebarIndexPage::treeBookmarkSelected(GtkWidget* treeview, SidebarIndexPage* sidebar) -> bool {
+void SidebarIndexPage::treeBookmarkSelected(GtkTreeView* treeview, SidebarIndexPage* sidebar) {
     if (sidebar->searchTimeout) {
-        return false;
+        return;
     }
 
     gtk_widget_grab_focus(GTK_WIDGET(treeview));
@@ -99,17 +99,14 @@ auto SidebarIndexPage::treeBookmarkSelected(GtkWidget* treeview, SidebarIndexPag
                 sidebar->control->getScrollHandler()->scrollToLinkDest(*dest);
             }
             g_object_unref(link);
-
-            return true;
         }
     }
-    return false;
 }
 
 auto SidebarIndexPage::searchTimeoutFunc(SidebarIndexPage* sidebar) -> bool {
     sidebar->searchTimeout = 0;
 
-    treeBookmarkSelected(sidebar->treeViewBookmarks, sidebar);
+    treeBookmarkSelected(GTK_TREE_VIEW(sidebar->treeViewBookmarks), sidebar);
 
     return false;
 }
@@ -297,7 +294,7 @@ void SidebarIndexPage::documentChanged(DocumentChangeType type) {
         int count = expandOpenLinks(model, nullptr);
         doc->unlock();
         g_signal_handler_unblock(this->treeViewBookmarks, this->selectHandler);
-        this->treeBookmarkSelected(this->treeViewBookmarks, this);
+        this->treeBookmarkSelected(GTK_TREE_VIEW(this->treeViewBookmarks), this);
 
         hasContents = (count != 0);
     }

--- a/src/core/gui/sidebar/indextree/SidebarIndexPage.h
+++ b/src/core/gui/sidebar/indextree/SidebarIndexPage.h
@@ -80,7 +80,7 @@ private:
     /**
      * A bookmark was selected
      */
-    static auto treeBookmarkSelected(GtkWidget* treeview, SidebarIndexPage* sidebar) -> bool;
+    static void treeBookmarkSelected(GtkTreeView* treeview, SidebarIndexPage* sidebar);
 
     /**
      * The function which is called after a search timeout

--- a/src/core/gui/sidebar/previews/base/SidebarPreviewBaseEntry.cpp
+++ b/src/core/gui/sidebar/previews/base/SidebarPreviewBaseEntry.cpp
@@ -25,19 +25,18 @@ SidebarPreviewBaseEntry::SidebarPreviewBaseEntry(SidebarPreviewBase* sidebar, co
 
     g_signal_connect(this->widget, "draw", G_CALLBACK(drawCallback), this);
 
-    g_signal_connect(this->widget, "clicked", G_CALLBACK(+[](GtkWidget* widget, SidebarPreviewBaseEntry* self) {
-                         self->mouseButtonPressCallback();
-                         return true;
+    g_signal_connect(GTK_BUTTON(this->widget), "clicked", G_CALLBACK(+[](GtkButton*, gpointer self) {
+                         static_cast<SidebarPreviewBaseEntry*>(self)->mouseButtonPressCallback();
                      }),
                      this);
 
-    const auto clickCallback = G_CALLBACK(+[](GtkWidget* widget, GdkEvent* event, SidebarPreviewBaseEntry* self) {
+    const auto clickCallback = G_CALLBACK(+[](GtkWidget*, GdkEvent* event, gpointer self) {
         // Open context menu on right mouse click
         if (event->type == GDK_BUTTON_PRESS) {
             auto mouseEvent = reinterpret_cast<GdkEventButton*>(event);
             if (mouseEvent->button == 3) {
-                self->mouseButtonPressCallback();
-                self->sidebar->openPreviewContextMenu();
+                static_cast<SidebarPreviewBaseEntry*>(self)->mouseButtonPressCallback();
+                static_cast<SidebarPreviewBaseEntry*>(self)->sidebar->openPreviewContextMenu();
                 return true;
             }
         }

--- a/src/core/gui/sidebar/previews/base/SidebarToolbar.cpp
+++ b/src/core/gui/sidebar/previews/base/SidebarToolbar.cpp
@@ -3,6 +3,12 @@
 #include <glib-object.h>  // for G_CALLBACK, g_signal_connect
 
 #include "gui/GladeGui.h"  // for GladeGui
+#include "util/glib_casts.h"
+
+template <SidebarActions a>
+void cb(GtkButton*, SidebarToolbar* toolbar) {
+    toolbar->runAction(a);
+}
 
 SidebarToolbar::SidebarToolbar(SidebarToolbarActionListener* listener, GladeGui* gui): listener(listener) {
     this->btUp = GTK_BUTTON(gui->get("btUp"));
@@ -10,31 +16,15 @@ SidebarToolbar::SidebarToolbar(SidebarToolbarActionListener* listener, GladeGui*
     this->btCopy = GTK_BUTTON(gui->get("btCopy"));
     this->btDelete = GTK_BUTTON(gui->get("btDelete"));
 
-    g_signal_connect(this->btUp, "clicked", G_CALLBACK(&btUpClicked), this);
-    g_signal_connect(this->btDown, "clicked", G_CALLBACK(&btDownClicked), this);
-    g_signal_connect(this->btCopy, "clicked", G_CALLBACK(&btCopyClicked), this);
-    g_signal_connect(this->btDelete, "clicked", G_CALLBACK(&btDeleteClicked), this);
+    g_signal_connect(this->btUp, "clicked", xoj::util::wrap_for_g_callback_v<cb<SIDEBAR_ACTION_MOVE_UP>>, this);
+    g_signal_connect(this->btDown, "clicked", xoj::util::wrap_for_g_callback_v<cb<SIDEBAR_ACTION_MOVE_DOWN>>, this);
+    g_signal_connect(this->btCopy, "clicked", xoj::util::wrap_for_g_callback_v<cb<SIDEBAR_ACTION_COPY>>, this);
+    g_signal_connect(this->btDelete, "clicked", xoj::util::wrap_for_g_callback_v<cb<SIDEBAR_ACTION_DELETE>>, this);
 }
 
 SidebarToolbar::~SidebarToolbar() = default;
 
 void SidebarToolbar::runAction(SidebarActions actions) { this->listener->actionPerformed(actions); }
-
-void SidebarToolbar::btUpClicked(GtkToolButton* toolbutton, SidebarToolbar* toolbar) {
-    toolbar->runAction(SIDEBAR_ACTION_MOVE_UP);
-}
-
-void SidebarToolbar::btDownClicked(GtkToolButton* toolbutton, SidebarToolbar* toolbar) {
-    toolbar->runAction(SIDEBAR_ACTION_MOVE_DOWN);
-}
-
-void SidebarToolbar::btCopyClicked(GtkToolButton* toolbutton, SidebarToolbar* toolbar) {
-    toolbar->runAction(SIDEBAR_ACTION_COPY);
-}
-
-void SidebarToolbar::btDeleteClicked(GtkToolButton* toolbutton, SidebarToolbar* toolbar) {
-    toolbar->runAction(SIDEBAR_ACTION_DELETE);
-}
 
 void SidebarToolbar::setHidden(bool hidden) {
     gtk_widget_set_visible(GTK_WIDGET(this->btUp), !hidden);

--- a/src/core/gui/sidebar/previews/base/SidebarToolbar.h
+++ b/src/core/gui/sidebar/previews/base/SidebarToolbar.h
@@ -60,13 +60,6 @@ public:
     void runAction(SidebarActions actions);
 
 private:
-private:
-    static void btUpClicked(GtkToolButton* toolbutton, SidebarToolbar* toolbar);
-    static void btDownClicked(GtkToolButton* toolbutton, SidebarToolbar* toolbar);
-    static void btCopyClicked(GtkToolButton* toolbutton, SidebarToolbar* toolbar);
-    static void btDeleteClicked(GtkToolButton* toolbutton, SidebarToolbar* toolbar);
-
-private:
     /**
      * Listener for actions
      */

--- a/src/core/gui/sidebar/previews/page/SidebarPreviewPages.cpp
+++ b/src/core/gui/sidebar/previews/page/SidebarPreviewPages.cpp
@@ -65,7 +65,7 @@ SidebarPreviewPages::SidebarPreviewPages(Control* control, GladeGui* gui, Sideba
 SidebarPreviewPages::~SidebarPreviewPages() {
     for (const auto& signalTuple: this->contextMenuSignals) {
         GtkWidget* const widget = std::get<0>(signalTuple);
-        const guint handlerId = std::get<1>(signalTuple);
+        const gulong handlerId = std::get<1>(signalTuple);
         if (g_signal_handler_is_connected(widget, handlerId)) {
             g_signal_handler_disconnect(widget, handlerId);
         }

--- a/src/core/gui/toolbarMenubar/FontButton.cpp
+++ b/src/core/gui/toolbarMenubar/FontButton.cpp
@@ -77,7 +77,6 @@ auto FontButton::createItem(bool horizontal) -> GtkToolItem* {
 
     this->item = newItem();
     g_object_ref(this->item);
-    g_signal_connect(fontButton, "font_set", G_CALLBACK(&toolButtonCallback), this);
     return this->item;
 }
 
@@ -126,7 +125,10 @@ auto FontButton::newItem() -> GtkToolItem* {
     gtk_tool_item_set_tooltip_text(it, this->description.c_str());
     gtk_tool_item_set_homogeneous(GTK_TOOL_ITEM(it), false);
 
-    g_signal_connect(this->fontButton, "font_set", G_CALLBACK(&toolButtonCallback), this);
+    g_signal_connect(GTK_FONT_BUTTON(this->fontButton), "font-set", G_CALLBACK(+[](GtkFontButton*, gpointer s) {
+                         static_cast<FontButton*>(s)->activated(nullptr, nullptr);
+                     }),
+                     this);
 
     if (!this->font.getName().empty()) {
         setFont(this->font);

--- a/src/core/gui/toolbarMenubar/PluginToolButton.cpp
+++ b/src/core/gui/toolbarMenubar/PluginToolButton.cpp
@@ -23,8 +23,10 @@ auto PluginToolButton::createItem(bool horizontal) -> GtkToolItem* {
     g_object_ref(this->item);
 
     // Connect signal
-    g_signal_connect(item, "clicked",
-                     G_CALLBACK(+[](GtkWidget* bt, ToolbarButtonEntry* te) { te->plugin->executeToolbarButton(te); }),
+    g_signal_connect(GTK_TOOL_BUTTON(item), "clicked", G_CALLBACK(+[](GtkToolButton* bt, gpointer te) {
+                         auto* self = static_cast<ToolbarButtonEntry*>(te);
+                         self->plugin->executeToolbarButton(self);
+                     }),
                      this->t);
 
     return this->item;


### PR DESCRIPTION
This fixes some UB around various signal handlers 

1. some had a return value and shouldn't have (probably inocuous)
2. some had no return value but should have had one
3. The FontButton callback was really messed up
    - some gpointer was cast to an unrelated type (GtkToolItem* vs GtkFontButton*)
    - The callback was set up twice (hence called twice)
4. some callbacks were dangerous, potentially causing SegFaults