### PR TITLE
Fix warning due to unescaped character in regex

### DIFF
--- a/src/core/gui/MainWindow.cpp
+++ b/src/core/gui/MainWindow.cpp
@@ -187,7 +187,7 @@ static ThemeProperties getThemeProperties(GtkWidget* w) {
 
     // Try to figure out if the theme is dark or light
     // Some themes handle their dark variant via "gtk-application-prefer-dark-theme" while other just append "-dark"
-    const std::regex nameparser("([a-zA-Z0-9_\.-]+?)([:-][dD]ark)?");
+    const std::regex nameparser("([a-zA-Z0-9_\\.-]+?)([:-][dD]ark)?");
     std::cmatch sm;
     std::regex_match(name.get(), sm, nameparser);
 


### PR DESCRIPTION
Fix a warning introduced in #7116
Merging once the CI clears