### PR TITLE
Fix CMake warning about DOWNLOAD_EXTRACT_TIMESTAMP

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.12)
 cmake_policy(VERSION 3.12)
+# Avoid warning about DOWNLOAD_EXTRACT_TIMESTAMP in CMake 3.24 and up
+if (POLICY CMP0135)
+    cmake_policy(SET CMP0135 NEW)
+endif()
 
 # For Windows: Prevent overriding the parent project's compiler/linker settings
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)


### PR DESCRIPTION
I've noticed a CMake warning about missing CMP0135 when building with `-DENABLE_GTEST=on`:
```
-- Downloading gtest...
CMake Warning (dev) at /usr/share/cmake/Modules/FetchContent.cmake:1383 (message):
  The DOWNLOAD_EXTRACT_TIMESTAMP option was not given and policy CMP0135 is
  not set.  The policy's OLD behavior will be used.  When using a URL
  download, the timestamps of extracted files should preferably be that of
  the time of extraction, otherwise code that depends on the extracted
  contents might not be rebuilt if the URL changes.  The OLD behavior
  preserves the timestamps from the archive instead, but this is usually not
  what you want.  Update your project to the NEW behavior or specify the
  DOWNLOAD_EXTRACT_TIMESTAMP option with a value of true to avoid this
  robustness issue.
Call Stack (most recent call first):
  test/CMakeLists.txt:19 (FetchContent_Declare)
This warning is for project developers.  Use -Wno-dev to suppress it.
```
This PR simply sets the policy to the improved `NEW` behavior when available. See the [documentation](https://cmake.org/cmake/help/latest/policy/CMP0135.html)

Another possibility would be to remove `cmake_policy(VERSION 3.12)` and inherit `cmake_policy(VERSION ${CMAKE_VERSION})` from the top-level script, or explicitly re-declare it. That sets all available policies to `NEW`, which might be good and desirable, but may also break builds occasionally.