### PR TITLE
Bump clang format version in CI test

### DIFF
--- a/.github/workflows/clang-format-applied.yml
+++ b/.github/workflows/clang-format-applied.yml
@@ -11,7 +11,7 @@ jobs:
   clang-format-checking:
     runs-on: ubuntu-latest
     env:
-      CLANG_FORMAT_VERSIONS: "19 18 17"
+      CLANG_FORMAT_VERSIONS: "22 21 20 19"
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
Bump the list of allowed clang-format versions from {17, 18, 19} to {19, 20, 21, 22}. (clang 19 is the most recent version available on the default PPA on Ubuntu 24.04LTS, clang 22 is the latest).

The version should seldom matter, but may, sometimes.

