### PR TITLE
Use macos-15-intel for MacOS x64 CI and releases

### DIFF
--- a/.github/available-build-targets.json
+++ b/.github/available-build-targets.json
@@ -33,7 +33,7 @@
   "macos_targets": {
     "mac-x64": {
       "displayed_name": "MacOS x64",
-      "runner": "macos-13",
+      "runner": "macos-15-intel",
       "run_ci": "true"
     },
     "mac-arm": {


### PR DESCRIPTION
The github runner macos-13 is deprecated and will be removed shortly: See https://github.com/actions/runner-images/issues/13046

Merging once the CI clears.