### PR TITLE
Fix warning in Windows build of Scheduler

### DIFF
--- a/src/core/control/jobs/Scheduler.cpp
+++ b/src/core/control/jobs/Scheduler.cpp
@@ -150,7 +150,7 @@ auto Scheduler::jobThreadCallback(Scheduler* scheduler) -> gpointer {
         SDEBUG("Job Thread: Blocked scheduler.");
 
         bool onlyNonRenderJobs = false;
-        glong diff = 1000;
+        gint64 diff = 1000;
         if (scheduler->blockRenderZoomTime) {
             SDEBUG("Zoom re-render blocking.");
 


### PR DESCRIPTION
Fix a warning I introduced with #6642 (only on windows). Merging once the CI passes.