### PR TITLE
Fix sidebar content not taking whole width when changing tabs 

### DIFF
--- a/src/core/gui/sidebar/Sidebar.cpp
+++ b/src/core/gui/sidebar/Sidebar.cpp
@@ -103,6 +103,15 @@ void Sidebar::setSelectedTab(size_t tab) {
 
         i++;
     }
+    if (this->visibleTab) {
+        g_idle_add(
+                [](gpointer data) -> gboolean {
+                    Sidebar* sidebar = static_cast<Sidebar*>(data);
+                    sidebar->layout();
+                    return G_SOURCE_REMOVE;
+                },
+                this);
+    }
 }
 
 void Sidebar::updateVisibleTabs() {


### PR DESCRIPTION
### Fixes #6653

#### Problem:
Switching away from a  sidebar tab, resizing the sidebar, and returning causes columns in the sidebar tab to display incorrectly, keeping their original width

#### Solution:
Defer layout() using g_idle_add() to run after GTK finishes size allocation.