### PR TITLE
Modify some simple Chinese terms to traditional Chinese

### DIFF
--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -20,7 +20,7 @@ msgstr ""
 #: ../src/core/control/AudioController.cpp:120
 msgid "Audio folder not set or invalid! Recording won't work!\n"
 "Please set the recording folder under \"Preferences > Audio recording\""
-msgstr "未設置音訊存放目錄或目錄位置不合法, 無法錄製聲音, 請到\"偏好設置 > 音訊錄製\"設定音訊存放目錄"
+msgstr "未設定音訊存放目錄或目錄位置不合法, 無法錄製聲音, 請到\"偏好設定 > 音訊錄製\"設定音訊存放目錄"
 
 #: ../src/core/control/Control.cpp:230
 msgid "Filesystem error: {1}"
@@ -36,7 +36,7 @@ msgstr ""
 
 #: ../src/core/control/Control.cpp:581
 msgid "The Toolbarconfiguration \"{1}\" is predefined, would you create a copy to edit?"
-msgstr "工具條配置\"{1}\"是預置的，要產生一個拷貝到編輯?"
+msgstr "工具條配置\"{1}\"是預置的，要產生一個複製到編輯?"
 
 #: ../src/core/control/Control.cpp:584 ../src/core/control/Control.cpp:1553
 msgid "Yes"
@@ -80,7 +80,7 @@ msgstr ""
 
 #: ../src/core/control/Control.cpp:866
 msgid "No pdf pages available to append. You may need to reopen the document first."
-msgstr "沒有可以添加的PDF頁面。您可能需要重新開啟文件檔。"
+msgstr "沒有可以新增的PDF頁面。您可能需要重新開啟檔案。"
 
 #: ../src/core/control/Control.cpp:880
 msgid "Unable to retrieve pdf page."
@@ -90,7 +90,7 @@ msgstr "無法獲取PDF頁面。"
 msgid "Do not open Autosave files. They may will be overwritten!\n"
 "Copy the files to another folder.\n"
 "Files from Folder {1} cannot be opened."
-msgstr "請勿開啟自動保存檔案，否則它們可能會被覆寫！\n"
+msgstr "請勿開啟自動儲存檔案，否則它們可能會被覆寫！\n"
 "請將這些檔案複製到另一個檔案夾。\n"
 "檔案夾 {1} 內的檔案無法開啟。"
 
@@ -100,7 +100,7 @@ msgstr "檔案: {1}"
 
 #: ../src/core/control/Control.cpp:1530
 msgid "Error opening file \"{1}\""
-msgstr "打開檔案\"{1}\"出錯"
+msgstr "開啟檔案\"{1}\"出錯"
 
 #: ../src/core/control/Control.cpp:1555
 msgid "File version mismatch"
@@ -108,7 +108,7 @@ msgstr ""
 
 #: ../src/core/control/Control.cpp:1556
 msgid "The file being loaded has a file format version newer than the one currently supported by this version of Xournal++, so it may not load properly. Open anyways?"
-msgstr "正在開啟的檔案格式版本筆目前Xournal++支持的文件格式版本更新， 可能無法正確開啟，仍要開啟？"
+msgstr "正在開啟的檔案格式版本筆目前Xournal++支援的檔案格式版本更新， 可能無法正確開啟，仍要開啟？"
 
 #: ../src/core/control/Control.cpp:1579
 msgid "Error reading PDF file \"{1}\"\n"
@@ -160,15 +160,15 @@ msgstr "選色"
 
 #: ../src/core/control/Control.cpp:1947
 msgid "Unsaved Document"
-msgstr "未保存文檔"
+msgstr "未儲存文件"
 
 #: ../src/core/control/Control.cpp:2098
 msgid "Document file was removed."
-msgstr "文檔已刪除。"
+msgstr "文件已刪除。"
 
 #: ../src/core/control/Control.cpp:2098
 msgid "This document is not saved yet."
-msgstr "此文件尚未存檔"
+msgstr "此檔案尚未存檔"
 
 #: ../src/core/control/Control.cpp:2100
 msgid "Save As..."
@@ -178,7 +178,7 @@ msgstr "另存為..."
 #: ../src/core/gui/dialog/XojSaveDlg.cpp:80
 #: ../src/core/gui/toolbarMenubar/ToolMenuHandler.cpp:286
 msgid "Save"
-msgstr "保存"
+msgstr "儲存"
 
 #: ../src/core/control/Control.cpp:2103
 msgid "Discard"
@@ -200,7 +200,7 @@ msgstr "錯誤：{1}"
 
 #: ../src/core/control/CrashHandler.cpp:42
 msgid "Successfully saved document to \"{1}\""
-msgstr "文檔已經保存為\"{1}\""
+msgstr "文件已經儲存為\"{1}\""
 
 #: ../src/core/control/DeviceListHelper.cpp:95
 msgid "mouse"
@@ -216,7 +216,7 @@ msgstr "橡皮"
 
 #: ../src/core/control/DeviceListHelper.cpp:101
 msgid "cursor"
-msgstr "光標"
+msgstr "鼠標"
 
 #: ../src/core/control/DeviceListHelper.cpp:104
 msgid "keyboard"
@@ -248,15 +248,15 @@ msgstr "PDF檔案成功建立"
 
 #: ../src/core/control/LatexController.cpp:79
 msgid "Global template file does not exist. Please check your settings."
-msgstr "全局模板檔案不存在，請檢查設定。"
+msgstr "全域性模板檔案不存在，請檢查設定。"
 
 #: ../src/core/control/LatexController.cpp:84
 msgid "Failed to read global template file. Please check your settings."
-msgstr "無法讀取全局模板檔案。請檢查設定。"
+msgstr "無法讀取全域性模板檔案。請檢查設定。"
 
 #: ../src/core/control/LatexController.cpp:90
 msgid "Global template file is not a regular file. Please check your settings. "
-msgstr "全局模板檔案格式不正確，請檢查設定。 "
+msgstr "全域性模板檔案格式不正確，請檢查設定。 "
 
 #: ../src/core/control/LatexController.cpp:236
 msgid "Latex generation encountered an error: {1} (exit code: {2})"
@@ -264,11 +264,11 @@ msgstr "LaTeX 產生遇到錯誤: {1} (退出代碼: {2})"
 
 #: ../src/core/control/LatexController.cpp:302
 msgid "Could not load LaTeX PDF file: {1}"
-msgstr "無法加載LaTeX PDF文檔: {1}"
+msgstr "無法載入LaTeX PDF文件: {1}"
 
 #: ../src/core/control/LatexController.cpp:307
 msgid "Could not load LaTeX PDF file"
-msgstr "無法加載LaTeX PDF文檔"
+msgstr "無法載入LaTeX PDF文件"
 
 #: ../src/core/control/PageBackgroundChangeController.cpp:110
 #: ../src/core/control/xojfile/LoadHandler.cpp:471
@@ -279,8 +279,8 @@ msgstr "讀入PDF出錯：{1}"
 #: ../src/core/control/PageBackgroundChangeController.cpp:271
 msgid "You don't have any PDF pages to select from. Cancel operation.\n"
 "Please select another background type: Menu \"Journal\" → \"Configure Page Template\"."
-msgstr "您没有任何可以選擇的 PDF 頁面。操作取消。\n"
-"請選擇另一個背景類型：點擊“日记”菜單 → “配置頁面模板”。"
+msgstr "您沒有任何可以選擇的 PDF 頁面。操作取消。\n"
+"請選擇另一個背景類型：點選“日記”選單 → “配置頁面模板”。"
 
 #: ../src/core/control/PdfCache.cpp:124
 msgid "PDF background missing"
@@ -320,11 +320,11 @@ msgstr ""
 
 #: ../src/core/control/XournalMain.cpp:169
 msgid "Open Logfile"
-msgstr "打開日誌檔案"
+msgstr "開啟日誌檔案"
 
 #: ../src/core/control/XournalMain.cpp:170
 msgid "Open Logfile directory"
-msgstr "打開日誌檔案目錄"
+msgstr "開啟日誌檔案目錄"
 
 #: ../src/core/control/XournalMain.cpp:171
 msgid "Delete Logfile"
@@ -336,7 +336,7 @@ msgstr ""
 
 #: ../src/core/control/XournalMain.cpp:194
 msgid "Xournal++ crashed last time. Would you like to restore the last edited file?"
-msgstr "Xournal++ 上次崩溃了。您想恢復最後一個编辑的文件？"
+msgstr "Xournal++ 上次崩潰了。您想恢復最後一個編輯的檔案？"
 
 #: ../src/core/control/XournalMain.cpp:197
 msgid "Recovery file detected"
@@ -361,7 +361,7 @@ msgid "<span foreground='red' size='x-large'>Missing the needed UI file:\n"
 "  Not relative\n"
 "  Not in the Working Path\n"
 "  Not in {2}"
