### PR TITLE
Fix xopp-WARNING "Fails to extract theme root name from: ..."

### DIFF
--- a/src/core/gui/MainWindow.cpp
+++ b/src/core/gui/MainWindow.cpp
@@ -171,7 +171,7 @@ static ThemeProperties getThemeProperties(GtkWidget* w) {
 
     // Try to figure out if the theme is dark or light
     // Some themes handle their dark variant via "gtk-application-prefer-dark-theme" while other just append "-dark"
-    const std::regex nameparser("([a-zA-Z-]+?)([:-][dD]ark)?");
+    const std::regex nameparser("([a-zA-Z0-9_\.-]+?)([:-][dD]ark)?");
     std::cmatch sm;
     std::regex_match(name.get(), sm, nameparser);
 


### PR DESCRIPTION
It is totaly legal to have numbers, underscore and even a dot in the name of a gtk-theme. F.E. Windows-8.1 or Unity-8 from the B00MERANG Project