### PR TITLE
Fix typing when GeometryTool is on

### DIFF
--- a/src/core/control/CompassController.cpp
+++ b/src/core/control/CompassController.cpp
@@ -80,8 +80,7 @@ void CompassController::updateOutlineStroke(double x) {
     stroke->deletePointsFrom(0);
     const auto h = view->getXournal()->getControl()->getToolHandler();
     const bool filled = (h->getFill() != -1);
-    const xoj::util::Point<double> c =
-            xoj::util::Point<double>{geometryTool->getTranslationX(), geometryTool->getTranslationY()};
+    const xoj::util::Point<double>& c = this->getGeometryTool()->getOrigin();
 
     if (filled && angleMax < angleMin + 2 * M_PI) {
         stroke->addPoint(Point(c.x, c.y));

--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -391,16 +391,15 @@ bool Control::toggleGeometryTool() {
     view->addOverlayView(std::make_unique<ViewClass>(tool, view, zoom));
     this->geometryTool = std::unique_ptr<GeometryTool>(tool);
     this->geometryToolController = std::make_unique<ControllerClass>(view, tool);
-    std::unique_ptr<InputHandlerClass> geometryToolInputHandler =
+    auto geometryToolInputHandler =
             std::make_unique<InputHandlerClass>(this->win->getXournal(), geometryToolController.get());
-    geometryToolInputHandler->registerToPool(tool->getHandlerPool());
     Range range = view->getVisiblePart();
     if (range.isValid()) {
         double originX = (range.minX + range.maxX) * .5;
         double originY = (range.minY + range.maxY) * .5;
-        geometryToolController->translate(originX, originY);
+        geometryToolController->translate({originX, originY});
     } else {
-        geometryToolController->translate(view->getWidth() * .5, view->getHeight() * .5);
+        geometryToolController->translate({view->getWidth() * .5, view->getHeight() * .5});
     }
     xournal->input->setGeometryToolInputHandler(std::move(geometryToolInputHandler));
     geometryTool->notify();

--- a/src/core/control/GeometryToolController.cpp
+++ b/src/core/control/GeometryToolController.cpp
@@ -21,40 +21,41 @@ GeometryToolController::GeometryToolController(XojPageView* view, GeometryTool* 
 
 GeometryToolController::~GeometryToolController() = default;
 
-void GeometryToolController::translate(double x, double y) {
-    geometryTool->setTranslationX(geometryTool->getTranslationX() + x);
-    geometryTool->setTranslationY(geometryTool->getTranslationY() + y);
+void GeometryToolController::translate(const xoj::util::Point<double>& offset) {
+    geometryTool->setOrigin(geometryTool->getOrigin() + offset);
     geometryTool->notify();
 }
 
-void GeometryToolController::rotate(double da, double cx, double cy) {
+void GeometryToolController::rotate(double da, const xoj::util::Point<double>& center) {
+    const auto offset = geometryTool->getOrigin() - center;
+    geometryTool->setOrigin(center + xoj::util::Point<double>(offset.x * std::cos(da) - offset.y * std::sin(da),
+                                                              offset.x * std::sin(da) + offset.y * std::cos(da)));
+    this->rotate(da);
+}
+void GeometryToolController::rotate(double da) {
     geometryTool->setRotation(geometryTool->getRotation() + da);
-    const auto offsetX = geometryTool->getTranslationX() - cx;
-    const auto offsetY = geometryTool->getTranslationY() - cy;
-    const auto mx = offsetX * cos(da) - offsetY * sin(da);
-    const auto my = offsetX * sin(da) + offsetY * cos(da);
-    geometryTool->setTranslationX(cx + mx);
-    geometryTool->setTranslationY(cy + my);
     geometryTool->notify();
 }
 
-void GeometryToolController::scale(double f, double cx, double cy) {
+
+void GeometryToolController::scale(double f, const xoj::util::Point<double>& center) {
+    geometryTool->setOrigin(center + (geometryTool->getOrigin() - center) * f);
+    this->scale(f);
+}
+void GeometryToolController::scale(double f) {
     geometryTool->setHeight(geometryTool->getHeight() * f);
-    const auto offsetX = geometryTool->getTranslationX() - cx;
-    const auto offsetY = geometryTool->getTranslationY() - cy;
-    const auto mx = offsetX * f;
-    const auto my = offsetY * f;
-    geometryTool->setTranslationX(cx + mx);
-    geometryTool->setTranslationY(cy + my);
     geometryTool->notify(true);
 }
 
-void GeometryToolController::markPoint(double x, double y) {
+
+void GeometryToolController::markOrigin() {
     const auto control = view->getXournal()->getControl();
     const auto h = control->getToolHandler();
     auto cross = std::make_unique<Stroke>();
     cross->setWidth(h->getToolThickness(TOOL_PEN)[TOOL_SIZE_FINE]);
     cross->setColor(h->getTool(TOOL_PEN).getColor());
+    const double x = geometryTool->getOrigin().x;
+    const double y = geometryTool->getOrigin().y;
     cross->addPoint(Point(x + MARK_SIZE, y + MARK_SIZE));
     cross->addPoint(Point(x - MARK_SIZE, y - MARK_SIZE));
     cross->addPoint(Point(x, y));

--- a/src/core/control/GeometryToolController.h
+++ b/src/core/control/GeometryToolController.h
@@ -35,33 +35,32 @@ public:
 public:
     /**
      * @brief translates the geometry tool in x- and y-direction
-     * @param x the translation in x-direction (in document coordinates)
-     * @param y the translation in y-direction (in document coordinates)
+     * @param offset the translation vector (in document coordinates)
      */
-    void translate(double x, double y);
+    void translate(const xoj::util::Point<double>& offset);
 
     /**
-     * @brief rotates the geometry tool around its rotation center
+     * @brief rotates the geometry tool around then given rotation center
      * @param da the rotation angle
-     * @param cx the x-coordinate of the rotation center (in document coordinates)
-     * @param cy the y-coordinate of the rotation center (in document coordinates)
+     * @param center the rotation center (in document coordinates
      */
-    void rotate(double da, double cx, double cy);
+    void rotate(double da, const xoj::util::Point<double>& center);
+    /// Rotates around the tool's origin
+    void rotate(double da);
 
     /**
      * @brief resizes the geometry tool by the factor f with respect to a given scaling center
      * @param f the scaling factor
-     * @param cx the x-coordinate of the scaling center (in document coordinates)
-     * @param cy the y-coordinate of the scaling center (in document coordiantes)
+     * @param center the scaling center (in document coordinates)
      */
-    void scale(double f, double cx, double cy);
+    void scale(double f, const xoj::util::Point<double>& center);
+    /// Rescales around the tools origin
+    void scale(double f);
 
     /**
-     * @brief marks a point with a "x" and puts the mark onto the current layer
-     * @param x the x-coordinate of the point (in document coordinates)
-     * @param y the y-coordinate of the point (in document coordinates)
+     * @brief marks the origin with a "x" and puts the mark onto the current layer
      */
-    void markPoint(double x, double y);
+    void markOrigin();
 
     /**
      * @brief adds the stroke to the layer and rerenders the stroke area
@@ -83,11 +82,13 @@ public:
      */
     const PageRef getPage() const;
 
+    inline GeometryTool* getGeometryTool() const { return geometryTool; }
+
     virtual bool isInsideGeometryTool(double x, double y, double border = 0.0) const = 0;
 
     virtual GeometryToolType getType() const = 0;
 
-public:
+protected:
     XojPageView* view;
 
     /**

--- a/src/core/gui/XournalView.cpp
+++ b/src/core/gui/XournalView.cpp
@@ -22,6 +22,7 @@
 #include "control/zoom/ZoomControl.h"            // for ZoomControl
 #include "gui/MainWindow.h"                      // for MainWindow
 #include "gui/PdfFloatingToolbox.h"              // for PdfFloatingToolbox
+#include "gui/inputdevices/GeometryToolInputHandler.h"  // for GeometryToolInputHandler
 #include "gui/inputdevices/HandRecognition.h"    // for HandRecognition
 #include "gui/inputdevices/InputContext.h"       // for InputContext
 #include "gui/toolbarMenubar/ColorToolItem.h"    // for ColorToolItem
@@ -172,6 +173,10 @@ auto XournalView::onKeyPressEvent(const KeyEvent& event) -> bool {
             selection->ensureWithinVisibleArea();
             return true;
         }
+    }
+
+    if (auto* geom = GTK_XOURNAL(widget)->input->getGeometryToolInputHandler(); geom && geom->keyPressed(event)) {
+        return true;
     }
 
     Layout* layout = gtk_xournal_get_layout(this->widget);

--- a/src/core/gui/inputdevices/CompassInputHandler.cpp
+++ b/src/core/gui/inputdevices/CompassInputHandler.cpp
@@ -14,9 +14,9 @@ constexpr double MIN_HEIGHT = 0.5;
 constexpr double MAX_HEIGHT = 10.0;
 
 CompassInputHandler::CompassInputHandler(XournalView* xournal, GeometryToolController* controller):
-        GeometryToolInputHandler(xournal, controller, Compass::INITIAL_HEIGHT, 0., 0.) {}
+        GeometryToolInputHandler(xournal, controller) {}
 
-CompassInputHandler::~CompassInputHandler() noexcept { this->unregisterFromPool(); }
+CompassInputHandler::~CompassInputHandler() noexcept = default;
 
 auto CompassInputHandler::handlePointer(InputEvent const& event) -> bool {
     const auto coords = getCoords(event);
@@ -34,10 +34,10 @@ auto CompassInputHandler::handlePointer(InputEvent const& event) -> bool {
                     lastProj = std::atan2(-p.y, p.x);
                     compassController->createOutlineStroke(lastProj);
                     return true;
-                } else if (controller->isInsideGeometryTool(coords.x, coords.y, 0.) &&
+                } else if (double h = controller->getGeometryTool()->getHeight();
+                           controller->isInsideGeometryTool(coords.x, coords.y, 0.) &&
                            std::abs(compassController->posRelToSide(coords.x, coords.y).y) <= 0.5 &&
-                           std::abs(compassController->posRelToSide(coords.x, coords.y).x - 0.5 * height) <=
-                                   0.5 * height) {
+                           std::abs(compassController->posRelToSide(coords.x, coords.y).x - 0.5 * h) <= 0.5 * h) {
                     compassController->createRadialStroke(std::hypot(p.x, p.y));
                     return true;
                 }

--- a/src/core/gui/inputdevices/GeometryToolInputHandler.cpp
+++ b/src/core/gui/inputdevices/GeometryToolInputHandler.cpp
@@ -33,9 +33,8 @@ constexpr double SNAPPING_DISTANCE_TOLERANCE = 5.0;                 // pt
 constexpr double SNAPPING_ROTATION_TOLERANCE = 3.0 * M_PI / 180.0;  // rad
 constexpr double ZOOM_DISTANCE_MIN = 0.01;
 
-GeometryToolInputHandler::GeometryToolInputHandler(XournalView* xournal, GeometryToolController* controller, double h,
-                                                   double tx, double ty):
-        xournal(xournal), controller(controller), height(h), translationX(tx), translationY(ty) {}
+GeometryToolInputHandler::GeometryToolInputHandler(XournalView* xournal, GeometryToolController* controller):
+        xournal(xournal), controller(controller) {}
 
 GeometryToolInputHandler::~GeometryToolInputHandler() = default;
 
@@ -63,13 +62,6 @@ auto GeometryToolInputHandler::handle(InputEvent const& event) -> bool {
             g_warning("Device class %d not handled by geometry tool", event.deviceClass);
             return false;
     }
-}
-
-void GeometryToolInputHandler::on(UpdateValuesRequest, double h, double rot, double tx, double ty) {
-    height = h;
-    rotation = rot;
-    translationX = tx;
-    translationY = ty;
 }
 
 auto GeometryToolInputHandler::handleTouchscreen(InputEvent const& event) -> bool {
@@ -162,36 +154,33 @@ auto GeometryToolInputHandler::keyPressed(KeyEvent const& event) -> bool {
             scale = (event.state & GDK_MOD1_MASK) ? 1. / SCALE_AMOUNT_SMALL : 1. / SCALE_AMOUNT;
             break;
         case GDK_KEY_m:
-            controller->markPoint(translationX, translationY);
+            controller->markOrigin();
             return true;
     }
 
     if (xdir != 0 || ydir != 0) {
-        const double c = std::cos(rotation);
-        const double s = std::sin(rotation);
-        double xshift{0.0};
-        double yshift{0.0};
+        xoj::util::Point<double> offset;
         const double amount = (event.state & GDK_MOD1_MASK) ? MOVE_AMOUNT_SMALL : MOVE_AMOUNT;
         if (event.state & GDK_SHIFT_MASK) {
-            xshift = amount * (c * xdir - s * ydir);
-            yshift = amount * (s * xdir + c * ydir);
+            double angle = controller->getGeometryTool()->getRotation();
+            const double c = std::cos(angle);
+            const double s = std::sin(angle);
+            offset = {amount * (c * xdir - s * ydir), amount * (s * xdir + c * ydir)};
         } else {
-            xshift = amount * xdir;
-            yshift = amount * ydir;
+            offset = {amount * xdir, amount * ydir};
         }
-        controller->translate(xshift, yshift);
+        controller->translate(offset);
         return true;
     }
 
-    auto p = xoj::util::Point(translationX, translationY);
     if (angle != 0) {
-        controller->rotate(angle, p.x, p.y);
+        controller->rotate(angle);
         return true;
     }
     if (scale != 1.0) {
-        const double h = height * scale;
+        const double h = controller->getGeometryTool()->getHeight() * scale;
         if (h <= getMaxHeight() && h >= getMinHeight()) {
-            controller->scale(scale, p.x, p.y);
+            controller->scale(scale);
             return true;
         }
     }
@@ -237,7 +226,8 @@ void GeometryToolInputHandler::scrollMotion(InputEvent const& event) {
             return offset;
         }
     }();
-    const auto pos = Point(translationX + offset.x, translationY + offset.y);
+    const auto& origin = controller->getGeometryTool()->getOrigin();
+    const auto pos = Point(origin.x + offset.x, origin.y + offset.y);
     double minDist = SNAPPING_DISTANCE_TOLERANCE;
     double diffAngle{NAN};
     for (const auto& l: lines) {
@@ -245,16 +235,16 @@ void GeometryToolInputHandler::scrollMotion(InputEvent const& event) {
         const Point second = l->getPoint(1);
         const double dist = Snapping::distanceLine(pos, first, second);
         const double angleLine = std::atan2(second.y - first.y, second.x - first.x);
-        const double diff = std::remainder(angleLine - rotation, M_PI_2);
+        const double diff = std::remainder(angleLine - controller->getGeometryTool()->getRotation(), M_PI_2);
         if (dist < minDist && std::abs(diff) <= SNAPPING_ROTATION_TOLERANCE) {
             minDist = dist;
             diffAngle = diff;
         }
     }
     if (!std::isnan(diffAngle)) {
-        controller->rotate(diffAngle, pos.x, pos.y);
+        controller->rotate(diffAngle, xoj::util::Point<double>(pos.x, pos.y));
     }
-    controller->translate(offset.x, offset.y);
+    controller->translate(offset);
 }
 
 void GeometryToolInputHandler::rotateAndZoomStart() {
@@ -293,17 +283,17 @@ void GeometryToolInputHandler::rotateAndZoomMotion(InputEvent const& event) {
     const double angle = atan2(shift.y, shift.x);
 
     const xoj::util::Point<double> offset = center - lastZoomScrollCenter;
-    controller->translate(offset.x, offset.y);
+    controller->translate(offset);
     const double angleIncrease = angle - lastAngle;
     const xoj::util::Point<double> centerRel = (this->priLastPageRel + this->secLastPageRel) / 2.0;
     if (controller->isInsideGeometryTool(secLastPageRel.x, secLastPageRel.y, 0.0)) {
-        controller->rotate(angleIncrease, centerRel.x, centerRel.y);
+        controller->rotate(angleIncrease, centerRel);
     }  // allow moving without accidental rotation
     const double scaleFactor = dist / lastDist;
-    const double h = height * scaleFactor;
+    const double h = controller->getGeometryTool()->getHeight() * scaleFactor;
 
     if (!canBlockZoom && h <= getMaxHeight() && h >= getMinHeight()) {
-        controller->scale(scaleFactor, centerRel.x, centerRel.y);
+        controller->scale(scaleFactor, centerRel);
     }
 
     this->lastZoomScrollCenter = center;

--- a/src/core/gui/inputdevices/GeometryToolInputHandler.h
+++ b/src/core/gui/inputdevices/GeometryToolInputHandler.h
@@ -35,7 +35,7 @@ struct KeyEvent;
  *
  * The touch handling part is adopted from the TouchInputHandler class
  */
-class GeometryToolInputHandler: public xoj::util::Listener<GeometryToolInputHandler> {
+class GeometryToolInputHandler {
 
 protected:
     /**
@@ -48,11 +48,6 @@ protected:
      *
      */
     GeometryToolController* controller;
-
-    double height;
-    double rotation = 0.;
-    double translationX;
-    double translationY;
 
     /**
      * @brief saves which devices are blocked, so they don't need to be handled
@@ -157,8 +152,7 @@ protected:
     virtual double getMaxHeight() const = 0;
 
 public:
-    explicit GeometryToolInputHandler(XournalView* xournalView, GeometryToolController* controller, double h, double tx,
-                                      double ty);
+    explicit GeometryToolInputHandler(XournalView* xournalView, GeometryToolController* controller);
     virtual ~GeometryToolInputHandler();
 
     bool handle(InputEvent const& event);
@@ -167,11 +161,4 @@ public:
 
     bool keyPressed(KeyEvent const& event);
     // bool keyReleased(KeyEvent const& event); // Implement if needed
-
-    /**
-     * Listener interface
-     */
-    static constexpr struct UpdateValuesRequest {
-    } UPDATE_VALUES = {};
-    void on(UpdateValuesRequest, double h, double rot, double tx, double ty);
 };

--- a/src/core/gui/inputdevices/KeyboardInputHandler.cpp
+++ b/src/core/gui/inputdevices/KeyboardInputHandler.cpp
@@ -10,9 +10,6 @@ KeyboardInputHandler::KeyboardInputHandler(InputContext* inputContext): inputCon
 
 KeyboardInputHandler::~KeyboardInputHandler() = default;
 
-bool KeyboardInputHandler::keyPressed(KeyEvent e) const {
-    auto* geom = inputContext->getGeometryToolInputHandler();
-    return (geom && geom->keyPressed(e)) || inputContext->getView()->onKeyPressEvent(e);
-}
+bool KeyboardInputHandler::keyPressed(KeyEvent e) const { return inputContext->getView()->onKeyPressEvent(e); }
 
 bool KeyboardInputHandler::keyReleased(KeyEvent e) const { return inputContext->getView()->onKeyReleaseEvent(e); }

--- a/src/core/gui/inputdevices/SetsquareInputHandler.cpp
+++ b/src/core/gui/inputdevices/SetsquareInputHandler.cpp
@@ -14,9 +14,9 @@ constexpr double MIN_HEIGHT = 4.5;
 constexpr double MAX_HEIGHT = 15.0;
 
 SetsquareInputHandler::SetsquareInputHandler(XournalView* xournal, GeometryToolController* controller):
-        GeometryToolInputHandler(xournal, controller, Setsquare::INITIAL_HEIGHT, 0., 0.) {}
+        GeometryToolInputHandler(xournal, controller) {}
 
-SetsquareInputHandler::~SetsquareInputHandler() noexcept { this->unregisterFromPool(); }
+SetsquareInputHandler::~SetsquareInputHandler() noexcept = default;
 
 auto SetsquareInputHandler::handlePointer(InputEvent const& event) -> bool {
     const auto coords = getCoords(event);

--- a/src/core/model/Compass.cpp
+++ b/src/core/model/Compass.cpp
@@ -18,8 +18,8 @@ auto Compass::getToolRange(bool transformed) const -> Range {
     const auto h = height * CM;
     Range rg;
     if (transformed) {
-        rg.addPoint(translationX - h, translationY - h);
-        rg.addPoint(translationX + h, translationY + h);
+        rg.addPoint(origin.x - h, origin.y - h);
+        rg.addPoint(origin.x + h, origin.y + h);
     } else {
         rg.addPoint(-h, -h);
         rg.addPoint(h, h);
@@ -41,6 +41,4 @@ void Compass::notify(bool resetMask) const {
                        this->getMatrix());
     Range rg = this->getToolRange(true);
     viewPool->dispatch(xoj::view::CompassView::FLAG_DIRTY_REGION, this->computeRepaintRange(rg));
-    handlerPool->dispatch(CompassInputHandler::UPDATE_VALUES, this->getHeight(), this->getRotation(),
-                          this->getTranslationX(), this->getTranslationY());
 }

--- a/src/core/model/GeometryTool.cpp
+++ b/src/core/model/GeometryTool.cpp
@@ -5,10 +5,8 @@
 GeometryTool::GeometryTool(double h, double r, double tx, double ty):
         height(h),
         rotation(r),
-        translationX(tx),
-        translationY(ty),
-        viewPool(std::make_shared<xoj::util::DispatchPool<xoj::view::GeometryToolView>>()),
-        handlerPool(std::make_shared<xoj::util::DispatchPool<GeometryToolInputHandler>>()) {}
+        origin(tx, ty),
+        viewPool(std::make_shared<xoj::util::DispatchPool<xoj::view::GeometryToolView>>()) {}
 
 GeometryTool::~GeometryTool() {}
 
@@ -18,16 +16,14 @@ auto GeometryTool::getHeight() const -> double { return this->height; }
 void GeometryTool::setRotation(double rotation) { this->rotation = rotation; }
 auto GeometryTool::getRotation() const -> double { return this->rotation; }
 
-void GeometryTool::setTranslationX(double x) { this->translationX = x; }
-auto GeometryTool::getTranslationX() const -> double { return this->translationX; }
+auto GeometryTool::getOrigin() const -> const xoj::util::Point<double>& { return origin; }
 
-void GeometryTool::setTranslationY(double y) { this->translationY = y; }
-auto GeometryTool::getTranslationY() const -> double { return this->translationY; }
+void GeometryTool::setOrigin(const xoj::util::Point<double>& o) { this->origin = o; }
 
 auto GeometryTool::getMatrix() const -> cairo_matrix_t {
     cairo_matrix_t matrix;
     cairo_matrix_init_identity(&matrix);
-    cairo_matrix_translate(&matrix, this->translationX, this->translationY);
+    cairo_matrix_translate(&matrix, this->origin.x, this->origin.y);
     cairo_matrix_rotate(&matrix, this->rotation);
     cairo_matrix_scale(&matrix, CM, CM);
     return matrix;
@@ -35,9 +31,6 @@ auto GeometryTool::getMatrix() const -> cairo_matrix_t {
 
 auto GeometryTool::getViewPool() const -> const std::shared_ptr<xoj::util::DispatchPool<xoj::view::GeometryToolView>>& {
     return viewPool;
-}
-auto GeometryTool::getHandlerPool() const -> const std::shared_ptr<xoj::util::DispatchPool<GeometryToolInputHandler>>& {
-    return handlerPool;
 }
 
 auto GeometryTool::getStroke() const -> Stroke* { return this->stroke; }

--- a/src/core/model/GeometryTool.h
+++ b/src/core/model/GeometryTool.h
@@ -16,6 +16,7 @@
 #include "model/OverlayBase.h"
 #include "model/Stroke.h"
 #include "util/DispatchPool.h"
+#include "util/Point.h"
 
 constexpr static double HALF_CM = 14.17;
 constexpr static double CM = 2. * HALF_CM;
@@ -57,10 +58,8 @@ public:
     double getHeight() const;
     void setRotation(double rotation);
     double getRotation() const;
-    void setTranslationX(double x);
-    double getTranslationX() const;
-    void setTranslationY(double y);
-    double getTranslationY() const;
+    const xoj::util::Point<double>& getOrigin() const;
+    void setOrigin(const xoj::util::Point<double>& o);
 
     cairo_matrix_t getMatrix() const;
 
@@ -91,19 +90,13 @@ protected:
     double rotation;
 
     /**
-     * @brief the x-coordinate (in pt) of the rotation center
+     * @brief the tool's origin
      */
-    double translationX;
-
-    /**
-     * @brief the y-coordinate (in pt) of the rotation center
-     */
-    double translationY;
+    xoj::util::Point<double> origin;
 
     Stroke* stroke = nullptr;
 
     std::shared_ptr<xoj::util::DispatchPool<xoj::view::GeometryToolView>> viewPool;
-    std::shared_ptr<xoj::util::DispatchPool<GeometryToolInputHandler>> handlerPool;
 
     /**
      * @brief Bounding box of the geometry tool and stroke after its last update

--- a/src/core/model/Setsquare.cpp
+++ b/src/core/model/Setsquare.cpp
@@ -22,9 +22,9 @@ auto Setsquare::getToolRange(bool transformed) const -> Range {
     if (transformed) {
         const auto cs = std::cos(rotation);
         const auto si = std::sin(rotation);
-        rg.addPoint(translationX + cs * h, translationY - si * h);
-        rg.addPoint(translationX - cs * h, translationY + si * h);
-        rg.addPoint(translationX - si * h, translationY + cs * h);
+        rg.addPoint(origin.x + cs * h, origin.y - si * h);
+        rg.addPoint(origin.x - cs * h, origin.y + si * h);
+        rg.addPoint(origin.x - si * h, origin.y + cs * h);
     } else {
         rg.addPoint(h, 0);
         rg.addPoint(-h, 0);
@@ -46,6 +46,4 @@ void Setsquare::notify(bool resetMask) const {
                        this->getMatrix());
     Range rg = this->getToolRange(true);
     viewPool->dispatch(xoj::view::SetsquareView::FLAG_DIRTY_REGION, this->computeRepaintRange(rg));
-    handlerPool->dispatch(SetsquareInputHandler::UPDATE_VALUES, this->getHeight(), this->getRotation(),
-                          this->getTranslationX(), this->getTranslationY());
 }

--- a/src/core/view/GeometryToolView.cpp
+++ b/src/core/view/GeometryToolView.cpp
@@ -27,7 +27,7 @@ void GeometryToolView::draw(cairo_t* cr) const {
         mask = createMask(cr);
         this->drawGeometryTool(mask.get());
     }
-    cairo_translate(cr, geometryTool->getTranslationX(), geometryTool->getTranslationY());
+    cairo_translate(cr, geometryTool->getOrigin().x, geometryTool->getOrigin().y);
     cairo_rotate(cr, geometryTool->getRotation());
     mask.paintTo(cr);
     cairo_restore(cr);


### PR DESCRIPTION
   * Remove data duplication between GeometryTool / GeometryToolinputHandler
   * Feed keyboard events after other tools but before navigation

Fix #5689 