### PR TITLE
Fix pixmap backgrounds attached backgrounds

### DIFF
--- a/src/core/control/xojfile/LoadHandler.cpp
+++ b/src/core/control/xojfile/LoadHandler.cpp
@@ -377,9 +377,10 @@ void LoadHandler::parseBgPixmap() {
     // in case of a cloned background image, filename is a string representation of the page number from which the image
     // is cloned
 
-    if (!strcmp(domain, "absolute") || (!strcmp(domain, "attach") && this->isGzFile)) {
+    bool attach = !strcmp(domain, "attach");
+    if (!strcmp(domain, "absolute") || (attach && this->isGzFile)) {
         fs::path fileToLoad;
-        if (!strcmp(domain, "attach")) {
+        if (attach) {
             fileToLoad = this->filepath;
             fileToLoad += ".";
             fileToLoad += filepath;
@@ -401,8 +402,9 @@ void LoadHandler::parseBgPixmap() {
             g_error_free(error);
         }
 
+        img.setAttach(attach);
         this->page->setBackgroundImage(img);
-    } else if (!strcmp(domain, "attach")) {
+    } else if (attach) {
         // This is the new zip file attach domain
         const auto readResult = readZipAttachment(filepath);  ///< Do not remove the const qualifier - see below
         if (!readResult) {
@@ -429,6 +431,7 @@ void LoadHandler::parseBgPixmap() {
             g_error_free(error);
         }
 
+        img.setAttach(attach);
         this->page->setBackgroundImage(img);
     } else if (!strcmp(domain, "clone")) {
         gchar* endptr = nullptr;


### PR DESCRIPTION
When loading a pixmap (image) page background, there are options for an "attached" file, which means that the filename is `<document_filename>.<background_filename>`, or that it is contained in the zip archive (for the zip file format). That attribute was not set on the background image itself, so that it was lost when re-saved.

### Steps to test
* Open "test/files/load/pages.xoj". The last page has an "attached" background.
* Save. The resulting file is "pages.xopp". The ".xoj" extension does not change anything here.
* Decompress file: `cp pages.xopp pages-resaved.xml.gz && gunzip pages-resaved.xml.gz`
* Compare the last page's background between "pages.xml" and "pages-resave.xml": the image was previously saved with an absolute path, but now stays correctly "attached"