### PR TITLE
Allow selecting objects that extend beyond page boundaries

### DIFF
--- a/src/core/control/tools/Selector.cpp
+++ b/src/core/control/tools/Selector.cpp
@@ -91,14 +91,18 @@ void RectangularSelector::extendAtPageEdges() {
     const double pageHeight = page->getHeight();
 
     if (pageWidth > 0 && pageHeight > 0) {
-        if (bbox.minX <= THRESHOLD)
+        if (bbox.minX <= THRESHOLD) {
             bbox.minX = -INF;
-        if (bbox.minY <= THRESHOLD)
+        }
+        if (bbox.minY <= THRESHOLD) {
             bbox.minY = -INF;
-        if (bbox.maxX >= pageWidth - THRESHOLD)
+        }
+        if (bbox.maxX >= pageWidth - THRESHOLD) {
             bbox.maxX = INF;
-        if (bbox.maxY >= pageHeight - THRESHOLD)
+        }
+        if (bbox.maxY >= pageHeight - THRESHOLD) {
             bbox.maxY = INF;
+        }
     }
 }
 
@@ -158,18 +162,18 @@ void LassoSelector::extendAtPageEdges() {
         return p.x <= THRESHOLD || p.x >= pageWidth - THRESHOLD || p.y <= THRESHOLD || p.y >= pageHeight - THRESHOLD;
     };
 
+    auto const extendCoordinate = [&](double value, double pageExtent) -> double {
+        if (value <= THRESHOLD) {
+            return -INF;
+        }
+        if (value >= pageExtent - THRESHOLD) {
+            return INF;
+        }
+        return value;
+    };
+
     auto const project = [&](BoundaryPoint const& p) -> BoundaryPoint {
-        double px = p.x;
-        double py = p.y;
-        if (px <= THRESHOLD)
-            px = -INF;
-        if (px >= pageWidth - THRESHOLD)
-            px = INF;
-        if (py <= THRESHOLD)
-            py = -INF;
-        if (py >= pageHeight - THRESHOLD)
-            py = INF;
-        return {px, py};
+        return {extendCoordinate(p.x, pageWidth), extendCoordinate(p.y, pageHeight)};
     };
 
     extendedBoundaryPoints.clear();

--- a/src/core/control/tools/Selector.cpp
+++ b/src/core/control/tools/Selector.cpp
@@ -21,20 +21,23 @@ auto Selector::finalize(PageRef page, bool disableMultilayer, Document* doc) -> 
     this->page = page;
     this->pageWidth = page->getWidth();
     this->pageHeight = page->getHeight();
-    this->selectionDomain = Range();
 
