### PR TITLE
fix(control): handle audio initialization failure gracefully

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -12,6 +12,9 @@
 #include <utility>     // for move
 
 #include "control/AudioController.h"                             // for Audi...
+#ifdef ENABLE_AUDIO
+#include <portaudiocpp/PortAudioCpp.hxx>  // for PaException
+#endif
 #include "control/ClipboardHandler.h"                            // for Clip...
 #include "control/CompassController.h"                           // for Comp...
 #include "control/NavigationHistory.h"                           // for Navi...
@@ -140,7 +143,13 @@ Control::Control(GApplication* gtkApp, GladeSearchpath* gladeSearchPath, bool di
 
 #ifdef ENABLE_AUDIO
     if (!(disableAudio || this->settings->isAudioDisabled())) {
-        this->audioController = std::make_unique<AudioController>(this->settings, this);
+        try {
+            this->audioController = std::make_unique<AudioController>(this->settings, this);
+        } catch (const portaudio::PaException& e) {
+            g_warning("Audio initialization failed: %s. Continuing without audio support.", e.what());
+        } catch (const std::exception& e) {
+            g_warning("Audio initialization failed: %s. Continuing without audio support.", e.what());
+        }
     }
 #endif
 


### PR DESCRIPTION
Fixes #7271

When PortAudio initialization fails (e.g., due to missing or misconfigured PulseAudio/JACK), the application crashes with a SIGSEGV. This happens because `portaudio::AutoSystem` throws an exception during `AudioController` construction, which propagates up and terminates the application.

**Changes:**
- Wrap `AudioController` creation in a try-catch block
- Catch `portaudio::PaException` and `std::exception` to handle initialization failures gracefully
- Log a warning message when audio initialization fails
- Allow the application to continue without audio support instead of crashing

**Testing:**
- The fix follows the existing error handling patterns used in `PortAudioProducer.cpp` and `PortAudioConsumer.cpp`
- When audio initialization fails, the app continues normally with `audioController` set to `nullptr`, which the rest of the codebase already handles gracefully

---
*This PR was prepared by [ClawOSS](https://github.com/kevinlin/clawOSS), an autonomous codebase helper.*