### PR TITLE
Revert "Remove Windows attach console business"

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -137,6 +137,8 @@ if (WIN32)
   add_dependencies(xournalpp-wrapper xournalpp_icon)
   
   # windows specific source files
+  target_sources(xournalpp PRIVATE exe/win32/console.cpp)
+  target_sources(xournalpp-wrapper PRIVATE exe/win32/console.cpp)
   if (MSVC)
     target_sources(xournalpp PRIVATE exe/win32/gui_main.cpp)
     target_sources(xournalpp-wrapper PRIVATE exe/win32/gui_main.cpp)

--- a/src/exe/Xournalpp.cpp
+++ b/src/exe/Xournalpp.cpp
@@ -18,9 +18,17 @@
 
 #ifdef _WIN32
 #include <cstdlib>
+
+#include "win32/console.h"
 #endif
 
 auto main(int argc, char* argv[]) -> int {
+#ifdef _WIN32
+    // Attach to the console here. Otherwise, gspawn-win32-helper will create annoying console popups,
+    // e.g. in the LaTeX tool after every change in the formula
+    attachConsole();
+#endif
+
     // init crash handler
     installCrashHandlers();
 

--- a/src/exe/win32/console.cpp
+++ b/src/exe/win32/console.cpp
@@ -1,0 +1,73 @@
+#include "console.h"
+
+#include <windows.h>
+
+void attachConsole() {
+    if (GetConsoleWindow() != NULL) {
+        // Console is already attached.
+        return;
+    }
+
+    // Make sure the console starts hidden.
+    STARTUPINFOW startupInfo = {0};
+    startupInfo.dwFlags = STARTF_USESHOWWINDOW;
+    startupInfo.wShowWindow = SW_HIDE;
+    startupInfo.cb = sizeof(startupInfo);
+
+    PROCESS_INFORMATION processInformation = {0};
+
+    bool consoleAttached = false;
+
+    if (CreateProcessW(L"C:\\Windows\\System32\\cmd.exe", NULL, NULL, NULL, FALSE, 0, NULL, NULL, &startupInfo,
+                       &processInformation)) {
+        HANDLE job = CreateJobObject(NULL, NULL);
+
+        if (job != NULL) {
+            // Terminate the console process automatically when Xournal++ exits.
+            JOBOBJECT_EXTENDED_LIMIT_INFORMATION jobInformation = {0};
+            jobInformation.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+
+            if (!SetInformationJobObject(job, JobObjectExtendedLimitInformation, &jobInformation,
+                                         sizeof(jobInformation)) ||
+                !AssignProcessToJobObject(job, processInformation.hProcess)) {
+                TerminateProcess(processInformation.hProcess, 0);
+                CloseHandle(processInformation.hProcess);
+                CloseHandle(processInformation.hThread);
+                CloseHandle(job);
+                processInformation.hProcess = processInformation.hThread = job = NULL;
+            } else {
+                // It takes a short time before the console becomes ready to be attached, unfortunately
+                // there is no API that would let us wait for it.
+                for (unsigned short i = 0; i < 20; i++) {
+                    if (AttachConsole(processInformation.dwProcessId)) {
+                        consoleAttached = true;
+                        break;
+                    }
+                    Sleep(50);
+                }
+            }
+        } else {
+            TerminateProcess(processInformation.hProcess, 0);
+            CloseHandle(processInformation.hProcess);
+            CloseHandle(processInformation.hThread);
+            processInformation.hProcess = processInformation.hThread = NULL;
+        }
+
+        if (processInformation.hProcess != NULL) {
+            if (!consoleAttached) {
+                TerminateProcess(processInformation.hProcess, 0);
+                CloseHandle(job);
+            }
+
+            CloseHandle(processInformation.hProcess);
+            CloseHandle(processInformation.hThread);
+        }
+    }
+
+    if (!consoleAttached) {
+        // Could not attach to the manually created console process, request one from the system instead.
+        // This will make the console window flash briefly before we hide it.
+        AllocConsole();
+        ShowWindow(GetConsoleWindow(), SW_HIDE);
+    }
+}

--- a/src/exe/win32/console.h
+++ b/src/exe/win32/console.h
@@ -1,0 +1,6 @@
+#pragma once
+
+/**
+ * Allocates a new (hidden) console and associates the standard input and output handles with it.
+ */
+void attachConsole();


### PR DESCRIPTION
This reverts commit c0e90dfebfdfa4a270d7897dcf43f7e88678aecc.

The attach console buisness is required for the LaTeX tool to work without annoying console popups.
Otherwise each time the formula changes a console window pops up (on Windows).