### PR TITLE
Expose new action system in Lua API and deprecate old one

### DIFF
--- a/plugins/BeamerPresentation/main.lua
+++ b/plugins/BeamerPresentation/main.lua
@@ -33,7 +33,7 @@ function BeamerClean()
         local prev = struct.pages[p-1].pdfBackgroundPageNo
         if app.getPageLabel(page) == app.getPageLabel(prev) then
             app.setCurrentPage(p)
-            app.uiAction({["action"]="ACTION_DELETE_PAGE"})
+            app.activateAction("delete-page")
         end
     end
 end

--- a/plugins/FitToContent/main.lua
+++ b/plugins/FitToContent/main.lua
@@ -50,7 +50,7 @@ local function fit_to_layer_or_selection(type)
 
     -- make the current layer invisible and add the moved strokes to a new layer
     app.setLayerVisibility(false)
-    app.layerAction("ACTION_NEW_LAYER")
+    app.activateAction("layer-new-above-current")
     app.setCurrentLayerName("moved for fitting")
     app.addStrokes{strokes=strokes}
 

--- a/plugins/HighlightPosition/main.lua
+++ b/plugins/HighlightPosition/main.lua
@@ -6,5 +6,5 @@ local toggleState = false;
 
 function laser()
   toggleState = not toggleState
-  app.uiAction({["action"] = "ACTION_HIGHLIGHT_POSITION", ["enabled"] = toggleState});
+  app.changeActionState("highlight-position", toggleState);
 end

--- a/plugins/ImageActions/main.lua
+++ b/plugins/ImageActions/main.lua
@@ -112,7 +112,7 @@ function Cb(mode)
   end
   app.clearSelection()
   app.addToSelection(refs)
-  app.uiAction({ action = "ACTION_DELETE" })
+  app.activateAction("delete")
   app.addImages({ images = imdata, allowUndoRedoAction = "grouped" })
 end
 
@@ -213,6 +213,6 @@ function Split(mode)
   end
   app.clearSelection()
   app.addToSelection(refs)
-  app.uiAction({ action = "ACTION_DELETE" })
+  app.activateAction("delete")
   app.addImages({ images = imdata, allowUndoRedoAction = "grouped" })
 end

--- a/plugins/LayerActions/main.lua
+++ b/plugins/LayerActions/main.lua
@@ -47,10 +47,7 @@ function proceed()
 
   local nextPdfPage = docStructure["pages"][nextPage]["pdfBackgroundPageNo"]
 
-  local sidebarPage = app.getSidebarPageNo()
-  app.setSidebarPageNo(2)
-  app.sidebarAction("COPY");
-  app.setSidebarPageNo(sidebarPage)
+  app.activateAction("duplicate-page")
 
   app.changeBackgroundPdfPageNr(nextPdfPage, false);
   app.refreshPage()

--- a/plugins/LayerActions/main.lua
+++ b/plugins/LayerActions/main.lua
@@ -81,8 +81,8 @@ function add()
 
   for i=1, numPages do
     app.setCurrentPage(i)
-    app.layerAction("ACTION_GOTO_TOP_LAYER")
-    app.layerAction("ACTION_NEW_LAYER")
+    app.activateAction("layer-goto-top")
+    app.activateAction("layer-new-above-current")
   end
 
   app.setCurrentPage(page)

--- a/plugins/LayerActions/main.lua
+++ b/plugins/LayerActions/main.lua
@@ -54,10 +54,10 @@ function proceed()
 
   app.changeBackgroundPdfPageNr(nextPdfPage, false);
   app.refreshPage()
-  app.uiAction({["action"]="ACTION_GOTO_NEXT"})
-  app.uiAction({["action"]="ACTION_DELETE_PAGE"})
+  app.activateAction("goto-next")
+  app.activateAction("delete-page")
   if currentPage < numPages -1 then
-    app.uiAction({["action"]="ACTION_GOTO_BACK"})
+    app.activateAction("goto-previous")
   end
 end
 

--- a/plugins/SpaceForNotes/main.lua
+++ b/plugins/SpaceForNotes/main.lua
@@ -22,7 +22,7 @@ function AddEmpty(mode)
         -- if mode is force => pred is set to true
         if pred then
             app.setCurrentPage(p)
-            app.uiAction{action="ACTION_NEW_PAGE_AFTER"}
+            app.activateAction("new-page-after")
         end
     end
 end

--- a/plugins/ToggleGrid/togglegrid.lua
+++ b/plugins/ToggleGrid/togglegrid.lua
@@ -8,10 +8,10 @@ local toggleState = false
 
 function toggleGridPaper()
   if toggleState == true then
-    app.uiAction({["action"] = "ACTION_GRID_SNAPPING", ["enabled"] = true});
+    app.changeState("grid-snapping", true);
     app.changeCurrentPageBackground("graph");
   else
-    app.uiAction({["action"] = "ACTION_GRID_SNAPPING", ["enabled"] = false});
+    app.changeState("grid-snapping", false);
     app.changeCurrentPageBackground("plain");
   end
   toggleState = not toggleState

--- a/plugins/luapi_application.def.lua
+++ b/plugins/luapi_application.def.lua
@@ -129,6 +129,23 @@ function app.registerUi(opts) end
 function app.changeActionState(action, state) end
 
 --- *
+--- Get the action's state. For actions with state from an enum
+--- (like ToolType, ToolSize, EraserSize, OrderChange) the return value should
+--- be compared to the app.C table of constants for consistency between different
+--- versions of Xournal++
+--- @param action Action
+--- 
+--- Example 1: if app.getActionState("select-tool") == app.C.Tool_text then
+---               print("Currently the text tool is selected")
+---            end
+--- Example 2: app.getActionState("set-layout-vertical")    -- whether the layout is vertical or not
+--- Example 3: app.getActionState("set-columns-or-rows")    -- number of columns (positive values) or rows (negative
+--- values) Example 4: app.getActionState("tool-color")             -- current color Example 5:
+--- app.getActionState("zoom")                   -- current zoom value Example 6:
+--- app.getActionState("tool-pen-line-style")    -- current pen line style (as a string)
+function app.getActionState(action) end
+
+--- *
 --- Activate the action, triggering callbacks. Actions with state from an enum
 --- (like ToolType, ToolSize, EraserSize, OrderChange) should be accessed via the app.C
 --- table of constants for consistency between different versions of Xournal++

--- a/plugins/luapi_application.def.lua
+++ b/plugins/luapi_application.def.lua
@@ -136,6 +136,10 @@ function app.changeActionState(action, state) end
 --- Example 3: app.activateAction("tool-fill")
 function app.activateAction(action, state) end
 
+--- THIS FUNCTION IS DEPRECATED AND WILL BE REMOVED SOON. Use applib_changeActionState or
+--- applib_activateAction instead.
+--- 
+--- @deprecated
 --- Execute an UI action (usually internally called from Toolbar / Menu)
 --- The argument consists of a Lua table with 3 keys: "action", "group" and "enabled"
 --- The key "group" is currently only used for debugging purpose and can safely be omitted.

--- a/plugins/luapi_application.def.lua
+++ b/plugins/luapi_application.def.lua
@@ -114,24 +114,28 @@ function app.openDialog(message, options, cb, error) end
 function app.registerUi(opts) end
 
 --- *
---- Change the action's state, triggering callbacks
+--- Change the action's state, triggering callbacks. Actions with state from an enum
+--- (like ToolType, ToolSize, EraserSize, OrderChange) should be accessed via the app.C
+--- table of constants for consistency between different versions of Xournal++
 --- @param action string
 --- @param state any
 --- 
---- Example 1: app.changeActionState("select-tool", 4)  -- but what does 4 mean?
+--- Example 1: app.changeActionState("select-tool",  app.C.Tool_text)
 --- Example 2: app.changeActionState("set-layout-vertical", false)
---- Example 3: app.changeActionState("set-columns-or-rows", -3)
---- Example 4: app.changeActionState("tool-color", 0xff0000)
+--- Example 3: app.changeActionState("set-columns-or-rows", -3)      # 3 rows
+--- Example 4: app.changeActionState("tool-color", 0xff0000)         # red color
 --- Example 5: app.changeActionState("zoom", 2.25)
 --- Example 6: app.changeActionState("tool-pen-line-style", "cust: 1 5 3 5")
 function app.changeActionState(action, state) end
 
 --- *
---- Activate the action, triggering callbacks
+--- Activate the action, triggering callbacks. Actions with state from an enum
+--- (like ToolType, ToolSize, EraserSize, OrderChange) should be accessed via the app.C
+--- table of constants for consistency between different versions of Xournal++
 --- @param action string
 --- @param state nilt | any
 --- 
---- Example 1: app.activateAction("arrange-selection-order", 1) -- but what does 1 mean?
+--- Example 1: app.activateAction("arrange-selection-order", app.C.OrderChange.bringForward)
 --- Example 2: app.activateAction("setsquare")
 --- Example 3: app.activateAction("tool-fill")
 function app.activateAction(action, state) end
@@ -932,3 +936,45 @@ function app.registerPlaceholder(id, description) end
 --- Updates the toolbar placeholder with the given value.
 function app.setPlaceholderValue(id, value) end
 
