### PR TITLE
Allow export-no-background even if pdf file is missing.

### DIFF
--- a/src/core/control/XournalMain.cpp
+++ b/src/core/control/XournalMain.cpp
@@ -188,7 +188,7 @@ auto exportImg(const char* input, const char* output, const char* range, const c
     if (doc == nullptr) {
         g_error("%s", loader.getLastError().c_str());
     }
-    
+
     if (exportBackground != EXPORT_BACKGROUND_NONE) {
         exitOnMissingPdfFileName(loader);
     }


### PR DESCRIPTION
This addresses issue #6979 by @MCXCC303
I modified exportPdf and exportImg to allow for exporting without background even if the xopp file references a pdf file that doesn't exist. This way users can save their notes even if the pdf has been deleted.

The issue also suggests skipping empty pages, let me know if this behavior would be desirable or if it's better to export with the empty pages.

This is my first PR here and I'm not sure if I should PR to master or some other branch, please advise.