### PR TITLE
fix: prevent crash when system locale is not supported

### DIFF
--- a/src/core/control/XournalMain.cpp
+++ b/src/core/control/XournalMain.cpp
@@ -77,7 +77,11 @@ void initCAndCoutLocales() {
      */
     setlocale(LC_NUMERIC, "C");
 
-    std::cout.imbue(std::locale());
+    try {
+        std::cout.imbue(std::locale());
+    } catch (const std::runtime_error& e) {
+        g_warning("Failed to imbue cout with locale: %s", e.what());
+    }
 }
 
 auto migrateSettings() -> MigrateResult {
@@ -592,14 +596,13 @@ void XournalMain::initLocalisation() {
     // Not working on GNU g++(mingww) forWindows! Only working on Linux/macOS and with msvc
     try {
         std::locale::global(std::locale(""));  // "" - system default locale
+        initCAndCoutLocales();
     } catch (const std::runtime_error& e) {
         g_warning("XournalMain: System default locale could not be set.\n - Caused by: %s\n - Note that it is not "
                   "supported to set the locale using mingw-w64 on windows.\n - This could be solved by compiling "
                   "xournalpp with msvc",
                   e.what());
     }
-
-    initCAndCoutLocales();
 }
 
 auto XournalMain::run(int argc, char** argv) -> int {

--- a/src/xoj-preview-extractor/xournalpp-thumbnailer.cpp
+++ b/src/xoj-preview-extractor/xournalpp-thumbnailer.cpp
@@ -47,8 +47,14 @@ void initLocalisation() {
     textdomain(GETTEXT_PACKAGE);
 #endif  // ENABLE_NLS
 
-    std::locale::global(std::locale(""));  //"" - system default locale
-    std::cout.imbue(std::locale());
+    try {
+        std::locale::global(std::locale(""));  // "" - system default locale
+        std::cout.imbue(std::locale());
+    } catch (const std::runtime_error& e) {
+        // Fallback to classic locale if system locale is not supported
+        std::locale::global(std::locale::classic());
+        std::cout.imbue(std::locale::classic());
+    }
 }
 
 void logMessage(string msg, bool error) {


### PR DESCRIPTION
**Problem:**
The application crashes with `std::runtime_error: locale not supported` when importing PDFs on Windows ARM64 (and potentially other platforms) where the system locale is not supported by the C++ standard library.

**Root Cause:**
In `XournalMain::initLocalisation()`, the `initCAndCoutLocales()` function was called OUTSIDE the try-catch block that handles locale initialization errors. Additionally, `std::cout.imbue()` could throw if the global locale failed to set properly.

**Fix:**
1. Move `initCAndCoutLocales()` inside the try-catch block in `initLocalisation()`
2. Add exception handling to `std::cout.imbue()` in `initCAndCoutLocales()`
3. Add exception handling to the thumbnailer's locale initialization with fallback to classic locale

**Testing:**
This is a defensive fix that catches the runtime_error thrown when the system locale is unsupported. The existing warning message already acknowledges this issue for mingw-w64 on Windows.

Fixes #7276