### PR TITLE
Restore GtkSourceView

### DIFF
--- a/src/core/gui/dialog/IntEdLatexDialog.cpp
+++ b/src/core/gui/dialog/IntEdLatexDialog.cpp
@@ -21,6 +21,7 @@
 #include <poppler-page.h>      // for poppler_page_get_size
 
 #include "AbstractLatexDialog.h"
+#include "config-features.h"
 
 #ifdef ENABLE_GTK_SOURCEVIEW
 #include <gtksourceview/gtksource.h>  // for GTK_SOURCE_VIEW, gtk_sou...


### PR DESCRIPTION
Fix #6967

The undo-redo stack is a feature of the GtkSourceView widget. The issue was that #6476 had inadvertently disabled the use of GtkSouceView (by forgetting a crucial include...). This PR fixes that.

Merging once the CI clears.