### PR TITLE
Forward Linux crash signals to default handler after emergency save

### DIFF
--- a/src/core/control/CrashHandlerUnix.h
+++ b/src/core/control/CrashHandlerUnix.h
@@ -103,6 +103,9 @@ void installCrashHandlers() {
 static void crashHandler(int sig) {
     if (alreadyCrashed)  // crasehd again on emergency save
     {
+        // Forward the signal for the system's default handling
+        signal(sig, SIG_DFL);
+        kill(getpid(), sig);
         exit(2);
     }
     alreadyCrashed = true;
@@ -163,6 +166,10 @@ static void crashHandler(int sig) {
     }
 
     emergencySave();
+
+    // Forward the signal for the system's default handling
+    signal(sig, SIG_DFL);
+    kill(getpid(), sig);
 
     exit(1);
 }


### PR DESCRIPTION
This allows for e.g. systemd-coredump to dump the core. It could help with debugging ellusive SegFaults.
See https://github.com/xournalpp/xournalpp/issues/4931#issuecomment-2809814384

Merging once the CI clears.