### PR TITLE
Fix rendering artifacts with Graph background with margin

### DIFF
--- a/src/core/view/background/GraphBackgroundView.cpp
+++ b/src/core/view/background/GraphBackgroundView.cpp
@@ -61,13 +61,17 @@ void GraphBackgroundView::draw(cairo_t* cr) const {
         maxY = std::min(maxY, squareSize * pageIndexMaxY);
     }
 
-    for (int i = indexMinX; i <= indexMaxX; ++i) {
-        cairo_move_to(cr, i * squareSize, minY);
-        cairo_line_to(cr, i * squareSize, maxY);
+    if (minY < maxY) {  // Can fail when rendering a mask contained in the bottom margin
+        for (int i = indexMinX; i <= indexMaxX; ++i) {
+            cairo_move_to(cr, i * squareSize, minY);
+            cairo_line_to(cr, i * squareSize, maxY);
+        }
     }
-    for (int i = indexMinY; i <= indexMaxY; ++i) {
-        cairo_move_to(cr, minX, i * squareSize);
-        cairo_line_to(cr, maxX, i * squareSize);
+    if (minX < maxX) {  // Can fail when rendering a mask contained in the right margin
+        for (int i = indexMinY; i <= indexMaxY; ++i) {
+            cairo_move_to(cr, minX, i * squareSize);
+            cairo_line_to(cr, maxX, i * squareSize);
+        }
     }
 
     cairo_save(cr);


### PR DESCRIPTION
The artifacts appear when rendering a mask contained in the bottom or right margin (e.g. draw a stroke in the margin and select the standard eraser).

This is a very simple fix. Merging once the CI clears.