### PR TITLE
Recognize triangles

### DIFF
--- a/src/core/control/shaperecognizer/ShapeRecognizer.cpp
+++ b/src/core/control/shaperecognizer/ShapeRecognizer.cpp
@@ -32,6 +32,77 @@ void ShapeRecognizer::resetRecognizer() {
     this->queueLength = 0;
 }
 
+inline double dist2(const Point& P, const Point& Q) {
+    const double dx = P.x - Q.x;
+    const double dy = P.y - Q.y;
+    return dx * dx + dy * dy;
+}
+
+auto ShapeRecognizer::tryTriangle() -> std::unique_ptr<Stroke> {
+    // first, we need whole strokes to combine to 3 segments...
+    if (this->queueLength < 3) {
+        return nullptr;
+    }
+
+    RecoSegment* rs = &this->queue[as_unsigned(this->queueLength - 3)];
+    if (rs->startpt != 0) {
+        return nullptr;
+    }
+
+    /*
+    Make segments be oriented so that, for every pair of neighbouring segments,
+    the first segment points towards the second. This should make the polygon
+    have all of its segments oriented either clockwise or counter-clockwise.
+
+    The direction of any segment R is defined from P to Q where
+    if R is not reversed then
+        P is (x1,y1)
+        Q is (x2,y2)
+    else
+        P is (x2,y2)
+        Q is (x1,y1)
+    */
+    for (int i = 0; i <= 2; i++) {
+        RecoSegment& r1 = rs[i];
+        const RecoSegment& r2 = rs[(i + 1) % 3];
+
+        const Point P(r1.x1, r1.y1);
+        const Point Q(r1.x2, r1.y2);
+        const Point R(r2.x1, r2.y1);
+        const Point S(r2.x2, r2.y2);
+        const double min_PR_PS = std::min(dist2(P, R), dist2(P, S));
+        const double min_QR_QS = std::min(dist2(Q, R), dist2(Q, S));
+        r1.reversed = min_PR_PS < min_QR_QS;
+    }
+
+    for (int i = 0; i <= 2; i++) {
+        const RecoSegment& r1 = rs[i];
+        const RecoSegment& r2 = rs[(i + 1) % 3];
+
+        const double x1 = r1.reversed ? r1.x1 : r1.x2;
+        const double y1 = r1.reversed ? r1.y1 : r1.y2;
+        const double x2 = r2.reversed ? r2.x2 : r2.x1;
+        const double y2 = r2.reversed ? r2.y2 : r2.y1;
+
+        const double dist = hypot(x1 - x2, y1 - y2);
+        if (dist > TRIANGLE_LINEAR_TOLERANCE * (r1.radius + r2.radius)) {
+            return nullptr;
+        }
+    }
+
+    auto s = std::make_unique<Stroke>();
+    s->applyStyleFrom(this->stroke);
+
+    for (int i = 0; i <= 2; i++) {
+        Point p = rs[i].calcEdgeIsect(&rs[(i + 1) % 3]);
+        s->addPoint(p);
+    }
+
+    s->addPoint(s->getPoint(0));
+
+    return s;
+}
+
 /**
  *  Test if segments form standard shapes
  */
@@ -305,6 +376,10 @@ auto ShapeRecognizer::recognizePatterns(Stroke* stroke, double strokeMinSize) ->
             rs[i].calcSegmentGeometry(stroke->getPoints(), brk[i], brk[i + 1], ss + i);
         }
 
+        if (auto result = tryTriangle(); result != nullptr) {
+            RDEBUG("return triangle");
+            return result;
+        }
         if (auto result = tryRectangle(); result != nullptr) {
             RDEBUG("return rectangle");
             return result;

--- a/src/core/control/shaperecognizer/ShapeRecognizer.h
+++ b/src/core/control/shaperecognizer/ShapeRecognizer.h
@@ -31,7 +31,9 @@ public:
     void resetRecognizer();
 
 private:
+    auto tryTriangle() -> std::unique_ptr<Stroke>;
     auto tryRectangle() -> std::unique_ptr<Stroke>;
+
     // function Stroke* tryArrow(); removed after commit a3f7a251282dcfea8b4de695f28ce52bf2035da2
 
     static void optimizePolygonal(const Point* pt, int nsides, int* breaks, Inertia* ss);

--- a/src/core/control/shaperecognizer/ShapeRecognizerConfig.h
+++ b/src/core/control/shaperecognizer/ShapeRecognizerConfig.h
@@ -21,6 +21,7 @@
 #define CIRCLE_MIN_DET 0.95                          // minimum det. score for circle (ideal circle = 1)
 #define CIRCLE_MAX_SCORE 0.10                        // max circle score for circle (ideal circle = 0)
 #define SLANT_TOLERANCE (5 * M_PI / 180)             // ignore slanting by +/- 5 degrees
+#define TRIANGLE_LINEAR_TOLERANCE 0.3                // vertex gap tolerance in triangles
 #define RECTANGLE_ANGLE_TOLERANCE (15 * M_PI / 180)  // angle tolerance in rectangles
 #define RECTANGLE_LINEAR_TOLERANCE 0.20              // vertex gap tolerance in rectangles
 #define POLYGON_LINEAR_TOLERANCE 0.20                // vertex gap tolerance in closed polygons


### PR DESCRIPTION
I was wondering why triangles were not recognized and I found issue #3665. I have implemented the recognition, but rather than recognizing a triangle, the code simply straightens the segments when the shape is closed (all endpoints of contiguous segments are close enough). Video of the result [here](https://www.youtube.com/watch?v=7UuRd2_55MQ).

Details of the changes:
- I copied the rectangle detection algorithm for triangles. The only difference is the detection of orientation of the segments: I could not make that work using an orientation test, and used a distance test.
- When a triangle is detected, the strokes are simply straightened up and no specific class of triangle is drawn. That is, the recognizer does not discard, say, non-equilateral triangles, or triangles of other classes. To be clearer: all 3-sided closed shapes are recognized as triangles.
- The algorithm does not change the value of the angles as given by the RecoSegment class (and other functions in ShapeRecognizer class).