-msgstr "<span foreground='red' size='x-large'>遺失必須的使用者界面檔案：\n"
+msgstr "<span foreground='red' size='x-large'>遺失必須的使用者介面檔案：\n"
 "<b>{1}</b></span>\n"
 "無法在任何位置找到他們。\n"
 "  不在相對位置\n"
@@ -421,7 +421,7 @@ msgid "Export FILE as image files (one per page)\n"
 "                                 Guess the output format from the extension of IMGFILE\n"
 "                                 Supported formats: .png, .svg"
 msgstr "將檔案輸出成圖片檔 (每頁一個)\n"
-"                                 從 IMGFILE 的擴展推測輸出檔格式\n"
+"                                 從 IMGFILE 的擴充套件推測輸出檔格式\n"
 "                                 支援格式：.png, .svg"
 
 #: ../src/core/control/XournalMain.cpp:670
@@ -471,7 +471,7 @@ msgstr "設定PNG輸出的DPI. 預設值是300\n"
 msgid "Set page width for PNG exports\n"
 "                                 No effect without -i/--create-img=foo.png\n"
 "                                 Ignored if --export-png-dpi is used"
-msgstr "設定PNG導出頁面的寬度\n"
+msgstr "設定PNG匯出頁面的寬度\n"
 "                                 No effect without -i/--create-img=foo.png\n"
 "                                 Ignored if --export-png-dpi is used"
 
@@ -546,20 +546,20 @@ msgstr "svg圖形"
 
 #: ../src/core/control/jobs/CustomExportJob.cpp:32
 msgid "Xournal (Compatibility)"
-msgstr "Xournal (兼容)"
+msgstr "Xournal (相容)"
 
 #: ../src/core/control/jobs/CustomExportJob.cpp:129
 #: ../src/core/control/jobs/SaveJob.cpp:138
 msgid "Save file error: {1}"
-msgstr "保存文件錯誤: {1}"
+msgstr "儲存檔案錯誤: {1}"
 
 #: ../src/core/control/jobs/ImageExport.cpp:108
 msgid "Unsupported graphics format: "
-msgstr "不支援的圖像格式: "
+msgstr "不支援的影像格式: "
 
 #: ../src/core/control/jobs/ImageExport.cpp:168
 msgid "Error save image #1"
-msgstr "保存圖片錯誤 #1"
+msgstr "儲存圖片錯誤 #1"
 
 #: ../src/core/control/jobs/ImageExport.cpp:177
 msgid "Error while exporting the pdf background: I cannot find the pdf page number "
@@ -567,7 +567,7 @@ msgstr "PDF 背景匯出錯誤：找不到頁碼 "
 
 #: ../src/core/control/jobs/ImageExport.cpp:201
 msgid "Error save image #2"
-msgstr "保存圖片錯誤 #2"
+msgstr "儲存圖片錯誤 #2"
 
 #: ../src/core/control/jobs/PdfExportJob.cpp:15
 msgid "PDF Export"
@@ -609,7 +609,7 @@ msgstr "{1}圖層"
 
 #: ../src/core/control/pagetype/PageTypeHandler.cpp:25
 msgid "Could not load pagetemplates.ini file"
-msgstr "無法加載 pagetemplates.ini 文檔"
+msgstr "無法載入 pagetemplates.ini 文件"
 
 #: ../src/core/control/pagetype/PageTypeHandler.cpp:29
 msgid "Plain"
@@ -683,19 +683,19 @@ msgstr ""
 
 #: ../src/core/control/xojfile/LoadHandler.cpp:133
 msgid "The file is no valid .xopp file (Mimetype missing): \"{1}\""
-msgstr "文件不是有效的 .xopp 文件 (Mimetype missing): \"{1}\""
+msgstr "檔案不是有效的 .xopp 檔案 (Mimetype missing): \"{1}\""
 
 #: ../src/core/control/xojfile/LoadHandler.cpp:141
 msgid "The file is no valid .xopp file (Mimetype wrong): \"{1}\""
-msgstr "文件不是有效的 .xopp 文件 (Mimetype wrong): \"{1}\""
+msgstr "檔案不是有效的 .xopp 檔案 (Mimetype wrong): \"{1}\""
 
 #: ../src/core/control/xojfile/LoadHandler.cpp:150
 msgid "The file is no valid .xopp file (Version missing): \"{1}\""
-msgstr "文件不是有效的 .xopp 文件 (Version missing): \"{1}\""
+msgstr "檔案不是有效的 .xopp 檔案 (Version missing): \"{1}\""
 
 #: ../src/core/control/xojfile/LoadHandler.cpp:163
 msgid "The file is not a valid .xopp file (Version string corrupted): \"{1}\""
-msgstr "文件不是有效的 .xopp 文件 (Version string corrupted): \"{1}\""
+msgstr "檔案不是有效的 .xopp 檔案 (Version string corrupted): \"{1}\""
 
 #: ../src/core/control/xojfile/LoadHandler.cpp:172
 msgid "Failed to open content.xml in zip archive: \"{1}\""
@@ -703,11 +703,11 @@ msgstr "從壓縮檔開啟 content.xml 失敗: \"{1}\""
 
 #: ../src/core/control/xojfile/LoadHandler.cpp:180
 msgid "Could not open file: \"{1}\""
-msgstr "不能打開檔案\"{1}\""
+msgstr "不能開啟檔案\"{1}\""
 
 #: ../src/core/control/xojfile/LoadHandler.cpp:247
 msgid "XML Parser error: {1}"
-msgstr "XML 分析错误：{1}"
+msgstr "XML 分析錯誤：{1}"
 
 #: ../src/core/control/xojfile/LoadHandler.cpp:250
 msgid "Unknown parser error"
@@ -715,7 +715,7 @@ msgstr "未知解析器的錯誤"
 
 #: ../src/core/control/xojfile/LoadHandler.cpp:261
 msgid "Document is not complete (maybe the end is cut off?)"
-msgstr "文檔檔案不完整"
+msgstr "文件檔案不完整"
 
 #: ../src/core/control/xojfile/LoadHandler.cpp:265
 msgid "Document is corrupted (no pages found in file)"
@@ -727,16 +727,16 @@ msgstr "意外的根標籤: {1}"
 
 #: ../src/core/control/xojfile/LoadHandler.cpp:331
 msgid "Unexpected tag in document: \"{1}\""
-msgstr "文件中中意外的標籤: \"{1}\""
+msgstr "檔案中中意外的標籤: \"{1}\""
 
 #: ../src/core/control/xojfile/LoadHandler.cpp:380
 #: ../src/core/control/xojfile/LoadHandler.cpp:409
 msgid "Could not read image: {1}. Error message: {2}"
-msgstr "未能讀入圖像：{1}。錯誤提示為：{2}"
+msgstr "未能讀入影像：{1}。錯誤提示為：{2}"
 
 #: ../src/core/control/xojfile/LoadHandler.cpp:419
 msgid "Could not read page number for cloned background image: {1}."
-msgstr "無法讀取複製背景圖像的頁數: {1}."
+msgstr "無法讀取複製背景影像的頁數: {1}."
 
 #: ../src/core/control/xojfile/LoadHandler.cpp:427
 msgid "Unknown pixmap::domain type: {1}"
@@ -760,7 +760,7 @@ msgstr "未知的筆觸類型：“{1}“，設為圓形"
 
 #: ../src/core/control/xojfile/LoadHandler.cpp:627
 msgid "Unknown stroke type: \"{1}\", assuming pen"
-msgstr "未知的筆類別： \"{1}\"，假設爲畫筆"
+msgstr "未知的筆類別： \"{1}\"，假設為畫筆"
 
 #: ../src/core/control/xojfile/LoadHandler.cpp:798
 #: ../src/core/control/xojfile/LoadHandler.cpp:814
@@ -777,11 +777,11 @@ msgstr "無法開啟附件: {1}. 錯誤訊息：未提供有效檔案大小"
 
 #: ../src/core/control/xojfile/LoadHandler.cpp:826
 msgid "Could not open attachment: {1}. Error message: Could not read file"
-msgstr "無法打開附件: {1}。錯誤消息: 無法讀取文檔"
+msgstr "無法開啟附件: {1}。錯誤訊息: 無法讀取文件"
 
 #: ../src/core/control/xojfile/LoadHandler.cpp:835
 msgid "Could not open attachment: {1}. Error message: Could not write file"
-msgstr "無法開啟附件: {1}. 錯誤訊息：無法寫入文檔"
+msgstr "無法開啟附件: {1}. 錯誤訊息：無法寫入文件"
 
 #: ../src/core/control/xojfile/LoadHandler.cpp:1022
 msgid "Wrong count of points ({1})"
