### PR TITLE
Reset DPI to default if the value in the settings is non-positive.

### DIFF
--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -402,6 +402,11 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur) {
         this->zoomStepScroll = tempg_ascii_strtod(reinterpret_cast<const char*>(value), nullptr);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("displayDpi")) == 0) {
         this->displayDpi = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
+        if (this->displayDpi <= 0) {
+            g_warning("Settings::load(): The displayDpi value is non-positive. Maybe it has been set to -1 when "
+                      "running version 1.3 or later. Resetting to the default 72.");
+            this->displayDpi = 72;
+        }
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("mainWndWidth")) == 0) {
         this->mainWndWidth = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("mainWndHeight")) == 0) {


### PR DESCRIPTION
 This may happen if the user opens v1.3 and enables automatic DPI detection. See https://github.com/xournalpp/xournalpp/issues/6666#issuecomment-3276843472

Merging to the release branch once the CI clears.