### PR TITLE
Group plugin menu items into named submenus

### DIFF
--- a/src/core/gui/menus/menubar/PluginsSubmenu.cpp
+++ b/src/core/gui/menus/menubar/PluginsSubmenu.cpp
@@ -16,8 +16,10 @@ PluginsSubmenu::PluginsSubmenu(PluginController* pluginController, GtkApplicatio
 
     g_menu_append_section(submenu.get(), nullptr, G_MENU_MODEL(firstSection.get()));
 
-    for (auto* section: pluginController->createMenuSections(win)) {
-        g_menu_append_section(submenu.get(), nullptr, section);
+    for (auto& [pluginName, section]: pluginController->createMenuSections(win)) {
+        xoj::util::GObjectSPtr<GMenuItem> pluginSubmenuItem(g_menu_item_new_submenu(pluginName.c_str(), section),
+                                                            xoj::util::adopt);
+        g_menu_append_item(submenu.get(), pluginSubmenuItem.get());
     }
 }
 

--- a/src/core/plugin/PluginController.cpp
+++ b/src/core/plugin/PluginController.cpp
@@ -162,15 +162,16 @@ void PluginController::showPluginManager() const {
 #endif
 }
 
-auto PluginController::createMenuSections(GtkApplicationWindow* win) -> std::vector<GMenuModel*> {
+auto PluginController::createMenuSections(GtkApplicationWindow* win)
+        -> std::vector<std::pair<std::string, GMenuModel*>> {
 #ifdef ENABLE_PLUGINS
     size_t id = 0;
-    std::vector<GMenuModel*> sections;
+    std::vector<std::pair<std::string, GMenuModel*>> sections;
     for (auto&& p: this->plugins) {
         id = p->populateMenuSection(win, id);
         auto* section = p->getMenuSection();
         if (section) {
-            sections.emplace_back(section);
+            sections.emplace_back(p->getName(), section);
         }
     }
     return sections;

--- a/src/core/plugin/PluginController.h
+++ b/src/core/plugin/PluginController.h
@@ -13,6 +13,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <gtk/gtk.h>  // for GtkApplicationWindow
@@ -34,10 +35,10 @@ public:
     void registerToolbar();
 
     /**
-     * @brief Create menu sections (one per enabled plugin with menu entries)
-     * The data is owned by the Plugin's themselves - do not unref
+     * @brief Create menu entries (one submenu per enabled plugin with menu entries)
+     * The data is owned by the Plugin's themselves - do not unref the GMenuModel*
      */
-    std::vector<GMenuModel*> createMenuSections(GtkApplicationWindow* win);
+    std::vector<std::pair<std::string, GMenuModel*>> createMenuSections(GtkApplicationWindow* win);
 
     /**
      * Add toolbar buttons


### PR DESCRIPTION
This change updates the plugin menu system to create one sub menu per enabled plugin instead of appending all plugins actions into plugin menu directly

why? because a plugin like vi-xournalpp populates the plugin menu and makes it hard to find other plugins actions (it was made to be accessed via keyboard not the ui, which makes it more awkward)