### PR TITLE
Update screenshots

### DIFF
--- a/resources-templates/com.github.xournalpp.xournalpp.appdata.xml.in
+++ b/resources-templates/com.github.xournalpp.xournalpp.appdata.xml.in
@@ -53,15 +53,15 @@
   <url type="homepage">https://xournalpp.github.io/</url>
   <screenshots>
     <screenshot type="default">
-      <image>https://raw.githubusercontent.com/xournalpp/xournalpp-examples/main/appdata/screenshots/note_taking_1600x900.png</image>
+      <image>https://raw.githubusercontent.com/xournalpp/xournalpp-examples/6aaf99756b0cc6a9d600b72490766330601daa67/appdata/screenshots_1.2.7/Note_taking.png</image>
       <caption>Note taking</caption>
     </screenshot>
     <screenshot>
-      <image>https://raw.githubusercontent.com/xournalpp/xournalpp-examples/main/appdata/screenshots/pdf_annotation_1600x900.png</image>
+      <image>https://raw.githubusercontent.com/xournalpp/xournalpp-examples/6aaf99756b0cc6a9d600b72490766330601daa67/appdata/screenshots_1.2.7/pdf_annotation.png</image>
       <caption>PDF annotation</caption>
     </screenshot>
     <screenshot>
-      <image>https://raw.githubusercontent.com/xournalpp/xournalpp-examples/main/appdata/screenshots/LaTeX_with_customized_preamble_1600x900.png</image>
+      <image>https://raw.githubusercontent.com/xournalpp/xournalpp-examples/6aaf99756b0cc6a9d600b72490766330601daa67/appdata/screenshots_1.2.7/LaTeX_with_customized_preamble.png</image>
       <caption>LaTeX with customized preamble</caption>
     </screenshot>
   </screenshots>


### PR DESCRIPTION
Taken with 1.2.7 on Fedora 42, these screenshots are more up-to-date an better adhere to the FreeDesktop standard.