### PR TITLE
Initialize PageType for new pages in PageBackgroundChangeController

### DIFF
--- a/src/core/control/PageBackgroundChangeController.cpp
+++ b/src/core/control/PageBackgroundChangeController.cpp
@@ -37,7 +37,8 @@
 #include "filesystem.h"  // for path
 
 
-PageBackgroundChangeController::PageBackgroundChangeController(Control* control): control(control) {
+PageBackgroundChangeController::PageBackgroundChangeController(Control* control):
+        control(control), pageTypeForNewPages(control->getSettings()->getPageTemplateSettings().getPageInsertType()) {
     registerListener(control);
 }
 

--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -16,6 +16,7 @@
 #include "control/DeviceListHelper.h"               // for InputDevice
 #include "control/ToolEnums.h"                      // for ERASER_TYPE_NONE
 #include "control/settings/LatexSettings.h"         // for LatexSettings
+#include "control/settings/PageTemplateSettings.h"  // for PageTemplateSettings
 #include "control/settings/SettingsEnums.h"         // for InputDeviceTypeOp...
 #include "gui/toolbarMenubar/model/ColorPalette.h"  // for Palette
 #include "model/FormatDefinitions.h"                // for FormatUnits, XOJ_...
@@ -1741,6 +1742,12 @@ void Settings::setDefaultPdfExportName(const std::u8string& name) {
 }
 
 auto Settings::getPageTemplate() const -> string const& { return this->pageTemplate; }
+
+auto Settings::getPageTemplateSettings() const -> PageTemplateSettings {
+    PageTemplateSettings model;
+    model.parse(this->pageTemplate);
+    return model;
+}
 
 void Settings::setPageTemplate(const string& pageTemplate) {
     if (this->pageTemplate == pageTemplate) {

--- a/src/core/control/settings/Settings.h
+++ b/src/core/control/settings/Settings.h
@@ -46,6 +46,7 @@ constexpr unsigned int MAX_SPACES_FOR_TAB = 8U;
 
 class ButtonConfig;
 class InputDevice;
+class PageTemplateSettings;
 
 class SAttribute {
 public:
@@ -409,6 +410,7 @@ public:
     void setEagerPageCleanup(bool b);
 
     std::string const& getPageTemplate() const;
+    PageTemplateSettings getPageTemplateSettings() const;
     void setPageTemplate(const std::string& pageTemplate);
 
 #ifdef ENABLE_AUDIO

--- a/src/core/gui/menus/PageTypeSelectionMenuBase.cpp
+++ b/src/core/gui/menus/PageTypeSelectionMenuBase.cpp
@@ -15,9 +15,7 @@
 namespace {
 std::optional<PageType> getInitiallySelectedPageType(const Settings* settings) {
     if (settings) {
-        PageTemplateSettings model;
-        model.parse(settings->getPageTemplate());
-        return model.getPageInsertType();
+        return settings->getPageTemplateSettings().getPageInsertType();
     }
     return std::nullopt;
 }


### PR DESCRIPTION
Fixes issue #7023

I tried to avoid simply duplicating code from `getInitiallySelectedPageType()`. Completely replacing the `PageTemplate` string with the `PageTemplateSettings` in the `Settings` class would be preferable but causes many more changes. I will open an other PR for that on master.