### PR TITLE
Fix wrongly spaced glyphs in Text elements

### DIFF
--- a/src/core/model/Text.cpp
+++ b/src/core/model/Text.cpp
@@ -83,6 +83,7 @@ void Text::setInEditing(bool inEditing) { this->inEditing = inEditing; }
 auto Text::createPangoLayout() const -> xoj::util::GObjectSPtr<PangoLayout> {
     xoj::util::GObjectSPtr<PangoContext> c(pango_font_map_create_context(pango_cairo_font_map_get_default()),
                                            xoj::util::adopt);
+    pango_context_set_round_glyph_positions(c.get(), false);  // Avoid weird glyph positioning on small fonts
     xoj::util::GObjectSPtr<PangoLayout> layout(pango_layout_new(c.get()), xoj::util::adopt);
 
 #if PANGO_VERSION_CHECK(1, 48, 5)  // see https://gitlab.gnome.org/GNOME/pango/-/issues/499


### PR DESCRIPTION
Fixes #1595

Thanks to @sakishrist for fishing out the relevant Pango [issues](https://gitlab.gnome.org/GNOME/pango/-/issues/801) with how to fix this.

Note that this will cause changes in how text elements are rendered. For small fonts, this may cause significant variations in the width of Text elements. I still think this patch is necessary, but it will incomodate some users... @rolandlo You have an opinion?