### PR TITLE
Fix crash when redoing page insertion with automatic page insertion involved

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -901,6 +901,7 @@ void Control::insertPage(const PageRef& page, size_t position, bool shouldScroll
     this->doc->lock();
     this->doc->insertPage(page, position);  // insert the new page to the document and update page numbers
     this->doc->unlock();
+    undoRedo->addUndoAction(std::make_unique<InsertDeletePageUndoAction>(page, position, true));
 
     // notify document listeners about the inserted page; this creates the new XojViewPage, recalculates the layout
     // and creates a preview page in the sidebar
@@ -916,7 +917,6 @@ void Control::insertPage(const PageRef& page, size_t position, bool shouldScroll
     }
 
     updatePageActions();
-    undoRedo->addUndoAction(std::make_unique<InsertDeletePageUndoAction>(page, position, true));
 }
 
 void Control::gotoPage() {


### PR DESCRIPTION
When
1. automatic insertion is enabled (in the mode "scrolling to the bottom of the last page") 
2. and the view is zoomed out enough so that a page can be seen entirely
3. and we manually add a page after the last page (e.g. the last page is half-visible and selected and we hit Ctrl+D)

then, as we added the new last page, the document scrolls down to this new last page and as the bottom of this last page becomes visible, the automated insertion then adds an extra page.

Now, scroll to the first page, undo twice and then redo: SegFault.

The problem is the undo stack is wrong: the undo action corresponding to the automatically inserted page comes BEFORE the undo action for the page we manually added.

This PR fixes that.

Note that some freaky behaviour is still happening when undoing-redoing page insertions with this automatic insertion on, but this is out of scope. This feature has not really been thought through. See also #4820 