### PR TITLE
update keywords on desktop file

### DIFF
--- a/desktop/com.github.xournalpp.xournalpp.desktop.in
+++ b/desktop/com.github.xournalpp.xournalpp.desktop.in
@@ -4,7 +4,7 @@ Type=Application
 Name=Xournal++
 GenericName=Note-taking application
 Comment=Take handwritten notes
-Keywords=tablet;Wacom;pen input;PDF Annotation;markup;journal;journalpp;journal++;diary;notes;
+Keywords=tablet;Wacom;pen input;PDF Annotation;markup;journal;handwriting;diary;notes;
 
 Exec=xournalpp-wrapper %f
 SingleMainWindow=false


### PR DESCRIPTION
I installed Linux (Mint) on someone's computer and installed all necessary programs. When I later asked her to open Xournal++ on phone she searched for "journal++" in the menu and it did not work. This will address such issues if someone hears the programs's name and tries the wrong spelling.

I also added "handwriting", "notes" and "diary".