### PR TITLE
Fix objects vanishing when selected near page edges and clicking on another page

### DIFF
--- a/src/core/control/tools/EditSelection.cpp
+++ b/src/core/control/tools/EditSelection.cpp
@@ -260,6 +260,21 @@ EditSelection::~EditSelection() {
     finalizeSelection();
 }
 
+void EditSelection::clampSelectionToPage() {
+    constexpr double MIN_OVERLAP = 20.0;  // pt
+    const PageRef page = this->view->getPage();
+    const auto [dx, dy] = this->contents->computePageClampOffset(this->getRect(), this->snappedBounds,
+                                                                 this->preserveAspectRatio, page->getWidth(),
+                                                                 page->getHeight(), MIN_OVERLAP);
+
+    if (dx != 0.0 || dy != 0.0) {
+        this->x += dx;
+        this->y += dy;
+        this->snappedBounds.x += dx;
+        this->snappedBounds.y += dy;
+    }
+}
+
 /**
  * Finishes all pending changes, move the elements, scale the elements and add
  * them to new layer if any or to the old if no new layer
@@ -267,75 +282,6 @@ EditSelection::~EditSelection() {
 void EditSelection::finalizeSelection() {
     auto insertOrder =
             this->contents->makeMoveEffective(this->getRect(), this->snappedBounds, this->preserveAspectRatio);
-
-    {
-        // Ensure every element keeps at least MIN_OVERLAP pt on the page.
-        //
-        // Each element imposes two constraints on the horizontal shift dx:
-        // - Not too far left:  rect.x + rect.w + dx >= overlap
-        // - Not too far right: rect.x + dx <= pageW - overlap
-        //
-        // dxMin = tightest lower bound across all elements (furthest off-left element)
-        // dxMax = tightest upper bound across all elements (furthest off-right element)
-        //
-        // If dxMin <= 0 <= dxMax: all elements are on-page, dx = 0.
-        // If dxMin > 0: elements are off the left, shift right by dxMin.
-        // If dxMax < 0: elements are off the right, shift left by |dxMax|.
-        // If dxMin > dxMax: elements span wider than the page, center them.
-        //
-        // Y axis works identically.
-
-        constexpr double MIN_OVERLAP = 20.0;  // pt
-        const PageRef page = this->view->getPage();
-        const double pageWidth = page->getWidth();
-        const double pageHeight = page->getHeight();
-
-        constexpr double INF = std::numeric_limits<double>::infinity();
-        double dxMin = -INF;
-        double dxMax = INF;
-        double dyMin = -INF;
-        double dyMax = INF;
-
-        for (const auto& [e, _]: insertOrder) {
-            const auto rect = e->boundingRect();
-            const double keepOnPageX = std::min(MIN_OVERLAP, rect.width);
-            const double keepOnPageY = std::min(MIN_OVERLAP, rect.height);
-
-            dxMin = std::max(dxMin, keepOnPageX - rect.x - rect.width);
-            dxMax = std::min(dxMax, pageWidth - keepOnPageX - rect.x);
-
-            dyMin = std::max(dyMin, keepOnPageY - rect.y - rect.height);
-            dyMax = std::min(dyMax, pageHeight - keepOnPageY - rect.y);
-        }
-
-        double dx = 0.0;
-        if (dxMin > dxMax) {
-            dx = (dxMin + dxMax) / 2;
-        } else if (dxMin > 0) {
-            dx = dxMin;
-        } else if (dxMax < 0) {
-            dx = dxMax;
-        }
-
-        double dy = 0.0;
-        if (dyMin > dyMax) {
-            dy = (dyMin + dyMax) / 2;
-        } else if (dyMin > 0) {
-            dy = dyMin;
-        } else if (dyMax < 0) {
-            dy = dyMax;
-        }
-
-        if (dx != 0.0 || dy != 0.0) {
-            for (auto& [e, _]: insertOrder) {
-                e->move(dx, dy);
-            }
-            this->x += dx;
-            this->y += dy;
-            this->snappedBounds.x += dx;
-            this->snappedBounds.y += dy;
-        }
-    }
 
     auto* doc = view->getXournal()->getControl()->getDocument();
     doc->lock();
@@ -571,13 +517,15 @@ void EditSelection::mouseUp() {
     this->sourcePage = page;
     this->sourceLayer = layer;
 
+    const bool wasEdgePanning = this->isEdgePanning();
+    this->setEdgePan(false);
+
+    clampSelectionToPage();
     this->contents->updateContent(this->getRect(), this->snappedBounds, this->rotation, this->preserveAspectRatio,
                                   layer, page, this->undo, this->mouseDownType);
 
     this->mouseDownType = CURSOR_SELECTION_NONE;
 
-    const bool wasEdgePanning = this->isEdgePanning();
-    this->setEdgePan(false);
     updateMatrix();
     if (wasEdgePanning) {
         this->ensureWithinVisibleArea();

--- a/src/core/control/tools/EditSelection.cpp
+++ b/src/core/control/tools/EditSelection.cpp
@@ -265,25 +265,37 @@ EditSelection::~EditSelection() {
  * them to new layer if any or to the old if no new layer
  */
 void EditSelection::finalizeSelection() {
-    XojPageView* v = getPageViewUnderCursor();
-    if (v == nullptr) {  // Not on any page - move back to original page and position
-        double ox = this->snappedBounds.x - this->x;
-        double oy = this->snappedBounds.y - this->y;
-        this->x = this->contents->getOriginalX();
-        this->y = this->contents->getOriginalY();
-        this->snappedBounds.x = this->x + ox;
-        this->snappedBounds.y = this->y + oy;
-        v = this->contents->getSourceView();
+    // Always finalize on the page the selection currently belongs to.
+    // Clamp position so the selection stays at least partially on the page.
+    {
+        constexpr double MIN_OVERLAP = 20.0;
+        const PageRef page = this->view->getPage();
+        const double pageW = page->getWidth();
+        const double pageH = page->getHeight();
+        const double selW = std::abs(this->width);
+        const double selH = std::abs(this->height);
+        const double overlap = std::min({MIN_OVERLAP, selW, selH});
 
-        PageRef page = v->getPage();
-        Layer* layer = page->getSelectedLayer();
-        // Create an Undo action to compensate - avoids Segfault/Freeze if the user presses undo after this happened
-        this->contents->updateContent(this->getRect(), this->snappedBounds, this->rotation, this->preserveAspectRatio,
-                                      layer, page, this->undo, CURSOR_SELECTION_MOVE);
+        double dx = 0.0;
+        double dy = 0.0;
+        if (this->x + selW < overlap) {
+            dx = overlap - (this->x + selW);
+        } else if (this->x > pageW - overlap) {
+            dx = (pageW - overlap) - this->x;
+        }
+        if (this->y + selH < overlap) {
+            dy = overlap - (this->y + selH);
+        } else if (this->y > pageH - overlap) {
+            dy = (pageH - overlap) - this->y;
+        }
+
+        if (dx != 0 || dy != 0) {
+            this->x += dx;
+            this->y += dy;
+            this->snappedBounds.x += dx;
+            this->snappedBounds.y += dy;
+        }
     }
-
-
-    this->view = v;
 
     auto insertOrder =
             this->contents->makeMoveEffective(this->getRect(), this->snappedBounds, this->preserveAspectRatio);

--- a/src/core/control/tools/EditSelection.cpp
+++ b/src/core/control/tools/EditSelection.cpp
@@ -263,9 +263,9 @@ EditSelection::~EditSelection() {
 void EditSelection::clampSelectionToPage() {
     constexpr double MIN_OVERLAP = 5.0;  // pt
     const PageRef page = this->view->getPage();
-    const auto [dx, dy] = this->contents->computePageClampOffset(this->getRect(), this->snappedBounds,
-                                                                 this->preserveAspectRatio, page->getWidth(),
-                                                                 page->getHeight(), MIN_OVERLAP);
+    const auto [dx, dy] =
+            this->contents->computePageClampOffset(this->getRect(), this->snappedBounds, this->preserveAspectRatio,
+                                                   page->getWidth(), page->getHeight(), MIN_OVERLAP);
 
     if (dx != 0.0 || dy != 0.0) {
         this->x += dx;

--- a/src/core/control/tools/EditSelection.cpp
+++ b/src/core/control/tools/EditSelection.cpp
@@ -261,7 +261,7 @@ EditSelection::~EditSelection() {
 }
 
 void EditSelection::clampSelectionToPage() {
-    constexpr double MIN_OVERLAP = 20.0;  // pt
+    constexpr double MIN_OVERLAP = 5.0;  // pt
     const PageRef page = this->view->getPage();
     const auto [dx, dy] = this->contents->computePageClampOffset(this->getRect(), this->snappedBounds,
                                                                  this->preserveAspectRatio, page->getWidth(),

--- a/src/core/control/tools/EditSelection.cpp
+++ b/src/core/control/tools/EditSelection.cpp
@@ -265,41 +265,77 @@ EditSelection::~EditSelection() {
  * them to new layer if any or to the old if no new layer
  */
 void EditSelection::finalizeSelection() {
-    // Always finalize on the page the selection currently belongs to.
-    // Clamp position so the selection stays at least partially on the page.
+    auto insertOrder =
+            this->contents->makeMoveEffective(this->getRect(), this->snappedBounds, this->preserveAspectRatio);
+
     {
-        constexpr double MIN_OVERLAP = 20.0;
+        // Ensure every element keeps at least MIN_OVERLAP pt on the page.
+        //
+        // Each element imposes two constraints on the horizontal shift dx:
+        // - Not too far left:  rect.x + rect.w + dx >= overlap
+        // - Not too far right: rect.x + dx <= pageW - overlap
+        //
+        // dxMin = tightest lower bound across all elements (furthest off-left element)
+        // dxMax = tightest upper bound across all elements (furthest off-right element)
+        //
+        // If dxMin <= 0 <= dxMax: all elements are on-page, dx = 0.
+        // If dxMin > 0: elements are off the left, shift right by dxMin.
+        // If dxMax < 0: elements are off the right, shift left by |dxMax|.
+        // If dxMin > dxMax: elements span wider than the page, center them.
+        //
+        // Y axis works identically.
+
+        constexpr double MIN_OVERLAP = 20.0;  // pt
         const PageRef page = this->view->getPage();
-        const double pageW = page->getWidth();
-        const double pageH = page->getHeight();
-        const double selW = std::abs(this->width);
-        const double selH = std::abs(this->height);
-        const double overlap = std::min({MIN_OVERLAP, selW, selH});
+        const double pageWidth = page->getWidth();
+        const double pageHeight = page->getHeight();
+
+        constexpr double INF = std::numeric_limits<double>::infinity();
+        double dxMin = -INF;
+        double dxMax = INF;
+        double dyMin = -INF;
+        double dyMax = INF;
+
+        for (const auto& [e, _]: insertOrder) {
+            const auto rect = e->boundingRect();
+            const double keepOnPageX = std::min(MIN_OVERLAP, rect.width);
+            const double keepOnPageY = std::min(MIN_OVERLAP, rect.height);
+
+            dxMin = std::max(dxMin, keepOnPageX - rect.x - rect.width);
+            dxMax = std::min(dxMax, pageWidth - keepOnPageX - rect.x);
+
+            dyMin = std::max(dyMin, keepOnPageY - rect.y - rect.height);
+            dyMax = std::min(dyMax, pageHeight - keepOnPageY - rect.y);
+        }
 
         double dx = 0.0;
-        double dy = 0.0;
-        if (this->x + selW < overlap) {
-            dx = overlap - (this->x + selW);
-        } else if (this->x > pageW - overlap) {
-            dx = (pageW - overlap) - this->x;
-        }
-        if (this->y + selH < overlap) {
-            dy = overlap - (this->y + selH);
-        } else if (this->y > pageH - overlap) {
-            dy = (pageH - overlap) - this->y;
+        if (dxMin > dxMax) {
+            dx = (dxMin + dxMax) / 2;
+        } else if (dxMin > 0) {
+            dx = dxMin;
+        } else if (dxMax < 0) {
+            dx = dxMax;
         }
 
-        if (dx != 0 || dy != 0) {
+        double dy = 0.0;
+        if (dyMin > dyMax) {
+            dy = (dyMin + dyMax) / 2;
+        } else if (dyMin > 0) {
+            dy = dyMin;
+        } else if (dyMax < 0) {
+            dy = dyMax;
+        }
+
+        if (dx != 0.0 || dy != 0.0) {
+            for (auto& [e, _]: insertOrder) {
+                e->move(dx, dy);
+            }
             this->x += dx;
             this->y += dy;
             this->snappedBounds.x += dx;
             this->snappedBounds.y += dy;
         }
     }
-
-    auto insertOrder =
-            this->contents->makeMoveEffective(this->getRect(), this->snappedBounds, this->preserveAspectRatio);
-
 
     auto* doc = view->getXournal()->getControl()->getDocument();
     doc->lock();

--- a/src/core/control/tools/EditSelection.h
+++ b/src/core/control/tools/EditSelection.h
@@ -326,6 +326,8 @@ private:
      */
     void finalizeSelection();
 
+    void clampSelectionToPage();
+
     /**
      * Gets the PageView under the cursor
      */

--- a/src/core/control/tools/EditSelectionContents.cpp
+++ b/src/core/control/tools/EditSelectionContents.cpp
@@ -390,19 +390,6 @@ auto EditSelectionContents::computePageClampOffset(const xoj::util::Rectangle<do
         return {0.0, 0.0};
     }
 
-    // Fast path: if the overall transformed content box is already fully inside the page
-    // with the required overlap, every element is necessarily inside as well.
-    const double keepOnPageX = std::min(minOverlap, std::abs(snappedBounds.width));
-    const double keepOnPageY = std::min(minOverlap, std::abs(snappedBounds.height));
-    const double minX = std::min(snappedBounds.x, snappedBounds.x + snappedBounds.width);
-    const double maxX = std::max(snappedBounds.x, snappedBounds.x + snappedBounds.width);
-    const double minY = std::min(snappedBounds.y, snappedBounds.y + snappedBounds.height);
-    const double maxY = std::max(snappedBounds.y, snappedBounds.y + snappedBounds.height);
-    if (minX >= keepOnPageX && maxX <= pageWidth - keepOnPageX && minY >= keepOnPageY &&
-        maxY <= pageHeight - keepOnPageY) {
-        return {0.0, 0.0};
-    }
-
     double fx = bounds.width / this->originalBounds.width;
     double fy = bounds.height / this->originalBounds.height;
 
@@ -415,6 +402,33 @@ auto EditSelectionContents::computePageClampOffset(const xoj::util::Rectangle<do
     bool scale = (bounds.width != this->originalBounds.width || bounds.height != this->originalBounds.height);
     bool rotate = (std::abs(this->rotation) > std::numeric_limits<double>::epsilon());
 
+    // For non-rotated selections, the transformed overall content box is both exact
+    // and sufficient for clamping.
+    if (!rotate) {
+        const double keepOnPageX = std::min(minOverlap, std::abs(snappedBounds.width));
+        const double keepOnPageY = std::min(minOverlap, std::abs(snappedBounds.height));
+        const double minX = std::min(snappedBounds.x, snappedBounds.x + snappedBounds.width);
+        const double maxX = std::max(snappedBounds.x, snappedBounds.x + snappedBounds.width);
+        const double minY = std::min(snappedBounds.y, snappedBounds.y + snappedBounds.height);
+        const double maxY = std::max(snappedBounds.y, snappedBounds.y + snappedBounds.height);
+
+        double dx = 0.0;
+        if (maxX < keepOnPageX) {
+            dx = keepOnPageX - maxX;
+        } else if (minX > pageWidth - keepOnPageX) {
+            dx = pageWidth - keepOnPageX - minX;
+        }
+
+        double dy = 0.0;
+        if (maxY < keepOnPageY) {
+            dy = keepOnPageY - maxY;
+        } else if (minY > pageHeight - keepOnPageY) {
+            dy = pageHeight - keepOnPageY - minY;
+        }
+
+        return {dx, dy};
+    }
+
     double mx = bounds.x - this->originalBounds.x;
     double my = bounds.y - this->originalBounds.y;
     bool move = mx != 0 || my != 0;
@@ -424,6 +438,26 @@ auto EditSelectionContents::computePageClampOffset(const xoj::util::Rectangle<do
     double dxMax = INF;
     double dyMin = -INF;
     double dyMax = INF;
+
+    if (rotate) {
+        const double w = std::abs(snappedBounds.width);
+        const double h = std::abs(snappedBounds.height);
+        const double cx = snappedBounds.x + snappedBounds.width / 2;
+        const double cy = snappedBounds.y + snappedBounds.height / 2;
+        const double rotatedWidth = std::abs(w * std::cos(this->rotation)) + std::abs(h * std::sin(this->rotation));
+        const double rotatedHeight = std::abs(w * std::sin(this->rotation)) + std::abs(h * std::cos(this->rotation));
+        const double minX = cx - rotatedWidth / 2;
+        const double maxX = cx + rotatedWidth / 2;
+        const double minY = cy - rotatedHeight / 2;
+        const double maxY = cy + rotatedHeight / 2;
+        const double keepOnPageX = std::min(minOverlap, rotatedWidth);
+        const double keepOnPageY = std::min(minOverlap, rotatedHeight);
+
+        dxMin = std::max(dxMin, keepOnPageX - minX);
+        dxMax = std::min(dxMax, pageWidth - keepOnPageX - maxX);
+        dyMin = std::max(dyMin, keepOnPageY - minY);
+        dyMax = std::min(dyMax, pageHeight - keepOnPageY - maxY);
+    }
 
     for (const auto& [e, _]: this->insertionOrder) {
         auto transformed = e->clone();

--- a/src/core/control/tools/EditSelectionContents.cpp
+++ b/src/core/control/tools/EditSelectionContents.cpp
@@ -382,6 +382,82 @@ InsertionOrder EditSelectionContents::makeMoveEffective(const xoj::util::Rectang
     return std::move(this->insertionOrder);
 }
 
+auto EditSelectionContents::computePageClampOffset(const xoj::util::Rectangle<double>& bounds,
+                                                   const xoj::util::Rectangle<double>& snappedBounds,
+                                                   bool preserveAspectRatio, double pageWidth, double pageHeight,
+                                                   double minOverlap) const -> std::pair<double, double> {
+    if (this->insertionOrder.empty()) {
+        return {0.0, 0.0};
+    }
+
+    double fx = bounds.width / this->originalBounds.width;
+    double fy = bounds.height / this->originalBounds.height;
+
+    if (preserveAspectRatio) {
+        double f = (fx + fy) / 2;
+        fx = f;
+        fy = f;
+    }
+
+    bool scale = (bounds.width != this->originalBounds.width || bounds.height != this->originalBounds.height);
+    bool rotate = (std::abs(this->rotation) > std::numeric_limits<double>::epsilon());
+
+    double mx = bounds.x - this->originalBounds.x;
+    double my = bounds.y - this->originalBounds.y;
+    bool move = mx != 0 || my != 0;
+
+    constexpr double INF = std::numeric_limits<double>::infinity();
+    double dxMin = -INF;
+    double dxMax = INF;
+    double dyMin = -INF;
+    double dyMax = INF;
+
+    for (const auto& [e, _]: this->insertionOrder) {
+        auto transformed = e->clone();
+
+        if (move) {
+            transformed->move(mx, my);
+        }
+        if (scale) {
+            transformed->scale(bounds.x, bounds.y, fx, fy, 0, this->restoreLineWidth);
+        }
+        if (rotate) {
+            transformed->rotate(snappedBounds.x + this->lastSnappedBounds.width / 2,
+                                snappedBounds.y + this->lastSnappedBounds.height / 2, this->rotation);
+        }
+
+        const auto rect = transformed->boundingRect();
+        const double keepOnPageX = std::min(minOverlap, rect.width);
+        const double keepOnPageY = std::min(minOverlap, rect.height);
+
+        dxMin = std::max(dxMin, keepOnPageX - rect.x - rect.width);
+        dxMax = std::min(dxMax, pageWidth - keepOnPageX - rect.x);
+
+        dyMin = std::max(dyMin, keepOnPageY - rect.y - rect.height);
+        dyMax = std::min(dyMax, pageHeight - keepOnPageY - rect.y);
+    }
+
+    double dx = 0.0;
+    if (dxMin > dxMax) {
+        dx = (dxMin + dxMax) / 2;
+    } else if (dxMin > 0) {
+        dx = dxMin;
+    } else if (dxMax < 0) {
+        dx = dxMax;
+    }
+
+    double dy = 0.0;
+    if (dyMin > dyMax) {
+        dy = (dyMin + dyMax) / 2;
+    } else if (dyMin > 0) {
+        dy = dyMin;
+    } else if (dyMax < 0) {
+        dy = dyMax;
+    }
+
+    return {dx, dy};
+}
+
 auto EditSelectionContents::getOriginalX() const -> double { return this->originalBounds.x; }
 
 auto EditSelectionContents::getOriginalY() const -> double { return this->originalBounds.y; }

--- a/src/core/control/tools/EditSelectionContents.cpp
+++ b/src/core/control/tools/EditSelectionContents.cpp
@@ -390,6 +390,19 @@ auto EditSelectionContents::computePageClampOffset(const xoj::util::Rectangle<do
         return {0.0, 0.0};
     }
 
+    // Fast path: if the overall transformed content box is already fully inside the page
+    // with the required overlap, every element is necessarily inside as well.
+    const double keepOnPageX = std::min(minOverlap, std::abs(snappedBounds.width));
+    const double keepOnPageY = std::min(minOverlap, std::abs(snappedBounds.height));
+    const double minX = std::min(snappedBounds.x, snappedBounds.x + snappedBounds.width);
+    const double maxX = std::max(snappedBounds.x, snappedBounds.x + snappedBounds.width);
+    const double minY = std::min(snappedBounds.y, snappedBounds.y + snappedBounds.height);
+    const double maxY = std::max(snappedBounds.y, snappedBounds.y + snappedBounds.height);
+    if (minX >= keepOnPageX && maxX <= pageWidth - keepOnPageX && minY >= keepOnPageY &&
+        maxY <= pageHeight - keepOnPageY) {
+        return {0.0, 0.0};
+    }
+
     double fx = bounds.width / this->originalBounds.width;
     double fy = bounds.height / this->originalBounds.height;
 

--- a/src/core/control/tools/EditSelectionContents.h
+++ b/src/core/control/tools/EditSelectionContents.h
@@ -123,6 +123,11 @@ public:
     InsertionOrder makeMoveEffective(const xoj::util::Rectangle<double>& bounds,
                                      const xoj::util::Rectangle<double>& snappedBounds, bool preserveAspectRatio);
 
+    auto computePageClampOffset(const xoj::util::Rectangle<double>& bounds,
+                                const xoj::util::Rectangle<double>& snappedBounds, bool preserveAspectRatio,
+                                double pageWidth, double pageHeight, double minOverlap) const
+            -> std::pair<double, double>;
+
     void updateContent(xoj::util::Rectangle<double> bounds, xoj::util::Rectangle<double> snappedBounds, double rotation,
                        bool aspectRatio, Layer* layer, const PageRef& targetPage, UndoRedoHandler* undo,
                        CursorSelectionType type);


### PR DESCRIPTION
When you select an object near a page edge and click elsewhere to deselect, the object can silently disappear. This happened because `finalizeSelection` used `getPageViewUnderCursor` to decide which page to re-insert elements into but this function relies on stale mouse position data from the last `mouseDown`, not the current cursor position. When the selection sits near a page boundary, the stale coordinates can resolve to an adjacent page, and elements get inserted there without any coordinate translation. They're gone from page 1 and invisible on page 2.

This replaces the `getPageViewUnderCursor` logic with a simpler approach: always finalize on the page the selection already belongs to (`this->view`), and clamp the position so at least 20pt stays on-page. Page changes during drag are already handled correctly by `moveSelection`/`translateToView`, so `finalizeSelection` never needs to second-guess the page.

Closes #4432.