### PR TITLE
Enable "Merge button events with stylus tip events" by default on Windows

### DIFF
--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -202,7 +202,14 @@ void Settings::loadDefault() {
 
     this->numIgnoredStylusEvents = 0;
 
+#ifdef _WIN32
+    // This option should be on on Windows:
+    // GTK (at least until 3.24.49) only creates GDK_BUTTON_PRESS events on mouse-events or stylus-down-events
+    this->inputSystemTPCButton = true;
+#else
     this->inputSystemTPCButton = false;
+#endif
+
     this->inputSystemDrawOutsideWindow = true;
 
     this->strokeFilterIgnoreTime = 150;


### PR DESCRIPTION
This only affects new installations. Long time users are not affected by this change.

We may want to enforce the setting on long time users as well. I'm not sure how to best do that though, so I'll leave it for another PR.

Merging once the CI clear.