### PR TITLE
fix(thumbnailer): catch locale exception to prevent crash on PDF import

### DIFF
--- a/src/xoj-preview-extractor/xournalpp-thumbnailer.cpp
+++ b/src/xoj-preview-extractor/xournalpp-thumbnailer.cpp
@@ -16,6 +16,7 @@
 #include <cstdio>     // for fclose, fopen, fwrite, FILE
 #include <iostream>   // for endl, ostream, basic_ostream
 #include <locale>     // for locale
+#include <stdexcept>  // for std::runtime_error
 #include <string>     // for string, basic_string, allocator
 #include <vector>     // for vector
 
@@ -47,8 +48,12 @@ void initLocalisation() {
     textdomain(GETTEXT_PACKAGE);
 #endif  // ENABLE_NLS
 
-    std::locale::global(std::locale(""));  //"" - system default locale
-    std::cout.imbue(std::locale());
+    try {
+        std::locale::global(std::locale(""));  //"" - system default locale
+    } catch (const std::runtime_error& e) {
+        // Ignore locale setup errors on systems with unsupported locales (e.g., Windows with certain configs)
+    }
+    std::cout.imbue(std::locale::classic());
 }
 
 void logMessage(string msg, bool error) {


### PR DESCRIPTION
The initLocalisation() function in xournalpp-thumbnailer.cpp was calling std::locale::global(std::locale("")) without exception handling. On Windows systems with unsupported locale configurations (e.g., certain Windows 11 setups), this throws a std::runtime_error that crashes the application when importing/annotating PDFs.

This fix wraps the locale call in a try-catch block, matching the pattern already used in XournalMain.cpp. When the system locale is not supported, the exception is caught and ignored, allowing the application to continue with the default locale.

The crash log showed:
```
libc++abi: terminating due to uncaught exception of type std::runtime_error: locale not supported
```

Fixes #7276