### PR TITLE
add option to save last window position (fix #4488)

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -279,6 +279,14 @@ void Control::saveSettings() {
 
     if (!this->win->isMaximized()) {
         this->settings->setMainWndSize(width, height);
+
+        // Save window position if remember option is enabled
+        if (this->settings->isRememberWindowPosition()) {
+            gint x = 0;
+            gint y = 0;
+            gtk_window_get_position(getGtkWindow(), &x, &y);
+            this->settings->setMainWndPosition(x, y);
+        }
     }
     this->settings->setMainWndMaximized(this->win->isMaximized());
 

--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -89,6 +89,9 @@ void Settings::loadDefault() {
 
     this->mainWndWidth = 800;
     this->mainWndHeight = 600;
+    this->mainWndX = -1;  // -1 means use default/system positioning
+    this->mainWndY = -1;
+    this->rememberWindowPosition = false;
 
     this->fullscreenActive = false;
 
@@ -430,8 +433,14 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur) {
         this->mainWndWidth = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("mainWndHeight")) == 0) {
         this->mainWndHeight = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("mainWndX")) == 0) {
+        this->mainWndX = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("mainWndY")) == 0) {
+        this->mainWndY = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("maximized")) == 0) {
         this->maximized = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("rememberWindowPosition")) == 0) {
+        this->rememberWindowPosition = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("showToolbar")) == 0) {
         this->showToolbar = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("filepathShownInTitlebar")) == 0) {
@@ -1019,7 +1028,10 @@ void Settings::save() {
     SAVE_INT_PROP(displayDpi);
     SAVE_INT_PROP(mainWndWidth);
     SAVE_INT_PROP(mainWndHeight);
+    SAVE_INT_PROP(mainWndX);
+    SAVE_INT_PROP(mainWndY);
     SAVE_BOOL_PROP(maximized);
+    SAVE_BOOL_PROP(rememberWindowPosition);
 
     SAVE_BOOL_PROP(showToolbar);
 
@@ -2054,6 +2066,26 @@ void Settings::setMainWndMaximized(bool max) {
     this->maximized = max;
     save();
 }
+
+void Settings::setMainWndPosition(int x, int y) {
+    this->mainWndX = x;
+    this->mainWndY = y;
+    save();
+}
+
+auto Settings::getMainWndX() const -> int { return this->mainWndX; }
+
+auto Settings::getMainWndY() const -> int { return this->mainWndY; }
+
+void Settings::setRememberWindowPosition(bool remember) {
+    if (this->rememberWindowPosition == remember) {
+        return;
+    }
+    this->rememberWindowPosition = remember;
+    save();
+}
+
+auto Settings::isRememberWindowPosition() const -> bool { return this->rememberWindowPosition; }
 
 void Settings::setSelectedToolbar(const string& name) {
     if (this->selectedToolbar == name) {

--- a/src/core/control/settings/Settings.h
+++ b/src/core/control/settings/Settings.h
@@ -214,6 +214,13 @@ public:
     int getMainWndHeight() const;
     bool isMainWndMaximized() const;
 
+    void setMainWndPosition(int x, int y);
+    int getMainWndX() const;
+    int getMainWndY() const;
+
+    void setRememberWindowPosition(bool remember);
+    bool isRememberWindowPosition() const;
+
     bool isFullscreen() const;
 
     bool isSidebarVisible() const;
@@ -819,6 +826,21 @@ private:
      * Height of the main window
      */
     int mainWndHeight{};
+
+    /**
+     * X position of the main window
+     */
+    int mainWndX{};
+
+    /**
+     * Y position of the main window
+     */
+    int mainWndY{};
+
+    /**
+     * Remember and restore the last window position
+     */
+    bool rememberWindowPosition{};
 
     /**
      * Show the scrollbar on the left side

--- a/src/core/gui/MainWindow.cpp
+++ b/src/core/gui/MainWindow.cpp
@@ -109,6 +109,16 @@ MainWindow::MainWindow(GladeSearchpath* gladeSearchPath, Control* control, GtkAp
     gtk_window_set_default_size(GTK_WINDOW(this->window), control->getSettings()->getMainWndWidth(),
                                 control->getSettings()->getMainWndHeight());
 
+    // Restore window position if remembered and not maximized
+    if (control->getSettings()->isRememberWindowPosition() && !control->getSettings()->isMainWndMaximized()) {
+        int x = control->getSettings()->getMainWndX();
+        int y = control->getSettings()->getMainWndY();
+        // Only restore if position was previously saved (values > -1)
+        if (x >= 0 && y >= 0) {
+            gtk_window_move(GTK_WINDOW(this->window), x, y);
+        }
+    }
+
     if (control->getSettings()->isMainWndMaximized()) {
         gtk_window_maximize(GTK_WINDOW(this->window));
     } else {

--- a/src/core/gui/dialog/SettingsDialog.cpp
+++ b/src/core/gui/dialog/SettingsDialog.cpp
@@ -617,6 +617,7 @@ void SettingsDialog::load() {
     loadCheckbox("cbHideMenubarStartup", settings->isMenubarVisible());
     loadCheckbox("cbShowFilepathInTitlebar", settings->isFilepathInTitlebarShown());
     loadCheckbox("cbShowPageNumberInTitlebar", settings->isPageNumberInTitlebarShown());
+    loadCheckbox("cbRememberWindowPosition", settings->isRememberWindowPosition());
 
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(builder.get("preloadPagesBefore")),
                               static_cast<double>(settings->getPreloadPagesBefore()));
@@ -904,6 +905,7 @@ void SettingsDialog::save() {
     settings->setMenubarVisible(getCheckbox("cbHideMenubarStartup"));
     settings->setFilepathInTitlebarShown(getCheckbox("cbShowFilepathInTitlebar"));
     settings->setPageNumberInTitlebarShown(getCheckbox("cbShowPageNumberInTitlebar"));
+    settings->setRememberWindowPosition(getCheckbox("cbRememberWindowPosition"));
 
     constexpr auto spinAsUint = [&](GtkSpinButton* btn) {
         int v = gtk_spin_button_get_value_as_int(btn);

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -2955,6 +2955,21 @@ This setting can make it easier to draw with touch. </property>
                                             <property name="position">2</property>
                                           </packing>
                                         </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="cbRememberWindowPosition">
+                                            <property name="label" translatable="yes">Remember window position</property>
+                                            <property name="name">cbRememberWindowPosition</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="draw-indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">3</property>
+                                          </packing>
+                                        </child>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>


### PR DESCRIPTION
This will fix #4488 

<img width="1046" height="764" alt="image" src="https://github.com/user-attachments/assets/d3fc9abb-1cde-43e9-a96f-1cfcda02fcba" />

I added a remember window position toggle switch that will use GTK3's inbuilt features to get the window position just before closing and save it in the config file. Upon loading, it will look for the last window position and window size in the config file (only if "remember window position" is checked) and apply them.

By default the feature is not turned on, but I can turn it on if you guys think it's helpful.