### PR TITLE
Bump github action versions and pin @actions/artifact version

### DIFF
--- a/.github/actions/install_deps_mac/action.yml
+++ b/.github/actions/install_deps_mac/action.yml
@@ -10,7 +10,7 @@ runs:
   steps:
   - name: 'Attempt to pull blob from cache'
     id: restore-blob
-    uses: actions/cache/restore@v4
+    uses: actions/cache/restore@v5
     with:
       path: "${{github.workspace}}/blob"
       key: ${{ runner.os }}-${{ runner.arch }}-blob-${{ hashFiles('mac-setup/CI_jhbuild.sh', 'mac-setup/jhbuild-version.lock', 'mac-setup/xournalpp.modules', 'mac-setup/gtk-osx.patch') }}
@@ -29,11 +29,11 @@ runs:
       mv xournalpp-binary-blob.tar.gz "${{github.workspace}}/blob/"
   - name: 'Push blob to cache'
     if: steps.restore-blob.outputs.cache-hit != 'true'
-    uses: actions/cache/save@v4
+    uses: actions/cache/save@v5
     with:
       key: ${{ steps.restore-blob.outputs.cache-primary-key }}
       path: "${{github.workspace}}/blob"
-  # - uses: actions/upload-artifact@v4
+  # - uses: actions/upload-artifact@v6
   #   with:
   #     name: my-artifact
   #     path: "${{github.workspace}}/blob/xournalpp-binary-blob.tar.gz"

--- a/.github/workflows/cache-macos-deps.yml
+++ b/.github/workflows/cache-macos-deps.yml
@@ -15,12 +15,12 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:  # Get the build targets **from the master branch**
           sparse-checkout: '${{ env.build-targets-json }}'
           sparse-checkout-cone-mode: false
       - id: parse
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const available_targets = require('${{ env.build-targets-json }}')
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.run.runner }}
     steps:
       - name: 'Checkout repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: 'Build dependencies'
         uses: ./.github/actions/install_deps_mac
         with:

--- a/.github/workflows/check-translations-build.yml
+++ b/.github/workflows/check-translations-build.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: 'Install dependencies'
         shell: bash
         run: |

