### PR TITLE
hierarchical plugin menus via `parentPath`

### DIFF
--- a/plugins/luapi_application.def.lua
+++ b/plugins/luapi_application.def.lua
@@ -96,8 +96,8 @@ function app.openDialog(message, options, cb, error) end
 
 --- Allow to register menupoints and toolbar buttons. This needs to be called from initUi
 --- 
---- @param opts {menu: string, callback: string, toolbarID: string, mode:integer, accelerator:string} options (`mode`,
----  `toolbarID` and `accelerator` are optional)
+--- @param opts {menu: string, callback: string, toolbarID: string, mode:integer, accelerator:string, parentPath:string}
+---   options (`mode`, `toolbarID`, `accelerator` and `parentPath` are optional)
 --- @return {menuId:integer}
 --- 
 --- Example 1: app.registerUi({["menu"] = "HelloWorld", callback="printMessage", mode=1, accelerator="<Control>a"})
@@ -109,8 +109,16 @@ function app.openDialog(message, options, cb, error) end
 --- to a toolbar via toolbar customization or by editing the toolbar.ini file using the name "Plugin::CUSTOM_PEN_1"
 --- Note that in toolbar.ini the string "Plugin::" must always be prepended to the toolbarId specified in the plugin
 --- 
+--- Example 3: app.registerUi({menu="Document", callback="newDoc", parentPath="File/New"})
+--- registers a menu item "Document" under a submenu "File/New" in the Plugins menu.
+--- Use "/" to create nested submenus, e.g., parentPath="File/Export/PDF" creates File > Export > PDF hierarchy.
+--- 
 --- The mode and accelerator are optional. When specifying the mode, the callback function should have one parameter
 ---    that receives the mode. This is useful for callback functions that are shared among multiple menu entries.
+--- 
+--- The parentPath parameter creates submenu hierarchy. Without it, the menu item appears directly in the Plugins menu.
+--- With parentPath, the item is placed under a nested submenu path. For example, parentPath="Tools/Custom"
+--- creates "Plugins > [plugin name] > Tools > Custom > [menu item]".
 function app.registerUi(opts) end
 
 --- *

--- a/src/core/plugin/Plugin.cpp
+++ b/src/core/plugin/Plugin.cpp
@@ -82,13 +82,77 @@ size_t Plugin::populateMenuSection(GtkApplicationWindow* win, size_t startId) {
         return startId;
     }
 
+    constexpr char PATH_SEP = '/';
+
     // The menu should never be populated twice.
     // If this assert ever fails, do not recreate the GSimpleAction's below
     xoj_assert(!menuSection);
 
     this->menuSection.reset(g_menu_new(), xoj::util::adopt);
 
