### PR TITLE
gitignore ./install directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ Debug
 # Miscellaneous
 .DS_STORE
 *~
+/install/


### PR DESCRIPTION
The official compile instructions (`./readme/Compile.md`) instruct to set the directory `install` as install prefix. This directory should be excluded from git as a user following these instructions automatically clutters their staging area.