### PR TITLE
Avoid `g_error` for command line parameter errors

### DIFF
--- a/src/core/control/ExportHelper.cpp
+++ b/src/core/control/ExportHelper.cpp
@@ -73,6 +73,7 @@ auto exportImg(Document* doc, const char* output, const char* range, const char*
     std::string errorMsg = imgExport.getLastErrorMsg();
     if (!errorMsg.empty()) {
         g_message("Error exporting image: %s\n", errorMsg.c_str());
+        return -3;
     }
 
     g_message("%s", _("Image file successfully created"));
@@ -105,7 +106,7 @@ auto exportPdf(Document* doc, const char* output, const char* range, const char*
     try {
         if (!backgroundPDF.empty() && fs::exists(backgroundPDF)) {
             if (fs::weakly_canonical(path) == fs::weakly_canonical(backgroundPDF)) {
-                g_error("Do not overwrite the background PDF! This will cause errors!");
+                g_message("Do not overwrite the background PDF! This will cause errors!");
                 return -3;  // Return error code for export failure
             }
         }
@@ -128,7 +129,8 @@ auto exportPdf(Document* doc, const char* output, const char* range, const char*
     }
 
     if (!exportSuccess) {
-        g_error("%s", pdfe->getLastError().c_str());
+        g_message("%s", pdfe->getLastError().c_str());
+        return -3;
     }
 
     g_message("%s", _("PDF file successfully created"));

--- a/src/core/control/XournalMain.cpp
+++ b/src/core/control/XournalMain.cpp
@@ -179,19 +179,27 @@ void exitOnMissingPdfFileName(const LoadHandler& loader) {
  *
  *  The priority is: pngDpi overwrites pngWidth overwrites pngHeight
  *
- * @return 0 on success, -2 on failure opening the input file, -3 on export failure
+ * @return 0 on success
+ *
+ * Calls std::exit(-2) on failure opening the input file and std::exit(-3) on export failure
  */
 auto exportImg(const char* input, const char* output, const char* range, const char* layerRange, int pngDpi,
                int pngWidth, int pngHeight, ExportBackgroundType exportBackground) -> int {
     LoadHandler loader;
     auto doc = loader.loadDocument(input);
     if (doc == nullptr) {
-        g_error("%s", loader.getLastError().c_str());
+        g_message("%s", loader.getLastError().c_str());
+        std::exit(-2);
     }
 
     exitOnMissingPdfFileName(loader);
 
-    return ExportHelper::exportImg(doc.get(), output, range, layerRange, pngDpi, pngWidth, pngHeight, exportBackground);
+    const auto res = ExportHelper::exportImg(doc.get(), output, range, layerRange, pngDpi, pngWidth, pngHeight,
+                                             exportBackground);
+    if (res != 0) {
+        std::exit(res);
+    }
+    return 0;
 }
 
 /**
@@ -199,7 +207,9 @@ auto exportImg(const char* input, const char* output, const char* range, const c
  *
  * @param input Path to the input .pdf file
  * @param output Path to the output .xopp file
- * @return int 0 on success
+ * @return 0 on success
+ *
+ * Calls std::exit(-2) on failure reading the input file and std::exit(-3) on save failure
  */
 auto saveDoc(const char* input, const char* output) -> int {
     SaveHandler saver;
@@ -208,14 +218,16 @@ auto saveDoc(const char* input, const char* output) -> int {
     auto newDoc = std::make_unique<Document>(handler.get());
     const bool res = newDoc->readPdf(in, /*initPages=*/true, false);
     if (!res) {
-        g_error("%s", FC(_F("Error: {1}") % newDoc->getLastErrorMsg().c_str()));
+        g_message("%s", FC(_F("Error: {1}") % newDoc->getLastErrorMsg().c_str()));
+        std::exit(-2);
     }
     const fs::path out = fs::absolute(Util::fromGFilename(output));
     saver.prepareSave(newDoc.get(), out);
     saver.saveTo(out);
 
     if (!saver.getErrorMessage().empty()) {
-        g_error("%s", FC(_F("Error: {1}") % saver.getErrorMessage()));
+        g_message("%s", FC(_F("Error: {1}") % saver.getErrorMessage()));
+        std::exit(-3);
     }
     return 0;
 }
@@ -233,19 +245,27 @@ auto saveDoc(const char* input, const char* output) -> int {
  * rendered one by one to produce as many pages as there are layers.
  * @param backend The requested backend
  *
- * @return 0 on success, -2 on failure opening the input file, -3 on export failure
+ * @return 0 on success
+ *
+ * Calls std::exit(-2) on failure opening the input file and std::exit(-3) on export failure
  */
 auto exportPdf(const char* input, const char* output, const char* range, const char* layerRange,
                ExportBackgroundType exportBackground, bool progressiveMode, ExportBackend backend) -> int {
     LoadHandler loader;
     auto doc = loader.loadDocument(input);
     if (doc == nullptr) {
-        g_error("%s", loader.getLastError().c_str());
+        g_message("%s", loader.getLastError().c_str());
+        std::exit(-2);
     }
 
     exitOnMissingPdfFileName(loader);
 
-    return ExportHelper::exportPdf(doc.get(), output, range, layerRange, exportBackground, progressiveMode, backend);
+    const auto res =
+            ExportHelper::exportPdf(doc.get(), output, range, layerRange, exportBackground, progressiveMode, backend);
+    if (res != 0) {
+        std::exit(res);
+    }
+    return 0;
 }
 
 struct XournalMainPrivate {


### PR DESCRIPTION
Xournal++ currently call `g_error` for errors that can originate from the command line parameters:
* Opening non-existent file
* Saving / exporting to unwritable location
* Exporting to same file as background PDF (see #6950)

This triggers the crash handler (application is terminated), which is probably not what we want. The documentation for `g_error` also explicitly states:
 > This is not intended for end user error reporting.

Three questions:
 * The function comments specify negative failure codes. However `handle_local_options` will stop processing options only if the return value is positive or 0. If we keep a simple `return -3;`, the GUI window will open on a failed command line call. Better to use `std::exit(-3)` or change the return code to a positive value?
 * Language: Some strings are translated, others aren't. What should we use on the command line?
 * Re-throwing the exception in `ExportHelper::exportPdf()`: nested exceptions are complicated. Wrapping the exception message should give enough context. Good as is?

This is a little bit on the edge for bugfix vs master. The only user difference should be text output and more correct return codes. I added the -2 / -3 pattern to the `--save` option. Maybe not all commits should go to the same branch.