### PR TITLE
fix(core): use classic locale to prevent crash on Windows ARM64

### DIFF
--- a/src/core/control/XournalMain.cpp
+++ b/src/core/control/XournalMain.cpp
@@ -77,7 +77,7 @@ void initCAndCoutLocales() {
      */
     setlocale(LC_NUMERIC, "C");
 
-    std::cout.imbue(std::locale());
+    std::cout.imbue(std::locale::classic());
 }
 
 auto migrateSettings() -> MigrateResult {

--- a/src/xoj-preview-extractor/xournalpp-thumbnailer.cpp
+++ b/src/xoj-preview-extractor/xournalpp-thumbnailer.cpp
@@ -47,8 +47,13 @@ void initLocalisation() {
     textdomain(GETTEXT_PACKAGE);
 #endif  // ENABLE_NLS
 
-    std::locale::global(std::locale(""));  //"" - system default locale
-    std::cout.imbue(std::locale());
+    try {
+        std::locale::global(std::locale(""));  //"" - system default locale
+    } catch (const std::runtime_error& e) {
+        // System default locale not supported, fall back to classic locale
+        std::locale::global(std::locale::classic());
+    }
+    std::cout.imbue(std::locale::classic());
 }
 
 void logMessage(string msg, bool error) {


### PR DESCRIPTION
Using `std::locale()` can throw "locale not supported" on Windows ARM64 with certain system locale configurations when importing PDF files.

The `initCAndCoutLocales()` function in XournalMain.cpp and `initLocalisation()` in xournalpp-thumbnailer.cpp now use `std::locale::classic()` instead of `std::locale()`. The classic "C" locale is always available and won't throw exceptions.

Also wrapped the locale initialization in a try-catch block in the thumbnailer code for extra safety.

Fixes #7276