+    // Non-owning map from parent path to submenu GMenu
+    std::map<std::string, GMenu*> submenuMap;
+    GMenu* const rootMenu = menuSection.get();
+    submenuMap[""] = rootMenu;
+
+    // Helper to get or create parent menu for a given path
+    auto getOrCreateParent = [&submenuMap, rootMenu](const std::string& parentPath) -> GMenu* {
+        GMenu* parentMenu = rootMenu;
+
+        // Lambda to create or reuse a submenu for a given segment and path prefix
+        auto createOrGetSubmenu = [&submenuMap](GMenu*& parent, const std::string& seg,
+                                                const std::string& builtPath) -> GMenu* {
+            auto it = submenuMap.find(builtPath);
+            if (it != submenuMap.end()) {
+                return it->second;
+            }
+            GMenu* submenu = g_menu_new();
+            xoj::util::GObjectSPtr<GMenuItem> item(g_menu_item_new_submenu(seg.c_str(), G_MENU_MODEL(submenu)),
+                                                   xoj::util::adopt);
+            g_menu_append_item(parent, item.get());
+            submenuMap[builtPath] = submenu;
+            return submenu;
+        };
+
+        std::string path = parentPath;
+        while (!path.empty() && path.back() == PATH_SEP) {
+            path.pop_back();
+        }
+        if (path.empty()) {
+            return parentMenu;
+        }
+
+        std::string builtPath;
+        size_t start = 0;
+        size_t end = path.find(PATH_SEP);
+
+        while (true) {
+            if (end == std::string::npos) {
+                end = path.size();
+            }
+            if (end > start) {
+                std::string segment = path.substr(start, end - start);
+                if (!segment.empty()) {
+                    if (!builtPath.empty()) {
+                        builtPath += PATH_SEP;
+                    }
+                    builtPath += segment;
+                    parentMenu = createOrGetSubmenu(parentMenu, segment, builtPath);
+                }
+            }
+            if (end == path.size()) {
+                break;
+            }
+            start = end + 1;
+            end = path.find(PATH_SEP, start);
+        }
+
+        return parentMenu;
+    };
+
     for (auto& m: menuEntries) {
+        GMenu* parentMenu = getOrCreateParent(m.parentPath);
+
         std::string actionName = G_ACTION_NAME_PREFIX;
         actionName += std::to_string(startId++);
         m.action.reset(g_simple_action_new(actionName.c_str(), nullptr), xoj::util::adopt);
@@ -96,7 +160,7 @@ size_t Plugin::populateMenuSection(GtkApplicationWindow* win, size_t startId) {
         actionName = "win." + actionName;
         xoj::util::GObjectSPtr<GMenuItem> entry(g_menu_item_new(m.label.c_str(), actionName.c_str()), xoj::util::adopt);
 
-        g_menu_append_item(menuSection.get(), entry.get());
+        g_menu_append_item(parentMenu, entry.get());
 
         // This might fail, when the vector reallocates, but then the order of initialisation is violated
         g_signal_connect(
@@ -116,8 +180,10 @@ size_t Plugin::populateMenuSection(GtkApplicationWindow* win, size_t startId) {
 
 void Plugin::executeMenuEntry(MenuEntry* entry) { callFunction(entry->callback, entry->mode); }
 
-auto Plugin::registerMenu(std::string menu, std::string callback, ptrdiff_t mode, std::string accelerator) -> size_t {
-    menuEntries.emplace_back(this, std::move(menu), std::move(callback), mode, std::move(accelerator));
+auto Plugin::registerMenu(std::string label, std::string callback, ptrdiff_t mode, std::string accelerator,
+                          std::string parentPath) -> size_t {
+    menuEntries.emplace_back(this, std::move(label), std::move(callback), mode, std::move(accelerator),
+                             std::move(parentPath));
     return menuEntries.size() - 1;
 }
 

--- a/src/core/plugin/Plugin.cpp
+++ b/src/core/plugin/Plugin.cpp
@@ -95,63 +95,56 @@ size_t Plugin::populateMenuSection(GtkApplicationWindow* win, size_t startId) {
     GMenu* const rootMenu = menuSection.get();
     submenuMap[""] = rootMenu;
 
-    // Helper to get or create parent menu for a given path
-    auto getOrCreateParent = [&submenuMap, rootMenu](const std::string& parentPath) -> GMenu* {
-        GMenu* parentMenu = rootMenu;
+    auto normalizePath = [](const std::string& path) {
+        std::string normalized;
+        normalized.reserve(path.size());
 
-        // Lambda to create or reuse a submenu for a given segment and path prefix
-        auto createOrGetSubmenu = [&submenuMap](GMenu*& parent, const std::string& seg,
-                                                const std::string& builtPath) -> GMenu* {
-            auto it = submenuMap.find(builtPath);
-            if (it != submenuMap.end()) {
-                return it->second;
-            }
-            GMenu* submenu = g_menu_new();
-            xoj::util::GObjectSPtr<GMenuItem> item(g_menu_item_new_submenu(seg.c_str(), G_MENU_MODEL(submenu)),
-                                                   xoj::util::adopt);
-            g_menu_append_item(parent, item.get());
-            submenuMap[builtPath] = submenu;
-            return submenu;
-        };
-
-        std::string path = parentPath;
-        while (!path.empty() && path.back() == PATH_SEP) {
-            path.pop_back();
-        }
-        if (path.empty()) {
-            return parentMenu;
-        }
-
-        std::string builtPath;
-        size_t start = 0;
-        size_t end = path.find(PATH_SEP);
-
-        while (true) {
-            if (end == std::string::npos) {
-                end = path.size();
-            }
-            if (end > start) {
-                std::string segment = path.substr(start, end - start);
-                if (!segment.empty()) {
-                    if (!builtPath.empty()) {
-                        builtPath += PATH_SEP;
-                    }
-                    builtPath += segment;
-                    parentMenu = createOrGetSubmenu(parentMenu, segment, builtPath);
+        bool lastWasSep = true;
+        for (char c: path) {
+            if (c == PATH_SEP) {
+                if (!lastWasSep) {
+                    normalized += c;
                 }
+                lastWasSep = true;
+            } else {
+                normalized += c;
+                lastWasSep = false;
             }
-            if (end == path.size()) {
-                break;
-            }
-            start = end + 1;
-            end = path.find(PATH_SEP, start);
         }
 
-        return parentMenu;
+        if (!normalized.empty() && normalized.back() == PATH_SEP) {
+            normalized.pop_back();
+        }
+
+        return normalized;
+    };
+
+    // Helper to get or create parent menu for a given path
+    auto getOrCreateParent = [&submenuMap, rootMenu](auto& self, const std::string& parentPath) -> GMenu* {
+        if (parentPath.empty()) {
+            return rootMenu;
+        }
+
+        auto it = submenuMap.find(parentPath);
+        if (it != submenuMap.end()) {
+            return it->second;
+        }
+
+        size_t sep = parentPath.rfind(PATH_SEP);
+        std::string parentPrefix = sep == std::string::npos ? std::string() : parentPath.substr(0, sep);
+        std::string segment = sep == std::string::npos ? parentPath : parentPath.substr(sep + 1);
+
+        GMenu* parentMenu = self(self, parentPrefix);
+        GMenu* submenu = g_menu_new();
+        xoj::util::GObjectSPtr<GMenuItem> item(g_menu_item_new_submenu(segment.c_str(), G_MENU_MODEL(submenu)),
+                                               xoj::util::adopt);
+        g_menu_append_item(parentMenu, item.get());
+        submenuMap[parentPath] = submenu;
+        return submenu;
     };
 
     for (auto& m: menuEntries) {
-        GMenu* parentMenu = getOrCreateParent(m.parentPath);
+        GMenu* parentMenu = getOrCreateParent(getOrCreateParent, normalizePath(m.parentPath));
 
         std::string actionName = G_ACTION_NAME_PREFIX;
         actionName += std::to_string(startId++);

--- a/src/core/plugin/Plugin.h
+++ b/src/core/plugin/Plugin.h
@@ -40,15 +40,18 @@ class ToolMenuHandler;
 
 struct MenuEntry final {
     MenuEntry() = default;
-    MenuEntry(Plugin* plugin, std::string label, std::string callback, ptrdiff_t mode, std::string accelerator):
+    MenuEntry(Plugin* plugin, std::string label, std::string callback, ptrdiff_t mode, std::string accelerator,
+              std::string parentPath = ""):
             plugin(plugin),
             label(std::move(label)),
+            parentPath(std::move(parentPath)),
             callback(std::move(callback)),
             mode(mode),
             accelerator(std::move(accelerator)) {}
 
     Plugin* plugin = nullptr;                               ///< The Plugin
     std::string label{};                                    ///< Menu display name
+    std::string parentPath{};                               ///< Submenu path (e.g., "File/Tools"), empty = root
     std::string callback{};                                 ///< Callback function name
     ptrdiff_t mode{std::numeric_limits<ptrdiff_t>::max()};  ///< mode in which the callback function is run
     /**
@@ -166,8 +169,14 @@ public:
     auto isInInitUi() const -> bool;
 
     /// Register a menu item
+    /// @param label Menu display name
+    /// @param callback Callback function name
+    /// @param mode Mode in which callback is run
+    /// @param accelerator Accelerator key
+    /// @param parentPath Submenu path (e.g., "File/Tools"), empty = root
     /// @return Internal ID, can e.g. be used to disable the menu
-    auto registerMenu(std::string menu, std::string callback, ptrdiff_t mode, std::string accelerator) -> size_t;
+    auto registerMenu(std::string label, std::string callback, ptrdiff_t mode, std::string accelerator,
+                      std::string parentPath = "") -> size_t;
 
     ///@return The main controller
     auto getControl() const -> Control*;

--- a/src/core/plugin/luapi_application.h
+++ b/src/core/plugin/luapi_application.h
@@ -501,8 +501,8 @@ static int applib_openDialog(lua_State* L) {
 /**
  * Allow to register menupoints and toolbar buttons. This needs to be called from initUi
  *
- * @param opts {menu: string, callback: string, toolbarID: string, mode:integer, accelerator:string} options (`mode`,
- `toolbarID` and `accelerator` are optional)
+ * @param opts {menu: string, callback: string, toolbarID: string, mode:integer, accelerator:string, parentPath:string}
+ *   options (`mode`, `toolbarID`, `accelerator` and `parentPath` are optional)
  * @return {menuId:integer}
  *
  * Example 1: app.registerUi({["menu"] = "HelloWorld", callback="printMessage", mode=1, accelerator="<Control>a"})
@@ -514,8 +514,16 @@ static int applib_openDialog(lua_State* L) {
  * to a toolbar via toolbar customization or by editing the toolbar.ini file using the name "Plugin::CUSTOM_PEN_1"
  * Note that in toolbar.ini the string "Plugin::" must always be prepended to the toolbarId specified in the plugin
  *
+ * Example 3: app.registerUi({menu="Document", callback="newDoc", parentPath="File/New"})
+ * registers a menu item "Document" under a submenu "File/New" in the Plugins menu.
+ * Use "/" to create nested submenus, e.g., parentPath="File/Export/PDF" creates File > Export > PDF hierarchy.
+ *
  * The mode and accelerator are optional. When specifying the mode, the callback function should have one parameter
    that receives the mode. This is useful for callback functions that are shared among multiple menu entries.
+ *
+ * The parentPath parameter creates submenu hierarchy. Without it, the menu item appears directly in the Plugins menu.
+ * With parentPath, the item is placed under a nested submenu path. For example, parentPath="Tools/Custom"
+ * creates "Plugins > [plugin name] > Tools > Custom > [menu item]".
  */
 static int applib_registerUi(lua_State* L) {
     Plugin* plugin = Plugin::getPluginFromLua(L);
@@ -532,6 +540,7 @@ static int applib_registerUi(lua_State* L) {
     // the stack first. Then convert those stack values
     // into an appropriate C type.
     lua_getfield(L, 1, "accelerator");
+    lua_getfield(L, 1, "parentPath");
     lua_getfield(L, 1, "menu");
     lua_getfield(L, 1, "callback");
     lua_getfield(L, 1, "mode");
@@ -539,14 +548,16 @@ static int applib_registerUi(lua_State* L) {
     lua_getfield(L, 1, "iconName");
     // In Example 1 stack now has following:
     //    1 = {"menu"="MenuName", callback="functionName", mode=1, accelerator="<Control>a"}
-    //   -6 = "<Control>a"
+    //   -7 = "<Control>a"
+    //   -6 = "" (parentPath)
     //   -5 = "MenuName"
     //   -4 = "functionName"
     //   -3 = mode
     //   -2 = nil
     //   -1 = nil
 
-    const char* accelerator = luaL_optstring(L, -6, "");
+    const char* accelerator = luaL_optstring(L, -7, "");
+    const char* parentPath = luaL_optstring(L, -6, "");
     const char* menu = luaL_optstring(L, -5, "");
     const char* callback = luaL_optstring(L, -4, nullptr);
     const ptrdiff_t mode = luaL_optinteger(L, -3, std::numeric_limits<ptrdiff_t>::max());
@@ -556,11 +567,11 @@ static int applib_registerUi(lua_State* L) {
         return luaL_error(L, "Missing callback function!");
     }
 
-    size_t menuId = plugin->registerMenu(menu, callback, mode, accelerator);
+    size_t menuId = plugin->registerMenu(menu, callback, mode, accelerator, parentPath);
     plugin->registerToolButton(menu, toolbarId, iconName, callback, mode);
 
     // Make sure to remove all vars which are put to the stack before!
-    lua_pop(L, 6);
+    lua_pop(L, 7);
 
     // Add return value to the Stack
     lua_createtable(L, 0, 2);


### PR DESCRIPTION
plugins can now place menu items into nested submenus

```lua
app.registerUi({menu="PDF", callback="exportPDF", parentPath="Tools/Export"})
```

I made an earlier attempt encoded the hierarchy directly into the `menu` field (`menu="Tools/Export/PDF"`), but this broke existing plugins that have slashes in their label strings and conflated two distinct conceptsc into one field, `parentPath` keeps label and location separate.

No existing plugins are affected.

closes #7317