### PR TITLE
Bump gtest version used on CI

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,7 +18,7 @@ if (${DOWNLOAD_GTEST})
   include(FetchContent)
   FetchContent_Declare(
       googletest
-      URL https://github.com/google/googletest/archive/refs/tags/release-1.11.0.zip
+      URL https://github.com/google/googletest/archive/refs/tags/v1.16.0.zip
   )
   # Prevent reloading if already downloaed
   set(FETCHCONTENT_UPDATES_DISCONNECTED ON)


### PR DESCRIPTION
Use gtest 1.16 instead of 1.11. Version 1.11 is no longer supported by cmake (hence all the CI runs are failling).

Merging once the CI clears.