### PR TITLE
fix(XournalMain): Catch locale exceptions on Windows

### DIFF
--- a/src/core/control/XournalMain.cpp
+++ b/src/core/control/XournalMain.cpp
@@ -503,7 +503,13 @@ void on_startup(GApplication* application, XMPtr app_data) {
 }
 
 auto on_handle_local_options(GApplication*, GVariantDict*, XMPtr app_data) -> gint {
-    initCAndCoutLocales();
+    try {
+        initCAndCoutLocales();
+    } catch (const std::runtime_error& e) {
+        g_warning("XournalMain: C locale could not be set.\n - Caused by: %s\n - Note that it is not "
+                  "supported to set the locale using mingw-w64 on windows.",
+                  e.what());
+    }
 
     auto print_version = [&] { std::cout << xoj::util::getVersionInfo() << std::endl; };
 
@@ -599,7 +605,13 @@ void XournalMain::initLocalisation() {
                   e.what());
     }
 
-    initCAndCoutLocales();
+    try {
+        initCAndCoutLocales();
+    } catch (const std::runtime_error& e) {
+        g_warning("XournalMain: C locale could not be set for streams.\n - Caused by: %s\n - Note that it is not "
+                  "supported to set the locale using mingw-w64 on windows.",
+                  e.what());
+    }
 }
 
 auto XournalMain::run(int argc, char** argv) -> int {

--- a/src/xoj-preview-extractor/xournalpp-thumbnailer.cpp
+++ b/src/xoj-preview-extractor/xournalpp-thumbnailer.cpp
@@ -47,8 +47,22 @@ void initLocalisation() {
     textdomain(GETTEXT_PACKAGE);
 #endif  // ENABLE_NLS
 
-    std::locale::global(std::locale(""));  //"" - system default locale
-    std::cout.imbue(std::locale());
+    // Not working on GNU g++(mingww) forWindows! Only working on Linux/macOS and with msvc
+    try {
+        std::locale::global(std::locale(""));  //"" - system default locale
+    } catch (const std::runtime_error& e) {
+        g_warning("xoj-preview-extractor: System default locale could not be set.\n - Caused by: %s\n - Note that it is not "
+                  "supported to set the locale using mingw-w64 on windows.",
+                  e.what());
+    }
+
+    try {
+        std::cout.imbue(std::locale());
+    } catch (const std::runtime_error& e) {
+        g_warning("xoj-preview-extractor: C++ locale could not be set for std::cout.\n - Caused by: %s\n - Note that it is not "
+                  "supported to set the locale using mingw-w64 on windows.",
+                  e.what());
+    }
 }
 
 void logMessage(string msg, bool error) {


### PR DESCRIPTION
This PR fixes #7276.

**Root Cause:**
On Windows with mingw-w64, calling std::locale(\"\") or std::cout.imbue(std::locale()) throws a std::runtime_error when the system locale is not supported by the C++ standard library implementation. This caused the application to crash when users tried to import/annotate PDFs.

**Changes:**
- Wrap initCAndCoutLocales() call in on_handle_local_options() with try-catch
- Wrap initCAndCoutLocales() call in initLocalisation() with try-catch  
- Add try-catch protection to locale setup in xoj-preview-extractor/xournalpp-thumbnailer.cpp

Each caught exception logs a warning message (consistent with existing code) rather than crashing the application.

**Testing:**
This fix prevents the crash described in #7276. The application will continue to function even if the locale cannot be set, falling back to the C locale.
