### PR TITLE
fix: don't reconvert absolute paths to absolute ones

### DIFF
--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -11,3 +11,19 @@ target_compile_features(util PUBLIC ${PROJECT_CXX_FEATURES})
 target_compile_features(util PUBLIC cxx_std_20)
 target_include_directories(util PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 add_library(xoj::util ALIAS util)
+
+# Check if std::filesystem::absolute needs to be wrapped.
+# With libstdc++, there's a bug where it corrupts UNC paths.
+if (WIN32)
+    include(CheckCXXSymbolExists)
+    check_cxx_symbol_exists(__GLIBCXX__ version GLIBCXX)
+    if(GLIBCXX)
+        target_link_options(util PUBLIC
+            # std::filesystem::absolute(std::filesystem::__cxx11::path const&)
+            "-Wl,--wrap=_ZNSt10filesystem8absoluteERKNS_7__cxx114pathE"
+            # std::filesystem::weakly_canonical(std::filesystem::__cxx11::path const&)
+            "-Wl,--wrap=_ZNSt10filesystem16weakly_canonicalERKNS_7__cxx114pathE"
+        )
+        target_compile_definitions(util PUBLIC XOURNALPP_WRAP_STD_FS_ABSOLUTE)
+    endif()
+endif()

--- a/src/util/include/util/PathUtil.h
+++ b/src/util/include/util/PathUtil.h
@@ -62,14 +62,6 @@ namespace Util {
 [[nodiscard]] bool hasPngFileExt(const fs::path& path);
 
 /**
- * Check if a path is absolute.
- *
- * Use this over fs::path::is_absolute to avoid a bug in libstdc++
- * regarding UNC paths on Windows.
- */
-[[nodiscard]] bool isAbsolute(const fs::path& path);
-
-/**
  * Clear the xournal extensions ignoring case (.xoj, .xopp)
  *
  * @param ext An extension to clear additionally, eg .pdf (would also clear


### PR DESCRIPTION
This fixes Windows users not being able to open documents from UNC paths (https://github.com/xournalpp/xournalpp/issues/5636#issuecomment-3690156180).

Like the original "fix" for #5636, this is rather hacky. With libstdc++ on Windows, UNC paths are not considered absolute. So when calling `fs::absolute`, a UNC path will get corrupted (a drive letter will be prepended, making it a regular path). If we check for the path already being absolute, we can avoid corrupting the path.

The proper solution would be to fix this in libstdc++, but my patch didn't receive any review since May. An alternative is to use libc++ instead of libstdc++. It implements the path operations on UNC paths correctly, but switching the STL opens another can of worms.