### PR TITLE
Use a shared_mutex to protect the document instance.

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -251,7 +251,7 @@ void Control::deleteLastAutosaveFile() {
 }
 
 auto Control::checkChangedDocument(Control* control) -> bool {
-    if (!control->doc->tryLock()) {
+    if (!control->doc->try_lock_shared()) {
         // call again later
         return true;
     }
@@ -264,7 +264,7 @@ auto Control::checkChangedDocument(Control* control) -> bool {
         }
     }
     control->changedPages.clear();
-    control->doc->unlock();
+    control->doc->unlock_shared();
 
     // Call again
     return true;
@@ -548,9 +548,9 @@ void Control::reorderSelection(EditSelection::OrderChange change) {
  * @return the page ID or size_t_npos if the page is not found
  */
 auto Control::firePageSelected(const PageRef& page) -> size_t {
-    this->doc->lock();
+    this->doc->lock_shared();
     size_t pageId = this->doc->indexOf(page);
-    this->doc->unlock();
+    this->doc->unlock_shared();
     if (pageId == npos) {
         return npos;
     }
@@ -703,9 +703,9 @@ void Control::deletePage() {
     // if the current page contains the geometry tool, reset it
     size_t pNr = getCurrentPageNo();
     if (geometryToolController) {
-        doc->lock();
+        doc->lock_shared();
         auto page = doc->indexOf(geometryToolController->getPage());
-        doc->unlock();
+        doc->unlock_shared();
         if (page == pNr) {
             resetGeometryTool();
         }
@@ -721,9 +721,9 @@ void Control::deletePage() {
         return;
     }
 
-    this->doc->lock();
+    this->doc->lock_shared();
     PageRef page = doc->getPage(pNr);
-    this->doc->unlock();
+    this->doc->unlock_shared();
 
     // first send event, then delete page...
     firePageDeleted(pNr);
@@ -846,11 +846,11 @@ void Control::askInsertPdfPage(size_t pdfPage) {
                                if (response == Responses::AFTER || response == Responses::END) {
                                    Document* doc = ctrl->getDocument();
 
-                                   doc->lock();
+                                   doc->lock_shared();
                                    size_t position = response == Responses::AFTER ? ctrl->getCurrentPageNo() + 1 :
                                                                                     doc->getPageCount();
                                    XojPdfPageSPtr pdf = doc->getPdfPage(pdfPage);
-                                   doc->unlock();
+                                   doc->unlock_shared();
 
                                    if (pdf) {
                                        auto page = std::make_shared<XojPage>(pdf->getWidth(), pdf->getHeight());
@@ -886,9 +886,9 @@ void Control::appendNewPdfPages() {
     }
     for (size_t i = 0; i != insertCount; ++i) {
 
-        doc->lock();
+        doc->lock_shared();
         XojPdfPageSPtr pdf = doc->getPdfPage(currentPdfPageCount + i);
-        doc->unlock();
+        doc->unlock_shared();
 
         if (pdf) {
             auto newPage = std::make_shared<XojPage>(pdf->getWidth(), pdf->getHeight());
@@ -983,9 +983,9 @@ void Control::paperFormat() {
 
 void Control::changePageBackgroundColor() {
     auto pNr = getCurrentPageNo();
-    this->doc->lock();
+    this->doc->lock_shared();
     auto const& p = this->doc->getPage(pNr);
-    this->doc->unlock();
+    this->doc->unlock_shared();
 
     if (!p) {
         return;
@@ -1118,9 +1118,9 @@ auto Control::searchTextOnPage(const std::string& text, size_t pageNumber, size_
 }
 
 auto Control::getCurrentPage() -> PageRef {
-    this->doc->lock();
+    this->doc->lock_shared();
     PageRef p = this->doc->getPage(getCurrentPageNo());
-    this->doc->unlock();
+    this->doc->unlock_shared();
 
     return p;
 }
@@ -1722,9 +1722,9 @@ void Control::openFile(fs::path filepath, std::function<void(bool)> callback, in
 }
 
 void Control::fileLoaded(int scrollToPage) {
-    this->doc->lock();
+    this->doc->lock_shared();
     auto filepath = this->doc->getEvMetadataFilename();
-    this->doc->unlock();
+    this->doc->unlock_shared();
 
     if (!filepath.empty()) {
         auto md = MetadataManager::getForFile(filepath);
@@ -1875,9 +1875,9 @@ void Control::askToAnnotatePdf() {
 }
 
 void Control::print() {
-    this->doc->lock();
+    this->doc->lock_shared();
     PrintHandler::print(this->doc, getCurrentPageNo(), this->getGtkWindow());
-    this->doc->unlock();
+    this->doc->unlock_shared();
 }
 
 void Control::block(const string& name) {
@@ -1969,7 +1969,7 @@ void Control::showColorChooserDialog() {
 void Control::updateWindowTitle() {
     std::string title{};  ///< Actually a UTF-8 string
 
-    this->doc->lock();
+    this->doc->lock_shared();
     const fs::path& refPath = doc->getFilepath().empty() ? doc->getPdfFilepath() : doc->getFilepath();
     if (refPath.empty()) {
         title = _("Unsaved Document");
@@ -1986,7 +1986,7 @@ void Control::updateWindowTitle() {
         }
         title += char_cast(refPath.filename().u8string());
     }
-    this->doc->unlock();
+    this->doc->unlock_shared();
 
     title += " - Xournal++";
 
@@ -2023,9 +2023,9 @@ void Control::saveImpl(bool saveAs, std::function<void(bool)> callback) {
     // clear selection before saving
     clearSelectionEndText();
 
-    this->doc->lock();
+    this->doc->lock_shared();
     fs::path filepath = this->doc->getFilepath();
-    this->doc->unlock();
+    this->doc->unlock_shared();
 
     auto doSave = [ctrl = this, cb = std::move(callback)]() {
         // clear selection before saving
@@ -2038,11 +2038,11 @@ void Control::saveImpl(bool saveAs, std::function<void(bool)> callback) {
 
     if (saveAs || filepath.empty()) {
         // No need to backup the old saved file, as there is none
-        this->doc->lock();
+        this->doc->lock_shared();
         this->doc->setCreateBackupOnSave(false);
         auto suggestedPath = this->doc->createSaveFoldername(this->settings->getLastSavePath());
         suggestedPath /= this->doc->createSaveFilename(Document::XOPP, this->settings->getDefaultSaveName());
-        this->doc->unlock();
+        this->doc->unlock_shared();
         xoj::SaveExportDialog::showSaveFileDialog(getGtkWindow(), settings, std::move(suggestedPath),
                                                   [doSave = std::move(doSave), ctrl = this](std::optional<fs::path> p) {
                                                       if (p && !p->empty()) {
@@ -2059,9 +2059,9 @@ void Control::saveImpl(bool saveAs, std::function<void(bool)> callback) {
 }
 
 void Control::resetSavedStatus() {
-    this->doc->lock();
+    this->doc->lock_shared();
     auto filepath = this->doc->getFilepath();
-    this->doc->unlock();
+    this->doc->unlock_shared();
 
     this->undoRedo->documentSaved();
     RecentManager::addRecentFileFilename(filepath);
@@ -2102,9 +2102,9 @@ void Control::close(std::function<void(bool)> callback, const bool allowDestroy,
                     const bool forceClose) {
     clearSelectionEndText();
 
-    doc->lock();
+    doc->lock_shared();
     auto const& file = doc->getEvMetadataFilename();
-    doc->unlock();
+    doc->unlock_shared();
     metadata->storeMetadata(file, static_cast<int>(getCurrentPageNo()), zoom->getZoomReal());
     metadata->documentChanged();
 
@@ -2255,11 +2255,12 @@ void Control::clipboardPasteImage(GdkPixbuf* img) {
         return;
     }
 
-    this->doc->lock();
+    this->doc->lock_shared();
     PageRef page = this->doc->getPage(pageNr);
     auto pageWidth = page->getWidth();
     auto pageHeight = page->getHeight();
-    this->doc->unlock();
+    page.reset();  // No need to hold a ref to the page anymore
+    this->doc->unlock_shared();
 
     // Size: 3/4 of the page size
     pageWidth = pageWidth * 3.0 / 4.0;
@@ -2297,10 +2298,10 @@ void Control::clipboardPaste(ElementPtr e) {
         return;
     }
 
-    this->doc->lock();
+    this->doc->lock_shared();
     PageRef page = this->doc->getPage(pageNr);
     Layer* layer = page->getSelectedLayer();
-    this->doc->unlock();
+    this->doc->unlock_shared();
 
     win->getXournal()->getPasteTarget(x, y);
 

--- a/src/core/control/LatexController.cpp
+++ b/src/core/control/LatexController.cpp
@@ -97,15 +97,13 @@ auto LatexController::findTexDependencies() -> LatexController::FindDependencySt
  * Find a selected tex element, and load it
  */
 void LatexController::findSelectedTexElement() {
-    this->doc->lock();
+    std::shared_lock<Document> lock(*doc);
     auto pageNr = this->control->getCurrentPageNo();
     if (pageNr == npos) {
-        this->doc->unlock();
         return;
     }
     this->view = this->control->getWindow()->getXournal()->getViewFor(pageNr);
     if (view == nullptr) {
-        this->doc->unlock();
         return;
     }
 
@@ -153,7 +151,6 @@ void LatexController::findSelectedTexElement() {
             this->posy = this->page->getHeight() / 2;
         }
     }
-    this->doc->unlock();
 }
 
 void LatexController::showTexEditDialog(std::unique_ptr<LatexController> ctrl) {

--- a/src/core/control/ScrollHandler.cpp
+++ b/src/core/control/ScrollHandler.cpp
@@ -47,9 +47,9 @@ void ScrollHandler::goToFirstPage() {
 void ScrollHandler::scrollToPage(const PageRef& page, XojPdfRectangle rect) {
     Document* doc = this->control->getDocument();
 
-    doc->lock();
+    doc->lock_shared();
     auto p = doc->indexOf(page);
-    doc->unlock();
+    doc->unlock_shared();
 
     if (p != npos) {
         scrollToPage(p, rect);
@@ -71,9 +71,9 @@ void ScrollHandler::scrollToLinkDest(const LinkDestination& dest) {
 
     if (pdfPage != npos) {
         Document* doc = control->getDocument();
-        doc->lock();
+        doc->lock_shared();
         size_t page = doc->findPdfPage(pdfPage);
-        doc->unlock();
+        doc->unlock_shared();
 
         if (page == npos) {
             control->askInsertPdfPage(pdfPage);

--- a/src/core/control/UndoRedoController.cpp
+++ b/src/core/control/UndoRedoController.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>  // for copy, max
 #include <cstddef>    // for size_t
 #include <iterator>   // for back_insert_iterator, back_...
+#include <mutex>      // for unique_lock
 
 #include "control/tools/EditSelection.h"  // for EditSelection
 #include "gui/MainWindow.h"               // for MainWindow
@@ -61,7 +62,7 @@ void UndoRedoController::after() {
     }
     if (!remainingElements.empty()) {
         auto removedElements = layer->removeElementsAt(remainingElements);
-        lock.unlock();  // Not needed anymore. For all other paths, the lock is released via ~unique_lock()
+        lock.unlock();  // For all other paths, the lock is released via ~unique_lock()
         auto [sel, bounds] =
                 SelectionFactory::createFromFloatingElements(control, page, layer, view, std::move(removedElements));
         control->getWindow()->getXournal()->setSelection(sel.release());

--- a/src/core/control/jobs/AutosaveJob.cpp
+++ b/src/core/control/jobs/AutosaveJob.cpp
@@ -29,7 +29,7 @@ void AutosaveJob::run() {
 
     Document* doc = control->getDocument();
 
-    doc->lock();
+    doc->lock_shared();
     auto filepath = doc->getFilepath();
 
     if (filepath.empty()) {
@@ -41,13 +41,17 @@ void AutosaveJob::run() {
     filepath += ".autosave.xopp";
 
     handler.prepareSave(doc, filepath);
-    doc->unlock();
+    doc->unlock_shared();
 
     g_message("%s", FS(_F("Autosaving to {1}") % filepath.string()).c_str());
 
     fs::path tempfile = filepath;
     tempfile += u8"~";
     handler.saveTo(tempfile);
+
+    doc->lock();
+    handler.updateDocumentInfo(doc);
+    doc->unlock();
 
     this->error = handler.getErrorMessage();
     if (!this->error.empty()) {

--- a/src/core/control/jobs/BaseExportJob.cpp
+++ b/src/core/control/jobs/BaseExportJob.cpp
@@ -53,11 +53,11 @@ auto BaseExportJob::checkOverwriteBackgroundPDF(fs::path const& file) const -> b
 void BaseExportJob::showFileChooser(std::function<void()> onFileSelected, std::function<void()> onCancel) {
     Settings* settings = control->getSettings();
     Document* doc = control->getDocument();
-    doc->lock();
+    doc->lock_shared();
     fs::path suggestedPath = doc->createSaveFoldername(settings->getLastSavePath());
     suggestedPath /=
             doc->createSaveFilename(Document::PDF, settings->getDefaultSaveName(), settings->getDefaultPdfExportName());
-    doc->unlock();
+    doc->unlock_shared();
 
     auto pathValidation = [job = this](fs::path& p, const char* filterName) {
         job->setExtensionFromFilter(p, filterName);

--- a/src/core/control/jobs/CustomExportJob.cpp
+++ b/src/core/control/jobs/CustomExportJob.cpp
@@ -123,10 +123,10 @@ void CustomExportJob::run() {
         Document* doc = this->control->getDocument();
 
         XojExportHandler h;
-        doc->lock();
+        doc->lock_shared();
         h.prepareSave(doc, filepath);
         h.saveTo(filepath, this->control);
-        doc->unlock();
+        doc->unlock_shared();
 
         if (!h.getErrorMessage().empty()) {
             this->lastError = FS(_F("Save file error: {1}") % h.getErrorMessage());

--- a/src/core/control/jobs/ImageExport.cpp
+++ b/src/core/control/jobs/ImageExport.cpp
@@ -159,9 +159,8 @@ auto ImageExport::getFilenameWithNumber(size_t no) const -> fs::path {
  */
 void ImageExport::exportImagePage(size_t pageId, size_t id, double zoomRatio, ExportGraphicsFormat format,
                                   DocumentView& view) {
-    doc->lock();
+    std::shared_lock<Document> lock(*doc);
     ConstPageRef page = doc->getPage(pageId);
-    doc->unlock();
 
     zoomRatio = createSurface(page->getWidth(), page->getHeight(), id, zoomRatio);
 

--- a/src/core/control/jobs/PdfExportJob.cpp
+++ b/src/core/control/jobs/PdfExportJob.cpp
@@ -29,9 +29,9 @@ void PdfExportJob::setExtensionFromFilter(fs::path& file, const char* /*filterNa
 void PdfExportJob::run() {
     Document* doc = control->getDocument();
 
-    doc->lock();
+    doc->lock_shared();
     std::unique_ptr<XojPdfExport> pdfe = XojPdfExportFactory::createExport(doc, control);
-    doc->unlock();
+    doc->unlock_shared();
 
     if (!pdfe->createPdf(this->filepath, false)) {
         this->errorMsg = pdfe->getLastError();

--- a/src/core/control/jobs/PreviewJob.cpp
+++ b/src/core/control/jobs/PreviewJob.cpp
@@ -59,7 +59,7 @@ void PreviewJob::drawPage() {
     PreviewRenderType type = this->sidebarPreview->getRenderType();
     Layer::Index layer = 0;
 
-    doc->lock();
+    doc->lock_shared();
 
     // getLayer is not defined for page preview
     if (type != RENDER_TYPE_PAGE_PREVIEW) {
@@ -110,7 +110,7 @@ void PreviewJob::drawPage() {
             break;
     }
 
-    doc->unlock();
+    doc->unlock_shared();
 }
 
 void PreviewJob::clipToPage() {

--- a/src/core/control/jobs/RenderJob.cpp
+++ b/src/core/control/jobs/RenderJob.cpp
@@ -113,7 +113,7 @@ void RenderJob::renderToBuffer(cairo_t* cr) const {
                                  TOOL_PLAY_OBJECT);
     localView.setPdfCache(this->view->xournal->getCache());
 
-    std::lock_guard<Document> lock(*this->view->xournal->getDocument());
+    std::shared_lock<Document> lock(*this->view->xournal->getDocument());
     localView.drawPage(this->view->page, cr, false);
 }
 

--- a/src/core/control/jobs/SaveJob.cpp
+++ b/src/core/control/jobs/SaveJob.cpp
@@ -48,9 +48,9 @@ void SaveJob::updatePreview(Control* control) {
     const int previewSize = 128;
 
     Document* doc = control->getDocument();
+    xoj::util::CairoSurfaceSPtr crBuffer;
 
-    doc->lock();
-
+    doc->lock_shared();
     if (doc->getPageCount() > 0) {
         PageRef page = doc->getPage(0);
 
@@ -67,10 +67,10 @@ void SaveJob::updatePreview(Control* control) {
         width *= zoom;
         height *= zoom;
 
-        cairo_surface_t* crBuffer =
-                cairo_image_surface_create(CAIRO_FORMAT_ARGB32, ceil_cast<int>(width), ceil_cast<int>(height));
+        crBuffer.reset(cairo_image_surface_create(CAIRO_FORMAT_ARGB32, ceil_cast<int>(width), ceil_cast<int>(height)),
+                       xoj::util::adopt);
 
-        cairo_t* cr = cairo_create(crBuffer);
+        cairo_t* cr = cairo_create(crBuffer.get());
         cairo_scale(cr, zoom, zoom);
 
         xoj::view::BackgroundFlags flags = xoj::view::BACKGROUND_SHOW_ALL;
@@ -91,12 +91,11 @@ void SaveJob::updatePreview(Control* control) {
         DocumentView view;
         view.drawPage(page, cr, true /* don't render erasable */, flags);
         cairo_destroy(cr);
-        doc->setPreview(crBuffer);
-        cairo_surface_destroy(crBuffer);
-    } else {
-        doc->setPreview(nullptr);
     }
+    doc->unlock_shared();
 
+    doc->lock();
+    doc->setPreview(std::move(crBuffer));
     doc->unlock();
 }
 
@@ -105,12 +104,12 @@ auto SaveJob::save() -> bool {
     Document* doc = this->control->getDocument();
     SaveHandler h;
 
-    doc->lock();
+    doc->lock_shared();
     fs::path target = doc->getFilepath();
     Util::safeReplaceExtension(target, "xopp");
 
     h.prepareSave(doc, target);
-    doc->unlock();
+    doc->unlock_shared();
 
     auto const createBackup = doc->shouldCreateBackupOnSave();
 
@@ -129,8 +128,10 @@ auto SaveJob::save() -> bool {
         }
     }
 
-    doc->lock();
     h.saveTo(target, this->control);
+
+    doc->lock();
+    h.updateDocumentInfo(doc);
     doc->setFilepath(target);
     doc->unlock();
 

--- a/src/core/control/tools/PdfElemSelection.cpp
+++ b/src/core/control/tools/PdfElemSelection.cpp
@@ -28,9 +28,9 @@ PdfElemSelection::PdfElemSelection(double x, double y, Control* control):
 
     if (auto pNr = control->getCurrentPage()->getPdfPageNr(); pNr != npos) {
         Document* doc = control->getDocument();
-        doc->lock();
+        doc->lock_shared();
         this->pdf = doc->getPdfPage(pNr);
-        doc->unlock();
+        doc->unlock_shared();
 
         this->selectionPageNr = pNr;
     }

--- a/src/core/control/tools/Selector.cpp
+++ b/src/core/control/tools/Selector.cpp
@@ -22,7 +22,7 @@ auto Selector::finalize(PageRef page, bool disableMultilayer, Document* doc) -> 
     size_t layerId = 0;
 
     if (multiLayer && !disableMultilayer) {
-        std::lock_guard lock(*doc);
+        std::shared_lock lock(*doc);
         const auto layers = page->getLayersView();
         for (auto it = layers.rbegin(); it != layers.rend(); it++) {
             const Layer* l = *it;
@@ -44,7 +44,7 @@ auto Selector::finalize(PageRef page, bool disableMultilayer, Document* doc) -> 
             }
         }
     } else {
-        std::lock_guard lock(*doc);
+        std::shared_lock lock(*doc);
         const Layer* l = page->getSelectedLayer();
         Element::Index pos = 0;
         for (const auto& e: l->getElementsView()) {

--- a/src/core/control/tools/StrokeHandler.cpp
+++ b/src/core/control/tools/StrokeHandler.cpp
@@ -174,14 +174,12 @@ void StrokeHandler::onButtonReleaseEvent(const PositionInputData& pos, double zo
     Settings* settings = control->getSettings();
     if (settings->getEmptyLastPageAppend() == EmptyLastPageAppendType::OnDrawOfLastPage) {
         auto* doc = control->getDocument();
-        doc->lock();
+        doc->lock_shared();
         auto pdfPageCount = doc->getPdfPageCount();
-        doc->unlock();
+        auto lastPage = doc->getPageCount() - 1;
+        doc->unlock_shared();
         if (pdfPageCount == 0) {
             auto currentPage = control->getCurrentPageNo();
-            doc->lock();
-            auto lastPage = doc->getPageCount() - 1;
-            doc->unlock();
             if (currentPage == lastPage) {
                 control->insertNewPage(currentPage + 1, true);
             }

--- a/src/core/control/xojfile/SaveHandler.cpp
+++ b/src/core/control/xojfile/SaveHandler.cpp
@@ -57,10 +57,10 @@ void SaveHandler::prepareSave(const Document* doc, const fs::path& target) {
 
     writeHeader();
 
-    cairo_surface_t* preview = doc->getPreview();
+    auto preview = doc->getPreview();
     if (preview) {
         auto* image = new XmlImageNode("preview");
-        image->setImage(preview);
+        image->setImage(preview.get());
         this->root->addChild(image);
     }
 
@@ -281,16 +281,8 @@ void SaveHandler::visitPage(XmlNode* root, ConstPageRef p, const Document* doc, 
             background->setAttrib("domain", "attach");
             background->setAttrib("filename", filename);
 
-            backgroundImages.emplace_back(p->getBackgroundImage());
-
-            /*
-             * Because BackgroundImage is basically a wrapped pointer, the following lines actually modify
-             * *(p->getBackgroundImage().content) and thus the Document.
-             * TODO Find a better way
-             */
-            backgroundImages.back().setFilepath(filename);
-            backgroundImages.back().setCloneId(id);
-
+            // Store the changed info to update the document in updateDocumentInfo()
+            backgroundImages.emplace_back(ImageInfo{p->getBackgroundImage(), fs::path(filename), id});
             g_free(filename);
         } else {
             // "absolute" just means path. For backward compatibility, it is hard to change the word
@@ -299,14 +291,8 @@ void SaveHandler::visitPage(XmlNode* root, ConstPageRef p, const Document* doc, 
                                                            doc->getPathStorageMode());
             background->setAttrib("filename", char_cast(normalizedPath.c_str()));
 
-            BackgroundImage img = p->getBackgroundImage();
-
-            /*
-             * Because BackgroundImage is basically a wrapped pointer, the following line actually modifies
-             * *(p->getBackgroundImage().content) and thus the Document.
-             * TODO Find a better way
-             */
-            img.setCloneId(id);
+            // Store the changed info to update the document in updateDocumentInfo()
+            backgroundImages.emplace_back(ImageInfo{p->getBackgroundImage(), std::nullopt, id});
         }
     } else {
         writeSolidBackground(background, p);
@@ -359,23 +345,35 @@ void SaveHandler::saveTo(const fs::path& filepath, ProgressListener* listener) {
 }
 
 void SaveHandler::saveTo(OutputStream* out, const fs::path& filepath, ProgressListener* listener) {
-    // XMLNode should be locale-safe ( store doubles using Locale 'C' format
-
     out->write("<?xml version=\"1.0\" standalone=\"no\"?>\n");
     root->writeOut(out, listener);
 
-    for (const BackgroundImage& img: backgroundImages) {
-        auto tmpfn = (fs::path(filepath) += ".") += img.getFilepath();
-        // Are we certain that does not modify the GdkPixbuf?
-        if (!gdk_pixbuf_save(const_cast<GdkPixbuf*>(img.getPixbuf()), Util::toGFilename(tmpfn).c_str(), "png", nullptr,
-                             nullptr)) {
-            if (!this->errorMessage.empty()) {
-                this->errorMessage += "\n";
-            }
+    for (const auto& info: backgroundImages) {
+        if (info.newPath) {
+            auto tmpfn = (fs::path(filepath) += ".") += info.newPath.value();
+            // Are we certain that does not modify the GdkPixbuf?
+            if (!gdk_pixbuf_save(const_cast<GdkPixbuf*>(info.image.getPixbuf()), Util::toGFilename(tmpfn).c_str(),
+                                 "png", nullptr, nullptr)) {
+                if (!this->errorMessage.empty()) {
+                    this->errorMessage += "\n";
+                }
 
-            this->errorMessage += FS(_F("Could not write background \"{1}\". Continuing anyway.") % tmpfn.u8string());
+                this->errorMessage +=
+                        FS(_F("Could not write background \"{1}\". Continuing anyway.") % tmpfn.u8string());
+            }
         }
     }
 }
+
+void SaveHandler::updateDocumentInfo(Document* doc) {
+    for (auto& info: backgroundImages) {
+        if (info.newPath) {
+            info.image.setFilepath(std::move(info.newPath.value()));
+        }
+        info.image.setCloneId(info.newId);
+    }
+    backgroundImages.clear();
+}
+
 
 auto SaveHandler::getErrorMessage() -> const std::string& { return this->errorMessage; }

--- a/src/core/control/xojfile/SaveHandler.h
+++ b/src/core/control/xojfile/SaveHandler.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <memory>  // for unique_ptr
+#include <optional>
 #include <string>  // for string
 #include <vector>  // for vector
 
@@ -36,9 +37,19 @@ public:
     SaveHandler();
 
 public:
+    /// Prepare an XML tree corresponding to the document - Needs read-only access to the Document
     void prepareSave(const Document* doc, const fs::path& target);
+    /// Writes the XML to the given path. Does not access the Document instance
     void saveTo(const fs::path& filepath, ProgressListener* listener = nullptr);
+    /**
+     * Writes the XML to the given stream. Does not access the Document instance with the following exception:
+     * attached background images are written to disk. This is safe as long as we do not modify the background images
+     * anywhere
+     */
     void saveTo(OutputStream* out, const fs::path& filepath, ProgressListener* listener = nullptr);
+    /// Update document information. Requires write access to the Document.
+    void updateDocumentInfo(Document* doc);
+
     const std::string& getErrorMessage();
 
 protected:
@@ -65,5 +76,10 @@ protected:
 
     std::string errorMessage;
 
-    std::vector<BackgroundImage> backgroundImages{};
+    struct ImageInfo {
+        BackgroundImage image;  ///< This is a wrapped shared pointer
+        std::optional<fs::path> newPath;
+        int newId;
+    };
+    std::vector<ImageInfo> backgroundImages{};
 };

--- a/src/core/gui/Layout.cpp
+++ b/src/core/gui/Layout.cpp
@@ -66,14 +66,12 @@ void Layout::maybeAddLastPage(Layout* layout) {
         // If the layout is 5px away from the end of the last page
         if (std::abs((layout->getMinimalHeight() - layout->getVisibleRect().y) - layout->getVisibleRect().height) < 5) {
             auto* doc = control->getDocument();
-            doc->lock();
+            doc->lock_shared();
             auto pdfPageCount = doc->getPdfPageCount();
-            doc->unlock();
+            auto lastPage = doc->getPageCount() - 1;
+            doc->unlock_shared();
             if (pdfPageCount == 0) {
                 auto currentPage = control->getCurrentPageNo();
-                doc->lock();
-                auto lastPage = doc->getPageCount() - 1;
-                doc->unlock();
                 if (currentPage == lastPage) {
                     control->insertNewPage(currentPage + 1, true);
                 }

--- a/src/core/gui/PageView.cpp
+++ b/src/core/gui/PageView.cpp
@@ -153,9 +153,9 @@ auto XojPageView::searchTextOnPage(const std::string& text, size_t index, size_t
         if (pNr != npos) {
             Document* doc = xournal->getControl()->getDocument();
 
-            doc->lock();
+            doc->lock_shared();
             pdf = doc->getPdfPage(pNr);
-            doc->unlock();
+            doc->unlock_shared();
         }
         this->search = std::make_unique<SearchControl>(page, pdf);
         this->overlayViews.emplace_back(std::make_unique<xoj::view::SearchResultView>(
@@ -991,9 +991,9 @@ bool XojPageView::displayLinkPopover(std::shared_ptr<XojPdfPage> page, double pa
             size_t pdfPage = dest->getPdfPage();
 
             Document* doc = xournal->getControl()->getDocument();
-            doc->lock();
+            doc->lock_shared();
             const size_t pageId = doc->findPdfPage(pdfPage);
-            doc->unlock();
+            doc->unlock_shared();
 
             GtkWidget* button{};
             if (pageId != npos) {

--- a/src/core/gui/PageViewFindObjectHelper.h
+++ b/src/core/gui/PageViewFindObjectHelper.h
@@ -46,7 +46,7 @@ public:
             ctrl->clearSelection();
         }
 
-        std::lock_guard lock(*ctrl->getDocument());
+        std::shared_lock lock(*ctrl->getDocument());
         if (multiLayer) {
             const auto& layers = this->view->getPage()->getLayers();
             size_t layerNo = layers.size();

--- a/src/core/gui/PdfFloatingToolbox.cpp
+++ b/src/core/gui/PdfFloatingToolbox.cpp
@@ -155,9 +155,9 @@ void PdfFloatingToolbox::createStrokes(PdfMarkerStyle position, PdfMarkerStyle w
     // Get the PDF page that the current page corresponds to.
     // It should be the same as the PDF page of the selection.
     auto doc = this->theMainWindow->getControl()->getDocument();
-    doc->lock();
+    doc->lock_shared();
     const size_t pdfPageOfCurrentPage = doc->getPage(currentPage)->getPdfPageNr();
-    doc->unlock();
+    doc->unlock_shared();
 
     if (pdfPageOfCurrentPage != pdfPageNo) {
         // There's probably a bug that violates our assumptions, so no-op.

--- a/src/core/gui/XournalView.cpp
+++ b/src/core/gui/XournalView.cpp
@@ -65,11 +65,11 @@ std::pair<size_t, size_t> XournalView::preloadPageBounds(size_t page, size_t max
 XournalView::XournalView(GtkWidget* parent, Control* control, ScrollHandling* scrollHandling):
         scrollHandling(scrollHandling), control(control) {
     Document* doc = control->getDocument();
-    doc->lock();
+    doc->lock_shared();
     if (doc->getPdfPageCount() != 0) {
         this->cache = std::make_unique<PdfCache>(doc->getPdfDocument(), control->getSettings());
     }
-    doc->unlock();
+    doc->unlock_shared();
 
     registerListener(control);
 
@@ -518,11 +518,11 @@ void XournalView::recreatePdfCache() {
     this->cache.reset();
 
     Document* doc = control->getDocument();
-    doc->lock();
+    doc->lock_shared();
     if (doc->getPdfPageCount() != 0) {
         this->cache = std::make_unique<PdfCache>(doc->getPdfDocument(), control->getSettings());
     }
-    doc->unlock();
+    doc->unlock_shared();
 }
 
 /**
@@ -616,9 +616,9 @@ auto XournalView::getCache() const -> PdfCache* { return this->cache.get(); }
 
 void XournalView::pageInserted(size_t page) {
     Document* doc = control->getDocument();
-    doc->lock();
+    doc->lock_shared();
     auto pageView = std::make_unique<XojPageView>(this, doc->getPage(page));
-    doc->unlock();
+    doc->unlock_shared();
 
     viewPages.insert(begin(viewPages) + as_signed(page), std::move(pageView));
 
@@ -771,20 +771,19 @@ void XournalView::documentChanged(DocumentChangeType type) {
 
     clearSelection();
 
-    viewPages.clear();
-
     recreatePdfCache();
 
     Document* doc = control->getDocument();
-    doc->lock();
+    doc->lock_shared();
 
+    viewPages.clear();
     size_t pagecount = doc->getPageCount();
     viewPages.reserve(pagecount);
     for (size_t i = 0; i < pagecount; i++) {
         viewPages.emplace_back(std::make_unique<XojPageView>(this, doc->getPage(i)));
     }
 
-    doc->unlock();
+    doc->unlock_shared();
 
     layoutPages();
     scrollTo(0);

--- a/src/core/gui/dialog/backgroundSelect/ImagesDialog.cpp
+++ b/src/core/gui/dialog/backgroundSelect/ImagesDialog.cpp
@@ -61,7 +61,7 @@ ImagesDialog::ImagesDialog(GladeSearchpath* gladeSearchPath, Document* doc, Sett
 ImagesDialog::~ImagesDialog() = default;
 
 void ImagesDialog::loadImagesFromPages() {
-    doc->lock();
+    doc->lock_shared();
     for (size_t i = 0; i < doc->getPageCount(); i++) {
         PageRef p = doc->getPage(i);
 
@@ -82,7 +82,7 @@ void ImagesDialog::loadImagesFromPages() {
         iv->backgroundImage = p->getBackgroundImage();
         this->entries.emplace_back(iv);
     }
-    doc->unlock();
+    doc->unlock_shared();
 }
 
 auto ImagesDialog::isImageAlreadyInTheList(BackgroundImage& image) -> bool {

--- a/src/core/gui/dialog/backgroundSelect/PdfPagesDialog.cpp
+++ b/src/core/gui/dialog/backgroundSelect/PdfPagesDialog.cpp
@@ -27,7 +27,7 @@ PdfPagesDialog::PdfPagesDialog(GladeSearchpath* gladeSearchPath, Document* doc, 
                                std::function<void(size_t)> callback):
         BackgroundSelectDialogBase(gladeSearchPath, doc, settings, _("Select PDF Page")),
         callback(std::move(callback)) {
-    doc->lock();
+    doc->lock_shared();
     for (size_t i = 0; i < doc->getPdfPageCount(); i++) {
         XojPdfPageSPtr p = doc->getPdfPage(i);
         entries.emplace_back(std::make_unique<PdfElementView>(entries.size(), p, this));
@@ -50,7 +50,7 @@ PdfPagesDialog::PdfPagesDialog(GladeSearchpath* gladeSearchPath, Document* doc, 
     }
     xoj_assert(used <= doc->getPdfPageCount());
     auto unused = doc->getPdfPageCount() - used;
-    doc->unlock();
+    doc->unlock_shared();
 
     cbUnusedOnly = GTK_CHECK_BUTTON(gtk_check_button_new_with_label(
             (unused == 1 ? _("Show only not used pages (one unused page)") :

--- a/src/core/gui/inputdevices/GeometryToolInputHandler.cpp
+++ b/src/core/gui/inputdevices/GeometryToolInputHandler.cpp
@@ -195,7 +195,7 @@ void GeometryToolInputHandler::sequenceStart(InputEvent const& event) {
     const Layer* layer = page->getSelectedLayer();
     this->lines.clear();
     Document* doc = xournal->getDocument();
-    doc->lock();
+    doc->lock_shared();
     // Performance improvement might be obtained by avoiding filtering all elements each
     // time a finger has been put onto the screen
     for (const auto& e: layer->getElementsView()) {
@@ -206,7 +206,7 @@ void GeometryToolInputHandler::sequenceStart(InputEvent const& event) {
             }
         }
     }
-    doc->unlock();
+    doc->unlock_shared();
 }
 
 void GeometryToolInputHandler::scrollMotion(InputEvent const& event) {

--- a/src/core/gui/sidebar/indextree/SidebarIndexPage.cpp
+++ b/src/core/gui/sidebar/indextree/SidebarIndexPage.cpp
@@ -210,15 +210,15 @@ auto SidebarIndexPage::selectPageNr(size_t page, size_t pdfPage, GtkTreeIter* pa
     GtkTreeIter iter;
 
     Document* doc = control->getDocument();
-    doc->lock();
+    doc->lock_shared();
     GtkTreeModel* model = doc->getContentsModel();
     if (model == nullptr) {
-        doc->unlock();
+        doc->unlock_shared();
         return false;
     }
 
     g_object_ref(model);
-    doc->unlock();
+    doc->unlock_shared();
 
     if (parent == nullptr) {
 
@@ -290,11 +290,11 @@ void SidebarIndexPage::documentChanged(DocumentChangeType type) {
         //  there will be a deadlock: both the selectHandler and this code will
         //  lock the document.
         g_signal_handler_block(this->treeViewBookmarks, this->selectHandler);
-        doc->lock();
+        doc->lock_shared();
         GtkTreeModel* model = doc->getContentsModel();
         gtk_tree_view_set_model(GTK_TREE_VIEW(this->treeViewBookmarks), model);
         int count = expandOpenLinks(model, nullptr);
-        doc->unlock();
+        doc->unlock_shared();
         g_signal_handler_unblock(this->treeViewBookmarks, this->selectHandler);
         this->treeBookmarkSelected(GTK_TREE_VIEW(this->treeViewBookmarks), this);
 

--- a/src/core/gui/sidebar/previews/base/SidebarPreviewBase.cpp
+++ b/src/core/gui/sidebar/previews/base/SidebarPreviewBase.cpp
@@ -31,11 +31,11 @@ SidebarPreviewBase::SidebarPreviewBase(Control* control, const char* menuId, con
     gtk_widget_set_vexpand(scrollableBox.get(), true);
 
     Document* doc = this->control->getDocument();
-    doc->lock();
+    doc->lock_shared();
     if (doc->getPdfPageCount() != 0) {
         this->cache = std::make_unique<PdfCache>(doc->getPdfDocument(), control->getSettings());
     }
-    doc->unlock();
+    doc->unlock_shared();
 
 
     registerListener(this->control);
@@ -97,11 +97,11 @@ void SidebarPreviewBase::documentChanged(DocumentChangeType type) {
         this->cache.reset();
 
         Document* doc = control->getDocument();
-        doc->lock();
+        doc->lock_shared();
         if (doc->getPdfPageCount() != 0) {
             this->cache = std::make_unique<PdfCache>(doc->getPdfDocument(), control->getSettings());
         }
-        doc->unlock();
+        doc->unlock_shared();
         updatePreviews();
     }
 }

--- a/src/core/gui/sidebar/previews/page/SidebarPreviewPages.cpp
+++ b/src/core/gui/sidebar/previews/page/SidebarPreviewPages.cpp
@@ -41,14 +41,14 @@ void SidebarPreviewPages::updatePreviews() {
     this->previews.clear();
 
     Document* doc = this->getControl()->getDocument();
-    doc->lock();
+    doc->lock_shared();
     size_t len = doc->getPageCount();
     for (size_t i = 0; i < len; i++) {
         auto p = std::make_unique<SidebarPreviewPageEntry>(this, doc->getPage(i), i);
         gtk_fixed_put(this->miniaturesContainer.get(), p->getWidget(), 0, 0);
         this->previews.emplace_back(std::move(p));
     }
-    doc->unlock();
+    doc->unlock_shared();
 
     layout();
 }
@@ -90,11 +90,9 @@ void SidebarPreviewPages::pageDeleted(size_t page) {
 
 void SidebarPreviewPages::pageInserted(size_t page) {
     Document* doc = control->getDocument();
-    doc->lock();
-
+    doc->lock_shared();
     auto p = std::make_unique<SidebarPreviewPageEntry>(this, doc->getPage(page), page);
-
-    doc->unlock();
+    doc->unlock_shared();
 
     gtk_fixed_put(this->miniaturesContainer.get(), p->getWidget(), 0, 0);
     this->previews.insert(this->previews.begin() + as_signed(page), std::move(p));

--- a/src/core/model/Document.cpp
+++ b/src/core/model/Document.cpp
@@ -64,40 +64,19 @@ auto Document::freeTreeContentEntry(GtkTreeModel* treeModel, GtkTreePath* path, 
     return false;
 }
 
-void Document::lock() {
-    this->documentLock.lock();
-
-    //	if(tryLock()) {
-    //		fprintf(stderr, "Locked by\n");
-    //		Stacktrace::printStacktrace();
-    //		fprintf(stderr, "\n\n\n\n");
-    //	} else {
-    //		g_mutex_lock(&this->documentLock);
-    //	}
-}
-
-void Document::unlock() {
-    this->documentLock.unlock();
-
-    //	fprintf(stderr, "Unlocked by\n");
-    //	Stacktrace::printStacktrace();
-    //	fprintf(stderr, "\n\n\n\n");
-}
-
-/*
-** Returns true when successfully acquiring lock.
-*/
-auto Document::tryLock() -> bool { return this->documentLock.try_lock(); }
+void Document::lock() { this->documentLock.lock(); }
+void Document::unlock() { this->documentLock.unlock(); }
+auto Document::try_lock() -> bool { return this->documentLock.try_lock(); }
+void Document::lock_shared() { this->documentLock.lock_shared(); }
+void Document::unlock_shared() { this->documentLock.unlock_shared(); }
+auto Document::try_lock_shared() -> bool { return this->documentLock.try_lock_shared(); }
 
 void Document::clearDocument(bool destroy) {
-    if (this->preview) {
-        cairo_surface_destroy(this->preview);
-        this->preview = nullptr;
-    }
+    this->preview.reset();
 
     if (!destroy) {
         // release lock
-        bool lastLock = tryLock();
+        bool lastLock = try_lock();
         unlock();
         this->handler->fireDocumentChanged(DOCUMENT_CHANGE_CLEARED);
         if (!lastLock)  // document was locked before
@@ -213,18 +192,9 @@ auto Document::createSaveFilename(DocumentType type, std::u8string_view defaultS
     return p;
 }
 
-auto Document::getPreview() const -> cairo_surface_t* { return this->preview; }
+auto Document::getPreview() const -> xoj::util::CairoSurfaceSPtr { return this->preview; }
 
-void Document::setPreview(cairo_surface_t* preview) {
-    if (this->preview) {
-        cairo_surface_destroy(this->preview);
-    }
-    if (preview) {
-        this->preview = cairo_surface_reference(preview);
-    } else {
-        this->preview = nullptr;
-    }
-}
+void Document::setPreview(xoj::util::CairoSurfaceSPtr preview) { this->preview = std::move(preview); }
 
 auto Document::getEvMetadataFilename() const -> fs::path {
     if (!this->filepath.empty()) {
@@ -486,7 +456,8 @@ auto Document::operator=(const Document& doc) -> Document& {
     buildContentsModel();
     updateIndexPageNumbers();
 
-    bool lastLock = tryLock();
+    bool lastLock = try_lock();
+    xoj_assert(!lastLock);
     unlock();
     this->handler->fireDocumentChanged(DOCUMENT_CHANGE_COMPLETE);
     if (!lastLock)  // document was locked before

--- a/src/core/model/Document.h
+++ b/src/core/model/Document.h
@@ -15,7 +15,7 @@
 
 #include <cstddef>        // for size_t
 #include <memory>         // for unique_ptr
-#include <mutex>          // for mutex
+#include <shared_mutex>   // for shared_mutex
 #include <string>         // for string
 #include <unordered_map>  // for unordered_map
 #include <vector>         // for vector
@@ -93,12 +93,15 @@ public:
 
     bool isAttachPdf() const;
 
-    cairo_surface_t* getPreview() const;
-    void setPreview(cairo_surface_t* preview);
+    xoj::util::CairoSurfaceSPtr getPreview() const;
+    void setPreview(xoj::util::CairoSurfaceSPtr preview);
 
     void lock();
     void unlock();
-    bool tryLock();
+    bool try_lock();
+    void lock_shared();
+    void unlock_shared();
+    bool try_lock_shared();
 
     inline Util::PathStorageMode getPathStorageMode() const { return pathStorageMode; }
     inline void setPathStorageMode(Util::PathStorageMode m) { pathStorageMode = m; }
@@ -165,12 +168,12 @@ private:
     /**
      * The preview for the file
      */
-    cairo_surface_t* preview = nullptr;
+    xoj::util::CairoSurfaceSPtr preview;
 
     /**
      * The lock of the document
      */
-    std::mutex documentLock;
+    std::shared_mutex documentLock;
 };
 
 template <class InputIter>

--- a/src/core/undo/InsertDeletePageUndoAction.cpp
+++ b/src/core/undo/InsertDeletePageUndoAction.cpp
@@ -62,9 +62,9 @@ auto InsertDeletePageUndoAction::deletePage(Control* control) -> bool {
     //***This might kill whatever we've got selected
     control->clearSelectionEndText();
 
-    doc->lock();
+    doc->lock_shared();
     auto pNr = doc->indexOf(page);
-    doc->unlock();
+    doc->unlock_shared();
     if (pNr == npos) {
         // this should not happen
         return false;


### PR DESCRIPTION
This PR improves the app's responsiveness by allowing several concurrent read-only accesses to the Document.

In practice, we use a shared_mutex and a shared lock for every read-only operations. Write operations still use the standard lock of the mutex.
It makes navigation way more fluid when opening heavy documents (see e.g. the document of #7224).

Note that for such documents, the rendering may still lag behind, but the user interface doesn't block anymore.