### PR TITLE
Add Space modifier to move in-progress shape without resizing

### DIFF
--- a/src/core/control/tools/BaseShapeHandler.cpp
+++ b/src/core/control/tools/BaseShapeHandler.cpp
@@ -43,7 +43,25 @@ void BaseShapeHandler::updateShape(bool isAltDown, bool isShiftDown, bool isCont
     viewPool->dispatch(xoj::view::ShapeToolView::FLAG_DIRTY_REGION, repaintRange);
 }
 
+void BaseShapeHandler::translateShape(double dx, double dy) {
+    if (this->shape.empty() || (dx == 0.0 && dy == 0.0)) {
+        return;
+    }
+
+    for (Point& point: this->shape) {
+        point.x += dx;
+        point.y += dy;
+    }
+
+    Range repaintRange = this->lastSnappingRange;
+    this->lastSnappingRange.translate(dx, dy);
+    repaintRange = repaintRange.unite(this->lastSnappingRange);
+    repaintRange.addPadding(0.5 * this->stroke->getWidth());
+    this->viewPool->dispatch(xoj::view::ShapeToolView::FLAG_DIRTY_REGION, repaintRange);
+}
+
 void BaseShapeHandler::cancelStroke() {
+    this->modSpace = false;
     this->shape.clear();
     Range repaintRange = this->lastSnappingRange;
     repaintRange.addPadding(0.5 * this->stroke->getWidth());
@@ -62,9 +80,19 @@ auto BaseShapeHandler::onKeyEvent(const KeyEvent& event, bool pressed) -> bool {
         isControlDown = pressed;
     } else if (event.keyval == GDK_KEY_Alt_L || event.keyval == GDK_KEY_Alt_R) {
         isAltDown = pressed;
+    } else if (event.keyval == GDK_KEY_space) {
+        this->modSpace = pressed;
+        return true;
     } else {
         return false;
     }
+
+    // While moving with Space, keep the current geometry frozen.
+    // Recompute only after Space is released and pointer moves again.
+    if (this->modSpace) {
+        return true;
+    }
+
     this->updateShape(isAltDown, isShiftDown, isControlDown);
 
     return true;
@@ -78,6 +106,15 @@ auto BaseShapeHandler::onKeyReleaseEvent(const KeyEvent& event) -> bool { return
 auto BaseShapeHandler::onMotionNotifyEvent(const PositionInputData& pos, double zoom) -> bool {
     Point newPoint(pos.x / zoom, pos.y / zoom);
     if (!validMotion(newPoint, this->currPoint)) {
+        return true;
+    }
+    if (this->modSpace) {
+        const double dx = newPoint.x - this->currPoint.x;
+        const double dy = newPoint.y - this->currPoint.y;
+        this->startPoint.x += dx;
+        this->startPoint.y += dy;
+        this->currPoint = newPoint;
+        this->translateShape(dx, dy);
         return true;
     }
     this->currPoint = newPoint;
@@ -122,6 +159,7 @@ void BaseShapeHandler::onButtonReleaseEvent(const PositionInputData& pos, double
 
 void BaseShapeHandler::onButtonPressEvent(const PositionInputData& pos, double zoom) {
     xoj_assert(this->viewPool->empty());
+    this->modSpace = false;
     this->buttonDownPoint.x = pos.x / zoom;
     this->buttonDownPoint.y = pos.y / zoom;
 

--- a/src/core/control/tools/BaseShapeHandler.cpp
+++ b/src/core/control/tools/BaseShapeHandler.cpp
@@ -10,6 +10,8 @@
 #include "control/settings/Settings.h"             // for Settings
 #include "control/tools/InputHandler.h"            // for InputHandler
 #include "control/tools/SnapToGridInputHandler.h"  // for SnapToGridInputHandler
+#include "gui/MainWindow.h"                        // for MainWindow
+#include "gui/XournalView.h"                       // for XournalView
 #include "gui/XournalppCursor.h"                   // for XournalppCursor
 #include "gui/inputdevices/PositionInputData.h"    // for PositionInputData
 #include "model/Document.h"                        // for Document
@@ -159,7 +161,8 @@ void BaseShapeHandler::onButtonReleaseEvent(const PositionInputData& pos, double
 
 void BaseShapeHandler::onButtonPressEvent(const PositionInputData& pos, double zoom) {
     xoj_assert(this->viewPool->empty());
-    this->modSpace = false;
+    this->modSpace = this->control && this->control->getWindow() && this->control->getWindow()->getXournal() &&
+                     this->control->getWindow()->getXournal()->isSpaceKeyDown();
     this->buttonDownPoint.x = pos.x / zoom;
     this->buttonDownPoint.y = pos.y / zoom;
 

--- a/src/core/control/tools/BaseShapeHandler.h
+++ b/src/core/control/tools/BaseShapeHandler.h
@@ -76,6 +76,7 @@ private:
      *      Also warns the listeners about the change, usually triggering a redraw during the next screen update.
      */
     void updateShape(bool isAltDown, bool isShiftDown, bool isControlDown);
+    void translateShape(double dx, double dy);
 
     /**
      * @brief Cancel the current shape creation: clears all data and wipes any drawing made
@@ -106,6 +107,8 @@ protected:
     bool flipControl = false;  // use to reverse Control key modifier action.
     bool modShift = false;
     bool modControl = false;
+    /** When true (Space held), pointer motion translates the shape without resizing. */
+    bool modSpace = false;
     SnapToGridInputHandler snappingHandler;
 
     Point currPoint;

--- a/src/core/gui/PageView.h
+++ b/src/core/gui/PageView.h
@@ -108,6 +108,7 @@ public:
 
     bool onKeyPressEvent(const KeyEvent& event);
     bool onKeyReleaseEvent(const KeyEvent& event);
+    bool hasActiveInput() const { return this->inputHandler != nullptr; }
 
     bool cut();
     bool copy();

--- a/src/core/gui/XournalView.cpp
+++ b/src/core/gui/XournalView.cpp
@@ -136,10 +136,25 @@ auto XournalView::getCurrentPage() const -> size_t { return currentPage; }
 const int scrollKeySize = 30;
 
 auto XournalView::onKeyPressEvent(const KeyEvent& event) -> bool {
+    if (event.keyval == GDK_KEY_space) {
+        this->isSpaceDown = true;
+    }
+
     size_t p = getCurrentPage();
     if (p != npos && p < this->viewPages.size()) {
-        auto& v = this->viewPages[p];
-        if (v->onKeyPressEvent(event)) {
+        if (this->viewPages[p]->onKeyPressEvent(event)) {
+            if (event.keyval == GDK_KEY_space) {
+                this->spaceConsumedByTool = true;
+            }
+            return true;
+        }
+    }
+
+    for (size_t i = 0; i < this->viewPages.size(); ++i) {
+        if (i != p && this->viewPages[i]->onKeyPressEvent(event)) {
+            if (event.keyval == GDK_KEY_space) {
+                this->spaceConsumedByTool = true;
+            }
             return true;
         }
     }
@@ -203,6 +218,16 @@ auto XournalView::onKeyPressEvent(const KeyEvent& event) -> bool {
     }
 
     if (keyval == GDK_KEY_space) {
+        if (this->spaceConsumedByTool) {
+            return true;
+        }
+
+        for (const auto& v : this->viewPages) {
+            if (v->hasActiveInput()) {
+                return true;
+            }
+        }
+
         GtkAllocation alloc = {0};
         gtk_widget_get_allocation(gtk_widget_get_parent(this->widget), &alloc);
         int windowHeight = alloc.height - scrollKeySize;
@@ -328,10 +353,20 @@ auto XournalView::onKeyPressEvent(const KeyEvent& event) -> bool {
 auto XournalView::getRepaintHandler() const -> RepaintHandler* { return this->repaintHandler.get(); }
 
 auto XournalView::onKeyReleaseEvent(const KeyEvent& event) -> bool {
+    if (event.keyval == GDK_KEY_space) {
+        this->isSpaceDown = false;
+        this->spaceConsumedByTool = false;
+    }
+
     size_t p = getCurrentPage();
     if (p != npos && p < this->viewPages.size()) {
-        auto& v = this->viewPages[p];
-        if (v->onKeyReleaseEvent(event)) {
+        if (this->viewPages[p]->onKeyReleaseEvent(event)) {
+            return true;
+        }
+    }
+
+    for (size_t i = 0; i < this->viewPages.size(); ++i) {
+        if (i != p && this->viewPages[i]->onKeyReleaseEvent(event)) {
             return true;
         }
     }

--- a/src/core/gui/XournalView.h
+++ b/src/core/gui/XournalView.h
@@ -155,6 +155,7 @@ public:
 public:
     bool onKeyPressEvent(const KeyEvent& event);
     bool onKeyReleaseEvent(const KeyEvent& event);
+    bool isSpaceKeyDown() const { return this->isSpaceDown; }
 
     void onSettingsChanged();
 
@@ -181,6 +182,18 @@ private:
 
     size_t currentPage = 0;
     size_t lastSelectedPage = npos;
+
+    /**
+     * Tracks whether the Space key is currently held down.
+     */
+    bool isSpaceDown = false;
+
+    /**
+     * Set to true when Space key was consumed by an active tool (e.g. shape translation).
+     * Prevents subsequent auto-repeat key-press-events from triggering the Space scroll shortcut
+     * if the mouse is released before the Space key.
+     */
+    bool spaceConsumedByTool = false;
 
     std::unique_ptr<PdfCache> cache;
 


### PR DESCRIPTION
## Summary
- Add a new shape-drawing interaction: hold `Space` while drawing to move the in-progress shape without resizing it.
- Preserve existing modifier behavior: `Ctrl` still resizes from center and `Shift` still constrains aspect ratio.
- Keep geometry frozen during `Space`-move, then resume normal resizing from the new position after releasing `Space`.

## Why
- Improves precision and workflow when placing shapes.
- Avoids cancel/restart when the initial anchor point is slightly off.
- Aligns shape creation behavior with common UX patterns in drawing/design tools.

## Implementation
- Implemented in `BaseShapeHandler` so all shape tools using this base get consistent behavior.
- Added a dedicated translation path for in-progress shapes while `Space` is held.
- Prevented resize recomputation during move mode to ensure movement-only behavior.

## Test Plan
- Start drawing a shape and verify normal resize behavior.
- Hold `Shift` and verify aspect ratio is constrained.
- Hold `Ctrl` and verify resizing is center-based.
- While drawing, hold `Space` and move pointer; verify shape translates without resizing.
- Release `Space`; verify shape keeps moved geometry and can be resized again.
- Verify no regressions across rectangle, ellipse, arrow, ruler, and coordinate system tools.

Closes #7381