+---@enum
+app.C = {
+    ToolSize_veryThin = 0,
+    ToolSize_thin = 1,
+    ToolSize_medium = 2,
+    ToolSize_thick = 3,
+    ToolSize_veryThick = 4,
+    ToolSize_none = 5,
+    Tool_none = 0,
+    Tool_pen = 1,
+    Tool_eraser = 2,
+    Tool_highlighter = 3,
+    Tool_text = 4,
+    Tool_image = 5,
+    Tool_selectRect = 6,
+    Tool_selectRegion = 7,
+    Tool_selectMultiLayerRect = 8,
+    Tool_selectMultiLayerRegion = 9,
+    Tool_selectObject = 10,
+    Tool_playObject = 11,
+    Tool_verticalSpace = 12,
+    Tool_hand = 13,
+    Tool_drawRect = 14,
+    Tool_drawEllipse = 15,
+    Tool_drawArrow = 16,
+    Tool_drawDoubleArrow = 17,
+    Tool_drawCoordinateSystem = 18,
+    Tool_showFloatingToolbox = 19,
+    Tool_drawSpline = 20,
+    Tool_selectPdfTextLinear = 21,
+    Tool_selectPdfTextRect = 22,
+    Tool_laserPointerPen = 23,
+    Tool_laserPointerHighlighter = 24,
+    EraserType_none = 0,
+    EraserType_default = 1,
+    EraserType_whiteout = 2,
+    EraserType_deleteStroke = 3,
+    OrderChange_bringToFront = 0,
+    OrderChange_bringForward = 1,
+    OrderChange_sendBackward = 2,
+    OrderChange_sendToBack = 3,
+}

--- a/plugins/luapi_application.def.lua
+++ b/plugins/luapi_application.def.lua
@@ -154,6 +154,9 @@ function app.activateAction(action, state) end
 --- turns off the Ellipse drawing type
 function app.uiAction(opts) end
 
+--- THIS FUNCTION IS DEPRECATED AND WILL BE REMOVED SOON. Use applib_activateAction instead.
+--- 
+--- @deprecated
 --- Execute action from sidebar menu
 --- 
 --- @param action string the desired action
@@ -162,6 +165,9 @@ function app.uiAction(opts) end
 --- moves down the current page or layer, depending on which sidebar tab is selected
 function app.sidebarAction(action) end
 
+--- THIS FUNCTION IS DEPRECATED AND WILL BE REMOVED SOON. No substitute needed.
+--- 
+--- @deprecated
 --- Get the index of the currently active sidebar-page.
 --- 
 --- @return integer pageNr pageNr of the sidebar page
@@ -169,6 +175,9 @@ function app.sidebarAction(action) end
 --- Example: app.getSidebarPageNo() -- returns e.g. 1
 function app.getSidebarPageNo() end
 
+--- THIS FUNCTION IS DEPRECATED AND WILL BE REMOVED SOON. No substitute needed.
+--- 
+--- @deprecated
 --- Set the currently active sidebar-page by its index.
 --- 
 --- @param pageNr integer pageNr of the sidebar page

--- a/plugins/luapi_application.def.lua
+++ b/plugins/luapi_application.def.lua
@@ -117,7 +117,7 @@ function app.registerUi(opts) end
 --- Change the action's state, triggering callbacks. Actions with state from an enum
 --- (like ToolType, ToolSize, EraserSize, OrderChange) should be accessed via the app.C
 --- table of constants for consistency between different versions of Xournal++
---- @param action string
+--- @param action Action
 --- @param state any
 --- 
 --- Example 1: app.changeActionState("select-tool",  app.C.Tool_text)
@@ -132,8 +132,8 @@ function app.changeActionState(action, state) end
 --- Activate the action, triggering callbacks. Actions with state from an enum
 --- (like ToolType, ToolSize, EraserSize, OrderChange) should be accessed via the app.C
 --- table of constants for consistency between different versions of Xournal++
---- @param action string
---- @param state nilt | any
+--- @param action Action
+--- @param state nil | any
 --- 
 --- Example 1: app.activateAction("arrange-selection-order", app.C.OrderChange.bringForward)
 --- Example 2: app.activateAction("setsquare")
@@ -935,6 +935,121 @@ function app.registerPlaceholder(id, description) end
 --- Example: app.setPlaceholderValue("vi-mode", "Current mode")
 --- Updates the toolbar placeholder with the given value.
 function app.setPlaceholderValue(id, value) end
+
+---@alias Action
+---| "new-file"
+---| "open"
+---| "annotate-pdf"
+---| "save"
+---| "save-as"
+---| "export-as-pdf"
+---| "export-as"
+---| "print"
+---| "quit"
+---| "arrange-selection-order"
+---| "undo"
+---| "redo"
+---| "cut"
+---| "copy"
+---| "paste"
+---| "search"
+---| "select-all"
+---| "delete"
+---| "move-selection-layer-up"
+---| "move-selection-layer-down"
+---| "rotation-snapping"
+---| "grid-snapping"
+---| "preferences"
+---| "paired-pages-mode"
+---| "paired-pages-offset"
+---| "presentation-mode"
+---| "fullscreen"
+---| "show-sidebar"
+---| "show-toolbar"
+---| "set-layout-vertical"
+---| "set-layout-right-to-left"
+---| "set-layout-bottom-to-top"
+---| "set-columns-or-rows"
+---| "manage-toolbar"
+---| "customize-toolbar"
+---| "show-menubar"
+---| "zoom-in"
+---| "zoom-out"
+---| "zoom-100"
+---| "zoom-fit"
+---| "zoom"
+---| "goto-first"
+---| "goto-previous"
+---| "goto-page"
+---| "goto-next"
+---| "goto-last"
+---| "goto-next-annotated-page"
+---| "goto-previous-annotated-page"
+---| "new-page-before"
+---| "new-page-after"
+---| "new-page-at-end"
+---| "duplicate-page"
+---| "move-page-towards-beginning"
+---| "move-page-towards-end"
+---| "append-new-pdf-pages"
+---| "configure-page-template"
+---| "delete-page"
+---| "paper-format"
+---| "paper-background-color"
+---| "select-tool"
+---| "select-default-tool"
+---| "tool-draw-shape-recognizer"
+---| "tool-draw-rectangle"
+---| "tool-draw-ellipse"
+---| "tool-draw-arrow"
+---| "tool-draw-double-arrow"
+---| "tool-draw-coordinate-system"
+---| "tool-draw-line"
+---| "tool-draw-spline"
+---| "setsquare"
+---| "compass"
+---| "tool-pen-size"
+---| "tool-pen-line-style"
+---| "tool-pen-fill"
+---| "tool-pen-fill-opacity"
+---| "tool-eraser-size"
+---| "tool-eraser-type"
+---| "tool-highlighter-size"
+---| "tool-highlighter-fill"
+---| "tool-highlighter-fill-opacity"
+---| "tool-select-pdf-text-marker-opacity"
+---| "audio-record"
+---| "audio-pause-playback"
+---| "audio-stop-playback"
+---| "audio-seek-forwards"
+---| "audio-seek-backwards"
+---| "select-font"
+---| "font"
+---| "tex"
+---| "plugin-manager"
+---| "help"
+---| "demo"
+---| "about"
+---| "tool-size"
+---| "tool-fill"
+---| "tool-fill-opacity"
+---| "tool-color"
+---| "select-color"
+---| "layer-show-all"
+---| "layer-hide-all"
+---| "layer-new-above-current"
+---| "layer-new-below-current"
+---| "layer-copy"
+---| "layer-move-up"
+---| "layer-move-down"
+---| "layer-delete"
+---| "layer-merge-down"
+---| "layer-rename"
+---| "layer-goto-next"
+---| "layer-goto-previous"
+---| "layer-goto-top"
+---| "layer-active"
+---| "position-highlighting"
 
 ---@enum
 app.C = {

--- a/plugins/luapi_application.def.lua
+++ b/plugins/luapi_application.def.lua
@@ -179,6 +179,9 @@ function app.getSidebarPageNo() end
 --- Example: app.setSidebarPageNo(3) -- sets the sidebar-page to preview Layer
 function app.setSidebarPageNo(pageNr) end
 
+--- THIS FUNCTION IS DEPRECATED AND WILL BE REMOVED SOON. Use applib_activateAction instead.
+--- 
+--- @deprecated
 --- Execute action from layer controller
 --- 
 --- @param action string the desired action

--- a/plugins/luapi_application.def.lua
+++ b/plugins/luapi_application.def.lua
@@ -113,6 +113,29 @@ function app.openDialog(message, options, cb, error) end
 ---    that receives the mode. This is useful for callback functions that are shared among multiple menu entries.
 function app.registerUi(opts) end
 
+--- *
+--- Change the action's state, triggering callbacks
+--- @param action string
+--- @param state any
+--- 
+--- Example 1: app.changeActionState("select-tool", 4)  -- but what does 4 mean?
+--- Example 2: app.changeActionState("set-layout-vertical", false)
+--- Example 3: app.changeActionState("set-columns-or-rows", -3)
+--- Example 4: app.changeActionState("tool-color", 0xff0000)
+--- Example 5: app.changeActionState("zoom", 2.25)
+--- Example 6: app.changeActionState("tool-pen-line-style", "cust: 1 5 3 5")
+function app.changeActionState(action, state) end
+
+--- *
+--- Activate the action, triggering callbacks
+--- @param action string
+--- @param state nilt | any
+--- 
+--- Example 1: app.activateAction("arrange-selection-order", 1) -- but what does 1 mean?
+--- Example 2: app.activateAction("setsquare")
+--- Example 3: app.activateAction("tool-fill")
+function app.activateAction(action, state) end
+
 --- Execute an UI action (usually internally called from Toolbar / Menu)
 --- The argument consists of a Lua table with 3 keys: "action", "group" and "enabled"
 --- The key "group" is currently only used for debugging purpose and can safely be omitted.

--- a/scripts/lua_def_file.py
+++ b/scripts/lua_def_file.py
@@ -228,6 +228,8 @@ if __name__ == "__main__":
     with open(fn_out, 'w') as f_out:
         print("---@meta", file=f_out)
         print("app = {}", file=f_out)
+
+        # Add functions
         funcs = dict(gather_functions(file_name))
         funcs_emitted = set()
         for x in docs_for_functions(file_name, funcs):

--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -451,7 +451,7 @@ void Control::selectAlpha(OpacityFeature feature) {
             alpha = this->toolHandler->getSelectPDFTextMarkerOpacity();
             break;
         default:
-            g_warning("Unhandled OpacityFeature for selectAlpha event: %s", opacityFeatureToString(feature).c_str());
+            g_warning("Unhandled OpacityFeature for selectAlpha event: %s", opacityFeatureToString(feature).data());
             Stacktrace::printStacktrace();
             break;
     }
@@ -469,7 +469,7 @@ void Control::selectAlpha(OpacityFeature feature) {
                         break;
                     default:
                         g_warning("Unhandled OpacityFeature for callback of SelectOpacityDialog: %s",
-                                  opacityFeatureToString(feature).c_str());
+                                  opacityFeatureToString(feature).data());
                         Stacktrace::printStacktrace();
                         break;
                 }

