### PR TITLE
Add ENABLE_CPPTRACE cmake flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,14 @@ include(GitRepo)
 ## Libraries ##
 ##############################
 
-if (NOT CMAKE_BUILD_TYPE STREQUAL "Release")
+option(ENABLE_CPPTRACE "Compile with cpptrace stacktrace library" ON)
+# Requires fetching content during build.
+if (CMAKE_BUILD_TYPE STREQUAL "Release")
+  set(ENABLE_CPPTRACE OFF)
+  message(STATUS "Disable cpptrace by lack of debug symbols in Release mode")
+endif ()
+
+if (ENABLE_CPPTRACE)
     include(FetchContent)
     FetchContent_Declare(
         cpptrace
@@ -125,7 +132,6 @@ if (NOT CMAKE_BUILD_TYPE STREQUAL "Release")
             add_subdirectory(${cpptrace_SOURCE_DIR} ${cpptrace_BINARY_DIR} EXCLUDE_FROM_ALL)
         endif()
     endif()
-    set(ENABLE_CPPTRACE ON)
 endif()
 
 

--- a/debian/rules
+++ b/debian/rules
@@ -12,4 +12,4 @@ override_dh_dwz:
 	dh_dwz --no-dwz-multifile
 
 override_dh_auto_configure:
-	dh_auto_configure -- -DCMAKE_BUILD_TYPE=RelWithDebInfo -DFETCHCONTENT_FULLY_DISCONNECTED=OFF
+	dh_auto_configure -- -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_CPPTRACE=OFF


### PR DESCRIPTION
The stacktrace library cpptrace uses cmake's FetchContent to fetch sources, which is inconvenient in situations where all sources should be available before build. Use -DENABLE_CPPTRACE=OFF in those situations.

This is a simple fix that only disables cpptrace without taking the wrapper out. The latter would require modifying the following files:
- `src/CMakeLists.txt`
- `xournalpp.nsi`
- `com.github.xournalpp.xournalpp.desktop`
- `Info.plist`
- `xournalpp.bundle`
That would increase the maintenance burden.

Fixes #6605