### PR TITLE
feat: add setting for initial zoom to fit

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -1724,7 +1724,7 @@ void Control::fileLoaded(int scrollToPage) {
         loadMetadata(md);
         RecentManager::addRecentFileFilename(filepath);
 
-        if(settings->getForceZoomToFitOnLoad()){
+        if (settings->getForceZoomToFitOnLoad()) {
             zoom->updateZoomFitValue();
             zoom->setZoomFitMode(true);
         }

--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -1723,6 +1723,12 @@ void Control::fileLoaded(int scrollToPage) {
 
         loadMetadata(md);
         RecentManager::addRecentFileFilename(filepath);
+
+        if(settings->ifForceZoomToFitOnLoad()){
+            zoom->updateZoomFitValue();
+            zoom->setZoomFitMode(true);
+        }
+
     } else {
         zoom->updateZoomFitValue();
         zoom->setZoomFitMode(true);

--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -1724,7 +1724,7 @@ void Control::fileLoaded(int scrollToPage) {
         loadMetadata(md);
         RecentManager::addRecentFileFilename(filepath);
 
-        if(settings->ifForceZoomToFitOnLoad()){
+        if(settings->getForceZoomToFitOnLoad()){
             zoom->updateZoomFitValue();
             zoom->setZoomFitMode(true);
         }

--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -1971,7 +1971,7 @@ void Settings::setForceZoomToFitOnLoad(bool force) {
     save();
 }
 
-const auto Settings::getForceZoomToFitOnLoad() -> bool { return this->forceZoomToFitOnLoad; }
+auto Settings::getForceZoomToFitOnLoad() const -> bool { return this->forceZoomToFitOnLoad; }
 
 void Settings::setEdgePanSpeed(double speed) {
     if (this->edgePanSpeed == speed) {

--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -423,6 +423,8 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur) {
         this->zoomStep = tempg_ascii_strtod(reinterpret_cast<const char*>(value), nullptr);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("zoomStepScroll")) == 0) {
         this->zoomStepScroll = tempg_ascii_strtod(reinterpret_cast<const char*>(value), nullptr);
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("forceZoomToFitOnLoad")) == 0) {
+        this->forceZoomToFitOnLoad = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("displayDpi")) == 0) {
         this->displayDpi = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("mainWndWidth")) == 0) {
@@ -1015,6 +1017,7 @@ void Settings::save() {
     SAVE_DOUBLE_PROP(edgePanMaxMult);
     SAVE_DOUBLE_PROP(zoomStep);
     SAVE_DOUBLE_PROP(zoomStepScroll);
+    SAVE_BOOL_PROP(forceZoomToFitOnLoad);
     SAVE_INT_PROP(displayDpi);
     SAVE_INT_PROP(mainWndWidth);
     SAVE_INT_PROP(mainWndHeight);
@@ -1957,6 +1960,20 @@ void Settings::setZoomStepScroll(double zoomStepScroll) {
 }
 
 auto Settings::getZoomStepScroll() const -> double { return this->zoomStepScroll; }
+
+bool Settings::ifForceZoomToFitOnLoad() { return this->forceZoomToFitOnLoad; }
+void Settings::setForceZoomToFitOnLoad(bool force) {
+    if (this->forceZoomToFitOnLoad == force) {
+        return;
+    }
+
+    this->forceZoomToFitOnLoad = force;
+
+    save();
+}
+
+auto Settings::getForceZoomToFitOnLoad() -> bool { return this->forceZoomToFitOnLoad; }
+
 
 void Settings::setEdgePanSpeed(double speed) {
     if (this->edgePanSpeed == speed) {

--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -1961,7 +1961,6 @@ void Settings::setZoomStepScroll(double zoomStepScroll) {
 
 auto Settings::getZoomStepScroll() const -> double { return this->zoomStepScroll; }
 
-bool Settings::ifForceZoomToFitOnLoad() { return this->forceZoomToFitOnLoad; }
 void Settings::setForceZoomToFitOnLoad(bool force) {
     if (this->forceZoomToFitOnLoad == force) {
         return;
@@ -1972,8 +1971,7 @@ void Settings::setForceZoomToFitOnLoad(bool force) {
     save();
 }
 
-auto Settings::getForceZoomToFitOnLoad() -> bool { return this->forceZoomToFitOnLoad; }
-
+const auto Settings::getForceZoomToFitOnLoad() -> bool { return this->forceZoomToFitOnLoad; }
 
 void Settings::setEdgePanSpeed(double speed) {
     if (this->edgePanSpeed == speed) {

--- a/src/core/control/settings/Settings.h
+++ b/src/core/control/settings/Settings.h
@@ -185,7 +185,6 @@ public:
     /**
      * Whether to force zoom to fit on loading document
      */
-    bool ifForceZoomToFitOnLoad();
     void setForceZoomToFitOnLoad(bool force);
     bool getForceZoomToFitOnLoad();
 

--- a/src/core/control/settings/Settings.h
+++ b/src/core/control/settings/Settings.h
@@ -183,6 +183,14 @@ public:
     double getZoomStepScroll() const;
 
     /**
+     * Whether to force zoom to fit on loading document
+     */
+    bool ifForceZoomToFitOnLoad();
+    void setForceZoomToFitOnLoad(bool force);
+    bool getForceZoomToFitOnLoad();
+
+
+    /**
      * Sets the screen resolution in DPI
      */
     void setDisplayDpi(int dpi);
@@ -797,6 +805,11 @@ private:
      * Zoomstep for Ctrl + Scroll zooming
      */
     double zoomStepScroll{};
+
+    /**
+     * Whether to force zoom to fit on loading document
+     */
+    bool forceZoomToFitOnLoad{};
 
     /**
      * The display resolution, in pixels per inch. -1 for automatic detection

--- a/src/core/control/settings/Settings.h
+++ b/src/core/control/settings/Settings.h
@@ -186,7 +186,7 @@ public:
      * Whether to force zoom to fit on loading document
      */
     void setForceZoomToFitOnLoad(bool force);
-    bool getForceZoomToFitOnLoad();
+    bool getForceZoomToFitOnLoad() const;
 
 
     /**

--- a/src/core/gui/dialog/SettingsDialog.cpp
+++ b/src/core/gui/dialog/SettingsDialog.cpp
@@ -962,7 +962,7 @@ void SettingsDialog::save() {
     settings->setZoomStepScroll(zoomStepScroll);
 
     GtkWidget* cbForceZoomToFitOnLoad = builder.get("cbForceZoomToFitOnLoad");
-    bool const forceZoomToFitOnLoad = gtk_check_button_get_active(GTK_CHECK_BUTTON(cbForceZoomToFitOnLoad));
+    const bool forceZoomToFitOnLoad = gtk_check_button_get_active(GTK_CHECK_BUTTON(cbForceZoomToFitOnLoad));
     settings->setForceZoomToFitOnLoad(forceZoomToFitOnLoad);
 
     GtkWidget* spAddHorizontalSpaceRight = builder.get("spAddHorizontalSpaceRight");

--- a/src/core/gui/dialog/SettingsDialog.cpp
+++ b/src/core/gui/dialog/SettingsDialog.cpp
@@ -446,7 +446,7 @@ void SettingsDialog::load() {
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spZoomStepScroll), settings->getZoomStepScroll());
 
     GtkWidget* cbForceZoomToFitOnLoad = builder.get("cbForceZoomToFitOnLoad");
-    gtk_spin_button_set_value(GTK_SPIN_BUTTON(cbForceZoomToFitOnLoad), settings->getForceZoomToFitOnLoad());
+    gtk_check_button_set_active(GTK_CHECK_BUTTON(cbForceZoomToFitOnLoad), settings->getForceZoomToFitOnLoad());
 
     GtkWidget* spAddHorizontalSpaceRight = builder.get("spAddHorizontalSpaceRight");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spAddHorizontalSpaceRight), settings->getAddHorizontalSpaceAmountRight());

--- a/src/core/gui/dialog/SettingsDialog.cpp
+++ b/src/core/gui/dialog/SettingsDialog.cpp
@@ -445,6 +445,9 @@ void SettingsDialog::load() {
     GtkWidget* spZoomStepScroll = builder.get("spZoomStepScroll");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spZoomStepScroll), settings->getZoomStepScroll());
 
+    GtkWidget* cbForceZoomToFitOnLoad = builder.get("cbForceZoomToFitOnLoad");
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(cbForceZoomToFitOnLoad), settings->getForceZoomToFitOnLoad());
+
     GtkWidget* spAddHorizontalSpaceRight = builder.get("spAddHorizontalSpaceRight");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spAddHorizontalSpaceRight), settings->getAddHorizontalSpaceAmountRight());
 
@@ -958,6 +961,9 @@ void SettingsDialog::save() {
     double zoomStepScroll = gtk_spin_button_get_value(GTK_SPIN_BUTTON(spZoomStepScroll));
     settings->setZoomStepScroll(zoomStepScroll);
 
+    GtkWidget* cbForceZoomToFitOnLoad = builder.get("cbForceZoomToFitOnLoad");
+    bool const forceZoomToFitOnLoad = gtk_check_button_get_active(GTK_CHECK_BUTTON(cbForceZoomToFitOnLoad));
+    settings->setForceZoomToFitOnLoad(forceZoomToFitOnLoad);
 
     GtkWidget* spAddHorizontalSpaceRight = builder.get("spAddHorizontalSpaceRight");
     const int addHorizontalSpaceAmountRight =

--- a/src/core/gui/dialog/SettingsDialog.cpp
+++ b/src/core/gui/dialog/SettingsDialog.cpp
@@ -333,6 +333,7 @@ void SettingsDialog::showStabilizerPreprocessorOptions(StrokeStabilizer::Preproc
 void SettingsDialog::load() {
     loadCheckbox("cbSettingPresureSensitivity", settings->isPressureSensitivity());
     loadCheckbox("cbEnableZoomGestures", settings->isZoomGesturesEnabled());
+    loadCheckbox("cbForceZoomToFitOnLoad", settings->getForceZoomToFitOnLoad());
     loadCheckbox("cbShowSidebarRight", settings->isSidebarOnRight());
     loadCheckbox("cbShowScrollbarLeft", settings->isScrollbarOnLeft());
     loadCheckbox("cbAutoloadMostRecent", settings->isAutoloadMostRecent());
@@ -444,9 +445,6 @@ void SettingsDialog::load() {
 
     GtkWidget* spZoomStepScroll = builder.get("spZoomStepScroll");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spZoomStepScroll), settings->getZoomStepScroll());
-
-    GtkWidget* cbForceZoomToFitOnLoad = builder.get("cbForceZoomToFitOnLoad");
-    gtk_check_button_set_active(GTK_CHECK_BUTTON(cbForceZoomToFitOnLoad), settings->getForceZoomToFitOnLoad());
 
     GtkWidget* spAddHorizontalSpaceRight = builder.get("spAddHorizontalSpaceRight");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spAddHorizontalSpaceRight), settings->getAddHorizontalSpaceAmountRight());

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -4391,6 +4391,50 @@ This setting can make it easier to draw with touch. </property>
                               </packing>
                             </child>
                             <child>
+                              <object class="GtkFrame" id="sid109">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
+                                <child>
+                                  <object class="GtkBox" id="box20">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">8</property>
+                                    <property name="orientation">vertical</property>
+                                    <child>
+                                      <object class="GtkCheckButton" id="cbForceZoomToFitOnLoad">
+                                        <property name="label" translatable="yes">Force zoom to fit on document load</property>
+                                        <property name="name">cbForceZoomToFitOnLoad </property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="draw-indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label">
+                                  <object class="GtkLabel" id="sid112">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">Default Zoom</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">3</property>
+                              </packing>
+                            </child>
+                            <child>
                               <object class="GtkFrame" id="sid129">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>


### PR DESCRIPTION
This partially resolves #5565 . I tried to implement an option which, when active, will zoom to fit upon loading any new file.

The feature itself works as far as I can tell. I am facing only one major issue, which is that upon setting the option and then reopening the settings dialog, the option is deselected, and will be turned off again after saving the current settings dialog. I am sorry for my oversight of the exact mechanics of saving and loading the settings for the menu, could anyone point me in the right direction?

If I made any grave errors in style I apologize and am happy for any feedback.