@@ -801,7 +801,7 @@ msgstr "找不到附件所需的暫存檔{1}"
 
 #: ../src/core/control/xojfile/LoadHandlerHelper.cpp:72
 msgid "Attribute color not set!"
-msgstr "顏色未設置"
+msgstr "顏色未設定"
 
 #: ../src/core/control/xojfile/LoadHandlerHelper.cpp:80
 msgid "Unknown color value \"{1}\""
@@ -847,7 +847,7 @@ msgstr "未能寫上背景\"{1}\"，不管啦繼續哦..."
 
 #: ../src/core/gui/GladeGui.cpp:25
 msgid "Error loading glade file \"{1}\" (try to load \"{2}\")"
-msgstr "加載glade檔案\"{1}\"出錯(嘗試加載\"{2}\")"
+msgstr "載入glade檔案\"{1}\"出錯(嘗試載入\"{2}\")"
 
 #: ../src/core/gui/PageView.cpp:388
 msgid "Unable to play audio recording {1}"
@@ -857,7 +857,7 @@ msgstr "無法播放錄音{1}"
 #: ../src/core/gui/sidebar/previews/base/SidebarPreviewBaseEntry.cpp:81
 #: ../src/core/gui/toolbarMenubar/ToolPageLayer.cpp:148
 msgid "Loading..."
-msgstr "加載中..."
+msgstr "載入中..."
 
 #: ../src/core/gui/PageView.cpp:979
 msgid "Scroll to page {1}"
@@ -878,11 +878,11 @@ msgstr ""
 
 #: ../src/core/gui/SearchBar.cpp:96
 msgid "Text not found"
-msgstr "文本未找到"
+msgstr "文字未找到"
 
 #: ../src/core/gui/SearchBar.cpp:139
 msgid "Text found once on page {1}"
-msgstr "文本在第{1}頁上找到"
+msgstr "文字在第{1}頁上找到"
 
 #: ../src/core/gui/SearchBar.cpp:140
 msgid "Text found {1} times on page {2} ({3} of {1})"
@@ -890,7 +890,7 @@ msgstr ""
 
 #: ../src/core/gui/SearchBar.cpp:145
 msgid "Text not found, searched on all pages"
-msgstr "找遍所有頁面未找到文本"
+msgstr "找遍所有頁面未找到文字"
 
 #: ../src/core/gui/dialog/AboutDialog.cpp:41
 msgid "Version"
@@ -910,7 +910,7 @@ msgstr "Git提交"
 
 #: ../src/core/gui/dialog/AboutDialog.cpp:61
 msgid "See the full list of contributors"
-msgstr "查看完整的貢獻者列表"
+msgstr "檢視完整的貢獻者列表"
 
 #: ../src/core/gui/dialog/AboutDialog.cpp:63
 msgid "GNU GPLv2 or later"
@@ -944,7 +944,7 @@ msgstr ""
 
 #: ../src/core/gui/dialog/ButtonConfigGui.cpp:57
 msgid "No device"
-msgstr "沒有設備"
+msgstr "沒有裝置"
 
 #: ../src/core/gui/dialog/ButtonConfigGui.cpp:78
 msgid "Tool - don't change"
@@ -968,7 +968,7 @@ msgstr "高亮"
 #: ../src/core/gui/dialog/ButtonConfigGui.cpp:82
 #: ../src/core/gui/toolbarMenubar/ToolMenuHandler.cpp:398
 msgid "Text"
-msgstr "文本"
+msgstr "文字"
 
 #: ../src/core/gui/dialog/ButtonConfigGui.cpp:83
 #: ../src/core/undo/InsertUndoAction.cpp:29
@@ -1096,7 +1096,7 @@ msgstr ""
 #: ../src/core/gui/dialog/FormatDialog.cpp:50
 #: ../src/core/gui/menus/popoverMenus/PageTypeSelectionPopover.cpp:163
 msgid "Custom"
-msgstr "設置"
+msgstr "設定"
 
 #: ../src/core/gui/dialog/LanguageConfigGui.cpp:47
 msgid "System Default"
@@ -1116,7 +1116,7 @@ msgstr "建立 Xournal++ 時已關閉 GtkSourceView！有些選項可能會無�
 
 #: ../src/core/gui/dialog/LatexSettingsPanel.cpp:142
 msgid "Unable to open global template file at {1}. Does it exist?"
-msgstr "無法打開全域模板檔案{1}。它存在嘛？"
+msgstr "無法開啟全域模板檔案{1}。它存在嘛？"
 
 #: ../src/core/gui/dialog/LatexSettingsPanel.cpp:153
 msgid "Sample LaTeX file generated successfully."
@@ -1133,7 +1133,7 @@ msgstr "錯誤:{1} 並不是正規檔案. 請檢查LaTex範本檔案之設定 "
 #: ../src/core/gui/dialog/PageTemplateDialog.cpp:115
 #: ../src/core/gui/dialog/XojSaveDlg.cpp:79
 msgid "Save File"
-msgstr "保存檔案"
+msgstr "儲存檔案"
 
 #: ../src/core/gui/dialog/PageTemplateDialog.cpp:115
 #: ../src/core/gui/dialog/XojOpenDlg.cpp:80
@@ -1151,7 +1151,7 @@ msgstr "預設啟用"
 
 #: ../src/core/gui/dialog/PluginDialogEntry.cpp:28
 msgid "default disabled"
-msgstr "默認禁用"
+msgstr "預設停用"
 
 #: ../src/core/gui/dialog/SelectBackgroundColorDialog.cpp:62
 msgid "Select background color"
@@ -1234,7 +1234,7 @@ msgstr "預定"
 
 #: ../src/core/gui/dialog/ToolbarManageDialog.cpp:39
 msgid "Customized"
-msgstr "設置過"
+msgstr "設定過"
 
 #: ../src/core/gui/dialog/ToolbarManageDialog.cpp:65
 msgid "Toolbars"
@@ -1260,7 +1260,7 @@ msgstr ""
 #: ../src/core/gui/dialog/XojOpenDlg.cpp:197
 #: ../src/core/gui/toolbarMenubar/ToolMenuHandler.cpp:285
 msgid "Open file"
-msgstr "打開檔案"
+msgstr "開啟檔案"
 
 #: ../src/core/gui/dialog/XojOpenDlg.cpp:155
 msgid "Annotate Pdf file"
@@ -1280,11 +1280,11 @@ msgstr "<b>...或者選擇已用圖片：</b>"
 
 #: ../src/core/gui/dialog/backgroundSelect/ImagesDialog.cpp:37
 msgid "Load file"
-msgstr "加載檔案"
+msgstr "載入檔案"
 
 #: ../src/core/gui/dialog/backgroundSelect/ImagesDialog.cpp:107
 msgid "This image could not be loaded. Error message: {1}"
-msgstr "無法加載此圖像。錯誤訊息: {1}"
+msgstr "無法載入此影像。錯誤訊息: {1}"
 
 #: ../src/core/gui/dialog/backgroundSelect/ImagesDialog.cpp:113
 msgid "This image could not be loaded."
@@ -1312,11 +1312,11 @@ msgstr "從工具列移除工具 {1} ID {2}"
 
 #: ../src/core/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:168
 msgid "Could not remove tool item {1} from Toolbar {2} on position {3}"
-msgstr "無法移除於工具列 {2}，位置為 {3} 的工具項目：{1}"
+msgstr "無法移除於工具列 {2}，位置為 {3} 的工具專案：{1}"
 
 #: ../src/core/gui/dialog/toolbarCustomize/ToolbarAdapter.cpp:173
 msgid "Could not remove tool item from Toolbar {1} on position {2}"
-msgstr "無法移除於 {1} 工具列，位置為 {2} 的工具項目"
+msgstr "無法移除於 {1} 工具列，位置為 {2} 的工具專案"
 
 #: ../src/core/gui/dialog/toolbarCustomize/ToolbarCustomizeDialog.cpp:61
 msgid "Separator"
@@ -1496,20 +1496,20 @@ msgstr "重複"
 
 #: ../src/core/gui/toolbarMenubar/ToolMenuHandler.cpp:303
 msgid "Cut"
-msgstr "剪切"
+msgstr "剪下"
 
 #: ../src/core/gui/toolbarMenubar/ToolMenuHandler.cpp:304
 msgid "Copy"
-msgstr "拷貝"
+msgstr "複製"
 
 #: ../src/core/gui/toolbarMenubar/ToolMenuHandler.cpp:305
 #: ../src/core/undo/AddUndoAction.cpp:72
 msgid "Paste"
-msgstr "粘貼"
+msgstr "貼上"
 
 #: ../src/core/gui/toolbarMenubar/ToolMenuHandler.cpp:307
 msgid "Search"
