### PR TITLE
fix: Use classic locale to prevent crash on Windows ARM64

### DIFF
--- a/src/core/control/XournalMain.cpp
+++ b/src/core/control/XournalMain.cpp
@@ -77,7 +77,13 @@ void initCAndCoutLocales() {
      */
     setlocale(LC_NUMERIC, "C");
 
-    std::cout.imbue(std::locale());
+    // Use classic locale to avoid issues when the global locale is not supported (e.g., Windows ARM64)
+    // See issue #7276
+    try {
+        std::cout.imbue(std::locale::classic());
+    } catch (const std::runtime_error& e) {
+        g_warning("XournalMain: Could not imbue cout with classic locale: %s", e.what());
+    }
 }
 
 auto migrateSettings() -> MigrateResult {

--- a/src/xoj-preview-extractor/xournalpp-thumbnailer.cpp
+++ b/src/xoj-preview-extractor/xournalpp-thumbnailer.cpp
@@ -47,8 +47,18 @@ void initLocalisation() {
     textdomain(GETTEXT_PACKAGE);
 #endif  // ENABLE_NLS
 
-    std::locale::global(std::locale(""));  //"" - system default locale
-    std::cout.imbue(std::locale());
+    // Use classic locale to avoid issues when the system locale is not supported (e.g., Windows ARM64)
+    // See issue #7276
+    try {
+        std::locale::global(std::locale::classic());
+    } catch (const std::runtime_error& e) {
+        // If classic locale fails, there's nothing we can do. Continue with the default locale.
+    }
+    try {
+        std::cout.imbue(std::locale::classic());
+    } catch (const std::runtime_error& e) {
+        // If imbue fails, continue without it.
+    }
 }
 
 void logMessage(string msg, bool error) {


### PR DESCRIPTION
Fixes #7276

## Problem
On Windows 11 ARM64, `std::locale("")` throws `std::runtime_error` because the system locale is not supported. When this exception is caught and the application continues, subsequent `std::locale()` calls can also fail because the global locale is left in an indeterminate state.

This causes the application to crash when users try to import a PDF file.

## Solution
This fix:
1. Uses `std::locale::classic()` instead of `std::locale()` in `initCAndCoutLocales()` to ensure consistent behavior even when the global locale is not set properly.
2. Adds exception handling around the `imbue()` call to catch any remaining edge cases.
3. Applies the same fix to the thumbnailer application.

The classic "C" locale is always available and provides consistent behavior for number formatting, which is what we need for the Cairo PDF export functionality (see #3551).