### PR TITLE
Fix a crash with cairo_show_text not being thread-safe

### DIFF
--- a/src/core/control/PdfCache.cpp
+++ b/src/core/control/PdfCache.cpp
@@ -125,5 +125,5 @@ void PdfCache::renderMissingPdfPage(cairo_t* cr, double pageWidth, double pageHe
 
     cairo_text_extents(cr, strMissing.c_str(), &extents);
     cairo_move_to(cr, pageWidth / 2 - extents.width / 2, pageHeight / 2 - extents.height / 2);
-    cairo_show_text(cr, strMissing.c_str());
+    cairo_text_path(cr, strMissing.c_str());
 }

--- a/src/core/gui/PageView.cpp
+++ b/src/core/gui/PageView.cpp
@@ -954,7 +954,7 @@ void XojPageView::drawLoadingPage(cairo_t* cr) {
     cairo_text_extents(cr, txtLoading.c_str(), &ex);
     cairo_move_to(cr, (page->getWidth() - ex.width) / 2 - ex.x_bearing,
                   (page->getHeight() - ex.height) / 2 - ex.y_bearing);
-    cairo_show_text(cr, txtLoading.c_str());
+    cairo_text_path(cr, txtLoading.c_str());
 
     rerenderPage();
 }

--- a/src/core/gui/sidebar/previews/base/SidebarPreviewBaseEntry.cpp
+++ b/src/core/gui/sidebar/previews/base/SidebarPreviewBaseEntry.cpp
@@ -89,7 +89,7 @@ void SidebarPreviewBaseEntry::drawLoadingPage() {
     cairo_text_extents(cr2, txtLoading, &ex);
     cairo_move_to(cr2, (page->getWidth() - ex.width) / 2 - ex.x_bearing,
                   (page->getHeight() - ex.height) / 2 - ex.y_bearing);
-    cairo_show_text(cr2, txtLoading);
+    cairo_text_path(cr2, txtLoading);
 
     cairo_destroy(cr2);
 }


### PR DESCRIPTION
Fixes #6921 

I managed to reproduce the issue every time I loaded a xopp-file with missing PDF background. With cairo_text_path instead of cairo_show_text there is no crash.

Wondering whether we should replace the remaining `cairo_show_text` occurences as well (page number in PagePreviewDecorations, "CONTROL" and "SHIFT" indications in createCustomDrawDirCursor and the zoom calibration marks in the preferences). They don't create crashes in my testing though and there might be some benefit in the font caching from `cairo_show_text` in those cases.