--- a/.github/workflows/clang-format-applied.yml
+++ b/.github/workflows/clang-format-applied.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       CLANG_FORMAT_VERSIONS: "19 18 17"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,13 +23,13 @@ jobs:
       macos_builds: ${{ steps.parse.outputs.macos_builds }}
       windows_builds: ${{ steps.parse.outputs.windows_builds }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:  # Get the build targets
           sparse-checkout: '${{ env.build-targets-json }}'
           sparse-checkout-cone-mode: false
       - name: 'Parse list of targets'
         id: parse
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const available_targets = require('${{ env.build-targets-json }}')
@@ -67,7 +67,7 @@ jobs:
       image: ${{ matrix.run.container_image }}
     name: 'Test Xournal++ on ${{ matrix.run.displayed_name }}'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: 'Install dependencies'
         uses: ./.github/actions/install_deps_ubuntu
         with:
@@ -139,7 +139,7 @@ jobs:
     runs-on: ${{ matrix.run.runner }}
     name: 'Test Xournal++ on ${{ matrix.run.displayed_name }}'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: 'Install dependencies'
         uses: ./.github/actions/install_deps_windows
         with:
@@ -169,7 +169,7 @@ jobs:
     runs-on: ${{ matrix.run.runner }}
     name: 'Test Xournal++ on ${{ matrix.run.displayed_name }}'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: 'Install dependencies'
         uses: ./.github/actions/install_deps_mac
         with:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -31,13 +31,13 @@ jobs:
       release_name: ${{ steps.parse.outputs.release-name }}
       tag: ${{ steps.parse.outputs.tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:  # Get the build targets
           sparse-checkout: '${{ env.build-targets-json }}'
           sparse-checkout-cone-mode: false
       - name: 'Parse targets list and setup version string'
         id: parse
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const available_targets = require('${{ env.build-targets-json }}')
@@ -101,7 +101,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v6
         with:
           merge-multiple: true
           path: ${{ github.workspace }}/artifacts
@@ -112,7 +112,7 @@ jobs:
         working-directory: ${{ github.workspace }}/artifacts
       - name: "Update tag and prepare body (Nightly builds)"
         if: ${{ needs.prepare.outputs.tag == 'nightly' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             github.rest.git.updateRef({  // Move the nightly tag forward
@@ -132,7 +132,7 @@ jobs:
             }
             core.exportVariable('body', body)
       - name: Pull changelog
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         if: ${{ needs.prepare.outputs.tag != 'nightly' }}
         with:  # Get the changelog
           sparse-checkout: 'debian/changelog'

--- a/.github/workflows/download-translations-from-crowdin.yml
+++ b/.github/workflows/download-translations-from-crowdin.yml
@@ -18,7 +18,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ matrix.branch }}
       - name: 'Pull translations from Crowdin'

--- a/.github/workflows/gen-lua-def-run.yml
+++ b/.github/workflows/gen-lua-def-run.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     name: 'Check that lua definitions file is up-to-date'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: 'Install python3'
         shell: bash
         run: |

--- a/.github/workflows/make-installer-linux.yml
+++ b/.github/workflows/make-installer-linux.yml
@@ -53,7 +53,7 @@ jobs:
       image: ${{ inputs.container_image }}
     steps:
       - name: 'Checkout repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.head_sha }}
       - name: 'Install dependencies (for AppImage)'
@@ -100,7 +100,7 @@ jobs:
           done
       - name: 'Publish packages'
         id: publish-packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: "Packages ${{ inputs.displayed_name }} ${{ runner.arch }}"
           compression-level: 0
@@ -124,7 +124,7 @@ jobs:
       - name: 'Publish AppImage'
         id: publish-appimage
         if: ${{ inputs.build_appimage }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: "Linux AppImage ${{ steps.build-appimage.outputs.appimage-arch }} (built on ${{ inputs.displayed_name }})"
           compression-level: 0

--- a/.github/workflows/make-installer-macos.yml
+++ b/.github/workflows/make-installer-macos.yml
@@ -34,7 +34,7 @@ jobs:
       link: ${{ steps.publish.outputs.artifact-url }}
     steps:
       - name: 'Checkout repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.head_sha }}
       - name: 'Install dependencies'
@@ -65,7 +65,7 @@ jobs:
           echo "artifact=$OUTPUT" >> $GITHUB_OUTPUT
       - name: 'Publish package'
         id: publish
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: "MacOS package ${{runner.os}}-${{runner.arch}}"
           compression-level: 0

--- a/.github/workflows/make-installer-windows.yml
+++ b/.github/workflows/make-installer-windows.yml
@@ -48,7 +48,7 @@ jobs:
       link_portable: ${{ steps.publish-portable.outputs.artifact-url }}
     steps:
       - name: 'Checkout repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.head_sha }}
       - name: 'Install dependencies'
@@ -83,7 +83,7 @@ jobs:
           fi
       - name: 'Publish package'
         id: publish
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: "Windows package ${{ runner.arch }} ${{ inputs.msys_package_env }}"
           path: "${{github.workspace}}/build/${{ steps.create-installer.outputs.artifact }}"
@@ -92,7 +92,7 @@ jobs:
       - name: 'Publish portable version'
         id: publish-portable
         if: ${{ inputs.publish_portable_version }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: "Windows package ${{ runner.arch }} ${{ inputs.msys_package_env }} (portable version)"
           path: "${{github.workspace}}/build/portable_content"

--- a/.github/workflows/trigger-create-installers-from-comment-on-pr.yml
+++ b/.github/workflows/trigger-create-installers-from-comment-on-pr.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: 'Check user permission'
         # To circumvent a security issue, only members/owners of the xournalpp team can run this CI.
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const perm = await github.rest.repos.getCollaboratorPermissionLevel({
@@ -45,7 +45,7 @@ jobs:
             }
       - name: 'Get pull request HEAD_SHA'
         id: get-sha
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             // Get the SHA of the PR's top commit so we build the right thing
@@ -57,14 +57,14 @@ jobs:
             });
             console.log('PR Head sha: ' + pr.data.head.sha)
             core.setOutput('head_sha', pr.data.head.sha)
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:  # Get the build targets **from the PR branch**
           sparse-checkout: '${{ env.build-targets-json }}'
           sparse-checkout-cone-mode: false
           ref: ${{ steps.get-sha.outputs.head_sha }}
       - name: 'Parse command and acknowledge order'
         id: parse
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           body: ${{ github.event.comment.body }} # Hardened security against code injection
         with:
@@ -182,10 +182,11 @@ jobs:
       pull-requests: write  # To post a comment with the results
       checks: write         # To update the check status
     steps:
-      - run: npm i @actions/artifact
+      - run: |
+          npm i @actions/artifact@">=5.0.0 <6.0.0"
       - name: 'Publish on PR page'
         id: publish
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const {DefaultArtifactClient} = require('@actions/artifact')

--- a/.github/workflows/upload-translatable-strings-to-crowdin.yml
+++ b/.github/workflows/upload-translatable-strings-to-crowdin.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: 'Install dependencies'
         shell: bash
         run: |


### PR DESCRIPTION
This fixes the issue we've been having with the \action create-installers command. I tested it on my fork.

Merging once the CI clears