-msgstr "搜索"
+msgstr "搜尋"
 
 #: ../src/core/gui/toolbarMenubar/ToolMenuHandler.cpp:309
 #: ../src/core/undo/DeleteUndoAction.cpp:74
@@ -1558,7 +1558,7 @@ msgstr "放大"
 
 #: ../src/core/gui/toolbarMenubar/ToolMenuHandler.cpp:333
 msgid "Zoom fit to screen"
-msgstr "適合屏幕"
+msgstr "適合螢幕"
 
 #: ../src/core/gui/toolbarMenubar/ToolMenuHandler.cpp:334
 msgid "Zoom to 100%"
@@ -1632,7 +1632,7 @@ msgstr "虛線"
 
 #: ../src/core/gui/toolbarMenubar/ToolMenuHandler.cpp:379
 msgid "whiteout"
-msgstr "涂白"
+msgstr "塗白"
 
 #: ../src/core/gui/toolbarMenubar/ToolMenuHandler.cpp:380
 msgid "delete stroke"
@@ -1649,11 +1649,11 @@ msgstr "預設工具"
 #: ../src/core/gui/toolbarMenubar/ToolMenuHandler.cpp:403
 #: ../src/core/gui/toolbarMenubar/ToolPdfCombocontrol.cpp:14
 msgid "Select Linear PDF Text"
-msgstr "從 PDF 中的行中選擇文本"
+msgstr "從 PDF 中的行中選擇文字"
 
 #: ../src/core/gui/toolbarMenubar/ToolMenuHandler.cpp:405
 msgid "Select PDF Text in Rectangle"
-msgstr "選擇矩形中的 PDF 文本"
+msgstr "選擇矩形中的 PDF 文字"
 
 #: ../src/core/gui/toolbarMenubar/ToolMenuHandler.cpp:407
 msgid "Setsquare"
@@ -1686,7 +1686,7 @@ msgstr ""
 #: ../src/core/gui/toolbarMenubar/ToolMenuHandler.cpp:434
 #: ../src/core/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:18
 msgid "Select Object"
-msgstr "選擇對象"
+msgstr "選擇物件"
 
 #: ../src/core/gui/toolbarMenubar/ToolMenuHandler.cpp:436
 msgid "Vertical Space"
@@ -1784,7 +1784,7 @@ msgstr ""
 
 #: ../src/core/gui/toolbarMenubar/ToolPdfCombocontrol.cpp:15
 msgid "Select PDF Text In Rectangle"
-msgstr "選擇矩形中的 PDF 文本"
+msgstr "選擇矩形中的 PDF 文字"
 
 #: ../src/core/gui/toolbarMenubar/ToolSelectCombocontrol.cpp:28
 msgid "Selection dropdown menu"
@@ -1792,7 +1792,7 @@ msgstr ""
 
 #: ../src/core/gui/toolbarMenubar/ToolZoomSlider.cpp:70
 msgid "Zoom Slider"
-msgstr "縮放游標"
+msgstr "縮放遊標"
 
 #: ../src/core/gui/toolbarMenubar/model/ColorPalette.cpp:119
 msgctxt "Color"
@@ -1852,12 +1852,12 @@ msgstr ""
 #: ../src/core/gui/toolbarMenubar/model/ToolbarModel.cpp:75
 msgctxt "as a noun: a copy of"
 msgid "Copy"
-msgstr "拷貝"
+msgstr "複製"
 
 #: ../src/core/model/Document.cpp:331 ../src/core/model/Document.cpp:340
 #: ../src/core/model/Document.cpp:343
 msgid "Document not loaded! ({1}), {2}"
-msgstr "文檔未加載！({1}), {2}"
+msgstr "文件未載入！({1}), {2}"
 
 #: ../src/core/model/Image.cpp:161 ../src/core/model/Image.cpp:171
 msgid "Error: "
@@ -1918,7 +1918,7 @@ msgstr "latex"
 #: ../src/core/undo/AddUndoAction.cpp:97
 #: ../src/core/undo/DeleteUndoAction.cpp:99
 msgid "text"
-msgstr "文本"
+msgstr "文字"
 
 #: ../src/core/undo/ColorUndoAction.cpp:97
 msgid "Change color"
@@ -1926,7 +1926,7 @@ msgstr "改變顏色"
 
 #: ../src/core/undo/EmergencySaveRestore.cpp:22
 msgid "Emergency saved document"
-msgstr "緊急保存檔案"
+msgstr "緊急儲存檔案"
 
 #: ../src/core/undo/FillUndoAction.cpp:88
 msgid "Change stroke fill"
@@ -1954,7 +1954,7 @@ msgstr "繪製筆劃"
 
 #: ../src/core/undo/InsertUndoAction.cpp:27
 msgid "Write text"
-msgstr "寫文本"
+msgstr "寫文字"
 
 #: ../src/core/undo/InsertUndoAction.cpp:31
 msgid "Insert latex"
@@ -2022,7 +2022,7 @@ msgstr "向後移動頁面"
 
 #: ../src/core/undo/TextBoxUndoAction.cpp:26
 msgid "Edit text"
-msgstr "編輯文本"
+msgstr "編輯文字"
 
 #: ../src/core/undo/UndoRedoHandler.cpp:114
 msgid "Could not undo \"{1}\"\n"
@@ -2062,7 +2062,7 @@ msgstr "ElementRange::parse(): 元素索引從 1 開始"
 
 #: ../src/util/OutputStream.cpp:27
 msgid "Error opening file: \"{1}\""
-msgstr "打開檔案\"{1}\"出錯"
+msgstr "開啟檔案\"{1}\"出錯"
 
 #: ../src/util/OutputStream.cpp:48
 msgid "Error writing data to file: \"{1}\""
@@ -2083,7 +2083,7 @@ msgstr ""
 #: ../src/util/PathUtil.cpp:199
 msgid "File couldn't be opened. You have to do it manually:\n"
 "URL: {1}"
-msgstr "未能打開檔案，請手動操作：\n"
+msgstr "未能開啟檔案，請手動操作：\n"
 "URL: {1}"
 
 #: ../src/util/PathUtil.cpp:309
@@ -2109,11 +2109,11 @@ msgstr "替換"
 
 #: ../src/util/XojMsgBox.cpp:215
 msgid "There was an error displaying help: {1}"
-msgstr "顯示說明文件時發生錯誤。{1}"
+msgstr "顯示說明檔案時發生錯誤。{1}"
 
 #: ../src/xoj-preview-extractor/xournalpp-thumbnailer.cpp:121
 msgid "xoj-preview-extractor: call with INPUT.xoj OUTPUT.png"
-msgstr "xoj-preview-extractor: 調用 INPUT.xoj OUTPUT.png"
+msgstr "xoj-preview-extractor: 呼叫 INPUT.xoj OUTPUT.png"
 
 #: ../src/xoj-preview-extractor/xournalpp-thumbnailer.cpp:134
 msgid "xoj-preview-extractor: file \"{1}\" is not .xoj file"
@@ -2121,23 +2121,23 @@ msgstr "xoj-preview-extractor: 檔案 \"{1}\" 不是 .xoj 檔案"
 
 #: ../src/xoj-preview-extractor/xournalpp-thumbnailer.cpp:138
 msgid "xoj-preview-extractor: opening input file \"{1}\" failed"
-msgstr "xoj-preview-extractor: 打開輸入檔案 \"{1}\" 失敗"
+msgstr "xoj-preview-extractor: 開啟輸入檔案 \"{1}\" 失敗"
 
 #: ../src/xoj-preview-extractor/xournalpp-thumbnailer.cpp:142
 msgid "xoj-preview-extractor: file \"{1}\" contains no preview"
-msgstr "xoj-preview-extractor: 檔案 \"{1}\" 没有預覽"
+msgstr "xoj-preview-extractor: 檔案 \"{1}\" 沒有預覽"
 
 #: ../src/xoj-preview-extractor/xournalpp-thumbnailer.cpp:147
 msgid "xoj-preview-extractor: no preview and page found, maybe an invalid file?"
-msgstr "xoj-preview-extractor: 沒有預覽及頁面，可能是無效的文件？"
+msgstr "xoj-preview-extractor: 沒有預覽及頁面，可能是無效的檔案？"
 
 #: ../src/xoj-preview-extractor/xournalpp-thumbnailer.cpp:187
 msgid "xoj-preview-extractor: could not find icon \"{1}\""
-msgstr "xoj-preview-extractor: 找不到圖標 \"{1}\""
+msgstr "xoj-preview-extractor: 找不到圖示 \"{1}\""
 
 #: ../src/xoj-preview-extractor/xournalpp-thumbnailer.cpp:205
 msgid "xoj-preview-extractor: opening output file \"{1}\" failed"
