### PR TITLE
Fix test-gtk-integration linkage

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -68,7 +68,7 @@ file (GLOB_RECURSE test-gtk-sources
 
 # Define test-gtk-integration target
 add_executable (test-gtk-integration EXCLUDE_FROM_ALL ${test-gtk-sources})
-target_link_libraries (test-gtk-integration xoj::core xoj::util std::filesystem gtest_main)
+target_link_libraries (test-gtk-integration xoj::core xoj::util std::filesystem gtest_main gtest)
 target_include_directories(test-gtk-integration PRIVATE "${PROJECT_BINARY_DIR}/test")
 
 ###############################################################################


### PR DESCRIPTION
For some reason, the test-gtk-integration target fails to build when the GTest version is the one installed with the distribution (so not downloaded via `-DDOWNLOAD_GTEST`). This fixes that.

Merging once the CI clears