### PR TITLE
Debian ARM64 builds

### DIFF
--- a/.github/available-build-targets.json
+++ b/.github/available-build-targets.json
@@ -18,6 +18,13 @@
       "container_image": "ghcr.io/xournalpp/debian-latest-sudo:master",
       "run_ci": "false"
     },
+    "debian-arm64": {
+      "displayed_name": "Debian ARM64",
+      "runner": "ubuntu-24.04-arm",
+      "extra_packages": "build-essential lsb-release git",
+      "container_image": "ghcr.io/xournalpp/debian-latest-sudo:master",
+      "run_ci": "false"
+    },
     "ubuntu-22-arm": {
       "displayed_name": "Ubuntu 22.04 ARM",
       "runner": "ubuntu-22.04-arm",


### PR DESCRIPTION
Why -- Chromebook tablets are all arm64. They run Debian (https://velvet-os.github.io/) and they are excellent for notetaking.

Please wait for https://github.com/xournalpp/debian-latest-sudo/pull/3 to be merged first