### PR TITLE
[fixup] adjust the descriptions to reflect the 'new' recolor logic

### DIFF
--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -3261,7 +3261,7 @@ This setting can make it easier to draw with touch. </property>
                                         <property name="visible">True</property>
                                         <property name="can-focus">True</property>
                                         <property name="receives-default">False</property>
-                                        <property name="tooltip-text" translatable="yes">Recolors the drawing area so that white regions get the dark color and black regions get the light color. Other colors are interpolated accordingly.</property>
+                                        <property name="tooltip-text" translatable="yes">Recolors the drawing area so that light regions get the "Light Color" and dark regions get the "Dark Color". Other colors are interpolated accordingly. Can be use to implement a dark-mode.</property>
                                         <property name="draw-indicator">True</property>
                                       </object>
                                       <packing>
@@ -3276,7 +3276,7 @@ This setting can make it easier to draw with touch. </property>
                                         <property name="visible">True</property>
                                         <property name="can-focus">True</property>
                                         <property name="receives-default">False</property>
-                                        <property name="tooltip-text" translatable="yes">Recolors the previews in the sidebar (Page/Layer Preview) so that white regions get the dark color and black regions get the light color. Other colors are interpolated accordingly.</property>
+                                        <property name="tooltip-text" translatable="yes">Recolors the previews in the sidebar (Page/Layer Preview) the same way as the drawing area.</property>
                                         <property name="draw-indicator">True</property>
                                       </object>
                                       <packing>
@@ -3290,7 +3290,8 @@ This setting can make it easier to draw with touch. </property>
                                         <property name="visible">True</property>
                                         <property name="can-focus">True</property>
                                         <property name="receives-default">True</property>
-                                        <property name="tooltip-text" translatable="yes">The color black regions are translated to</property>
+                                        <property name="tooltip-text" translatable="yes">The color light regions are translated to
+(use a dark color for a dark-mode)</property>
                                         <property name="halign">start</property>
                                       </object>
                                       <packing>
@@ -3304,7 +3305,8 @@ This setting can make it easier to draw with touch. </property>
                                         <property name="visible">True</property>
                                         <property name="can-focus">True</property>
                                         <property name="receives-default">True</property>
-                                        <property name="tooltip-text" translatable="yes">The color white regions are translated to</property>
+                                        <property name="tooltip-text" translatable="yes">The color dark regions are translated to
+(use a light color for dark-mode)</property>
                                         <property name="halign">start</property>
                                       </object>
                                       <packing>
@@ -3346,7 +3348,7 @@ This setting can make it easier to draw with touch. </property>
                                   <object class="GtkLabel">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="label" translatable="yes">Recoloring / Inverting colors</property>
+                                    <property name="label" translatable="yes">Recoloring (allows theming)</property>
                                   </object>
                                 </child>
                               </object>


### PR DESCRIPTION
fixes https://github.com/xournalpp/xournalpp/issues/6915#issuecomment-3876754042

In https://github.com/xournalpp/xournalpp/pull/6948 we kinda generalized the recoloring feature introduced in https://github.com/xournalpp/xournalpp/pull/6090. This slightly changed how the two parameters from the config are interpreted/used. Somehow, we totally forgot to adjust the description tests accordingly which is fixed with this PR.

The changes should cover all texts related to the recolor feature. If I'm missing something, just let me know.