-    auto addToSelectionDomain = [this](const Layer* layer) {
+    const bool useMultiLayer = multiLayer && !disableMultilayer;
+    Range selectionDomain;
+
+    // First pass: compute selectionDomain from all candidate elements
+    auto addToSelectionDomain = [&selectionDomain](const Layer* layer) {
         if (!layer->isVisible()) {
             return;
         }
         for (const auto& e: layer->getElementsView()) {
-            this->selectionDomain = this->selectionDomain.unite(Range(e->boundingRect()));
+            selectionDomain = selectionDomain.unite(Range(e->boundingRect()));
         }
     };
 
     {
         std::shared_lock lock(*doc);
-        if (multiLayer && !disableMultilayer) {
+        if (useMultiLayer) {
             for (const Layer* layer: page->getLayersView()) {
                 addToSelectionDomain(layer);
             }
@@ -43,15 +46,16 @@ auto Selector::finalize(PageRef page, bool disableMultilayer, Document* doc) -> 
         }
     }
 
-    if (this->selectionDomain.empty()) {
-        this->selectionDomain = this->bbox;
+    if (selectionDomain.empty()) {
+        selectionDomain = this->bbox;
     }
 
-    this->tailorToSelectionDomain();
+    this->tailorToSelectionDomain(selectionDomain);
 
+    // Second pass: find selected elements
     size_t layerId = 0;
 
-    if (multiLayer && !disableMultilayer) {
+    if (useMultiLayer) {
         std::shared_lock lock(*doc);
         const auto layers = page->getLayersView();
         for (auto it = layers.rbegin(); it != layers.rend(); it++) {
@@ -106,7 +110,7 @@ RectangularSelector::~RectangularSelector() = default;
 
 auto RectangularSelector::contains(double x, double y) const -> bool { return extendedBbox.contains(x, y); }
 
-void RectangularSelector::tailorToSelectionDomain() {
+void RectangularSelector::tailorToSelectionDomain(const Range& selectionDomain) {
     constexpr double THRESHOLD = 1.0;  // pt
 
     extendedBbox = bbox;
@@ -165,7 +169,7 @@ void LassoSelector::currentPos(double x, double y) {
     }
 }
 
-void LassoSelector::tailorToSelectionDomain() {
+void LassoSelector::tailorToSelectionDomain(const Range& selectionDomain) {
     constexpr double THRESHOLD = 1.0;  // pt
 
     if (pageWidth <= 0 || pageHeight <= 0 || boundaryPoints.size() <= 2 || !selectionDomain.isValid()) {

--- a/src/core/control/tools/Selector.cpp
+++ b/src/core/control/tools/Selector.cpp
@@ -19,8 +19,6 @@ Selector::~Selector() = default;
 
 auto Selector::finalize(PageRef page, bool disableMultilayer, Document* doc) -> size_t {
     this->page = page;
-    this->pageWidth = page->getWidth();
-    this->pageHeight = page->getHeight();
 
     const bool useMultiLayer = multiLayer && !disableMultilayer;
     Range selectionDomain;
@@ -112,6 +110,8 @@ auto RectangularSelector::contains(double x, double y) const -> bool { return ex
 
 void RectangularSelector::tailorToSelectionDomain(const Range& selectionDomain) {
     constexpr double THRESHOLD = 1.0;  // pt
+    const double pageWidth = page->getWidth();
+    const double pageHeight = page->getHeight();
 
     extendedBbox = bbox;
 
@@ -171,6 +171,8 @@ void LassoSelector::currentPos(double x, double y) {
 
 void LassoSelector::tailorToSelectionDomain(const Range& selectionDomain) {
     constexpr double THRESHOLD = 1.0;  // pt
+    const double pageWidth = page->getWidth();
+    const double pageHeight = page->getHeight();
 
     if (pageWidth <= 0 || pageHeight <= 0 || boundaryPoints.size() <= 2 || !selectionDomain.isValid()) {
         extendedBoundaryPoints = boundaryPoints;

--- a/src/core/control/tools/Selector.cpp
+++ b/src/core/control/tools/Selector.cpp
@@ -158,6 +158,12 @@ void LassoSelector::extendAtPageEdges() {
         return;
     }
 
+    if (bbox.minX > THRESHOLD && bbox.minY > THRESHOLD && bbox.maxX < pageWidth - THRESHOLD &&
+        bbox.maxY < pageHeight - THRESHOLD) {
+        extendedBoundaryPoints.clear();
+        return;
+    }
+
     auto const isOnEdge = [&](BoundaryPoint const& p) -> bool {
         return p.x <= THRESHOLD || p.x >= pageWidth - THRESHOLD || p.y <= THRESHOLD || p.y >= pageHeight - THRESHOLD;
     };

--- a/src/core/control/tools/Selector.cpp
+++ b/src/core/control/tools/Selector.cpp
@@ -13,6 +13,7 @@
 #include "model/XojPage.h"         // for XojPage
 #include "util/safe_casts.h"       // for as_unsigned
 
+// Ensures that `-std::numeric_limits<double>::infinity()` behaves as minus infinity
 static_assert(std::numeric_limits<double>::is_iec559);
 
 Selector::Selector(bool multiLayer):

--- a/src/core/control/tools/Selector.cpp
+++ b/src/core/control/tools/Selector.cpp
@@ -160,7 +160,6 @@ void LassoSelector::extendAtPageEdges() {
 
     if (bbox.minX > THRESHOLD && bbox.minY > THRESHOLD && bbox.maxX < pageWidth - THRESHOLD &&
         bbox.maxY < pageHeight - THRESHOLD) {
-        extendedBoundaryPoints.clear();
         return;
     }
 
@@ -182,11 +181,11 @@ void LassoSelector::extendAtPageEdges() {
         return {extendCoordinate(p.x, pageWidth), extendCoordinate(p.y, pageHeight)};
     };
 
-    extendedBoundaryPoints.clear();
-    extendedBoundaryPoints.reserve(boundaryPoints.size() * 2);
+    std::vector<BoundaryPoint> newBoundaryPoints;
+    newBoundaryPoints.reserve(boundaryPoints.size() * 2);
 
     auto const appendExtendedPoint = [&](BoundaryPoint const& p) {
-        extendedBoundaryPoints.push_back(p);
+        newBoundaryPoints.push_back(p);
         bbox.addPoint(p.x, p.y);
     };
 
@@ -217,25 +216,26 @@ void LassoSelector::extendAtPageEdges() {
             appendExtendedPoint(project(current));
         }
     }
+
+    boundaryPoints = std::move(newBoundaryPoints);
 }
 
 auto LassoSelector::contains(double x, double y) const -> bool {
-    auto const& pts = extendedBoundaryPoints.empty() ? boundaryPoints : extendedBoundaryPoints;
-
-    if (pts.size() <= 2 || !bbox.contains(x, y)) {
+    if (boundaryPoints.size() <= 2 || !bbox.contains(x, y)) {
         return false;
     }
 
     int hits = 0;
 
-    const BoundaryPoint& last = pts.back();
+    const BoundaryPoint& last = boundaryPoints.back();
 
     double lastx = last.x;
     double lasty = last.y;
     double curx = NAN, cury = NAN;
 
     // Walk the edges of the polygon
-    for (auto pointIterator = pts.begin(); pointIterator != pts.end(); lastx = curx, lasty = cury, ++pointIterator) {
+    for (auto pointIterator = boundaryPoints.begin(); pointIterator != boundaryPoints.end();
+         lastx = curx, lasty = cury, ++pointIterator) {
         curx = pointIterator->x;
         cury = pointIterator->y;
 

--- a/src/core/control/tools/Selector.cpp
+++ b/src/core/control/tools/Selector.cpp
@@ -185,13 +185,18 @@ void LassoSelector::extendAtPageEdges() {
     extendedBoundaryPoints.clear();
     extendedBoundaryPoints.reserve(boundaryPoints.size() * 2);
 
+    auto const appendExtendedPoint = [&](BoundaryPoint const& p) {
+        extendedBoundaryPoints.push_back(p);
+        bbox.addPoint(p.x, p.y);
+    };
+
     auto const n = boundaryPoints.size();
     for (size_t i = 0; i < n; i++) {
         auto const& current = boundaryPoints[i];
         auto const currentOnEdge = isOnEdge(current);
 
         if (!currentOnEdge) {
-            extendedBoundaryPoints.push_back(current);
+            appendExtendedPoint(current);
             continue;
         }
 
@@ -201,21 +206,16 @@ void LassoSelector::extendAtPageEdges() {
 
         if (!prevOnEdge) {
             // Entering an edge run: emit original, then projected
-            extendedBoundaryPoints.push_back(current);
-            extendedBoundaryPoints.push_back(project(current));
+            appendExtendedPoint(current);
+            appendExtendedPoint(project(current));
         } else if (!nextOnEdge) {
             // Leaving an edge run: emit projected, then original
-            extendedBoundaryPoints.push_back(project(current));
-            extendedBoundaryPoints.push_back(current);
+            appendExtendedPoint(project(current));
+            appendExtendedPoint(current);
         } else {
             // Interior of an edge run: emit only projected
-            extendedBoundaryPoints.push_back(project(current));
+            appendExtendedPoint(project(current));
         }
-    }
-
-    // Extend bounding box to infinity where needed
-    for (auto const& p: extendedBoundaryPoints) {
-        bbox.addPoint(p.x, p.y);
     }
 }
 

--- a/src/core/control/tools/Selector.cpp
+++ b/src/core/control/tools/Selector.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>  // for max, min
 #include <cmath>      // for abs, NAN
+#include <limits>     // for numeric_limits
 #include <memory>     // for __shared_ptr_access
 
 #include <gdk/gdk.h>  // for GdkRGBA, gdk_cairo_set_source_rgba
@@ -20,40 +21,15 @@ Selector::~Selector() = default;
 auto Selector::finalize(PageRef page, bool disableMultilayer, Document* doc) -> size_t {
     this->page = page;
 
-    const bool useMultiLayer = multiLayer && !disableMultilayer;
-    Range selectionDomain;
+    // Trigger redraw before any geometry modifications
+    this->viewPool->dispatchAndClear(xoj::view::SelectorView::DELETE_VIEWS_REQUEST, this->bbox);
 
-    // First pass: compute selectionDomain from all candidate elements
-    auto addToSelectionDomain = [&selectionDomain](const Layer* layer) {
-        if (!layer->isVisible()) {
-            return;
-        }
-        for (const auto& e: layer->getElementsView()) {
-            selectionDomain = selectionDomain.unite(Range(e->boundingRect()));
-        }
-    };
+    // Extend selection geometry (bbox) to infinity where touching page edges
+    this->extendAtPageEdges();
 
-    {
-        std::shared_lock lock(*doc);
-        if (useMultiLayer) {
-            for (const Layer* layer: page->getLayersView()) {
-                addToSelectionDomain(layer);
-            }
-        } else {
-            addToSelectionDomain(page->getSelectedLayer());
-        }
-    }
-
-    if (selectionDomain.empty()) {
-        selectionDomain = this->bbox;
-    }
-
-    this->tailorToSelectionDomain(selectionDomain);
-
-    // Second pass: find selected elements
+    // Find selected elements
     size_t layerId = 0;
-
-    if (useMultiLayer) {
+    if (multiLayer && !disableMultilayer) {
         std::shared_lock lock(*doc);
         const auto layers = page->getLayersView();
         for (auto it = layers.rbegin(); it != layers.rend(); it++) {
@@ -88,8 +64,6 @@ auto Selector::finalize(PageRef page, bool disableMultilayer, Document* doc) -> 
         }
     }
 
-    this->viewPool->dispatchAndClear(xoj::view::SelectorView::DELETE_VIEWS_REQUEST, this->bbox);
-
     return layerId;
 }
 
@@ -106,24 +80,23 @@ RectangularSelector::RectangularSelector(double x, double y, bool multiLayer):
 
 RectangularSelector::~RectangularSelector() = default;
 
-auto RectangularSelector::contains(double x, double y) const -> bool { return extendedBbox.contains(x, y); }
+auto RectangularSelector::contains(double x, double y) const -> bool { return bbox.contains(x, y); }
 
-void RectangularSelector::tailorToSelectionDomain(const Range& selectionDomain) {
+void RectangularSelector::extendAtPageEdges() {
     constexpr double THRESHOLD = 1.0;  // pt
+    constexpr double INF = std::numeric_limits<double>::infinity();
     const double pageWidth = page->getWidth();
     const double pageHeight = page->getHeight();
 
-    extendedBbox = bbox;
-
-    if (pageWidth > 0 && pageHeight > 0 && selectionDomain.isValid()) {
-        if (extendedBbox.minX <= THRESHOLD)
-            extendedBbox.minX = selectionDomain.minX;
-        if (extendedBbox.minY <= THRESHOLD)
-            extendedBbox.minY = selectionDomain.minY;
-        if (extendedBbox.maxX >= pageWidth - THRESHOLD)
-            extendedBbox.maxX = selectionDomain.maxX;
-        if (extendedBbox.maxY >= pageHeight - THRESHOLD)
-            extendedBbox.maxY = selectionDomain.maxY;
+    if (pageWidth > 0 && pageHeight > 0) {
+        if (bbox.minX <= THRESHOLD)
+            bbox.minX = -INF;
+        if (bbox.minY <= THRESHOLD)
+            bbox.minY = -INF;
+        if (bbox.maxX >= pageWidth - THRESHOLD)
+            bbox.maxX = INF;
+        if (bbox.maxY >= pageHeight - THRESHOLD)
+            bbox.maxY = INF;
     }
 }
 
@@ -169,14 +142,13 @@ void LassoSelector::currentPos(double x, double y) {
     }
 }
 
-void LassoSelector::tailorToSelectionDomain(const Range& selectionDomain) {
+void LassoSelector::extendAtPageEdges() {
     constexpr double THRESHOLD = 1.0;  // pt
+    constexpr double INF = std::numeric_limits<double>::infinity();
     const double pageWidth = page->getWidth();
     const double pageHeight = page->getHeight();
 
-    if (pageWidth <= 0 || pageHeight <= 0 || boundaryPoints.size() <= 2 || !selectionDomain.isValid()) {
-        extendedBoundaryPoints = boundaryPoints;
-        extendedBbox = bbox;
+    if (pageWidth <= 0 || pageHeight <= 0 || boundaryPoints.size() <= 2) {
         return;
     }
 
@@ -188,13 +160,13 @@ void LassoSelector::tailorToSelectionDomain(const Range& selectionDomain) {
         double px = p.x;
         double py = p.y;
         if (px <= THRESHOLD)
-            px = selectionDomain.minX;
+            px = -INF;
         if (px >= pageWidth - THRESHOLD)
-            px = selectionDomain.maxX;
+            px = INF;
         if (py <= THRESHOLD)
-            py = selectionDomain.minY;
+            py = -INF;
         if (py >= pageHeight - THRESHOLD)
-            py = selectionDomain.maxY;
+            py = INF;
         return {px, py};
     };
 
@@ -229,18 +201,16 @@ void LassoSelector::tailorToSelectionDomain(const Range& selectionDomain) {
         }
     }
 
-    // Build extended bounding box
-    extendedBbox = Range();
+    // Extend bounding box to infinity where needed
     for (auto const& p: extendedBoundaryPoints) {
-        extendedBbox.addPoint(p.x, p.y);
+        bbox.addPoint(p.x, p.y);
     }
 }
 
 auto LassoSelector::contains(double x, double y) const -> bool {
     auto const& pts = extendedBoundaryPoints.empty() ? boundaryPoints : extendedBoundaryPoints;
-    auto const& bboxRef = extendedBoundaryPoints.empty() ? bbox : extendedBbox;
 
-    if (pts.size() <= 2 || !bboxRef.contains(x, y)) {
+    if (pts.size() <= 2 || !bbox.contains(x, y)) {
         return false;
     }
 

--- a/src/core/control/tools/Selector.cpp
+++ b/src/core/control/tools/Selector.cpp
@@ -19,6 +19,8 @@ Selector::~Selector() = default;
 
 auto Selector::finalize(PageRef page, bool disableMultilayer, Document* doc) -> size_t {
     this->page = page;
+    this->pageWidth = page->getWidth();
+    this->pageHeight = page->getHeight();
     size_t layerId = 0;
 
     if (multiLayer && !disableMultilayer) {
@@ -74,7 +76,30 @@ RectangularSelector::RectangularSelector(double x, double y, bool multiLayer):
 
 RectangularSelector::~RectangularSelector() = default;
 
-auto RectangularSelector::contains(double x, double y) const -> bool { return bbox.contains(x, y); }
+auto RectangularSelector::contains(double x, double y) const -> bool {
+    // If the selection rectangle touches a page edge, extend it to infinity
+    // in that direction. This allows selecting objects that extend beyond the page.
+    constexpr double eps = 1.0;
+    constexpr double INF = 1e9;
+
+    double minX = bbox.minX;
+    double minY = bbox.minY;
+    double maxX = bbox.maxX;
+    double maxY = bbox.maxY;
+
+    if (pageWidth > 0 && pageHeight > 0) {
+        if (minX <= eps)
+            minX = -INF;
+        if (minY <= eps)
+            minY = -INF;
+        if (maxX >= pageWidth - eps)
+            maxX = INF;
+        if (maxY >= pageHeight - eps)
+            maxY = INF;
+    }
+
+    return x >= minX && x <= maxX && y >= minY && y <= maxY;
+}
 
 void RectangularSelector::currentPos(double x, double y) {
     bbox = Range(sx, sy);

--- a/src/core/control/tools/Selector.cpp
+++ b/src/core/control/tools/Selector.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>  // for max, min
 #include <cmath>      // for abs, NAN
-#include <limits>     // for numeric_limits
 #include <memory>     // for __shared_ptr_access
 
 #include <gdk/gdk.h>  // for GdkRGBA, gdk_cairo_set_source_rgba
@@ -22,9 +21,33 @@ auto Selector::finalize(PageRef page, bool disableMultilayer, Document* doc) -> 
     this->page = page;
     this->pageWidth = page->getWidth();
     this->pageHeight = page->getHeight();
+    this->selectionDomain = Range();
 
-    // Let subclasses extend their geometry to infinity at page edges
-    this->extendAtPageEdges();
+    auto addToSelectionDomain = [this](const Layer* layer) {
+        if (!layer->isVisible()) {
+            return;
+        }
+        for (const auto& e: layer->getElementsView()) {
+            this->selectionDomain = this->selectionDomain.unite(Range(e->boundingRect()));
+        }
+    };
+
+    {
+        std::shared_lock lock(*doc);
+        if (multiLayer && !disableMultilayer) {
+            for (const Layer* layer: page->getLayersView()) {
+                addToSelectionDomain(layer);
+            }
+        } else {
+            addToSelectionDomain(page->getSelectedLayer());
+        }
+    }
+
+    if (this->selectionDomain.empty()) {
+        this->selectionDomain = this->bbox;
+    }
+
+    this->tailorToSelectionDomain();
 
     size_t layerId = 0;
 
@@ -83,21 +106,20 @@ RectangularSelector::~RectangularSelector() = default;
 
 auto RectangularSelector::contains(double x, double y) const -> bool { return extendedBbox.contains(x, y); }
 
-void RectangularSelector::extendAtPageEdges() {
+void RectangularSelector::tailorToSelectionDomain() {
     constexpr double THRESHOLD = 1.0;  // pt
-    constexpr double INF = std::numeric_limits<double>::infinity();
 
     extendedBbox = bbox;
 
-    if (pageWidth > 0 && pageHeight > 0) {
+    if (pageWidth > 0 && pageHeight > 0 && selectionDomain.isValid()) {
         if (extendedBbox.minX <= THRESHOLD)
-            extendedBbox.minX = -INF;
+            extendedBbox.minX = selectionDomain.minX;
         if (extendedBbox.minY <= THRESHOLD)
-            extendedBbox.minY = -INF;
+            extendedBbox.minY = selectionDomain.minY;
         if (extendedBbox.maxX >= pageWidth - THRESHOLD)
-            extendedBbox.maxX = INF;
+            extendedBbox.maxX = selectionDomain.maxX;
         if (extendedBbox.maxY >= pageHeight - THRESHOLD)
-            extendedBbox.maxY = INF;
+            extendedBbox.maxY = selectionDomain.maxY;
     }
 }
 
@@ -143,11 +165,10 @@ void LassoSelector::currentPos(double x, double y) {
     }
 }
 
-void LassoSelector::extendAtPageEdges() {
+void LassoSelector::tailorToSelectionDomain() {
     constexpr double THRESHOLD = 1.0;  // pt
-    constexpr double INF = std::numeric_limits<double>::infinity();
 
-    if (pageWidth <= 0 || pageHeight <= 0 || boundaryPoints.size() <= 2) {
+    if (pageWidth <= 0 || pageHeight <= 0 || boundaryPoints.size() <= 2 || !selectionDomain.isValid()) {
         extendedBoundaryPoints = boundaryPoints;
         extendedBbox = bbox;
         return;
@@ -161,13 +182,13 @@ void LassoSelector::extendAtPageEdges() {
         double px = p.x;
         double py = p.y;
         if (px <= THRESHOLD)
-            px = -INF;
+            px = selectionDomain.minX;
         if (px >= pageWidth - THRESHOLD)
-            px = INF;
+            px = selectionDomain.maxX;
         if (py <= THRESHOLD)
-            py = -INF;
+            py = selectionDomain.minY;
         if (py >= pageHeight - THRESHOLD)
-            py = INF;
+            py = selectionDomain.maxY;
         return {px, py};
     };
 

--- a/src/core/control/tools/Selector.cpp
+++ b/src/core/control/tools/Selector.cpp
@@ -21,6 +21,12 @@ auto Selector::finalize(PageRef page, bool disableMultilayer, Document* doc) -> 
     this->page = page;
     this->pageWidth = page->getWidth();
     this->pageHeight = page->getHeight();
+
+    // Let subclasses prepare extended geometry now that page dimensions are known
+    if (auto* lasso = dynamic_cast<LassoSelector*>(this)) {
+        lasso->buildExtendedBoundary();
+    }
+
     size_t layerId = 0;
 
     if (multiLayer && !disableMultilayer) {
@@ -143,22 +149,90 @@ void LassoSelector::currentPos(double x, double y) {
     }
 }
 
+void LassoSelector::buildExtendedBoundary() {
+    constexpr double eps = 1.0;
+    constexpr double INF = 1e9;
+
+    if (pageWidth <= 0 || pageHeight <= 0 || boundaryPoints.size() <= 2) {
+        extendedBoundaryPoints = boundaryPoints;
+        extendedBbox = bbox;
+        return;
+    }
+
+    auto const isOnEdge = [&](BoundaryPoint const& p) -> bool {
+        return p.x <= eps || p.x >= pageWidth - eps || p.y <= eps || p.y >= pageHeight - eps;
+    };
+
+    auto const project = [&](BoundaryPoint const& p) -> BoundaryPoint {
+        double px = p.x;
+        double py = p.y;
+        if (px <= eps)
+            px = -INF;
+        if (px >= pageWidth - eps)
+            px = INF;
+        if (py <= eps)
+            py = -INF;
+        if (py >= pageHeight - eps)
+            py = INF;
+        return {px, py};
+    };
+
+    extendedBoundaryPoints.clear();
+    extendedBoundaryPoints.reserve(boundaryPoints.size() * 2);
+
+    auto const n = boundaryPoints.size();
+    for (size_t i = 0; i < n; i++) {
+        auto const& current = boundaryPoints[i];
+        auto const currentOnEdge = isOnEdge(current);
+
+        if (!currentOnEdge) {
+            extendedBoundaryPoints.push_back(current);
+            continue;
+        }
+
+        // Current point is on a page edge.
+        auto const prevOnEdge = isOnEdge(boundaryPoints[(i + n - 1) % n]);
+        auto const nextOnEdge = isOnEdge(boundaryPoints[(i + 1) % n]);
+
+        if (!prevOnEdge) {
+            // Entering an edge run: emit original, then projected
+            extendedBoundaryPoints.push_back(current);
+            extendedBoundaryPoints.push_back(project(current));
+        } else if (!nextOnEdge) {
+            // Leaving an edge run: emit projected, then original
+            extendedBoundaryPoints.push_back(project(current));
+            extendedBoundaryPoints.push_back(current);
+        } else {
+            // Interior of an edge run: emit only projected
+            extendedBoundaryPoints.push_back(project(current));
+        }
+    }
+
+    // Build extended bounding box
+    extendedBbox = Range();
+    for (auto const& p: extendedBoundaryPoints) {
+        extendedBbox.addPoint(p.x, p.y);
+    }
+}
+
 auto LassoSelector::contains(double x, double y) const -> bool {
-    if (boundaryPoints.size() <= 2 || !this->bbox.contains(x, y)) {
+    auto const& pts = extendedBoundaryPoints.empty() ? boundaryPoints : extendedBoundaryPoints;
+    auto const& bboxRef = extendedBoundaryPoints.empty() ? bbox : extendedBbox;
+
+    if (pts.size() <= 2 || !bboxRef.contains(x, y)) {
         return false;
     }
 
     int hits = 0;
 
-    const BoundaryPoint& last = boundaryPoints.back();
+    const BoundaryPoint& last = pts.back();
 
     double lastx = last.x;
     double lasty = last.y;
     double curx = NAN, cury = NAN;
 
     // Walk the edges of the polygon
-    for (auto pointIterator = boundaryPoints.begin(); pointIterator != boundaryPoints.end();
-         lastx = curx, lasty = cury, ++pointIterator) {
+    for (auto pointIterator = pts.begin(); pointIterator != pts.end(); lastx = curx, lasty = cury, ++pointIterator) {
         curx = pointIterator->x;
         cury = pointIterator->y;
 

--- a/src/core/control/tools/Selector.cpp
+++ b/src/core/control/tools/Selector.cpp
@@ -152,6 +152,7 @@ void LassoSelector::extendAtPageEdges() {
     const double pageWidth = page->getWidth();
     const double pageHeight = page->getHeight();
 
+    // Skip extension when the page geometry is invalid or the lasso cannot form a polygon.
     if (pageWidth <= 0 || pageHeight <= 0 || boundaryPoints.size() <= 2) {
         return;
     }
@@ -167,6 +168,7 @@ void LassoSelector::extendAtPageEdges() {
                p.y <= EDGE_TOUCHING_THRESHOLD || p.y >= pageHeight - EDGE_TOUCHING_THRESHOLD;
     };
 
+    // Project edge-touching coordinates to infinity while leaving interior coordinates unchanged.
     auto const extendCoordinate = [&](double value, double pageExtent) -> double {
         if (value <= EDGE_TOUCHING_THRESHOLD) {
             return -INF;
@@ -181,14 +183,17 @@ void LassoSelector::extendAtPageEdges() {
         return {extendCoordinate(p.x, pageWidth), extendCoordinate(p.y, pageHeight)};
     };
 
+    // Build the final polygon in a scratch buffer because one input point may emit multiple output points.
     std::vector<BoundaryPoint> newBoundaryPoints;
     newBoundaryPoints.reserve(boundaryPoints.size() * 2);
 
-    auto const appendExtendedPoint = [&](BoundaryPoint const& p) {
+    // Keep the extended polygon and bbox in sync as points are emitted.
+    auto const appendExtendedPoint = [&](BoundaryPoint const& p) -> void {
         newBoundaryPoints.push_back(p);
         bbox.addPoint(p.x, p.y);
     };
 
+    // Walk the original lasso and splice in projected points for runs that touch the page edge.
     auto const n = boundaryPoints.size();
     for (size_t i = 0; i < n; i++) {
         auto const& current = boundaryPoints[i];
@@ -217,6 +222,7 @@ void LassoSelector::extendAtPageEdges() {
         }
     }
 
+    // Replace the original lasso with the extended polygon used for containment checks.
     boundaryPoints = std::move(newBoundaryPoints);
 }
 

--- a/src/core/control/tools/Selector.cpp
+++ b/src/core/control/tools/Selector.cpp
@@ -85,22 +85,21 @@ RectangularSelector::~RectangularSelector() = default;
 auto RectangularSelector::contains(double x, double y) const -> bool { return bbox.contains(x, y); }
 
 void RectangularSelector::extendAtPageEdges() {
-    constexpr double THRESHOLD = 1.0;  // pt
     constexpr double INF = std::numeric_limits<double>::infinity();
     const double pageWidth = page->getWidth();
     const double pageHeight = page->getHeight();
 
     if (pageWidth > 0 && pageHeight > 0) {
-        if (bbox.minX <= THRESHOLD) {
+        if (bbox.minX <= EDGE_TOUCHING_THRESHOLD) {
             bbox.minX = -INF;
         }
-        if (bbox.minY <= THRESHOLD) {
+        if (bbox.minY <= EDGE_TOUCHING_THRESHOLD) {
             bbox.minY = -INF;
         }
-        if (bbox.maxX >= pageWidth - THRESHOLD) {
+        if (bbox.maxX >= pageWidth - EDGE_TOUCHING_THRESHOLD) {
             bbox.maxX = INF;
         }
-        if (bbox.maxY >= pageHeight - THRESHOLD) {
+        if (bbox.maxY >= pageHeight - EDGE_TOUCHING_THRESHOLD) {
             bbox.maxY = INF;
         }
     }
@@ -149,7 +148,6 @@ void LassoSelector::currentPos(double x, double y) {
 }
 
 void LassoSelector::extendAtPageEdges() {
-    constexpr double THRESHOLD = 1.0;  // pt
     constexpr double INF = std::numeric_limits<double>::infinity();
     const double pageWidth = page->getWidth();
     const double pageHeight = page->getHeight();
@@ -158,20 +156,22 @@ void LassoSelector::extendAtPageEdges() {
         return;
     }
 
-    if (bbox.minX > THRESHOLD && bbox.minY > THRESHOLD && bbox.maxX < pageWidth - THRESHOLD &&
-        bbox.maxY < pageHeight - THRESHOLD) {
+    // Fast path: Most lassos stay fully inside the page, so avoid the projection work in that common case.
+    if (bbox.minX > EDGE_TOUCHING_THRESHOLD && bbox.minY > EDGE_TOUCHING_THRESHOLD &&
+        bbox.maxX < pageWidth - EDGE_TOUCHING_THRESHOLD && bbox.maxY < pageHeight - EDGE_TOUCHING_THRESHOLD) {
         return;
     }
 
     auto const isOnEdge = [&](BoundaryPoint const& p) -> bool {
-        return p.x <= THRESHOLD || p.x >= pageWidth - THRESHOLD || p.y <= THRESHOLD || p.y >= pageHeight - THRESHOLD;
+        return p.x <= EDGE_TOUCHING_THRESHOLD || p.x >= pageWidth - EDGE_TOUCHING_THRESHOLD ||
+               p.y <= EDGE_TOUCHING_THRESHOLD || p.y >= pageHeight - EDGE_TOUCHING_THRESHOLD;
     };
 
     auto const extendCoordinate = [&](double value, double pageExtent) -> double {
-        if (value <= THRESHOLD) {
+        if (value <= EDGE_TOUCHING_THRESHOLD) {
             return -INF;
         }
-        if (value >= pageExtent - THRESHOLD) {
+        if (value >= pageExtent - EDGE_TOUCHING_THRESHOLD) {
             return INF;
         }
         return value;

--- a/src/core/control/tools/Selector.cpp
+++ b/src/core/control/tools/Selector.cpp
@@ -13,6 +13,8 @@
 #include "model/XojPage.h"         // for XojPage
 #include "util/safe_casts.h"       // for as_unsigned
 
+static_assert(std::numeric_limits<double>::is_iec559);
+
 Selector::Selector(bool multiLayer):
         multiLayer(multiLayer), viewPool(std::make_shared<xoj::util::DispatchPool<xoj::view::SelectorView>>()) {}
 

--- a/src/core/control/tools/Selector.cpp
+++ b/src/core/control/tools/Selector.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>  // for max, min
 #include <cmath>      // for abs, NAN
+#include <limits>     // for numeric_limits
 #include <memory>     // for __shared_ptr_access
 
 #include <gdk/gdk.h>  // for GdkRGBA, gdk_cairo_set_source_rgba
@@ -22,10 +23,8 @@ auto Selector::finalize(PageRef page, bool disableMultilayer, Document* doc) -> 
     this->pageWidth = page->getWidth();
     this->pageHeight = page->getHeight();
 
-    // Let subclasses prepare extended geometry now that page dimensions are known
-    if (auto* lasso = dynamic_cast<LassoSelector*>(this)) {
-        lasso->buildExtendedBoundary();
-    }
+    // Let subclasses extend their geometry to infinity at page edges
+    this->extendAtPageEdges();
 
     size_t layerId = 0;
 
@@ -82,29 +81,24 @@ RectangularSelector::RectangularSelector(double x, double y, bool multiLayer):
 
 RectangularSelector::~RectangularSelector() = default;
 
-auto RectangularSelector::contains(double x, double y) const -> bool {
-    // If the selection rectangle touches a page edge, extend it to infinity
-    // in that direction. This allows selecting objects that extend beyond the page.
-    constexpr double eps = 1.0;
-    constexpr double INF = 1e9;
+auto RectangularSelector::contains(double x, double y) const -> bool { return extendedBbox.contains(x, y); }
 
-    double minX = bbox.minX;
-    double minY = bbox.minY;
-    double maxX = bbox.maxX;
-    double maxY = bbox.maxY;
+void RectangularSelector::extendAtPageEdges() {
+    constexpr double THRESHOLD = 1.0;  // pt
+    constexpr double INF = std::numeric_limits<double>::infinity();
+
+    extendedBbox = bbox;
 
     if (pageWidth > 0 && pageHeight > 0) {
-        if (minX <= eps)
-            minX = -INF;
-        if (minY <= eps)
-            minY = -INF;
-        if (maxX >= pageWidth - eps)
-            maxX = INF;
-        if (maxY >= pageHeight - eps)
-            maxY = INF;
+        if (extendedBbox.minX <= THRESHOLD)
+            extendedBbox.minX = -INF;
+        if (extendedBbox.minY <= THRESHOLD)
+            extendedBbox.minY = -INF;
+        if (extendedBbox.maxX >= pageWidth - THRESHOLD)
+            extendedBbox.maxX = INF;
+        if (extendedBbox.maxY >= pageHeight - THRESHOLD)
+            extendedBbox.maxY = INF;
     }
-
-    return x >= minX && x <= maxX && y >= minY && y <= maxY;
 }
 
 void RectangularSelector::currentPos(double x, double y) {
@@ -149,9 +143,9 @@ void LassoSelector::currentPos(double x, double y) {
     }
 }
 
-void LassoSelector::buildExtendedBoundary() {
-    constexpr double eps = 1.0;
-    constexpr double INF = 1e9;
+void LassoSelector::extendAtPageEdges() {
+    constexpr double THRESHOLD = 1.0;  // pt
+    constexpr double INF = std::numeric_limits<double>::infinity();
 
     if (pageWidth <= 0 || pageHeight <= 0 || boundaryPoints.size() <= 2) {
         extendedBoundaryPoints = boundaryPoints;
@@ -160,19 +154,19 @@ void LassoSelector::buildExtendedBoundary() {
     }
 
     auto const isOnEdge = [&](BoundaryPoint const& p) -> bool {
-        return p.x <= eps || p.x >= pageWidth - eps || p.y <= eps || p.y >= pageHeight - eps;
+        return p.x <= THRESHOLD || p.x >= pageWidth - THRESHOLD || p.y <= THRESHOLD || p.y >= pageHeight - THRESHOLD;
     };
 
     auto const project = [&](BoundaryPoint const& p) -> BoundaryPoint {
         double px = p.x;
         double py = p.y;
-        if (px <= eps)
+        if (px <= THRESHOLD)
             px = -INF;
-        if (px >= pageWidth - eps)
+        if (px >= pageWidth - THRESHOLD)
             px = INF;
-        if (py <= eps)
+        if (py <= THRESHOLD)
             py = -INF;
-        if (py >= pageHeight - eps)
+        if (py >= pageHeight - THRESHOLD)
             py = INF;
         return {px, py};
     };

--- a/src/core/control/tools/Selector.h
+++ b/src/core/control/tools/Selector.h
@@ -104,7 +104,4 @@ public:
     const std::vector<BoundaryPoint>& getBoundary() const override;
 
     void extendAtPageEdges() override;
-
-private:
-    std::vector<BoundaryPoint> extendedBoundaryPoints;
 };

--- a/src/core/control/tools/Selector.h
+++ b/src/core/control/tools/Selector.h
@@ -42,10 +42,10 @@ public:
     virtual const std::vector<BoundaryPoint>& getBoundary() const = 0;
 
     /**
-     * Tailor the selector geometry to the finite selection domain on the page.
-     * Called by finalize() after page dimensions and candidate element bounds are known.
+     * Extend the selector geometry to infinity at page edges.
+     * Called by finalize() before element containment checks.
      */
-    virtual void tailorToSelectionDomain(const Range& selectionDomain) {};
+    virtual void extendAtPageEdges() = 0;
 
     inline auto getViewPool() const -> const std::shared_ptr<xoj::util::DispatchPool<xoj::view::SelectorView>>& {
         return viewPool;
@@ -83,7 +83,7 @@ public:
     bool contains(double x, double y) const override;
     bool userTapped(double zoom) const override;
     const std::vector<BoundaryPoint>& getBoundary() const override;
-    void tailorToSelectionDomain(const Range& selectionDomain) override;
+    void extendAtPageEdges() override;
 
 private:
     double sx;
@@ -91,7 +91,6 @@ private:
     double ex;
     double ey;
     double maxDist = 0;
-    Range extendedBbox;
 };
 
 class LassoSelector: public Selector {
@@ -104,9 +103,8 @@ public:
     bool userTapped(double zoom) const override;
     const std::vector<BoundaryPoint>& getBoundary() const override;
 
-    void tailorToSelectionDomain(const Range& selectionDomain) override;
+    void extendAtPageEdges() override;
 
 private:
     std::vector<BoundaryPoint> extendedBoundaryPoints;
-    Range extendedBbox;
 };

--- a/src/core/control/tools/Selector.h
+++ b/src/core/control/tools/Selector.h
@@ -57,6 +57,11 @@ public:
      */
     auto releaseElements() -> InsertionOrderRef;
 
+    /**
+     * If the selector touches page edges, the selection area is extended to infinity along the touching edge.
+     * Define a threshold in pt for the vicinity the selection area must be in to trigger extension.
+     */
+    static constexpr double EDGE_TOUCHING_THRESHOLD = 1.0;  // pt
 private:
 protected:
     std::vector<BoundaryPoint> boundaryPoints;

--- a/src/core/control/tools/Selector.h
+++ b/src/core/control/tools/Selector.h
@@ -45,7 +45,7 @@ public:
      * Tailor the selector geometry to the finite selection domain on the page.
      * Called by finalize() after page dimensions and candidate element bounds are known.
      */
-    virtual void tailorToSelectionDomain() {};
+    virtual void tailorToSelectionDomain(const Range& selectionDomain) {};
 
     inline auto getViewPool() const -> const std::shared_ptr<xoj::util::DispatchPool<xoj::view::SelectorView>>& {
         return viewPool;
@@ -67,7 +67,6 @@ protected:
     PageRef page;
 
     Range bbox;
-    Range selectionDomain;
 
     double pageWidth = 0;
     double pageHeight = 0;
@@ -87,7 +86,7 @@ public:
     bool contains(double x, double y) const override;
     bool userTapped(double zoom) const override;
     const std::vector<BoundaryPoint>& getBoundary() const override;
-    void tailorToSelectionDomain() override;
+    void tailorToSelectionDomain(const Range& selectionDomain) override;
 
 private:
     double sx;
@@ -108,7 +107,7 @@ public:
     bool userTapped(double zoom) const override;
     const std::vector<BoundaryPoint>& getBoundary() const override;
 
-    void tailorToSelectionDomain() override;
+    void tailorToSelectionDomain(const Range& selectionDomain) override;
 
 private:
     std::vector<BoundaryPoint> extendedBoundaryPoints;

--- a/src/core/control/tools/Selector.h
+++ b/src/core/control/tools/Selector.h
@@ -41,6 +41,12 @@ public:
     virtual bool userTapped(double zoom) const = 0;
     virtual const std::vector<BoundaryPoint>& getBoundary() const = 0;
 
+    /**
+     * Extend the selector's geometry to infinity where it touches a page edge.
+     * Called by finalize() after page dimensions are known. Default is a no-op.
+     */
+    virtual void extendAtPageEdges() {};
+
     inline auto getViewPool() const -> const std::shared_ptr<xoj::util::DispatchPool<xoj::view::SelectorView>>& {
         return viewPool;
     }
@@ -80,6 +86,7 @@ public:
     bool contains(double x, double y) const override;
     bool userTapped(double zoom) const override;
     const std::vector<BoundaryPoint>& getBoundary() const override;
+    void extendAtPageEdges() override;
 
 private:
     double sx;
@@ -87,6 +94,7 @@ private:
     double ex;
     double ey;
     double maxDist = 0;
+    Range extendedBbox;
 };
 
 class LassoSelector: public Selector {
@@ -99,11 +107,7 @@ public:
     bool userTapped(double zoom) const override;
     const std::vector<BoundaryPoint>& getBoundary() const override;
 
-    /**
-     * Build an extended polygon that bulges outward to infinity where the lasso
-     * touches a page edge. Must be called after page dimensions are set.
-     */
-    void buildExtendedBoundary();
+    void extendAtPageEdges() override;
 
 private:
     std::vector<BoundaryPoint> extendedBoundaryPoints;

--- a/src/core/control/tools/Selector.h
+++ b/src/core/control/tools/Selector.h
@@ -62,6 +62,9 @@ protected:
 
     Range bbox;
 
+    double pageWidth = 0;
+    double pageHeight = 0;
+
     std::shared_ptr<xoj::util::DispatchPool<xoj::view::SelectorView>> viewPool;
 
     friend class EditSelection;

--- a/src/core/control/tools/Selector.h
+++ b/src/core/control/tools/Selector.h
@@ -68,9 +68,6 @@ protected:
 
     Range bbox;
 
-    double pageWidth = 0;
-    double pageHeight = 0;
-
     std::shared_ptr<xoj::util::DispatchPool<xoj::view::SelectorView>> viewPool;
 
     friend class EditSelection;

--- a/src/core/control/tools/Selector.h
+++ b/src/core/control/tools/Selector.h
@@ -42,10 +42,10 @@ public:
     virtual const std::vector<BoundaryPoint>& getBoundary() const = 0;
 
     /**
-     * Extend the selector's geometry to infinity where it touches a page edge.
-     * Called by finalize() after page dimensions are known. Default is a no-op.
+     * Tailor the selector geometry to the finite selection domain on the page.
+     * Called by finalize() after page dimensions and candidate element bounds are known.
      */
-    virtual void extendAtPageEdges() {};
+    virtual void tailorToSelectionDomain() {};
 
     inline auto getViewPool() const -> const std::shared_ptr<xoj::util::DispatchPool<xoj::view::SelectorView>>& {
         return viewPool;
@@ -67,6 +67,7 @@ protected:
     PageRef page;
 
     Range bbox;
+    Range selectionDomain;
 
     double pageWidth = 0;
     double pageHeight = 0;
@@ -86,7 +87,7 @@ public:
     bool contains(double x, double y) const override;
     bool userTapped(double zoom) const override;
     const std::vector<BoundaryPoint>& getBoundary() const override;
-    void extendAtPageEdges() override;
+    void tailorToSelectionDomain() override;
 
 private:
     double sx;
@@ -107,7 +108,7 @@ public:
     bool userTapped(double zoom) const override;
     const std::vector<BoundaryPoint>& getBoundary() const override;
 
-    void extendAtPageEdges() override;
+    void tailorToSelectionDomain() override;
 
 private:
     std::vector<BoundaryPoint> extendedBoundaryPoints;

--- a/src/core/control/tools/Selector.h
+++ b/src/core/control/tools/Selector.h
@@ -98,4 +98,14 @@ public:
     bool contains(double x, double y) const override;
     bool userTapped(double zoom) const override;
     const std::vector<BoundaryPoint>& getBoundary() const override;
+
+    /**
+     * Build an extended polygon that bulges outward to infinity where the lasso
+     * touches a page edge. Must be called after page dimensions are set.
+     */
+    void buildExtendedBoundary();
+
+private:
+    std::vector<BoundaryPoint> extendedBoundaryPoints;
+    Range extendedBbox;
 };


### PR DESCRIPTION
As mentioned in #1292 objects extending beyond the page boundary cannot be selected via rectangular or lasso selection tool. This PR introduces the extension of these selections to infinity if the selection touches the page boundary. As this selection still happens on the same page (just with a huge box) this shouldn't affect any neighboring pages and does not open the can of multi-page selection. I did the same for the lasso selection tool with a polygon extending to infinity whenever the lasso touches the boundary. The lasso extension is precomputed.

This should actually be a full fix and close #1292.