### PR TITLE
Fix missing return statement in move_only_function

### DIFF
--- a/src/util/include/util/move_only_function.h
+++ b/src/util/include/util/move_only_function.h
@@ -36,6 +36,7 @@ public:
     move_only_function& operator=(std::nullptr_t) {
         invoke = nullptr;
         callable.reset();
+        return *this;
     }
 
     operator bool() const { return static_cast<bool>(invoke) && static_cast<bool>(callable); }


### PR DESCRIPTION
Fix a missing return statement. MErging once the CI clears.