### PR TITLE
Fixed a few Todo items

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -982,7 +982,7 @@ void Control::changePageBackgroundColor() {
         return;
     }
 
-    xoj::popup::PopupWindowWrapper<SelectBackgroundColorDialog> dlg(this, [p, pNr, ctrl = this](Color color) {
+    xoj::popup::PopupWindowWrapper<SelectBackgroundColorDialog> dlg(this, [p, pNr, ctrl = this](const Color& color) {
         p->setBackgroundColor(color);
         ctrl->firePageChanged(pNr);
     });
@@ -1310,9 +1310,7 @@ void Control::changeColorOfSelection() {
         }
 
         TextEditor* edit = getTextEditor();
-
-
-        if (this->toolHandler->getToolType() == TOOL_TEXT && edit != nullptr) {
+        if (edit != nullptr and this->toolHandler->getToolType() == TOOL_TEXT) {
             // Todo move into selection
             edit->setColor(toolHandler->getColor());
         }

--- a/src/core/control/RecentManager.h
+++ b/src/core/control/RecentManager.h
@@ -15,6 +15,7 @@
 
 #include "util/TinyVector.h"
 #include "util/raii/CLibrariesSPtr.h"
+#include "util/raii/IdentityFunction.h"
 
 #include "filesystem.h"  // for path
 
@@ -48,8 +49,8 @@ class GtkRecentInfoHandler {
 public:
     constexpr static auto ref = gtk_recent_info_ref;
     constexpr static auto unref = gtk_recent_info_unref;
-    // Todo(cpp20): replace with std:identity()
-    constexpr static auto adopt = [](GtkRecentInfo* p) { return p; };
+    // Todo(cpp20): replace with std::identity()
+    constexpr static auto adopt = std::identity<GtkRecentInfo*>;
 };
 using GtkRecentInfoSPtr = xoj::util::CLibrariesSPtr<GtkRecentInfo, GtkRecentInfoHandler>;
 

--- a/src/core/control/ToolBase.cpp
+++ b/src/core/control/ToolBase.cpp
@@ -9,12 +9,12 @@ ToolBase::~ToolBase() = default;
 /**
  * @return Color of the tool for all drawing tools
  */
-auto ToolBase::getColor() const -> Color { return this->color; }
+auto ToolBase::getColor() const -> const Color& { return this->color; }
 
 /**
  * @param color Color of the tool for all drawing tools
  */
-void ToolBase::setColor(Color color) { this->color = color; }
+void ToolBase::setColor(const Color& color) { this->color = color; }
 
 /**
  * @return Size of a drawing tool

--- a/src/core/control/ToolBase.h
+++ b/src/core/control/ToolBase.h
@@ -31,12 +31,12 @@ public:
     /**
      * @return Color of the tool for all drawing tools
      */
-    Color getColor() const;
+    const Color& getColor() const;
 
     /**
      * @param color Color of the tool for all drawing tools
      */
-    virtual void setColor(Color color);
+    virtual void setColor(const Color& color);
 
     /**
      * @return Size of a drawing tool

--- a/src/core/control/ToolHandler.cpp
+++ b/src/core/control/ToolHandler.cpp
@@ -32,13 +32,14 @@ public:
     ToolSelectPDFText(std::string name, ToolType type, Color color):
             Tool(name, type, color, TOOL_CAP_COLOR | TOOL_CAP_RULER, std::nullopt) {}
 
-    ~ToolSelectPDFText() override{};
+    ~ToolSelectPDFText() override {};
 
-    void setColor(Color color) override {
-        if (color.alpha == 0) {
-            color.alpha = DEFAULT_SELECT_PDF_TEXT_MARKER_OPACITY;
+    void setColor(const Color& color) override {
+        Color color_copy = color;
+        if (color_copy.alpha == 0) {
+            color_copy.alpha = DEFAULT_SELECT_PDF_TEXT_MARKER_OPACITY;
         }
-        Tool::setColor(color);
+        Tool::setColor(color_copy);
     }
 
 private:
@@ -92,11 +93,11 @@ void ToolHandler::initTools() {
     tools[TOOL_SELECT_REGION - TOOL_PEN] =
             std::make_unique<Tool>("selectRegion", TOOL_SELECT_REGION, Colors::black, TOOL_CAP_NONE, std::nullopt);
 
-    tools[TOOL_SELECT_MULTILAYER_RECT - TOOL_PEN] =
-            std::make_unique<Tool>("selectMultiLayerRect", TOOL_SELECT_MULTILAYER_RECT, Colors::black, TOOL_CAP_NONE, std::nullopt);
+    tools[TOOL_SELECT_MULTILAYER_RECT - TOOL_PEN] = std::make_unique<Tool>(
+            "selectMultiLayerRect", TOOL_SELECT_MULTILAYER_RECT, Colors::black, TOOL_CAP_NONE, std::nullopt);
 
-    tools[TOOL_SELECT_MULTILAYER_REGION - TOOL_PEN] =
-            std::make_unique<Tool>("selectMultiLayerRegion", TOOL_SELECT_MULTILAYER_REGION, Colors::black, TOOL_CAP_NONE, std::nullopt);
+    tools[TOOL_SELECT_MULTILAYER_REGION - TOOL_PEN] = std::make_unique<Tool>(
+            "selectMultiLayerRegion", TOOL_SELECT_MULTILAYER_REGION, Colors::black, TOOL_CAP_NONE, std::nullopt);
 
     tools[TOOL_SELECT_OBJECT - TOOL_PEN] =
             std::make_unique<Tool>("selectObject", TOOL_SELECT_OBJECT, Colors::black, TOOL_CAP_NONE, std::nullopt);
@@ -104,8 +105,7 @@ void ToolHandler::initTools() {
     tools[TOOL_VERTICAL_SPACE - TOOL_PEN] =
             std::make_unique<Tool>("verticalSpace", TOOL_VERTICAL_SPACE, Colors::black, TOOL_CAP_NONE, std::nullopt);
 
-    tools[TOOL_HAND - TOOL_PEN] =
-            std::make_unique<Tool>("hand", TOOL_HAND, Colors::black, TOOL_CAP_NONE, std::nullopt);
+    tools[TOOL_HAND - TOOL_PEN] = std::make_unique<Tool>("hand", TOOL_HAND, Colors::black, TOOL_CAP_NONE, std::nullopt);
 
     tools[TOOL_PLAY_OBJECT - TOOL_PEN] =
             std::make_unique<Tool>("playObject", TOOL_PLAY_OBJECT, Colors::black, TOOL_CAP_NONE, std::nullopt);
@@ -209,7 +209,9 @@ void ToolHandler::selectTool(ToolType type) {
 }
 
 void ToolHandler::fireToolChanged() const {
-    for (auto&& listener: this->toolChangeListeners) { listener(this->activeTool->type); }
+    for (auto&& listener: this->toolChangeListeners) {
+        listener(this->activeTool->type);
+    }
 
     stateChangeListener->toolChanged();
 }
@@ -220,7 +222,7 @@ void ToolHandler::addToolChangedListener(ToolChangedCallback listener) {
 
 auto ToolHandler::getTool(ToolType type) const -> Tool& { return *(this->tools[type - TOOL_PEN]); }
 
-auto ToolHandler::getActiveTool() const -> Tool* {return this->activeTool; }
+auto ToolHandler::getActiveTool() const -> Tool* { return this->activeTool; }
 
 auto ToolHandler::getToolType() const -> ToolType {
     Tool* tool = this->activeTool;
@@ -359,7 +361,7 @@ void ToolHandler::setLineStyle(const LineStyle& style) {
     this->stateChangeListener->toolLineStyleChanged();
 }
 
-void ToolHandler::setColor(Color color, bool userSelection) {
+void ToolHandler::setColor(const Color& color, bool userSelection) {
     if (this->activeTool != this->toolbarSelectedTool && !this->hasCapability(TOOL_CAP_COLOR, SelectedTool::active)) {
         this->toolbarSelectedTool->setColor(color);
     }
@@ -374,12 +376,12 @@ void ToolHandler::setColor(Color color, bool userSelection) {
     }
 }
 
-void ToolHandler::setButtonColor(Color color, Button button) {
+void ToolHandler::setButtonColor(const Color& color, Button button) {
     Tool* tool = this->getButtonTool(button);
     tool->setColor(color);
 }
 
-auto ToolHandler::getColor() const -> Color { return this->activeTool->getColor(); }
+auto ToolHandler::getColor() const -> const Color& { return this->activeTool->getColor(); }
 
 auto ToolHandler::getColorMaskAlpha() const -> Color {
     Color c = this->activeTool->getColor();
@@ -602,8 +604,9 @@ void ToolHandler::setSelectionEditTools(bool setColor, bool setSize, bool setFil
     }
 
     if (this->activeTool->type == TOOL_SELECT_RECT || this->activeTool->type == TOOL_SELECT_REGION ||
-        this->activeTool->type == TOOL_SELECT_MULTILAYER_RECT || this->activeTool->type == TOOL_SELECT_MULTILAYER_REGION ||
-        this->activeTool->type == TOOL_SELECT_OBJECT || this->activeTool->type == TOOL_PLAY_OBJECT) {
+        this->activeTool->type == TOOL_SELECT_MULTILAYER_RECT ||
+        this->activeTool->type == TOOL_SELECT_MULTILAYER_REGION || this->activeTool->type == TOOL_SELECT_OBJECT ||
+        this->activeTool->type == TOOL_PLAY_OBJECT) {
         this->stateChangeListener->toolColorChanged();
         this->stateChangeListener->toolSizeChanged();
         this->stateChangeListener->toolFillChanged();
@@ -622,11 +625,10 @@ auto ToolHandler::isSinglePageTool() const -> bool {
              drawingType == DRAWING_TYPE_LINE || drawingType == DRAWING_TYPE_RECTANGLE ||
              drawingType == DRAWING_TYPE_SPLINE)) ||
            toolType == TOOL_SELECT_RECT || toolType == TOOL_SELECT_REGION || toolType == TOOL_SELECT_MULTILAYER_RECT ||
-           toolType == TOOL_SELECT_MULTILAYER_REGION || toolType == TOOL_SELECT_OBJECT ||
-           toolType == TOOL_DRAW_RECT || toolType == TOOL_DRAW_ELLIPSE || toolType == TOOL_DRAW_COORDINATE_SYSTEM ||
-           toolType == TOOL_DRAW_ARROW || toolType == TOOL_DRAW_DOUBLE_ARROW || toolType == TOOL_FLOATING_TOOLBOX ||
-           toolType == TOOL_DRAW_SPLINE || toolType == TOOL_SELECT_PDF_TEXT_LINEAR ||
-           toolType == TOOL_SELECT_PDF_TEXT_RECT;
+           toolType == TOOL_SELECT_MULTILAYER_REGION || toolType == TOOL_SELECT_OBJECT || toolType == TOOL_DRAW_RECT ||
+           toolType == TOOL_DRAW_ELLIPSE || toolType == TOOL_DRAW_COORDINATE_SYSTEM || toolType == TOOL_DRAW_ARROW ||
+           toolType == TOOL_DRAW_DOUBLE_ARROW || toolType == TOOL_FLOATING_TOOLBOX || toolType == TOOL_DRAW_SPLINE ||
+           toolType == TOOL_SELECT_PDF_TEXT_LINEAR || toolType == TOOL_SELECT_PDF_TEXT_RECT;
 }
 
 auto ToolHandler::acceptsOutOfPageEvents() const -> bool {

--- a/src/core/control/ToolHandler.h
+++ b/src/core/control/ToolHandler.h
@@ -86,7 +86,7 @@ public:
      * 			false if the color is selected by a tool change
      * 			and therefore should not be applied to a selection
      */
-    void setColor(Color color, bool userSelection);
+    void setColor(const Color& color, bool userSelection);
 
     /**
      * @brief Set the color for a Button
@@ -95,14 +95,14 @@ public:
      * @param color color to be set
      * @param button button to set color for
      */
-    void setButtonColor(Color color, Button button);
+    void setButtonColor(const Color& color, Button button);
 
     /**
      * @brief Get the Color of the active tool
      *
      * @return Color of active tool
      */
-    Color getColor() const;
+    const Color& getColor() const;
 
     /**
      * @brief Get the Color of the active tool except the alpha value is replaced by 0xFF

--- a/src/core/control/actions/ActionDatabase.cpp
+++ b/src/core/control/actions/ActionDatabase.cpp
@@ -160,7 +160,7 @@ void ActionDatabase::Populator::populate(ActionDatabase* db) {
     ACTIONDB_PRINT_DEBUG("Populating ActionDatabase:");
     ACTIONDB_PRINT_DEBUG("        ACTION NAME:                |  STATE INIT   | PARAM TYPE |");
 
-    populateImpl(std::make_index_sequence<xoj::to_underlying(Action::ENUMERATOR_COUNT)>(), db);
+    populateImpl(std::make_index_sequence<std::to_underlying(Action::ENUMERATOR_COUNT)>(), db);
 }
 
 ActionDatabase::ActionDatabase(Control* control):
@@ -205,5 +205,5 @@ static void resetEnableStatusImpl(std::index_sequence<As...>, ActionDatabase* db
 }
 
 void ActionDatabase::resetEnableStatus() {
-    resetEnableStatusImpl(std::make_index_sequence<xoj::to_underlying(Action::ENUMERATOR_COUNT)>(), this, control);
+    resetEnableStatusImpl(std::make_index_sequence<std::to_underlying(Action::ENUMERATOR_COUNT)>(), this, control);
 }

--- a/src/core/control/actions/ActionDatabase.h
+++ b/src/core/control/actions/ActionDatabase.h
@@ -43,7 +43,7 @@ struct to_stream<T, std::enable_if_t<std::is_enum_v<T>, void>> {
     to_stream(const T& t): t(t) {}
     const T& t;
     friend std::ostream& operator<<(std::ostream& str, const to_stream& self) {
-        return str << xoj::to_underlying(self.t);
+        return str << std::to_underlying(self.t);
     }
 };
 template <>

--- a/src/core/control/settings/PageTemplateSettings.cpp
+++ b/src/core/control/settings/PageTemplateSettings.cpp
@@ -36,7 +36,7 @@ auto PageTemplateSettings::getPageHeight() const -> double { return this->pageHe
 
 void PageTemplateSettings::setPageHeight(double pageHeight) { this->pageHeight = pageHeight; }
 
-auto PageTemplateSettings::getBackgroundColor() const -> Color { return this->backgroundColor; }
+auto PageTemplateSettings::getBackgroundColor() const -> const Color& { return this->backgroundColor; }
 
 void PageTemplateSettings::setBackgroundColor(Color backgroundColor) { this->backgroundColor = backgroundColor; }
 

--- a/src/core/control/settings/PageTemplateSettings.h
+++ b/src/core/control/settings/PageTemplateSettings.h
@@ -48,7 +48,7 @@ public:
     double getPageHeight() const;
     void setPageHeight(double pageHeight);
 
-    Color getBackgroundColor() const;
+    const Color& getBackgroundColor() const;
     void setBackgroundColor(Color backgroundColor);
 
     PageType getBackgroundType();

--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -1533,9 +1533,9 @@ void Settings::setHighlightPosition(bool highlight) {
     save();
 }
 
-auto Settings::getCursorHighlightColor() const -> Color { return this->cursorHighlightColor; }
+auto Settings::getCursorHighlightColor() const -> const Color& { return this->cursorHighlightColor; }
 
-void Settings::setCursorHighlightColor(Color color) {
+void Settings::setCursorHighlightColor(const Color& color) {
     if (this->cursorHighlightColor != color) {
         this->cursorHighlightColor = color;
         save();
@@ -1551,9 +1551,9 @@ void Settings::setCursorHighlightRadius(double radius) {
     }
 }
 
-auto Settings::getCursorHighlightBorderColor() const -> Color { return this->cursorHighlightBorderColor; }
+auto Settings::getCursorHighlightBorderColor() const -> const Color& { return this->cursorHighlightBorderColor; }
 
-void Settings::setCursorHighlightBorderColor(Color color) {
+void Settings::setCursorHighlightBorderColor(const Color& color) {
     if (this->cursorHighlightBorderColor != color) {
         this->cursorHighlightBorderColor = color;
         save();
@@ -2147,9 +2147,9 @@ void Settings::setEagerPageCleanup(bool b) {
     save();
 }
 
-auto Settings::getBorderColor() const -> Color { return this->selectionBorderColor; }
+auto Settings::getBorderColor() const -> const Color& { return this->selectionBorderColor; }
 
-void Settings::setBorderColor(Color color) {
+void Settings::setBorderColor(const Color& color) {
     if (this->selectionBorderColor == color) {
         return;
     }
@@ -2157,9 +2157,9 @@ void Settings::setBorderColor(Color color) {
     save();
 }
 
-auto Settings::getSelectionColor() const -> Color { return this->selectionMarkerColor; }
+auto Settings::getSelectionColor() const -> const Color& { return this->selectionMarkerColor; }
 
-void Settings::setSelectionColor(Color color) {
+void Settings::setSelectionColor(const Color& color) {
     if (this->selectionMarkerColor == color) {
         return;
     }
@@ -2167,9 +2167,9 @@ void Settings::setSelectionColor(Color color) {
     save();
 }
 
-auto Settings::getActiveSelectionColor() const -> Color { return this->activeSelectionColor; }
+auto Settings::getActiveSelectionColor() const -> const Color& { return this->activeSelectionColor; }
 
-void Settings::setActiveSelectionColor(Color color) {
+void Settings::setActiveSelectionColor(const Color& color) {
     if (this->activeSelectionColor == color) {
         return;
     }
@@ -2187,9 +2187,9 @@ void Settings::setRecolorParameters(RecolorParameters&& recolor) {
     save();
 }
 
-auto Settings::getBackgroundColor() const -> Color { return this->backgroundColor; }
+auto Settings::getBackgroundColor() const -> const Color& { return this->backgroundColor; }
 
-void Settings::setBackgroundColor(Color color) {
+void Settings::setBackgroundColor(const Color& color) {
     if (this->backgroundColor == color) {
         return;
     }

--- a/src/core/control/settings/Settings.h
+++ b/src/core/control/settings/Settings.h
@@ -339,14 +339,14 @@ public:
     bool isHighlightPosition() const;
     void setHighlightPosition(bool highlight);
 
-    Color getCursorHighlightColor() const;
-    void setCursorHighlightColor(Color color);
+    const Color& getCursorHighlightColor() const;
+    void setCursorHighlightColor(const Color& color);
 
     double getCursorHighlightRadius() const;
     void setCursorHighlightRadius(double radius);
 
-    Color getCursorHighlightBorderColor() const;
-    void setCursorHighlightBorderColor(Color color);
+    const Color& getCursorHighlightBorderColor() const;
+    void setCursorHighlightBorderColor(const Color& color);
 
     double getCursorHighlightBorderWidth() const;
     void setCursorHighlightBorderWidth(double width);
@@ -370,17 +370,17 @@ public:
 
     void setViewMode(ViewModeId mode, ViewMode ViewMode);
 
-    Color getBorderColor() const;
-    void setBorderColor(Color color);
+    const Color& getBorderColor() const;
+    void setBorderColor(const Color& color);
 
-    Color getSelectionColor() const;
-    void setSelectionColor(Color color);
+    const Color& getSelectionColor() const;
+    void setSelectionColor(const Color& color);
 
-    Color getBackgroundColor() const;
-    void setBackgroundColor(Color color);
+    const Color& getBackgroundColor() const;
+    void setBackgroundColor(const Color& color);
 
-    Color getActiveSelectionColor() const;
-    void setActiveSelectionColor(Color color);
+    const Color& getActiveSelectionColor() const;
+    void setActiveSelectionColor(const Color& color);
 
     const RecolorParameters& getRecolorParameters() const;
     void setRecolorParameters(RecolorParameters&& recolorParameters);

--- a/src/core/control/tools/EditSelection.cpp
+++ b/src/core/control/tools/EditSelection.cpp
@@ -428,7 +428,7 @@ auto EditSelection::setLineStyle(LineStyle style) -> UndoActionPtr { return this
  * Set the color of all elements, return an undo action
  * (Or nullptr if nothing done, e.g. because there is only an image)
  */
-auto EditSelection::setColor(Color color) -> UndoActionPtr { return this->contents->setColor(color); }
+auto EditSelection::setColor(const Color& color) -> UndoActionPtr { return this->contents->setColor(color); }
 
 /**
  * Sets the font of all containing text elements, return an undo action

--- a/src/core/control/tools/EditSelection.h
+++ b/src/core/control/tools/EditSelection.h
@@ -12,7 +12,7 @@
 
 #pragma once
 
-#include <memory>  // for unique_ptr
+#include <memory>   // for unique_ptr
 #include <utility>  // for pair
 #include <vector>   // for vector
 
@@ -181,7 +181,7 @@ public:
      * Set the color of all elements, return an undo action
      * (Or nullptr if nothing done, e.g. because there is only an image)
      */
-    UndoActionPtr setColor(Color color);
+    UndoActionPtr setColor(const Color& color);
 
     /**
      * Sets the font of all containing text elements, return an undo action

--- a/src/core/control/tools/EditSelectionContents.cpp
+++ b/src/core/control/tools/EditSelectionContents.cpp
@@ -284,7 +284,7 @@ auto EditSelectionContents::setLineStyle(LineStyle style) -> UndoActionPtr {
  * Set the color of all elements, return an undo action
  * (Or nullptr if nothing done, e.g. because there is only an image)
  */
-auto EditSelectionContents::setColor(Color color) -> UndoActionPtr {
+auto EditSelectionContents::setColor(const Color& color) -> UndoActionPtr {
     auto undo = std::make_unique<ColorUndoAction>(this->sourcePage, this->sourceLayer);
 
     bool found = false;

--- a/src/core/control/tools/EditSelectionContents.h
+++ b/src/core/control/tools/EditSelectionContents.h
@@ -63,7 +63,7 @@ public:
      * Set the color of all elements, return an undo action
      * (Or nullptr if nothing done, e.g. because there is only an image)
      */
-    UndoActionPtr setColor(Color color);
+    UndoActionPtr setColor(const Color& color);
 
     /**
      * Sets the font of all containing text elements, return an undo action

--- a/src/core/control/tools/TextEditor.cpp
+++ b/src/core/control/tools/TextEditor.cpp
@@ -195,7 +195,7 @@ void TextEditor::replaceBufferContent(const std::string& text) {
     this->cursorBox = computeCursorBox();
 }
 
-void TextEditor::setColor(Color color) {
+void TextEditor::setColor(const Color& color) {
     this->textElement->setColor(color);
     repaintEditor(false);
 }
@@ -899,7 +899,7 @@ void TextEditor::setTextToPangoLayout(PangoLayout* pl) const {
     }
 }
 
-Color TextEditor::getSelectionColor() const { return this->control->getSettings()->getSelectionColor(); }
+const Color& TextEditor::getSelectionColor() const { return this->control->getSettings()->getSelectionColor(); }
 
 void TextEditor::setSelectionAttributesToPangoLayout(PangoLayout* pl) const {
     xoj::util::PangoAttrListSPtr attrlist(pango_attr_list_new(), xoj::util::adopt);

--- a/src/core/control/tools/TextEditor.h
+++ b/src/core/control/tools/TextEditor.h
@@ -66,13 +66,13 @@ public:
     bool bufferEmpty() const;
 
     void setFont(XojFont font);
-    void setColor(Color color);
+    void setColor(const Color& color);
 
     PangoLayout* getUpToDateLayout() const;
 
     const std::shared_ptr<xoj::util::DispatchPool<xoj::view::TextEditionView>>& getViewPool() const;
 
-    Color getSelectionColor() const;
+    const Color& getSelectionColor() const;
 
     const Range& getCursorBox() const;
     const Range& getContentBoundingBox() const;

--- a/src/core/control/xojfile/SaveHandler.cpp
+++ b/src/core/control/xojfile/SaveHandler.cpp
@@ -1,8 +1,8 @@
 #include "SaveHandler.h"
 
-#include <cinttypes>   // for PRIx32
-#include <cstdint>     // for uint32_t
-#include <cstdio>      // for sprintf, size_t
+#include <cinttypes>  // for PRIx32
+#include <cstdint>    // for uint32_t
+#include <cstdio>     // for sprintf, size_t
 
 #include <cairo.h>                  // for cairo_surface_t
 #include <gdk-pixbuf/gdk-pixbuf.h>  // for gdk_pixbuf_save
@@ -81,7 +81,7 @@ void SaveHandler::writeHeader() {
     this->root->addChild(new XmlTextNode("title", std::string{"Xournal++ document - see "} + PROJECT_HOMEPAGE_URL));
 }
 
-auto SaveHandler::getColorStr(Color c, unsigned char alpha) -> std::string {
+auto SaveHandler::getColorStr(const Color& c, unsigned char alpha) -> std::string {
     char str[10];
     sprintf(str, "#%08" PRIx32, uint32_t(c) << 8U | alpha);
     std::string color(str);

--- a/src/core/control/xojfile/SaveHandler.h
+++ b/src/core/control/xojfile/SaveHandler.h
@@ -42,7 +42,7 @@ public:
     const std::string& getErrorMessage();
 
 protected:
-    static std::string getColorStr(Color c, unsigned char alpha = 0xff);
+    static std::string getColorStr(const Color& c, unsigned char alpha = 0xff);
 
     virtual void visitPage(XmlNode* root, ConstPageRef p, const Document* doc, int id, const fs::path& target);
     virtual void visitLayer(XmlNode* page, const Layer* l);

--- a/src/core/enums/Action.enum.h
+++ b/src/core/enums/Action.enum.h
@@ -183,7 +183,7 @@ constexpr auto Action_toString(Action value) -> const char* {
 }
 
 constexpr auto Action_fromString(const std::string_view value) -> Action {
-    for (size_t n = 0; n < xoj::to_underlying(Action::ENUMERATOR_COUNT); n++) {
+    for (size_t n = 0; n < std::to_underlying(Action::ENUMERATOR_COUNT); n++) {
         if (value == ACTION_NAMES[n]) {
             return static_cast<Action>(n);
         }

--- a/src/core/gui/dialog/AbstractLatexDialog.cpp
+++ b/src/core/gui/dialog/AbstractLatexDialog.cpp
@@ -40,7 +40,7 @@ void AbstractLatexDialog::setTempRender(PopplerDocument* pdf) {
     gtk_widget_queue_draw(GTK_WIDGET(this->previewDrawingArea));
 }
 
-void AbstractLatexDialog::setPreviewBackgroundColor(Color newColor) { this->previewBackgroundColor = newColor; }
+void AbstractLatexDialog::setPreviewBackgroundColor(const Color& newColor) { this->previewBackgroundColor = newColor; }
 
 void AbstractLatexDialog::previewDrawFunc(GtkDrawingArea*, cairo_t* cr, int width, int height,
                                           AbstractLatexDialog* self) {

--- a/src/core/gui/dialog/AbstractLatexDialog.h
+++ b/src/core/gui/dialog/AbstractLatexDialog.h
@@ -44,7 +44,7 @@ public:
      * Set TeX preview background color to the given color.
      * @param color New preview background color.
      */
-    void setPreviewBackgroundColor(Color color);
+    void setPreviewBackgroundColor(const Color& color);
 
     inline GtkWindow* getWindow() const { return window.get(); }
 

--- a/src/core/gui/dialog/toolbarCustomize/ToolbarCustomizeDialog.cpp
+++ b/src/core/gui/dialog/toolbarCustomize/ToolbarCustomizeDialog.cpp
@@ -87,7 +87,7 @@ ToolbarCustomizeDialog::ToolbarCustomizeDialog(GladeSearchpath* gladeSearchPath,
     labels[Cat::PLUGINS] = C_("Item category in toolbar customization dialog", "Plugins");
     EnumIndexedArray<GtkWidget*, Cat> tabs;
 
-    for (std::underlying_type_t<Cat> n = 0; n < xoj::to_underlying(Cat::ENUMERATOR_COUNT); n++) {
+    for (std::underlying_type_t<Cat> n = 0; n < std::to_underlying(Cat::ENUMERATOR_COUNT); n++) {
         Cat c = static_cast<Cat>(n);
         tabs[c] = gtk_list_box_new();
         GtkWidget* w = gtk_scrolled_window_new();

--- a/src/core/gui/inputdevices/TouchDrawingInputHandler.cpp
+++ b/src/core/gui/inputdevices/TouchDrawingInputHandler.cpp
@@ -39,7 +39,6 @@ TouchDrawingInputHandler::TouchDrawingInputHandler(InputContext* inputContext): 
 TouchDrawingInputHandler::~TouchDrawingInputHandler() = default;
 
 auto TouchDrawingInputHandler::handleImpl(InputEvent const& event) -> bool {
-    auto* mainWindow = inputContext->getView()->getControl()->getWindow();
     ToolHandler* toolHandler = this->inputContext->getToolHandler();
 
     // Do we need to end the touch sequence?

--- a/src/core/gui/toolbarMenubar/ColorToolItem.cpp
+++ b/src/core/gui/toolbarMenubar/ColorToolItem.cpp
@@ -20,7 +20,7 @@ ColorToolItem::ColorToolItem(NamedColor namedColor, const std::optional<Recolor>
 
 ColorToolItem::~ColorToolItem() = default;
 
-auto ColorToolItem::getColor() const -> Color { return this->namedColor.getColor(); }
+auto ColorToolItem::getColor() const -> const Color& { return this->namedColor.getColor(); }
 
 auto ColorToolItem::createItem(bool) -> xoj::util::WidgetSPtr {
     auto* btn = gtk_toggle_button_new();

--- a/src/core/gui/toolbarMenubar/ColorToolItem.h
+++ b/src/core/gui/toolbarMenubar/ColorToolItem.h
@@ -38,7 +38,7 @@ public:
     std::string getToolDisplayName() const override;
     GtkWidget* getNewToolIcon() const override;
 
-    Color getColor() const;
+    const Color& getColor() const;
 
     /**
      * @brief Update Color based on (new) palette

--- a/src/core/gui/toolbarMenubar/icon/ColorIcon.cpp
+++ b/src/core/gui/toolbarMenubar/icon/ColorIcon.cpp
@@ -9,7 +9,7 @@ namespace ColorIcon {
 /**
  * Create a new GtkImage with preview color
  */
-auto newGtkImage(Color color, int size, bool circle, std::optional<Color> secondaryColor) -> GtkWidget* {
+auto newGtkImage(const Color& color, int size, bool circle, std::optional<Color> secondaryColor) -> GtkWidget* {
     xoj::util::GObjectSPtr<GdkPixbuf> img(newGdkPixbuf(color, size, circle, secondaryColor));
     GtkWidget* w = gtk_image_new_from_pixbuf(img.get());
     gtk_widget_show(w);
@@ -19,7 +19,7 @@ auto newGtkImage(Color color, int size, bool circle, std::optional<Color> second
 /**
  * Create a new GdkPixbuf* with preview color
  */
-auto newGdkPixbuf(Color color, int size, bool circle, std::optional<Color> secondaryColor)
+auto newGdkPixbuf(const Color& color, int size, bool circle, std::optional<Color> secondaryColor)
         -> xoj::util::GObjectSPtr<GdkPixbuf> {
     xoj::util::CairoSurfaceSPtr buf(cairo_image_surface_create(CAIRO_FORMAT_ARGB32, size, size), xoj::util::adopt);
     xoj::util::CairoSPtr cr(cairo_create(buf.get()), xoj::util::adopt);

--- a/src/core/gui/toolbarMenubar/icon/ColorIcon.h
+++ b/src/core/gui/toolbarMenubar/icon/ColorIcon.h
@@ -24,12 +24,12 @@ namespace ColorIcon {
  * @brief Create a new GtkImage with preview color
  * @return The pointer is a floating ref
  */
-GtkWidget* newGtkImage(Color color, int size = 22, bool circle = true,
+GtkWidget* newGtkImage(const Color& color, int size = 22, bool circle = true,
                        std::optional<Color> secondaryColor = std::nullopt);
 
 /**
  * @brief Create a new GdkPixbuf* with preview color
  */
-xoj::util::GObjectSPtr<GdkPixbuf> newGdkPixbuf(Color color, int size = 22, bool circle = true,
+xoj::util::GObjectSPtr<GdkPixbuf> newGdkPixbuf(const Color& color, int size = 22, bool circle = true,
                                                std::optional<Color> secondaryColor = std::nullopt);
 };  // namespace ColorIcon

--- a/src/core/model/Element.cpp
+++ b/src/core/model/Element.cpp
@@ -75,9 +75,9 @@ auto Element::boundingRect() const -> Rectangle<double> {
     return Rectangle<double>(getX(), getY(), getElementWidth(), getElementHeight());
 }
 
-void Element::setColor(Color color) { this->color = color; }
+void Element::setColor(const Color& color) { this->color = color; }
 
-auto Element::getColor() const -> Color { return this->color; }
+auto Element::getColor() const -> const Color& { return this->color; }
 
 auto Element::intersectsArea(const GdkRectangle* src) const -> bool {
     // compute the smallest rectangle with integer coordinates containing the bounding box and having width, height > 0

--- a/src/core/model/Element.h
+++ b/src/core/model/Element.h
@@ -58,8 +58,8 @@ public:
     virtual void scale(double x0, double y0, double fx, double fy, double rotation, bool restoreLineWidth) = 0;
     virtual void rotate(double x0, double y0, double th) = 0;
 
-    void setColor(Color color);
-    Color getColor() const;
+    void setColor(const Color& color);
+    const Color& getColor() const;
 
     double getElementWidth() const;
     double getElementHeight() const;

--- a/src/core/model/XojPage.cpp
+++ b/src/core/model/XojPage.cpp
@@ -11,7 +11,8 @@
 
 #include "BackgroundImage.h"  // for BackgroundImage
 
-XojPage::XojPage(double width, double height, bool suppressLayerCreation): width(width), height(height), bgType(PageTypeFormat::Lined) {
+XojPage::XojPage(double width, double height, bool suppressLayerCreation):
+        width(width), height(height), bgType(PageTypeFormat::Lined) {
     if (!suppressLayerCreation) {
         // ensure at least one valid layer exists
         this->addLayer(new Layer());
@@ -20,7 +21,9 @@ XojPage::XojPage(double width, double height, bool suppressLayerCreation): width
 }
 
 XojPage::~XojPage() {
-    for (Layer* l: this->layer) { delete l; }
+    for (Layer* l: this->layer) {
+        delete l;
+    }
     this->layer.clear();
 }
 
@@ -117,9 +120,9 @@ void XojPage::setBackgroundPdfPageNr(size_t page) {
     this->bgType.config = "";
 }
 
-void XojPage::setBackgroundColor(Color color) { this->backgroundColor = color; }
+void XojPage::setBackgroundColor(const Color& color) { this->backgroundColor = color; }
 
-auto XojPage::getBackgroundColor() const -> Color { return this->backgroundColor; }
+auto XojPage::getBackgroundColor() const -> const Color& { return this->backgroundColor; }
 
 void XojPage::setSize(double width, double height) {
     this->width = width;

--- a/src/core/model/XojPage.h
+++ b/src/core/model/XojPage.h
@@ -59,8 +59,8 @@ public:
 
     bool isAnnotated() const;
 
-    void setBackgroundColor(Color color);
-    Color getBackgroundColor() const;
+    void setBackgroundColor(const Color& color);
+    const Color& getBackgroundColor() const;
 
     std::vector<Layer*>& getLayers();
     xoj::util::PointerContainerView<std::vector<Layer*>> getLayersView() const;

--- a/src/util/Color.cpp
+++ b/src/util/Color.cpp
@@ -4,24 +4,24 @@
 #include <iomanip>    // for operator<<, setfill, setw
 #include <sstream>    // for operator<<, stringstream, basic_ostream, char_t...
 
-#include "util/Assert.h"  // for xoj_assert
+#include "util/Assert.h"        // for xoj_assert
 #include "util/serdesstream.h"  // for serdes_stream
 
-float Util::as_grayscale_color(Color color) {
+float Util::as_grayscale_color(const Color& color) {
     GdkRGBA components = rgb_to_GdkRGBA(color);
     float componentAvg = static_cast<float>(components.red + components.green + components.blue) / 3.0f;
 
     return componentAvg;
 }
 
-float Util::get_color_contrast(Color color1, Color color2) {
+float Util::get_color_contrast(const Color& color1, const Color& color2) {
     float grayscale1 = as_grayscale_color(color1);
     float grayscale2 = as_grayscale_color(color2);
 
     return std::max(grayscale1, grayscale2) - std::min(grayscale1, grayscale2);
 }
 
-auto Util::rgb_to_hex_string(Color rgb) -> std::string {
+auto Util::rgb_to_hex_string(const Color& rgb) -> std::string {
     auto s = serdes_stream<std::ostringstream>();
     auto tmp_color = rgb;
     tmp_color.alpha = 0;

--- a/src/util/NamedColor.cpp
+++ b/src/util/NamedColor.cpp
@@ -20,7 +20,7 @@ NamedColor::NamedColor(size_t paletteIndex):
         color{Color(0u)},
         isPaletteColor{true} {}
 
-NamedColor::NamedColor(Color color):
+NamedColor::NamedColor(const Color& color):
         paletteIndex{0},
         name{"Custom Color"},
         colorU16(Util::argb_to_ColorU16(color)),
@@ -56,9 +56,9 @@ auto operator>>(std::istream& str, NamedColor& namedColor) -> std::istream& {
     return str;
 }
 
-auto NamedColor::getColorU16() const -> ColorU16 { return colorU16; }
+auto NamedColor::getColorU16() const -> const ColorU16& { return colorU16; }
 
-auto NamedColor::getColor() const -> Color { return color; }
+auto NamedColor::getColor() const -> const Color& { return color; }
 
 auto NamedColor::getIndex() const -> size_t { return paletteIndex; };
 

--- a/src/util/include/util/Color.h
+++ b/src/util/include/util/Color.h
@@ -116,7 +116,7 @@ constexpr auto floatToUIntColor(double color) -> uint8_t;
  * @param color Color to convert to grayscale.
  * @return Given color converted to grayscale 1.0 -> white, 0.0 -> black.
  */
-float as_grayscale_color(Color color);
+float as_grayscale_color(const Color& color);
 
 /**
  *  Get the fraction by which the grayscale value of color1 contrasts
@@ -125,14 +125,14 @@ float as_grayscale_color(Color color);
  * @return Scale factor by which the two given colors differ. Must be in
  *          [0.0, 1.0].
  */
-float get_color_contrast(Color color1, Color color2);
+float get_color_contrast(const Color& color1, const Color& color2);
 
 /**
  * @param rgb Color to get a representation for, while ignoring the alpha channel.
  * @return a CSS-style representation of the color, in hex. For example,
  *          red might be #ff0000, green, #00ff00, and blue, #0000ff.
  */
-std::string rgb_to_hex_string(Color rgb);
+std::string rgb_to_hex_string(const Color& rgb);
 }  // namespace Util
 
 constexpr auto Util::rgb_to_GdkRGBA(Color color) -> GdkRGBA {  //

--- a/src/util/include/util/EnumIndexedArray.h
+++ b/src/util/include/util/EnumIndexedArray.h
@@ -22,17 +22,17 @@ template <class T, typename enum_class,
           std::enable_if_t<std::is_enum_v<enum_class> && std::is_unsigned_v<std::underlying_type_t<enum_class>> &&
                                    !std::is_convertible_v<enum_class, std::underlying_type_t<enum_class>>,
                            bool> = true>
-class EnumIndexedArray: private std::array<T, xoj::to_underlying(enum_class::ENUMERATOR_COUNT)> {
+class EnumIndexedArray: private std::array<T, std::to_underlying(enum_class::ENUMERATOR_COUNT)> {
 public:
-    using underlying_array_type = std::array<T, xoj::to_underlying(enum_class::ENUMERATOR_COUNT)>;
+    using underlying_array_type = std::array<T, std::to_underlying(enum_class::ENUMERATOR_COUNT)>;
 
     T& operator[](enum_class value) {
         xoj_assert(value < enum_class::ENUMERATOR_COUNT);
-        return underlying_array_type::operator[](xoj::to_underlying(value));
+        return underlying_array_type::operator[](std::to_underlying(value));
     }
     const T& operator[](enum_class value) const {
         xoj_assert(value < enum_class::ENUMERATOR_COUNT);
-        return underlying_array_type::operator[](xoj::to_underlying(value));
+        return underlying_array_type::operator[](std::to_underlying(value));
     }
     using underlying_array_type::begin;
     using underlying_array_type::end;

--- a/src/util/include/util/NamedColor.h
+++ b/src/util/include/util/NamedColor.h
@@ -54,7 +54,7 @@ struct NamedColor {
      *
      * @param color color to set for the custom NamedColor instance
      */
-    explicit NamedColor(Color color);
+    explicit NamedColor(const Color& color);
 
     /**
      * @brief Input operator for parsing NamedColor from input string stream
@@ -70,14 +70,14 @@ struct NamedColor {
      *
      * @return ColorU16
      */
-    auto getColorU16() const -> ColorU16;
+    auto getColorU16() const -> const ColorU16&;
 
     /**
      * @brief Get the color formatted as Color object
      *
      * @return Color
      */
-    auto getColor() const -> Color;
+    auto getColor() const -> const Color&;
 
     /**
      * @brief Get the Index of the NamedColor inside the Palette

--- a/src/util/include/util/PointerContainerView.h
+++ b/src/util/include/util/PointerContainerView.h
@@ -17,9 +17,9 @@
 
 #include "util/safe_casts.h"
 
-namespace xoj::util {
-
 // Todo(cpp20) use std::to_address instead
+namespace std {
+
 template <typename T>
 T* to_address(T*& t) {
     return t;
@@ -38,6 +38,10 @@ template <typename T>
 const T* to_address(const std::unique_ptr<T>& t) {
     return t.get();
 }
+
+}  // namespace std
+
+namespace xoj::util {
 
 template <typename container_type>
 class PointerContainerView {
@@ -60,8 +64,8 @@ public:
         iterator_impl(base_it it): base_it(it) {}
 
         // We must return by value
-        value_type operator*() const { return to_address(base_it::operator*()); }
-        value_type operator[](difference_type n) const { return to_address(base_it::operator[](n)); }
+        value_type operator*() const { return std::to_address(base_it::operator*()); }
+        value_type operator[](difference_type n) const { return std::to_address(base_it::operator[](n)); }
 
     private:
         using base_it::operator->;

--- a/src/util/include/util/raii/CairoWrappers.h
+++ b/src/util/include/util/raii/CairoWrappers.h
@@ -26,21 +26,21 @@ class CairoHandler {
 public:
     constexpr static auto ref = [](cairo_t* cr) { return cairo_reference(cr); };
     constexpr static auto unref = [](cairo_t* cr) { cairo_destroy(cr); };
-    constexpr static auto adopt = identity<cairo_t>;
+    constexpr static auto adopt = std::identity<cairo_t>;
 };
 
 class CairoSurfaceHandler {
 public:
     constexpr static auto ref = [](cairo_surface_t* cs) { return cairo_surface_reference(cs); };
     constexpr static auto unref = [](cairo_surface_t* cs) { cairo_surface_destroy(cs); };
-    constexpr static auto adopt = identity<cairo_surface_t>;
+    constexpr static auto adopt = std::identity<cairo_surface_t>;
 };
 
 class CairoRegionHandler {
 public:
     constexpr static auto ref = [](cairo_region_t* cr) { return cairo_region_reference(cr); };
     constexpr static auto unref = [](cairo_region_t* cr) { cairo_region_destroy(cr); };
-    constexpr static auto adopt = identity<cairo_region_t>;
+    constexpr static auto adopt = std::identity<cairo_region_t>;
 };
 };  // namespace specialization
 

--- a/src/util/include/util/raii/IdentityFunction.h
+++ b/src/util/include/util/raii/IdentityFunction.h
@@ -11,12 +11,10 @@
 
 #pragma once
 
-namespace xoj::util {
+namespace std {
 
-inline namespace raii {
-namespace specialization {
-template <typename T>  // Todo(cpp20): use std:identity() and remove this header
+// Todo(cpp20): use std::identity() and remove this header
+template <typename T>
 constexpr auto identity = [](T* p) { return p; };
-};
-};  // namespace raii
-};  // namespace xoj::util
+
+};  // namespace std

--- a/src/util/include/util/raii/PangoSPtr.h
+++ b/src/util/include/util/raii/PangoSPtr.h
@@ -24,7 +24,7 @@ class PangoAttrListHandler {
 public:
     constexpr static auto ref = pango_attr_list_ref;
     constexpr static auto unref = pango_attr_list_unref;
-    constexpr static auto adopt = identity<PangoAttrList>;
+    constexpr static auto adopt = std::identity<PangoAttrList>;
 };
 };  // namespace specialization
 

--- a/src/util/include/util/safe_casts.h
+++ b/src/util/include/util/safe_casts.h
@@ -100,12 +100,13 @@ inline auto floor_cast(Float f) -> Integral {
     return rv1;
 }
 
-namespace xoj {
+// Todo(cpp23) This is available in std:: since C++23
+namespace std {
 template <class Enum>
 constexpr std::underlying_type_t<Enum> to_underlying(Enum e) noexcept {
     return static_cast<std::underlying_type_t<Enum>>(e);
 }
-}  // namespace xoj
+}  // namespace std
 
 #if defined __has_include && !defined(XOJ_USE_STD_BIT_CAST)
 #if __has_include(<bit>)

--- a/test/unit_tests/control/ActionDatabaseTest.cpp
+++ b/test/unit_tests/control/ActionDatabaseTest.cpp
@@ -51,7 +51,7 @@ static auto setupImpl(std::index_sequence<As...>) {
     return expectedTypes;
 }
 
-static const auto expectedTypes = setupImpl(std::make_index_sequence<xoj::to_underlying(Action::ENUMERATOR_COUNT)>());
+static const auto expectedTypes = setupImpl(std::make_index_sequence<std::to_underlying(Action::ENUMERATOR_COUNT)>());
 
 void exploreMenu(GMenuModel* m, int lvl = 1) {
     int n = g_menu_model_get_n_items(m);


### PR DESCRIPTION
I was browsing the source code and I found several "Todo" items, and I thought I could get them out of the way for you. Some of the changes are due to clang-format.

1. TODO: struct for return type in getAudioAttributes.
    
    I added a struct as a return type for a method in the class `AudioQueue`.

2. TODO: fictitious namespace 'std' for easier replacement of library functions.

    So I have replaced the `xoj_utils` namespace in some files with `std`. This is a little unorthodox, but this way the rest of the code uses the `to_underlying`, `to_address`, and `identity` functions in defined in xournalpp as if they were from the standard library. Once the project is upgraded to C++20, using these functions from the STL will be a little easier since you will only have to remove the code and replace the corresponding `#include`.

Other changes that are not "Todo" items

1. I found a lot of `Color` parameters (and return values) that were not declared as constant references. This implies copying, even if it just 4 `uint32_t`. So I changed the function signatures to `const Color&` wherever possible.

2. I removed an unused variable. I looked at the code and that was added on 2021.