-msgstr "xoj-preview-extractor: 打開輸出檔案 \"{1}\" 失敗"
+msgstr "xoj-preview-extractor: 開啟輸出檔案 \"{1}\" 失敗"
 
 #: ../src/xoj-preview-extractor/xournalpp-thumbnailer.cpp:212
 msgid "xoj-preview-extractor: successfully extracted"
@@ -2173,7 +2173,7 @@ msgstr "原始碼 / 錯誤追蹤"
 
 #: ../ui/about.glade:283
 msgid "With help from the community"
-msgstr "来自社區的幫忙"
+msgstr "來自社群的幫忙"
 
 #: ../ui/about.glade:311
 msgid "License"
@@ -2224,8 +2224,8 @@ msgstr "全部"
 #: ../ui/exportSettings.glade:91
 msgid "<b>Document export settings</b>\n"
 "Set export parameters"
-msgstr "<b>文件輸出設定</b>\n"
-"設定輸出參數"
+msgstr "<b>檔案輸出設定</b>\n"
+"設定輸出引數"
 
 #: ../ui/exportSettings.glade:114
 msgid "Image quality"
@@ -2258,15 +2258,15 @@ msgstr "DPI"
 #. Keep the order the same as in listBackgroundType and use the translation of these types in parentheses.
 #: ../ui/exportSettings.glade:321
 msgid "Export the document without any background (None) or with PDF and image backgrounds only (No ruling) or with all background types (All)."
-msgstr "導出文件時不帶任何背景（無）或僅具有PDF和圖像背景（無規則）或全部背景類別。"
+msgstr "導出文件時不帶任何背景（無）或僅具有PDF和影像背景（無規則）或全部背景類別。"
 
 #: ../ui/exportSettings.glade:336
 msgid "Export layers progressively"
-msgstr "逐步導出圖層"
+msgstr "逐步匯出圖層"
 
 #: ../ui/exportSettings.glade:340
 msgid "If enabled, the layers of each page will be added one by one. The resulting PDF file can be used for a presentation."
-msgstr "如果啟用，每個頁面的圖層將被一層一層添加。 生成的 PDF 文件可用於演示。"
+msgstr "如果啟用，每個頁面的圖層將被一層一層新增。 生成的 PDF 檔案可用於演示。"
 
 #: ../ui/goto.glade:23
 msgid "Go to Page"
@@ -2274,11 +2274,11 @@ msgstr "轉到頁"
 
 #: ../ui/latexSettings.glade:36
 msgid "Always check LaTeX dependencies before running"
-msgstr "執行前總是检查 LaTeX 依賴關係"
+msgstr "執行前總是檢查 LaTeX 依賴關係"
 
 #: ../ui/latexSettings.glade:40
 msgid "If enabled, check that required LaTeX packages are installed and that the LaTeX commands are available before running the LaTeX tool."
-msgstr "如果啟用，請在運行 LaTeX 工具之前檢查是否安裝了所需的 LaTeX 包以及 LaTeX 命令是否可用。"
+msgstr "如果啟用，請在執行 LaTeX 工具之前檢查是否安裝了所需的 LaTeX 包以及 LaTeX 命令是否可用。"
 
 #: ../ui/latexSettings.glade:48
 msgid "General LaTeX tool settings"
@@ -2290,7 +2290,7 @@ msgstr ""
 
 #: ../ui/latexSettings.glade:105
 msgid "The LaTeX file to use as a template for the LaTeX tool."
-msgstr "LaTeX 文件用作 LaTeX 工具的模板。"
+msgstr "LaTeX 檔案用作 LaTeX 工具的模板。"
 
 #: ../ui/latexSettings.glade:107
 msgid "Global template file path"
@@ -2298,7 +2298,7 @@ msgstr "全域範本檔案路徑"
 
 #: ../ui/latexSettings.glade:119
 msgid "The following strings will be substituted in the global template file when running the LaTeX tool:"
-msgstr "運行 LaTeX 工具時，將在全局模板文件中替換以下字符串："
+msgstr "執行 LaTeX 工具時，將在全域性模板檔案中替換以下字串："
 
 #: ../ui/latexSettings.glade:133
 msgid "%%XPP_TOOL_INPUT%%"
@@ -2310,7 +2310,7 @@ msgstr "在 LaTeX 工具中鍵入的數學模式公式。"
 
 #: ../ui/latexSettings.glade:158
 msgid "Choose a global LaTeX template file"
-msgstr "選擇LaTex全局模板文件"
+msgstr "選擇LaTex全域性模板檔案"
 
 #: ../ui/latexSettings.glade:170
 msgid "%%XPP_TEXT_COLOR%%"
@@ -2318,7 +2318,7 @@ msgstr "%%XPP_TEXT_COLOR%%"
 
 #: ../ui/latexSettings.glade:182
 msgid "The current color of the Text Tool, in hex RGB format."
-msgstr "當前文字工具的顏色格式為16進制。"
+msgstr "當前文字工具的顏色格式為16進位制。"
 
 #: ../ui/latexSettings.glade:195
 msgid "Template file settings"
@@ -2334,11 +2334,11 @@ msgstr "測試配置"
 
 #: ../ui/latexSettings.glade:249
 msgid "Test if the current configuration is valid by running the LaTeX generation command on the global template file with a test formula."
-msgstr "通過使用測試公式對全局模板文件運行 LaTeX 生成命令來測試當前配置是否有效。"
+msgstr "透過使用測試公式對全域性模板檔案執行 LaTeX 生成命令來測試當前配置是否有效。"
 
 #: ../ui/latexSettings.glade:265
 msgid "LaTeX executable settings"
-msgstr "LaTeX 執行设置"
+msgstr "LaTeX 執行設定"
 
 #: ../ui/latexSettings.glade:340
 msgid "Line numbers"
@@ -2366,7 +2366,7 @@ msgstr "字型： "
 
 #: ../ui/latexSettings.glade:469
 msgid "Pick the Editor's Font"
-msgstr "選擇編輯器字體"
+msgstr "選擇編輯器字型"
 
 #: ../ui/latexSettings.glade:507
 msgid "Editor settings"
@@ -2380,15 +2380,15 @@ msgstr " = 浮動工具箱 (實驗功能) ="
 msgid "<b>Empty Toolbox</b>\n"
 "            <i>Menu: View/Toolbars</i>"
 msgstr "<b>空工具箱</b>\n"
-"            <i>菜單：查看/工具列</i>"
+"            <i>選單：檢視/工具列</i>"
 
 #: ../ui/main.glade:421
 msgid "Find previous occurrence of the search string"
-msgstr "向上查找搜索字串"
+msgstr "向上查詢搜尋字串"
 
 #: ../ui/main.glade:443
 msgid "Find next occurrence of the search string"
-msgstr "向下查找搜索字串"
+msgstr "向下查詢搜尋字串"
 
 #: ../ui/main.glade:645
 msgid "Copy selected text"
@@ -2404,11 +2404,11 @@ msgstr "將所選文字加上底線"
 
 #: ../ui/main.glade:707
 msgid "Strikethrough selected text"
-msgstr "為選中文字添加刪除線"
+msgstr "為選中文字新增刪除線"
 
 #: ../ui/main.glade:727
 msgid "Toggle standard / region text selection"
-msgstr "切換標準/區域文本選擇"
+msgstr "切換標準/區域文字選擇"
 
 #: ../ui/pageFormat.glade:28
 msgid "Paper Format"
@@ -2460,7 +2460,7 @@ msgstr "複製當前頁面背景"
 
 #: ../ui/pageTemplate.glade:124
 msgid "Copy the background of the current page instead of using the background set above."
-msgstr "複製當前頁面的背景，而不是使用上面設置的背景。"
+msgstr "複製當前頁面的背景，而不是使用上面設定的背景。"
 
 #: ../ui/pageTemplate.glade:179
 msgid "<b>Background Color</b>"
@@ -2496,7 +2496,7 @@ msgstr ""
 
 #: ../ui/plugin.glade:81
 msgid "Plugin changes are only applied after Xournal++ is restarted"
-msgstr "插件僅在Xournal++重新啟動後生效"
+msgstr "外掛僅在Xournal++重新啟動後生效"
 
 #: ../ui/pluginEntry.glade:51
 msgid "Author: "
@@ -2544,7 +2544,7 @@ msgstr "慣性"
 
 #: ../ui/settings.glade:285
 msgid "Xournal++ Preferences"
-msgstr "Xournal++偏好設置"
+msgstr "Xournal++偏好設定"
 
 #: ../ui/settings.glade:346
 msgid "<i>If the document already was saved you can find it in the same folder with the extension .autosave.xopp\n"
@@ -2569,7 +2569,7 @@ msgstr "自動儲存中"
 
 #: ../ui/settings.glade:469
 msgid "<i>This name will be proposed if you save a new document.</i>"
