### PR TITLE
fix(gui): add null check before calling draw() in createPreviewImage

### DIFF
--- a/src/core/gui/CreatePreviewImage.cpp
+++ b/src/core/gui/CreatePreviewImage.cpp
@@ -19,7 +19,9 @@ auto createPreviewImage(const PageType& pt) -> GtkWidget* {
 
     auto bgView = xoj::view::BackgroundView::createRuled(PREVIEW_WIDTH / zoom, PREVIEW_HEIGHT / zoom, Colors::white, pt,
                                                          1. / zoom);
-    bgView->draw(cr);
+    if (bgView) {
+        bgView->draw(cr);
+    }
 
     cairo_identity_matrix(cr);
 


### PR DESCRIPTION
## Bug Description

Fixes #7270 - Crash when accessing the page template dialog.

## Root Cause Analysis

The function <code>xoj::view::BackgroundView::createRuled()</code> can return <code>nullptr</code> for special page types (Pdf, Image) or unknown types. The code in <code>createPreviewImage()</code> was calling <code>bgView->draw(cr)</code> without checking if <code>bgView</code> was null, causing a segmentation fault when the page template dialog is accessed with certain page types.

## Fix

Added a null check before calling <code>draw()</code> to prevent the crash. When <code>bgView</code> is null, the function will still create a preview image (showing just the border), which is a reasonable fallback for special page types that cannot be rendered with a ruled background.

## Changes

- <code>src/core/gui/CreatePreviewImage.cpp</code>: Added null check before calling <code>bgView->draw(cr)</code>

## Testing

The fix prevents the null pointer dereference by checking if <code>bgView</code> is valid before calling methods on it. This is a minimal, defensive fix that addresses the root cause of the crash.