### PR TITLE
Fix FloatingToolbox clamp assertion failure

### DIFF
--- a/src/core/gui/FloatingToolbox.cpp
+++ b/src/core/gui/FloatingToolbox.cpp
@@ -184,6 +184,10 @@ auto FloatingToolbox::getOverlayPosition(GtkOverlay* overlay, GtkWidget* widget,
             int minY = scrollY + margin;
             int maxY = scrollY + scrollAllocation.height - allocation->height - margin;
 
+            // Ensure valid clamp bounds when toolbox is larger than viewport
+            maxX = std::max(maxX, minX);
+            maxY = std::max(maxY, minY);
+
             allocation->x = std::clamp(centerX, minX, maxX);
             allocation->y = std::clamp(centerY, minY, maxY);
             self->floatingToolboxState = noChange;


### PR DESCRIPTION
Fixes a crash introduced in 6ed3d6b5d where std::clamp() was called with inverted bounds (min > max)

Reported by @mjg
issue comment: https://github.com/xournalpp/xournalpp/pull/6682#issuecomment-3478112111
