### PR TITLE
Fix pixelized Color icons

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,7 @@ if (ENABLE_CPPTRACE)
         cpptrace
         GIT_REPOSITORY https://github.com/jeremy-rifkin/cpptrace.git
         GIT_TAG        v1.0.4 # <HASH or TAG>
+        GIT_SHALLOW     ON
         EXCLUDE_FROM_ALL
     )
     set(FETCHCONTENT_UPDATES_DISCONNECTED ON) # Prevent reloading if already downloaded
@@ -134,13 +135,34 @@ if (ENABLE_CPPTRACE)
     endif()
 endif()
 
+##############################
+# GVDB -- GVariant database library. Used to generate GResources on the fly
+##############################
+
+FetchContent_Declare(
+    gvdb
+    GIT_REPOSITORY https://gitlab.gnome.org/GNOME/gvdb.git
+    GIT_TAG           4758f6fb7f889e074e13df3f914328f3eecb1fd3 # <HASH or TAG>$
+    GIT_SHALLOW     ON
+    EXCLUDE_FROM_ALL
+)
+set(FETCHCONTENT_UPDATES_DISCONNECTED ON) # Prevents reloading if already downloaded
+FetchContent_GetProperties(gvdb)          # Sets gvdb_SOURCE_DIR
+FetchContent_MakeAvailable(gvdb)
+add_library(gvdb_obj STATIC ${gvdb_SOURCE_DIR}/gvdb/gvdb-builder.c)
+pkg_check_modules(GvdbDeps REQUIRED IMPORTED_TARGET "glib-2.0 >= 2.44.0" "gio-2.0")
+target_link_libraries(gvdb_obj PRIVATE PkgConfig::GvdbDeps)
+target_include_directories(gvdb_obj PUBLIC ${gvdb_SOURCE_DIR})
+add_library(gvdb::libgvdb ALIAS gvdb_obj)
+
 
 ##############################
 # other externals
 ##############################
 
 set(pkg-module-spec "")
-list(APPEND pkg-module-spec "glib-2.0 >= 2.32.0")
+list(APPEND pkg-module-spec "glib-2.0 >= 2.44.0")
+list(APPEND pkg-module-spec "gio-2.0")
 list(APPEND pkg-module-spec "gtk+-3.0 >= 3.18.9")
 list(APPEND pkg-module-spec "poppler-glib >= 0.41.0")
 if (APPLE)
