### PR TITLE
Remove double-deletion in case of exception when pasting

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -2334,11 +2334,6 @@ void Control::clipboardPasteXournal(ObjectInputStream& in) {
     } catch (const std::exception& e) {
         g_warning("could not paste, Exception occurred: %s", e.what());
         Stacktrace::printStacktrace();
-        if (selection) {
-            for (Element* el: selection->getElements()) {
-                delete el;
-            }
-        }
     }
 }
 


### PR DESCRIPTION
Elements created when pasting Xournal++ contents from clipboard are deleted twice in case an exception is raised.
This PR fixes that.

Note that the release branch is not affected by this (we only implement RAII-like mem management for selected elements on master).