### PR TITLE
Use windows-2022 instead of windows-2025

### DIFF
--- a/.github/available-build-targets.json
+++ b/.github/available-build-targets.json
@@ -45,7 +45,7 @@
   "windows_targets": {
     "windows": {
       "displayed_name": "Windows x86_64",
-      "runner": "windows-latest",
+      "runner": "windows-2022",
       "msystem": "mingw64",
       "msys_package_env": "x86_64",
       "build_portable": "true",


### PR DESCRIPTION
The goal is to fix the create installers CI which fails on windows-2025.

~~Update the Windows CI as the latest Windows github runner images do not ship nsis anymore.~~

New solution: use windows-2022 instead of windows-2025 as a github runner image.

This fix is not great in terms of longevity. Other solutions to be discussed for a future PR include:

1. Install nsis using MSys. This has the problem that there is not ARM package for nsis on MSys
2. Install nsis using Chocolatey
3. Install nsis using some github action available out there.
4. Move away from nsis (to what?)

For each of those potential solutions, the key problem is to have something that works on both Intel and ARM runners, AND works for devs who want to build a package at home.