### PR TITLE
Fix default filename preprocessing for Windows

### DIFF
--- a/src/core/model/Document.cpp
+++ b/src/core/model/Document.cpp
@@ -136,6 +136,26 @@ auto Document::createSaveFoldername(const fs::path& lastSavePath) const -> fs::p
     return lastSavePath;
 }
 
+
+static std::string preprocessFormatString(const std::string& formatStr) {
+    std::string processed = formatStr;
+    // Replace %F with %Y-%m-%d
+    size_t pos;
+    while ((pos = processed.find("%F")) != std::string::npos) {
+        processed.replace(pos, 2, "%Y-%m-%d");
+    }
+    // Replace %T with %H-%M-%S
+    while ((pos = processed.find("%T")) != std::string::npos) {
+        processed.replace(pos, 2, "%H-%M-%S");
+    }
+    // Replace %V with %U
+    while ((pos = processed.find("%V")) != std::string::npos) {
+        processed.replace(pos, 2, "%U");
+    }
+    return processed;
+}
+
+
 auto Document::createSaveFilename(DocumentType type, const std::string& defaultSaveName,
                                   const std::string& defaultPdfName) const -> fs::path {
     constexpr static std::wstring_view forbiddenChars = {L"\\/:*?\"<>|"};
@@ -162,6 +182,7 @@ auto Document::createSaveFilename(DocumentType type, const std::string& defaultS
 
     auto format_str = wildcardString.empty() ? defaultSaveName : wildcardString;
 
+    format_str = preprocessFormatString(format_str);
     std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
     auto format = converter.from_bytes(format_str);
 


### PR DESCRIPTION
Problem:
When creating a new file in Xournal++ on Windows (without a PDF background), the suggested filename is empty if the default filename contains %F, %T, or %V (e.g., %F-Note-%H-%M). This prevents users from saving the file unless they manually enter a name.

The root cause is that MinGW-w64 does not fully support strftime formatting codes like %F, %T, or %V (ISO 8601), which results in an empty string when generating the suggested filename.

Solution:
Replaced unsupported strftime codes with equivalents supported on Windows:

%F → %Y-%m-%d
%T → %H-%M-%S
%V → %U

Added a preprocessing function that converts the default filename format to a Windows-compatible version before generating the suggested filename.
Ensures forbidden characters are replaced and the filename is never empty.

Testing:
Tested on Windows 10 using a freshly compiled Xournal++ build from master.
Verified that new files now have a suggested filename according to the default pattern, e.g., 2025-08-25-Note-15-30.

Additional context:
Beginner contribution: This is my first pull request, and it’s not my last!
I really appreciate the maintainers and all contributors for this amazing app that I use daily.