### PR TITLE
Fix horizontal page alignement of unequal page sizes

### DIFF
--- a/src/core/gui/Layout.cpp
+++ b/src/core/gui/Layout.cpp
@@ -289,7 +289,7 @@ void Layout::layoutPages(int width, int height) {
                         }
                     } else {  // not paired page mode - center
                         paddingLeft = XOURNAL_PADDING_BETWEEN / 2.0 + columnPadding / 2.0;  // center justify
-                        paddingRight = XOURNAL_PADDING_BETWEEN - paddingLeft + columnPadding / 2.0;
+                        paddingRight = XOURNAL_PADDING_BETWEEN - paddingLeft + columnPadding;
                     }
 
                     x += paddingLeft;


### PR DESCRIPTION
Correct the right-side padding for pages that narrower than their layout column so that all pages align consistently in a grid.

Fixes #5268