### PR TITLE
feat: improve windows installer directory handling

### DIFF
--- a/windows-setup/xournalpp.nsi
+++ b/windows-setup/xournalpp.nsi
@@ -13,7 +13,6 @@ Unicode true
 !include x64.nsh
 !include "${SCRIPT_DIR}\FileAssociation.nsh"
 !include nsDialogs.nsh
-!include "WordFunc.nsh"
 
 ; Options for MultiUser plugin
 !define MULTIUSER_INSTALLMODE_INSTDIR "Xournal++"


### PR DESCRIPTION
This PR enhances the Windows installer script to prevent accidental installation into mixed or incorrect directories.

## The Problem I Want to Address
Currently, when we choose a custom location in the installer, it won't check the directory is empty or not, and will not create a folder for the software automatically.

For example, I choose `C:\Users\cheng\Downloads\test` as my target to download. I actually hope xournal to be installed at `C:\Users\cheng\Downloads\test\Xournal++`. However, it will decompress the files into `C:\Users\cheng\Downloads\test`  directly. 🥲 And the `test1.txt` and `test2.txt` are mixed with the Xournal files. 
<img width="834" height="439" alt="image" src="https://github.com/user-attachments/assets/78c79cbf-fd4e-4f04-b192-f18eeedece1b" />


## What feature I added

### When browsing for a target location, the installer now automatically appends `\Xournal++` to the selected path.

I chose C:\Users\cheng\Downloads here, it automatically append \Xournal++ at the end.
<img width="629" height="498" alt="image" src="https://github.com/user-attachments/assets/f8ae0c2e-6698-4a27-b40a-290e6f9da3dd"/>





### When the folder we choose is not empty, we will get a warning.
<img width="638" height="510" alt="image" src="https://github.com/user-attachments/assets/564c4768-f52d-484c-b225-0b6b6beae41e" />
