### PR TITLE
Feat: Auto reload PDF when it is modified

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -114,6 +114,7 @@
 #include "CrashHandler.h"                    // for emer...
 #include "LatexController.h"                 // for Late...
 #include "PageBackgroundChangeController.h"  // for Page...
+#include "PdfAutoReloadController.h"
 #include "PrintHandler.h"                    // for print
 #include "UndoRedoController.h"              // for Undo...
 #include "config-dev.h"                      // for SETT...
@@ -162,12 +163,14 @@ Control::Control(GApplication* gtkApp, GladeSearchpath* gladeSearchPath, bool di
     this->toolHandler->loadSettings();
     this->initButtonTool();
 
+    this->pageBackgroundChangeController = std::make_unique<PageBackgroundChangeController>(this);
+    this->pdfAutoReloadController = std::make_unique<PdfAutoReloadController>(this);
+
     /**
      * This is needed to update the previews
      */
     this->changeTimout = g_timeout_add_seconds(5, xoj::util::wrap_v<checkChangedDocument>, this);
-
-    this->pageBackgroundChangeController = std::make_unique<PageBackgroundChangeController>(this);
+    this->pdfAutoReloadController->startMonitoring();
 
     this->layerController = new LayerController(this);
     this->layerController->registerListener(this);
@@ -270,6 +273,13 @@ auto Control::checkChangedDocument(Control* control) -> bool {
     // Call again
     return true;
 }
+
+void Control::firePdfContentChanged() {
+    xoj_assert(this->win);
+    this->fireDocumentChanged(DOCUMENT_CHANGE_PDF_CONTENT);
+}
+
+void Control::refreshAfterPdfChange() { this->pdfAutoReloadController->onPdfChanged(); }
 
 void Control::saveSettings() {
     this->toolHandler->saveSettings();
@@ -1459,6 +1469,7 @@ void Control::showSettings() {
                 ctrl->updateWindowTitle();
 
                 ctrl->enableAutosave(settings->isAutosaveEnabled());
+                ctrl->refreshAfterPdfChange();
 
                 ctrl->zoom->setZoomStep(settings->getZoomStep() / 100.0);
                 ctrl->zoom->setZoomStepScroll(settings->getZoomStepScroll() / 100.0);
@@ -1541,6 +1552,7 @@ void Control::replaceDocument(std::unique_ptr<Document> doc, int scrollToPage) {
     this->doc->unlock();
 
     setEmergencyDocument(this->doc);
+    refreshAfterPdfChange();
 
     // Set folder as last save path, so the next save will be at the current document location
     // This is important because of the new .xopp format, where Xournal .xoj handled as import,

--- a/src/core/control/Control.h
+++ b/src/core/control/Control.h
@@ -50,6 +50,7 @@ class ToolbarDragDropHandler;
 class MetadataEntry;
 class MetadataCallbackData;
 class PageBackgroundChangeController;
+class PdfAutoReloadController;
 class PageTemplateSettings;
 class PageTypeHandler;
 class BaseExportJob;
@@ -327,6 +328,8 @@ public:
     LayerController* getLayerController() const;
     PluginController* getPluginController() const;
     const Palette& getPalette() const;
+    void firePdfContentChanged();
+    void refreshAfterPdfChange();
 
     /**
      * Show floating toolbox at specified coordinates
@@ -502,6 +505,7 @@ private:
     ToolHandler* toolHandler;
 
     ScrollHandler* scrollHandler;
+    std::unique_ptr<PdfAutoReloadController> pdfAutoReloadController;
 
     ToolbarDragDropHandler* dragDropHandler = nullptr;
 

--- a/src/core/control/PageBackgroundChangeController.cpp
+++ b/src/core/control/PageBackgroundChangeController.cpp
@@ -1,8 +1,10 @@
 #include "PageBackgroundChangeController.h"
 
+#include <cmath>    // for std::abs
 #include <memory>   // for __shared_ptr...
 #include <string>   // for allocator
 #include <utility>  // for move
+#include <vector>   // for vector
 
 #include <gdk-pixbuf/gdk-pixbuf.h>  // for gdk_pixbuf_g...
 #include <gio/gio.h>                // for GFile
@@ -41,6 +43,8 @@ PageBackgroundChangeController::PageBackgroundChangeController(Control* control)
         control(control), pageTypeForNewPages(control->getSettings()->getPageTemplateSettings().getPageInsertType()) {
     registerListener(control);
 }
+
+static void setPagePdfBackground(const PageRef& page, size_t pdfPageNr, Document* doc);
 
 void PageBackgroundChangeController::applyBackgroundToAllPages(const PageType& pt) {
     control->clearSelectionEndText();
@@ -112,12 +116,78 @@ void PageBackgroundChangeController::changePdfPagesBackground(const fs::path& fi
         XojMsgBox::showErrorToUser(this->control->getGtkWindow(), msg);
         return;
     }
-    this->control->getWindow()->getXournal()->recreatePdfCache();
 
-    this->control->fireDocumentChanged(DOCUMENT_CHANGE_COMPLETE);
+    this->control->firePdfContentChanged();
+    this->control->refreshAfterPdfChange();
 
     auto undoAction = std::make_unique<MissingPdfUndoAction>(oldFilepath, oldAttachPdf);
     this->control->getUndoRedoHandler()->addUndoAction(std::move(undoAction));
+}
+
+void PageBackgroundChangeController::showPdfBackgroundSizeChangeMessage(const PdfPageResizeStats& stats) const {
+    if (stats.skippedCount == 0) {
+        return;
+    }
+
+    std::string message = FS(_F("Detected updated external PDF dimensions. "
+                                "Resized {1} page(s) without annotations and kept {2} annotated page(s) "
+                                "unchanged to avoid moving handwritten content.") %
+                             stats.resizedCount % stats.skippedCount);
+    XojMsgBox::showMessageToUser(control->getGtkWindow(), message, GTK_MESSAGE_WARNING);
+}
+
+
+void PageBackgroundChangeController::resizePagesToMatchPdf() {
+    PdfPageResizeStats stats;
+    std::vector<size_t> resizedPages;
+
+    Document* doc = control->getDocument();
+    doc->lock();
+    const size_t pageCount = doc->getPageCount();
+
+    for (size_t pageNo = 0; pageNo < pageCount; ++pageNo) {
+        auto page = doc->getPage(pageNo);
+        if (!page || !page->getBackgroundType().isPdfPage()) {
+            continue;
+        }
+
+        const size_t pdfPageNr = page->getPdfPageNr();
+        if (pdfPageNr >= doc->getPdfPageCount()) {
+            continue;
+        }
+
+        auto pdfPage = doc->getPdfPage(pdfPageNr);
+        if (!pdfPage) {
+            continue;
+        }
+
+        const double width = pdfPage->getWidth();
+        const double height = pdfPage->getHeight();
+        // Allow small floating-point differences (0.1) between stored page sizes and PDF-reported dimensions.
+        const bool isSameSizeAsPdf =
+                std::abs(page->getWidth() - width) < 0.1 && std::abs(page->getHeight() - height) < 0.1;
+        if (isSameSizeAsPdf) {
+            continue;
+        }
+
+        if (page->isAnnotated()) {
+            stats.skippedCount++;  // pdf page is resized but has annotation, skip it.
+            continue;
+        }
+
+        setPagePdfBackground(page, pdfPageNr, doc);
+        resizedPages.push_back(pageNo);
+        stats.resizedCount++;
+    }
+    doc->unlock();
+
+    if (stats.resizedCount > 0) {
+        for (size_t pageNo: resizedPages) {
+            control->firePageSizeChanged(pageNo);
+        }
+    }
+
+    showPdfBackgroundSizeChangeMessage(stats);
 }
 
 void PageBackgroundChangeController::changeCurrentPageBackground(const PageType& pt) {

--- a/src/core/control/PageBackgroundChangeController.h
+++ b/src/core/control/PageBackgroundChangeController.h
@@ -31,6 +31,11 @@ class UndoAction;
 
 class PageBackgroundChangeController: public DocumentListener {
 public:
+    struct PdfPageResizeStats {
+        size_t resizedCount = 0;
+        size_t skippedCount = 0;
+    };
+
     PageBackgroundChangeController(Control* control);
     ~PageBackgroundChangeController() override = default;
 
@@ -56,6 +61,14 @@ public:
     void applyPageSizeToAllPages(const PaperSize& paperSize);
     void changePdfPagesBackground(const fs::path& filepath, bool attachPdf);
     void insertNewPage(size_t position, bool automatedInsertion = false);
+
+    /**
+     * Resize pages to match external PDF dimensions.
+     */
+    void resizePagesToMatchPdf();
+
+private:
+    void showPdfBackgroundSizeChangeMessage(const PdfPageResizeStats& stats) const;
 
     // DocumentListener
 public:

--- a/src/core/control/PdfAutoReloadController.cpp
+++ b/src/core/control/PdfAutoReloadController.cpp
@@ -1,0 +1,146 @@
+#include "PdfAutoReloadController.h"
+
+#include <system_error>
+
+#include "control/PageBackgroundChangeController.h"
+#include "control/settings/Settings.h"
+#include "model/Document.h"
+#include "util/glib_casts.h"
+
+#include "Control.h"
+
+namespace {
+
+struct MonitoredPdfState {
+    std::optional<fs::file_time_type> loadedModifiedTime;
+    fs::path pdfPath;
+};
+
+auto tryReadMonitoredPdfState(Document* doc, MonitoredPdfState* state, bool nonBlocking) -> bool {
+    const bool locked = nonBlocking ? doc->try_lock_shared() : (doc->lock_shared(), true);
+    if (!locked) {
+        return false;
+    }
+
+    const bool canAutoReload = doc->canAutoReloadPdf();
+    if (canAutoReload && state != nullptr) {
+        state->loadedModifiedTime = doc->getPdfLastModifiedTime();
+        state->pdfPath = doc->getPdfFilepath();
+    }
+    doc->unlock_shared();
+
+    return canAutoReload;
+}
+
+}  // namespace
+
+PdfAutoReloadController::PdfAutoReloadController(Control* control): control(control) {}
+
+PdfAutoReloadController::~PdfAutoReloadController() { stopMonitoring(); }
+
+void PdfAutoReloadController::startMonitoring() {
+    this->monitoringStarted = true;
+    reconfigurePolling();
+}
+
+void PdfAutoReloadController::stopMonitoring() {
+    this->monitoringStarted = false;
+    if (this->timeoutId) {
+        g_source_remove(this->timeoutId);
+        this->timeoutId = 0;
+    }
+    clearPendingReloadState();
+}
+
+void PdfAutoReloadController::onPdfChanged() {
+    if (!this->monitoringStarted) {
+        return;
+    }
+    reconfigurePolling();
+}
+
+bool PdfAutoReloadController::onPollingTimeout(PdfAutoReloadController* controller) {
+    // Periodically poll the external PDF, debounce mtime changes, and reload once the file is stable.
+    controller->checkForModifiedPdfAndReload();
+    return true;
+}
+
+bool PdfAutoReloadController::shouldPollForPdfChanges() const {
+    return this->monitoringStarted && this->control->getSettings()->getPdfAutoReloadEnabled();
+}
+
+void PdfAutoReloadController::reconfigurePolling() {
+    if (this->timeoutId) {
+        g_source_remove(this->timeoutId);
+        this->timeoutId = 0;
+    }
+
+    if (!shouldPollForPdfChanges()) {
+        clearPendingReloadState();
+        return;
+    }
+
+    auto* doc = this->control->getDocument();
+    // Reconfiguration runs in direct response to document/state changes, so waiting for a shared lock here is fine.
+    if (!tryReadMonitoredPdfState(doc, nullptr, false)) {
+        clearPendingReloadState();
+        return;
+    }
+
+    this->timeoutId = g_timeout_add(this->control->getSettings()->getPdfAutoReloadIntervalMs(),
+                                    xoj::util::wrap_v<onPollingTimeout>, this);
+}
+
+void PdfAutoReloadController::checkForModifiedPdfAndReload() {
+    if (!shouldPollForPdfChanges()) {
+        clearPendingReloadState();
+        return;
+    }
+
+    auto* doc = this->control->getDocument();
+    MonitoredPdfState state;
+    // Polling runs on the GTK main loop. Avoid blocking the UI if a writer currently owns the document lock.
+    if (!tryReadMonitoredPdfState(doc, &state, true)) {
+        clearPendingReloadState();
+        return;
+    }
+
+    std::error_code ec;
+    const auto currentModifiedTime = fs::last_write_time(state.pdfPath, ec);
+    if (ec || (state.loadedModifiedTime && currentModifiedTime <= *state.loadedModifiedTime)) {
+        clearPendingReloadState();
+        return;
+    }
+
+    if (!this->pendingReloadTime || *this->pendingReloadTime != currentModifiedTime) {
+        this->pendingReloadTime = currentModifiedTime;
+        this->pendingReloadSinceUs = g_get_monotonic_time();
+        return;
+    }
+
+    const gint64 stableForUs = g_get_monotonic_time() - this->pendingReloadSinceUs;
+    const guint requiredStableUs = this->control->getSettings()->getPdfAutoReloadDebounceMs() * 1000;
+    if (stableForUs < requiredStableUs) {
+        return;
+    }
+
+    reloadExternalPdfAndRefreshDocument();
+}
+
+void PdfAutoReloadController::reloadExternalPdfAndRefreshDocument() {
+    clearPendingReloadState();
+
+    auto* doc = this->control->getDocument();
+    if (!doc->reloadPdf()) {
+        return;
+    }
+
+    this->control->getPageBackgroundChangeController()->resizePagesToMatchPdf();
+    this->control->firePdfContentChanged();
+    onPdfChanged();
+}
+
+void PdfAutoReloadController::clearPendingReloadState() {
+    this->pendingReloadTime.reset();
+    this->pendingReloadSinceUs = 0;
+}

--- a/src/core/control/PdfAutoReloadController.h
+++ b/src/core/control/PdfAutoReloadController.h
@@ -1,0 +1,46 @@
+/*
+ * Xournal++
+ *
+ * Handle automatic reloading of external PDF backgrounds
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+#include <optional>
+
+#include <glib.h>
+
+#include "filesystem.h"
+
+class Control;
+
+class PdfAutoReloadController final {
+public:
+    explicit PdfAutoReloadController(Control* control);
+    ~PdfAutoReloadController();
+
+    void startMonitoring();
+    void stopMonitoring();
+    void onPdfChanged();
+
+private:
+    bool shouldPollForPdfChanges() const;
+    static bool onPollingTimeout(PdfAutoReloadController* controller);
+
+    void reconfigurePolling();
+    void checkForModifiedPdfAndReload();
+    void reloadExternalPdfAndRefreshDocument();
+    void clearPendingReloadState();
+
+private:
+    Control* control = nullptr;
+    guint timeoutId = 0;
+    bool monitoringStarted = false;
+    std::optional<fs::file_time_type> pendingReloadTime;
+    gint64 pendingReloadSinceUs = 0;
+};

--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -194,6 +194,9 @@ void Settings::loadDefault() {
     this->touchZoomStartThreshold = 0.0;
 
     this->pageRerenderThreshold = 5.0;
+    this->pdfAutoReloadEnabled = true;
+    this->pdfAutoReloadIntervalMs = PDF_AUTO_RELOAD_INTERVAL_DEFAULT_MS;
+    this->pdfAutoReloadDebounceMs = PDF_AUTO_RELOAD_INTERVAL_DEFAULT_MS;
     this->pdfPageCacheSize = 10;
     this->preloadPagesBefore = 3U;
     this->preloadPagesAfter = 5U;
@@ -537,6 +540,14 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur) {
         this->touchZoomStartThreshold = g_ascii_strtod(reinterpret_cast<const char*>(value), nullptr);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("pageRerenderThreshold")) == 0) {
         this->pageRerenderThreshold = g_ascii_strtod(reinterpret_cast<const char*>(value), nullptr);
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("pdfAutoReloadEnabled")) == 0) {
+        this->pdfAutoReloadEnabled = xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("pdfAutoReloadIntervalMs")) == 0) {
+        this->pdfAutoReloadIntervalMs = std::max<int>(
+                g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10), PDF_AUTO_RELOAD_INTERVAL_MIN_MS);
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("pdfAutoReloadDebounceMs")) == 0) {
+        this->pdfAutoReloadDebounceMs = std::max<int>(
+                g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10), PDF_AUTO_RELOAD_INTERVAL_MIN_MS);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("pdfPageCacheSize")) == 0) {
         this->pdfPageCacheSize = g_ascii_strtoll(reinterpret_cast<const char*>(value), nullptr, 10);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("preloadPagesBefore")) == 0) {
@@ -1146,6 +1157,9 @@ void Settings::save() {
 
     SAVE_DOUBLE_PROP(touchZoomStartThreshold);
     SAVE_DOUBLE_PROP(pageRerenderThreshold);
+    SAVE_BOOL_PROP(pdfAutoReloadEnabled);
+    SAVE_INT_PROP(pdfAutoReloadIntervalMs);
+    xmlNode = savePropertyUnsigned("pdfAutoReloadDebounceMs", getPdfAutoReloadDebounceMs(), root);
 
     SAVE_INT_PROP(pdfPageCacheSize);
     ATTACH_COMMENT("The count of rendered PDF pages which will be cached.");
@@ -2124,6 +2138,52 @@ void Settings::setPDFPageRerenderThreshold(double threshold) {
     }
 
     this->pageRerenderThreshold = threshold;
+    save();
+}
+
+auto Settings::getPdfAutoReloadEnabled() const -> bool { return this->pdfAutoReloadEnabled; }
+
+void Settings::setPdfAutoReloadEnabled(bool enabled) {
+    if (this->pdfAutoReloadEnabled == enabled) {
+        return;
+    }
+
+    this->pdfAutoReloadEnabled = enabled;
+    save();
+}
+
+auto Settings::getPdfAutoReloadIntervalMs() const -> unsigned int { return this->pdfAutoReloadIntervalMs; }
+
+void Settings::setPdfAutoReloadIntervalMs(unsigned int intervalMs) {
+    if (this->pdfAutoReloadIntervalMs == intervalMs) {
+        return;
+    }
+
+    if (intervalMs < PDF_AUTO_RELOAD_INTERVAL_MIN_MS) {
+        g_warning("Settings::Invalid PDF auto-reload interval (%u ms). Minimum value is %u ms. Using minimum instead!",
+                  intervalMs, PDF_AUTO_RELOAD_INTERVAL_MIN_MS);
+        intervalMs = PDF_AUTO_RELOAD_INTERVAL_MIN_MS;
+    }
+
+    this->pdfAutoReloadIntervalMs = intervalMs;
+    save();
+}
+
+auto Settings::getPdfAutoReloadDebounceMs() const -> unsigned int { return this->pdfAutoReloadDebounceMs; }
+
+void Settings::setPdfAutoReloadDebounceMs(unsigned int debounceMs) {
+    if (debounceMs < PDF_AUTO_RELOAD_INTERVAL_MIN_MS) {
+        g_warning("Settings::Invalid PDF auto-reload debounce interval (%u ms). Minimum value is %u ms. Using minimum "
+                  "instead!",
+                  debounceMs, PDF_AUTO_RELOAD_INTERVAL_MIN_MS);
+        debounceMs = PDF_AUTO_RELOAD_INTERVAL_MIN_MS;
+    }
+
+    if (this->pdfAutoReloadDebounceMs == debounceMs) {
+        return;
+    }
+
+    this->pdfAutoReloadDebounceMs = debounceMs;
     save();
 }
 

--- a/src/core/control/settings/Settings.h
+++ b/src/core/control/settings/Settings.h
@@ -45,6 +45,12 @@ struct Palette;
 constexpr auto DEFAULT_GRID_SIZE = 14.17;
 constexpr unsigned int MAX_SPACES_FOR_TAB = 8U;
 
+/**
+ * PDF auto-reload polling interval settings
+ */
+constexpr guint PDF_AUTO_RELOAD_INTERVAL_DEFAULT_MS = 200;
+constexpr guint PDF_AUTO_RELOAD_INTERVAL_MIN_MS = 50;
+
 class ButtonConfig;
 class InputDevice;
 class PageTemplateSettings;
@@ -397,6 +403,15 @@ public:
     // Re-render pages if document zoom differs from the last render zoom by the given threshold.
     double getPDFPageRerenderThreshold() const;
     void setPDFPageRerenderThreshold(double threshold);
+
+    bool getPdfAutoReloadEnabled() const;
+    void setPdfAutoReloadEnabled(bool enabled);
+
+    unsigned int getPdfAutoReloadIntervalMs() const;
+    void setPdfAutoReloadIntervalMs(unsigned int intervalMs);
+
+    unsigned int getPdfAutoReloadDebounceMs() const;
+    void setPdfAutoReloadDebounceMs(unsigned int debounceMs);
 
     double getTouchZoomStartThreshold() const;
     void setTouchZoomStartThreshold(double threshold);
@@ -987,6 +1002,21 @@ private:
      * for PDF pages to re-render while zooming.
      */
     double pageRerenderThreshold{};
+
+    /**
+     * Whether Xournal++ should detect changes to external PDF backgrounds and reload them automatically.
+     */
+    bool pdfAutoReloadEnabled;
+
+    /**
+     * Polling interval in milliseconds for checking whether the external PDF has changed on disk.
+     */
+    unsigned int pdfAutoReloadIntervalMs;
+
+    /**
+     * Time in milliseconds that a detected PDF file modification must remain unchanged before reloading.
+     */
+    unsigned int pdfAutoReloadDebounceMs;
 
     /**
      * Don't start zooming with touch until the difference in distances between the

--- a/src/core/gui/LegacyRedrawable.h
+++ b/src/core/gui/LegacyRedrawable.h
@@ -58,10 +58,9 @@ public:
     virtual void repaintPage() const = 0;
 
     /**
-     * Rerender our buffer, then redraw the widget
-     * @param sizeChanged whether or not this rerendering is caused by the size of the page changing
+     * Rerender our buffer, then redraw the widget.
      */
-    virtual void rerenderPage(bool sizeChanged = false) = 0;
+    virtual void rerenderPage() = 0;
 
     /**
      * Call this if you add an element, remove an element etc.

--- a/src/core/gui/PageView.cpp
+++ b/src/core/gui/PageView.cpp
@@ -802,17 +802,12 @@ auto XojPageView::onKeyReleaseEvent(const KeyEvent& event) -> bool {
     return false;
 }
 
-void XojPageView::rerenderPage(bool sizeChanged) {
+void XojPageView::rerenderPage() {
     this->rerenderComplete = true;
-    // We must preserve this flag until the pending RenderJob executes, even if ordinary
-    // rerender requests occur in the meantime.
-    //
-    // Note: While PageBackgroundChangeController::resizePagesToPdf may set this to true,
-    // it might be reset to false later in XournalView::pageSelected. Therefore, we strictly
-    // enforce the flag here to ensure the resize is handled correctly.
-    this->sizeChanged = this->sizeChanged || sizeChanged;
     this->xournal->getControl()->getScheduler()->addRerenderPage(this);
 }
+
+void XojPageView::markSizeChanged() { this->sizeChanged = true; }
 
 void XojPageView::repaintPage() const { xournal->getRepaintHandler()->repaintPage(this); }
 

--- a/src/core/gui/PageView.cpp
+++ b/src/core/gui/PageView.cpp
@@ -804,7 +804,13 @@ auto XojPageView::onKeyReleaseEvent(const KeyEvent& event) -> bool {
 
 void XojPageView::rerenderPage(bool sizeChanged) {
     this->rerenderComplete = true;
-    this->sizeChanged = sizeChanged;
+    // We must preserve this flag until the pending RenderJob executes, even if ordinary
+    // rerender requests occur in the meantime.
+    //
+    // Note: While PageBackgroundChangeController::resizePagesToPdf may set this to true,
+    // it might be reset to false later in XournalView::pageSelected. Therefore, we strictly
+    // enforce the flag here to ensure the resize is handled correctly.
+    this->sizeChanged = this->sizeChanged || sizeChanged;
     this->xournal->getControl()->getScheduler()->addRerenderPage(this);
 }
 

--- a/src/core/gui/PageView.h
+++ b/src/core/gui/PageView.h
@@ -63,7 +63,8 @@ public:
 
 public:
     void addOverlayView(std::unique_ptr<xoj::view::OverlayView>);
-    void rerenderPage(bool sizeChanged = false) override;
+    void rerenderPage() override;
+    void markSizeChanged();
     void rerenderRect(double x, double y, double width, double height) override;
 
     void repaintPage() const override;

--- a/src/core/gui/XournalView.cpp
+++ b/src/core/gui/XournalView.cpp
@@ -735,7 +735,8 @@ auto XournalView::isPageVisible(size_t page, int* visibleHeight) const -> bool {
 }
 
 void XournalView::documentChanged(DocumentChangeType type) {
-    if (type != DOCUMENT_CHANGE_CLEARED && type != DOCUMENT_CHANGE_COMPLETE) {
+
+    if (type != DOCUMENT_CHANGE_CLEARED && type != DOCUMENT_CHANGE_COMPLETE && type != DOCUMENT_CHANGE_PDF_CONTENT) {
         return;
     }
 
@@ -747,20 +748,31 @@ void XournalView::documentChanged(DocumentChangeType type) {
 
     recreatePdfCache();
 
-    Document* doc = control->getDocument();
-    doc->lock_shared();
+    if (type == DOCUMENT_CHANGE_PDF_CONTENT) {
+        // PDF reload keeps the existing document pages alive. Re-render in place so active overlays
+        // such as TextEditor are not destroyed just to refresh the background PDF content.
+        for (auto& viewPage: viewPages) {
+            viewPage->rerenderPage();
+        }
+    } else {
+        Document* doc = control->getDocument();
+        doc->lock_shared();
 
-    viewPages.clear();
-    size_t pagecount = doc->getPageCount();
-    viewPages.reserve(pagecount);
-    for (size_t i = 0; i < pagecount; i++) {
-        viewPages.emplace_back(std::make_unique<XojPageView>(this, doc->getPage(i)));
+        viewPages.clear();
+        size_t pagecount = doc->getPageCount();
+        viewPages.reserve(pagecount);
+        for (size_t i = 0; i < pagecount; i++) {
+            viewPages.emplace_back(std::make_unique<XojPageView>(this, doc->getPage(i)));
+        }
+
+        doc->unlock_shared();
     }
 
-    doc->unlock_shared();
-
     layoutPages();
-    scrollTo(0);
+
+    if (type != DOCUMENT_CHANGE_PDF_CONTENT) {
+        scrollTo(0);
+    }
 
     scheduler->unlock();
 }

--- a/src/core/gui/XournalView.cpp
+++ b/src/core/gui/XournalView.cpp
@@ -561,7 +561,8 @@ void XournalView::zoomChanged() {
 void XournalView::pageSizeChanged(size_t page) {
     layoutPages();
     if (page != npos && page < this->viewPages.size()) {
-        this->viewPages[page]->rerenderPage(/* sizeChanged */ true);
+        this->viewPages[page]->markSizeChanged();
+        this->viewPages[page]->rerenderPage();
     }
 }
 

--- a/src/core/gui/dialog/SettingsDialog.cpp
+++ b/src/core/gui/dialog/SettingsDialog.cpp
@@ -163,6 +163,9 @@ SettingsDialog::SettingsDialog(GladeSearchpath* gladeSearchPath, Settings* setti
                              }),
                              this);
 
