### PR TITLE
Do not strip the thumbnailer

### DIFF
--- a/src/xoj-preview-extractor/CMakeLists.txt
+++ b/src/xoj-preview-extractor/CMakeLists.txt
@@ -33,12 +33,6 @@ target_link_libraries (xournalpp-thumbnailer
 
 target_include_directories (xournalpp-thumbnailer PRIVATE ${librsvg_INCLUDE_DIRS})
 
-set (THUMBNAILER_BIN "xournalpp-thumbnailer")
-
-add_custom_command (TARGET xournalpp-thumbnailer POST_BUILD
-  COMMAND ${CMAKE_STRIP} ${THUMBNAILER_BIN}
-)
-
 ## Install ##
 
 install (TARGETS xournalpp-thumbnailer


### PR DESCRIPTION
Gentoo has been patching it out for years now:
https://github.com/gentoo/gentoo/blame/b81f91bf721b0f5adbc4ab71ef95310c8b5ab39c/app-text/xournalpp/xournalpp-9999.ebuild#L48
so I thought I would fix the issue upstream.

From the blame I can see that this was probably added in `xournal` itself.