### PR TITLE
Improve plugin manager entry layout

### DIFF
--- a/ui/pluginEntry.glade
+++ b/ui/pluginEntry.glade
@@ -13,8 +13,12 @@
         <property name="visible">True</property>
         <property name="can-focus">False</property>
         <property name="label">pluginName</property>
+        <property name="halign">start</property>
+        <property name="xalign">0</property>
+        <property name="margin-top">8</property>
         <attributes>
           <attribute name="weight" value="bold"/>
+          <attribute name="scale" value="1.44"/>
         </attributes>
       </object>
       <packing>
@@ -28,7 +32,10 @@
         <property name="name">lbDescription</property>
         <property name="visible">True</property>
         <property name="can-focus">False</property>
-        <property name="margin-bottom">10</property>
+        <property name="halign">start</property>
+        <property name="xalign">0</property>
+        <property name="margin-start">12</property>
+        <property name="margin-bottom">6</property>
         <property name="label">Description</property>
         <property name="wrap">True</property>
         <property name="selectable">True</property>
@@ -43,7 +50,8 @@
       <object class="GtkBox">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
-        <property name="halign">center</property>
+        <property name="halign">start</property>
+        <property name="margin-start">12</property>
         <child>
           <object class="GtkLabel">
             <property name="visible">True</property>
@@ -80,7 +88,8 @@
       <object class="GtkBox">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
-        <property name="halign">center</property>
+        <property name="halign">start</property>
+        <property name="margin-start">12</property>
         <child>
           <object class="GtkLabel">
             <property name="visible">True</property>
@@ -116,7 +125,8 @@
       <object class="GtkBox">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
-        <property name="halign">center</property>
+        <property name="halign">start</property>
+        <property name="margin-start">12</property>
         <child>
           <object class="GtkLabel">
             <property name="visible">True</property>
@@ -153,7 +163,8 @@
       <object class="GtkBox">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
-        <property name="halign">center</property>
+        <property name="halign">start</property>
+        <property name="margin-start">12</property>
         <child>
           <object class="GtkCheckButton" id="cbEnabled">
             <property name="label" translatable="yes">enabled,</property>
@@ -193,6 +204,7 @@
       <object class="GtkSeparator">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
+        <property name="margin-top">10</property>
       </object>
       <packing>
         <property name="expand">False</property>


### PR DESCRIPTION
Left-justify and adjusted alignment/margin properties for plugin details UI elements so they are easier to view.

Current layout is center-justified which is not the most visually pleasing style.  Left-justified is a more typical layouts and conforms to more traditional norms users expect so requires a lower cognitive load to process visually.  IMHO, the left-justified version also looks more polished compared to center version.

# Example new layout (light & dark themes):
<img width="897" height="667" alt="image" src="https://github.com/user-attachments/assets/9576b43f-6d04-425e-be40-16b9157b38ef" />


# Current layout:
<img width="851" height="421" alt="image" src="https://github.com/user-attachments/assets/08aebdd6-3571-4872-9285-faa0cf8b2589" />
