### PR TITLE
Fix typo in clipboard input stream length check

### DIFF
--- a/src/util/serializing/ObjectInputStream.cpp
+++ b/src/util/serializing/ObjectInputStream.cpp
@@ -94,8 +94,11 @@ auto ObjectInputStream::readString() -> std::string {
 
     size_t lenString = (size_t)readType<int>();
 
-    if (istream.str().size() < len) {
-        throw InputStreamException("End reached, but try to read an string", __FILE__, __LINE__);
+    if (istream.str().size() < lenString) {
+        std::ostringstream oss;
+        oss << "End reached: trying to read a string of " << lenString << " bytes while only " << istream.str().size()
+            << " bytes are available";
+        throw InputStreamException(oss.str(), __FILE__, __LINE__);
     }
 
     std::string output;
@@ -113,13 +116,16 @@ auto ObjectInputStream::readImage() -> std::string {
         throw InputStreamException("End reached, but try to read an image's data's length", __FILE__, __LINE__);
     }
 
-    const size_t len = readType<size_t>();
-    if (istream.str().size() < len) {
-        throw InputStreamException("End reached, but try to read an image", __FILE__, __LINE__);
+    const size_t lenString = readType<size_t>();
+    if (istream.str().size() < lenString) {
+        std::ostringstream oss;
+        oss << "End reached: trying to read an image of " << lenString << " bytes while only " << istream.str().size()
+            << " bytes are available";
+        throw InputStreamException(oss.str(), __FILE__, __LINE__);
     }
     std::string data;
-    data.resize(len);
-    istream.read(data.data(), static_cast<int>(len));
+    data.resize(lenString);
+    istream.read(data.data(), static_cast<int>(lenString));
 
     return data;
 }


### PR DESCRIPTION
Fixes #6669

The modifications in `readImage()` aren't strictly necessary, but shadowing isn't pretty and it's probably what caused the issue in the first place. I can remove them if you the fixes-only policy on the release branch is strict.