### PR TITLE
Try to avoid shortening line strokes unnecessarily

### DIFF
--- a/src/core/control/shaperecognizer/ShapeRecognizer.cpp
+++ b/src/core/control/shaperecognizer/ShapeRecognizer.cpp
@@ -333,9 +333,26 @@ auto ShapeRecognizer::recognizePatterns(Stroke* stroke, double strokeMinSize) ->
                 s->addPoint(Point(rs->x1, rs->y1));
                 s->addPoint(Point(rs->x2, rs->y2));
             } else {
-                auto points = stroke->getPointVector();
-                s->addPoint(Point(points.front().x, points.front().y));
-                s->addPoint(Point(points.back().x, points.back().y));
+                const Point P(rs->x1, rs->y1);
+                const Point Q(rs->x2, rs->y2);
+
+                const auto& points = stroke->getPointVector();
+                const Point& last = points.back();
+
+                const double dx = Q.x - P.x;
+                const double dy = Q.y - P.y;
+                const double num = dy * last.x - dx * last.y + Q.x * P.y - Q.y * P.x;
+                const double num2 = num * num;
+                const double den2 = dy * dy + dx * dx;
+                const double dist2 = num2 / den2;
+
+                if (dist2 < LINE_POINT_DIST2_THRESHOLD) {
+                    s->addPoint(P);
+                    s->addPoint(Q);
+                } else {
+                    s->addPoint(Point(points.front().x, points.front().y));
+                    s->addPoint(Point(points.back().x, points.back().y));
+                }
             }
 
             RDEBUG("return line");

--- a/src/core/control/shaperecognizer/ShapeRecognizerConfig.h
+++ b/src/core/control/shaperecognizer/ShapeRecognizerConfig.h
@@ -15,6 +15,7 @@
 
 #define MAX_POLYGON_SIDES 4
 
+#define LINE_POINT_DIST2_THRESHOLD 15                // threshold of maximum distance from point to line
 #define SEGMENT_MAX_DET 0.045                        // maximum score for a polygon segment (ideal line = 0)
 #define LINE_MAX_DET 0.015                           // maximum score for single line, stricter than for polygons
 #define CIRCLE_MIN_DET 0.95                          // minimum det. score for circle (ideal circle = 1)


### PR DESCRIPTION
Lines drawn from point P to point Q may be recognized by the stroke recognizer and drawn as a straight line. However, if there is a third point R as a result of an accidental touch of the device (stylus against the pad, or late release of the mouse's button) the stroke recognizer may shorten the line in an unexpected way (#5637).

This PR proposes a fix to avoid shortening a line when R is collinear with P and Q. The test used does not check if P, Q and R line on the same line, but rather the (squared) distance from R to the line through P and Q: when close enough to 0, R is not considered to make the line, when large enough R is used as an endpoint, in order to respect the current behaviour when this is justifiable. I found this method more robust than using an orientation test, that is, the side of the oriented line PQ on which the point R lies (when close to 0, the points are collinear).

Behaviour _before_ the changes are shown in [this video](https://youtu.be/0Qj5ZXaz4MI).
Behaviour _after_ the changes are shown in [this video](https://youtu.be/h2QIhu2Tlcg).