### PR TITLE
fix Compile On msys2 On Windows

### DIFF
--- a/readme/WindowsBuild.md
+++ b/readme/WindowsBuild.md
@@ -47,7 +47,7 @@ pacman -S \
   mingw-w64-x86_64-libzip \
   mingw-w64-x86_64-lua \
   mingw-w64-x86_64-portaudio \
-  mingw-w64-clang-x86_64-gtksourceview4 \
+  mingw-w64-x86_64-gtksourceview4 \
   mingw-w64-x86_64-qpdf
 ```
 


### PR DESCRIPTION
Why did it suddenly can not compiling after some time? I found out that the package was wrongly installed in the clang64 environment.