### PR TITLE
feat(graph): support bold lines every Nth interval (#6744)

### DIFF
--- a/resources-templates/pagetemplates.ini.in
+++ b/resources-templates/pagetemplates.ini.in
@@ -42,3 +42,8 @@ name=Graph with border
 format=graph
 config=m1=40,rm=1
 
+[graphWithBorderBold5]
+name=Graph with border (bold every 5th)
+format=graph
+config=m1=20,rm=1,bli=5,blw=1.5
+

--- a/src/core/model/BackgroundConfig.h
+++ b/src/core/model/BackgroundConfig.h
@@ -42,4 +42,6 @@ constexpr static char CFG_LINE_WIDTH[] = "lw";
 constexpr static char CFG_MARGIN[] = "m1";
 constexpr static char CFG_ROUND_MARGIN[] = "rm";
 constexpr static char CFG_RASTER[] = "r1";
+constexpr static char CFG_BOLD_LINE_INTERVAL[] = "bli";
+constexpr static char CFG_BOLD_LINE_WIDTH[] = "blw";
 }  // namespace background_config_strings

--- a/src/core/view/background/GraphBackgroundView.cpp
+++ b/src/core/view/background/GraphBackgroundView.cpp
@@ -1,6 +1,7 @@
 #include "GraphBackgroundView.h"
 
 #include <algorithm>  // for max, min
+#include <cmath>      // for floor
 #include <memory>     // for allocator
 
 #include "model/BackgroundConfig.h"                  // for BackgroundConfig
