### PR TITLE
Prevent crash when saving and empty text node

### DIFF
--- a/src/core/control/xojfile/SaveHandler.cpp
+++ b/src/core/control/xojfile/SaveHandler.cpp
@@ -175,6 +175,10 @@ void SaveHandler::visitLayer(XmlNode* page, const Layer* l) {
             visitStroke(stroke, s);
         } else if (e->getType() == ELEMENT_TEXT) {
             const Text* t = dynamic_cast<const Text*>(e);
+            if (t->getText().empty()) {
+                g_warning("Trying to save an empty Text element. Discarding it!");
+                continue;
+            }
             auto* text = new XmlTextNode("text", t->getText());
             layer->addChild(text);
 


### PR DESCRIPTION
Fix #6322 

This fix prevents the crash and issues a warning. I do not know how the empty Text elements can be created.