-msgstr "<i>如果您保存新文檔，系統會建議使用此名稱。</i>"
+msgstr "<i>如果您儲存新文件，系統會建議使用此名稱。</i>"
 
 #: ../ui/settings.glade:502 ../ui/settings.glade:671
 msgid "Default name: "
@@ -2649,19 +2649,19 @@ msgstr ""
 
 #: ../ui/settings.glade:807
 msgid "Enable Autoloading of Journals"
-msgstr "啟用日誌的自動加載"
+msgstr "啟用日誌的自動載入"
 
 #: ../ui/settings.glade:812
 msgid "If you open a PDF and there is a Xournal file with the same name it will open the xoj file."
-msgstr "如果您打開 PDF 並且有一個同名的 Xournal 文件，它將打開 xoj 文件。"
+msgstr "如果您開啟 PDF 並且有一個同名的 Xournal 檔案，它將開啟 xoj 檔案。"
 
 #: ../ui/settings.glade:823
 msgid "Enable autoloading of most recent file on application startup"
-msgstr "啟動時自動讀取上次打開的文件"
+msgstr "啟動時自動讀取上次開啟的檔案"
 
 #: ../ui/settings.glade:828
 msgid "If enabled Xournal++ will open the most recent document automatically that you can continue editing your last saved document."
-msgstr "如果啟用， Xournal++ 將自動打開最近的文檔，您可以繼續編輯上次保存的文檔。"
+msgstr "如果啟用， Xournal++ 將自動開啟最近的文件，您可以繼續編輯上次儲存的文件。"
 
 #: ../ui/settings.glade:843
 msgid "Autoloading"
@@ -2669,7 +2669,7 @@ msgstr "自動載入"
 
 #: ../ui/settings.glade:871
 msgid "Load / Save"
-msgstr "加載/保存"
+msgstr "載入/儲存"
 
 #: ../ui/settings.glade:917
 msgid "<i>Assign device classes to each input device of your system. Only change these values if your devices are not correctly matched. (e.g. your pen shows up as touchscreen)</i>"
@@ -2681,7 +2681,7 @@ msgstr "輸入裝置"
 
 #: ../ui/settings.glade:985
 msgid "Enable drawing outside of window <i>(Drawing will not stop at the border of the window)</i>"
-msgstr "啟用窗口外繪圖<i>（繪圖不會在窗口邊界處停止）</i>"
+msgstr "啟用視窗外繪圖<i>（繪圖不會在視窗邊界處停止）</i>"
 
 #: ../ui/settings.glade:1003
 msgid "Drag LEFT from start point acts like shift key is being held.\n"
@@ -2696,18 +2696,18 @@ msgstr "從起點向左拖動就像按住 shift 鍵一樣。\n"
 #: ../ui/settings.glade:1014
 msgid "Merge button events with stylus tip events\n"
 "\t    <i>(Check this if</i> \"<tt>xsetwacom get *deviceId* TabletPCButton</tt>\" <i>returns</i> \"<tt>on</tt>\"<i>)</i>"
-msgstr "將按鈕事件與觸控筆點擊事件合併\n"
+msgstr "將按鈕事件與觸控筆點選事件合併\n"
 "<i>(如果</i> \"<tt>xsetwacom get *deviceId* TabletPCButton</tt>\" <i>返回</i> \"<tt>on</tt>\"<i> ，請勾選這一向)</i>"
 
 #: ../ui/settings.glade:1033
 msgid "Slower strokes are assigned a greater pressure than faster strokes, if pressure information is absent.\n\n"
 "<i>This feature may be useful for devices that lack pressure sensitivity. For example, a mouse or touchscreen.</i>"
 msgstr "如果缺少壓力訊息，緩速筆劃的壓力要大於更快的筆劃。\n\n"
-"<i>此功能可能對缺乏筆壓感應的設備有用。例如，滑鼠或觸控螢幕。</i>"
+"<i>此功能可能對缺乏筆壓感應的裝置有用。例如，滑鼠或觸控螢幕。</i>"
 
 #: ../ui/settings.glade:1041
 msgid "Enable Pressure Inference <i>(Guess pressure from drawing speed when device-supplied pressure is not available)</i>"
-msgstr "啟用壓力推斷<i>（當設備提供的壓力不可用時，根據繪圖速度猜測壓力）</i>"
+msgstr "啟用壓力推斷<i>（當裝置提供的壓力不可用時，根據繪圖速度猜測壓力）</i>"
 
 #: ../ui/settings.glade:1059
 msgid "Options"
@@ -2719,7 +2719,7 @@ msgstr "平均方法"
 
 #: ../ui/settings.glade:1122
 msgid "<i>Pick an input stabilization algorithm and its parameters</i>"
-msgstr "<i>選擇輸入穩定算法及其參數</i>"
+msgstr "<i>選擇輸入穩定演算法及其引數</i>"
 
 #: ../ui/settings.glade:1138
 msgid "Buffersize"
@@ -2767,7 +2767,7 @@ msgstr "5"
 
 #: ../ui/settings.glade:1261 ../ui/settings.glade:1281
 msgid "Gaussian parameter: the higher, the more stabilization and the more lag between your cursor and the painting tip."
-msgstr "高斯参数：值越大，線條月穩定，光標到筆劃末端的缺口也越大。"
+msgstr "高斯引數：值越大，線條月穩定，游標到筆劃末端的缺口也越大。"
 
 #: ../ui/settings.glade:1263
 msgid "0,50"
@@ -2839,7 +2839,7 @@ msgstr "滑鼠"
 
 #: ../ui/settings.glade:1697
 msgid "<i>Pressure Sensitivity allows you to draw lines with different widths, depending on how much pressure you apply to the pen. If your tablet does not support this feature this setting has no effect.</i>"
-msgstr "<i>筆壓感應 允許您繪製不同寬度的線條，具體取決於您對筆施加的壓力。 如果您的平板電腦不支持此功能，則此設置無效。</i>"
+msgstr "<i>筆壓感應 允許您繪製不同寬度的線條，具體取決於您對筆施加的壓力。 如果您的平板電腦不支援此功能，則此設定無效。</i>"
 
 #: ../ui/settings.glade:1711
 msgid "Enable Pressure Sensitivity"
@@ -2847,7 +2847,7 @@ msgstr "啟用筆壓感應"
 
 #: ../ui/settings.glade:1741
 msgid "<i>Some devices report unexpectedly small or large pressures. This can be fixed by setting a minimum pressure or scaling the pressure reported by the device.</i>"
-msgstr "<i>一些設備報告出乎意料的小或大壓力。 這可以通過設置最小壓力或縮放設備報告的壓力來解決。</i>"
+msgstr "<i>一些裝置報告出乎意料的小或大壓力。 這可以透過設定最小壓力或縮放裝置報告的壓力來解決。</i>"
 
 #: ../ui/settings.glade:1763
 msgid "Minimum Pressure:"
@@ -2867,7 +2867,7 @@ msgstr "筆壓感應"
 
 #: ../ui/settings.glade:1873
 msgid "<i>With some setup, pen strokes have artifacts at their beginning. This can be avoided by ignoring the first few events/stroke-points when the pen touches the screen.</i>"
-msgstr "<i>通過一些設置，筆劃在開始時會出現偽影。 這可以通過忽略筆觸摸屏幕時的前幾個事件/筆劃點來避免。</i>"
+msgstr "<i>透過一些設定，筆劃在開始時會出現偽影。 這可以透過忽略筆觸控式螢幕幕時的前幾個事件/筆劃點來避免。</i>"
 
 #: ../ui/settings.glade:1891
 msgid "Ignore the first"
@@ -2935,7 +2935,7 @@ msgstr "手寫筆"
 
 #: ../ui/settings.glade:2237
 msgid "<i>You can configure devices, not identified by GTK as touchscreen, to behave as if they were one.</i>"
-msgstr "<i>您可以配置未被 GTK 識別為觸摸屏的設備，使其表現得像一個設備。</i>"
+msgstr "<i>您可以配置未被 GTK 識別為觸控式螢幕的裝置，使其表現得像一個裝置。</i>"
 
 #: ../ui/settings.glade:2270 ../ui/settings.glade:2858
 #: ../ui/settingsDeviceClassConfig.glade:39
@@ -2944,7 +2944,7 @@ msgstr "觸控螢幕"
 
 #: ../ui/settings.glade:2297
 msgid "<i>If your hardware does not support hand recognition, Xournal++ can disable your touchscreen when your pen is near the screen.</i>"
-msgstr "<i>如果您的硬件不支持手部識別，當您的筆靠近屏幕時，Xournal++ 可以禁用您的觸摸屏。</i>"
+msgstr "<i>如果您的硬體不支援手部識別，當您的筆靠近螢幕時，Xournal++ 可以停用您的觸控式螢幕。</i>"
 
 #: ../ui/settings.glade:2311
 msgid "Enable internal Hand Recognition"