@@ -18,6 +19,8 @@ GraphBackgroundView::GraphBackgroundView(double pageWidth, double pageHeight, Co
 
     config.loadValue(CFG_RASTER, squareSize);
     config.loadValue(CFG_MARGIN, margin);
+    config.loadValue(CFG_BOLD_LINE_INTERVAL, boldLineInterval);
+    config.loadValue(CFG_BOLD_LINE_WIDTH, boldLineWidth);
 
     if (int roundToGrid = 0; margin > 0.0 && config.loadValue(CFG_ROUND_MARGIN, roundToGrid) && roundToGrid) {
         roundUpMargin = true;
@@ -25,59 +28,114 @@ GraphBackgroundView::GraphBackgroundView(double pageWidth, double pageHeight, Co
 }
 
 void GraphBackgroundView::draw(cairo_t* cr) const {
-    // Paint the background color
     PlainBackgroundView::draw(cr);
 
-    // Get the bounds of the mask, in page coordinates
     double minX;
     double maxX;
     double minY;
     double maxY;
     cairo_clip_extents(cr, &minX, &minY, &maxX, &maxY);
 
-    if (margin > 0.0) {
-        minX = std::max(minX, margin);
-        maxX = std::min(maxX, pageWidth - margin);
-        minY = std::max(minY, margin);
-        maxY = std::min(maxY, pageHeight - margin);
+    double effectiveMarginX = margin;
+    double effectiveMarginY = margin;
+
+    if (roundUpMargin && margin > 0.0) {
+        double roundingUnit = (boldLineInterval > 0) ? (squareSize * boldLineInterval) : squareSize;
+
+        double maxGridWidth = pageWidth - 2 * margin;
+        double maxGridHeight = pageHeight - 2 * margin;
+
+        int completeUnitsX = static_cast<int>(std::floor(maxGridWidth / roundingUnit));
+        int completeUnitsY = static_cast<int>(std::floor(maxGridHeight / roundingUnit));
+
+        double actualGridWidth = completeUnitsX * roundingUnit;
+        double actualGridHeight = completeUnitsY * roundingUnit;
+
+        effectiveMarginX = (pageWidth - actualGridWidth) / 2.0;
+        effectiveMarginY = (pageHeight - actualGridHeight) / 2.0;
     }
 
-    //  Add a 0.5 * lineWidth padding in case the line is just outside the mask but its thickness still makes it
-    //  (partially) visible
-    const double halfLineWidth = 0.5 * lineWidth;
-    auto [indexMinX, indexMaxX] =
-            getIndexBounds(minX - halfLineWidth, maxX + halfLineWidth, squareSize, squareSize, pageWidth);
-    auto [indexMinY, indexMaxY] =
-            getIndexBounds(minY - halfLineWidth, maxY + halfLineWidth, squareSize, squareSize, pageHeight);
-
-    if (roundUpMargin) {
-        auto [pageIndexMinX, pageIndexMaxX] = getIndexBounds(margin - halfLineWidth, pageWidth - margin + halfLineWidth,
-                                                             squareSize, squareSize, pageWidth);
-        auto [pageIndexMinY, pageIndexMaxY] = getIndexBounds(
-                margin - halfLineWidth, pageHeight - margin + halfLineWidth, squareSize, squareSize, pageHeight);
-        minX = std::max(minX, squareSize * pageIndexMinX);
-        maxX = std::min(maxX, squareSize * pageIndexMaxX);
-        minY = std::max(minY, squareSize * pageIndexMinY);
-        maxY = std::min(maxY, squareSize * pageIndexMaxY);
+    if (margin > 0.0 || roundUpMargin) {
+        minX = std::max(minX, effectiveMarginX);
+        maxX = std::min(maxX, pageWidth - effectiveMarginX);
+        minY = std::max(minY, effectiveMarginY);
+        maxY = std::min(maxY, pageHeight - effectiveMarginY);
     }
 
-    if (minY < maxY) {  // Can fail when rendering a mask contained in the bottom margin
-        for (int i = indexMinX; i <= indexMaxX; ++i) {
-            cairo_move_to(cr, i * squareSize, minY);
-            cairo_line_to(cr, i * squareSize, maxY);
-        }
-    }
-    if (minX < maxX) {  // Can fail when rendering a mask contained in the right margin
-        for (int i = indexMinY; i <= indexMaxY; ++i) {
-            cairo_move_to(cr, minX, i * squareSize);
-            cairo_line_to(cr, maxX, i * squareSize);
-        }
-    }
+    const double halfLineWidth = 0.5 * (boldLineInterval > 0 ? boldLineWidth : lineWidth);
+
+    int indexMinX = static_cast<int>(std::ceil((minX - halfLineWidth - effectiveMarginX) / squareSize));
+    int indexMaxX = static_cast<int>(std::floor((maxX + halfLineWidth - effectiveMarginX) / squareSize));
+    int indexMinY = static_cast<int>(std::ceil((minY - halfLineWidth - effectiveMarginY) / squareSize));
+    int indexMaxY = static_cast<int>(std::floor((maxY + halfLineWidth - effectiveMarginY) / squareSize));
+
+    indexMinX = std::max(0, indexMinX);
+    indexMinY = std::max(0, indexMinY);
 
     cairo_save(cr);
     Util::cairo_set_source_rgbi(cr, foregroundColor);
-    cairo_set_line_width(cr, lineWidth);
     cairo_set_line_cap(cr, CAIRO_LINE_CAP_SQUARE);
-    cairo_stroke(cr);
+
+    if (boldLineInterval > 0) {
+        cairo_set_line_width(cr, lineWidth);
+        if (minY < maxY) {
+            for (int i = indexMinX; i <= indexMaxX; ++i) {
+                if (i % boldLineInterval != 0) {
+                    double x = effectiveMarginX + i * squareSize;
+                    cairo_move_to(cr, x, minY);
+                    cairo_line_to(cr, x, maxY);
+                }
+            }
+        }
+        if (minX < maxX) {
+            for (int i = indexMinY; i <= indexMaxY; ++i) {
+                if (i % boldLineInterval != 0) {
+                    double y = effectiveMarginY + i * squareSize;
+                    cairo_move_to(cr, minX, y);
+                    cairo_line_to(cr, maxX, y);
+                }
+            }
+        }
+        cairo_stroke(cr);
+
+        cairo_set_line_width(cr, boldLineWidth);
+        if (minY < maxY) {
+            for (int i = indexMinX; i <= indexMaxX; ++i) {
+                if (i % boldLineInterval == 0) {
+                    double x = effectiveMarginX + i * squareSize;
+                    cairo_move_to(cr, x, minY);
+                    cairo_line_to(cr, x, maxY);
+                }
+            }
+        }
+        if (minX < maxX) {
+            for (int i = indexMinY; i <= indexMaxY; ++i) {
+                if (i % boldLineInterval == 0) {
+                    double y = effectiveMarginY + i * squareSize;
+                    cairo_move_to(cr, minX, y);
+                    cairo_line_to(cr, maxX, y);
+                }
+            }
+        }
+        cairo_stroke(cr);
+    } else {
+        cairo_set_line_width(cr, lineWidth);
+        if (minY < maxY) {
+            for (int i = indexMinX; i <= indexMaxX; ++i) {
+                double x = effectiveMarginX + i * squareSize;
+                cairo_move_to(cr, x, minY);
+                cairo_line_to(cr, x, maxY);
+            }
+        }
+        if (minX < maxX) {
+            for (int i = indexMinY; i <= indexMaxY; ++i) {
+                double y = effectiveMarginY + i * squareSize;
+                cairo_move_to(cr, minX, y);
+                cairo_line_to(cr, maxX, y);
+            }
+        }
+        cairo_stroke(cr);
+    }
+
     cairo_restore(cr);
 }

--- a/src/core/view/background/GraphBackgroundView.h
+++ b/src/core/view/background/GraphBackgroundView.h
@@ -31,9 +31,12 @@ protected:
     bool roundUpMargin = false;
     double margin = 0.0;
     double squareSize = 14.17;  // 5mm
+    int boldLineInterval = 0;   // 0 means no bold lines, otherwise every Nth line is bold
+    double boldLineWidth = 1.5;
 
     constexpr static Color DEFAULT_LINE_COLOR = Colors::xopp_silver;
     constexpr static Color ALT_DEFAULT_LINE_COLOR = Colors::xopp_darkslategray;
     constexpr static double DEFAULT_LINE_WIDTH = 0.5;
+    constexpr static double DEFAULT_BOLD_LINE_WIDTH = 1.5;
 };
 };  // namespace xoj::view


### PR DESCRIPTION
- Added new config options: `bli` (bold line interval), `blw` (bold line width)
- Implemented logic to render every Nth grid line with increased thickness
- Updated page template

closes #6744 