--- a/src/core/control/ToolEnums.cpp
+++ b/src/core/control/ToolEnums.cpp
@@ -1,99 +1,23 @@
 #include "ToolEnums.h"
 
+#include <algorithm>  // for find, remove_if
+
 #include "model/StrokeStyle.h"
 
-auto toolSizeToString(ToolSize size) -> std::string {
-    switch (size) {
-        case TOOL_SIZE_NONE:
-            return "none";
-        case TOOL_SIZE_VERY_FINE:
-            return "veryThin";
-        case TOOL_SIZE_FINE:
-            return "thin";
-        case TOOL_SIZE_MEDIUM:
-            return "medium";
-        case TOOL_SIZE_THICK:
-            return "thick";
-        case TOOL_SIZE_VERY_THICK:
-            return "veryThick";
-        default:
-            return "";
-    }
-}
 
 auto toolSizeFromString(const std::string& size) -> ToolSize {
-    if (size == "veryThin") {
-        return TOOL_SIZE_VERY_FINE;
-    }
-    if (size == "thin") {
-        return TOOL_SIZE_FINE;
-    }
-    if (size == "medium") {
-        return TOOL_SIZE_MEDIUM;
-    }
-    if (size == "thick") {
-        return TOOL_SIZE_THICK;
-    }
-    if (size == "veryThick") {
-        return TOOL_SIZE_VERY_THICK;
+    auto it = std::find(toolSizeNames.begin(), toolSizeNames.end(), size);
+    if (it != toolSizeNames.end()) {
+        return static_cast<ToolSize>(std::distance(toolSizeNames.begin(), it));
     }
     return TOOL_SIZE_NONE;
 }
 
-auto drawingTypeToString(DrawingType type) -> std::string {
-    switch (type) {
-        case DRAWING_TYPE_DONT_CHANGE:
-            return "dontChange";
-        case DRAWING_TYPE_DEFAULT:
-            return "default";
-        case DRAWING_TYPE_LINE:
-            return "line";
-        case DRAWING_TYPE_RECTANGLE:
-            return "rectangle";
-        case DRAWING_TYPE_ELLIPSE:
-            return "ellipse";
-        case DRAWING_TYPE_ARROW:
-            return "arrow";
-        case DRAWING_TYPE_DOUBLE_ARROW:
-            return "doubleArrow";
-        case DRAWING_TYPE_SHAPE_RECOGNIZER:
-            return "strokeRecognizer";
-        case DRAWING_TYPE_COORDINATE_SYSTEM:
-            return "drawCoordinateSystem";
-        case DRAWING_TYPE_SPLINE:
-            return "spline";
-        default:
-            return "";
-    }
-}
 
 auto drawingTypeFromString(const std::string& type) -> DrawingType {
-    if (type == "dontChange") {
-        return DRAWING_TYPE_DONT_CHANGE;
-    }
-    if (type == "line") {
-        return DRAWING_TYPE_LINE;
-    }
-    if (type == "rectangle") {
-        return DRAWING_TYPE_RECTANGLE;
-    }
-    if (type == "ellipse") {
-        return DRAWING_TYPE_ELLIPSE;
-    }
-    if (type == "arrow") {
-        return DRAWING_TYPE_ARROW;
-    }
-    if (type == "doubleArrow") {
-        return DRAWING_TYPE_DOUBLE_ARROW;
-    }
-    if (type == "strokeRecognizer") {
-        return DRAWING_TYPE_SHAPE_RECOGNIZER;
-    }
-    if (type == "drawCoordinateSystem") {
-        return DRAWING_TYPE_COORDINATE_SYSTEM;
-    }
-    if (type == "spline") {
-        return DRAWING_TYPE_SPLINE;
+    auto it = std::find(drawingTypeNames.begin(), drawingTypeNames.end(), type);
+    if (it != drawingTypeNames.end()) {
+        return static_cast<DrawingType>(std::distance(drawingTypeNames.begin(), it));
     }
     return DRAWING_TYPE_DEFAULT;
 }
@@ -113,196 +37,37 @@ auto requiresClearedSelection(ToolType type) -> bool {
            type == TOOL_VERTICAL_SPACE;
 }
 
-auto toolTypeToString(ToolType type) -> std::string {
-    switch (type) {
-        case TOOL_NONE:
-            return "none";
-        case TOOL_PEN:
-            return "pen";
-        case TOOL_ERASER:
-            return "eraser";
-        case TOOL_HIGHLIGHTER:
-            return "highlighter";
-        case TOOL_TEXT:
-            return "text";
-        case TOOL_IMAGE:
-            return "image";
-        case TOOL_SELECT_RECT:
-            return "selectRect";
-        case TOOL_SELECT_REGION:
-            return "selectRegion";
-        case TOOL_SELECT_MULTILAYER_RECT:
-            return "selectMultiLayerRect";
-        case TOOL_SELECT_MULTILAYER_REGION:
-            return "selectMultiLayerRegion";
-        case TOOL_SELECT_OBJECT:
-            return "selectObject";
-        case TOOL_PLAY_OBJECT:
-            return "playObject";
-        case TOOL_VERTICAL_SPACE:
-            return "verticalSpace";
-        case TOOL_HAND:
-            return "hand";
-        case TOOL_DRAW_RECT:
-            return "drawRect";
-        case TOOL_DRAW_ELLIPSE:
-            return "drawEllipse";
-        case TOOL_DRAW_ARROW:
-            return "drawArrow";
-        case TOOL_DRAW_DOUBLE_ARROW:
-            return "drawDoubleArrow";
-        case TOOL_DRAW_COORDINATE_SYSTEM:
-            return "drawCoordinateSystem";
-        case TOOL_DRAW_SPLINE:
-            return "drawSpline";
-        case TOOL_FLOATING_TOOLBOX:
-            return "showFloatingToolbox";
-        case TOOL_SELECT_PDF_TEXT_LINEAR:
-            return "selectPdfTextLinear";
-        case TOOL_SELECT_PDF_TEXT_RECT:
-            return "selectPdfTextRect";
-        case TOOL_LASER_POINTER_PEN:
-            return "laserPointerPen";
-        case TOOL_LASER_POINTER_HIGHLIGHTER:
-            return "laserPointerHighlighter";
-        default:
-            return "";
-    }
-}
 
 auto toolTypeFromString(const std::string& type) -> ToolType {
-    if (type == "pen") {
-        return TOOL_PEN;
-    }
-    if (type == "eraser") {
-        return TOOL_ERASER;
+    auto it = std::find(toolNames.begin(), toolNames.end(), type);
+    if (it != toolNames.end()) {
+        return static_cast<ToolType>(std::distance(toolNames.begin(), it));
     }
     // recognize previous spelling of Highlighter, V1.0.19 (Dec 2020) and earlier
-    if (type == "highlighter" || type == "hilighter") {
+    if (type == "hilighter") {
         return TOOL_HIGHLIGHTER;
     }
-    if (type == "text") {
-        return TOOL_TEXT;
-    }
-    if (type == "image") {
-        return TOOL_IMAGE;
-    }
-    if (type == "selectRect") {
-        return TOOL_SELECT_RECT;
-    }
-    if (type == "selectRegion") {
-        return TOOL_SELECT_REGION;
-    }
-    if (type == "selectMultiLayerRect") {
-        return TOOL_SELECT_MULTILAYER_RECT;
-    }
-    if (type == "selectMultiLayerRegion") {
-        return TOOL_SELECT_MULTILAYER_REGION;
-    }
-    if (type == "selectObject") {
-        return TOOL_SELECT_OBJECT;
-    }
-    if (type == "playObject") {
-        return TOOL_PLAY_OBJECT;
-    }
-    if (type == "verticalSpace") {
-        return TOOL_VERTICAL_SPACE;
-    }
-    if (type == "hand") {
-        return TOOL_HAND;
-    }
-    if (type == "drawRect") {
-        return TOOL_DRAW_RECT;
-    }
     // recognize previous spelling of Ellipse, V1.1.0+dev (Jan 2021) and earlier
-    if (type == "drawEllipse" || type == "drawCircle") {
+    if (type == "drawCircle") {
         return TOOL_DRAW_ELLIPSE;
-    }
-    if (type == "drawArrow") {
-        return TOOL_DRAW_ARROW;
-    }
-    if (type == "drawDoubleArrow") {
-        return TOOL_DRAW_DOUBLE_ARROW;
-    }
-    if (type == "drawCoordinateSystem") {
-        return TOOL_DRAW_COORDINATE_SYSTEM;
-    }
-    if (type == "drawSpline") {
-        return TOOL_DRAW_SPLINE;
-    }
-    if (type == "showFloatingToolbox") {
-        return TOOL_FLOATING_TOOLBOX;
-    }
-    if (type == "selectPdfTextLinear") {
-        return TOOL_SELECT_PDF_TEXT_LINEAR;
-    }
-    if (type == "selectPdfTextRect") {
-        return TOOL_SELECT_PDF_TEXT_RECT;
-    }
-    if (type == "laserPointerPen") {
-        return TOOL_LASER_POINTER_PEN;
-    }
-    if (type == "laserPointerHighlighter") {
-        return TOOL_LASER_POINTER_HIGHLIGHTER;
     }
     return TOOL_NONE;
 }
 
-auto opacityFeatureToString(OpacityFeature feature) -> std::string {
-    switch (feature) {
-        case OPACITY_NONE:
-            return "none";
-        case OPACITY_FILL_PEN:
-            return "opacityFillPen";
-        case OPACITY_FILL_HIGHLIGHTER:
-            return "opacityFillHighlighter";
-        case OPACITY_SELECT_PDF_TEXT_MARKER:
-            return "opacitySelectPdfTextMarker";
-        default:
-            return "";
-    }
-}
 
 auto opacityFeatureFromString(const std::string& feature) -> OpacityFeature {
-    if (feature == "none") {
-        return OPACITY_NONE;
-    }
-    if (feature == "opacityFillPen") {
-        return OPACITY_FILL_PEN;
-    }
-    if (feature == "opacityFillHighlighter") {
-        return OPACITY_FILL_HIGHLIGHTER;
-    }
-    if (feature == "opacitySelectPdfTextMarker") {
-        return OPACITY_SELECT_PDF_TEXT_MARKER;
+    auto it = std::find(opacityFeatureNames.begin(), opacityFeatureNames.end(), feature);
+    if (it != opacityFeatureNames.end()) {
+        return static_cast<OpacityFeature>(std::distance(opacityFeatureNames.begin(), it));
     }
     return OPACITY_NONE;
 }
 
-auto eraserTypeToString(EraserType type) -> std::string {
-    switch (type) {
-        case ERASER_TYPE_NONE:
-            return "none";
-        case ERASER_TYPE_DEFAULT:
-            return "default";
-        case ERASER_TYPE_WHITEOUT:
-            return "whiteout";
-        case ERASER_TYPE_DELETE_STROKE:
-            return "deleteStroke";
-        default:
-            return "";
-    }
-}
 
 auto eraserTypeFromString(const std::string& type) -> EraserType {
-    if (type == "default") {
-        return ERASER_TYPE_DEFAULT;
-    }
-    if (type == "whiteout") {
-        return ERASER_TYPE_WHITEOUT;
-    }
-    if (type == "deleteStroke") {
-        return ERASER_TYPE_DELETE_STROKE;
+    auto it = std::find(eraserTypeNames.begin(), eraserTypeNames.end(), type);
+    if (it != eraserTypeNames.end()) {
+        return static_cast<EraserType>(std::distance(eraserTypeNames.begin(), it));
     }
     return ERASER_TYPE_NONE;
 }
@@ -322,32 +87,11 @@ auto strokeTypeToLineStyle(StrokeType type) -> LineStyle {
     }
 }
 
-auto strokeTypeToString(StrokeType type) -> std::string {
-    switch (type) {
-        case STROKE_TYPE_NONE:
-            return "none";
-        case STROKE_TYPE_STANDARD:
-            return "standard";
-        case STROKE_TYPE_DASHED:
-            return "dash";
-        case STROKE_TYPE_DASHDOTTED:
-            return "dashdot";
-        case STROKE_TYPE_DOTTED:
-            return "dot";
-        default:
-            return "";
-    }
-}
 auto strokeTypeFromString(const std::string& type) -> StrokeType {
-    if (type == "standard")
-        return STROKE_TYPE_STANDARD;
-    if (type == "dash")
-        return STROKE_TYPE_DASHED;
-    if (type == "dashdot")
-        return STROKE_TYPE_DASHDOTTED;
-    if (type == "dot")
-        return STROKE_TYPE_DOTTED;
-
+    auto it = std::find(strokeTypeNames.begin(), strokeTypeNames.end(), type);
+    if (it != strokeTypeNames.end()) {
+        return static_cast<StrokeType>(std::distance(strokeTypeNames.begin(), it));
+    }
     return STROKE_TYPE_NONE;
 }
 

--- a/src/core/control/ToolEnums.h
+++ b/src/core/control/ToolEnums.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <array>
 #include <string>  // for string
 
 #include "model/LineStyle.h"
@@ -24,7 +25,13 @@ enum ToolSize {
     // None has to be at the end, because this enum is used as memory offset
     TOOL_SIZE_NONE
 };
-std::string toolSizeToString(ToolSize size);
+
+static constexpr std::array<std::string_view, 6> toolSizeNames{"veryThin", "thin",      "medium",
+                                                               "thick",    "veryThick", "none"};
+
+static constexpr std::string_view toolSizeToString(ToolSize size) {
+    return toolSizeNames.at(static_cast<size_t>(size));
+}
 ToolSize toolSizeFromString(const std::string& size);
 
 
@@ -47,11 +54,15 @@ enum DrawingType {
     DRAWING_TYPE_SHAPE_RECOGNIZER,
     DRAWING_TYPE_SPLINE
 };
-std::string drawingTypeToString(DrawingType type);
+static constexpr std::array<std::string_view, 10> drawingTypeNames{
+        "dontChange",           "default",          "line",  "rectangle", "ellipse", "arrow", "doubleArrow",
+        "drawCoordinateSystem", "strokeRecognizer", "spline"};
+
+static constexpr std::string_view drawingTypeToString(DrawingType type) {
+    return drawingTypeNames.at(static_cast<size_t>(type));
+}
 DrawingType drawingTypeFromString(const std::string& type);
 
-
-// Has to be in the same order as in Action.h: ActionType!
 // The numbers must agree with the action's targets in ui/mainmenubar.xml
 enum ToolType {
     TOOL_NONE = 0,
@@ -84,6 +95,32 @@ enum ToolType {
 
     TOOL_END_ENTRY
 };
+static constexpr std::array<std::string_view, 25> toolNames{"none",
+                                                            "pen",
+                                                            "eraser",
+                                                            "highlighter",
+                                                            "text",
+                                                            "image",
+                                                            "selectRect",
+                                                            "selectRegion",
+                                                            "selectMultiLayerRect",
+                                                            "selectMultiLayerRegion",
+                                                            "selectObject",
+                                                            "playObject",
+                                                            "verticalSpace",
+                                                            "hand",
+                                                            "drawRect",
+                                                            "drawEllipse",
+                                                            "drawArrow",
+                                                            "drawDoubleArrow",
+                                                            "drawCoordinateSystem",
+                                                            "showFloatingToolbox",
+                                                            "drawSpline",
+                                                            "selectPdfTextLinear",
+                                                            "selectPdfTextRect",
+                                                            "laserPointerPen",
+                                                            "laserPointerHighlighter"};
+
 auto isSelectToolType(ToolType type) -> bool;
 auto isSelectToolTypeSingleLayer(ToolType type) -> bool;
 
@@ -95,8 +132,9 @@ auto requiresClearedSelection(ToolType type) -> bool;
 // The count of tools
 #define TOOL_COUNT (TOOL_END_ENTRY - 1)
 
-std::string toolTypeToString(ToolType type);
+static constexpr std::string_view toolTypeToString(ToolType type) { return toolNames.at(static_cast<size_t>(type)); }
 ToolType toolTypeFromString(const std::string& type);
+
 
 enum OpacityFeature {
     OPACITY_NONE,
@@ -104,11 +142,20 @@ enum OpacityFeature {
     OPACITY_FILL_HIGHLIGHTER,
     OPACITY_SELECT_PDF_TEXT_MARKER,
 };
-std::string opacityFeatureToString(OpacityFeature feature);
+static constexpr std::array<std::string_view, 4> opacityFeatureNames{"none", "opacityFillPen", "opacityFillHighlighter",
+                                                                     "opacitySelectPdfTextMarker"};
+
+static constexpr std::string_view opacityFeatureToString(OpacityFeature feature) {
+    return opacityFeatureNames.at(static_cast<size_t>(feature));
+}
 OpacityFeature opacityFeatureFromString(const std::string& feature);
 
 enum EraserType { ERASER_TYPE_NONE = 0, ERASER_TYPE_DEFAULT, ERASER_TYPE_WHITEOUT, ERASER_TYPE_DELETE_STROKE };
-std::string eraserTypeToString(EraserType type);
+static constexpr std::array<std::string_view, 4> eraserTypeNames{"none", "default", "whiteout", "deleteStroke"};
+
+static constexpr std::string_view eraserTypeToString(EraserType type) {
+    return eraserTypeNames.at(static_cast<size_t>(type));
+}
 EraserType eraserTypeFromString(const std::string& type);
 
 
@@ -136,9 +183,14 @@ enum StrokeType {
     STROKE_TYPE_DASHDOTTED = 3,
     STROKE_TYPE_DOTTED = 4
 };
+
+static constexpr std::array<std::string_view, 5> strokeTypeNames{"none", "standard", "dashed", "dashdot", "dot"};
+
 auto strokeTypeFromString(const std::string& type) -> StrokeType;
 auto strokeTypeToLineStyle(StrokeType type) -> LineStyle;
-auto strokeTypeToString(StrokeType type) -> std::string;
+static constexpr auto strokeTypeToString(StrokeType type) -> std::string_view {
+    return strokeTypeNames.at(static_cast<size_t>(type));
+}
 
 namespace xoj::tool {
 /// \return Whether the provided tool is used for selecting objects on a PDF.

--- a/src/core/control/ToolHandler.cpp
+++ b/src/core/control/ToolHandler.cpp
@@ -444,7 +444,7 @@ void ToolHandler::saveSettings() const {
             st.setIntHex("color", int(uint32_t(tool->getColor())));
         }
 
-        st.setString("drawingType", drawingTypeToString(tool->getDrawingType()));
+        st.setString("drawingType", drawingTypeToString(tool->getDrawingType()).data());
 
         if (tool->hasCapability(TOOL_CAP_SIZE)) {
             std::string value;

--- a/src/core/control/actions/ActionProperties.h
+++ b/src/core/control/actions/ActionProperties.h
@@ -446,6 +446,7 @@ struct ActionProperties<Action::ZOOM_FIT> {
 template <>
 struct ActionProperties<Action::ZOOM> {
     using state_type = double;
+    using parameter_type = state_type;
     static state_type initialState(Control* ctrl) { return ctrl->getZoomControl()->getZoom(); }
     static void callback(GSimpleAction* ga, GVariant* p, Control* ctrl) {
         g_simple_action_set_state(ga, p);

--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -930,15 +930,15 @@ void Settings::saveButtonConfig() {
         const auto& cfg = buttonConfig[i];
 
         ToolType const type = cfg->action;
-        e.setString("tool", toolTypeToString(type));
+        e.setString("tool", toolTypeToString(type).data());
 
         if (type == TOOL_PEN) {
-            e.setString("strokeType", strokeTypeToString(cfg->strokeType));
+            e.setString("strokeType", strokeTypeToString(cfg->strokeType).data());
         }
 
         if (type == TOOL_PEN || type == TOOL_HIGHLIGHTER) {
-            e.setString("drawingType", drawingTypeToString(cfg->drawingType));
-            e.setString("size", toolSizeToString(cfg->size));
+            e.setString("drawingType", drawingTypeToString(cfg->drawingType).data());
+            e.setString("size", toolSizeToString(cfg->size).data());
         }
 
         if (type == TOOL_PEN || type == TOOL_HIGHLIGHTER || type == TOOL_TEXT) {
@@ -946,8 +946,8 @@ void Settings::saveButtonConfig() {
         }
 
         if (type == TOOL_ERASER) {
-            e.setString("eraserMode", eraserTypeToString(cfg->eraserMode));
-            e.setString("size", toolSizeToString(cfg->size));
+            e.setString("eraserMode", eraserTypeToString(cfg->eraserMode).data());
+            e.setString("size", toolSizeToString(cfg->size).data());
         }
 
         // Touch device

--- a/src/core/control/tools/EditSelection.cpp
+++ b/src/core/control/tools/EditSelection.cpp
@@ -518,6 +518,21 @@ auto EditSelection::rearrangeInsertionOrder(const OrderChange change) -> UndoAct
                                                std::move(newOrd));
 }
 
+auto EditSelection::orderChangeToString(const OrderChange change) -> std::string {
+    switch (change) {
+        case OrderChange::BringToFront:
+            return "bringToFront";
+        case OrderChange::BringForward:
+            return "bringForward";
+        case OrderChange::SendBackward:
+            return "sendBackward";
+        case OrderChange::SendToBack:
+            return "sendToBack";
+        default:
+            return "";
+    }
+}
+
 /**
  * Finish the current movement
  * (should be called in the mouse-button-released event handler)

--- a/src/core/control/tools/EditSelection.cpp
+++ b/src/core/control/tools/EditSelection.cpp
@@ -518,21 +518,6 @@ auto EditSelection::rearrangeInsertionOrder(const OrderChange change) -> UndoAct
                                                std::move(newOrd));
 }
 
-auto EditSelection::orderChangeToString(const OrderChange change) -> std::string {
-    switch (change) {
-        case OrderChange::BringToFront:
-            return "bringToFront";
-        case OrderChange::BringForward:
-            return "bringForward";
-        case OrderChange::SendBackward:
-            return "sendBackward";
-        case OrderChange::SendToBack:
-            return "sendToBack";
-        default:
-            return "";
-    }
-}
-
 /**
  * Finish the current movement
  * (should be called in the mouse-button-released event handler)

--- a/src/core/control/tools/EditSelection.h
+++ b/src/core/control/tools/EditSelection.h
@@ -228,6 +228,11 @@ public:
         SendToBack,
     };
 
+    static constexpr std::array<OrderChange, 4> allChanges = {OrderChange::BringToFront, OrderChange::BringForward,
+                                                              OrderChange::SendBackward, OrderChange::SendToBack};
+
+    static auto orderChangeToString(const OrderChange change) -> std::string;
+
     /**
      * Change the insert order of this selection.
      */

--- a/src/core/control/tools/EditSelection.h
+++ b/src/core/control/tools/EditSelection.h
@@ -12,7 +12,9 @@
 
 #pragma once
 
+#include <array>
 #include <memory>  // for unique_ptr
+#include <string>
 #include <utility>  // for pair
 #include <vector>   // for vector
 
@@ -228,10 +230,14 @@ public:
         SendToBack,
     };
 
+    static constexpr std::array<std::string_view, 4> orderChangeNames{"bringToFront", "bringForward", "sendBackward",
+                                                                      "sendToBack"};
     static constexpr std::array<OrderChange, 4> allChanges = {OrderChange::BringToFront, OrderChange::BringForward,
                                                               OrderChange::SendBackward, OrderChange::SendToBack};
 
-    static auto orderChangeToString(const OrderChange change) -> std::string;
+    static constexpr auto orderChangeToString(const OrderChange change) -> std::string_view {
+        return orderChangeNames.at(static_cast<size_t>(change));
+    }
 
     /**
      * Change the insert order of this selection.

--- a/src/core/gui/dialog/SelectOpacityDialog.cpp
+++ b/src/core/gui/dialog/SelectOpacityDialog.cpp
@@ -41,7 +41,7 @@ static inline void buildLabel(Builder& builder, OpacityFeature opacityFeature) {
             opacityFeatureDesc = _("PDF Text Marker");
             break;
         default:
-            g_warning("No opacityFeature description set for '%s'", opacityFeatureToString(opacityFeature).c_str());
+            g_warning("No opacityFeature description set for '%s'", opacityFeatureToString(opacityFeature).data());
             Stacktrace::printStacktrace();
             break;
     }

--- a/src/core/plugin/luapi_application.h
+++ b/src/core/plugin/luapi_application.h
@@ -578,14 +578,16 @@ GVariant* lua_to_gvariant(lua_State* L, int idx, const GVariantType* typeHint) {
 }
 
 /***
- * Change the action's state, triggering callbacks
+ * Change the action's state, triggering callbacks. Actions with state from an enum
+ * (like ToolType, ToolSize, EraserSize, OrderChange) should be accessed via the app.C
+ * table of constants for consistency between different versions of Xournal++
  * @param action string
  * @param state any
  *
- * Example 1: app.changeActionState("select-tool", 4)  -- but what does 4 mean?
+ * Example 1: app.changeActionState("select-tool",  app.C.Tool_text)
  * Example 2: app.changeActionState("set-layout-vertical", false)
- * Example 3: app.changeActionState("set-columns-or-rows", -3)
- * Example 4: app.changeActionState("tool-color", 0xff0000)
+ * Example 3: app.changeActionState("set-columns-or-rows", -3)      # 3 rows
+ * Example 4: app.changeActionState("tool-color", 0xff0000)         # red color
  * Example 5: app.changeActionState("zoom", 2.25)
  * Example 6: app.changeActionState("tool-pen-line-style", "cust: 1 5 3 5")
  */
@@ -606,11 +608,13 @@ static int applib_changeActionState(lua_State* L) {
 }
 
 /***
- * Activate the action, triggering callbacks
+ * Activate the action, triggering callbacks. Actions with state from an enum
+ * (like ToolType, ToolSize, EraserSize, OrderChange) should be accessed via the app.C
+ * table of constants for consistency between different versions of Xournal++
  * @param action string
  * @param state nilt | any
  *
- * Example 1: app.activateAction("arrange-selection-order", 1) -- but what does 1 mean?
+ * Example 1: app.activateAction("arrange-selection-order", app.C.OrderChange.bringForward)
  * Example 2: app.activateAction("setsquare")
  * Example 3: app.activateAction("tool-fill")
  */

--- a/src/core/plugin/luapi_application.h
+++ b/src/core/plugin/luapi_application.h
@@ -634,6 +634,10 @@ static int applib_activateAction(lua_State* L) {
 
 
 /**
+ * THIS FUNCTION IS DEPRECATED AND WILL BE REMOVED SOON. Use applib_changeActionState or
+ * applib_activateAction instead.
+ *
+ * @deprecated
  * Execute an UI action (usually internally called from Toolbar / Menu)
  * The argument consists of a Lua table with 3 keys: "action", "group" and "enabled"
  * The key "group" is currently only used for debugging purpose and can safely be omitted.
@@ -3302,7 +3306,7 @@ static const luaL_Reg applib[] = {{"msgbox", applib_msgbox},  // Todo(gtk4) remo
                                   {"saveAs", applib_saveAs},  // Todo(gtk4) remove this deprecated function
                                   {"fileDialogSave", applib_fileDialogSave},
                                   {"registerUi", applib_registerUi},
-                                  {"uiAction", applib_uiAction},
+                                  {"uiAction", applib_uiAction},  // Todo(gtk4) remove this deprecated function
                                   {"sidebarAction", applib_sidebarAction},
                                   {"layerAction", applib_layerAction},
                                   {"changeToolColor", applib_changeToolColor},

--- a/src/core/plugin/luapi_application.h
+++ b/src/core/plugin/luapi_application.h
@@ -678,6 +678,9 @@ static int applib_uiAction(lua_State* L) {
 }
 
 /**
+ * THIS FUNCTION IS DEPRECATED AND WILL BE REMOVED SOON. Use applib_activateAction instead.
+ *
+ * @deprecated
  * Execute action from sidebar menu
  *
  * @param action string the desired action
@@ -727,6 +730,9 @@ static int applib_sidebarAction(lua_State* L) {
 }
 
 /**
+ * THIS FUNCTION IS DEPRECATED AND WILL BE REMOVED SOON. No substitute needed.
+ *
+ * @deprecated
  * Get the index of the currently active sidebar-page.
  *
  * @return integer pageNr pageNr of the sidebar page
@@ -741,6 +747,9 @@ static int applib_getSidebarPageNo(lua_State* L) {
 }
 
 /**
+ * THIS FUNCTION IS DEPRECATED AND WILL BE REMOVED SOON. No substitute needed.
+ *
+ * @deprecated
  * Set the currently active sidebar-page by its index.
  *
  * @param pageNr integer pageNr of the sidebar page
@@ -3300,58 +3309,58 @@ static int applib_setPlaceholderValue(lua_State* L) {
 }
 
 
-static const luaL_Reg applib[] = {{"msgbox", applib_msgbox},  // Todo(gtk4) remove this deprecated function
-                                  {"openDialog", applib_openDialog},
-                                  {"changeActionState", applib_changeActionState},
-                                  {"activateAction", applib_activateAction},
-                                  {"getPageLabel", applib_getPageLabel},
-                                  {"glib_rename", applib_glib_rename},
-                                  {"saveAs", applib_saveAs},  // Todo(gtk4) remove this deprecated function
-                                  {"fileDialogSave", applib_fileDialogSave},
-                                  {"registerUi", applib_registerUi},
-                                  {"uiAction", applib_uiAction},  // Todo(gtk4) remove this deprecated function
-                                  {"sidebarAction", applib_sidebarAction},
-                                  {"layerAction", applib_layerAction},  // Todo(gtk4) remove this deprecated function
-                                  {"changeToolColor", applib_changeToolColor},
-                                  {"getColorPalette", applib_getColorPalette},
-                                  {"changeCurrentPageBackground", applib_changeCurrentPageBackground},
-                                  {"changeBackgroundPdfPageNr", applib_changeBackgroundPdfPageNr},
-                                  {"getToolInfo", applib_getToolInfo},
-                                  {"getFolder", applib_getFolder},
-                                  {"getSidebarPageNo", applib_getSidebarPageNo},
-                                  {"setSidebarPageNo", applib_setSidebarPageNo},
-                                  {"getDocumentStructure", applib_getDocumentStructure},
-                                  {"scrollToPage", applib_scrollToPage},
-                                  {"scrollToPos", applib_scrollToPos},
-                                  {"setCurrentPage", applib_setCurrentPage},
-                                  {"setPageSize", applib_setPageSize},
-                                  {"setCurrentLayer", applib_setCurrentLayer},
-                                  {"setLayerVisibility", applib_setLayerVisibility},
-                                  {"setCurrentLayerName", applib_setCurrentLayerName},
-                                  {"setBackgroundName", applib_setBackgroundName},
-                                  {"getDisplayDpi", applib_getDisplayDpi},
-                                  {"getZoom", applib_getZoom},
-                                  {"setZoom", applib_setZoom},
-                                  {"export", applib_export},
-                                  {"addStrokes", applib_addStrokes},
-                                  {"addSplines", applib_addSplines},
-                                  {"addImages", applib_addImages},
-                                  {"addTexts", applib_addTexts},
-                                  {"addToSelection", applib_addToSelection},
-                                  {"clearSelection", applib_clearSelection},
-                                  {"getFilePath", applib_getFilePath},  // Todo(gtk4) remove this deprecated function
-                                  {"fileDialogOpen", applib_fileDialogOpen},
-                                  {"refreshPage", applib_refreshPage},
-                                  {"getStrokes", applib_getStrokes},
-                                  {"getImages", applib_getImages},
-                                  {"getTexts", applib_getTexts},
-                                  {"openFile", applib_openFile},
-                                  {"registerPlaceholder", applib_registerPlaceholder},
-                                  {"setPlaceholderValue", applib_setPlaceholderValue},
-                                  // Placeholder
-                                  // {"MSG_BT_OK", nullptr},
-
-                                  {nullptr, nullptr}};
+static const luaL_Reg applib[] = {
+        {"msgbox", applib_msgbox},  // Todo(gtk4) remove this deprecated function
+        {"openDialog", applib_openDialog},
+        {"changeActionState", applib_changeActionState},
+        {"activateAction", applib_activateAction},
+        {"getPageLabel", applib_getPageLabel},
+        {"glib_rename", applib_glib_rename},
+        {"saveAs", applib_saveAs},  // Todo(gtk4) remove this deprecated function
+        {"fileDialogSave", applib_fileDialogSave},
+        {"registerUi", applib_registerUi},
+        {"uiAction", applib_uiAction},            // Todo(gtk4) remove this deprecated function
+        {"sidebarAction", applib_sidebarAction},  // Todo(gtk4) remove this deprecated function
+        {"layerAction", applib_layerAction},      // Todo(gtk4) remove this deprecated function
+        {"changeToolColor", applib_changeToolColor},
+        {"getColorPalette", applib_getColorPalette},
+        {"changeCurrentPageBackground", applib_changeCurrentPageBackground},
+        {"changeBackgroundPdfPageNr", applib_changeBackgroundPdfPageNr},
+        {"getToolInfo", applib_getToolInfo},
+        {"getFolder", applib_getFolder},
+        {"getSidebarPageNo", applib_getSidebarPageNo},  // Todo(gtk4) remove this deprecated function
+        {"setSidebarPageNo", applib_setSidebarPageNo},  // Todo(gtk4) remove this deprecated function
+        {"getDocumentStructure", applib_getDocumentStructure},
+        {"scrollToPage", applib_scrollToPage},
+        {"scrollToPos", applib_scrollToPos},
+        {"setCurrentPage", applib_setCurrentPage},
+        {"setPageSize", applib_setPageSize},
+        {"setCurrentLayer", applib_setCurrentLayer},
+        {"setLayerVisibility", applib_setLayerVisibility},
+        {"setCurrentLayerName", applib_setCurrentLayerName},
+        {"setBackgroundName", applib_setBackgroundName},
+        {"getDisplayDpi", applib_getDisplayDpi},
+        {"getZoom", applib_getZoom},
+        {"setZoom", applib_setZoom},
+        {"export", applib_export},
+        {"addStrokes", applib_addStrokes},
+        {"addSplines", applib_addSplines},
+        {"addImages", applib_addImages},
+        {"addTexts", applib_addTexts},
+        {"addToSelection", applib_addToSelection},
+        {"clearSelection", applib_clearSelection},
+        {"getFilePath", applib_getFilePath},  // Todo(gtk4) remove this deprecated function
+        {"fileDialogOpen", applib_fileDialogOpen},
+        {"refreshPage", applib_refreshPage},
+        {"getStrokes", applib_getStrokes},
+        {"getImages", applib_getImages},
+        {"getTexts", applib_getTexts},
+        {"openFile", applib_openFile},
+        {"registerPlaceholder", applib_registerPlaceholder},
+        {"setPlaceholderValue", applib_setPlaceholderValue},
+        // Placeholder
+        // {"MSG_BT_OK", nullptr},
+        {nullptr, nullptr}};
 
 /**
  * Open application Library

--- a/src/core/plugin/luapi_application.h
+++ b/src/core/plugin/luapi_application.h
@@ -777,6 +777,9 @@ static int applib_setSidebarPageNo(lua_State* L) {
 }
 
 /**
+ * THIS FUNCTION IS DEPRECATED AND WILL BE REMOVED SOON. Use applib_activateAction instead.
+ *
+ * @deprecated
  * Execute action from layer controller
  *
  * @param action string the desired action
@@ -3308,7 +3311,7 @@ static const luaL_Reg applib[] = {{"msgbox", applib_msgbox},  // Todo(gtk4) remo
                                   {"registerUi", applib_registerUi},
                                   {"uiAction", applib_uiAction},  // Todo(gtk4) remove this deprecated function
                                   {"sidebarAction", applib_sidebarAction},
-                                  {"layerAction", applib_layerAction},
+                                  {"layerAction", applib_layerAction},  // Todo(gtk4) remove this deprecated function
                                   {"changeToolColor", applib_changeToolColor},
                                   {"getColorPalette", applib_getColorPalette},
                                   {"changeCurrentPageBackground", applib_changeCurrentPageBackground},

--- a/src/core/plugin/luapi_application.h
+++ b/src/core/plugin/luapi_application.h
@@ -581,7 +581,7 @@ GVariant* lua_to_gvariant(lua_State* L, int idx, const GVariantType* typeHint) {
  * Change the action's state, triggering callbacks. Actions with state from an enum
  * (like ToolType, ToolSize, EraserSize, OrderChange) should be accessed via the app.C
  * table of constants for consistency between different versions of Xournal++
- * @param action string
+ * @param action Action
  * @param state any
  *
  * Example 1: app.changeActionState("select-tool",  app.C.Tool_text)
@@ -611,8 +611,8 @@ static int applib_changeActionState(lua_State* L) {
  * Activate the action, triggering callbacks. Actions with state from an enum
  * (like ToolType, ToolSize, EraserSize, OrderChange) should be accessed via the app.C
  * table of constants for consistency between different versions of Xournal++
- * @param action string
- * @param state nilt | any
+ * @param action Action
+ * @param state nil | any
  *
  * Example 1: app.activateAction("arrange-selection-order", app.C.OrderChange.bringForward)
  * Example 2: app.activateAction("setsquare")

--- a/src/core/plugin/luapi_application.h
+++ b/src/core/plugin/luapi_application.h
@@ -24,6 +24,7 @@
 #include "control/PageBackgroundChangeController.h"
 #include "control/ScrollHandler.h"
 #include "control/Tool.h"
+#include "control/ToolEnums.h"               // for ToolSize, ToolType
 #include "control/actions/ActionDatabase.h"  // for ActionDatabase
 #include "control/actions/ActionProperties.h"
 #include "control/layer/LayerController.h"
@@ -3367,7 +3368,41 @@ static const luaL_Reg applib[] = {
  */
 inline int luaopen_app(lua_State* L) {
     luaL_newlib(L, applib);
-    // lua_pushnumber(L, MSG_BT_OK);
-    // lua_setfield(L, -2, "MSG_BT_OK");
+
+    lua_newtable(L);  // table of constants
+    // ToolType enum
+    for (unsigned int i = 0; i < TOOL_END_ENTRY; i++) {
+        auto toolType = static_cast<ToolType>(i);
+        std::string s = toolTypeToString(toolType);
+        std::string key = "Tool_" + s;
+        lua_pushinteger(L, i);  // value
+        lua_setfield(L, -2, key.c_str());
+    }
+    // ToolSize enum
+    for (unsigned int i = 0; i <= TOOL_SIZE_NONE; i++) {
+        auto toolSize = static_cast<ToolSize>(i);
+        std::string s = toolSizeToString(toolSize);
+        std::string key = "ToolSize_" + s;
+        lua_pushinteger(L, i);  // value
+        lua_setfield(L, -2, key.c_str());
+    }
+    // EraserType enum
+    for (unsigned int i = 0; i <= ERASER_TYPE_DELETE_STROKE; i++) {
+        auto eraserType = static_cast<EraserType>(i);
+        std::string s = eraserTypeToString(eraserType);
+        std::string key = "EraserType_" + s;
+        lua_pushinteger(L, i);  // value
+        lua_setfield(L, -2, key.c_str());
+    }
+    // EditSelection::OrderChange enum
+    for (auto change: EditSelection::allChanges) {
+        std::string s = EditSelection::orderChangeToString(change);
+        std::string key = "OrderChange_" + s;
+        lua_pushinteger(L, static_cast<int>(change));  // value
+        lua_setfield(L, -2, key.c_str());
+    }
+
+    lua_setfield(L, -2, "C");
+
     return 1;
 }

--- a/src/core/plugin/luapi_application.h
+++ b/src/core/plugin/luapi_application.h
@@ -1853,7 +1853,7 @@ static int applib_changeToolColor(lua_State* L) {
     if (toolType == TOOL_NONE) {
         lua_pop(L, 3);
         return luaL_error(L, "tool \"%s\" is not valid or no tool has been selected",
-                          toolTypeToString(toolType).c_str());
+                          toolTypeToString(toolType).data());
     }
 
     uint32_t color = 0x000000;
@@ -1879,7 +1879,7 @@ static int applib_changeToolColor(lua_State* L) {
             ctrl->changeColorOfSelection();
         }
     } else {
-        return luaL_error(L, "tool \"%s\" has no color capability", toolTypeToString(toolType).c_str());
+        return luaL_error(L, "tool \"%s\" has no color capability", toolTypeToString(toolType).data());
     }
 
     return 0;
@@ -2098,23 +2098,23 @@ static int applib_getToolInfo(lua_State* L) {
     //   -1 = table to be returned
 
     if (strcmp(mode, "active") == 0) {
-        std::string toolType = toolTypeToString(toolHandler->getToolType());
+        auto toolType = toolTypeToString(toolHandler->getToolType());
 
-        std::string toolSize = toolSizeToString(toolHandler->getSize());
+        auto toolSize = toolSizeToString(toolHandler->getSize());
         double thickness = toolHandler->getThickness();
 
         Color color = toolHandler->getColor();
         int fillOpacity = toolHandler->getFill();
-        std::string drawingType = drawingTypeToString(toolHandler->getDrawingType());
-        std::string lineStyle = StrokeStyle::formatStyle(toolHandler->getLineStyle());
+        auto drawingType = drawingTypeToString(toolHandler->getDrawingType());
+        auto lineStyle = StrokeStyle::formatStyle(toolHandler->getLineStyle());
 
 
-        lua_pushstring(L, toolType.c_str());  // value
+        lua_pushstring(L, toolType.data());   // value
         lua_setfield(L, -2, "type");          // insert
 
         lua_newtable(L);  // beginning of "size" table
 
-        lua_pushstring(L, toolSize.c_str());  // value
+        lua_pushstring(L, toolSize.data());   // value
         lua_setfield(L, -2, "name");          // insert
 
         lua_pushnumber(L, thickness);  // value
@@ -2128,26 +2128,26 @@ static int applib_getToolInfo(lua_State* L) {
         lua_pushinteger(L, fillOpacity);     // value
         lua_setfield(L, -2, "fillOpacity");  // insert
 
-        lua_pushstring(L, drawingType.c_str());  // value
+        lua_pushstring(L, drawingType.data());   // value
         lua_setfield(L, -2, "drawingType");      // insert
 
-        lua_pushstring(L, lineStyle.c_str());  // value
+        lua_pushstring(L, lineStyle.data());   // value
         lua_setfield(L, -2, "lineStyle");      // insert
     } else if (strcmp(mode, "pen") == 0) {
-        std::string size = toolSizeToString(toolHandler->getPenSize());
-        double thickness = toolHandler->getToolThickness(TOOL_PEN)[toolSizeFromString(size)];
+        auto size = toolSizeToString(toolHandler->getPenSize());
+        double thickness = toolHandler->getToolThickness(TOOL_PEN)[toolSizeFromString(size.data())];
 
         int fillOpacity = toolHandler->getPenFill();
         bool filled = toolHandler->getPenFillEnabled();
 
         Tool& tool = toolHandler->getTool(TOOL_PEN);
         Color color = tool.getColor();
-        std::string drawingType = drawingTypeToString(tool.getDrawingType());
+        auto drawingType = drawingTypeToString(tool.getDrawingType());
         std::string lineStyle = StrokeStyle::formatStyle(tool.getLineStyle());
 
         lua_newtable(L);  // beginning of "size" table
 
-        lua_pushstring(L, size.c_str());  // value
+        lua_pushstring(L, size.data());   // value
         lua_setfield(L, -2, "name");      // insert
 
         lua_pushnumber(L, thickness);  // value
@@ -2158,7 +2158,7 @@ static int applib_getToolInfo(lua_State* L) {
         lua_pushinteger(L, as_signed(uint32_t(color) & 0xffffffU));  // value
         lua_setfield(L, -2, "color");                                // insert
 
-        lua_pushstring(L, drawingType.c_str());  // value
+        lua_pushstring(L, drawingType.data());   // value
         lua_setfield(L, -2, "drawingType");      // insert
 
         lua_pushstring(L, lineStyle.c_str());  // value
@@ -2170,19 +2170,19 @@ static int applib_getToolInfo(lua_State* L) {
         lua_pushinteger(L, fillOpacity);     // value
         lua_setfield(L, -2, "fillOpacity");  // insert
     } else if (strcmp(mode, "highlighter") == 0) {
-        std::string size = toolSizeToString(toolHandler->getHighlighterSize());
-        double thickness = toolHandler->getToolThickness(TOOL_HIGHLIGHTER)[toolSizeFromString(size)];
+        auto size = toolSizeToString(toolHandler->getHighlighterSize());
+        double thickness = toolHandler->getToolThickness(TOOL_HIGHLIGHTER)[toolSizeFromString(size.data())];
 
         int fillOpacity = toolHandler->getHighlighterFill();
         bool filled = toolHandler->getHighlighterFillEnabled();
 
         Tool& tool = toolHandler->getTool(TOOL_HIGHLIGHTER);
         Color color = tool.getColor();
-        std::string drawingType = drawingTypeToString(tool.getDrawingType());
+        auto drawingType = drawingTypeToString(tool.getDrawingType());
 
         lua_newtable(L);  // beginning of "size" table
 
-        lua_pushstring(L, size.c_str());  // value
+        lua_pushstring(L, size.data());   // value
         lua_setfield(L, -2, "name");      // insert
 
         lua_pushnumber(L, thickness);  // value
@@ -2193,7 +2193,7 @@ static int applib_getToolInfo(lua_State* L) {
         lua_pushinteger(L, as_signed(uint32_t(color) & 0xffffffU));  // value
         lua_setfield(L, -2, "color");                                // insert
 
-        lua_pushstring(L, drawingType.c_str());  // value
+        lua_pushstring(L, drawingType.data());   // value
         lua_setfield(L, -2, "drawingType");      // insert
 
         lua_pushboolean(L, filled);     // value
@@ -2202,17 +2202,17 @@ static int applib_getToolInfo(lua_State* L) {
         lua_pushinteger(L, fillOpacity);     // value
         lua_setfield(L, -2, "fillOpacity");  // insert
     } else if (strcmp(mode, "eraser") == 0) {
-        std::string type = eraserTypeToString(toolHandler->getEraserType());
+        auto type = eraserTypeToString(toolHandler->getEraserType());
 
-        std::string size = toolSizeToString(toolHandler->getEraserSize());
-        double thickness = toolHandler->getToolThickness(ToolType::TOOL_ERASER)[toolSizeFromString(size)];
+        auto size = toolSizeToString(toolHandler->getEraserSize());
+        double thickness = toolHandler->getToolThickness(ToolType::TOOL_ERASER)[toolSizeFromString(size.data())];
 
-        lua_pushstring(L, type.c_str());  // value
+        lua_pushstring(L, type.data());   // value
         lua_setfield(L, -2, "type");      // insert
 
         lua_newtable(L);  // beginning of "size" table
 
-        lua_pushstring(L, size.c_str());  // value
+        lua_pushstring(L, size.data());   // value
         lua_setfield(L, -2, "name");      // insert
 
         lua_pushnumber(L, thickness);  // value
@@ -3373,7 +3373,7 @@ inline int luaopen_app(lua_State* L) {
     // ToolType enum
     for (unsigned int i = 0; i < TOOL_END_ENTRY; i++) {
         auto toolType = static_cast<ToolType>(i);
-        std::string s = toolTypeToString(toolType);
+        std::string s = toolTypeToString(toolType).data();
         std::string key = "Tool_" + s;
         lua_pushinteger(L, i);  // value
         lua_setfield(L, -2, key.c_str());
@@ -3381,7 +3381,7 @@ inline int luaopen_app(lua_State* L) {
     // ToolSize enum
     for (unsigned int i = 0; i <= TOOL_SIZE_NONE; i++) {
         auto toolSize = static_cast<ToolSize>(i);
-        std::string s = toolSizeToString(toolSize);
+        std::string s = toolSizeToString(toolSize).data();
         std::string key = "ToolSize_" + s;
         lua_pushinteger(L, i);  // value
         lua_setfield(L, -2, key.c_str());
@@ -3389,14 +3389,14 @@ inline int luaopen_app(lua_State* L) {
     // EraserType enum
     for (unsigned int i = 0; i <= ERASER_TYPE_DELETE_STROKE; i++) {
         auto eraserType = static_cast<EraserType>(i);
-        std::string s = eraserTypeToString(eraserType);
+        std::string s = eraserTypeToString(eraserType).data();
         std::string key = "EraserType_" + s;
         lua_pushinteger(L, i);  // value
         lua_setfield(L, -2, key.c_str());
     }
     // EditSelection::OrderChange enum
     for (auto change: EditSelection::allChanges) {
-        std::string s = EditSelection::orderChangeToString(change);
+        std::string s = EditSelection::orderChangeToString(change).data();
         std::string key = "OrderChange_" + s;
         lua_pushinteger(L, static_cast<int>(change));  // value
         lua_setfield(L, -2, key.c_str());

--- a/src/util/include/util/GVariantTemplate.h
+++ b/src/util/include/util/GVariantTemplate.h
@@ -58,6 +58,13 @@ struct GVariantWrapperImpl<double> {
     static inline GVariant* make(double v) { return g_variant_new_double(v); }
 };
 
+template <>
+struct GVariantWrapperImpl<GVariant*> {
+    static inline GVariant* getValue(GVariant* v) { return v; }
+    static inline const GVariantType* getType() { return G_VARIANT_TYPE_VARIANT; }
+    static inline GVariant* make(GVariant* v) { return v; }
+};
+
 template <class T>
 struct GVariantWrapperImpl<T, std::enable_if_t<match_gint32<T>(), void>> {
     static inline T getValue(GVariant* v) { return g_variant_get_int32(v); }

--- a/test/unit_tests/control/ToolEnumsTest.cpp
+++ b/test/unit_tests/control/ToolEnumsTest.cpp
@@ -24,7 +24,7 @@
 TEST(ToolEnumsTest, testToolSizeSerialization) {
     for (unsigned int i = 0; i <= TOOL_SIZE_NONE; i++) {
         auto toolSize = static_cast<ToolSize>(i);
-        std::string s = toolSizeToString(toolSize);
+        std::string s = toolSizeToString(toolSize).data();
         EXPECT_FALSE(s.empty());
         EXPECT_EQ(toolSize, toolSizeFromString(s));
     }
@@ -38,7 +38,7 @@ TEST(ToolEnumsTest, testToolSizeSerialization) {
 TEST(ToolEnumsTest, testToolTypeSerialization) {
     for (unsigned int i = 0; i < TOOL_END_ENTRY; i++) {
         auto toolType = static_cast<ToolType>(i);
-        std::string s = toolTypeToString(toolType);
+        std::string s = toolTypeToString(toolType).data();
         EXPECT_FALSE(s.empty());
         EXPECT_EQ(toolType, toolTypeFromString(s));
     }


### PR DESCRIPTION
The basic functionality works already. E.g. one can write
```lua
app.activateAction("setsquare")
```
to toggle the setsquare or
```lua
app.changeActionState("set-layout-vertical", false)
```
to change to horizontal layout.

The action states are not always self-explanatory and this still needs to be addressed (brainstorming below). One can write e.g.
```lua
app.changeActionState("select-tool", 4)
```
but how would you know that 4 corresponds to the Text tool?

One idea would be to automatically generate a .lua file that defines all these enum values. The .lua file would have to put somewhere where it can be found.

Another idea would be to add runtime info (something like `app.getAllActionNames()` and `app.getActionStates(action))`
but that would leave the readability problem to the plugin developer and have issues when the state values change between versions for a certain action, e.g. because a new tool was introduced.

@bhennion @atticus-sullivan Any ideas/suggestions?