+    g_signal_connect_swapped(builder.get("cbPdfAutoReload"), "toggled",
+                             G_CALLBACK(+[](SettingsDialog* self) { self->pdfAutoReloadToggled(); }), this);
+
     g_signal_connect_swapped(builder.get("cbStylusCursorType"), "changed",
                              G_CALLBACK(+[](SettingsDialog* self) { self->customStylusIconTypeChanged(); }), this);
 
@@ -297,6 +300,8 @@ void SettingsDialog::customStylusIconTypeChanged() {
             (stylusCursorType != STYLUS_CURSOR_NONE && stylusCursorType != STYLUS_CURSOR_ARROW);
     gtk_widget_set_sensitive(builder.get("highlightCursorGrid"), showCursorHighlightOptions);
 }
+
+void SettingsDialog::pdfAutoReloadToggled() { enableWithCheckbox("cbPdfAutoReload", "boxPdfAutoReloadInterval"); }
 
 void SettingsDialog::showStabilizerAvMethodOptions(StrokeStabilizer::AveragingMethod method) {
     bool showArithmetic = method == StrokeStabilizer::AveragingMethod::ARITHMETIC;
@@ -465,6 +470,13 @@ void SettingsDialog::load() {
 
     GtkWidget* spReRenderThreshold = builder.get("spReRenderThreshold");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spReRenderThreshold), settings->getPDFPageRerenderThreshold());
