### PR TITLE
fix: Argument forceOpen in Control::openFile has no effect

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -1697,12 +1697,14 @@ void Control::openFile(fs::path filepath, std::function<void(bool)> callback, in
         return;
     }
 
-    this->close([ctrl = this, filepath = std::move(filepath), cb = std::move(callback),
-                 scrollToPage](bool closed) mutable {
-        if (closed) {
-            ctrl->openFileWithoutSavingTheCurrentDocument(std::move(filepath), false, scrollToPage, std::move(cb));
-        }
-    }, false, true, forceOpen);
+    this->close(
+            [ctrl = this, filepath = std::move(filepath), cb = std::move(callback), scrollToPage](bool closed) mutable {
+                if (closed) {
+                    ctrl->openFileWithoutSavingTheCurrentDocument(std::move(filepath), false, scrollToPage,
+                                                                  std::move(cb));
+                }
+            },
+            false, true, forceOpen);
 }
 
 void Control::fileLoaded(int scrollToPage) {
@@ -2089,7 +2091,8 @@ void Control::quit(bool allowCancel) {
     this->close(std::move(afterClosed), true, allowCancel);
 }
 
-void Control::close(std::function<void(bool)> callback, const bool allowDestroy, const bool allowCancel, const bool forceClose) {
+void Control::close(std::function<void(bool)> callback, const bool allowDestroy, const bool allowCancel,
+                    const bool forceClose) {
     clearSelectionEndText();
     metadata->documentChanged();
     resetGeometryTool();

--- a/src/core/control/Control.h
+++ b/src/core/control/Control.h
@@ -141,7 +141,8 @@ public:
      * @param forceClose Whether to skip the save dialog and unconditionally discard unsaved changes.
      * @return true if the user closed the document, otherwise false.
      */
-    void close(std::function<void(bool)> callback, bool allowDestroy = false, bool allowCancel = true, bool forceClose = false);
+    void close(std::function<void(bool)> callback, bool allowDestroy = false, bool allowCancel = true,
+               bool forceClose = false);
 
     // Menu edit
     void showSettings();


### PR DESCRIPTION
Apparently this argument was only ever tested with no unsaved changes present - the save prompt is skipped in that case regardless. All this does is forward the force argument into Control::close, where all the necessary logic is already present. Another potential thing to do here is to allow a callback to be specified into openFile from the lua api.