### PR TITLE
Remove the [skip ci] tag from translation update automated commits

### DIFF
--- a/.github/workflows/download-translations-from-crowdin.yml
+++ b/.github/workflows/download-translations-from-crowdin.yml
@@ -84,7 +84,7 @@ jobs:
         shell: bash
         env:
           localization-branch: ${{ steps.compute-changes.outputs.localization-branch }}
-          commit-message: '[skip ci] Update translation files'
+          commit-message: 'Update translation files'
           pr-title: "Update translations for ${{ matrix.branch }} branch"
           pr-body: 'New translations. When merging this PR, use \"Squash and Merge\"'
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
We want `.github/workflows/check-translations-build.yml` to run on translation updates, like #6871.

Note that all other workflows we have that are triggered by a pull request or a commit explicitly ignore the *po and pot files, so no other CI should run on those PRs.

Merging once the CI clears.