### PR TITLE
Fix zero inertia

### DIFF
--- a/src/core/control/shaperecognizer/CircleRecognizer.cpp
+++ b/src/core/control/shaperecognizer/CircleRecognizer.cpp
@@ -61,7 +61,7 @@ auto CircleRecognizer::scoreCircle(Stroke* s, Inertia& inertia) -> double {
 
 auto CircleRecognizer::recognize(Stroke* stroke) -> std::unique_ptr<Stroke> {
     Inertia s;
-    s.calc(stroke->getPoints(), 0, static_cast<int>(stroke->getPointCount()));
+    s.calc(stroke->getPointVector());
     RDEBUG("Mass=%.0f, Center=(%.1f,%.1f), I=(%.0f,%.0f, %.0f), Rad=%.2f, Det=%.4f", s.getMass(), s.centerX(),
            s.centerY(), s.xx(), s.yy(), s.xy(), s.rad(), s.det());
 

--- a/src/core/control/shaperecognizer/Inertia.cpp
+++ b/src/core/control/shaperecognizer/Inertia.cpp
@@ -1,6 +1,7 @@
 #include "Inertia.h"
 
 #include <cmath>
+#include <span>
 
 #include "model/Point.h"
 
@@ -78,7 +79,9 @@ void Inertia::increase(Point p1, Point p2, int coef) {
     this->sxy += dm * p1.x * p1.y;
 }
 
-void Inertia::calc(const Point* pt, int start, int end) {
+void Inertia::calc(std::span<const Point> points) {
     this->mass = this->sx = this->sy = this->sxx = this->sxy = this->syy = 0.;
-    for (int i = start; i < end - 1; i++) { this->increase(pt[i], pt[i + 1], 1); }
+    for (auto it = points.begin(); it + 1 < points.end(); ++it) {
+        this->increase(*it, *(it + 1), 1);
+    }
 }

--- a/src/core/control/shaperecognizer/Inertia.h
+++ b/src/core/control/shaperecognizer/Inertia.h
@@ -11,6 +11,8 @@
 
 #pragma once
 
+#include <span>
+
 class Point;
 
 class Inertia {
@@ -34,7 +36,7 @@ public:
     double getMass() const;
 
     void increase(Point p1, Point p2, int coef);
-    void calc(const Point* pt, int start, int end);
+    void calc(std::span<const Point> points);
 
 private:
     double mass{};

--- a/src/core/control/shaperecognizer/ShapeRecognizer.h
+++ b/src/core/control/shaperecognizer/ShapeRecognizer.h
@@ -38,7 +38,7 @@ private:
 
     static void optimizePolygonal(const Point* pt, int nsides, int* breaks, Inertia* ss);
 
-    int findPolygonal(const Point* pt, int start, int end, int nsides, int* breaks, Inertia* ss);
+    int findPolygonal(const Point* pt, int start, int finish, int nsides, int* breaks, Inertia* ss);
 
     static bool isStrokeLargeEnough(Stroke* stroke, double strokeMinSize);
 


### PR DESCRIPTION
Fixes #6717

This is a different approach than #6737. I believe this fixes the source of the issue, rather than catching it later.

`Inertia::calc()` received two indices from `findPolygon()` that were both inclusive. This isn't the same as we usually know from iterators, and not the way it was intended to initially in `Inertia::calc()` as well as its usage in `CircleRecognizer::recognize()`. There's two ways of fixing that:
* Align `Inertia::calc()` with the usage of `findPolygon()` and `RecoSegment::calcSegmentGeometry()` (first commit)
* Use `std::span` as argument to `Inertia::calc()` (squash of both commits)

I think modifying the used pattern in `findPolygon()` is more risky than it should be. I find that `std::span` fits well here, as it is more expressive than `first, last` pointers, which was the cause of the issue at hand.

There is _technically_ a change in how the strokes are recognized, but since it only includes one more point in the initial detection, it shouldn't really change much.