### PR TITLE
Const correctness of Element pointers

### DIFF
--- a/src/core/control/ClipboardHandler.cpp
+++ b/src/core/control/ClipboardHandler.cpp
@@ -76,7 +76,7 @@ auto ClipboardHandler::cut() -> bool {
     return result;
 }
 
-auto ElementCompareFunc(Element* a, Element* b) -> bool {
+auto ElementCompareFunc(const Element* a, const Element* b) -> bool {
     if (a->getY() == b->getY()) {
         return (a->getX() - b->getX()) < 0;
     }
@@ -154,16 +154,16 @@ auto ClipboardHandler::copy() -> bool {
     // prepare text contents
     /////////////////////////////////////////////////////////////////
 
-    std::multiset<Text*, decltype(&ElementCompareFunc)> textElements(ElementCompareFunc);
+    std::multiset<const Text*, decltype(&ElementCompareFunc)> textElements(ElementCompareFunc);
 
-    for (Element* e: this->selection->getElements()) {
+    for (const Element* e: this->selection->getElementsView()) {
         if (e->getType() == ELEMENT_TEXT) {
-            textElements.insert(dynamic_cast<Text*>(e));
+            textElements.insert(dynamic_cast<const Text*>(e));
         }
     }
 
     string text{};
-    for (Text* t: textElements) {
+    for (const Text* t: textElements) {
         if (!text.empty()) {
             text += "\n";
         }

--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -1272,7 +1272,7 @@ auto Control::getLineStyleToSelect() -> std::optional<string> const {
     std::optional<std::string> previous_style;
 
     // Todo(cpp20) Replace with std::ranges::filter_view and for_first_then_for_each
-    for (const Element* e: sel->getElements()) {
+    for (const Element* e: sel->getElementsView()) {
         if (e->getType() == ELEMENT_STROKE) {
             const auto* s = dynamic_cast<const Stroke*>(e);
 
@@ -2396,7 +2396,7 @@ void Control::moveSelectionToLayer(size_t layerNo) {
     auto* newLayer = currentP->getLayers().at(layerNo);
     auto moveSelUndo = std::make_unique<MoveSelectionToLayerUndoAction>(currentP, getLayerController(), oldLayer,
                                                                         currentP->getSelectedLayerId() - 1, layerNo);
-    for (auto* e: selection->getElements()) {
+    for (const auto* e: selection->getElementsView()) {
         moveSelUndo->addElement(newLayer, e, newLayer->indexOf(e));
     }
     undoRedo->addUndoAction(std::move(moveSelUndo));

--- a/src/core/control/LatexController.cpp
+++ b/src/core/control/LatexController.cpp
@@ -113,8 +113,10 @@ void LatexController::findSelectedTexElement() {
     this->page = this->doc->getPage(pageNr);
     this->layer = page->getSelectedLayer();
 
-    this->selectedElem = view->getSelectedTex() != nullptr ? static_cast<Element*>(view->getSelectedTex()) :
-                                                             static_cast<Element*>(view->getSelectedText());
+    auto* tex = view->getSelectedTex();
+    this->selectedElem =
+            tex != nullptr ? static_cast<const Element*>(tex) : static_cast<const Element*>(view->getSelectedText());
+
     if (this->selectedElem) {
         // this will get the position of the Latex properly
         EditSelection* theSelection = control->getWindow()->getXournal()->getSelection();
@@ -122,11 +124,11 @@ void LatexController::findSelectedTexElement() {
         this->posx = rect.x;
         this->posy = rect.y;
 
-        if (auto* img = dynamic_cast<TexImage*>(this->selectedElem)) {
+        if (auto* img = dynamic_cast<const TexImage*>(this->selectedElem)) {
             this->initialTex = img->getText();
             this->temporaryRender = img->cloneTexImage();
             this->isValidTex = true;
-        } else if (auto* txt = dynamic_cast<Text*>(this->selectedElem)) {
+        } else if (auto* txt = dynamic_cast<const Text*>(this->selectedElem)) {
             this->initialTex = "\\text{" + txt->getText() + "}";
         }
         this->imgwidth = this->selectedElem->getElementWidth();

--- a/src/core/control/LatexController.h
+++ b/src/core/control/LatexController.h
@@ -218,7 +218,7 @@ private:
     /**
      * The element that is currently being edited.
      */
-    Element* selectedElem = nullptr;
+    const Element* selectedElem = nullptr;
 
     /**
      * The controller owns the rendered preview in order to be able to delete it

--- a/src/core/control/SearchControl.cpp
+++ b/src/core/control/SearchControl.cpp
@@ -41,9 +41,9 @@ auto SearchControl::search(const std::string& text, size_t index, size_t* occurr
                 continue;
             }
 
-            for (auto&& e: l->getElements()) {
+            for (auto&& e: l->getElementsView()) {
                 if (e->getType() == ELEMENT_TEXT) {
-                    Text* t = dynamic_cast<Text*>(e.get());
+                    const Text* t = dynamic_cast<const Text*>(e);
 
                     std::vector<XojPdfRectangle> textResult = t->findText(text);
                     this->results.insert(this->results.end(), textResult.begin(), textResult.end());

--- a/src/core/control/UndoRedoController.cpp
+++ b/src/core/control/UndoRedoController.cpp
@@ -26,7 +26,7 @@ void UndoRedoController::before() {
     EditSelection* selection = control->getWindow()->getXournal()->getSelection();
     if (selection != nullptr) {
         layer = selection->getSourceLayer();
-        elements = selection->getElements();
+        elements = selection->getElementsView().clone();
     }
 
     control->clearSelectionEndText();
@@ -53,7 +53,7 @@ void UndoRedoController::after() {
     }
 
     InsertionOrderRef remainingElements;
-    for (Element* e: elements) {
+    for (const Element* e: elements) {
         // Test, if the element has been removed since
         if (auto pos = layer->indexOf(e); pos != -1) {
             remainingElements.emplace_back(e, pos);

--- a/src/core/control/UndoRedoController.h
+++ b/src/core/control/UndoRedoController.h
@@ -44,5 +44,5 @@ private:
     /**
      * Selected elements
      */
-    std::vector<Element*> elements;
+    std::vector<const Element*> elements;
 };

--- a/src/core/control/jobs/ImageExport.cpp
+++ b/src/core/control/jobs/ImageExport.cpp
@@ -158,7 +158,7 @@ auto ImageExport::getFilenameWithNumber(size_t no) const -> fs::path {
 void ImageExport::exportImagePage(size_t pageId, size_t id, double zoomRatio, ExportGraphicsFormat format,
                                   DocumentView& view) {
     doc->lock();
-    PageRef page = doc->getPage(pageId);
+    ConstPageRef page = doc->getPage(pageId);
     doc->unlock();
 
     zoomRatio = createSurface(page->getWidth(), page->getHeight(), id, zoomRatio);

--- a/src/core/control/tools/EditSelection.h
+++ b/src/core/control/tools/EditSelection.h
@@ -26,6 +26,7 @@
 #include "model/PageRef.h"                   // for PageRef
 #include "undo/UndoAction.h"                 // for UndoAction (ptr only)
 #include "util/Color.h"                      // for Color
+#include "util/PointerContainerView.h"       // for PointerContainerView
 #include "util/Rectangle.h"                  // for Rectangle
 #include "util/serializing/Serializable.h"   // for Serializable
 
@@ -51,7 +52,7 @@ auto createFromFloatingElement(Control* ctrl, const PageRef& page, Layer* layer,
 auto createFromFloatingElements(Control* ctrl, const PageRef& page, Layer* layer, XojPageView* view,
                                 InsertionOrder elts)  //
         -> std::pair<std::unique_ptr<EditSelection>, Range>;
-auto createFromElementOnActiveLayer(Control* ctrl, const PageRef& page, XojPageView* view, Element* e,
+auto createFromElementOnActiveLayer(Control* ctrl, const PageRef& page, XojPageView* view, const Element* e,
                                     Element::Index pos = Element::InvalidIndex)  //
         -> std::unique_ptr<EditSelection>;
 auto createFromElementsOnActiveLayer(Control* ctrl, const PageRef& page, XojPageView* view, InsertionOrderRef elts)
@@ -60,7 +61,7 @@ auto createFromElementsOnActiveLayer(Control* ctrl, const PageRef& page, XojPage
  * @brief Creates a new instance containing base->getElements() and *e. The content of *base is cleared but *base is not
  * destroyed.
  */
-auto addElementFromActiveLayer(Control* ctrl, EditSelection* base, Element* e, Element::Index pos)
+auto addElementFromActiveLayer(Control* ctrl, EditSelection* base, const Element* e, Element::Index pos)
         -> std::unique_ptr<EditSelection>;
 /**
  * @brief Creates a new instance containing base->getElements() and the content of elts. The content of *base is cleared
@@ -211,9 +212,9 @@ public:
     /**
      * Returns all containing elements of this selection
      */
-    auto getElements() const -> std::vector<Element*> const&;
+    auto getElementsView() const -> xoj::util::PointerContainerView<std::vector<Element*>>;
 
-    void forEachElement(std::function<void(Element*)> f) const override;
+    void forEachElement(std::function<void(const Element*)> f) const override;
 
     /**
      * Returns the insert order of this selection

--- a/src/core/control/tools/EditSelectionContents.cpp
+++ b/src/core/control/tools/EditSelectionContents.cpp
@@ -89,9 +89,11 @@ auto EditSelectionContents::stealInsertionOrder() -> InsertionOrder { return std
 /**
  * Returns all containing elements of this selection
  */
-auto EditSelectionContents::getElements() const -> std::vector<Element*> const& { return this->selected; }
+auto EditSelectionContents::getElementsView() const -> xoj::util::PointerContainerView<std::vector<Element*>> {
+    return this->selected;
+}
 
-void EditSelectionContents::forEachElement(std::function<void(Element*)> f) const {
+void EditSelectionContents::forEachElement(std::function<void(const Element*)> f) const {
     for (auto const& e: this->selected) {
         f(e);
     }

--- a/src/core/control/tools/EditSelectionContents.h
+++ b/src/core/control/tools/EditSelectionContents.h
@@ -24,6 +24,7 @@
 #include "model/PageRef.h"                   // for PageRef
 #include "undo/UndoAction.h"                 // for UndoAction (ptr only)
 #include "util/Color.h"                      // for Color
+#include "util/PointerContainerView.h"       // for PointerContainerView
 #include "util/Rectangle.h"                  // for Rectangle
 #include "util/serializing/Serializable.h"   // for Serializable
 
@@ -93,9 +94,9 @@ public:
     /**
      * Returns all containing elements of this selection
      */
-    auto getElements() const -> std::vector<Element*> const&;
+    auto getElementsView() const -> xoj::util::PointerContainerView<std::vector<Element*>>;
 
-    void forEachElement(std::function<void(Element*)> f) const override;
+    void forEachElement(std::function<void(const Element*)> f) const override;
 
     /**
      * Returns the insert order of this selection

--- a/src/core/control/tools/Selector.cpp
+++ b/src/core/control/tools/Selector.cpp
@@ -23,17 +23,17 @@ auto Selector::finalize(PageRef page, bool disableMultilayer, Document* doc) -> 
 
     if (multiLayer && !disableMultilayer) {
         std::lock_guard lock(*doc);
-        const auto layers = page->getLayers();
+        const auto layers = page->getLayersView();
         for (auto it = layers.rbegin(); it != layers.rend(); it++) {
-            Layer* l = *it;
+            const Layer* l = *it;
             if (!l->isVisible()) {
                 continue;
             }
             bool selectionOnLayer = false;
             Element::Index pos = 0;
-            for (auto&& e: l->getElements()) {
+            for (const auto& e: l->getElementsView()) {
                 if (e->isInSelection(this)) {
-                    this->selectedElements.emplace_back(e.get(), pos);
+                    this->selectedElements.emplace_back(e, pos);
                     selectionOnLayer = true;
                 }
                 pos++;
@@ -45,11 +45,11 @@ auto Selector::finalize(PageRef page, bool disableMultilayer, Document* doc) -> 
         }
     } else {
         std::lock_guard lock(*doc);
-        Layer* l = page->getSelectedLayer();
+        const Layer* l = page->getSelectedLayer();
         Element::Index pos = 0;
-        for (auto&& e: l->getElements()) {
+        for (const auto& e: l->getElementsView()) {
             if (e->isInSelection(this)) {
-                this->selectedElements.emplace_back(e.get(), pos);
+                this->selectedElements.emplace_back(e, pos);
                 layerId = page->getSelectedLayerId();
             }
             pos++;

--- a/src/core/control/tools/VerticalToolHandler.cpp
+++ b/src/core/control/tools/VerticalToolHandler.cpp
@@ -46,7 +46,7 @@ void VerticalToolHandler::adoptElements(const Side side) {
     this->elements.clear();
 
     // Add new elements based on position
-    for (Element* e: xoj::refElementContainer(this->layer->getElements())) {
+    for (const Element* e: this->layer->getElementsView()) {
         if ((side == Side::Below && e->getY() >= this->startY) ||
             (side == Side::Above && e->getY() + e->getElementHeight() <= this->startY)) {
             this->elements.push_back(this->layer->removeElement(e).e);
@@ -95,7 +95,7 @@ auto VerticalToolHandler::refElements() const -> std::vector<Element*> {
     return result;
 }
 
-void VerticalToolHandler::forEachElement(std::function<void(Element*)> f) const {
+void VerticalToolHandler::forEachElement(std::function<void(const Element*)> f) const {
     for (auto const& e: this->elements) {
         f(e.get());
     }

--- a/src/core/control/tools/VerticalToolHandler.h
+++ b/src/core/control/tools/VerticalToolHandler.h
@@ -67,7 +67,7 @@ public:
 
     std::unique_ptr<MoveUndoAction> finalize();
 
-    void forEachElement(std::function<void(Element*)> f) const override;
+    void forEachElement(std::function<void(const Element*)> f) const override;
 
     auto createView(xoj::view::Repaintable* parent, ZoomControl* zoomControl, const Settings* settings) const
             -> std::unique_ptr<xoj::view::OverlayView>;

--- a/src/core/control/xojfile/SaveHandler.cpp
+++ b/src/core/control/xojfile/SaveHandler.cpp
@@ -165,18 +165,18 @@ void SaveHandler::visitLayer(XmlNode* page, const Layer* l) {
         layer->setAttrib("name", l->getName().c_str());
     }
 
-    for (auto&& e: l->getElements()) {
+    for (const auto& e: l->getElementsView()) {
         if (e->getType() == ELEMENT_STROKE) {
-            auto* s = dynamic_cast<Stroke*>(e.get());
+            auto* s = dynamic_cast<const Stroke*>(e);
             auto* stroke = new XmlPointNode("stroke");
             layer->addChild(stroke);
             visitStroke(stroke, s);
         } else if (e->getType() == ELEMENT_TEXT) {
-            Text* t = dynamic_cast<Text*>(e.get());
+            const Text* t = dynamic_cast<const Text*>(e);
             auto* text = new XmlTextNode("text", t->getText());
             layer->addChild(text);
 
-            XojFont& f = t->getFont();
+            const XojFont& f = t->getFont();
 
             text->setAttrib("font", f.getName().c_str());
             text->setAttrib("size", f.getSize());
@@ -186,7 +186,7 @@ void SaveHandler::visitLayer(XmlNode* page, const Layer* l) {
 
             writeTimestamp(text, t);
         } else if (e->getType() == ELEMENT_IMAGE) {
-            auto* i = dynamic_cast<Image*>(e.get());
+            auto* i = dynamic_cast<const Image*>(e);
             auto* image = new XmlImageNode("image");
             layer->addChild(image);
 
@@ -197,7 +197,7 @@ void SaveHandler::visitLayer(XmlNode* page, const Layer* l) {
             image->setAttrib("right", i->getX() + i->getElementWidth());
             image->setAttrib("bottom", i->getY() + i->getElementHeight());
         } else if (e->getType() == ELEMENT_TEXIMAGE) {
-            auto* i = dynamic_cast<TexImage*>(e.get());
+            auto* i = dynamic_cast<const TexImage*>(e);
             auto* image = new XmlTexNode("teximage", std::string(i->getBinaryData()));
             layer->addChild(image);
 

--- a/src/core/gui/LegacyRedrawable.cpp
+++ b/src/core/gui/LegacyRedrawable.cpp
@@ -13,6 +13,6 @@ void LegacyRedrawable::repaintRect(double x, double y, double width, double heig
 
 void LegacyRedrawable::rerenderRange(const Range& r) { rerenderRect(r.getX(), r.getY(), r.getWidth(), r.getHeight()); }
 
-void LegacyRedrawable::rerenderElement(Element* e) {
+void LegacyRedrawable::rerenderElement(const Element* e) {
     rerenderRect(e->getX(), e->getY(), e->getElementWidth(), e->getElementHeight());
 }

--- a/src/core/gui/LegacyRedrawable.h
+++ b/src/core/gui/LegacyRedrawable.h
@@ -66,7 +66,7 @@ public:
     /**
      * Call this if you add an element, remove an element etc.
      */
-    void rerenderElement(Element* e);
+    void rerenderElement(const Element* e);
     void rerenderRange(const Range& r);
 
     /**

--- a/src/core/gui/PageView.cpp
+++ b/src/core/gui/PageView.cpp
@@ -446,12 +446,12 @@ auto XojPageView::onButtonDoublePressEvent(const PositionInputData& pos) -> bool
         // original coordinates of the selection.
         double origx = x - (selection->getXOnView() - selection->getOriginalXOnView());
         double origy = y - (selection->getYOnView() - selection->getOriginalYOnView());
-        const std::vector<Element*>& elems = selection->getElements();
+        auto elems = selection->getElementsView();
         auto it = std::find_if(elems.begin(), elems.end(),
-                               [&](Element* elem) { return elem->intersectsArea(origx - 5, origy - 5, 5, 5); });
+                               [&](const Element* elem) { return elem->intersectsArea(origx - 5, origy - 5, 5, 5); });
         if (it != elems.end()) {
             // Enter editing mode on the selected object
-            Element* object = *it;
+            const Element* object = *it;
             ElementType elemType = object->getType();
             if (elemType == ELEMENT_TEXT) {
                 this->xournal->clearSelection();
@@ -1108,29 +1108,29 @@ auto XojPageView::getDisplayHeightDouble() const -> double {
     return this->page->getHeight() * this->xournal->getZoom();
 }
 
-auto XojPageView::getSelectedTex() -> TexImage* {
+auto XojPageView::getSelectedTex() const -> const TexImage* {
     EditSelection* theSelection = this->xournal->getSelection();
     if (!theSelection) {
         return nullptr;
     }
 
-    for (Element* e: theSelection->getElements()) {
+    for (const Element* e: theSelection->getElementsView()) {
         if (e->getType() == ELEMENT_TEXIMAGE) {
-            return dynamic_cast<TexImage*>(e);
+            return dynamic_cast<const TexImage*>(e);
         }
     }
     return nullptr;
 }
 
-auto XojPageView::getSelectedText() -> Text* {
+auto XojPageView::getSelectedText() const -> const Text* {
     EditSelection* theSelection = this->xournal->getSelection();
     if (!theSelection) {
         return nullptr;
     }
 
-    for (Element* e: theSelection->getElements()) {
+    for (const Element* e: theSelection->getElementsView()) {
         if (e->getType() == ELEMENT_TEXT) {
-            return dynamic_cast<Text*>(e);
+            return dynamic_cast<const Text*>(e);
         }
     }
     return nullptr;
@@ -1146,7 +1146,7 @@ void XojPageView::rangeChanged(Range& range) { rerenderRange(range); }
 
 void XojPageView::pageChanged() { rerenderPage(); }
 
-void XojPageView::elementChanged(Element* elem) {
+void XojPageView::elementChanged(const Element* elem) {
     /*
      * The input handlers issue an elementChanged event when creating an element.
      * There is however no need to redraw the element in this case: the element was already painted to the buffer via a
@@ -1164,7 +1164,7 @@ void XojPageView::elementChanged(Element* elem) {
     }
 }
 
-void XojPageView::elementsChanged(const std::vector<Element*>& elements, const Range& range) {
+void XojPageView::elementsChanged(const std::vector<const Element*>& elements, const Range& range) {
     if (!range.empty()) {
         rerenderRange(range);
     }

--- a/src/core/gui/PageView.h
+++ b/src/core/gui/PageView.h
@@ -170,8 +170,8 @@ public:
      */
     int getY() const override;
 
-    TexImage* getSelectedTex();
-    Text* getSelectedText();
+    const TexImage* getSelectedTex() const;
+    const Text* getSelectedText() const;
 
     xoj::util::Rectangle<double> getRect() const;
 
@@ -200,8 +200,8 @@ public:  // listener
     void rectChanged(xoj::util::Rectangle<double>& rect) override;
     void rangeChanged(Range& range) override;
     void pageChanged() override;
-    void elementChanged(Element* elem) override;
-    void elementsChanged(const std::vector<Element*>& elements, const Range& range) override;
+    void elementChanged(const Element* elem) override;
+    void elementsChanged(const std::vector<const Element*>& elements, const Range& range) override;
 
 private:
     void startText(double x, double y);

--- a/src/core/gui/PageViewFindObjectHelper.h
+++ b/src/core/gui/PageViewFindObjectHelper.h
@@ -113,19 +113,19 @@ public:
     bool checkLayer(const Layer* l) override {
         double minDistance = ACTION_RADIUS;
         // Iterate starting from the front-most element
-        Element::Index pos = as_signed(l->getElements().size());
-        for (auto it = l->getElements().rbegin(); it < l->getElements().rend(); ++it) {
+        Element::Index pos = as_signed(l->getElementsView().size());
+        for (auto it = l->getElementsView().rbegin(); it < l->getElementsView().rend(); ++it) {
             pos--;
             // First perform a rough check to avoid expensive calls to Stroke::distanceTo()
             if ((*it)->intersectsArea(x - minDistance, y - minDistance, 2. * minDistance, 2. * minDistance)) {
                 double d = (*it)->distanceTo(x, y);
                 if (d == 0.0) {
-                    this->match = it->get();
+                    this->match = *it;
                     this->matchIndex = pos;
                     return true;
                 }
                 if (d < minDistance) {
-                    this->match = it->get();
+                    this->match = *it;
                     this->matchIndex = pos;
                     minDistance = d;
                     // Keep going, we may find something closer
@@ -136,7 +136,7 @@ public:
     }
 
 private:
-    Element* match;
+    const Element* match;
     Element::Index matchIndex;
 };
 
@@ -162,8 +162,8 @@ protected:
     /// Plays every element of the layer that are closer than ACTION_RADIUS
     bool checkLayer(const Layer* l) override {
         bool found = false;
-        for (auto&& e: l->getElements()) {
-            if (auto* audio = dynamic_cast<AudioElement*>(e.get()); audio) {
+        for (auto&& e: l->getElementsView()) {
+            if (auto* audio = dynamic_cast<const AudioElement*>(e); audio) {
                 // First perform a rough check to avoid expensive calls to Stroke::distanceTo()
                 if (audio->intersectsArea(x - ACTION_RADIUS, y - ACTION_RADIUS, 2. * ACTION_RADIUS,
                                           2. * ACTION_RADIUS)) {

--- a/src/core/gui/PdfFloatingToolbox.cpp
+++ b/src/core/gui/PdfFloatingToolbox.cpp
@@ -206,7 +206,7 @@ void PdfFloatingToolbox::createStrokes(PdfMarkerStyle position, PdfMarkerStyle w
         strokes.push_back(std::move(stroke));
     }
 
-    std::vector<Element*> strokePtrs(strokes.size());
+    std::vector<const Element*> strokePtrs(strokes.size());
     std::transform(strokes.begin(), strokes.end(), strokePtrs.begin(), [](auto& e) { return e.get(); });
 
     doc->lock();

--- a/src/core/gui/XournalView.cpp
+++ b/src/core/gui/XournalView.cpp
@@ -683,7 +683,7 @@ void XournalView::setSelection(EditSelection* selection) {
     bool canChangeFill = false;
     bool canChangeLineStyle = false;
 
-    for (const Element* e: selection->getElements()) {
+    for (const Element* e: selection->getElementsView()) {
         switch (e->getType()) {
             case ELEMENT_TEXT:
                 canChangeColor = true;

--- a/src/core/gui/inputdevices/GeometryToolInputHandler.cpp
+++ b/src/core/gui/inputdevices/GeometryToolInputHandler.cpp
@@ -201,9 +201,9 @@ void GeometryToolInputHandler::sequenceStart(InputEvent const& event) {
     doc->lock();
     // Performance improvement might be obtained by avoiding filtering all elements each
     // time a finger has been put onto the screen
-    for (const auto& e: layer->getElements()) {
+    for (const auto& e: layer->getElementsView()) {
         if (e->getType() == ELEMENT_STROKE) {
-            auto* s = dynamic_cast<Stroke*>(e.get());
+            auto* s = dynamic_cast<const Stroke*>(e);
             if (s->getPointCount() == 2) {
                 lines.push_back(s);
             }

--- a/src/core/gui/inputdevices/GeometryToolInputHandler.h
+++ b/src/core/gui/inputdevices/GeometryToolInputHandler.h
@@ -105,7 +105,7 @@ protected:
      * @brief the line segments (strokes with two points) of the current layer, that are used for rotation snapping the
      * geometry tool
      */
-    std::vector<Stroke*> lines;
+    std::vector<const Stroke*> lines;
 
 protected:
     /**

--- a/src/core/model/Element.cpp
+++ b/src/core/model/Element.cpp
@@ -128,8 +128,8 @@ auto Element::isInSelection(ShapeContainer* container) const -> bool {
     return true;
 }
 
-auto Element::rescaleOnlyAspectRatio() -> bool { return false; }
-auto Element::rescaleWithMirror() -> bool { return false; }
+auto Element::rescaleOnlyAspectRatio() const -> bool { return false; }
+auto Element::rescaleWithMirror() const -> bool { return false; }
 
 void Element::serialize(ObjectOutputStream& out) const {
     out.writeObject("Element");

--- a/src/core/model/Element.h
+++ b/src/core/model/Element.h
@@ -75,8 +75,8 @@ public:
 
     virtual bool isInSelection(ShapeContainer* container) const;
 
-    virtual bool rescaleOnlyAspectRatio();
-    virtual bool rescaleWithMirror();
+    virtual bool rescaleOnlyAspectRatio() const;
+    virtual bool rescaleWithMirror() const;
 
     /**
      * Take 1:1 copy of this element

--- a/src/core/model/ElementContainer.h
+++ b/src/core/model/ElementContainer.h
@@ -17,7 +17,7 @@ class Element;
 
 class ElementContainer {
 public:
-    virtual void forEachElement(std::function<void(Element*)> f) const = 0;
+    virtual void forEachElement(std::function<void(const Element*)> f) const = 0;
 
 protected:
     // interface -> protected, non virtual

--- a/src/core/model/ElementInsertionPosition.h
+++ b/src/core/model/ElementInsertionPosition.h
@@ -16,13 +16,12 @@
 
 #include "Element.h"
 
-
 struct InsertionPositionRef {
     constexpr InsertionPositionRef() = default;
-    constexpr explicit InsertionPositionRef(Element* e,
+    constexpr explicit InsertionPositionRef(const Element* e,
                                             Element::Index pos = std::numeric_limits<Element::Index>::max()):
             e(e), pos(pos) {}
-    Element* e{};
+    const Element* e{};
     Element::Index pos{};
 
     constexpr friend auto operator<(const InsertionPositionRef& p1, const InsertionPositionRef& p2) -> bool {

--- a/src/core/model/Layer.cpp
+++ b/src/core/model/Layer.cpp
@@ -62,7 +62,7 @@ void Layer::insertElement(ElementPtr e, Element::Index pos) {
     }
 }
 
-auto Layer::indexOf(Element* e) const -> Element::Index {
+auto Layer::indexOf(const Element* e) const -> Element::Index {
     for (unsigned int i = 0; i < this->elements.size(); i++) {
         if (this->elements[i].get() == e) {
             return i;
@@ -72,7 +72,7 @@ auto Layer::indexOf(Element* e) const -> Element::Index {
     return Element::InvalidIndex;
 }
 
-auto Layer::removeElement(Element* e) -> InsertionPosition {
+auto Layer::removeElement(const Element* e) -> InsertionPosition {
     for (unsigned int i = 0; i < this->elements.size(); i++) {
         if (e == this->elements[i].get()) {
             auto res = std::move(this->elements[i]);
@@ -86,7 +86,7 @@ auto Layer::removeElement(Element* e) -> InsertionPosition {
     return InsertionPosition{nullptr, Element::InvalidIndex};
 }
 
-auto Layer::removeElementAt(Element* e, Element::Index pos) -> InsertionPosition {
+auto Layer::removeElementAt(const Element* e, Element::Index pos) -> InsertionPosition {
     if (pos >= 0 && as_unsigned(pos) < elements.size() && this->elements[as_unsigned(pos)].get() == e) {
         auto iter = std::next(this->elements.begin(), pos);
         auto res = std::move(*iter);
@@ -131,7 +131,12 @@ auto Layer::isVisible() const -> bool { return visible; }
  */
 void Layer::setVisible(bool visible) { this->visible = visible; }
 
-auto Layer::getElements() const -> std::vector<ElementPtr> const& { return this->elements; }
+auto Layer::getElements() -> std::vector<ElementPtr>& { return this->elements; }
+
+auto Layer::getElementsView() const -> xoj::util::PointerContainerView<std::vector<ElementPtr>> {
+    return this->elements;
+}
+
 
 auto Layer::hasName() const -> bool { return name.has_value(); }
 

--- a/src/core/model/Layer.h
+++ b/src/core/model/Layer.h
@@ -17,7 +17,9 @@
 #include <string>    // for string
 #include <vector>    // for vector
 
-#include "Element.h"  // for Element, Element::Index
+#include "util/PointerContainerView.h"
+
+#include "Element.h"                   // for Element, Element::Index
 #include "ElementInsertionPosition.h"  // for InsertionOrder
 
 template <class T>
@@ -48,20 +50,20 @@ public:
     /**
      * Returns the index of the given Element with respect to the internal list
      */
-    auto indexOf(Element* e) const -> Element::Index;
+    auto indexOf(const Element* e) const -> Element::Index;
 
     /**
      * Removes an Element from the Layer and optionally deletes it
      * @return the position the element occupied
      */
-    auto removeElement(Element* e) -> InsertionPosition;
+    auto removeElement(const Element* e) -> InsertionPosition;
 
     /**
      * Removes the Element. If e is not at index pos, tries to find it elsewhere (this could happen is the layer was
      * modified between now and when pos was computed)
      * @return The actual position of the removed element
      */
-    auto removeElementAt(Element* e, Element::Index pos) -> InsertionPosition;
+    auto removeElementAt(const Element* e, Element::Index pos) -> InsertionPosition;
 
     /**
      * Removes the Elements. If an element cannot be found at its designated position, it is search through the layer
@@ -74,9 +76,11 @@ public:
     auto clearNoFree() -> std::vector<ElementPtr>;
 
     /**
-     * Returns an iterator over the Element%s contained in this Layer
+     * Returns an iteratable over the Element%s contained in this Layer
      */
-    auto getElements() const -> std::vector<ElementPtr> const&;
+    auto getElements() -> std::vector<ElementPtr>&;
+
+    auto getElementsView() const -> xoj::util::PointerContainerView<std::vector<ElementPtr>>;
 
     /**
      * Returns whether or not the Layer is empty

--- a/src/core/model/PageHandler.cpp
+++ b/src/core/model/PageHandler.cpp
@@ -25,11 +25,11 @@ void PageHandler::fireRangeChanged(Range& range) {
     for (PageListener* pl: this->listeners) { pl->rangeChanged(range); }
 }
 
-void PageHandler::fireElementChanged(Element* elem) {
+void PageHandler::fireElementChanged(const Element* elem) {
     for (PageListener* pl: this->listeners) { pl->elementChanged(elem); }
 }
 
-void PageHandler::fireElementsChanged(const std::vector<Element*>& elements, Range range) {
+void PageHandler::fireElementsChanged(const std::vector<const Element*>& elements, Range range) {
     for (PageListener* pl: this->listeners) {
         pl->elementsChanged(elements, range);
     }

--- a/src/core/model/PageHandler.h
+++ b/src/core/model/PageHandler.h
@@ -32,13 +32,13 @@ public:
 public:
     void fireRectChanged(xoj::util::Rectangle<double>& rect);
     void fireRangeChanged(Range& range);
-    void fireElementChanged(Element* elem);
+    void fireElementChanged(const Element* elem);
     /**
      * @brief The listed elements have been changed
      * @param range (optional) if provided, the Range must contain the bounding boxes of the changed elements, both
      * before and after they were changed
      */
-    void fireElementsChanged(const std::vector<Element*>& elements, Range range = Range());
+    void fireElementsChanged(const std::vector<const Element*>& elements, Range range = Range());
     void firePageChanged();
 
 private:

--- a/src/core/model/PageListener.h
+++ b/src/core/model/PageListener.h
@@ -33,8 +33,8 @@ public:
 
     virtual void rectChanged(xoj::util::Rectangle<double>& rect) {}
     virtual void rangeChanged(Range& range) {}
-    virtual void elementChanged(Element* elem) {}
-    virtual void elementsChanged(const std::vector<Element*>& elements, const Range& range) {}
+    virtual void elementChanged(const Element* elem) {}
+    virtual void elementsChanged(const std::vector<const Element*>& elements, const Range& range) {}
     virtual void pageChanged() {}
 
 private:

--- a/src/core/model/Stroke.cpp
+++ b/src/core/model/Stroke.cpp
@@ -230,7 +230,7 @@ void Stroke::setWidth(double width) {
 
 auto Stroke::getWidth() const -> double { return this->width; }
 
-auto Stroke::rescaleWithMirror() -> bool { return true; }
+auto Stroke::rescaleWithMirror() const -> bool { return true; }
 
 auto Stroke::isInSelection(ShapeContainer* container) const -> bool {
     for (auto&& p: this->points) {

--- a/src/core/model/Stroke.h
+++ b/src/core/model/Stroke.h
@@ -196,7 +196,7 @@ public:
     void serialize(ObjectOutputStream& out) const override;
     void readSerialized(ObjectInputStream& in) override;
 
-    bool rescaleWithMirror() override;
+    bool rescaleWithMirror() const override;
 
 protected:
     void calcSize() const override;

--- a/src/core/model/Text.cpp
+++ b/src/core/model/Text.cpp
@@ -46,6 +46,7 @@ auto Text::cloneText() const -> std::unique_ptr<Text> {
 auto Text::clone() const -> ElementPtr { return cloneText(); }
 
 auto Text::getFont() -> XojFont& { return font; }
+auto Text::getFont() const -> const XojFont& { return font; }
 
 void Text::setFont(const XojFont& font) {
     this->font = font;
@@ -134,7 +135,7 @@ void Text::rotate(double x0, double y0, double th) {}
 
 auto Text::isInEditing() const -> bool { return this->inEditing; }
 
-auto Text::rescaleOnlyAspectRatio() -> bool { return true; }
+auto Text::rescaleOnlyAspectRatio() const -> bool { return true; }
 
 void Text::serialize(ObjectOutputStream& out) const {
     out.writeObject("Text");

--- a/src/core/model/Text.h
+++ b/src/core/model/Text.h
@@ -35,6 +35,7 @@ public:
 public:
     void setFont(const XojFont& font);
     XojFont& getFont();
+    const XojFont& getFont() const;
     double getFontSize() const;       // same result as getFont()->getSize(), but const
     std::string getFontName() const;  // same result as getFont()->getName(), but const
 
@@ -53,7 +54,7 @@ public:
     void scale(double x0, double y0, double fx, double fy, double rotation, bool restoreLineWidth) override;
     void rotate(double x0, double y0, double th) override;
 
-    bool rescaleOnlyAspectRatio() override;
+    bool rescaleOnlyAspectRatio() const override;
 
     auto cloneText() const -> std::unique_ptr<Text>;
     auto clone() const -> ElementPtr override;

--- a/src/core/plugin/luapi_application.h
+++ b/src/core/plugin/luapi_application.h
@@ -69,19 +69,19 @@ extern "C" {
 }
 
 
-static std::tuple<std::optional<std::string>, std::vector<Element*>> getElementsFromHelper(Control* control,
-                                                                                           const std::string& type) {
-    std::vector<Element*> elements = {};
+static std::tuple<std::optional<std::string>, std::vector<const Element*>> getElementsFromHelper(
+        Control* control, const std::string& type) {
+    std::vector<const Element*> elements = {};
     if (type == "layer") {
         auto sel = control->getWindow()->getXournal()->getSelection();
         if (sel) {
             control->clearSelection();  // otherwise texts in the selection won't be recognized
         }
-        elements = xoj::refElementContainer(control->getCurrentPage()->getSelectedLayer()->getElements());
+        elements = control->getCurrentPage()->getSelectedLayer()->getElementsView().clone();
     } else if (type == "selection") {
         auto sel = control->getWindow()->getXournal()->getSelection();
         if (sel) {
-            elements = sel->getElements();
+            elements = sel->getElementsView().clone();
         } else {
             return std::make_tuple(std::make_optional("There is no selection"), elements);
         }
@@ -671,7 +671,7 @@ static int applib_layerAction(lua_State* L) {
  * If there are no elements emits a warning and does not add an UndoAction.
  */
 static int handleUndoRedoActionHelper(lua_State* L, Control* control, const char* allowUndoRedoAction,
-                                      const std::vector<Element*>& elements) {
+                                      const std::vector<const Element*>& elements) {
     if (elements.empty()) {
         g_warning("No elements, therefore not adding an undo action");
         return 0;
@@ -685,7 +685,7 @@ static int handleUndoRedoActionHelper(lua_State* L, Control* control, const char
         PageRef const& page = control->getCurrentPage();
         Layer* layer = page->getSelectedLayer();
         UndoRedoHandler* undo = control->getUndoRedoHandler();
-        for (Element* element: elements) {
+        for (const Element* element: elements) {
             undo->addUndoAction(std::make_unique<InsertUndoAction>(page, layer, element));
         }
     } else if (strcmp("none", allowUndoRedoAction) == 0) {
@@ -701,13 +701,13 @@ static int handleUndoRedoActionHelper(lua_State* L, Control* control, const char
  * Helper function for API adding elements. Empties the stack and then pushes the pointers
  * to all elements in the given vector into a table on the stack.
  */
-static void refsHelper(lua_State* L, std::vector<Element*> elements) {
+static void refsHelper(lua_State* L, std::vector<const Element*> elements) {
     lua_settop(L, 0);
     lua_newtable(L);
     size_t count = 0;
-    for (Element* element: elements) {
+    for (const Element* element: elements) {
         lua_pushinteger(L, strict_cast<lua_Integer>(++count));  // index
-        lua_pushlightuserdata(L, static_cast<void*>(element));  // value
+        lua_pushlightuserdata(L, const_cast<void*>(static_cast<const void*>(element)));  // value
         lua_settable(L, -3);                                    // insert
     }
 }
@@ -870,7 +870,7 @@ static void addStrokeHelper(lua_State* L, std::unique_ptr<Stroke> stroke) {
 static int applib_addSplines(lua_State* L) {
     Plugin* plugin = Plugin::getPluginFromLua(L);
     Control* ctrl = plugin->getControl();
-    std::vector<Element*> strokes;
+    std::vector<const Element*> strokes;
     const char* allowUndoRedoAction;
 
     // Discard any extra arguments passed in
@@ -1020,7 +1020,7 @@ static int applib_addSplines(lua_State* L) {
 static int applib_addStrokes(lua_State* L) {
     Plugin* plugin = Plugin::getPluginFromLua(L);
     Control* ctrl = plugin->getControl();
-    std::vector<Element*> strokes;
+    std::vector<const Element*> strokes;
     const char* allowUndoRedoAction;
 
     // Discard any extra arguments passed in
@@ -1141,7 +1141,7 @@ static int applib_addStrokes(lua_State* L) {
         PageRef const& page = ctrl->getCurrentPage();
         Layer* layer = page->getSelectedLayer();
         UndoRedoHandler* undo = ctrl->getUndoRedoHandler();
-        for (Element* element: strokes) {
+        for (const Element* element: strokes) {
             undo->addUndoAction(std::make_unique<InsertUndoAction>(page, layer, element));
         }
     } else if (strcmp("none", allowUndoRedoAction) == 0)
@@ -1198,7 +1198,7 @@ static int applib_addTexts(lua_State* L) {
     Layer* layer = page->getSelectedLayer();
     Settings* settings = control->getSettings();
 
-    std::vector<Element*> texts;
+    std::vector<const Element*> texts;
 
     // Discard any extra arguments passed in
     lua_settop(L, 1);
@@ -1380,9 +1380,9 @@ static int applib_getTexts(lua_State* L) {
     //  1 = type (string)
     // -1 = table of texts (to be returned)
 
-    for (Element* e: elements) {
+    for (const Element* e: elements) {
         if (e->getType() == ELEMENT_TEXT) {
-            auto* t = static_cast<Text*>(e);
+            auto* t = static_cast<const Text*>(e);
             lua_pushinteger(L, ++currTextNo);  // index for later (settable)
             lua_newtable(L);                   // create text table
 
@@ -1417,7 +1417,7 @@ static int applib_getTexts(lua_State* L) {
             lua_pushnumber(L, t->getElementHeight());
             lua_setfield(L, -2, "height");  // add height to text
 
-            lua_pushlightuserdata(L, static_cast<void*>(t));
+            lua_pushlightuserdata(L, const_cast<void*>(static_cast<const void*>(t)));
             lua_setfield(L, -2, "ref");
 
             lua_settable(L, -3);  // add text to elements
@@ -1497,9 +1497,9 @@ static int applib_getStrokes(lua_State* L) {
     //  1 = type (string)
     // -1 = table of strokes (to be returned)
 
-    for (Element* e: elements) {
+    for (const Element* e: elements) {
         if (e->getType() == ELEMENT_STROKE) {
-            auto* s = static_cast<Stroke*>(e);
+            auto* s = static_cast<const Stroke*>(e);
             lua_pushinteger(L, ++currStrokeNo);  // index for later (settable)
             lua_newtable(L);                     // create stroke table
 
@@ -1568,7 +1568,7 @@ static int applib_getStrokes(lua_State* L) {
             lua_pushstring(L, StrokeStyle::formatStyle(s->getLineStyle()).c_str());
             lua_setfield(L, -2, "lineStyle");  // add linestyle to stroke
 
-            lua_pushlightuserdata(L, static_cast<void*>(s));
+            lua_pushlightuserdata(L, const_cast<void*>(static_cast<const void*>(s)));
             lua_setfield(L, -2, "ref");
 
             lua_settable(L, -3);  // add stroke to returned table
@@ -2769,7 +2769,8 @@ static int applib_addImages(lua_State* L) {
 
     auto cntParams = static_cast<int>(lua_rawlen(L, -1));
 
-    std::vector<Element*> images{};
+    std::vector<const Element*> images{};
+
     for (int imgParam{1}; imgParam <= cntParams; imgParam++) {
         lua_pushinteger(L, imgParam);
         lua_gettable(L, -2);
@@ -2974,9 +2975,9 @@ static int applib_getImages(lua_State* L) {
     lua_newtable(L);  // create table of all images
     int currImageNo = 0;
 
-    for (Element* e: elements) {
+    for (const Element* e: elements) {
         if (e->getType() == ELEMENT_IMAGE) {
-            auto* im = static_cast<Image*>(e);
+            auto* im = static_cast<const Image*>(e);
             lua_pushinteger(L, ++currImageNo);  // index for later (settable)
             lua_newtable(L);                    // create table for current image
 
@@ -3012,7 +3013,7 @@ static int applib_getImages(lua_State* L) {
             lua_pushinteger(L, imageSize.second);
             lua_setfield(L, -2, "imageHeight");
 
-            lua_pushlightuserdata(L, static_cast<void*>(im));
+            lua_pushlightuserdata(L, const_cast<void*>(static_cast<const void*>(im)));
             lua_setfield(L, -2, "ref");
 
             lua_settable(L, -3);  // add image to table
@@ -3110,9 +3111,9 @@ static int applib_addToSelection(lua_State* L) {
     InsertionOrderRef insertionOrder;
     insertionOrder.reserve(refs.size());
     Element::Index n = 0;
-    for (auto&& e: page->getSelectedLayer()->getElements()) {
-        if (refs.count(e.get())) {
-            insertionOrder.emplace_back(e.get(), n++);
+    for (auto&& e: page->getSelectedLayer()->getElementsView()) {
+        if (refs.count(const_cast<void*>(static_cast<const void*>(e)))) {
+            insertionOrder.emplace_back(e, n++);
         }
     }
 

--- a/src/core/undo/ArrangeUndoAction.cpp
+++ b/src/core/undo/ArrangeUndoAction.cpp
@@ -39,7 +39,7 @@ void ArrangeUndoAction::applyRearrange(Control* control) {
     const auto& srcOrder = this->undone ? this->newOrder : this->oldOrder;
     const auto& tgtOrder = this->undone ? this->oldOrder : this->newOrder;
 
-    std::unordered_map<Element*, ElementPtr> removedElements;
+    std::unordered_map<const Element*, ElementPtr> removedElements;
     removedElements.reserve(srcOrder.size());
 
     Document* doc = control->getDocument();

--- a/src/core/undo/InsertUndoAction.cpp
+++ b/src/core/undo/InsertUndoAction.cpp
@@ -12,7 +12,7 @@
 #include "undo/UndoAction.h"  // for UndoAction
 #include "util/i18n.h"        // for _
 
-InsertUndoAction::InsertUndoAction(const PageRef& page, Layer* layer, Element* element):
+InsertUndoAction::InsertUndoAction(const PageRef& page, Layer* layer, const Element* element):
         UndoAction("InsertUndoAction"), layer(layer), element(element), elementOwn(nullptr) {
     this->page = page;
 }
@@ -60,7 +60,7 @@ auto InsertUndoAction::redo(Control* control) -> bool {
     return true;
 }
 
-InsertsUndoAction::InsertsUndoAction(const PageRef& page, Layer* layer, std::vector<Element*> elements):
+InsertsUndoAction::InsertsUndoAction(const PageRef& page, Layer* layer, std::vector<const Element*> elements):
         UndoAction("InsertsUndoAction"), layer(layer), elements(std::move(elements)), elementsOwn(0) {
     this->page = page;
 }
@@ -74,11 +74,11 @@ auto InsertsUndoAction::undo(Control* control) -> bool {
 
     Document* doc = control->getDocument();
     doc->lock();
-    for (Element* elem: this->elements) {
+    for (const Element* elem: this->elements) {
         this->elementsOwn.emplace_back(this->layer->removeElement(elem).e);
     }
     doc->unlock();
-    for (Element* elem: this->elements) {
+    for (const Element* elem: this->elements) {
         this->page->fireElementChanged(elem);
     }
 

--- a/src/core/undo/InsertUndoAction.h
+++ b/src/core/undo/InsertUndoAction.h
@@ -27,7 +27,7 @@ using ElementPtr = std::unique_ptr<Element>;
 
 class InsertUndoAction: public UndoAction {
 public:
-    InsertUndoAction(const PageRef& page, Layer* layer, Element* element);
+    InsertUndoAction(const PageRef& page, Layer* layer, const Element* element);
     ~InsertUndoAction() override;
 
 public:
@@ -38,13 +38,13 @@ public:
 
 private:
     Layer* layer;
-    Element* element;
+    const Element* element;
     ElementPtr elementOwn;
 };
 
 class InsertsUndoAction: public UndoAction {
 public:
-    InsertsUndoAction(const PageRef& page, Layer* layer, std::vector<Element*> elements);
+    InsertsUndoAction(const PageRef& page, Layer* layer, std::vector<const Element*> elements);
     ~InsertsUndoAction() override;
 
 public:
@@ -55,6 +55,6 @@ public:
 
 private:
     Layer* layer;
-    std::vector<Element*> elements;
+    std::vector<const Element*> elements;
     std::vector<ElementPtr> elementsOwn;
 };

--- a/src/core/undo/MergeLayerDownUndoAction.cpp
+++ b/src/core/undo/MergeLayerDownUndoAction.cpp
@@ -43,7 +43,7 @@ auto MergeLayerDownUndoAction::undo(Control* control) -> bool {
     Document* doc = control->getDocument();
     doc->lock();
     // remove all elements present in the upper layer from the lower layer again
-    for (Element* elem: upperLayerElements) {
+    for (const Element* elem: upperLayerElements) {
         this->upperLayer->addElement(this->lowerLayer->removeElement(elem).e);
     }
 
@@ -67,7 +67,7 @@ auto MergeLayerDownUndoAction::redo(Control* control) -> bool {
     // remove the upper layer
     layerController->removeLayer(this->page, this->upperLayer);
 
-    this->upperLayerElements = xoj::refElementContainer(this->upperLayer->getElements());
+    this->upperLayerElements = this->upperLayer->getElementsView().clone();
     auto elements = this->upperLayer->clearNoFree();
     // add all elements back to the lower layer
     for (auto&& elem: elements) {

--- a/src/core/undo/MergeLayerDownUndoAction.h
+++ b/src/core/undo/MergeLayerDownUndoAction.h
@@ -39,7 +39,7 @@ private:
     LayerController* layerController;
 
     Layer* upperLayer;
-    std::vector<Element*> upperLayerElements;
+    std::vector<const Element*> upperLayerElements;
     Layer::Index upperLayerPos;
     Layer::Index upperLayerID;
 

--- a/src/core/undo/MoveSelectionToLayerUndoAction.cpp
+++ b/src/core/undo/MoveSelectionToLayerUndoAction.cpp
@@ -63,6 +63,6 @@ auto MoveSelectionToLayerUndoAction::redo(Control* control) -> bool {
     return true;
 }
 
-void MoveSelectionToLayerUndoAction::addElement(Layer* layer, Element* e, Element::Index pos) {
+void MoveSelectionToLayerUndoAction::addElement(Layer* layer, const Element* e, Element::Index pos) {
     elements.emplace(layer, e, pos);
 }

--- a/src/core/undo/MoveSelectionToLayerUndoAction.h
+++ b/src/core/undo/MoveSelectionToLayerUndoAction.h
@@ -32,12 +32,12 @@ public:
     bool undo(Control* control) override;
     bool redo(Control* control) override;
 
-    void addElement(Layer* layer, Element* e, Element::Index pos);
+    void addElement(Layer* layer, const Element* e, Element::Index pos);
 
     std::string getText() override;
 
 private:
-    std::multiset<PageLayerPosEntry<Element>> elements{};
+    std::multiset<PageLayerPosEntry<const Element>> elements{};
     LayerController* layerController;
     Layer* oldLayer;
     size_t oldLayerNo;

--- a/src/core/view/ElementContainerView.cpp
+++ b/src/core/view/ElementContainerView.cpp
@@ -13,7 +13,7 @@ using namespace xoj::view;
 ElementContainerView::ElementContainerView(const ElementContainer* container): container(container) {}
 
 void ElementContainerView::draw(const Context& ctx) const {
-    container->forEachElement([&ctx](Element* e) {
+    container->forEachElement([&ctx](const Element* e) {
         auto elementView = ElementView::createFromElement(e);
         elementView->draw(ctx);
     });

--- a/src/core/view/LayerView.cpp
+++ b/src/core/view/LayerView.cpp
@@ -27,7 +27,7 @@ void LayerView::draw(const Context& ctx) const {
     double maxY;
     cairo_clip_extents(ctx.cr, &minX, &minY, &maxX, &maxY);
 
-    for (auto const& e: layer->getElements()) {
+    for (auto const& e: layer->getElementsView()) {
 
         IF_DEBUG_REPAINT({
             auto cr = ctx.cr;
@@ -39,7 +39,7 @@ void LayerView::draw(const Context& ctx) const {
         });
 
         if (e->intersectsArea(minX, minY, maxX - minX, maxY - minY)) {
-            ElementView::createFromElement(e.get())->draw(ctx);
+            ElementView::createFromElement(e)->draw(ctx);
             IF_DEBUG_REPAINT(drawn++;);
         }
         IF_DEBUG_REPAINT(else { notDrawn++; });

--- a/test/unit_tests/control/LoadHandlerTest.cpp
+++ b/test/unit_tests/control/LoadHandlerTest.cpp
@@ -46,7 +46,7 @@ void testLoadStoreLoadHelper(const fs::path& filepath, double tol = 1e-8) {
         EXPECT_EQ((size_t)1, page->getLayerCount());
         const Layer* layer = page->getLayersView()[0];
 
-        const auto& elements = xoj::refElementContainer(layer->getElements());
+        auto elements = layer->getElementsView();
         EXPECT_EQ(8, static_cast<int>(elements.size()));
 
         Stroke* e0 = (Stroke*)elements[0];
@@ -93,8 +93,8 @@ void testLoadStoreLoadHelper(const fs::path& filepath, double tol = 1e-8) {
     auto coordEq = [tol](double a, double b) { return std::abs(a - b) <= tol; };
 
     for (unsigned long i = 0; i < elements1.size(); i++) {
-        Element* a = elements1.at(i);
-        Element* b = elements2.at(i);
+        const Element* a = elements1[i];
+        const Element* b = elements2[i];
         EXPECT_EQ(a->getType(), b->getType());
         EXPECT_TRUE(coordEq(a->getX(), b->getX()));
         EXPECT_TRUE(coordEq(a->getY(), b->getY()));
@@ -103,8 +103,8 @@ void testLoadStoreLoadHelper(const fs::path& filepath, double tol = 1e-8) {
         EXPECT_EQ(a->getColor(), b->getColor());
         switch (a->getType()) {
             case ELEMENT_STROKE: {
-                auto sA = dynamic_cast<Stroke*>(a);
-                auto sB = dynamic_cast<Stroke*>(b);
+                auto sA = dynamic_cast<const Stroke*>(a);
+                auto sB = dynamic_cast<const Stroke*>(b);
                 EXPECT_EQ(sA->getPointCount(), sB->getPointCount());
                 EXPECT_EQ(sA->getToolType(), sB->getToolType());
                 EXPECT_EQ(sA->getLineStyle().hasDashes(), sB->getLineStyle().hasDashes());
@@ -119,8 +119,8 @@ void testLoadStoreLoadHelper(const fs::path& filepath, double tol = 1e-8) {
                 break;
             }
             case ELEMENT_TEXT: {
-                auto tA = dynamic_cast<Text*>(a);
-                auto tB = dynamic_cast<Text*>(b);
+                auto tA = dynamic_cast<const Text*>(a);
+                auto tB = dynamic_cast<const Text*>(b);
                 EXPECT_EQ(tA->getText(), tB->getText());
                 EXPECT_EQ(tA->getFontSize(), tB->getFontSize());
                 break;
@@ -133,19 +133,20 @@ void testLoadStoreLoadHelper(const fs::path& filepath, double tol = 1e-8) {
     }
 }
 
-void checkPageType(Document* doc, size_t pageIndex, string expectedText, PageType expectedBgType) {
-    PageRef page = doc->getPage(pageIndex);
+void checkPageType(const Document* doc, size_t pageIndex, string expectedText, PageType expectedBgType) {
+    ConstPageRef page = doc->getPage(pageIndex);
 
     PageType bgType = page->getBackgroundType();
     EXPECT_TRUE(expectedBgType == bgType);
 
     EXPECT_EQ((size_t)1, page->getLayerCount());
-    Layer* layer = page->getLayers()[0];
+    const Layer* layer = page->getLayersView()[0];
 
-    auto&& element = layer->getElements().front();
+    auto* element = layer->getElementsView().front();
     EXPECT_EQ(ELEMENT_TEXT, element->getType());
 
-    Text* text = (Text*)element.get();
+    auto* text = dynamic_cast<const Text*>(element);
+    EXPECT_NE(text, nullptr);
     EXPECT_EQ(expectedText, text->getText());
 }
 
@@ -153,11 +154,12 @@ void checkPageType(Document* doc, size_t pageIndex, string expectedText, PageTyp
 void checkLayer(ConstPageRef page, size_t layerIndex, string expectedText) {
     const Layer* layer = page->getLayersView()[layerIndex];
 
-    auto&& element = layer->getElements().front();
+    auto* element = layer->getElementsView().front();
 
     EXPECT_EQ(ELEMENT_TEXT, element->getType());
 
-    Text* text = (Text*)element.get();
+    auto* text = dynamic_cast<const Text*>(element);
+    EXPECT_NE(text, nullptr);
     EXPECT_EQ(expectedText, text->getText());
 }
 
@@ -166,15 +168,16 @@ TEST(ControlLoadHandler, testLoad) {
     auto doc = handler.loadDocument(GET_TESTFILE("test1.xoj"));
 
     EXPECT_EQ((size_t)1, doc->getPageCount());
-    PageRef page = doc->getPage(0);
+    ConstPageRef page = doc->getPage(0);
 
     EXPECT_EQ((size_t)1, page->getLayerCount());
-    Layer* layer = page->getLayers()[0];
+    const Layer* layer = page->getLayersView()[0];
 
-    auto&& element = layer->getElements().front();
+    auto* element = layer->getElementsView().front();
     EXPECT_EQ(ELEMENT_TEXT, element->getType());
 
-    Text* text = (Text*)element.get();
+    auto* text = dynamic_cast<const Text*>(element);
+    EXPECT_NE(text, nullptr);
 
     EXPECT_EQ(string("12345"), text->getText());
 }
@@ -184,15 +187,16 @@ TEST(ControlLoadHandler, testLoadZipped) {
     auto doc = handler.loadDocument(GET_TESTFILE("packaged_xopp/test.xopp"));
 
     EXPECT_EQ((size_t)1, doc->getPageCount());
-    PageRef page = doc->getPage(0);
+    ConstPageRef page = doc->getPage(0);
 
     EXPECT_EQ((size_t)1, page->getLayerCount());
-    Layer* layer = page->getLayers()[0];
+    const Layer* layer = page->getLayersView()[0];
 
-    auto&& element = layer->getElements().front();
+    auto* element = layer->getElementsView().front();
     EXPECT_EQ(ELEMENT_TEXT, element->getType());
 
-    Text* text = (Text*)element.get();
+    auto* text = dynamic_cast<const Text*>(element);
+    EXPECT_NE(text, nullptr);
 
     EXPECT_EQ(string("12345"), text->getText());
 }
@@ -202,15 +206,16 @@ TEST(ControlLoadHandler, testLoadUnzipped) {
     auto doc = handler.loadDocument(GET_TESTFILE("test1.unzipped.xoj"));
 
     EXPECT_EQ((size_t)1, doc->getPageCount());
-    PageRef page = doc->getPage(0);
+    ConstPageRef page = doc->getPage(0);
 
     EXPECT_EQ((size_t)1, page->getLayerCount());
-    Layer* layer = page->getLayers()[0];
+    const Layer* layer = page->getLayersView()[0];
 
-    auto&& element = layer->getElements().front();
+    auto* element = layer->getElementsView().front();
     EXPECT_EQ(ELEMENT_TEXT, element->getType());
 
-    Text* text = (Text*)element.get();
+    auto* text = dynamic_cast<const Text*>(element);
+    EXPECT_NE(text, nullptr);
 
     EXPECT_EQ(string("12345"), text->getText());
 }
@@ -271,7 +276,7 @@ TEST(ControlLoadHandler, testLayer) {
     auto doc = handler.loadDocument(GET_TESTFILE("load/layer.xoj"));
 
     EXPECT_EQ((size_t)1, doc->getPageCount());
-    PageRef page = doc->getPage(0);
+    ConstPageRef page = doc->getPage(0);
 
     EXPECT_EQ((size_t)3, page->getLayerCount());
     checkLayer(page, 0, "l1");
@@ -284,7 +289,7 @@ TEST(ControlLoadHandler, testLayerZipped) {
     auto doc = handler.loadDocument(GET_TESTFILE("packaged_xopp/layer.xopp"));
 
     EXPECT_EQ((size_t)1, doc->getPageCount());
-    PageRef page = doc->getPage(0);
+    ConstPageRef page = doc->getPage(0);
 
     EXPECT_EQ((size_t)3, page->getLayerCount());
     checkLayer(page, 0, "l1");
@@ -297,18 +302,21 @@ TEST(ControlLoadHandler, testText) {
     auto doc = handler.loadDocument(GET_TESTFILE("load/text.xml"));
 
     EXPECT_EQ((size_t)1, doc->getPageCount());
-    PageRef page = doc->getPage(0);
+    ConstPageRef page = doc->getPage(0);
 
     EXPECT_EQ((size_t)1, page->getLayerCount());
-    Layer* layer = page->getLayers()[0];
+    const Layer* layer = page->getLayersView()[0];
 
-    Text* t1 = (Text*)layer->getElements()[0].get();
+    auto* t1 = dynamic_cast<const Text*>(layer->getElementsView()[0]);
+    EXPECT_NE(t1, nullptr);
     EXPECT_EQ(ELEMENT_TEXT, t1->getType());
 
-    Text* t2 = (Text*)layer->getElements()[1].get();
+    auto* t2 = dynamic_cast<const Text*>(layer->getElementsView()[1]);
+    EXPECT_NE(t2, nullptr);
     EXPECT_EQ(ELEMENT_TEXT, t2->getType());
 
-    Text* t3 = (Text*)layer->getElements()[2].get();
+    auto* t3 = dynamic_cast<const Text*>(layer->getElementsView()[2]);
+    EXPECT_NE(t3, nullptr);
     EXPECT_EQ(ELEMENT_TEXT, t3->getType());
 
     EXPECT_EQ(string("red"), t1->getText());
@@ -325,18 +333,21 @@ TEST(ControlLoadHandler, testTextZipped) {
     auto doc = handler.loadDocument(GET_TESTFILE("packaged_xopp/text.xopp"));
 
     EXPECT_EQ((size_t)1, doc->getPageCount());
-    PageRef page = doc->getPage(0);
+    ConstPageRef page = doc->getPage(0);
 
     EXPECT_EQ((size_t)1, page->getLayerCount());
-    Layer* layer = page->getLayers()[0];
+    const Layer* layer = page->getLayersView().front();
 
-    Text* t1 = (Text*)layer->getElements()[0].get();
+    auto* t1 = dynamic_cast<const Text*>(layer->getElementsView()[0]);
+    EXPECT_NE(t1, nullptr);
     EXPECT_EQ(ELEMENT_TEXT, t1->getType());
 
-    Text* t2 = (Text*)layer->getElements()[1].get();
+    auto* t2 = dynamic_cast<const Text*>(layer->getElementsView()[1]);
+    EXPECT_NE(t2, nullptr);
     EXPECT_EQ(ELEMENT_TEXT, t2->getType());
 
-    Text* t3 = (Text*)layer->getElements()[2].get();
+    auto* t3 = dynamic_cast<const Text*>(layer->getElementsView()[2]);
+    EXPECT_NE(t3, nullptr);
     EXPECT_EQ(ELEMENT_TEXT, t3->getType());
 
     EXPECT_EQ(string("red"), t1->getText());
@@ -353,17 +364,17 @@ TEST(ControlLoadHandler, testImageZipped) {
     auto doc = handler.loadDocument(GET_TESTFILE("packaged_xopp/imgAttachment/new.xopp"));
 
     EXPECT_EQ(1U, doc->getPageCount());
-    PageRef page = doc->getPage(0);
+    ConstPageRef page = doc->getPage(0);
     EXPECT_EQ(1U, page->getLayerCount());
-    Layer* layer = page->getLayers()[0];
-    EXPECT_EQ(layer->getElements().size(), 1);
+    const Layer* layer = page->getLayersView()[0];
+    EXPECT_EQ(layer->getElementsView().size(), 1);
 
-    Image* img = dynamic_cast<Image*>(layer->getElements()[0].get());
+    const Image* img = dynamic_cast<const Image*>(layer->getElementsView()[0]);
     EXPECT_TRUE(img);
 }
 
 namespace {
-void checkImageFormat(Image* img, const char* formatName) {
+void checkImageFormat(const Image* img, const char* formatName) {
     GdkPixbufLoader* imgLoader = gdk_pixbuf_loader_new();
     ASSERT_TRUE(gdk_pixbuf_loader_write(imgLoader, img->getRawData(), img->getRawDataLength(), nullptr));
     ASSERT_TRUE(gdk_pixbuf_loader_close(imgLoader, nullptr));
@@ -382,12 +393,12 @@ TEST(ControlLoadHandler, imageLoadJpeg) {
     auto doc = handler.loadDocument(GET_TESTFILE("packaged_xopp/imgAttachment/doc_with_jpg.xopp"));
     ASSERT_TRUE(doc) << "doc should not be null";
     ASSERT_EQ(1U, doc->getPageCount());
-    PageRef page = doc->getPage(0);
+    ConstPageRef page = doc->getPage(0);
     ASSERT_EQ(1U, page->getLayerCount());
-    Layer* layer = page->getLayers()[0];
-    ASSERT_EQ(layer->getElements().size(), 1);
+    const Layer* layer = page->getLayersView()[0];
+    ASSERT_EQ(layer->getElementsView().size(), 1);
 
-    Image* img = dynamic_cast<Image*>(layer->getElements()[0].get());
+    const Image* img = dynamic_cast<const Image*>(layer->getElementsView()[0]);
     ASSERT_TRUE(img) << "element should be an image";
 
     checkImageFormat(img, "jpeg");
@@ -417,12 +428,12 @@ TEST(ControlLoadHandler, imageSaveJpegBackwardCompat) {
     auto doc = handler.loadDocument(outPath);
     ASSERT_TRUE(doc) << "saved doc should not be null";
     ASSERT_EQ(1U, doc->getPageCount());
-    PageRef page = doc->getPage(0);
+    ConstPageRef page = doc->getPage(0);
     ASSERT_EQ(1U, page->getLayerCount());
-    Layer* layer = page->getLayers()[0];
-    ASSERT_EQ(layer->getElements().size(), 1);
+    const Layer* layer = page->getLayersView()[0];
+    ASSERT_EQ(layer->getElementsView().size(), 1);
 
-    Image* img = dynamic_cast<Image*>(layer->getElements()[0].get());
+    const Image* img = dynamic_cast<const Image*>(layer->getElementsView()[0]);
     ASSERT_TRUE(img) << "element should be an image";
     checkImageFormat(img, "png");
 }
@@ -479,22 +490,23 @@ TEST(ControlLoadHandler, testStrokeWidthRecovery) {
     auto doc = handler.loadDocument(GET_TESTFILE("packaged_xopp/stroke/width_recovery.xopp"));
 
     EXPECT_EQ((size_t)1, doc->getPageCount());
-    PageRef page = doc->getPage(0);
+    ConstPageRef page = doc->getPage(0);
 
     EXPECT_EQ((size_t)1, page->getLayerCount());
 
-    Layer* layer = page->getLayers()[0];
+    const Layer* layer = page->getLayersView()[0];
 
-    EXPECT_EQ(9U, layer->getElements().size());
+    EXPECT_EQ(9U, layer->getElementsView().size());
 
-    auto* s1 = (Stroke*)layer->getElements()[0].get();
+    auto* s1 = dynamic_cast<const Stroke*>(layer->getElementsView()[0]);
+    EXPECT_NE(s1, nullptr);
     EXPECT_EQ(ELEMENT_STROKE, s1->getType());
     for (auto& p: s1->getPointVector()) {
         EXPECT_EQ(p.z, Point::NO_PRESSURE);
     }
 
-    auto testPressureValues = [&elts = layer->getElements()](size_t n, const std::vector<double>& pressures) {
-        auto* s = (Stroke*)elts[n].get();
+    auto testPressureValues = [elts = layer->getElementsView()](size_t n, const std::vector<double>& pressures) {
+        auto* s = static_cast<const Stroke*>(elts[n]);
         printf("Testing stroke %zu\n", n);
         EXPECT_EQ(ELEMENT_STROKE, s->getType());
         EXPECT_EQ(Color(0x0000ff00), s->getColor());
@@ -531,7 +543,7 @@ TEST(ControlLoadHandler, testStrokeWidthRecovery) {
 TEST(ControlLoadHandler, testLoadStoreCJK) {
     LoadHandler handler;
     auto filepath = string(GET_TESTFILE("cjk/测试.xopp"));
-    const auto doc = handler.loadDocument(fs::u8path(filepath));
+    auto doc = handler.loadDocument(fs::u8path(filepath));
     ASSERT_NE(doc.get(), nullptr);
 
     EXPECT_STREQ(doc->getPdfFilepath().filename().u8string().c_str(), u8"测试.pdf");
@@ -542,12 +554,12 @@ TEST(ControlLoadHandler, testLoadStoreCJK) {
     EXPECT_EQ((size_t)1, page->getLayerCount());
     const auto* layer = page->getLayersView()[0];
 
-    const auto& elements = layer->getElements();
-    ASSERT_EQ((size_t)3, layer->getElements().size());
+    auto elements = layer->getElementsView();
+    ASSERT_EQ((size_t)3, layer->getElementsView().size());
 
     auto check_element = [&](size_t i, const char* answer) {
         EXPECT_EQ(ELEMENT_TEXT, elements[i]->getType());
-        auto* text = dynamic_cast<Text*>(elements[i].get());
+        auto* text = dynamic_cast<const Text*>(elements[i]);
         ASSERT_NE(text, nullptr);
         EXPECT_STREQ(text->getText().c_str(), answer);
     };


### PR DESCRIPTION
- Most `Element*` are changed into `const Element*`. We should only modify an element via its owner `std::unique_ptr<Element>`.
- Layers and other containers expose a view of `const Element*` to see their content.

This PR is based on #5263.

This PR highlights 3 places where we break the MVC pattern: Elements are modified by someone else than their owner. Those places are:
1. In EraseHandler: we call setErasable() on Stroke instances
2. In TextEditor: we call setInEditing() on Text instances
3. In the Lua interface `applib_scaleTextElements()`. It seems like a weird feature to expose. It was probably added for the font migration plugin. We should probably retire this plugin by now and remove this function from the Lua interface.

I see good reasons for the way things are done in 1. (to preserve the z-index while erasing) and 2. (so the edited text still appears in autosaves). I don't think we should do anything about it for now, but I wanted to point this fact out.