### PR TITLE
Show PDF page labels in toolbar page spinner

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -741,6 +741,7 @@ void Control::deletePage() {
     this->doc->unlock();
 
     this->undoRedo->addUndoAction(std::make_unique<InsertDeletePageUndoAction>(page, pNr, false));
+    const size_t deletedPos = pNr;
 
     if (pNr >= this->doc->getPageCount()) {
         pNr = this->doc->getPageCount() - 1;
@@ -748,6 +749,7 @@ void Control::deletePage() {
 
     scrollHandler->scrollToPage(pNr);
     this->win->getXournal()->forceUpdatePagenumbers();
+    notifyPageDeleted(deletedPos);
 }
 
 void Control::duplicatePage() {
@@ -792,6 +794,7 @@ void Control::movePageTowardsBeginning() {
     this->firePageSelected(currentPageNo - 1);
 
     this->getScrollHandler()->scrollToPage(currentPageNo - 1);
+    notifyPagesSwapped(currentPageNo - 1, currentPageNo);
 }
 
 
@@ -827,6 +830,7 @@ void Control::movePageTowardsEnd() {
     this->firePageSelected(currentPageNo + 1);
 
     this->getScrollHandler()->scrollToPage(currentPageNo + 1);
+    notifyPagesSwapped(currentPageNo, currentPageNo + 1);
 }
 
 /// Remove mnemonic indicators in menu labels
@@ -929,6 +933,7 @@ void Control::insertPage(const PageRef& page, size_t position, bool shouldScroll
     }
 
     updatePageActions();
+    notifyPageInserted(position, page);
 }
 
 void Control::gotoPage() {
@@ -1798,6 +1803,41 @@ void Control::buildAndPushPageLabels() {
     this->doc->unlock_shared();
 
     this->win->setPageLabels(anyNonStandard ? std::move(labels) : std::vector<std::string>{});
+}
+
+void Control::notifyPageInserted(size_t pos, const PageRef& page) {
+    if (!this->win) {
+        return;
+    }
+
+    std::string label;
+    if (page) {
+        const size_t pdfPageNr = page->getPdfPageNr();
+        if (pdfPageNr != npos) {
+            this->doc->lock_shared();
+            if (auto pdfPage = this->doc->getPdfPage(pdfPageNr)) {
+                label = pdfPage->getPageLabel();
+                if (label == std::to_string(pdfPageNr + 1)) {
+                    label.clear();
+                }
+            }
+            this->doc->unlock_shared();
+        }
+    }
+
+    this->win->insertPageLabel(pos, std::move(label));
+}
+
+void Control::notifyPageDeleted(size_t pos) {
+    if (this->win) {
+        this->win->deletePageLabel(pos);
+    }
+}
+
+void Control::notifyPagesSwapped(size_t a, size_t b) {
+    if (this->win) {
+        this->win->swapPageLabels(a, b);
+    }
 }
 
 enum class MissingPdfDialogOptions : gint { USE_PROPOSED, SELECT_OTHER, REMOVE, CANCEL };

--- a/src/core/control/Control.h
+++ b/src/core/control/Control.h
@@ -376,6 +376,10 @@ public:
     inline ActionDatabase* getActionDatabase() const { return actionDB.get(); }
     void loadPaletteFromSettings();
 
+    void notifyPageInserted(size_t pos, const PageRef& page);
+    void notifyPageDeleted(size_t pos);
+    void notifyPagesSwapped(size_t a, size_t b);
+
 protected:
     void setRotationSnapping(bool enable);
     void setGridSnapping(bool enable);
@@ -401,10 +405,6 @@ protected:
 
     void saveImpl(bool saveAs, std::function<void(bool)> callback);
 
-    /**
-     * Collect PDF page labels from the loaded document and push them to the toolbar
-     * Call once after each document load
-     */
     void buildAndPushPageLabels();
 
 private:

--- a/src/core/gui/MainWindow.cpp
+++ b/src/core/gui/MainWindow.cpp
@@ -713,6 +713,10 @@ void MainWindow::updatePageNumbers(size_t page, size_t pagecount) { toolbar->set
 
 void MainWindow::setPageLabels(std::vector<std::string> labels) { toolbar->setPageLabels(std::move(labels)); }
 
+void MainWindow::insertPageLabel(size_t pos, std::string label) { toolbar->insertPageLabel(pos, std::move(label)); }
+void MainWindow::deletePageLabel(size_t pos) { toolbar->deletePageLabel(pos); }
+void MainWindow::swapPageLabels(size_t a, size_t b) { toolbar->swapPageLabels(a, b); }
+
 auto MainWindow::getMenubar() const -> Menubar* { return menubar.get(); }
 
 void MainWindow::show(GtkWindow* parent) { gtk_widget_show(this->window); }

--- a/src/core/gui/MainWindow.h
+++ b/src/core/gui/MainWindow.h
@@ -75,6 +75,9 @@ public:
 
     void updatePageNumbers(size_t page, size_t pagecount);
     void setPageLabels(std::vector<std::string> labels);
+    void insertPageLabel(size_t pos, std::string label);
+    void deletePageLabel(size_t pos);
+    void swapPageLabels(size_t a, size_t b);
 
     void setMaximized(bool maximized);
     bool isMaximized() const;

--- a/src/core/gui/toolbarMenubar/ToolMenuHandler.cpp
+++ b/src/core/gui/toolbarMenubar/ToolMenuHandler.cpp
@@ -524,6 +524,24 @@ void ToolMenuHandler::setPageLabels(std::vector<std::string> labels) {
     }
 }
 
+void ToolMenuHandler::insertPageLabel(size_t pos, std::string label) {
+    if (this->toolPageSpinner) {
+        this->toolPageSpinner->insertPageLabel(pos, std::move(label));
+    }
+}
+
+void ToolMenuHandler::deletePageLabel(size_t pos) {
+    if (this->toolPageSpinner) {
+        this->toolPageSpinner->deletePageLabel(pos);
+    }
+}
+
+void ToolMenuHandler::swapPageLabels(size_t a, size_t b) {
+    if (this->toolPageSpinner) {
+        this->toolPageSpinner->swapPageLabels(a, b);
+    }
+}
+
 auto ToolMenuHandler::getModel() -> ToolbarModel* { return this->tbModel.get(); }
 
 auto ToolMenuHandler::getControl() -> Control* { return this->control; }

--- a/src/core/gui/toolbarMenubar/ToolMenuHandler.h
+++ b/src/core/gui/toolbarMenubar/ToolMenuHandler.h
@@ -91,6 +91,9 @@ public:
 
     void setPageInfo(size_t currentPage, size_t pageCount);
     void setPageLabels(std::vector<std::string> labels);
+    void insertPageLabel(size_t pos, std::string label);
+    void deletePageLabel(size_t pos);
+    void swapPageLabels(size_t a, size_t b);
 
     [[maybe_unused]] void removeColorToolItem(AbstractToolItem* it);
     void addColorToolItem(std::unique_ptr<ColorToolItem> it);

--- a/src/core/gui/toolbarMenubar/ToolPageSpinner.cpp
+++ b/src/core/gui/toolbarMenubar/ToolPageSpinner.cpp
@@ -78,8 +78,26 @@ public:
     }
 
     void setLabels(std::vector<std::string> labels) {
-        hasLabels = !labels.empty();
+        hasLabels = false;
+        for (const auto& label: labels) {
+            if (!label.empty()) {
+                hasLabels = true;
+                break;
+            }
+        }
         spinner.setLabels(std::move(labels));
+    }
+    void insertLabel(size_t pos, std::string label) {
+        spinner.insertLabel(pos, std::move(label));
+        hasLabels = spinner.hasAnyLabels();
+    }
+    void deleteLabel(size_t pos) {
+        spinner.deleteLabel(pos);
+        hasLabels = spinner.hasAnyLabels();
+    }
+    void swapLabels(size_t a, size_t b) {
+        spinner.swapLabels(a, b);
+        hasLabels = spinner.hasAnyLabels();
     }
     ToolPageSpinner* getHandler() const { return handler; }
 
@@ -87,7 +105,6 @@ private:
     void updateLabel(size_t currentPage1based, size_t pageCount) {
         std::string ofString;
         if (hasLabels) {
-            // The spinner displays the PDF label; show the physical index for cross-reference.
             ofString = std::to_string(currentPage1based) +
                        FS(C_F("Page {pagenumber} \"of {pagecount}\"", " of {1}") % pageCount);
         } else {
@@ -120,6 +137,28 @@ void ToolPageSpinner::setPageLabels(std::vector<std::string> labels) {
         (*it)->setLabels(labels);
     }
     instances.back()->setLabels(std::move(labels));
+}
+
+void ToolPageSpinner::insertPageLabel(size_t pos, std::string label) {
+    if (instances.empty()) {
+        return;
+    }
+    for (auto it = instances.begin(); it != std::prev(instances.end()); ++it) {
+        (*it)->insertLabel(pos, label);
+    }
+    instances.back()->insertLabel(pos, std::move(label));
+}
+
+void ToolPageSpinner::deletePageLabel(size_t pos) {
+    for (auto* i: instances) {
+        i->deleteLabel(pos);
+    }
+}
+
+void ToolPageSpinner::swapPageLabels(size_t a, size_t b) {
+    for (auto* i: instances) {
+        i->swapLabels(a, b);
+    }
 }
 
 auto ToolPageSpinner::getToolDisplayName() const -> std::string { return _("Page number"); }

--- a/src/core/gui/toolbarMenubar/ToolPageSpinner.h
+++ b/src/core/gui/toolbarMenubar/ToolPageSpinner.h
@@ -32,10 +32,11 @@ public:
     ~ToolPageSpinner() override;
 
 public:
-    /// Propagates the info to all instances of the Page Spinner
     void setPageInfo(size_t currentPage, size_t pageCount);
-    /// Set PDF page labels for the loaded document.
     void setPageLabels(std::vector<std::string> labels);
+    void insertPageLabel(size_t pos, std::string label);
+    void deletePageLabel(size_t pos);
+    void swapPageLabels(size_t a, size_t b);
     std::string getToolDisplayName() const override;
     xoj::util::WidgetSPtr createItem(bool horizontal) override;
 

--- a/src/core/gui/widgets/SpinPageAdapter.cpp
+++ b/src/core/gui/widgets/SpinPageAdapter.cpp
@@ -1,7 +1,9 @@
 #include "SpinPageAdapter.h"
 
+#include <algorithm>  // for min
 #include <cstdint>  // for uint64_t
-#include <string>   // for string, stoul
+#include <string>   // for string
+#include <utility>  // for swap
 
 #include <glib-object.h>  // for g_signal_handler_disconnect, G_CALLBACK
 
@@ -77,17 +79,47 @@ void SpinPageAdapter::removeListener(SpinPageListener* listener) {
 
 void SpinPageAdapter::setLabels(std::vector<std::string> newLabels) {
     this->labels = std::move(newLabels);
-    this->labelToPage.clear();
-    for (size_t i = 0; i < this->labels.size(); ++i) {
-        if (!this->labels[i].empty()) {
-            this->labelToPage[this->labels[i]] = i + 1;
-        }
-    }
     if (this->widget) {
         gtk_spin_button_set_numeric(GTK_SPIN_BUTTON(this->widget.get()), this->labels.empty() ? TRUE : FALSE);
         gboolean did_output = FALSE;
         g_signal_emit_by_name(this->widget.get(), "output", &did_output);
     }
+}
+
+void SpinPageAdapter::insertLabel(size_t pos, std::string label) {
+    if (this->labels.empty()) {
+        if (label.empty()) {
+            return;
+        }
+        this->labels.resize(this->max);
+    }
+    if (this->labels.empty()) {
+        return;
+    }
+    this->labels.insert(this->labels.begin() + std::min(pos, this->labels.size()), std::move(label));
+}
+
+void SpinPageAdapter::deleteLabel(size_t pos) {
+    if (this->labels.empty() || pos >= this->labels.size()) {
+        return;
+    }
+    this->labels.erase(this->labels.begin() + pos);
+}
+
+void SpinPageAdapter::swapLabels(size_t a, size_t b) {
+    if (this->labels.empty() || a >= this->labels.size() || b >= this->labels.size()) {
+        return;
+    }
+    std::swap(this->labels[a], this->labels[b]);
+}
+
+auto SpinPageAdapter::hasAnyLabels() const -> bool {
+    for (const auto& lbl: this->labels) {
+        if (!lbl.empty()) {
+            return true;
+        }
+    }
+    return false;
 }
 
 gboolean SpinPageAdapter::spinOutputCallback(GtkSpinButton* spin, SpinPageAdapter* adapter) {
@@ -108,23 +140,16 @@ gint SpinPageAdapter::spinInputCallback(GtkSpinButton* spin, gdouble* newValue, 
     }
     const std::string input(gtk_entry_get_text(GTK_ENTRY(spin)));
 
-    auto it = adapter->labelToPage.find(input);
-    if (it != adapter->labelToPage.end()) {
-        *newValue = static_cast<gdouble>(it->second);
-        return TRUE;
-    }
-
-    // Fall back to numeric page index
-    try {
-        std::size_t pos = 0;
-        const unsigned long page = std::stoul(input, &pos);
-        if (pos == input.size() && page >= adapter->min && page <= adapter->max) {
-            *newValue = static_cast<gdouble>(page);
+    const size_t labelCount = adapter->labels.size();
+    const size_t startIndex = labelCount == 0 ? 0 : adapter->page % labelCount;
+    for (size_t offset = 0; offset < labelCount; ++offset) {
+        const size_t idx = (startIndex + offset) % labelCount;
+        if (adapter->labels[idx] == input) {
+            *newValue = static_cast<gdouble>(idx + 1);
             return TRUE;
         }
-    } catch (...) {}
+    }
 
-    // Invalid input, keep the current page rather than jumping to page 1
     *newValue = static_cast<gdouble>(adapter->page);
     return TRUE;
 }

--- a/src/core/gui/widgets/SpinPageAdapter.h
+++ b/src/core/gui/widgets/SpinPageAdapter.h
@@ -11,11 +11,10 @@
 
 #pragma once
 
-#include <cstddef>        // for size_t
-#include <list>           // for list
-#include <string>         // for string
-#include <unordered_map>  // for unordered_map
-#include <vector>         // for vector
+#include <cstddef>  // for size_t
+#include <list>     // for list
+#include <string>   // for string
+#include <vector>   // for vector
 
 #include <glib.h>     // for guint, gulong
 #include <gtk/gtk.h>  // for GtkWidget, GtkSpinButton
@@ -43,8 +42,11 @@ public:
     void addListener(SpinPageListener* listener);
     void removeListener(SpinPageListener* listener);
 
-    /// Set PDF page labels (one per xournal page). Empty vector restores numeric mode.
     void setLabels(std::vector<std::string> labels);
+    void insertLabel(size_t pos, std::string label);
+    void deleteLabel(size_t pos);
+    void swapLabels(size_t a, size_t b);
+    bool hasAnyLabels() const;
 
 private:
     static bool pageNrSpinChangedTimerCallback(SpinPageAdapter* adapter);
@@ -68,7 +70,6 @@ private:
     size_t max = 0;
 
     std::vector<std::string> labels;
-    std::unordered_map<std::string, size_t> labelToPage;  ///< label → 1-based xournal page number
 };
 
 class SpinPageListener {

--- a/src/core/undo/InsertDeletePageUndoAction.cpp
+++ b/src/core/undo/InsertDeletePageUndoAction.cpp
@@ -50,6 +50,7 @@ auto InsertDeletePageUndoAction::insertPage(Control* control) -> bool {
     control->firePageInserted(this->pagePos);
     control->getCursor()->updateCursor();
     control->getScrollHandler()->scrollToPage(this->pagePos);
+    control->notifyPageInserted(this->pagePos, this->page);
 
     return true;
 }
@@ -75,6 +76,7 @@ auto InsertDeletePageUndoAction::deletePage(Control* control) -> bool {
     doc->lock();
     doc->deletePage(pNr);
     doc->unlock();
+    control->notifyPageDeleted(pNr);
     return true;
 }
 

--- a/src/core/undo/SwapUndoAction.cpp
+++ b/src/core/undo/SwapUndoAction.cpp
@@ -55,6 +55,7 @@ void SwapUndoAction::swap(Control* control) {
     control->firePageSelected(insertPos);
 
     control->getScrollHandler()->scrollToPage(insertPos);
+    control->notifyPagesSwapped(insertPos, deletePos);
 }
 
 auto SwapUndoAction::getPages() -> std::vector<PageRef> {


### PR DESCRIPTION
## Problem

when using PDFs with non-sequential page labels (roman numerals, named front matter, ...) page spinner show pages indexed starting from 1, in order to navigate to a page you had to know the page shift (the diff between actual page order and its index order), then add it to the page number

## Changes

PDFs with non-sequential page labels now show those labels in the toolbar page spinner instead of the raw page index

At document load, `buildAndPushPageLabels` walks the xournal pages, reads their PDF page labels, and filters out any label that matches its numeric index. If any non-standard labels are found the full label vector is pushed to `SpinPageAdapter` via a `setPageLabels` path

The spinner entry then displays the PDF label and accepts label input for navigation, with a fallback to numeric page index for unlabelled pages or plain number input

As a cleanup, the `pdfPage` parameter is dropped from the `setPageInfo` call stack it was only used to show "PDF Page N" in the label

<sub>sorry for strange commit names I will clean them up on squash</sub>