@@ -2952,7 +2952,7 @@ msgstr "啟用手勢感知"
 
 #: ../ui/settings.glade:2341
 msgid "Disabling Method"
-msgstr "禁用方法"
+msgstr "停用方法"
 
 #: ../ui/settings.glade:2352
 msgid "Timeout"
@@ -2964,11 +2964,11 @@ msgstr "自動偵測"
 
 #: ../ui/settings.glade:2395
 msgid "s <i>(after which the touchscreen will be reactivated again)</i>"
-msgstr "s <i>(在此之後觸控螢幕將被重新激活)</i>"
+msgstr "s <i>(在此之後觸控螢幕將被重新啟用)</i>"
 
 #: ../ui/settings.glade:2440
 msgid "<i>Specify commands that are called once Hand Recognition triggers. The commands will be executed in the UI Thread, make sure they are not blocking!</i>"
-msgstr "<i>指定一旦觸發手部識別就調用的命令。 命令將在 UI 線程中執行，請確保它們沒有阻塞！</i>"
+msgstr "<i>指定一旦觸發手部識別就呼叫的命令。 命令將在 UI 執行緒中執行，請確保它們沒有阻塞！</i>"
 
 #: ../ui/settings.glade:2463
 msgid "Enable"
@@ -3021,7 +3021,7 @@ msgstr "縮放手勢"
 
 #: ../ui/settings.glade:2733
 msgid "<i>Use the touchscreen like a multi-touch-aware pen.</i>"
-msgstr "<i>像使用多點觸控筆一樣使用觸摸屏。</i>"
+msgstr "<i>像使用多點觸控筆一樣使用觸控式螢幕。</i>"
 
 #: ../ui/settings.glade:2747
 msgid "Enable touch drawing"
@@ -3037,11 +3037,11 @@ msgstr "觸控繪圖"
 
 #: ../ui/settings.glade:2794
 msgid "<i>Disabling GTK's built-in touchscreen scrolling can work around scrolling bugs on some platforms. Consider changing this setting if you experience jumps/sudden changes in scroll position when attempting to scroll with a touchscreen.</i>"
-msgstr "<i>禁用 GTK 的內置觸摸屏滾動可以解決某些平台上的滾動錯誤。 如果您在嘗試使用觸摸屏滾動時遇到滾動位置跳躍/突然變化，請考慮更改此設置。</i>"
+msgstr "<i>停用 GTK 的內建觸控式螢幕滾動可以解決某些平臺上的滾動錯誤。 如果您在嘗試使用觸控式螢幕滾動時遇到滾動位置跳躍/突然變化，請考慮更改此設定。</i>"
 
 #: ../ui/settings.glade:2808
 msgid "Disable GTK's built-in inertial scroll functionality (requires restart)."
-msgstr "禁用 GTK 内置的管性滾動功能。（需要重啟）"
+msgstr "停用 GTK 內建的管性滾動功能。（需要重啟）"
 
 #: ../ui/settings.glade:2827
 msgid "Touch Scrolling"
@@ -3053,7 +3053,7 @@ msgstr "在啟動時顯示選單列"
 
 #: ../ui/settings.glade:2932
 msgid "<i>Toggle visibility of menubar with F10</i>"
-msgstr "<i>使用 F10 切換菜單欄的可見性</i>"
+msgstr "<i>使用 F10 切換選單欄的可見性</i>"
 
 #: ../ui/settings.glade:2950
 msgid "Show filepath in title bar"
@@ -3165,7 +3165,7 @@ msgstr ""
 
 #: ../ui/settings.glade:3401
 msgid "Cursor icon for pen"
-msgstr "筆的鼠標圖案"
+msgstr "筆的滑鼠圖案"
 
 #: ../ui/settings.glade:3416
 msgctxt "stylus cursor uses no icon"
@@ -3185,19 +3185,19 @@ msgstr "粗筆圖示"
 #: ../ui/settings.glade:3419
 msgctxt "stylus cursor uses system cursor"
 msgid "System cursor"
-msgstr "系統游標"
+msgstr "系統遊標"
 
 #: ../ui/settings.glade:3444
 msgid "Highlight cursor position"
-msgstr "高亮鼠標位置"
+msgstr "高亮滑鼠位置"
 
 #: ../ui/settings.glade:3449
 msgid "Draw a transparent circle around the cursor"
-msgstr "在光標周圍畫一個透明的圓圈"
+msgstr "在游標周圍畫一個透明的圓圈"
 
 #: ../ui/settings.glade:3467 ../ui/settings.glade:3610
 msgid "Choose the color to use for \"Highlight cursor position\""
-msgstr "選擇 “高亮鼠標位置” 所使用的颜色"
+msgstr "選擇 “高亮滑鼠位置” 所使用的顏色"
 
 #: ../ui/settings.glade:3481
 msgid "Circle Color"
@@ -3226,7 +3226,7 @@ msgstr "邊框顏色"
 
 #: ../ui/settings.glade:3656
 msgid "Cursor"
-msgstr "游標"
+msgstr "遊標"
 
 #: ../ui/settings.glade:3681
 msgid "Show sidebar on the right side"
@@ -3240,7 +3240,7 @@ msgstr "垂直捲動條左置"
 msgid "Left / Right-Handed"
 msgstr "左/右-慣用手"
 
-#: ../ui/settings.glade:3740
+#: ../ui/settings.glade:3740‰
 msgid "Page numbering  "
 msgstr ""
 
@@ -3270,11 +3270,11 @@ msgstr "隱藏垂直捲軸"
 
 #: ../ui/settings.glade:3834
 msgid "Disable scrollbar fade out"
-msgstr "禁用滾動條淡出"
+msgstr "停用捲軸淡出"
 
 #: ../ui/settings.glade:3852
 msgid "Scrollbars"
-msgstr "滾動條"
+msgstr "捲軸"
 
 #: ../ui/settings.glade:3906
 msgid "When an element is selected and moved past the visible portion of the canvas, pan the screen by an amount equal to this percentage of the visible part of the canvas. "
@@ -3344,7 +3344,7 @@ msgstr "效能"
 
 #: ../ui/settings.glade:4267
 msgid "View"
-msgstr "視圖"
+msgstr "檢視"
 
 #: ../ui/settings.glade:4316
 msgid "Speed for Ctrl + Scroll"
@@ -3364,7 +3364,7 @@ msgstr "<i>確保 100% 縮放元素的大小是自然的。 （需要重啟）</
 
 #: ../ui/settings.glade:4450
 msgid "<i>Put a ruler on your screen and move the slider until both rulers match.</i>"
-msgstr "<i>將尺放在屏幕上並移動滑塊，直到兩個尺匹配。</i>"
+msgstr "<i>將尺放在螢幕上並移動滑塊，直到兩個尺匹配。</i>"
 
 #: ../ui/settings.glade:4497
 msgid "The unit of the ruler is cm"
@@ -3380,7 +3380,7 @@ msgstr "縮放"
 
 #: ../ui/settings.glade:4598
 msgid "<i>If you add additional space beside the pages you can choose the area of the screen you would like to work on.</i>"
-msgstr "<i>如果您在頁面旁邊添加額外的空間，您可以選擇您想要處理的屏幕區域。</i>"
+msgstr "<i>如果您在頁面旁邊新增額外的空間，您可以選擇您想要處理的螢幕區域。</i>"
 
 #: ../ui/settings.glade:4721
 msgid "Add additional horizontal space"
@@ -3454,7 +3454,7 @@ msgstr "從起點向左拖動就像按住 shift 鍵一樣。\n"
 
 #: ../ui/settings.glade:5036
 msgid "Drawing Tools - Set Modifiers by Draw Direction (Experimental)"
-msgstr "繪圖工具 - 按繪製方向設置修改器（實驗性）"
+msgstr "繪圖工具 - 按繪製方向設定修改器（實驗性）"
 
 #: ../ui/settings.glade:5053
 msgid "Preserve line width"
@@ -3486,7 +3486,7 @@ msgstr "對已識別的形狀使用捕捉"
 
 #: ../ui/settings.glade:5194
 msgid "If activated, shapes that have been recognized by the shape recognizer will be snapped to the grid automatically. This may lead to unexpected results if you have the shape recognizer turned on while writing."
-msgstr "如果激活，已被形狀識別器識別的形狀將自動捕捉到網格。 如果您在書寫時打開了形狀識別器，這可能會導致意外結果。"
+msgstr "如果啟用，已被形狀識別器識別的形狀將自動捕捉到網格。 如果您在書寫時開啟了形狀識別器，這可能會導致意外結果。"
 
 #: ../ui/settings.glade:5209
 msgid "Snapping"
@@ -3499,7 +3499,7 @@ msgstr "最小筆刷尺寸"
 #: ../ui/settings.glade:5292
 msgctxt "Short taps/clicks will trigger special actions"
 msgid "Enable Tap action"