+
+    loadCheckbox("cbPdfAutoReload", settings->getPdfAutoReloadEnabled());
+    GtkWidget* spPdfAutoReloadInterval = builder.get("spPdfAutoReloadInterval");
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(spPdfAutoReloadInterval), settings->getPdfAutoReloadIntervalMs());
+    GtkWidget* spPdfAutoReloadDebounce = builder.get("spPdfAutoReloadDebounce");
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(spPdfAutoReloadDebounce), settings->getPdfAutoReloadDebounceMs());
+    pdfAutoReloadToggled();
 
     GtkWidget* spTouchZoomStartThreshold = builder.get("spTouchZoomStartThreshold");
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(spTouchZoomStartThreshold), settings->getTouchZoomStartThreshold());
@@ -1003,6 +1015,14 @@ void SettingsDialog::save() {
     GtkWidget* spReRenderThreshold = builder.get("spReRenderThreshold");
     double rerenderThreshold = gtk_spin_button_get_value(GTK_SPIN_BUTTON(spReRenderThreshold));
     settings->setPDFPageRerenderThreshold(rerenderThreshold);
+
+    settings->setPdfAutoReloadEnabled(getCheckbox("cbPdfAutoReload"));
+    GtkWidget* spPdfAutoReloadInterval = builder.get("spPdfAutoReloadInterval");
+    settings->setPdfAutoReloadIntervalMs(
+            static_cast<unsigned int>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(spPdfAutoReloadInterval))));
+    GtkWidget* spPdfAutoReloadDebounce = builder.get("spPdfAutoReloadDebounce");
+    settings->setPdfAutoReloadDebounceMs(
+            static_cast<unsigned int>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(spPdfAutoReloadDebounce))));
 
     settings->setDisplayDpi(gtk_check_button_get_active(GTK_CHECK_BUTTON(builder.get("zoomCallibAutomaticCb"))) ? -1 :
                                                                                                                   dpi);

