### PR TITLE
Release 1.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,24 @@
 # Changelog
 
-## 1.2.7~dev (Unreleased)
+## 1.2.7
+
+The support for Ubuntu 20 LTS is dropped.
+This release also includes bugfixes from various community contributors:
+
+* Improved error logs (#6319)
+* Fixed some undefined behaviours that may have caused crashes (#6326)
+* Fixed some memory leaks (#6356)
+* Ensured timers are cancelled on exit (#6351)
+* Fixed handling of linebreaks in latex tool (#6374)
+* Linux: forward crash signals to system handler after emergency save (#6392)
+* Fixed wrong glyph spacing in texts using small fonts (#6393)
+* Windows: Fixed opening of UNC paths (#6409)
+* Fixed rasterization of Tex elements on PDF/SVG export or printing (#6395)
+* Updated translations
 
 ## 1.2.6
+
+Bugfixes from various community contributors.
 
 * Fixed a weird behaviour when drawing the outline of the compass multiple times (#6265, #6256)
 * Exposed selected text to the windowing system for accessibility purposes (#6221, #6215)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ project(xournalpp
         LANGUAGES CXX C)
 # according to https://cmake.org/cmake/help/latest/command/project.html we must fix the suffix:
 # And https://gitlab.kitware.com/cmake/cmake/-/issues/16716 is still open:
-set(VERSION_SUFFIX "~dev")
+set(VERSION_SUFFIX "")
 set(PROJECT_VERSION "${PROJECT_VERSION}${VERSION_SUFFIX}")
 set(xournalpp_VERSION ${PROJECT_VERSION})
 set(CMAKE_PROJECT_VERSION ${PROJECT_VERSION})

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,13 @@
-xournalpp (1.2.7~dev-1) UNRELEASED; urgency=medium
+xournalpp (1.2.7-1) unstable; urgency=medium
 
-  * 
+  * Improved error logs
+  * Fixed some undefined behaviours and memory leaks
+  * Fixed handling of linebreaks in latex tool
+  * Linux: forward crash signals to system handler after emergency save
+  * Fixed wrong glyph spacing in texts using small fonts
+  * Fixed rasterization of Tex elements on PDF/SVG export or printing
 
- -- Roland Lötscher <roland_loetscher@hotmail.com>  Wed, 19 Feb 2025 10:59:27 +0100
+ -- Benjamin Hennion <17818041+bhennion@users.noreply.github.com>  Thu, 08 May 2025 15:20:59 +0200
 
 xournalpp (1.2.6-1) unstable; urgency=medium
 

--- a/desktop/com.github.xournalpp.xournalpp.appdata.xml
+++ b/desktop/com.github.xournalpp.xournalpp.appdata.xml
@@ -121,7 +121,7 @@
     <!-- Could be automated more:
 	 `git tag -l | grep "^[0-9]*\.[0-9]*\.[0-9]*$`"
     -->
-    <release date="2025-02-19" version="1.2.7~dev" />
+    <release date="2025-05-08" version="1.2.7" />
     <release date="2025-02-19" version="1.2.6" />
     <release date="2024-12-04" version="1.2.5" />
     <release date="2024-10-20" version="1.2.4" />

--- a/mac-setup/Info.plist
+++ b/mac-setup/Info.plist
@@ -16,9 +16,9 @@
     <string>Xournal++</string>
 
     <key>CFBundleShortVersionString</key>
-    <string>1.2.7~dev</string>
+    <string>1.2.7</string>
     <key>CFBundleVersion</key>
-    <string>1.2.7~dev.0</string>
+    <string>1.2.7.0</string>
     <key>CFBundleInfoDictionaryVersion</key>
     <string>6.0</string>
     <key>NSHumanReadableCopyright</key>

--- a/rpm/fedora/xournalpp.spec
+++ b/rpm/fedora/xournalpp.spec
@@ -4,7 +4,7 @@
 #This spec file is intended for daily development snapshot release
 %global	build_repo https://github.com/xournalpp/xournalpp/
 %global	build_branch master
-%global	version_string 1.2.7~dev
+%global	version_string 1.2.7
 %define	build_commit %(git ls-remote %{build_repo} | grep "refs/heads/%{build_branch}" | cut -c1-41)
 %define	build_shortcommit %(c=%{build_commit}; echo ${c:0:7})
 %global	build_timestamp %(date +"%Y%m%d")


### PR DESCRIPTION
Updates the changelogs and bumps the version numbers.
@xournalpp/core Could you have a look at the changelogs? I went through the commit tree (I omitted the purely "code readability" and CI improvements).

DO NO MERGE VIA GITHUB