### PR TITLE
Fix regressions on master in export dialogs

### DIFF
--- a/src/core/control/jobs/BaseExportJob.cpp
+++ b/src/core/control/jobs/BaseExportJob.cpp
@@ -60,7 +60,8 @@ void BaseExportJob::showFileChooser(std::function<void()> onFileSelected, std::f
     doc->unlock();
 
     auto pathValidation = [job = this](fs::path& p, const char* filterName) {
-        return job->testAndSetFilepath(p, filterName);
+        job->setExtensionFromFilter(p, filterName);
+        return job->testAndSetFilepath(p);
     };
 
     auto callback = [settings, onFileSelected = std::move(onFileSelected),
@@ -83,9 +84,9 @@ void BaseExportJob::showFileChooser(std::function<void()> onFileSelected, std::f
     popup.show(GTK_WINDOW(this->control->getWindow()->getWindow()));
 }
 
-auto BaseExportJob::testAndSetFilepath(const fs::path& file, const char* /*filterName*/) -> bool {
+auto BaseExportJob::testAndSetFilepath(const fs::path& file) -> bool {
     try {
-        if (!file.empty() && fs::is_directory(file.parent_path())) {
+        if (!file.empty() && fs::is_directory(file.parent_path()) && checkOverwriteBackgroundPDF(file)) {
             this->filepath = file;
             return true;
         }

--- a/src/core/control/jobs/BaseExportJob.h
+++ b/src/core/control/jobs/BaseExportJob.h
@@ -45,7 +45,15 @@ protected:
     virtual void addFilterToDialog(GtkFileChooser* dialog) = 0;
     static void addFileFilterToDialog(GtkFileChooser* dialog, const std::string& name, const std::string& mimetype);
     bool checkOverwriteBackgroundPDF(fs::path const& file) const;
-    virtual bool testAndSetFilepath(const fs::path& file, const char* filterName = nullptr);
+
+    virtual void setExtensionFromFilter(fs::path& p, const char* filterName) const = 0;
+
+    /**
+     * Test if the given path is valid and records the path for the instance's later export tasks.
+     *
+     * Returns true if the path is validated.
+     */
+    bool testAndSetFilepath(const fs::path& file);
 
 private:
 protected:

--- a/src/core/control/jobs/CustomExportJob.h
+++ b/src/core/control/jobs/CustomExportJob.h
@@ -40,13 +40,13 @@ protected:
     void afterRun() override;
 
     void addFilterToDialog(GtkFileChooser* dialog) override;
+    void setExtensionFromFilter(fs::path& p, const char* filterName) const override;
 
     /**
      * Create one Graphics file per page
      */
     void exportGraphics();
 
-    bool testAndSetFilepath(const fs::path& file, const char* filterName = nullptr) override;
 
 private:
     /**

--- a/src/core/control/jobs/PdfExportJob.cpp
+++ b/src/core/control/jobs/PdfExportJob.cpp
@@ -20,18 +20,11 @@ void PdfExportJob::addFilterToDialog(GtkFileChooser* dialog) {
     addFileFilterToDialog(dialog, _("PDF files"), "application/pdf");
 }
 
-auto PdfExportJob::testAndSetFilepath(const fs::path& file, const char* /*filterName*/) -> bool {
-    if (!BaseExportJob::testAndSetFilepath(file)) {
-        return false;
-    }
-
+void PdfExportJob::setExtensionFromFilter(fs::path& file, const char* /*filterName*/) const {
     // Remove any pre-existing extension and adds .pdf
-    Util::clearExtensions(filepath, ".pdf");
-    filepath += ".pdf";
-
-    return checkOverwriteBackgroundPDF(filepath);
+    Util::clearExtensions(file, ".pdf");
+    file += ".pdf";
 }
-
 
 void PdfExportJob::run() {
     Document* doc = control->getDocument();

--- a/src/core/control/jobs/PdfExportJob.h
+++ b/src/core/control/jobs/PdfExportJob.h
@@ -28,7 +28,5 @@ public:
 
 protected:
     void addFilterToDialog(GtkFileChooser* dialog) override;
-    bool testAndSetFilepath(const fs::path& file, const char* filterName = nullptr) override;
-
-private:
+    void setExtensionFromFilter(fs::path& p, const char* filterName) const override;
 };


### PR DESCRIPTION
While working on #6364, I noticed regressions on master in the export dialogs:
1. For Export As..., the file chooser did not disappear once the file was selected.
2. For all export dialogs: the "Do you want to overwrite?" test was not working when typing `foobar` in the file chooser to
export to `foobar.pdf`

This PR fixes those.