### PR TITLE
Fix: clear laser pointer traces on reselect

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -1,8 +1,8 @@
 #include "Control.h"
 
-#include <algorithm>  // for max
-#include <cstdlib>    // for size_t
-#include <exception>  // for exce...
+#include <algorithm>   // for max
+#include <cstdlib>     // for size_t
+#include <exception>   // for exce...
 #include <functional>  // for bind
 #include <iterator>    // for end
 #include <memory>      // for make...
@@ -1151,6 +1151,7 @@ void Control::undoRedoPageChanged(PageRef page) {
 void Control::selectTool(ToolType type) {
     // keep text-selection when switching from text to seletion tool
     auto oldTool = getToolHandler()->getActiveTool();
+    auto oldToolType = oldTool ? oldTool->getToolType() : TOOL_NONE;
     if (oldTool && win && isSelectToolType(type) && oldTool->getToolType() == ToolType::TOOL_TEXT &&
         this->win->getXournal()->getTextEditor() && !(this->win->getXournal()->getTextEditor()->bufferEmpty())) {
         auto xournal = this->win->getXournal();
@@ -1164,6 +1165,10 @@ void Control::selectTool(ToolType type) {
         auto sel = SelectionFactory::createFromElementOnActiveLayer(this, page, view, textobj);
 
         xournal->setSelection(sel.release());
+    }
+
+    if (win && oldToolType == type && (type == TOOL_LASER_POINTER_PEN || type == TOOL_LASER_POINTER_HIGHLIGHTER)) {
+        win->getXournal()->clearLaserPointers();
     }
 
     toolHandler->selectTool(type);

--- a/src/core/control/tools/LaserPointerHandler.cpp
+++ b/src/core/control/tools/LaserPointerHandler.cpp
@@ -42,6 +42,21 @@ std::unique_ptr<xoj::view::OverlayView> LaserPointerHandler::createView(xoj::vie
     return view;
 }
 
+void LaserPointerHandler::clearNow() {
+    this->fadeoutTimer.cancel();
+
+    auto s = std::move(this->strokehandler);
+    if (s && s->getStroke()) {
+        this->viewPool->dispatch(xoj::view::LaserPointerView::INPUT_CANCELLATION_REQUEST,
+                                 Range(s->getStroke()->boundingRect()));
+    }
+
+    this->fadeoutAlpha = 255;
+    this->hasFinishedStrokes = false;
+    this->viewPool->dispatchAndClear(xoj::view::LaserPointerView::FINALIZATION_REQUEST);
+    this->pageView->deleteLaserPointerHandler();
+}
+
 void LaserPointerHandler::onButtonPressEvent(const PositionInputData& pos, double zoom) {
     this->strokehandler = std::make_unique<TemporaryStrokeHandler>(ctrl, page);
     this->strokehandler->onButtonPressEvent(pos, zoom);

--- a/src/core/control/tools/LaserPointerHandler.h
+++ b/src/core/control/tools/LaserPointerHandler.h
@@ -40,6 +40,7 @@ public:
     LaserPointerHandler(XojPageView* pageView, Control* control, const PageRef& page);
     ~LaserPointerHandler() override;
 
+    void clearNow();
     void onSequenceCancelEvent();
     bool onMotionNotifyEvent(const PositionInputData& pos, double zoom);
     void onButtonReleaseEvent(const PositionInputData& pos, double zoom);

--- a/src/core/gui/PageView.cpp
+++ b/src/core/gui/PageView.cpp
@@ -209,6 +209,12 @@ void XojPageView::endSpline() {
     }
 }
 
+void XojPageView::clearLaserPointer() {
+    if (this->laserPointer) {
+        this->laserPointer->clearNow();
+    }
+}
+
 void XojPageView::deleteLaserPointerHandler() {
     xoj_assert(hasNoViewOf(overlayViews, laserPointer.get()));
     laserPointer.reset();

--- a/src/core/gui/PageView.h
+++ b/src/core/gui/PageView.h
@@ -103,6 +103,7 @@ public:
     void endText();
 
     void endSpline();
+    void clearLaserPointer();
 
     bool searchTextOnPage(const std::string& text, size_t index, size_t* occurrences, XojPdfRectangle* matchRect);
 

--- a/src/core/gui/XournalView.cpp
+++ b/src/core/gui/XournalView.cpp
@@ -9,40 +9,40 @@
 #include <gdk/gdkkeysyms.h>  // for GDK_KEY_Page_Down
 #include <glib-object.h>     // for g_object_ref_sink
 
-#include "control/Control.h"                     // for Control
-#include "control/PdfCache.h"                    // for PdfCache
-#include "control/ScrollHandler.h"               // for ScrollHandler
-#include "control/ToolHandler.h"                 // for ToolHandler
-#include "control/actions/ActionDatabase.h"      // for ActionDatabase
-#include "control/jobs/XournalScheduler.h"       // for XournalScheduler
-#include "control/settings/MetadataManager.h"    // for MetadataManager
-#include "control/settings/Settings.h"           // for Settings
-#include "control/tools/CursorSelectionType.h"   // for CURSOR_SELECTION_NONE
-#include "control/tools/EditSelection.h"         // for EditSelection
-#include "control/zoom/ZoomControl.h"            // for ZoomControl
-#include "gui/MainWindow.h"                      // for MainWindow
-#include "gui/PdfFloatingToolbox.h"              // for PdfFloatingToolbox
+#include "control/Control.h"                            // for Control
+#include "control/PdfCache.h"                           // for PdfCache
+#include "control/ScrollHandler.h"                      // for ScrollHandler
+#include "control/ToolHandler.h"                        // for ToolHandler
+#include "control/actions/ActionDatabase.h"             // for ActionDatabase
+#include "control/jobs/XournalScheduler.h"              // for XournalScheduler
+#include "control/settings/MetadataManager.h"           // for MetadataManager
+#include "control/settings/Settings.h"                  // for Settings
+#include "control/tools/CursorSelectionType.h"          // for CURSOR_SELECTION_NONE
+#include "control/tools/EditSelection.h"                // for EditSelection
+#include "control/zoom/ZoomControl.h"                   // for ZoomControl
+#include "gui/MainWindow.h"                             // for MainWindow
+#include "gui/PdfFloatingToolbox.h"                     // for PdfFloatingToolbox
 #include "gui/inputdevices/GeometryToolInputHandler.h"  // for GeometryToolInputHandler
-#include "gui/inputdevices/HandRecognition.h"    // for HandRecognition
-#include "gui/inputdevices/InputContext.h"       // for InputContext
-#include "gui/scroll/ScrollHandling.h"           // for ScrollHandling
-#include "gui/toolbarMenubar/ColorToolItem.h"    // for ColorToolItem
-#include "gui/toolbarMenubar/ToolMenuHandler.h"  // for ToolMenuHandler
-#include "gui/widgets/XournalWidget.h"           // for gtk_xournal_get_layout
-#include "model/Document.h"                      // for Document
-#include "model/Element.h"                       // for Element, ELEMENT_STROKE
-#include "model/PageRef.h"                       // for PageRef
-#include "model/Stroke.h"                        // for Stroke, StrokeTool::E...
-#include "model/XojPage.h"                       // for XojPage
-#include "undo/DeleteUndoAction.h"               // for DeleteUndoAction
-#include "undo/UndoRedoHandler.h"                // for UndoRedoHandler
-#include "util/Assert.h"                         // for xoj_assert
-#include "util/Point.h"                          // for Point
-#include "util/Rectangle.h"                      // for Rectangle
-#include "util/Util.h"                           // for npos
-#include "util/glib_casts.h"                     // for wrap_v
-#include "util/gtk4_helper.h"                    // for gtk_scrolled_window_set_child
-#include "util/safe_casts.h"                     // for round_cast
+#include "gui/inputdevices/HandRecognition.h"           // for HandRecognition
+#include "gui/inputdevices/InputContext.h"              // for InputContext
+#include "gui/scroll/ScrollHandling.h"                  // for ScrollHandling
+#include "gui/toolbarMenubar/ColorToolItem.h"           // for ColorToolItem
+#include "gui/toolbarMenubar/ToolMenuHandler.h"         // for ToolMenuHandler
+#include "gui/widgets/XournalWidget.h"                  // for gtk_xournal_get_layout
+#include "model/Document.h"                             // for Document
+#include "model/Element.h"                              // for Element, ELEMENT_STROKE
+#include "model/PageRef.h"                              // for PageRef
+#include "model/Stroke.h"                               // for Stroke, StrokeTool::E...
+#include "model/XojPage.h"                              // for XojPage
+#include "undo/DeleteUndoAction.h"                      // for DeleteUndoAction
+#include "undo/UndoRedoHandler.h"                       // for UndoRedoHandler
+#include "util/Assert.h"                                // for xoj_assert
+#include "util/Point.h"                                 // for Point
+#include "util/Rectangle.h"                             // for Rectangle
+#include "util/Util.h"                                  // for npos
+#include "util/glib_casts.h"                            // for wrap_v
+#include "util/gtk4_helper.h"                           // for gtk_scrolled_window_set_child
+#include "util/safe_casts.h"                            // for round_cast
 
 #include "Layout.h"           // for Layout
 #include "PageView.h"         // for XojPageView
@@ -467,6 +467,12 @@ void XournalView::endTextAllPages(XojPageView* except) const {
 void XournalView::endSplineAllPages() const {
     for (auto& v: this->viewPages) {
         v->endSpline();
+    }
+}
+
+void XournalView::clearLaserPointers() const {
+    for (auto& v: this->viewPages) {
+        v->clearLaserPointer();
     }
 }
 

--- a/src/core/gui/XournalView.h
+++ b/src/core/gui/XournalView.h
@@ -86,6 +86,7 @@ public:
     void endTextAllPages(XojPageView* except = nullptr) const;
 
     void endSplineAllPages() const;
+    void clearLaserPointers() const;
 
     int getDisplayWidth() const;
     int getDisplayHeight() const;


### PR DESCRIPTION
## Summary
This PR implements instant clearing of laser pointer traces when re-clicking the active laser tool.

https://github.com/user-attachments/assets/e3b0de73-c37e-417a-b0b7-db1e97ec88e9

## Changes
1. Detect when the active laser tool is reselected in `Control::selectTool()`
2. Added `LaserPointerHandler::clearNow()` to clear active overlays
3. Added page-level and view-level helpers to clear laser pointers across all pages
4. Made sure reselecting the active laser tool removes existing traces immediately

## Issue
Closes #7243

## Testing
I tested the following behaviors:
- Laser pen: reselect laser pen: clears immediately
- Laser highlighter: reselect laser highlighter: clears immediately
- Multiple pages with laser traces: reselecting clears all traces across pages

## Questions
1. Currently, switching between laser pen and laser highlighter does not clear existing traces (only reselecting the same tool clears them). So one question I do have is should switching laser tools (pen to highlighter or reversed) also clear the trace?
2. Another thing I could think of is whether when reselecting the laser tool, if it should disappear instantly or fade out.