### PR TITLE
Plugin API to get current Scroll position

### DIFF
--- a/plugins/luapi_application.def.lua
+++ b/plugins/luapi_application.def.lua
@@ -730,7 +730,8 @@ function app.scrollToPage(page, relative) end
 --- scrolls to absolute pixel coordinates (200, 50) from top left corner of the layout (absolute mode)
 function app.scrollToPos(x, y, relative) end
 
---- Obtains the current absolute scroll position (position on the whole layout) and width and height of the currently visible window, measured in pixels.
+--- Obtains the current absolute scroll position (position on the whole layout) and width and height of the currently
+--- visible window, measured in pixels.
 --- 
 --- @return {x:number, y:number, width:number, height:number}
 --- 

--- a/src/core/plugin/luapi_application.h
+++ b/src/core/plugin/luapi_application.h
@@ -2647,7 +2647,8 @@ static int applib_scrollToPos(lua_State* L) {
 }
 
 /**
- * Obtains the current absolute scroll position (position on the whole layout) and width and height of the currently visible window, measured in pixels.
+ * Obtains the current absolute scroll position (position on the whole layout) and width and height of the currently
+ * visible window, measured in pixels.
  *
  * @return {x:number, y:number, width:number, height:number}
  *


### PR DESCRIPTION
This would be the pull reqeust to #7190. 

This adds the functionality to the api to get the current scroll position.