### PR TITLE
docs: fix outdated build requirements (C++20, Ninja required, compiler minimums)

### DIFF
--- a/readme/Compile.md
+++ b/readme/Compile.md
@@ -20,7 +20,7 @@ For testing purposes, install in a subdirectory:
 mkdir build
 cd build
 
-cmake .. -DCMAKE_INSTALL_PREFIX=install
+cmake .. -DCMAKE_INSTALL_PREFIX=install -G Ninja
 
 cmake --build . # For a faster build, set the flag -DCMAKE_BUILD_TYPE=RelWithDebInfo
 cmake --build . --target install
@@ -48,7 +48,7 @@ download and build `googletest`.
 mkdir build
 cd build
 
-cmake .. -DENABLE_GTEST=on
+cmake .. -DENABLE_GTEST=on -G Ninja
 
 # Build unit test executables
 cmake --build . --target test-units

--- a/readme/LinuxBuild.md
+++ b/readme/LinuxBuild.md
@@ -2,9 +2,9 @@
 
 ## Introduction
 
-Xournal++ is programmed with C++17 and needs the `<optional>` header and one filesystem library, either the STL or the boost implementation.
+Xournal++ is programmed with C++20.
 Therefore it is required to install a compiler implementing those features.
-We recommend using at least GCC 8 or Clang 9.
+We recommend using at least GCC 11 or Clang 15.
 
 Please file an issue or create a pull request if you require more precise dependencies.
 
@@ -12,39 +12,39 @@ Lua is needed for plugins; if it is missing, the plugins will be disabled.
 
 ### Install Dependencies
 
-The minimum required CMake version is 3.13, but we recommend using >=3.15. Also, either `make` or `ninja` must be installed.
+The minimum required CMake version is 3.13, but we recommend using >=3.15. Also, `ninja` must be installed (the `cpptrace` dependency uses C++20 modules, which are not supported by the Unix Makefiles generator).
 
 #### For Arch Linux:
 ```sh
-sudo pacman -S cmake gtk3 base-devel libxml2 portaudio libsndfile \
+sudo pacman -S cmake ninja gtk3 base-devel libxml2 portaudio libsndfile \
   poppler-glib texlive-bin texlive-pictures libzip lua \
   gtksourceview4 help2man qpdf
 ```
 
 #### For Fedora:
 ```sh
-sudo dnf install gcc-c++ cmake gtk3-devel libxml2-devel portaudio-devel libsndfile-devel \
+sudo dnf install gcc-c++ cmake ninja-build gtk3-devel libxml2-devel portaudio-devel libsndfile-devel \
   poppler-glib-devel texlive-scheme-basic texlive-dvipng 'tex(standalone.cls)' gettext libzip-devel \
   librsvg2-devel lua-devel gtksourceview4-devel help2man qpdf-devel
 ```
 
 #### For CentOS/RHEL:
 ```sh
-sudo dnf install gcc-c++ cmake gtk3-devel libxml2-devel cppunit-devel portaudio-devel libsndfile-devel \
+sudo dnf install gcc-c++ cmake ninja-build gtk3-devel libxml2-devel cppunit-devel portaudio-devel libsndfile-devel \
   poppler-glib-devel texlive-scheme-basic texlive-dvipng 'tex(standalone.cls)' gettext libzip-devel \
   librsvg2-devel gtksourceview4-devel qpdf-devel
 ```
 
 #### For Ubuntu/Debian and Raspberry Pi OS:
 ```sh
-sudo apt-get install cmake libgtk-3-dev libpoppler-glib-dev portaudio19-dev libsndfile-dev \
+sudo apt-get install cmake ninja-build libgtk-3-dev libpoppler-glib-dev portaudio19-dev libsndfile-dev \
   dvipng texlive libxml2-dev liblua5.4-dev libzip-dev librsvg2-dev gettext \
   libgtksourceview-4-dev help2man libqpdf-dev
 ```
 
 #### For openSUSE:
 ```sh
-sudo zypper install gcc-c++ cmake gtk3-devel portaudio-devel libsndfile-devel \
+sudo zypper install gcc-c++ cmake ninja gtk3-devel portaudio-devel libsndfile-devel \
   texlive-dvipng texlive libxml2-devel libpoppler-glib-devel libzip-devel librsvg-devel lua-devel \
   gtksourceview4-devel lsb-release help2man qpdf-devel
 ```
@@ -52,7 +52,7 @@ sudo zypper install gcc-c++ cmake gtk3-devel portaudio-devel libsndfile-devel \
 #### For Solus:
 ```sh
 sudo eopkg it -c system.devel
-sudo eopkg it cmake libgtk-3-devel libxml2-devel poppler-devel libzip-devel \
+sudo eopkg it cmake ninja libgtk-3-devel libxml2-devel poppler-devel libzip-devel \
   portaudio-devel libsndfile-devel alsa-lib-devel lua-devel \
   librsvg-devel gettext libgtksourceview-devel qpdf-devel
 ```
@@ -79,7 +79,7 @@ can be found in `doc/html` and `doc/latex`. Launch a server hosting the files wi
 ### `.deb` packages
 
 ```sh
-cmake .. -DCPACK_GENERATOR="DEB" ..
+cmake .. -DCPACK_GENERATOR="DEB" -G Ninja
 cmake --build . --target package
 ```
 
@@ -94,7 +94,7 @@ package and then use that with the `linux-setup/build_appimage.sh`
 script.
 
 ```sh
-cmake .. -DCPACK_GENERATOR="TGZ"
+cmake .. -DCPACK_GENERATOR="TGZ" -G Ninja
 cmake --build . --target package
 ../linux-setup/build_appimage.sh
 ```
@@ -147,7 +147,7 @@ If you don't want to make a package, you can install Xournal++ into your user
 folder (or any other folder) by specifying `CMAKE_INSTALL_PREFIX`:
 
 ```sh
-cmake .. -DCMAKE_INSTALL_PREFIX="$HOME/.local"
+cmake .. -DCMAKE_INSTALL_PREFIX="$HOME/.local" -G Ninja
 cmake --build . --target install
 ./cmake/postinst configure
 ```
@@ -155,7 +155,7 @@ cmake --build . --target install
 If you want to install Xournal++ system-wide directly from the build directory, run
 
 ```sh
-cmake .. -DCMAKE_INSTALL_PREFIX=/usr
+cmake .. -DCMAKE_INSTALL_PREFIX=/usr -G Ninja
 sudo cmake --build . --target install
 ./cmake/postinst configure
 ```


### PR DESCRIPTION
The build documentation had several outdated or incorrect entries, This PR update them

## Changes

`readme/Compile.md`

- Add `-G Ninja` to all `cmake` configure commands (required due to `cpptrace` using C++20 modules, which are unsupported by the Unix Makefiles generator)

`readme/LinuxBuild.md`

- Update C++ standard: C++17 → C++20 (#6676)
- Update minimum compiler: GCC 8/Clang 9 -> GCC 11/Clang 15 (https://en.cppreference.com/w/cpp/compiler_support/20)
- `ninja` is now a required dependency, not optional, add it to all distro install commands and all `cmake` configure commands

## Root cause

`cpptrace` (added in #6777) uses C++20 modules. CMake only supports C++20 modules with the Ninja generator