### PR TITLE
Reduce PDF cache retention for off-screen pages

### DIFF
--- a/src/core/control/PdfCache.cpp
+++ b/src/core/control/PdfCache.cpp
@@ -11,6 +11,7 @@
 
 #include "control/settings/Settings.h"  // for Settings
 #include "pdf/base/XojPdfDocument.h"    // for XojPdfDocument
+#include "util/Assert.h"                // for xoj_assert
 #include "util/Range.h"                 // for Range
 #include "util/i18n.h"                  // for _
 #include "util/safe_casts.h"            // for as_unsigned
@@ -72,9 +73,8 @@ void PdfCache::evictAllExcept(const std::unordered_set<size_t>& retainedPdfPages
     std::lock_guard<std::mutex> lock(this->renderMutex);
 
     for (auto& entry: this->data) {
-        if (!entry || !entry->popplerPage) {
-            continue;
-        }
+        xoj_assert(entry);
+        xoj_assert(entry->popplerPage);
 
         const size_t pdfPageNo = static_cast<size_t>(entry->popplerPage->getPageId());
         if (retainedPdfPages.find(pdfPageNo) == retainedPdfPages.end()) {
@@ -96,13 +96,15 @@ auto PdfCache::lookup(size_t pdfPageNo) const -> const PdfCacheEntry* {
 }
 
 auto PdfCache::cache(XojPdfPageSPtr popplerPage, xoj::view::Mask&& buffer) -> const PdfCacheEntry* {
-    const auto pageId = popplerPage ? popplerPage->getPageId() : -1;
+    xoj_assert(popplerPage);
+    const auto pageId = popplerPage->getPageId();
 
-    this->data.erase(std::remove_if(this->data.begin(), this->data.end(),
-                                    [pageId](const auto& entry) {
-                                        return entry && entry->popplerPage && entry->popplerPage->getPageId() == pageId;
-                                    }),
-                     this->data.end());
+    auto existingIt = std::find_if(this->data.begin(), this->data.end(), [pageId](const auto& entry) {
+        return entry->popplerPage->getPageId() == pageId;
+    });
+    if (existingIt != this->data.end()) {
+        this->data.erase(existingIt);
+    }
 
     if (this->maxSize == 0) {
         this->data.clear();

--- a/src/core/control/PdfCache.cpp
+++ b/src/core/control/PdfCache.cpp
@@ -94,6 +94,7 @@ auto PdfCache::lookup(size_t pdfPageNo) const -> const PdfCacheEntry* {
 }
 
 auto PdfCache::cache(XojPdfPageSPtr popplerPage, xoj::view::Mask&& buffer) -> const PdfCacheEntry* {
+    xoj_assert(this->maxSize > 0);
     xoj_assert(popplerPage);
     const auto pageId = popplerPage->getPageId();
 
@@ -101,11 +102,6 @@ auto PdfCache::cache(XojPdfPageSPtr popplerPage, xoj::view::Mask&& buffer) -> co
                                    [pageId](const auto& entry) { return entry->popplerPage->getPageId() == pageId; });
     if (existingIt != this->data.end()) {
         this->data.erase(existingIt);
-    }
-
-    if (this->maxSize == 0) {
-        this->data.clear();
-        return nullptr;
     }
 
     if (this->data.size() >= this->maxSize) {
@@ -149,9 +145,9 @@ void PdfCache::render(cairo_t* cr, size_t pdfPageNo, double zoom, double pageWid
         if (this->maxSize == 0) {
             buffer.paintTo(cr);
             return;
-        } else {
-            cacheResult = cache(popplerPage, std::move(buffer));
         }
+
+        cacheResult = cache(popplerPage, std::move(buffer));
     }
 
     cacheResult->buffer.paintTo(cr);

--- a/src/core/control/PdfCache.cpp
+++ b/src/core/control/PdfCache.cpp
@@ -162,4 +162,3 @@ void PdfCache::renderMissingPdfPage(cairo_t* cr, double pageWidth, double pageHe
     cairo_move_to(cr, pageWidth / 2 - extents.width / 2, pageHeight / 2 - extents.height / 2);
     cairo_text_path(cr, strMissing.c_str());
 }
-

--- a/src/core/control/PdfCache.cpp
+++ b/src/core/control/PdfCache.cpp
@@ -38,12 +38,10 @@ public:
     xoj::view::Mask buffer;
 };
 
-namespace {
-double getPercentZoomChange(double oldZoom, double newZoom) {
+static double getPercentZoomChange(double oldZoom, double newZoom) {
     double averagedZoom = (oldZoom + newZoom) / 2.0;
     return std::abs(oldZoom - newZoom) * 100.0 / averagedZoom;
 }
-}  // namespace
 
 PdfCache::PdfCache(const XojPdfDocument& doc, Settings* settings): pdfDocument(doc) { updateSettings(settings); }
 

--- a/src/core/control/PdfCache.cpp
+++ b/src/core/control/PdfCache.cpp
@@ -162,3 +162,4 @@ void PdfCache::renderMissingPdfPage(cairo_t* cr, double pageWidth, double pageHe
     cairo_move_to(cr, pageWidth / 2 - extents.width / 2, pageHeight / 2 - extents.height / 2);
     cairo_text_path(cr, strMissing.c_str());
 }
+

--- a/src/core/control/PdfCache.cpp
+++ b/src/core/control/PdfCache.cpp
@@ -47,13 +47,9 @@ PdfCache::PdfCache(const XojPdfDocument& doc, Settings* settings): pdfDocument(d
 
 PdfCache::~PdfCache() = default;
 
-void PdfCache::setRefreshThreshold(double threshold) {
-    std::lock_guard<std::mutex> lock(this->renderMutex);
-    this->zoomRefreshThreshold = threshold;
-}
+void PdfCache::setRefreshThreshold(double threshold) { this->zoomRefreshThreshold = threshold; }
 
 void PdfCache::setMaxSize(size_t newSize) {
-    std::lock_guard<std::mutex> lock(this->renderMutex);
     this->maxSize = newSize;
     if (this->data.size() > this->maxSize) {
         this->data.resize(this->maxSize);

--- a/src/core/control/PdfCache.cpp
+++ b/src/core/control/PdfCache.cpp
@@ -123,8 +123,8 @@ void PdfCache::render(cairo_t* cr, size_t pdfPageNo, double zoom, double pageWid
     if (!needsRefresh) {
         // If we do have a cached result, is its rendering quality
         // acceptable for our current zoom?
-        needsRefresh = (zoom > 1.0 &&
-                        getPercentZoomChange(cacheResult->buffer.getZoom(), zoom) > this->zoomRefreshThreshold);
+        needsRefresh =
+                (zoom > 1.0 && getPercentZoomChange(cacheResult->buffer.getZoom(), zoom) > this->zoomRefreshThreshold);
     }
 
     if (needsRefresh) {

--- a/src/core/control/PdfCache.cpp
+++ b/src/core/control/PdfCache.cpp
@@ -37,13 +37,24 @@ public:
     xoj::view::Mask buffer;
 };
 
+namespace {
+double getPercentZoomChange(double oldZoom, double newZoom) {
+    double averagedZoom = (oldZoom + newZoom) / 2.0;
+    return std::abs(oldZoom - newZoom) * 100.0 / averagedZoom;
+}
+}  // namespace
+
 PdfCache::PdfCache(const XojPdfDocument& doc, Settings* settings): pdfDocument(doc) { updateSettings(settings); }
 
 PdfCache::~PdfCache() = default;
 
-void PdfCache::setRefreshThreshold(double threshold) { this->zoomRefreshThreshold = threshold; }
+void PdfCache::setRefreshThreshold(double threshold) {
+    std::lock_guard<std::mutex> lock(this->renderMutex);
+    this->zoomRefreshThreshold = threshold;
+}
 
 void PdfCache::setMaxSize(size_t newSize) {
+    std::lock_guard<std::mutex> lock(this->renderMutex);
     this->maxSize = newSize;
     if (this->data.size() > this->maxSize) {
         this->data.resize(this->maxSize);
@@ -57,6 +68,17 @@ void PdfCache::updateSettings(Settings* settings) {
     }
 }
 
+void PdfCache::evict(size_t pdfPageNo) {
+    std::lock_guard<std::mutex> lock(this->renderMutex);
+
+    this->data.erase(std::remove_if(this->data.begin(), this->data.end(),
+                                    [pdfPageNo](const auto& entry) {
+                                        return entry && entry->popplerPage &&
+                                               static_cast<size_t>(entry->popplerPage->getPageId()) == pdfPageNo;
+                                    }),
+                     this->data.end());
+}
+
 auto PdfCache::lookup(size_t pdfPageNo) const -> const PdfCacheEntry* {
     for (auto& e: this->data) {
         if (static_cast<size_t>(e->popplerPage->getPageId()) == pdfPageNo) {
@@ -68,8 +90,21 @@ auto PdfCache::lookup(size_t pdfPageNo) const -> const PdfCacheEntry* {
 }
 
 auto PdfCache::cache(XojPdfPageSPtr popplerPage, xoj::view::Mask&& buffer) -> const PdfCacheEntry* {
-    if (this->data.size() > this->maxSize) {
-        this->data.resize(this->maxSize);
+    const auto pageId = popplerPage ? popplerPage->getPageId() : -1;
+
+    this->data.erase(std::remove_if(this->data.begin(), this->data.end(),
+                                    [pageId](const auto& entry) {
+                                        return entry && entry->popplerPage && entry->popplerPage->getPageId() == pageId;
+                                    }),
+                     this->data.end());
+
+    if (this->maxSize == 0) {
+        this->data.clear();
+        return nullptr;
+    }
+
+    if (this->data.size() >= this->maxSize) {
+        this->data.resize(this->maxSize - 1);
     }
 
     this->data.emplace_front(
@@ -86,12 +121,10 @@ void PdfCache::render(cairo_t* cr, size_t pdfPageNo, double zoom, double pageWid
     bool needsRefresh = cacheResult == nullptr;
 
     if (!needsRefresh) {
-        double averagedZoom = (zoom + cacheResult->buffer.getZoom()) / 2.0;
-        double percentZoomChange = std::abs(cacheResult->buffer.getZoom() - zoom) * 100.0 / averagedZoom;
-
         // If we do have a cached result, is its rendering quality
         // acceptable for our current zoom?
-        needsRefresh = (zoom > 1.0 && percentZoomChange > this->zoomRefreshThreshold);
+        needsRefresh = (zoom > 1.0 &&
+                        getPercentZoomChange(cacheResult->buffer.getZoom(), zoom) > this->zoomRefreshThreshold);
     }
 
     if (needsRefresh) {
@@ -108,7 +141,12 @@ void PdfCache::render(cairo_t* cr, size_t pdfPageNo, double zoom, double pageWid
         xoj::view::Mask buffer(cairo_get_target(cr), Range(0, 0, popplerPage->getWidth(), popplerPage->getHeight()),
                                renderZoom, CAIRO_CONTENT_COLOR_ALPHA);
         popplerPage->render(buffer.get());
-        cacheResult = cache(popplerPage, std::move(buffer));
+        if (this->maxSize == 0) {
+            buffer.paintTo(cr);
+            return;
+        } else {
+            cacheResult = cache(popplerPage, std::move(buffer));
+        }
     }
 
     cacheResult->buffer.paintTo(cr);

--- a/src/core/control/PdfCache.cpp
+++ b/src/core/control/PdfCache.cpp
@@ -68,15 +68,21 @@ void PdfCache::updateSettings(Settings* settings) {
     }
 }
 
-void PdfCache::evict(size_t pdfPageNo) {
+void PdfCache::evictAllExcept(const std::unordered_set<size_t>& retainedPdfPages) {
     std::lock_guard<std::mutex> lock(this->renderMutex);
 
-    this->data.erase(std::remove_if(this->data.begin(), this->data.end(),
-                                    [pdfPageNo](const auto& entry) {
-                                        return entry && entry->popplerPage &&
-                                               static_cast<size_t>(entry->popplerPage->getPageId()) == pdfPageNo;
-                                    }),
-                     this->data.end());
+    for (auto& entry: this->data) {
+        if (!entry || !entry->popplerPage) {
+            continue;
+        }
+
+        const size_t pdfPageNo = static_cast<size_t>(entry->popplerPage->getPageId());
+        if (retainedPdfPages.find(pdfPageNo) == retainedPdfPages.end()) {
+            entry.reset();
+        }
+    }
+
+    this->data.erase(std::remove(this->data.begin(), this->data.end(), nullptr), this->data.end());
 }
 
 auto PdfCache::lookup(size_t pdfPageNo) const -> const PdfCacheEntry* {

--- a/src/core/control/PdfCache.cpp
+++ b/src/core/control/PdfCache.cpp
@@ -99,9 +99,8 @@ auto PdfCache::cache(XojPdfPageSPtr popplerPage, xoj::view::Mask&& buffer) -> co
     xoj_assert(popplerPage);
     const auto pageId = popplerPage->getPageId();
 
-    auto existingIt = std::find_if(this->data.begin(), this->data.end(), [pageId](const auto& entry) {
-        return entry->popplerPage->getPageId() == pageId;
-    });
+    auto existingIt = std::find_if(this->data.begin(), this->data.end(),
+                                   [pageId](const auto& entry) { return entry->popplerPage->getPageId() == pageId; });
     if (existingIt != this->data.end()) {
         this->data.erase(existingIt);
     }

--- a/src/core/control/PdfCache.h
+++ b/src/core/control/PdfCache.h
@@ -61,6 +61,11 @@ public:
     void updateSettings(Settings* settings);
 
     /**
+     * @brief Remove the cached rendering of a specific PDF page.
+     */
+    void evict(size_t pdfPageNo);
+
+    /**
      * @brief Renders an error background, for when the pdf page cannot be rendered
      */
     static void renderMissingPdfPage(cairo_t* cr, double pageWidth, double pageHeight);

--- a/src/core/control/PdfCache.h
+++ b/src/core/control/PdfCache.h
@@ -14,6 +14,7 @@
 #include <cstddef>  // for size_t
 #include <deque>    // for deque
 #include <mutex>    // for mutex
+#include <unordered_set>
 
 #include <cairo.h>  // for cairo_t, cairo_surface_t
 
@@ -61,9 +62,9 @@ public:
     void updateSettings(Settings* settings);
 
     /**
-     * @brief Remove the cached rendering of a specific PDF page.
+     * @brief Remove cached renderings for PDF pages that are not retained.
      */
-    void evict(size_t pdfPageNo);
+    void evictAllExcept(const std::unordered_set<size_t>& retainedPdfPages);
 
     /**
      * @brief Renders an error background, for when the pdf page cannot be rendered

--- a/src/core/gui/XournalView.cpp
+++ b/src/core/gui/XournalView.cpp
@@ -56,10 +56,6 @@ constexpr int SMALL_MOVE_AMOUNT = 1;
 constexpr int LARGE_MOVE_AMOUNT = 10;
 
 std::pair<size_t, size_t> XournalView::preloadPageBounds(size_t page, size_t maxPage) {
-    if (page == npos || page >= maxPage) {
-        return {0, 0};
-    }
-
     const size_t preloadBefore = this->control->getSettings()->getPreloadPagesBefore();
     const size_t preloadAfter = this->control->getSettings()->getPreloadPagesAfter();
     const size_t lower = page > preloadBefore ? page - preloadBefore : 0;

--- a/src/core/gui/XournalView.cpp
+++ b/src/core/gui/XournalView.cpp
@@ -126,10 +126,7 @@ auto XournalView::cleanupBufferCache() -> void {
     xoj_assert(pagesLower <= pagesUpper);
 
     std::unordered_set<size_t> retainedPdfPages;
-    std::unordered_set<size_t> evictedPdfPages;
 
-    // Collect retained PDF pages first so shared PDF backgrounds are kept as long as
-    // at least one visible or preloaded XojPageView still refers to them.
     for (size_t i = 0; i < this->viewPages.size(); i++) {
         auto&& page = this->viewPages[i];
         const bool isPreload = pagesLower <= i && i < pagesUpper;
@@ -140,28 +137,16 @@ auto XournalView::cleanupBufferCache() -> void {
             if (pdfPageNo != npos) {
                 retainedPdfPages.insert(pdfPageNo);
             }
-        }
-    }
-
-    for (size_t i = 0; i < this->viewPages.size(); i++) {
-        auto&& page = this->viewPages[i];
-        const bool isPreload = pagesLower <= i && i < pagesUpper;
-        const bool shouldRetain = isPreload || page->isVisible();
-        const size_t pdfPageNo = page->getPage()->getPdfPageNr();
-
-        if (shouldRetain) {
             continue;
         }
 
         if (page->hasBuffer()) {
             page->deleteViewBuffer();
         }
+    }
 
-        if (this->cache && pdfPageNo != npos && retainedPdfPages.find(pdfPageNo) == retainedPdfPages.end() &&
-            evictedPdfPages.find(pdfPageNo) == evictedPdfPages.end()) {
-            this->cache->evict(pdfPageNo);
-            evictedPdfPages.insert(pdfPageNo);
-        }
+    if (this->cache) {
+        this->cache->evictAllExcept(retainedPdfPages);
     }
 }
 

--- a/src/core/gui/XournalView.cpp
+++ b/src/core/gui/XournalView.cpp
@@ -138,9 +138,7 @@ auto XournalView::cleanupBufferCache() -> void {
                 retainedPdfPages.insert(pdfPageNo);
             }
             continue;
-        }
-
-        if (page->hasBuffer()) {
+        } else if (page->hasBuffer()) {
             page->deleteViewBuffer();
         }
     }

--- a/src/core/gui/XournalView.cpp
+++ b/src/core/gui/XournalView.cpp
@@ -131,9 +131,9 @@ auto XournalView::cleanupBufferCache() -> void {
         auto&& page = this->viewPages[i];
         const bool isPreload = pagesLower <= i && i < pagesUpper;
         const bool shouldRetain = isPreload || page->isVisible();
-        const size_t pdfPageNo = page->getPage()->getPdfPageNr();
 
         if (shouldRetain) {
+            const size_t pdfPageNo = page->getPage()->getPdfPageNr();
             if (pdfPageNo != npos) {
                 retainedPdfPages.insert(pdfPageNo);
             }

--- a/src/core/gui/XournalView.cpp
+++ b/src/core/gui/XournalView.cpp
@@ -4,6 +4,7 @@
 #include <iterator>   // for begin
 #include <memory>     // for unique_ptr, make_unique
 #include <optional>   // for optional
+#include <unordered_set>
 
 #include <gdk/gdk.h>         // for GdkEventKey, GDK_SHIF...
 #include <gdk/gdkkeysyms.h>  // for GDK_KEY_Page_Down
@@ -55,10 +56,14 @@ constexpr int SMALL_MOVE_AMOUNT = 1;
 constexpr int LARGE_MOVE_AMOUNT = 10;
 
 std::pair<size_t, size_t> XournalView::preloadPageBounds(size_t page, size_t maxPage) {
+    if (page == npos || page >= maxPage) {
+        return {0, 0};
+    }
+
     const size_t preloadBefore = this->control->getSettings()->getPreloadPagesBefore();
     const size_t preloadAfter = this->control->getSettings()->getPreloadPagesAfter();
     const size_t lower = page > preloadBefore ? page - preloadBefore : 0;
-    const size_t upper = std::min(maxPage, page + preloadAfter);
+    const size_t upper = std::min(maxPage, page + preloadAfter + 1);
     return {lower, upper};
 }
 
@@ -120,12 +125,42 @@ auto XournalView::cleanupBufferCache() -> void {
     const auto& [pagesLower, pagesUpper] = this->preloadPageBounds(this->currentPage, this->viewPages.size());
     xoj_assert(pagesLower <= pagesUpper);
 
+    std::unordered_set<size_t> retainedPdfPages;
+    std::unordered_set<size_t> evictedPdfPages;
+
+    // Collect retained PDF pages first so shared PDF backgrounds are kept as long as
+    // at least one visible or preloaded XojPageView still refers to them.
     for (size_t i = 0; i < this->viewPages.size(); i++) {
         auto&& page = this->viewPages[i];
-        const size_t pageNum = i + 1;
-        const bool isPreload = pagesLower <= pageNum && pageNum <= pagesUpper;
-        if (!isPreload && !page->isVisible() && page->hasBuffer()) {
+        const bool isPreload = pagesLower <= i && i < pagesUpper;
+        const bool shouldRetain = isPreload || page->isVisible();
+        const size_t pdfPageNo = page->getPage()->getPdfPageNr();
+
+        if (shouldRetain) {
+            if (pdfPageNo != npos) {
+                retainedPdfPages.insert(pdfPageNo);
+            }
+        }
+    }
+
+    for (size_t i = 0; i < this->viewPages.size(); i++) {
+        auto&& page = this->viewPages[i];
+        const bool isPreload = pagesLower <= i && i < pagesUpper;
+        const bool shouldRetain = isPreload || page->isVisible();
+        const size_t pdfPageNo = page->getPage()->getPdfPageNr();
+
+        if (shouldRetain) {
+            continue;
+        }
+
+        if (page->hasBuffer()) {
             page->deleteViewBuffer();
+        }
+
+        if (this->cache && pdfPageNo != npos && retainedPdfPages.find(pdfPageNo) == retainedPdfPages.end() &&
+            evictedPdfPages.find(pdfPageNo) == evictedPdfPages.end()) {
+            this->cache->evict(pdfPageNo);
+            evictedPdfPages.insert(pdfPageNo);
         }
     }
 }


### PR DESCRIPTION
## Summary

This change reduces memory growth when scrolling through PDF-backed pages, especially at very high zoom levels.

When writing in narrow PDF margins at around 400% zoom, scrolling through pages could cause memory usage to grow very aggressively, sometimes beyond **10 GB**. The main issue was that cleaning up page view buffers did not aggressively evict the corresponding PDF render cache entries, so large high-zoom PDF surfaces could accumulate in memory.

## What changed

- Reworked `XournalView::cleanupBufferCache()` to:
  - first collect the set of PDF pages that must be retained because they are visible or inside the preload range
  - then delete off-screen page view buffers
  - evict PDF cache entries for off-screen pages whose PDF backgrounds are no longer retained
- Added ~~`PdfCache::evict(size_t pdfPageNo)` to remove cached renderings for a specific PDF page~~ `PdfCache::evictAllExcept(const std::unordered_set<size_t>& retainedPdfPages)` to prune cached renderings in one pass based on the retained PDF pages
- Changed `PdfCache::cache()` to always replace existing entries for the same PDF page instead of allowing duplicates
- ~~Guarded cache setting updates with the existing render mutex~~


This may also fix two off-by-one or indexing issue in the preload range logic.

- Handled the `maxSize == 0` case explicitly by rendering directly without storing a cache entry
- Fixed `preloadPageBounds()` usage, since the cleanup path previously mixed inclusive checks with `i + 1`, while other callers use half-open zero-based bounds

## Results

After this change, only visible or preloaded PDF pages keep their cached renderings, so memory remains much more tightly bounded during scrolling.

Manual results from testing this scenario:

- Before: memory usage could exceed **10 GB** while scrolling at around 400% zoom
- After: under the same workflow, memory usage rarely exceeds **1.8 GB**, and I do not notice any lag despite the reduced caching.
