### PR TITLE
Plug memory leaks

### DIFF
--- a/src/core/gui/dialog/DeviceClassConfigGui.cpp
+++ b/src/core/gui/dialog/DeviceClassConfigGui.cpp
@@ -35,7 +35,7 @@ void DeviceClassConfigGui::loadSettings() {
             this->settings->getDeviceClassForDevice(this->device.getName(), this->device.getSource());
     // Use the ID of each option in case the combo box options get rearranged in the future
     gtk_combo_box_set_active_id(GTK_COMBO_BOX(this->cbDeviceClass),
-                                g_strdup_printf("%i", static_cast<int>(deviceType)));
+                                std::to_string(static_cast<int>(deviceType)).c_str());
 }
 
 void DeviceClassConfigGui::show(GtkWindow* parent) {

--- a/src/core/gui/dialog/LatexSettingsPanel.cpp
+++ b/src/core/gui/dialog/LatexSettingsPanel.cpp
@@ -20,6 +20,7 @@
 #include "util/PathUtil.h"                   // for fromGFilename, getTmpDir...
 #include "util/PlaceholderString.h"          // for PlaceholderString
 #include "util/i18n.h"                       // for FS, _F, _
+#include "util/raii/CStringWrapper.h"
 
 #include "filesystem.h"  // for path, is_regular_file
 
@@ -121,8 +122,8 @@ void LatexSettingsPanel::save(LatexSettings& settings) {
             gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(this->get("cbSyntaxHighlight")));
 
     GtkFontChooser* fontSelector = GTK_FONT_CHOOSER(this->get("selBtnEditorFont"));
-    std::string fontDescription{gtk_font_chooser_get_font(fontSelector)};
-    settings.editorFont = fontDescription;
+    auto fontDescription = xoj::util::OwnedCString::assumeOwnership(gtk_font_chooser_get_font(fontSelector));
+    settings.editorFont = std::string(fontDescription.get());
     settings.useCustomEditorFont = !gtk_toggle_button_get_active(this->cbUseSystemFont);
 
     settings.editorWordWrap = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(this->get("cbWordWrap")));

--- a/src/core/undo/EraseUndoAction.cpp
+++ b/src/core/undo/EraseUndoAction.cpp
@@ -16,6 +16,13 @@ class Control;
 
 EraseUndoAction::EraseUndoAction(const PageRef& page): UndoAction("EraseUndoAction") { this->page = page; }
 
+EraseUndoAction::~EraseUndoAction() {
+    auto& notInDoc = undone ? edited : original;
+    for (auto& s: notInDoc) {
+        delete s.element;
+    }
+}
+
 void EraseUndoAction::addOriginal(Layer* layer, Stroke* element, int pos) { original.emplace(layer, element, pos); }
 
 void EraseUndoAction::addEdited(Layer* layer, Stroke* element, int pos) { edited.emplace(layer, element, pos); }

--- a/src/core/undo/EraseUndoAction.h
+++ b/src/core/undo/EraseUndoAction.h
@@ -26,6 +26,7 @@ class Layer;
 class EraseUndoAction: public UndoAction {
 public:
     EraseUndoAction(const PageRef& page);
+    ~EraseUndoAction() override;
 
 public:
     bool undo(Control* control) override;


### PR DESCRIPTION
I ran with Valgrind trying desperately to reproduce #4931. I couldn't. But I got a good memory leak report:
 - plenty of memleaks in GTK/GDK/PortAudio/rsvg/pango. Nothing we can really do about them. Possibly some are false positives.
 - I found a couple of memleaks. The most notable one: strokes erased with "standard" eraser were never deleted.

This PR fixes those memleaks I could locate and fix.