### PR TITLE
Allow to set cmake flags on a per-target base in available-build-targets.json

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -9,6 +9,10 @@ inputs:
     default: '-DENABLE_GTEST=ON -DDOWNLOAD_GTEST=on'
     type: string
     required: false
+  extra_cmake_flags:
+    default: ''
+    type: string
+    required: false
   cmake_commands:
     default: ''
     type: string
@@ -29,7 +33,7 @@ runs:
     run: |
       which pkg-config
       pkg-config --version
-      cmake -GNinja .. -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} ${{ inputs.cmake_flags }}
+      cmake -GNinja .. -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} ${{ inputs.cmake_flags }} ${{ inputs.extra_cmake_flags }}
       # Make sure pot is up to date with sources (maybe translation pipeline is currently running)
       cmake --build . --target pot
       cmake --build . --target translations

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -75,6 +75,7 @@ jobs:
         uses: ./.github/actions/build
         with:
           build_type: ${{env.BUILD_TYPE}}
+          extra_cmake_flags: ${{ matrix.run.extra_cmake_flags }}
       - name: 'Build tests'
         id: build-test
         run: |
@@ -140,6 +141,7 @@ jobs:
         uses: ./.github/actions/build
         with:
           build_type: ${{env.BUILD_TYPE}}
+          extra_cmake_flags: ${{ matrix.run.extra_cmake_flags }}
           shell: msys2 {0}
       - name: 'Build tests'
         shell: msys2 {0}
@@ -168,6 +170,7 @@ jobs:
         uses: ./.github/actions/build
         with:
           build_type: ${{env.BUILD_TYPE}}
+          extra_cmake_flags: ${{ matrix.run.extra_cmake_flags }}
       - name: 'Build tests'
         shell: bash
         run: |

--- a/.github/workflows/create-installers.yml
+++ b/.github/workflows/create-installers.yml
@@ -57,6 +57,7 @@ jobs:
       container_image: ${{ matrix.run.container_image }}
       head_sha: ${{ inputs.head_sha }}
       artifact_version_suffix: ${{ inputs.artifact_version_suffix }}
+      extra_cmake_flags: ${{ matrix.run.extra_cmake_flags }}
 
   ci-windows:
     name: Create installer (Windows)
@@ -74,6 +75,7 @@ jobs:
       publish_portable_version:  ${{ matrix.run.build_portable == 'true' }}
       head_sha: ${{ inputs.head_sha }}
       artifact_version_suffix: ${{ inputs.artifact_version_suffix }}
+      extra_cmake_flags: ${{ matrix.run.extra_cmake_flags }}
 
   ci-macos:
     name: Create installer (MacOS)
@@ -88,3 +90,4 @@ jobs:
       displayed_name: ${{ matrix.run.displayed_name }}
       head_sha: ${{ inputs.head_sha }}
       artifact_version_suffix: ${{ inputs.artifact_version_suffix }}
+      extra_cmake_flags: ${{ matrix.run.extra_cmake_flags }}

--- a/.github/workflows/make-installer-linux.yml
+++ b/.github/workflows/make-installer-linux.yml
@@ -28,6 +28,9 @@ on:
       build_type:
         type: string
         default: 'RelWithDebInfo'
+      extra_cmake_flags:
+        type: string
+        default: ''
       artifact_version_suffix:  # Additional version string appended to 1.2.3+dev (for instance) in artifacts names
         type: string
         default: ''
@@ -80,6 +83,7 @@ jobs:
           cmake_flags: >-
             -DCMAKE_INSTALL_PREFIX=/usr
             -DCPACK_GENERATOR="TGZ;DEB"
+          extra_cmake_flags: ${{ inputs.extra_cmake_flags }}
           cmake_commands: '--target package'
       - name: 'Rename assets'
         if: ${{ inputs.artifact_version_suffix != '' }}

--- a/.github/workflows/make-installer-macos.yml
+++ b/.github/workflows/make-installer-macos.yml
@@ -15,6 +15,9 @@ on:
       build_type:
         type: string
         default: 'RelWithDebInfo'
+      extra_cmake_flags:
+        type: string
+        default: ''
       artifact_version_suffix:  # Additional version string appended to 1.2.3+dev (for instance) in artifacts names
         type: string
         default: ''
@@ -44,6 +47,7 @@ jobs:
           build_type: ${{ inputs.build_type }}
           cmake_flags: >-
             -DCMAKE_INSTALL_PREFIX="$HOME/gtk/inst"
+          extra_cmake_flags: ${{ inputs.extra_cmake_flags }}
       - name: 'Create installer'
         id: create-installer
         shell: bash

--- a/.github/workflows/make-installer-windows.yml
+++ b/.github/workflows/make-installer-windows.yml
@@ -25,6 +25,9 @@ on:
       build_type:
         type: string
         default: 'RelWithDebInfo'
+      extra_cmake_flags:
+        type: string
+        default: ''
       artifact_version_suffix:  # Additional version string appended to 1.2.3+dev (for instance) in artifacts names
         type: string
         default: ''
@@ -57,6 +60,7 @@ jobs:
         uses: ./.github/actions/build
         with:
           build_type: ${{ inputs.build_type }}
+          extra_cmake_flags: ${{ inputs.extra_cmake_flags }}
           shell: msys2 {0}
       - name: 'Create installer'
         id: create-installer


### PR DESCRIPTION
Adds some flexibility in the CI targets by specifying cmake flags per targets. See https://github.com/xournalpp/xournalpp/commit/81f380435f45ce4f3e641edf12b23b70469a1272 for an example:
Adding 
```
"extra_cmake_flags": "-DENABLE_AUDIO=off -DENABLE_PLUGINS=off"
```
to the target in available-build-targets.json will build without audio or plugin support.

This is for instance needed by #6594.