### PR TITLE
Clean up ZoomControl signals

### DIFF
--- a/src/core/control/zoom/ZoomControl.h
+++ b/src/core/control/zoom/ZoomControl.h
@@ -259,7 +259,4 @@ private:
     size_t current_page = static_cast<size_t>(-1);
     size_t last_page = static_cast<size_t>(-1);
     bool isZoomFittingNow = false;
-
-    /// The last monitor the window has been moved to -- used for setting dpi
-    GdkMonitor* lastMonitor = nullptr;
 };

--- a/src/core/gui/MainWindow.cpp
+++ b/src/core/gui/MainWindow.cpp
@@ -97,6 +97,22 @@ MainWindow::MainWindow(GladeSearchpath* gladeSearchPath, Control* control, GtkAp
                      this);
 #endif
 
+    g_signal_connect(
+            this->window, "configure-event", G_CALLBACK(+[](GtkWidget* widget, GdkEvent*, gpointer self) -> gboolean {
+                auto win = static_cast<MainWindow*>(self);
+                GdkWindow* gdkWindow = gtk_widget_get_window(widget);
+                GdkDisplay* display = gdkWindow ? gdk_window_get_display(gdkWindow) : nullptr;
+                GdkMonitor* monitor = display ? gdk_display_get_monitor_at_window(display, gdkWindow) : nullptr;
+                if (monitor && monitor != win->lastMonitor) {
+                    win->lastMonitor = monitor;
+                    const char* monitorName = gdk_monitor_get_model(monitor);
+                    g_debug("Window moved to monitor \"%s\"", monitorName);
+                    win->setDPI();
+                }
+                return false;
+            }),
+            this);
+
     // "watch over" all key events
     auto keyPropagate = +[](GtkWidget* w, GdkEvent* e, gpointer) {
         return gtk_window_propagate_key_event(GTK_WINDOW(w), (GdkEventKey*)(e));

--- a/src/core/gui/MainWindow.h
+++ b/src/core/gui/MainWindow.h
@@ -189,6 +189,9 @@ private:
 
     bool sidebarVisible = true;
 
+    /// The last monitor the window has been moved to -- used for setting dpi
+    GdkMonitor* lastMonitor = nullptr;
+
     xoj::util::WidgetSPtr boxContainerWidget;
     xoj::util::WidgetSPtr panedContainerWidget;
     xoj::util::WidgetSPtr mainContentWidget;


### PR DESCRIPTION
The PR cleans up the use of signals in ZoomControl, following a TODO left therein.

~~The PR is based on #7081 and will wait until it is merged.~~