### PR TITLE
Properly destroy custom widgets when gtk_widget_destroy() is called on them

### DIFF
--- a/src/core/gui/widgets/XournalWidget.cpp
+++ b/src/core/gui/widgets/XournalWidget.cpp
@@ -24,45 +24,22 @@
 
 using xoj::util::Rectangle;
 
-static void gtk_xournal_class_init(GtkXournalClass* klass);
-static void gtk_xournal_init(GtkXournal* xournal);
+/*
+ * Declares:
+ *      static void gtk_xournal_class_init(GtkXournalClass*);
+ *      static void gtk_xournal_init(GtkXournal*);
+ * Defines
+ *      gtk_xournal_parent_class (pointer to GtkWidgetClass instance)
+ *      GType gtk_xournal_get_type();
+ */
+G_DEFINE_TYPE(GtkXournal, gtk_xournal, GTK_TYPE_WIDGET)
+
 static void gtk_xournal_get_preferred_width(GtkWidget* widget, gint* minimal_width, gint* natural_width);
 static void gtk_xournal_get_preferred_height(GtkWidget* widget, gint* minimal_height, gint* natural_height);
 static void gtk_xournal_size_allocate(GtkWidget* widget, GtkAllocation* allocation);
 static void gtk_xournal_realize(GtkWidget* widget);
 static auto gtk_xournal_draw(GtkWidget* widget, cairo_t* cr) -> gboolean;
 static void gtk_xournal_dispose(GObject* object);
-
-auto gtk_xournal_get_type(void) -> GType {
-    static GType gtk_xournal_type = 0;
-
-    if (!gtk_xournal_type) {
-        static const GTypeInfo gtk_xournal_info = {sizeof(GtkXournalClass),
-                                                   // base initialize
-                                                   nullptr,
-                                                   // base finalize
-                                                   nullptr,
-                                                   // class initialize
-                                                   reinterpret_cast<GClassInitFunc>(gtk_xournal_class_init),
-                                                   // class finalize
-                                                   nullptr,
-                                                   // class data,
-                                                   nullptr,
-                                                   // instance size
-                                                   sizeof(GtkXournal),
-                                                   // n_preallocs
-                                                   0,
-                                                   // instance init
-                                                   reinterpret_cast<GInstanceInitFunc>(gtk_xournal_init),
-                                                   // value table
-                                                   nullptr};
-
-        gtk_xournal_type =
-                g_type_register_static(GTK_TYPE_WIDGET, "GtkXournal", &gtk_xournal_info, static_cast<GTypeFlags>(0));
-    }
-
-    return gtk_xournal_type;
-}
 
 auto gtk_xournal_new(XournalView* view, InputContext* inputContext) -> GtkWidget* {
     GtkXournal* xoj = GTK_XOURNAL(g_object_new(gtk_xournal_get_type(), nullptr));
@@ -87,7 +64,7 @@ static void gtk_xournal_class_init(GtkXournalClass* cptr) {
 
     widget_class->draw = gtk_xournal_draw;
 
-    reinterpret_cast<GObjectClass*>(widget_class)->dispose = gtk_xournal_dispose;
+    G_OBJECT_CLASS(cptr)->dispose = gtk_xournal_dispose;
 }
 
 auto gtk_xournal_get_visible_area(GtkWidget* widget, const XojPageView* p) -> Rectangle<double>* {
@@ -310,4 +287,6 @@ static void gtk_xournal_dispose(GObject* object) {
 
     delete xournal->input;
     xournal->input = nullptr;
+
+    G_OBJECT_CLASS(gtk_xournal_parent_class)->dispose(object);
 }

--- a/src/core/gui/widgets/ZoomCallib.cpp
+++ b/src/core/gui/widgets/ZoomCallib.cpp
@@ -13,7 +13,7 @@
 #include <cairo.h>    // for cairo_set_source_rgb, cairo_fill, cairo_move_to
 #include <gdk/gdk.h>  // for GdkWindowAttr, gdk_window_move_resize, gdk_wind...
 
-G_DEFINE_TYPE(ZoomCallib, zoomcallib, GTK_TYPE_WIDGET);  // NOLINT // @suppress("Unused static function")
+G_DEFINE_TYPE(ZoomCallib, zoomcallib, GTK_TYPE_WIDGET);
 
 static void zoomcallib_get_preferred_width(GtkWidget* widget, gint* minimal_width, gint* natural_width);
 static void zoomcallib_get_preferred_height(GtkWidget* widget, gint* minimal_height, gint* natural_height);
@@ -21,7 +21,6 @@ static void zoomcallib_get_preferred_height(GtkWidget* widget, gint* minimal_hei
 static void zoomcallib_size_allocate(GtkWidget* widget, GtkAllocation* allocation);
 static void zoomcallib_realize(GtkWidget* widget);
 static auto zoomcallib_draw(GtkWidget* widget, cairo_t* cr) -> gboolean;
-// static void zoomcallib_destroy(GtkObject* object);
 
 void zoomcallib_set_val(ZoomCallib* callib, gint val) {
     callib->val = val;

--- a/src/core/gui/widgets/gtkmenutooltogglebutton.cpp
+++ b/src/core/gui/widgets/gtkmenutooltogglebutton.cpp
@@ -49,8 +49,7 @@ enum { PROP_0, PROP_MENU };
 
 static gint signals[LAST_SIGNAL];
 
-G_DEFINE_TYPE(GtkMenuToolToggleButton, gtk_menu_tool_toggle_button,  // @suppress("Unused static function")
-              GTK_TYPE_TOGGLE_TOOL_BUTTON)
+G_DEFINE_TYPE(GtkMenuToolToggleButton, gtk_menu_tool_toggle_button, GTK_TYPE_TOGGLE_TOOL_BUTTON)
 
 static void gtk_menu_tool_toggle_button_construct_contents(GtkMenuToolToggleButton* button) {
     GtkMenuToolToggleButtonPrivate* priv = button->priv;
@@ -338,6 +337,8 @@ static void gtk_menu_tool_toggle_button_dispose(GObject* object) {
         g_signal_handlers_disconnect_by_func(button->priv->arrow_button,
                                              (gpointer)G_CALLBACK(arrow_button_button_press_event_cb), button);
     }
+
+    G_OBJECT_CLASS(gtk_menu_tool_toggle_button_parent_class)->dispose(object);
 }
 
 /**


### PR DESCRIPTION
Our custom widgets with their own dispose/destroy functions did not call their parent class' dispose/destroy. The lead to #6112: calling gtk_widget_destroy() didn't actually remove the widget from its hierarchy.

This PR:
1. ~~Removes custom dispose functions (GObject) in favour of destroy functions (GtkWidget).~~
2. Properly calls the parent class' (GtkWidgetClass) ~~destroy~~ dispose function.

This is a better fix to #6112 than #6577 was.