### PR TITLE
Make the release script update the Crowdin github action

### DIFF
--- a/.github/workflows/download-translations-from-crowdin.yml
+++ b/.github/workflows/download-translations-from-crowdin.yml
@@ -12,7 +12,7 @@ jobs:
     name: Download translated strings from Crowdin
     strategy:
       matrix:
-        branch: ['master', 'release-1.2']
+        branch: ['master', 'release-1.3']
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/scripts/release_helper.sh
+++ b/scripts/release_helper.sh
@@ -222,6 +222,10 @@ function prepare_new_version() {
         abort 9 "Could not bump version of release branch"
     fi
 
+    if ! sed -i "s/release-[0-9]*\.[0-9]*/${branch_name}/g" "${SCRIPT_PATH}/../.github/workflows/download-translations-from-crowdin.yml"; then
+        abort 9 "Could not bump release branch version in Crowdin github action"
+    fi
+
     # Commit version bump
     if ! git commit --quiet -a -m "Automated version bump to $new_version"; then
         abort 10 "Could not commit version bump on release branch"


### PR DESCRIPTION
The Crowdin translations of the newly created `release-1.3` branch were not pulled from Crowdin to make a PR: the github action needed an update.

I made this update by hand, and ensured the release script now does it automatically (during the `prepare` phase).