### PR TITLE
Store parsed PageTemplateSettings in Settings

### DIFF
--- a/src/core/control/Control.h
+++ b/src/core/control/Control.h
@@ -50,6 +50,7 @@ class ToolbarDragDropHandler;
 class MetadataEntry;
 class MetadataCallbackData;
 class PageBackgroundChangeController;
+class PageTemplateSettings;
 class PageTypeHandler;
 class BaseExportJob;
 class LayerController;
@@ -232,7 +233,7 @@ public:
     size_t firePageSelected(const PageRef& page);
     void firePageSelected(size_t page);
 
-    void addDefaultPage(const std::optional<std::string>& pageTemplate, Document* doc = nullptr);
+    void addDefaultPage(const std::optional<PageTemplateSettings>& pageTemplate, Document* doc = nullptr);
     void duplicatePage();
     void insertNewPage(size_t position, bool automatedInsertion = false);
     void appendNewPdfPages();

--- a/src/core/control/PageBackgroundChangeController.cpp
+++ b/src/core/control/PageBackgroundChangeController.cpp
@@ -352,8 +352,7 @@ void PageBackgroundChangeController::insertNewPage(size_t position, bool automat
         page->setBackgroundType(pageTypeForNewPages.value());
 
         // Set background Color
-        PageTemplateSettings model;
-        model.parse(control->getSettings()->getPageTemplate());
+        const auto& model = control->getSettings()->getPageTemplateSettings();
         page->setBackgroundColor(model.getBackgroundColor());
 
         afterConfigured(std::move(page));

--- a/src/core/control/settings/PageTemplateSettings.cpp
+++ b/src/core/control/settings/PageTemplateSettings.cpp
@@ -40,9 +40,9 @@ auto PageTemplateSettings::getBackgroundColor() const -> Color { return this->ba
 
 void PageTemplateSettings::setBackgroundColor(Color backgroundColor) { this->backgroundColor = backgroundColor; }
 
-auto PageTemplateSettings::getBackgroundType() -> PageType { return backgroundType; }
+auto PageTemplateSettings::getBackgroundType() const -> PageType { return backgroundType; }
 
-auto PageTemplateSettings::getPageInsertType() -> std::optional<PageType> {
+auto PageTemplateSettings::getPageInsertType() const -> std::optional<PageType> {
     if (copyLastPageSettings) {
         return std::nullopt;
     }

--- a/src/core/control/settings/PageTemplateSettings.h
+++ b/src/core/control/settings/PageTemplateSettings.h
@@ -51,9 +51,11 @@ public:
     Color getBackgroundColor() const;
     void setBackgroundColor(Color backgroundColor);
 
-    PageType getBackgroundType();
-    std::optional<PageType> getPageInsertType();
+    PageType getBackgroundType() const;
+    std::optional<PageType> getPageInsertType() const;
     void setBackgroundType(const PageType& backgroundType);
+
+    bool operator==(const PageTemplateSettings&) const = default;
 
 private:
     /**

--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -201,7 +201,7 @@ void Settings::loadDefault() {
     this->backgroundColor = Colors::xopp_gainsboro02;
 
     // clang-format off
-	this->pageTemplate = "xoj/template\ncopyLastPageSettings=true\nsize=595.275591x841.889764\nbackgroundType=lined\nbackgroundColor=#ffffff\n";
+	this->pageTemplateSettings.parse("xoj/template\ncopyLastPageSettings=true\nsize=595.275591x841.889764\nbackgroundType=lined\nbackgroundColor=#ffffff\n");
     // clang-format on
 
 #ifdef ENABLE_AUDIO
@@ -506,7 +506,7 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur) {
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("pluginDisabled")) == 0) {
         this->pluginDisabled = reinterpret_cast<const char*>(value);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("pageTemplate")) == 0) {
-        this->pageTemplate = reinterpret_cast<const char*>(value);
+        this->pageTemplateSettings.parse(reinterpret_cast<const char*>(value));
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("sizeUnit")) == 0) {
         this->sizeUnit = reinterpret_cast<const char*>(value);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("audioFolder")) == 0) {
@@ -1143,6 +1143,7 @@ void Settings::save() {
     SAVE_UINT_PROP(preloadPagesAfter);
     SAVE_BOOL_PROP(eagerPageCleanup);
 
+    const auto pageTemplate = pageTemplateSettings.toString();
     SAVE_STRING_PROP(pageTemplate);
     ATTACH_COMMENT("Config for new pages");
 
@@ -1741,20 +1742,14 @@ void Settings::setDefaultPdfExportName(const std::u8string& name) {
     save();
 }
 
-auto Settings::getPageTemplate() const -> string const& { return this->pageTemplate; }
+auto Settings::getPageTemplateSettings() const -> PageTemplateSettings const& { return this->pageTemplateSettings; }
 
-auto Settings::getPageTemplateSettings() const -> PageTemplateSettings {
-    PageTemplateSettings model;
-    model.parse(this->pageTemplate);
-    return model;
-}
-
-void Settings::setPageTemplate(const string& pageTemplate) {
-    if (this->pageTemplate == pageTemplate) {
+void Settings::setPageTemplateSettings(const PageTemplateSettings& newSettings) {
+    if (this->pageTemplateSettings == newSettings) {
         return;
     }
 
-    this->pageTemplate = pageTemplate;
+    this->pageTemplateSettings = newSettings;
 
     save();
 }

--- a/src/core/control/settings/Settings.h
+++ b/src/core/control/settings/Settings.h
@@ -28,12 +28,13 @@
 #include "model/Font.h"                          // for XojFont
 #include "util/Color.h"                          // for Color
 
-#include "LatexSettings.h"      // for LatexSettings
-#include "RecolorParameters.h"  // for RecolorParameters
-#include "SettingsEnums.h"      // for InputDeviceTypeOption
-#include "ViewModes.h"          // for ViewModes
-#include "config-features.h"    // for ENABLE_AUDIO
-#include "filesystem.h"         // for path
+#include "LatexSettings.h"         // for LatexSettings
+#include "PageTemplateSettings.h"  // for PageTemplateSettings
+#include "RecolorParameters.h"     // for RecolorParameters
+#include "SettingsEnums.h"         // for InputDeviceTypeOption
+#include "ViewModes.h"             // for ViewModes
+#include "config-features.h"       // for ENABLE_AUDIO
+#include "filesystem.h"            // for path
 
 #ifdef ENABLE_AUDIO
 #include <portaudiocpp/PortAudioCpp.hxx>  // for PaDeviceIndex
@@ -409,9 +410,8 @@ public:
     bool isEagerPageCleanup() const;
     void setEagerPageCleanup(bool b);
 
-    std::string const& getPageTemplate() const;
-    PageTemplateSettings getPageTemplateSettings() const;
-    void setPageTemplate(const std::string& pageTemplate);
+    PageTemplateSettings const& getPageTemplateSettings() const;
+    void setPageTemplateSettings(const PageTemplateSettings& pageTemplateSettings);
 
 #ifdef ENABLE_AUDIO
     fs::path const& getAudioFolder() const;
@@ -1015,9 +1015,9 @@ private:
     RecolorParameters recolorParameters{};
 
     /**
-     * Page template String
+     * Page template (format, background, color...)
      */
-    std::string pageTemplate;
+    PageTemplateSettings pageTemplateSettings;
 
     /**
      * Unit, see XOJ_UNITS

--- a/src/core/gui/dialog/PageTemplateDialog.cpp
+++ b/src/core/gui/dialog/PageTemplateDialog.cpp
@@ -38,7 +38,7 @@ using namespace xoj::popup;
 PageTemplateDialog::PageTemplateDialog(GladeSearchpath* gladeSearchPath, Settings* settings, ToolMenuHandler* toolmenu,
                                        PageTypeHandler* types):
         gladeSearchPath(gladeSearchPath), settings(settings), toolMenuHandler(toolmenu), types(types) {
-    model.parse(settings->getPageTemplate());
+    model = settings->getPageTemplateSettings();
 
     Builder builder(gladeSearchPath, UI_FILE);
     window.reset(GTK_WINDOW(builder.get(UI_DIALOG_NAME)));
@@ -67,7 +67,7 @@ PageTemplateDialog::PageTemplateDialog(GladeSearchpath* gladeSearchPath, Setting
     g_signal_connect_swapped(builder.get("btCancel"), "clicked", G_CALLBACK(gtk_window_close), this->getWindow());
     g_signal_connect_swapped(builder.get("btOk"), "clicked", G_CALLBACK(+[](PageTemplateDialog* self) {
                                  self->saveToModel();
-                                 self->settings->setPageTemplate(self->model.toString());
+                                 self->settings->setPageTemplateSettings(self->model);
                                  self->toolMenuHandler->setDefaultNewPageType(self->model.getPageInsertType());
                                  self->toolMenuHandler->setDefaultNewPaperSize(
                                          self->model.isCopyLastPageSize() ? std::nullopt :

--- a/src/core/gui/menus/PageTypeSelectionMenuBase.cpp
+++ b/src/core/gui/menus/PageTypeSelectionMenuBase.cpp
@@ -13,13 +13,6 @@
 #include "util/raii/GVariantSPtr.h"
 
 namespace {
-std::optional<PageType> getInitiallySelectedPageType(const Settings* settings) {
-    if (settings) {
-        return settings->getPageTemplateSettings().getPageInsertType();
-    }
-    return std::nullopt;
-}
-
 /**
  * @brief Returns the action target value associated to the given page type.
  */
@@ -46,7 +39,7 @@ GSimpleAction* createPageTypeSelectionAction(PageTypeHandler* types, const std::
 
 PageTypeSelectionMenuBase::PageTypeSelectionMenuBase(PageTypeHandler* typesHandler, const Settings* settings,
                                                      const std::string_view& actionName):
-        selectedPT(getInitiallySelectedPageType(settings)),
+        selectedPT(settings->getPageTemplateSettings().getPageInsertType()),
         typeSelectionAction(createPageTypeSelectionAction(typesHandler, selectedPT, actionName), xoj::util::adopt),
         types(typesHandler) {
     g_signal_connect(G_OBJECT(typeSelectionAction.get()), "change-state", G_CALLBACK(changeSelectionCallback), this);

--- a/src/core/gui/menus/popoverMenus/PageTypeSelectionPopover.cpp
+++ b/src/core/gui/menus/popoverMenus/PageTypeSelectionPopover.cpp
@@ -61,9 +61,9 @@ GtkGrid* createEmptyGrid() {
 }
 auto getInitiallySelectedPaperSize(const Settings* settings) -> std::optional<PaperSize> {
     if (settings) {
-        PageTemplateSettings model;
-        model.parse(settings->getPageTemplate());
-        return model.isCopyLastPageSize() ? std::nullopt : std::optional(PaperSize(model));
+        return settings->getPageTemplateSettings().isCopyLastPageSize() ?
+                       std::nullopt :
+                       std::optional{PaperSize(settings->getPageTemplateSettings())};
     }
     return std::nullopt;
 }
@@ -424,8 +424,7 @@ void PageTypeSelectionPopover::changedPaperFormatTemplateCb(GtkComboBox* widget,
                     self->control->getGladeSearchPath(), self->settings, self->selectedPageSize->width,
                     self->selectedPageSize->height, callback);
         } else {
-            PageTemplateSettings model;
-            model.parse(self->settings->getPageTemplate());
+            const auto& model = self->settings->getPageTemplateSettings();
             popup = std::make_unique<xoj::popup::PopupWindowWrapper<xoj::popup::FormatDialog>>(
                     self->control->getGladeSearchPath(), self->settings, model.getPageWidth(), model.getPageHeight(),
                     callback);


### PR DESCRIPTION
- Use parsed template everywhere and remove repeated parsing
- Correctly initialize pageTypeForNewPages

This goes a little bit further than #7055, but no functionality is modified.