### PR TITLE
Fix macos environment setup

### DIFF
--- a/readme/MacBuild.md
+++ b/readme/MacBuild.md
@@ -39,33 +39,34 @@ git clone http://github.com/xournalpp/xournalpp.git
 cd xournalpp
 mkdir build
 cd build
-cmake .. -GNinja -DCMAKE_INSTALL_PREFIX="$(brew --prefix)"
+cmake .. -GNinja -DCMAKE_INSTALL_PREFIX=inst
 ninja install
 ````
 
-Here `"$(brew --prefix)"` where Xournal++ gets installed defaults to `/usr/local` on MacOS Intel and to `/opt/homebrew` on MacOS ARM.
-This installation prefix is essential when running the binary, since otherwise pixbuf loaders don't work properly.
 
 ### Run Xournal++:
 
-On MacOS Intel:
+From the build folder run:
 ```sh
-/usr/local/bin/xournalpp
+inst/bin/xournalpp
 ```
 or using the wrapper (in the development version):
 ```sh
-/usr/local/bin/xournalpp-wrapper
+inst/bin/xournalpp-wrapper
 ```
 
-On MacOS ARM:
+### Using plugins with LuaGObject:
 
+For plugins that offer a graphical user interface using LuaGObject you can install LuaGObject via
 ```sh
-/opt/homebrew/bin/xournalpp
+brew install luarocks
+sudo luarocks install LuaGObject
 ```
-or using the wrapper:
+In order that LuaGObject can load dynamic libraries you should set the `DYLD_LIBRARY_PATH`:
 ```sh
-/opt/homebrew/bin/xournalpp-wrapper
+export DYLD_LIBRARY_PATH = $(brew --prefix)/lib:$DYLD_LIBRARY_PATH
 ```
+To make it permanent add that line to ~/.zshenv
 
 
 ## Bundling Xournal++ into a `.app` with gtk-osx
@@ -260,10 +261,9 @@ jhbuild run bash ./build-app.sh "$HOME"/gtk
 Once the `Xournal++.app` bundle is created, you can install it in your
 Applications directory and run it.
 