@@ -242,6 +264,7 @@ target_link_libraries(external_modules INTERFACE
         $<$<TARGET_EXISTS:qpdf::libqpdf>:qpdf::libqpdf>
         ZLIB::ZLIB
         Threads::Threads
+        gvdb::libgvdb
         )
 
 target_compile_definitions(external_modules INTERFACE

--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -63,6 +63,7 @@
 #include "gui/menus/menubar/Menubar.h"                           // for Menubar
 #include "gui/sidebar/Sidebar.h"                                 // for Sidebar
 #include "gui/toolbarMenubar/ToolMenuHandler.h"                  // for Tool...
+#include "gui/toolbarMenubar/icon/ColorIcon.h"                   // for createColorIconResources
 #include "gui/toolbarMenubar/model/ToolbarData.h"                // for Tool...
 #include "gui/toolbarMenubar/model/ToolbarModel.h"               // for Tool...
 #include "model/BackgroundImage.h"                               // for Back...
@@ -134,6 +135,11 @@ Control::Control(GApplication* gtkApp, GladeSearchpath* gladeSearchPath, bool di
     this->settings = new Settings(std::move(name));
     this->settings->load();
     this->loadPaletteFromSettings();
+
+    ColorIcon::createPaletteIconResources(this->getPalette(),
+                                          settings->getRecolorParameters().recolorizeMainView ?
+                                                  std::make_optional(settings->getRecolorParameters().recolor) :
+                                                  std::nullopt);
 
     this->pageTypes = new PageTypeHandler(gladeSearchPath);
 
@@ -1440,6 +1446,10 @@ void Control::showSettings() {
                 }
 
                 if (reloadToolbars) {
+                    ColorIcon::createPaletteIconResources(
+                            ctrl->getPalette(), settings->getRecolorParameters().recolorizeMainView ?
+                                                        std::make_optional(settings->getRecolorParameters().recolor) :
+                                                        std::nullopt);
                     ctrl->getWindow()->reloadToolbars();
                 }
 

--- a/src/core/gui/dialog/SettingsDialogPaletteTab.cpp
+++ b/src/core/gui/dialog/SettingsDialogPaletteTab.cpp
@@ -2,6 +2,7 @@
 
 #include "gui/toolbarMenubar/icon/ColorIcon.h"
 #include "util/PathUtil.h"
+#include "util/Recolor.h"
 #include "util/gtk4_helper.h"
 #include "util/i18n.h"
 
@@ -84,6 +85,7 @@ auto SettingsDialogPaletteTab::renderPaletteListBoxRow(GtkListBox* lb, const fs:
 
     try {
         palette.load();
+        ColorIcon::createPaletteIconResources(palette, std::nullopt);
         listBoxRow = newPaletteListBoxRow(palette);
     } catch (const std::exception& e) {
         listBoxRow = newErrorListBoxRow(p, e.what());
@@ -196,10 +198,8 @@ auto SettingsDialogPaletteTab::newPaletteTextBox(const std::string& mainContent,
 
 auto SettingsDialogPaletteTab::newPaletteColorIconsBox(const Palette& palette) -> GtkWidget* {
     GtkWidget* colors = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 3);
-    for (unsigned long i = 0; i < palette.size(); i++) {
-        const NamedColor& namedColor = palette.getColorAt(i);
-        const Color c = namedColor.getColor();
-        GtkWidget* icon = ColorIcon::newGtkImage(c, 16, true);
+    for (const auto& namedColor: palette.getColors()) {
+        GtkWidget* icon = ColorIcon::newGtkImage(namedColor.getColor(), 16, true);
         gtk_box_append(GTK_BOX(colors), icon);
     }
     gtk_widget_set_halign(colors, GTK_ALIGN_END);

--- a/src/core/gui/toolbarMenubar/icon/ColorIcon.cpp
+++ b/src/core/gui/toolbarMenubar/icon/ColorIcon.cpp
@@ -1,17 +1,142 @@
 #include "ColorIcon.h"
 
-#include <cmath>  // for M_PI
+#include <iomanip>
+#include <memory>
+#include <sstream>
 
-#include "util/raii/CairoWrappers.h"
+extern "C" {
+#include <gvdb/gvdb-builder.h>
+}
+
+#include "gui/toolbarMenubar/model/ColorPalette.h"
+#include "util/Recolor.h"
+#include "util/glib_casts.h"
 #include "util/raii/GObjectSPtr.h"
+#include "util/serdesstream.h"
 
 namespace ColorIcon {
+
+static constexpr auto ICON_THEME_RESOURCE_PATH = "/org/xournalpp/colors/icons/";
+static constexpr auto FULL_RESOURCE_PATH = "/org/xournalpp/colors/icons/scalable/actions/";
+
+static constexpr auto CIRCLE_ICON_CORE_NAME = "circle";
+static constexpr auto SQUARE_ICON_CORE_NAME = "square";
+static constexpr auto ICON_EXTENSION = ".svg";
+
+static std::string colorToHex(Color c) {
+    auto s = serdes_stream<std::stringstream>();
+    s << std::hex << std::setw(6) << std::setfill('0') << (uint32_t(c) & 0x00ffffff);
+    return s.str();
+};
+
+static GvdbItem* createParent(GHashTable* table) {
+    std::string path = FULL_RESOURCE_PATH;
+    auto* parent = gvdb_hash_table_insert(table, path.c_str());
+    // We need to add the whole hierarchy
+    auto* ancestor = parent;
+    for (auto it = std::next(path.rbegin()); it != path.rend(); it++) {
+        if (*it == '/') {
+            it[-1] = '\0';  // The c-string ends here now
+            auto* item = gvdb_hash_table_insert(table, path.c_str());
+            gvdb_item_set_parent(ancestor, item);
+            ancestor = item;
+        }
+    }
+    return parent;
+}
+
+void createPaletteIconResources(const Palette& palette, const std::optional<Recolor>& recolor) {
+    // Create the suitable GResource
+    auto* table = gvdb_hash_table_new(nullptr, nullptr);
+    auto* parent = createParent(table);
+
+    auto makeSVG = [](const std::string& colorAsHex, const std::string& secColorAsHex, bool circle) {
+        auto stream = serdes_stream<std::stringstream>();
+
+        stream << "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"48\" height=\"48\" stroke-width=\"4\" "
+                  "stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke=\"#000000\" stroke-opacity=\"1\">";
+        if (circle) {
+            stream << "<circle cx=\"24\" cy=\"24\" r=\"20\" ";
+        } else {
+            stream << "<rect width=\"40\" height=\"40\" x=\"4\" y=\"4\" rx=\"2\" ry=\"2\" ";
+        }
+        stream << "style=\"fill:#" << colorAsHex << "\"/>";
+
+        if (!secColorAsHex.empty()) {
+            stream << "<path d=\"M 46 22 A 22 22 0 0 0 22 46 L 46 46 Z\" style=\"fill:#" << secColorAsHex << "\"/>";
+        }
+        stream << "</svg>";
+        return stream.str();
+    };
+
+    auto makeGVariant = [](std::string&& content) {
+        auto c = std::make_unique<std::string>(std::move(content));
+        GVariantBuilder builder;
+        g_variant_builder_init(&builder, G_VARIANT_TYPE("(uuay)"));
+        g_variant_builder_add(&builder, "u", content.size()); /* Size */
+        g_variant_builder_add(&builder, "u", 0);              /* Flags (compression or so) - none for us */
+        g_variant_builder_add_value(&builder,
+                                    g_variant_new_from_data(G_VARIANT_TYPE("ay"), c->c_str(), c->size() + 1, TRUE,
+                                                            xoj::util::destroy_cb<std::string>, c.get()));
+        c.release();  // Now owned by the GVariant
+        return g_variant_builder_end(&builder);
+    };
+
+    for (const auto& c: palette.getColors()) {
+        auto colorAsHex = colorToHex(c.getColor());
+        auto key = FULL_RESOURCE_PATH + colorAsHex + CIRCLE_ICON_CORE_NAME + ICON_EXTENSION;
+        auto* item = gvdb_hash_table_insert(table, key.c_str());
+        gvdb_item_set_value(item, makeGVariant(makeSVG(colorAsHex, "", true)));
+        gvdb_item_set_parent(item, parent);
+        // And the square icon
+        key = FULL_RESOURCE_PATH + colorAsHex + SQUARE_ICON_CORE_NAME + ICON_EXTENSION;
+        item = gvdb_hash_table_insert(table, key.c_str());
+        gvdb_item_set_value(item, makeGVariant(makeSVG(colorAsHex, "", false)));
+        gvdb_item_set_parent(item, parent);
+    }
+    if (recolor) {
+        // Also add icons with the converted color in a corner
+        // We still need the normal icons in various places (e.g. Toolbar customization or Palette settings)
+        for (const auto& c: palette.getColors()) {
+            auto colorAsHex = colorToHex(c.getColor());
+            auto secColorAsHex = colorToHex(recolor->convertColor(c.getColor()));
+            auto key = FULL_RESOURCE_PATH + colorAsHex + CIRCLE_ICON_CORE_NAME + secColorAsHex + ICON_EXTENSION;
+            auto* item = gvdb_hash_table_insert(table, key.c_str());
+            gvdb_item_set_value(item, makeGVariant(makeSVG(colorAsHex, secColorAsHex, true)));
+            gvdb_item_set_parent(item, parent);
+        }
+    }
+
+    // Now add our icons to the available resources
+    GBytes* bytes = gvdb_table_get_contents(table, G_BYTE_ORDER != G_LITTLE_ENDIAN);
+    g_hash_table_destroy(table);
+
+    GError* err = nullptr;
+    GResource* res = g_resource_new_from_data(bytes, &err);
+    g_bytes_unref(bytes);
+    g_resources_register(res);
+    g_resource_unref(res);
+    if (err) {
+        g_warning("Error when creating color icon cache: %s\n", err->message);
+    }
+
+    // By calling this we ensure the path is known AND make the theme update itself
+    gtk_icon_theme_add_resource_path(gtk_icon_theme_get_default(), ICON_THEME_RESOURCE_PATH);
+}
+
+static std::string getName(Color color, std::optional<Color> secondaryColor, bool circle) {
+    auto colorAsHex = colorToHex(color);
+    auto secColorAsHex = secondaryColor ? colorToHex(secondaryColor.value()) : std::string();
+    return colorAsHex + (circle ? CIRCLE_ICON_CORE_NAME : SQUARE_ICON_CORE_NAME) + secColorAsHex;
+}
+
 /**
  * Create a new GtkImage with preview color
  */
 auto newGtkImage(Color color, int size, bool circle, std::optional<Color> secondaryColor) -> GtkWidget* {
-    xoj::util::GObjectSPtr<GdkPixbuf> img(newGdkPixbuf(color, size, circle, secondaryColor));
-    GtkWidget* w = gtk_image_new_from_pixbuf(img.get());
+    auto name = getName(color, secondaryColor, circle);
+    GtkWidget* w = gtk_image_new_from_icon_name(name.c_str(),
+                                                circle ? GTK_ICON_SIZE_SMALL_TOOLBAR : GTK_ICON_SIZE_LARGE_TOOLBAR);
     gtk_widget_show(w);
     return w;
 }
@@ -21,42 +146,10 @@ auto newGtkImage(Color color, int size, bool circle, std::optional<Color> second
  */
 auto newGdkPixbuf(Color color, int size, bool circle, std::optional<Color> secondaryColor)
         -> xoj::util::GObjectSPtr<GdkPixbuf> {
-    xoj::util::CairoSurfaceSPtr buf(cairo_image_surface_create(CAIRO_FORMAT_ARGB32, size, size), xoj::util::adopt);
-    xoj::util::CairoSPtr cr(cairo_create(buf.get()), xoj::util::adopt);
-
-    Util::cairo_set_source_rgbi(cr.get(), color, 1);
-
-    constexpr double PADDING = 1;
-
-    if (circle) {
-        const double mid = .5 * size;
-        const double radius = mid - PADDING;
-        cairo_arc(cr.get(), mid, mid, radius, 0, 2 * M_PI);
-    } else {
-        cairo_rectangle(cr.get(), PADDING, PADDING, size - 2 * PADDING, size - 2 * PADDING);
-    }
-    cairo_fill_preserve(cr.get());
-
-    cairo_set_source_rgba(cr.get(), 0, 0, 0, 1);
-    cairo_set_line_width(cr.get(), 1);
-    cairo_stroke(cr.get());
-
-    if (secondaryColor) {
-        // Draw an indicator for the secondary color
-        Util::cairo_set_source_rgbi(cr.get(), secondaryColor.value(), 1);
-
-        const double indicatorMid = size - 2 * PADDING;
-        const double indicatorRadius = (0.5 * size) - PADDING;
-        // only draws the upper left quarter of the arc
-        cairo_arc(cr.get(), indicatorMid, indicatorMid, indicatorRadius, M_PI, M_PI / 2);
-        cairo_fill_preserve(cr.get());
-
-        cairo_set_source_rgba(cr.get(), 0, 0, 0, 1);
-        cairo_set_line_width(cr.get(), 1);
-        cairo_stroke(cr.get());
-    }
-
-    return xoj::util::GObjectSPtr<GdkPixbuf>(gdk_pixbuf_get_from_surface(buf.get(), 0, 0, size, size),
-                                             xoj::util::adopt);
+    auto name = getName(color, secondaryColor, circle);
+    return xoj::util::GObjectSPtr<GdkPixbuf>(
+            gdk_pixbuf_new_from_resource_at_scale((FULL_RESOURCE_PATH + name + ICON_EXTENSION).c_str(), size, size,
+                                                  false, nullptr),
+            xoj::util::adopt);
 }
 };  // namespace ColorIcon

--- a/src/core/gui/toolbarMenubar/icon/ColorIcon.h
+++ b/src/core/gui/toolbarMenubar/icon/ColorIcon.h
@@ -19,7 +19,12 @@
 #include "util/Color.h"  // for Color
 #include "util/raii/GObjectSPtr.h"
 
+struct Palette;
+class Recolor;
+
 namespace ColorIcon {
+void createPaletteIconResources(const Palette& palette, const std::optional<Recolor>& recolor);
+
 /**
  * @brief Create a new GtkImage with preview color
  * @return The pointer is a floating ref

--- a/src/core/gui/toolbarMenubar/model/ColorPalette.cpp
+++ b/src/core/gui/toolbarMenubar/model/ColorPalette.cpp
@@ -180,3 +180,5 @@ auto Palette::parseErrorDialog(const std::exception& e) const -> void {
     // Call later, to make sure the main window has been set up, so the popup is displayed in front of it (and modal)
     Util::execInUiThread([msg = msg_stream.str()]() { XojMsgBox::showErrorToUser(nullptr, msg); });
 }
+
+auto Palette::getColors() const -> const std::vector<NamedColor>& { return namedColors; }

--- a/src/core/gui/toolbarMenubar/model/ColorPalette.h
+++ b/src/core/gui/toolbarMenubar/model/ColorPalette.h
@@ -131,6 +131,8 @@ struct Palette {
 
     std::string getHeader(const std::string& attr) const;
 
+    const std::vector<NamedColor>& getColors() const;
+
 
 private:
     /**


### PR DESCRIPTION
Fix #6892 

The color icons in the toolbar are not really scalable the way they are implemented in 1.3.
The reason is: we create a GtkImage from a GdkPixbuf and there is no way of telling GTK that this Pixbuf should be interpreted as a HiDPI buffer.
Two solutions

1. Revert back to how it worked in 1.2: connect to the signal Widget::draw and handle the drawing by hand. Not a solution that could work with GTK4 though.
2. Feed the icon as named icons for GTK and use gtk_image_new_from_icon_name(). This then relies in GTK's proper handling of icons: HiDPI works, changes in the CSS style are taken into account, and probably other things.

This PR proposes to implement 2. To achieve that each color icon is created as an SVG GResource and added to the global GResource context.
I could not find any documentation on how to create the GResources, so I looked at how they are made in `glib-compile-resource`. It relies on the "source-only" library libgvdb (GVariant DataBase) which is pulled in by the CMake.
An alternative would be to create icon files in a tmp directory, but it seems less clean to me and possibly less safe (in case the tmp files are modified, I'm not sure).

This solution works with GTK4 as well.

Note: I targetted this to release-1.3 but it may be a bit too big of a fix. To be debated.
