### PR TITLE
Pass Text Tool color to external LaTeX editor via environment variable

### DIFF
--- a/src/core/gui/dialog/ExtEdLatexDialog.cpp
+++ b/src/core/gui/dialog/ExtEdLatexDialog.cpp
@@ -116,8 +116,16 @@ void ExtEdLatexDialog::openEditor() {
         return;
     }
 
+    xoj::util::GObjectSPtr<GSubprocessLauncher> launcher(g_subprocess_launcher_new(G_SUBPROCESS_FLAGS_NONE),
+                                                         xoj::util::adopt);
+
+    Color textColor = texCtrl->control->getToolHandler()->getTool(TOOL_TEXT).getColor();
+    std::string colorStr = Util::rgb_to_hex_string(textColor).substr(1);
+
+    g_subprocess_launcher_setenv(launcher.get(), "XPP_TEXT_COLOR", colorStr.c_str(), TRUE);
+
     xoj::util::GObjectSPtr<GSubprocess> process(
-            g_subprocess_newv(argv.get(), G_SUBPROCESS_FLAGS_NONE, xoj::util::out_ptr(err)), xoj::util::adopt);
+            g_subprocess_launcher_spawnv(launcher.get(), argv.get(), xoj::util::out_ptr(err)), xoj::util::adopt);
 
     if (err) {
         XojMsgBox::showErrorToUser(getWindow(), FS(_F("Could not spawn editor: {1}") % err->message));

--- a/ui/latexSettings.glade
+++ b/ui/latexSettings.glade
@@ -513,7 +513,7 @@
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
                                 <property name="halign">start</property>
-                                <property name="label" translatable="yes">You can optionally use an external editor program instead of the built-in editor. If you enable the option below, the provided editor command (defaulting to $EDITOR) will start with a popup that only shows a preview and potential error message instead of the normal one with a built-in editor.</property>
+                                <property name="label" translatable="yes">You can optionally use an external editor program instead of the built-in editor. If you enable the option below, the provided editor command (defaulting to $EDITOR) will start with a popup that only shows a preview and potential error message instead of the normal one with a built-in editor. The environment variable XPP_TEXT_COLOR is set to the current Text Tool color in hex RGB format.</property>
                                 <property name="wrap">True</property>
                               </object>
                               <packing>


### PR DESCRIPTION
This small PR introduces the XPP_TEXT_COLOR environment variable, which passes the current text tool color to external LaTeX editors.

When using the built-in LaTeX editor, Xournal++ injects the selected text color into the LaTeX template by replacing the placeholder %%XPP_TEXT_COLOR%% in a template latex file:
```
\definecolor{xpp_font_color}{HTML}{%%XPP_TEXT_COLOR%%}
```
The PR allows external editors to achieve the same behavior by accessing the XPP_TEXT_COLOR environment variable. The value is a lowercase hex string in the rrggbb format (e.g., 2a3b7f).

Note: This feature is intended for users who write editor wrappers or use programmable editors that can access environment variables and replace placeholders accordingly.