--- a/src/core/gui/dialog/SettingsDialog.h
+++ b/src/core/gui/dialog/SettingsDialog.h
@@ -59,6 +59,7 @@ private:
      */
     void customHandRecognitionToggled();
     void customStylusIconTypeChanged();
+    void pdfAutoReloadToggled();
 
     /**
      * Update whether options can be selected, tooltips, etc. for

--- a/src/core/gui/sidebar/previews/base/SidebarPreviewBase.cpp
+++ b/src/core/gui/sidebar/previews/base/SidebarPreviewBase.cpp
@@ -93,7 +93,7 @@ auto SidebarPreviewBase::hasData() -> bool { return true; }
 auto SidebarPreviewBase::getWidget() -> GtkWidget* { return this->mainBox.get(); }
 
 void SidebarPreviewBase::documentChanged(DocumentChangeType type) {
-    if (type == DOCUMENT_CHANGE_COMPLETE || type == DOCUMENT_CHANGE_CLEARED) {
+    if (type == DOCUMENT_CHANGE_COMPLETE || type == DOCUMENT_CHANGE_CLEARED || type == DOCUMENT_CHANGE_PDF_CONTENT) {
         this->cache.reset();
 
         Document* doc = control->getDocument();

--- a/src/core/model/Document.cpp
+++ b/src/core/model/Document.cpp
@@ -91,6 +91,7 @@ void Document::clearDocument(bool destroy) {
 
     this->filepath = fs::path{};
     this->pdfFilepath = fs::path{};
+    this->pdfLastModifiedTime.reset();
 }
 
 /**
@@ -317,6 +318,7 @@ void Document::updateIndexPageNumbers() {
 void Document::setPdfAttributes(const fs::path& filename, bool attachToDocument) {
     this->pdfFilepath = filename;
     this->attachPdf = attachToDocument;
+    updatePdfLastModifiedTime();
 }
 
 auto Document::readPdf(const fs::path& filename, bool initPages, bool attachToDocument,
@@ -348,6 +350,7 @@ auto Document::readPdf(const fs::path& filename, bool initPages, bool attachToDo
 
     this->pdfFilepath = filename;
     this->attachPdf = attachToDocument;
+    updatePdfLastModifiedTime();
     lastError = "";
 
     if (initPages) {
@@ -368,13 +371,27 @@ auto Document::readPdf(const fs::path& filename, bool initPages, bool attachToDo
     updateIndexPageNumbers();
 
     unlock();
-
     this->handler->fireDocumentChanged(DOCUMENT_CHANGE_PDF_BOOKMARKS);
-
     return true;
 }
 
-void Document::resetPdf() { pdfDocument.reset(); }
+void Document::resetPdf() {
+    pdfDocument.reset();
+    pdfLastModifiedTime.reset();
+}
+
+auto Document::reloadPdf() -> bool { return readPdf(this->pdfFilepath, false, this->attachPdf); }
+
+auto Document::canAutoReloadPdf() const -> bool {
+    if (this->attachPdf || this->pdfFilepath.empty()) {
+        return false;
+    }
+
+    std::error_code ec;
+    return fs::is_regular_file(this->pdfFilepath, ec);
+}
+
+auto Document::getPdfLastModifiedTime() const -> std::optional<fs::file_time_type> { return this->pdfLastModifiedTime; }
 
 void Document::setPageSize(PageRef p, double width, double height) { p->setSize(width, height); }
 
@@ -447,6 +464,7 @@ auto Document::operator=(const Document& doc) -> Document& {
     this->password = doc.password;
     this->createBackupOnSave = doc.createBackupOnSave;
     this->pdfFilepath = doc.pdfFilepath;
+    this->pdfLastModifiedTime = doc.pdfLastModifiedTime;
     this->filepath = doc.filepath;
     this->pages = doc.pages;
     this->attachPdf = doc.attachPdf;
@@ -470,3 +488,19 @@ auto Document::operator=(const Document& doc) -> Document& {
 void Document::setCreateBackupOnSave(bool backup) { this->createBackupOnSave = backup; }
 
 auto Document::shouldCreateBackupOnSave() const -> bool { return this->createBackupOnSave; }
+
+void Document::updatePdfLastModifiedTime() {
+    if (this->attachPdf || this->pdfFilepath.empty()) {
+        return;
+    }
+
+    std::error_code ec;
+    if (!fs::is_regular_file(this->pdfFilepath, ec)) {
+        return;
+    }
+
+    auto modified = fs::last_write_time(this->pdfFilepath, ec);
+    if (!ec) {
+        this->pdfLastModifiedTime = modified;
+    }
+}

--- a/src/core/model/Document.h
+++ b/src/core/model/Document.h
@@ -15,6 +15,7 @@
 
 #include <cstddef>        // for size_t
 #include <memory>         // for unique_ptr
+#include <optional>       // for optional
 #include <shared_mutex>   // for shared_mutex
 #include <string>         // for string
 #include <unordered_map>  // for unordered_map
@@ -47,6 +48,9 @@ public:
     bool readPdf(const fs::path& filename, bool initPages, bool attachToDocument,
                  std::unique_ptr<std::string> data = {});
     void resetPdf();
+    bool reloadPdf();
+    bool canAutoReloadPdf() const;
+    std::optional<fs::file_time_type> getPdfLastModifiedTime() const;
 
     size_t getPageCount() const;
     size_t getPdfPageCount() const;
@@ -114,6 +118,7 @@ private:
     void buildTreeContentsModel(GtkTreeIter* parent, XojPdfBookmarkIterator* iter);
     void updateIndexPageNumbers();
     static bool fillPageLabels(GtkTreeModel* treeModel, GtkTreePath* path, GtkTreeIter* iter, Document* doc);
+    void updatePdfLastModifiedTime();
 
 private:
     DocumentHandler* handler = nullptr;
@@ -123,6 +128,7 @@ private:
     fs::path filepath;
     fs::path pdfFilepath;
     bool attachPdf = false;
+    std::optional<fs::file_time_type> pdfLastModifiedTime;
 
     Util::PathStorageMode pathStorageMode = Util::PathStorageMode::AS_RELATIVE_PATH;
 

--- a/src/core/model/DocumentChangeType.h
+++ b/src/core/model/DocumentChangeType.h
@@ -11,4 +11,10 @@
 
 #pragma once
 
-enum DocumentChangeType { DOCUMENT_CHANGE_CLEARED, DOCUMENT_CHANGE_COMPLETE, DOCUMENT_CHANGE_PDF_BOOKMARKS };
+enum DocumentChangeType {
+    DOCUMENT_CHANGE_CLEARED,
+    DOCUMENT_CHANGE_COMPLETE,
+    DOCUMENT_CHANGE_PDF_BOOKMARKS,
+    /// The loaded PDF content changed and PDF-backed views/caches should refresh.
+    DOCUMENT_CHANGE_PDF_CONTENT
+};

--- a/src/core/pdf/popplerapi/PopplerGlibDocument.cpp
+++ b/src/core/pdf/popplerapi/PopplerGlibDocument.cpp
@@ -101,6 +101,9 @@ auto PopplerGlibDocument::getPage(size_t page) const -> XojPdfPageSPtr {
     }
 
     PopplerPage* pg = poppler_document_get_page(document, int(page));
+    if (pg == nullptr) {
+        return nullptr;
+    }
     XojPdfPageSPtr pageptr = std::make_shared<PopplerGlibPage>(pg, document);
     g_object_unref(pg);
 

--- a/src/core/undo/MissingPdfUndoAction.cpp
+++ b/src/core/undo/MissingPdfUndoAction.cpp
@@ -1,14 +1,9 @@
 #include "MissingPdfUndoAction.h"
 
-#include "control/Control.h"                         // for Control
-#include "control/PageBackgroundChangeController.h"  // for PageBackGroundChangeController
-#include "gui/MainWindow.h"                          // for MainWindow
-#include "gui/XournalView.h"                         // for XournalView
-#include "model/Document.h"                          // for Document
-#include "model/PageType.h"                          // for PageTypeFormat
-#include "model/XojPage.h"                           // for XojPage
-#include "undo/UndoAction.h"                         // for UndoAction
-#include "util/i18n.h"                               // for _
+#include "control/Control.h"  // for Control
+#include "model/Document.h"   // for Document
+#include "undo/UndoAction.h"  // for UndoAction
+#include "util/i18n.h"        // for _
 
 MissingPdfUndoAction::MissingPdfUndoAction(const fs::path& oldFilepath, bool oldAttachPdf):
         UndoAction("MissingPdfUndoAction"), filepath(oldFilepath), attachPdf(oldAttachPdf) {}
@@ -26,13 +21,8 @@ auto MissingPdfUndoAction::undo(Control* control) -> bool {
     doc->setPdfAttributes(this->filepath, this->attachPdf);
     doc->unlock();
 
-    control->getWindow()->getXournal()->recreatePdfCache();
-
-    for (size_t p = 0; p < doc->getPageCount(); p++) {
-        if (doc->getPage(p)->getBackgroundType().format == PageTypeFormat::Pdf) {
-            control->firePageChanged(p);
-        }
-    }
+    control->firePdfContentChanged();
+    control->refreshAfterPdfChange();
 
     this->filepath = std::move(redoFilepath);
     this->attachPdf = redoAttachPdf;
@@ -49,13 +39,8 @@ auto MissingPdfUndoAction::redo(Control* control) -> bool {
     doc->unlock();
 
     doc->readPdf(this->filepath, false, this->attachPdf);
-    control->getWindow()->getXournal()->recreatePdfCache();
-
-    for (size_t p = 0; p < doc->getPageCount(); p++) {
-        if (doc->getPage(p)->getBackgroundType().format == PageTypeFormat::Pdf) {
-            control->firePageChanged(p);
-        }
-    }
+    control->firePdfContentChanged();
+    control->refreshAfterPdfChange();
 
     this->filepath = std::move(undoFilepath);
     this->attachPdf = undoAttachPdf;

--- a/test/unit_tests/control/SettingsTest.cpp
+++ b/test/unit_tests/control/SettingsTest.cpp
@@ -43,6 +43,8 @@ TEST(SettingsTest, testReadWrite) {
         settings.setBackgroundColor(Color(123, 45, 67));               // Color
         settings.setColorPaletteSetting("foo/bar€_palette");           // path
         settings.setEraserVisibility(ERASER_VISIBILITY_HOVER);         // enum
+        settings.setPdfAutoReloadEnabled(false);                       // bool
+        settings.setPdfAutoReloadIntervalMs(750);                      // unsigned int
         settings.setFont(XojFont{"myfontname italic 34"});             // Font
         settings.latexSettings.editorFont = XojFont{"myfonttest 52"};  // Font
         settings.setPreloadPagesAfter(145);                            // unsigned int
@@ -54,11 +56,13 @@ TEST(SettingsTest, testReadWrite) {
         // For each type, we test one that has been changed and one that should be default
         EXPECT_EQ(settings.isAudioDisabled(), loaded.isAudioDisabled());                                    // bool
         EXPECT_EQ(settings.isAutoloadPdfXoj(), loaded.isAutoloadPdfXoj());                                  // bool
+        EXPECT_EQ(settings.getPdfAutoReloadEnabled(), loaded.getPdfAutoReloadEnabled());                    // bool
         EXPECT_EQ(settings.getDefaultSaveName(), loaded.getDefaultSaveName());                              // u8string
         EXPECT_EQ(settings.getDefaultPdfExportName(), loaded.getDefaultPdfExportName());                    // u8string
         EXPECT_EQ(settings.getPreferredLocale(), loaded.getPreferredLocale());                              // string
         EXPECT_EQ(settings.getPageTemplateSettings(), loaded.getPageTemplateSettings());                    // string
         EXPECT_EQ(settings.getDisplayDpi(), loaded.getDisplayDpi());                                        // int
+        EXPECT_EQ(settings.getPdfAutoReloadIntervalMs(), loaded.getPdfAutoReloadIntervalMs());  // unsigned int
         EXPECT_EQ(settings.getAddHorizontalSpaceAmountLeft(), loaded.getAddHorizontalSpaceAmountLeft());    // int
         EXPECT_EQ(settings.getStabilizerDrag(), loaded.getStabilizerDrag());                                // double
         EXPECT_EQ(settings.getCursorHighlightBorderWidth(), loaded.getCursorHighlightBorderWidth());        // double

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -102,6 +102,20 @@
     <property name="step-increment">5</property>
     <property name="page-increment">100</property>
   </object>
+  <object class="GtkAdjustment" id="adjustmentPdfAutoReloadInterval">
+    <property name="lower">50</property>
+    <property name="upper">10000</property>
+    <property name="value">200</property>
+    <property name="step-increment">10</property>
+    <property name="page-increment">100</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustmentPdfAutoReloadDebounce">
+    <property name="lower">50</property>
+    <property name="upper">10000</property>
+    <property name="value">200</property>
+    <property name="step-increment">10</property>
+    <property name="page-increment">100</property>
+  </object>
   <object class="GtkAdjustment" id="adjustmentSeekTime">
     <property name="lower">1</property>
     <property name="upper">90</property>
@@ -854,6 +868,161 @@ Illegal characters are replaced with "_"</property>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
                                 <property name="position">3</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkFrame" id="frameAutoReloadPdf">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0.009999999776482582</property>
+                                <child>
+                                  <object class="GtkBox" id="boxAutoReloadPdf">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">12</property>
+                                    <property name="margin-bottom">8</property>
+                                    <property name="orientation">vertical</property>
+                                    <child>
+                                      <object class="GtkCheckButton" id="cbPdfAutoReload">
+                                        <property name="label" translatable="yes">Automatically reload updated external PDFs</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="draw-indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkBox" id="boxPdfAutoReloadInterval">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                          <object class="GtkBox">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">Check for updated external PDFs every </property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSpinButton" id="spPdfAutoReloadInterval">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="input-purpose">number</property>
+                                                <property name="adjustment">adjustmentPdfAutoReloadInterval</property>
+                                                <property name="climb-rate">10</property>
+                                                <property name="numeric">True</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">1</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">ms.</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">2</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkBox">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">Only reload after the PDF is unchanged for </property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSpinButton" id="spPdfAutoReloadDebounce">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="input-purpose">number</property>
+                                                <property name="adjustment">adjustmentPdfAutoReloadDebounce</property>
+                                                <property name="climb-rate">10</property>
+                                                <property name="numeric">True</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">1</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">ms.</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">2</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label">
+                                  <object class="GtkLabel" id="labelAutoReloadPdf">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">Auto-Reload PDF</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">4</property>
                               </packing>
                             </child>
                           </object>


### PR DESCRIPTION
## Summary

Add automatic detection, reloading and flicker-free re-rendering of modified external PDF backgrounds, replacing the previous manual workflow where users had to reload manually. This feature is very helpful when opening a LaTeX generated PDF. Fix #6255 . 

## Key Changes

- **Add `PdfAutoReloadController`** — Periodically polls the external PDF file's last-modified time. Uses a debounce mechanism to wait until the file size is stable before triggering a reload, avoiding partial-write issues. As a sub-controller, it can be started and stopped by `Controller`.
- **Reuse previous code logic to reload and re-render PDF** Add `DOCUMENT_CHANGE_PDF_CONTENT` event type, allowing listeners to handle PDF content refreshes by reusing logic in `XournalView::documentChanged`, `SidebarPreviewBase::documentChanged`, etc.
- **Add three new settings in `Load / Save` Page -- `Auto-Reload PDF` (new)** (`pdfAutoReloadEnabled`, `pdfAutoReloadIntervalMs`, `pdfAutoReloadDebounceMs`)
-**Handling Page resizing on PDF update edge case** — resizes pages without annotation to match updated PDF dimensions. Pages with annotations are left unchanged to avoid content displacement, and the user is warned about skipped pages.

## For Reviewer

To look at the code, a possible way is to start from changes in `src/core/control/Control.cpp` (**~20 lines**) and then the new controller `src/core/control/PdfAutoReloadController.cpp` (**~150 lines**). There are **~20 lines** for reusing the previous code to handle rerendering. 
The other code are  boilerplate for settings UI and show warning dialog for PDF page size changing.

## Screencast


https://github.com/user-attachments/assets/9d739524-9d20-4000-9930-1a596c1e4454


