### PR TITLE
Add brand-colours

### DIFF
--- a/resources-templates/com.github.xournalpp.xournalpp.appdata.xml.in
+++ b/resources-templates/com.github.xournalpp.xournalpp.appdata.xml.in
@@ -65,6 +65,10 @@
       <caption>LaTeX with customized preamble</caption>
     </screenshot>
   </screenshots>
+  <branding>
+    <color type="primary" scheme_preference="light">#77767b</color>
+    <color type="primary" scheme_preference="dark">#241f31</color>
+  </branding>
   <launchable type="desktop-id">com.github.xournalpp.xournalpp.desktop</launchable>
   <provides>
     <id>xournalpp.desktop</id>


### PR DESCRIPTION
I've picked light and dark gray, since Xournal++ is a productivity tool and it makes most sense to be a bit conservative.

## Info about it 
https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/quality-guidelines#brand-colors

## Preview
![Screenshot from 2025-07-08 09-44-55](https://github.com/user-attachments/assets/e6cf0b8a-ef99-4308-99d7-f44e362ef2bc)