-msgstr "啟用點擊動作"
+msgstr "啟用點選動作"
 
 #: ../ui/settings.glade:5297
 msgid "Do not draw for inputs of short time and length unless it comes in short succession. Instead, show floating toolbox."
@@ -3538,13 +3538,13 @@ msgstr "請先選擇物件"
 
 #: ../ui/settings.glade:5406 ../ui/settings.glade:5436
 msgid "Try to select object first; if nothing selected then show floating toolbox if enabled."
-msgstr "嘗試先選擇對象； 如果未選擇任何內容，則如果啟用則顯示浮動工具箱。"
+msgstr "嘗試先選擇物件； 如果未選擇任何內容，則如果啟用則顯示浮動工具箱。"
 
 #: ../ui/settings.glade:5419
 msgid "All three conditions must be met before stroke is ignored.\n"
 "It must be short in time and length and we can't have ignored another stroke recently."
 msgstr "在忽略筆劃之前，必須滿足三個條件。\n"
-"它必須是短時間、短距離，且最近没有可忽略的另一条筆劃。"
+"它必須是短時間、短距離，且最近沒有可忽略的另一條筆劃。"
 
 #: ../ui/settings.glade:5422
 msgid "Settings:"
@@ -3556,7 +3556,7 @@ msgstr "顯示浮動工具箱"
 
 #: ../ui/settings.glade:5450
 msgid "Action on Tool Tap"
-msgstr "點擊工具時的動作"
+msgstr "點選工具時的動作"
 
 #: ../ui/settings.glade:5478
 msgid "<i>Re-render PDF backgrounds more often while zooming for better render quality.\n"
@@ -3566,8 +3566,8 @@ msgstr ""
 #: ../ui/settings.glade:5500
 msgid "When zoomed in on a high-resolution PDF, each re-render can take a long time. Setting this to a large value causes these re-renders to happen less often.\n\n"
 "Set this to 0% to always re-render on zoom."
-msgstr "當PDF放大至高分辨率时，每次重新渲染都可能需要很長時間，設置該值可以减少重新渲染的次數。\n"
-"設置为0時，縮放總是重新渲染。"
+msgstr "當PDF放大至高解析度時，每次重新渲染都可能需要很長時間，設定該值可以減少重新渲染的次數。\n"
+"設定為0時，縮放總是重新渲染。"
 
 #: ../ui/settings.glade:5503
 msgid "Re-render when the page's zoom changes by more than "
@@ -3618,7 +3618,7 @@ msgstr ""
 
 #: ../ui/settings.glade:5842
 msgid "<i>Audio recordings are currently stored in a separate folder and referenced from the journal.</i>"
-msgstr "<i>錄音現在儲存在獨立的資料夾裏, 並可以在您的日記中引用.</i>"
+msgstr "<i>錄音現在儲存在獨立的資料夾裡, 並可以在您的日記中引用.</i>"
 
 #: ../ui/settings.glade:5861 ../ui/settings.glade:5897
 msgid "Storage Folder"
@@ -3631,12 +3631,12 @@ msgstr "選擇資料夾"
 #: ../ui/settings.glade:5924
 msgid "<i>Specify the audio devices used for recording and playback of audio attachments.\n"
 "If available select <small><tt>pulse</tt></small> as input / output device.</i>"
-msgstr "<i>指定用於錄製和播放音頻附件的音頻設備。\n"
-"如果可用，請選擇 <small><tt>pulse</tt></small> 作為輸入/輸出設備。</i>"
+msgstr "<i>指定用於錄製和播放音訊附件的音訊裝置。\n"
+"如果可用，請選擇 <small><tt>pulse</tt></small> 作為輸入/輸出裝置。</i>"
 
 #: ../ui/settings.glade:5948
 msgid "Input Device"
-msgstr "輸入設備"
+msgstr "輸入裝置"
 
 #: ../ui/settings.glade:5970
 msgid "Output Device"
@@ -3648,7 +3648,7 @@ msgstr "音訊裝置"
 
 #: ../ui/settings.glade:6030
 msgid "Sample Rate"
-msgstr "採樣率"
+msgstr "取樣率"
 
 #: ../ui/settings.glade:6041
 msgid "Gain"
@@ -3696,11 +3696,11 @@ msgstr ""
 
 #: ../ui/settingsButtonConfig.glade:20
 msgid "Device"
-msgstr "設備"
+msgstr "裝置"
 
 #: ../ui/settingsButtonConfig.glade:44
 msgid "Disable drawing for this device"
-msgstr "取消此設備繪製"
+msgstr "取消此裝置繪製"
 
 #: ../ui/settingsButtonConfig.glade:125
 msgid "Eraser Type - don't change"
@@ -3712,7 +3712,7 @@ msgstr "標準"
 
 #: ../ui/settingsButtonConfig.glade:127
 msgid "Whiteout"
-msgstr "涂白"
+msgstr "塗白"
 
 #: ../ui/settingsButtonConfig.glade:128
 msgid "Delete stroke"
@@ -3736,7 +3736,7 @@ msgstr "已停用"
 
 #: ../ui/settingsDeviceClassConfig.glade:36
 msgid "Mouse+Keyboard Combo"
-msgstr "滑鼠+键盘结合"
+msgstr "滑鼠+鍵盤結合"
 
 #: ../ui/texdialog.glade:18
 msgid "Insert Latex"
@@ -3744,11 +3744,11 @@ msgstr "插入LaTeX"
 
 #: ../ui/texdialog.glade:37
 msgid "Enter / edit LaTeX Text"
-msgstr "輸入/编辑 LaTeX 文本"
+msgstr "輸入/編輯 LaTeX 文字"
 
 #: ../ui/texdialog.glade:98
 msgid "TeX Source"
-msgstr "TeX源碼"
+msgstr "TeX原始碼"
 
 #: ../ui/texdialog.glade:116
 msgid "Output generated by the LaTeX command."
@@ -4431,4 +4431,3 @@ msgstr ""
 #: ../resources-templates/com.github.xournalpp.xournalpp.xml.in:12
 msgid "Xournal++ page template file"
 msgstr ""
-


### PR DESCRIPTION
This pull request includes updates to the Traditional Chinese (`zh_TW`) translation file (`po/zh_TW.po`) for Xournal++. The changes focus on improving translation accuracy, consistency, and localization quality. The most important changes include revisions to terminology, adjustments for grammatical correctness, and enhancements to localization for better alignment with native language conventions.

### Terminology Updates:
* Replaced "保存" with "儲存" for consistency in translations related to saving files. [[1]](diffhunk://#diff-a64fa7d47df62b3312bb1d5d2d1570677ae9a1a022c5cee34d1af4a975f2c240L163-R171) [[2]](diffhunk://#diff-a64fa7d47df62b3312bb1d5d2d1570677ae9a1a022c5cee34d1af4a975f2c240L181-R181) [[3]](diffhunk://#diff-a64fa7d47df62b3312bb1d5d2d1570677ae9a1a022c5cee34d1af4a975f2c240L203-R203)
* Updated "文件" to "檔案" in contexts where "檔案" is more commonly used in Traditional Chinese. [[1]](diffhunk://#diff-a64fa7d47df62b3312bb1d5d2d1570677ae9a1a022c5cee34d1af4a975f2c240L103-R111) [[2]](diffhunk://#diff-a64fa7d47df62b3312bb1d5d2d1570677ae9a1a022c5cee34d1af4a975f2c240L686-R718)

### Localization Enhancements:
* Changed "光標" to "鼠標" to better reflect native terminology for "cursor."
* Adjusted "日记" to "日記" and "菜單" to "選單" for improved localization of UI-related terms.

### Grammatical and Stylistic Improvements:
* Revised translations for grammatical correctness, e.g., changing "加載" to "載入" and "文本" to "文字." [[1]](diffhunk://#diff-a64fa7d47df62b3312bb1d5d2d1570677ae9a1a022c5cee34d1af4a975f2c240L860-R860) [[2]](diffhunk://#diff-a64fa7d47df62b3312bb1d5d2d1570677ae9a1a022c5cee34d1af4a975f2c240L881-R893)
* Improved phrasing for user-facing messages, such as "無法打開附件" to "無法開啟附件."

### Consistency in Technical Terms:
* Unified translations for technical terms like "影像格式" instead of "圖像格式."
* Standardized translations for LaTeX-related messages, e.g., "全局模板" changed to "全域性模板."

### Error Message Refinements:
* Enhanced clarity in error messages, such as "XML 分析错误" updated to "XML 分析錯誤."
* Improved accuracy in descriptions of file-related errors, e.g., "檔案不是有效的 .xopp 檔案."

These updates aim to provide a more accurate and user-friendly experience for Traditional Chinese speakers using Xournal++.