### PR TITLE
Remove metadata updates on every zoom/scroll event

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -559,7 +559,11 @@ auto Control::firePageSelected(const PageRef& page) -> size_t {
     return pageId;
 }
 
-void Control::firePageSelected(size_t page) { DocumentHandler::firePageSelected(page); }
+void Control::firePageSelected(size_t page) {
+    if (page != this->getCurrentPageNo()) {
+        DocumentHandler::firePageSelected(page);
+    }
+}
 
 void Control::manageToolbars() {
     xoj::popup::PopupWindowWrapper<ToolbarManageDialog> dlg(
@@ -2097,7 +2101,13 @@ void Control::quit(bool allowCancel) {
 void Control::close(std::function<void(bool)> callback, const bool allowDestroy, const bool allowCancel,
                     const bool forceClose) {
     clearSelectionEndText();
+
+    doc->lock();
+    auto const& file = doc->getEvMetadataFilename();
+    doc->unlock();
+    metadata->storeMetadata(file, static_cast<int>(getCurrentPageNo()), zoom->getZoomReal());
     metadata->documentChanged();
+
     resetGeometryTool();
 
     bool safeToClose = forceClose || !undoRedo->isChanged();

--- a/src/core/gui/XournalView.cpp
+++ b/src/core/gui/XournalView.cpp
@@ -376,13 +376,6 @@ void XournalView::pageSelected(size_t page) {
         return;
     }
 
-    Document* doc = control->getDocument();
-    doc->lock();
-    auto const& file = doc->getEvMetadataFilename();
-    doc->unlock();
-
-    control->getMetadataManager()->storeMetadata(file, static_cast<int>(page), getZoom());
-
     control->getWindow()->getPdfToolbox()->userCancelSelection();
 
     if (this->lastSelectedPage != npos && this->lastSelectedPage < this->viewPages.size()) {
@@ -571,13 +564,6 @@ void XournalView::zoomChanged() {
         Layout* layout = this->getLayout();
         layout->scrollAbs(pos.x, pos.y);
     }
-
-    Document* doc = control->getDocument();
-    doc->lock();
-    auto const& file = doc->getEvMetadataFilename();
-    doc->unlock();
-
-    control->getMetadataManager()->storeMetadata(file, static_cast<int>(getCurrentPage()), zoom->getZoomReal());
 
     // Updates the Eraser's cursor icon in order to make it as big as the erasing area
     control->getCursor()->updateCursor();


### PR DESCRIPTION


This PR addresses the very basic cause of #1783 without touching the rendering methods.
The problem is that at every or scroll operation, the document mutex was locked, thus blocking the UI if a RenderJob was rendering in a separate thread.

This PR:

1. Postpones the update of the metadata to right before writing the metadata down to the disk (instead of updating it all the time), thus removing one source of the problem entirely
2. Only calls DocumentHandler::firePageSelected if the page has actually changed. This saves another doc->lock() in PageBackgroundChangeController::pageSelected() (calling Control::getCurrentPage() which locks the mutex).

The scroll/zoom feels way more fluid. 
You can try it out on this demanding file for instance
[render-benchmark-strokes.xopp.zip](https://github.com/user-attachments/files/25614687/render-benchmark-strokes.xopp.zip)
(rename the .zip away).