### PR TITLE
Add missing gtksourceview dependency to Windows Readme

### DIFF
--- a/readme/WindowsBuild.md
+++ b/readme/WindowsBuild.md
@@ -47,6 +47,7 @@ pacman -S \
   mingw-w64-x86_64-libzip \
   mingw-w64-x86_64-lua \
   mingw-w64-x86_64-portaudio \
+  mingw-w64-clang-x86_64-gtksourceview4 \
   mingw-w64-x86_64-qpdf
 ```
 

--- a/readme/WindowsBuildArm.md
+++ b/readme/WindowsBuildArm.md
@@ -47,6 +47,7 @@ pacman -S \
   mingw-w64-clang-aarch64-libzip \
   mingw-w64-clang-aarch64-lua \
   mingw-w64-clang-aarch64-portaudio \
+  mingw-w64-clang-aarch64-gtksourceview4 \
   mingw-w64-clang-aarch64-qpdf
 ```
 


### PR DESCRIPTION
Fix #6729 