### PR TITLE
Fix various occurrences of display DPI when using automated detection

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -2227,10 +2227,10 @@ void Control::clipboardPasteImage(GdkPixbuf* img) {
     auto image = std::make_unique<Image>();
     image->setImage(img);
 
-    auto width =
-            static_cast<double>(gdk_pixbuf_get_width(img)) / settings->getDisplayDpi() * Util::DPI_NORMALIZATION_FACTOR;
-    auto height = static_cast<double>(gdk_pixbuf_get_height(img)) / settings->getDisplayDpi() *
-                  Util::DPI_NORMALIZATION_FACTOR;
+    auto zoom100 = this->getZoomControl()->getZoom100Value();
+
+    auto width = static_cast<double>(gdk_pixbuf_get_width(img)) / zoom100;
+    auto height = static_cast<double>(gdk_pixbuf_get_height(img)) / zoom100;
 
     auto pageNr = getCurrentPageNo();
     if (pageNr == npos) {

--- a/src/core/control/tools/EditSelection.cpp
+++ b/src/core/control/tools/EditSelection.cpp
@@ -207,10 +207,14 @@ auto addElementsFromActiveLayer(Control* ctrl, EditSelection* base, const Insert
 }
 };  // namespace SelectionFactory
 
+static int getBtnWidth(Control* c) {
+    return std::max(10, round_cast<int>(c->getZoomControl()->getZoom100Value() * Util::DPI_NORMALIZATION_FACTOR / 8));
+}
+
 EditSelection::EditSelection(Control* ctrl, InsertionOrder elts, const PageRef& page, Layer* layer, XojPageView* view,
                              const Range& bounds, const Range& snappingBounds):
         snappedBounds(snappingBounds),
-        btnWidth(std::max(10, ctrl->getSettings()->getDisplayDpi() / 8)),
+        btnWidth(getBtnWidth(ctrl)),
         sourcePage(page),
         sourceLayer(layer),
         view(view),
@@ -242,7 +246,7 @@ EditSelection::EditSelection(Control* ctrl, InsertionOrder elts, const PageRef& 
 
 EditSelection::EditSelection(Control* ctrl, const PageRef& page, Layer* layer, XojPageView* view):
         snappedBounds(Rectangle<double>{}),
-        btnWidth(std::max(10, ctrl->getSettings()->getDisplayDpi() / 8)),
+        btnWidth(getBtnWidth(ctrl)),
         sourcePage(page),
         sourceLayer(layer),
         view(view),

--- a/src/core/gui/inputdevices/PenInputHandler.cpp
+++ b/src/core/gui/inputdevices/PenInputHandler.cpp
@@ -12,11 +12,13 @@
 #include <glib.h>     // for gdouble, gint, g_message
 #include <gtk/gtk.h>  // for gtk_adjustment_get_value
 
+#include "control/Control.h"                    // for Control
 #include "control/ToolEnums.h"                  // for TOOL_HAND, TOOL_IMAGE
 #include "control/ToolHandler.h"                // for ToolHandler
 #include "control/settings/Settings.h"          // for Settings
 #include "control/tools/CursorSelectionType.h"  // for CursorSelectionType
 #include "control/tools/EditSelection.h"        // for EditSelection
+#include "control/zoom/ZoomControl.h"           // for ZoomControl
 #include "gui/Layout.h"                         // for Layout
 #include "gui/PageView.h"                       // for XojPageView
 #include "gui/XournalView.h"                    // for XournalView
@@ -246,7 +248,8 @@ bool PenInputHandler::isCurrentTapSelection(InputEvent const& event) const {
 
     settings->getStrokeFilter(&tapMaxDuration, &tapMaxDistance, &filterRepetitionTime);
 
-    const double dpmm = settings->getDisplayDpi() / 25.4;
+    const double dpmm = inputContext->getView()->getControl()->getZoomControl()->getZoom100Value() *
+                        Util::DPI_NORMALIZATION_FACTOR / 25.4;
     const double dist = this->sequenceStartPosition.distance(event.absolute);
 
     const bool noMovement = dist < tapMaxDistance * dpmm;

--- a/src/core/plugin/luapi_application.h
+++ b/src/core/plugin/luapi_application.h
@@ -2767,7 +2767,7 @@ static int applib_setBackgroundName(lua_State* L) {
 static int applib_getDisplayDpi(lua_State* L) {
     Plugin* plugin = Plugin::getPluginFromLua(L);
     Control* control = plugin->getControl();
-    int dpi = control->getSettings()->getDisplayDpi();
+    int dpi = round_cast<int>(control->getZoomControl()->getZoom100Value() * Util::DPI_NORMALIZATION_FACTOR);
     lua_pushinteger(L, dpi);
 
     return 1;


### PR DESCRIPTION
In several places, we used settings->getDisplayDpi() to get the DPI. When automated detection is on, this returns -1 instead of the right value.
This causes several bugs (#6879, wrongly sized selection anchors and broken tap detection).

This PR fixes that, by replacing `Settings::getDisplayDpi()` by `ZoomControl::getZoom100Value() * Util::DPI_NORMALIZATION_FACTOR` almost everywhere.

I apologize for missing those predictable issues when automated detection was introduced.