-At the time of writing, it is not possible to run the application from the
-`build` folder (at least if you're using the special build user). If you have
-found a nice way to get this to run, it would be great if you could contribute
-the steps to this document!
+If the application is installed in a different folder than $HOME/gtk/inst, 
+it will crash unless in GDK_PIXBUF_MODULE_FILE relative paths are replaced
+by absolute paths.
 
 ### FAQ
 

--- a/src/exe/osx/setup-env.cpp
+++ b/src/exe/osx/setup-env.cpp
@@ -10,60 +10,95 @@
 
 #include "filesystem.h"
 
+namespace {
+void prependPathToEnvVar(const char* name, fs::path const& path) {
+    const char* currentVal = g_getenv(name);
+    std::string newVar;
+    if (currentVal == nullptr || strlen(currentVal) == 0) {
+        newVar = path.string();
+    } else {
+        newVar = path.string() + ":" + currentVal;
+    }
+    g_setenv(name, newVar.c_str(), 1);
+}
+
+void prependPathToLua(const char* name, const std::string& path) {
+    const char* currentVal = g_getenv(name);
+    std::string newVar;
+    if (currentVal == nullptr || strlen(currentVal) == 0) {
+        newVar = path + ";;";
+    } else {
+        newVar = path + ";" + currentVal;
+    }
+    g_setenv(name, newVar.c_str(), true);
+}
+}  // end namespace
+
 void setupEnvironment() {
     /**
      * see https://gitlab.gnome.org/GNOME/gtk-mac-bundler/-/blob/master/examples/gtk3-launcher.sh
      * and https://gitlab.gnome.org/GNOME/gtk-mac-bundler/-/issues/12
      */
-    auto base = Util::getExePath().parent_path();  // Xournal++.app/Contents or $HOME/gtk/inst
+    auto base = Util::getExePath().parent_path();  // Xournal++.app/Contents or $HOME/gtk/inst or e.g. build/inst (via
+                                                   // Homebrew or MacPorts)
 
-    if (fs::exists(base / "Resources")) {  // app-bundle
-        base = base / "Resources";
-        // Set poppler data directory for (relocatable) app bundles. Otherwise a compile time value is used.
-        auto popplerDataDir = base / "share" / "poppler";
-        poppler::set_data_dir(popplerDataDir.string().c_str());
-    }  // Now base is Xournal++.app/Contents/Resources or $HOME/gtk/inst
+    bool isAppBundle = fs::exists(base / "Resources");
+    bool underJHBuild = g_strcmp0(g_getenv("UNDER_JHBUILD"), "true") == 0;
+
+    if (isAppBundle) {
+        base = base / "Resources";  // Now base is Xournal++.app/Contents/Resources
+    }
 
     auto libPath = base / "lib";
     auto dataPath = base / "share";
-    auto xdgPath = base / "etc" / "xdg";
 
-    auto imModuleFile = libPath / "gtk-3.0" / "3.0.0" / "immodules.cache";
-    auto pixbufModuleFile = libPath / "gdk-pixbuf-2.0" / "2.10.0" / "loaders.cache";
+    if (isAppBundle) {
+        // Set poppler data directory for (relocatable) app bundles. Otherwise a compile time value is used.
+        auto popplerDataDir = dataPath / "poppler";
+        poppler::set_data_dir(popplerDataDir.string().c_str());
 
-    auto typelibPath = libPath / "girepository-1.0";
+        auto imModuleFile = libPath / "gtk-3.0" / "3.0.0" / "immodules.cache";
+        auto pixbufModuleFile = libPath / "gdk-pixbuf-2.0" / "2.10.0" / "loaders.cache";
 
-    std::string luaPath = dataPath.string() + "/lua/5.4/?.lua";
-    std::string luaCPath = libPath.string() + "/lua/5.4/?.so";
+        auto typelibPath = libPath / "girepository-1.0";
+        auto xdgPath = base / "etc" / "xdg";
 
-    setenv("XDG_CONFIG_DIRS", xdgPath.string().c_str(), 1);
-    setenv("XDG_DATA_DIRS", dataPath.string().c_str(), 1);
-    setenv("GTK_DATA_PREFIX", base.string().c_str(), 1);
-    setenv("GTK_EXE_PREFIX", base.string().c_str(), 1);
-    setenv("GTK_PATH", base.string().c_str(), 1);
+        prependPathToEnvVar("XDG_CONFIG_DIRS", xdgPath);
+        prependPathToEnvVar("XDG_DATA_DIRS", dataPath);
+        g_setenv("GTK_DATA_PREFIX", base.string().c_str(), 1);
+        g_setenv("GTK_EXE_PREFIX", base.string().c_str(), 1);
+        g_setenv("GTK_PATH", base.string().c_str(), 1);
 
-    setenv("GTK_IM_MODULE_FILE", imModuleFile.string().c_str(), 0);
-    setenv("GDK_PIXBUF_MODULE_FILE", pixbufModuleFile.string().c_str(), 0);
+        g_setenv("GTK_IM_MODULE_FILE", imModuleFile.string().c_str(), 0);
+        g_setenv("GDK_PIXBUF_MODULE_FILE", pixbufModuleFile.string().c_str(), 0);
 
-    setenv("GI_TYPELIB_PATH", typelibPath.string().c_str(), 0);
+        g_setenv("GI_TYPELIB_PATH", typelibPath.string().c_str(), 0);
+    }
 
-    setenv("LUA_PATH", luaPath.c_str(), 0);
-    setenv("LUA_CPATH", luaCPath.c_str(), 0);
+    if (isAppBundle || underJHBuild) {  // in both cases we have non-standard paths for Lua
+        std::string luaPath = dataPath.string() + "/lua/5.4/?.lua";
+        std::string luaCPath = libPath.string() + "/lua/5.4/?.so";
 
-    auto environ = g_get_environ();
-    const char* usedPixbufModuleFile = g_environ_getenv(environ, "GDK_PIXBUF_MODULE_FILE");
-    const char* usedTypelibPath = g_environ_getenv(environ, "GI_TYPELIB_PATH");
+        prependPathToLua("LUA_PATH", luaPath);
+        prependPathToLua("LUA_CPATH", luaCPath);
+    }
+
+    const char* usedPixbufModuleFile = g_getenv("GDK_PIXBUF_MODULE_FILE");
+    const char* usedXDGDataDirs = g_getenv("XDG_DATA_DIRS");
+    const char* usedTypelibPath = g_getenv("GI_TYPELIB_PATH");
     // The DYLD_LIBRARY_PATH is only read when the process is started, so it can't be set here. It is set in
     // the Info.plist therefore, which only takes effect when running the App from Finder or using the "open" command.
-    const char* usedDYLDLibraryPath = g_environ_getenv(environ, "DYLD_LIBRARY_PATH");
-    const char* usedLuaPath = g_environ_getenv(environ, "LUA_PATH");
-    const char* usedLuaCPath = g_environ_getenv(environ, "LUA_CPATH");
-    g_message("Continue with GDK_PIXBUF_MODULE_FILE = %s\n"
-              "GI_TYPELIB_PATH = %s\n"
-              "DYLD_LIBRARY_PATH = %s\n"
-              "LUA_PATH = %s\n"
-              "LUA_CPATH = %s",
-              usedPixbufModuleFile, usedTypelibPath, usedDYLDLibraryPath, usedLuaPath, usedLuaCPath);
+    const char* usedDYLDLibraryPath = g_getenv("DYLD_LIBRARY_PATH");
+    const char* usedLuaPath = g_getenv("LUA_PATH");
+    const char* usedLuaCPath = g_getenv("LUA_CPATH");
+    g_debug("Continue with:\n"
+            "GDK_PIXBUF_MODULE_FILE = %s\n"
+            "XDG_DATA_DIRS = %s\n"
+            "GI_TYPELIB_PATH = %s\n"
+            "DYLD_LIBRARY_PATH = %s\n"
+            "LUA_PATH = %s\n"
+            "LUA_CPATH = %s",
+            usedPixbufModuleFile, usedXDGDataDirs, usedTypelibPath, usedDYLDLibraryPath, usedLuaPath, usedLuaCPath);
 
     /**
      * set LANG and LC_MESSAGES in order to detect the default language

--- a/src/exe/osx/setup-env.cpp
+++ b/src/exe/osx/setup-env.cpp
@@ -26,9 +26,9 @@ void prependPathToLua(const char* name, const std::string& path) {
     const char* currentVal = g_getenv(name);
     std::string newVar;
     if (currentVal == nullptr || strlen(currentVal) == 0) {
-        newVar = path + ";;";
+        newVar = std::string(Util::toGFilename(path).c_str()) + ";;";
     } else {
-        newVar = path + ";" + currentVal;
+        newVar = std::string(Util::toGFilename(path).c_str()) + ";" + currentVal;
     }
     g_setenv(name, newVar.c_str(), true);
 }
@@ -42,7 +42,11 @@ void setupEnvironment() {
     auto base = Util::getExePath().parent_path();  // Xournal++.app/Contents or $HOME/gtk/inst or e.g. build/inst (via
                                                    // Homebrew or MacPorts)
 
-    bool isAppBundle = fs::exists(base / "Resources");
+    std::error_code err;
+    bool isAppBundle = fs::exists(base / "Resources", err);
+    if (err) {
+        g_warning("Failed to determine if the app runs as an app bundle: %s", err.message().c_str());
+    }
     bool underJHBuild = g_strcmp0(g_getenv("UNDER_JHBUILD"), "true") == 0;
 
     if (isAppBundle) {
@@ -65,19 +69,19 @@ void setupEnvironment() {
 
         prependPathToEnvVar("XDG_CONFIG_DIRS", xdgPath);
         prependPathToEnvVar("XDG_DATA_DIRS", dataPath);
-        g_setenv("GTK_DATA_PREFIX", base.string().c_str(), 1);
-        g_setenv("GTK_EXE_PREFIX", base.string().c_str(), 1);
-        g_setenv("GTK_PATH", base.string().c_str(), 1);
+        g_setenv("GTK_DATA_PREFIX", Util::toGFilename(base).c_str(), 1);
+        g_setenv("GTK_EXE_PREFIX", Util::toGFilename(base).c_str(), 1);
+        g_setenv("GTK_PATH", Util::toGFilename(base).c_str(), 1);
 
-        g_setenv("GTK_IM_MODULE_FILE", imModuleFile.string().c_str(), 0);
-        g_setenv("GDK_PIXBUF_MODULE_FILE", pixbufModuleFile.string().c_str(), 0);
+        g_setenv("GTK_IM_MODULE_FILE", Util::toGFilename(imModuleFile).c_str(), 0);
+        g_setenv("GDK_PIXBUF_MODULE_FILE", Util::toGFilename(pixbufModuleFile).c_str(), 0);
 
-        g_setenv("GI_TYPELIB_PATH", typelibPath.string().c_str(), 0);
+        g_setenv("GI_TYPELIB_PATH", Util::toGFilename(typelibPath).c_str(), 0);
     }
 
     if (isAppBundle || underJHBuild) {  // in both cases we have non-standard paths for Lua
-        std::string luaPath = dataPath.string() + "/lua/5.4/?.lua";
-        std::string luaCPath = libPath.string() + "/lua/5.4/?.so";
+        std::string luaPath = std::string(Util::toGFilename(dataPath).c_str()) + "/lua/5.4/?.lua";
+        std::string luaCPath = std::string(Util::toGFilename(libPath).c_str()) + "/lua/5.4/?.so";
 
         prependPathToLua("LUA_PATH", luaPath);
         prependPathToLua("LUA_CPATH", luaCPath);
@@ -118,8 +122,8 @@ void setupEnvironment() {
                 }
                 lang += ".UTF-8";  // e.g. "de_DE.UTF-8"
                 g_message("Setting LANG and LC_MESSAGES to %s", lang.c_str());
-                setenv("LANG", lang.c_str(), 0);
-                setenv("LC_MESSAGES", lang.c_str(), 0);
+                g_setenv("LANG", lang.c_str(), 0);
+                g_setenv("LC_MESSAGES", lang.c_str(), 0);
             }
         }
     }


### PR DESCRIPTION
- Set environment variables on MacOS only for app bundles
- Prepend to XDG_DATA_DIRS and XDG_CONFIG_DIRS instead of overwriting
- Prepend to LUA_PATH and LUA_CPATH (when built using jhbuild) instead of overwriting
- Use g_getenv and g_setenv consistently
- Output most relevant environment variables when run through G_MESSAGES_DEBUG=xopp

The following methods of running Xournal++ on MacOS have been tested to work
1) Opening the Xournal++.app bundle either from Finder or using the open command in the terminal
2) Running the binary in Xournal++.app/Contents/MacOS directly from the terminal
3) Compiling Gtk using jhbuild, building and installing Xournal++ in $JHBUILD_PREFIX and running it
   using jhbuild run xournalpp (in order to set up the environment)
4) Compiling Xournal++ using Homebrew, installing it anywhere and running it from that folder
5) Compiling Xournal++ using MacPorts, installing it anywhere and running it from that folder

Method 4) only worked previously when installing into $(brew --prefix), which was inconvenient

The DYLD_LIBRARY_PATH is only set for method 1) through Info.plist. For the other methods it may need
to be set for some use cases, e.g. for plugins using LuaGObject.
The LUA_PATH and LUA_CPATH must be set when Lua (or Lua modules) are installed in non-standard locations