### PR TITLE
Revert "Downgrade gtk to 3.24.43 for Windows"

### DIFF
--- a/.github/actions/install_deps_windows/action.yml
+++ b/.github/actions/install_deps_windows/action.yml
@@ -39,11 +39,4 @@ runs:
       run: |
         # install LuaGObject via luarocks as long as there is no MinGW package
         luarocks install --lua-version=5.4 LuaGObject
-    - shell: msys2 {0}
-      run: |
-        # Downgrade gtk to avoid https://github.com/xournalpp/xournalpp/issues/6315
-        wget -q https://repo.msys2.org/mingw/${{inputs.msystem}}/mingw-w64-${{inputs.msys_package_env}}-gtk3-3.24.43-1-any.pkg.tar.zst
-        wget -q https://repo.msys2.org/mingw/${{inputs.msystem}}/mingw-w64-${{inputs.msys_package_env}}-gtk3-3.24.43-1-any.pkg.tar.zst.sig
-
-        pacman -U --noconfirm mingw-w64-${{inputs.msys_package_env}}-gtk3-3.24.43-1-any.pkg.tar.zst
 


### PR DESCRIPTION
This reverts commit 78ea7198aea04052ecadfc05fa2d0df8f4b2fe16 and needs to be tested.

Downgrading Gtk to 3.24.43 was introduced in Xournal++ 1.2.8 (released on Sep 2, 2025), as a temporary fix for #6315.
It looks like the issue was fixed in Gtk 3.24.49 released on March 5, 2025, see [changelog](https://gitlab.gnome.org/GNOME/gtk/-/blob/gtk-3-24/NEWS?ref_type=heads) and [corresponding MR](https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/8199), but some users have said that Gtk 3.24.49/Xournal++ 1.2.7 (released on May 8, 2025) is also affected (https://github.com/xournalpp/xournalpp/issues/6315#issuecomment-2935413584, #6452, https://github.com/xournalpp/xournalpp/issues/6315#issuecomment-2924950494), so there may have been multiple issues and not all of them have been fixed in Gtk 3.24.49. 