### PR TITLE
Use windows-latest runner to run CI

### DIFF
--- a/.github/available-build-targets.json
+++ b/.github/available-build-targets.json
@@ -29,7 +29,7 @@
   "windows_targets": {
     "windows": {
         "displayed_name": "Windows",
-        "runner": "windows-2019",
+        "runner": "windows-latest",
         "build_portable": "true"
       }
     }


### PR DESCRIPTION
The github runner image windows-2019 has been retired. Now using windows-latest.

Merging once the CI clears