### PR TITLE
Add custom variable support to LaTeX generator via `%xpp:key=value`

### DIFF
--- a/ui/latexSettings.glade
+++ b/ui/latexSettings.glade
@@ -186,6 +186,30 @@
                         <property name="top-attach">3</property>
                       </packing>
                     </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="label" translatable="yes">%%XPP_VARNAME%%</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">4</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="label" translatable="yes">Any custom variable defined with a %xpp:varname=value directive in the formula input.</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">4</property>
+                      </packing>
+                    </child>
                   </object>
                 </child>
                 <child type="label">


### PR DESCRIPTION
Adds a way to define custom variables in LaTeX input that can be used in templates

Example:

```latex
\documentclass[varwidth=0.999\maxdimen, crop, border=5pt]{standalone}
\newcommand*{\setTextWidthReference}{%
  \setlength{\textwidth}{345.0pt}%
  \setlength{\linewidth}{\textwidth}%
  \setlength{\columnwidth}{\textwidth}%
}
% Packages
\usepackage{amsmath}
\usepackage{amssymb}
\usepackage{scontents}
\usepackage{ifthen}
\newlength{\pheight}
% Color support
\usepackage{xcolor}
\definecolor{xpp_font_color}{HTML}{%%XPP_TEXT_COLOR%%}

% Custom variable example:
% Add %xpp:mode=inline at the top of your input
% to make the formula render in inline mode
% it is display mode by default
\newcommand{\xppmode}{%%XPP_MODE%%}

% User input
\begin{scontents}[store-env=preview]
  \ifthenelse{\equal{\xppmode}{inline}}{%
    \( %%XPP_TOOL_INPUT%% \)
  }{%
    \( \displaystyle %%XPP_TOOL_INPUT%% \)
  }
\end{scontents}
\begin{document}
  \setTextWidthReference
  \settoheight{\pheight}{\getstored[1]{preview}}%
  \ifthenelse{\pheight=0}{\GenericError{}{xournalpp:blankformula}{}{}}
  \textcolor{xpp_font_color}{\getstored[1]{preview}}
\end{document}
```

```latex
%xpp:mode=inline
\left[ x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a} \right]
```

`%%XPP_MODE%%` will be substituted in the template with `inline`

just like `%%XPP_TOOL_INPUT%%` and `%%XPP_TEXT_COLOR%%` was getting substituted

<p align="center">
  <img src="https://github.com/user-attachments/assets/50481672-3a67-462a-9333-d020d2c07bec" width="49%" />
  <img src="https://github.com/user-attachments/assets/777c3185-fde0-4306-b398-e0864c7700b0" width="49%" />
</p>

btw writing `%xpp:mode=display` has no effect at all, the example is just (if inline, else) not else if, but you can custom it however you want

---

other useful tip

you can also add it in the beginning of your default prompt so you do not have to type it every time (Edit -> preferences -> LaTeX -> Default LaTeX text)

<img width="901" height="237" alt="image" src="https://github.com/user-attachments/assets/d7b22343-e272-40eb-bf07-595633e9f60d" />

closes #7157