### PR TITLE
Avoid crash when triggering automatic page addition by dragging selection

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -857,8 +857,8 @@ void Control::askInsertPdfPage(size_t pdfPage) {
                            });
 }
 
-void Control::insertNewPage(size_t position, bool shouldScrollToPage) {
-    pageBackgroundChangeController->insertNewPage(position, shouldScrollToPage);
+void Control::insertNewPage(size_t position, bool automatedInsertion) {
+    pageBackgroundChangeController->insertNewPage(position, automatedInsertion);
 }
 
 void Control::appendNewPdfPages() {

--- a/src/core/control/Control.h
+++ b/src/core/control/Control.h
@@ -232,7 +232,7 @@ public:
 
     void addDefaultPage(const std::optional<std::string>& pageTemplate, Document* doc = nullptr);
     void duplicatePage();
-    void insertNewPage(size_t position, bool shouldScrollToPage = true);
+    void insertNewPage(size_t position, bool automatedInsertion = false);
     void appendNewPdfPages();
     void insertPage(const PageRef& page, size_t position, bool shouldScrollToPage = true);
     void deletePage();

--- a/src/core/control/PageBackgroundChangeController.h
+++ b/src/core/control/PageBackgroundChangeController.h
@@ -55,7 +55,7 @@ public:
     void applyBackgroundToAllPages(const PageType& pt);
     void applyPageSizeToAllPages(const PaperSize& paperSize);
     void changePdfPagesBackground(const fs::path& filepath, bool attachPdf);
-    void insertNewPage(size_t position, bool shouldScrollToPage = true);
+    void insertNewPage(size_t position, bool automatedInsertion = false);
 
     // DocumentListener
 public:

--- a/src/core/control/tools/EditSelection.h
+++ b/src/core/control/tools/EditSelection.h
@@ -19,7 +19,6 @@
 #include <vector>   // for vector
 
 #include <cairo.h>  // for cairo_t, cairo_matrix_t
-#include <glib.h>   // for GSource
 
 #include "control/ToolEnums.h"               // for ToolSize
 #include "model/Element.h"                   // for Element, Element::Index
@@ -30,6 +29,7 @@
 #include "util/Color.h"                      // for Color
 #include "util/PointerContainerView.h"       // for PointerContainerView
 #include "util/Rectangle.h"                  // for Rectangle
+#include "util/raii/GSourceURef.h"           // for GSourceURef
 #include "util/serializing/Serializable.h"   // for Serializable
 
 #include "CursorSelectionType.h"     // for CursorSelectionType, CURS...
@@ -458,7 +458,7 @@ private:  // HANDLER
     /**
      * Edge pan timer
      */
-    GSource* edgePanHandler = nullptr;
+    xoj::util::GSourceURef edgePanHandler;
 
     /**
      * Inhibit the next move event after edge panning finishes. This prevents

--- a/src/core/control/tools/StrokeHandler.cpp
+++ b/src/core/control/tools/StrokeHandler.cpp
@@ -183,7 +183,7 @@ void StrokeHandler::onButtonReleaseEvent(const PositionInputData& pos, double zo
             auto lastPage = doc->getPageCount() - 1;
             doc->unlock();
             if (currentPage == lastPage) {
-                control->insertNewPage(currentPage + 1, false);
+                control->insertNewPage(currentPage + 1, true);
             }
         }
     }

--- a/src/core/gui/Layout.cpp
+++ b/src/core/gui/Layout.cpp
@@ -75,7 +75,7 @@ void Layout::maybeAddLastPage(Layout* layout) {
                 auto lastPage = doc->getPageCount() - 1;
                 doc->unlock();
                 if (currentPage == lastPage) {
-                    control->insertNewPage(currentPage + 1, false);
+                    control->insertNewPage(currentPage + 1, true);
                 }
             }
         }


### PR DESCRIPTION
Fix #6240

~~This fixes the crash, but does not really fix the underlying issue with the automatic page addition feature.~~

The crash was caused by the following path. As the user drags the selection downwards, the `EditSelection::edgePanHandler()` callback gets called. It triggers a scrolling (`Layout::scrollRelative()`). This scrolling in turn triggers a call to `Layout::maybeAddPage()`, with then adds a page.
When adding a page, we always clear selections and text edition (see `PageBackgroundController::insertNewPage()`), so the EditSelection instance which triggered all that gets destroyed... We then get the SegFault when the EditSelection instance gets accessed after deletion.

~~Now, this PR fixes the crash, BUT the selected items still often disappear (they are in fact added to a page, but outside its bound and thus get deleted...).
A proper fix would need to have the automatic page addition feature made aware of existing selections, and ensuring that the content stays selected. That would be some work - the code around this feature is a bit scattered and some refactoring would be required.~~

Edit: Stroke out the outdated description. See post below.