### PR TITLE
Fixes for shebang lines

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,4 +1,4 @@
-#!/usr/bin/make -f
+#!/usr/bin/env -S make -f
 
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 

--- a/scripts/color-names
+++ b/scripts/color-names
@@ -1,4 +1,4 @@
-#! /bin/python3
+#!/usr/bin/env python3
 
 from functools import partial
 from math import sqrt

--- a/scripts/lua_def_file.py
+++ b/scripts/lua_def_file.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import re
 import sys

--- a/src/xoj-preview-extractor/desktop-install.sh
+++ b/src/xoj-preview-extractor/desktop-install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 export GCONF_CONFIG_SOURCE=`gconftool-2 --get-default-source`
 gconftool-2 --makefile-$1-rule xournalpp-thumbnailer-xoj.schemas

--- a/windows-setup/package.sh
+++ b/windows-setup/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Windows packaging script. This does the following:
 # 1. Run "install" target from CMake into setup folder


### PR DESCRIPTION
As title says, these are changes to shebang lines to be more portable by using env instead of calling the binaries (e.g., python3) directly to (1) maintain compatibility with non-FHS compliant operating systems (e.g., NixOS) and (2) use the preferred binaries in the user's path. 

This is a new, more exhaustive PR (and rebased on release-1.3) instead of the earlier one I made.