### PR TITLE
fix: adjustments for MSVC STL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,8 +215,8 @@ check_cxx_source_compiles([[
     int main() {
         const std::string_view sv = "7.381450";
         double val{};
-        auto [ptr, ec] = std::from_chars(sv.begin(), sv.end(), val);
-        return ptr != sv.end() || ec != std::errc{};
+        auto [ptr, ec] = std::from_chars(sv.data(), sv.data() + sv.size(), val);
+        return ptr != (sv.data() + sv.size()) || ec != std::errc{};
     }
 ]] HAVE_FLOAT_FROM_CHARS)
 if (HAVE_FLOAT_FROM_CHARS)

--- a/src/core/control/xojfile/XmlParser.cpp
+++ b/src/core/control/xojfile/XmlParser.cpp
@@ -331,8 +331,8 @@ void XmlParser::parseStrokeTag(const XmlParserHelper::AttributeMap& attributeMap
 
     // width
     auto widthSV = XmlParserHelper::getAttribMandatory<std::string_view>(xoj::xml_attrs::WIDTH_STR, attributeMap, "1");
-    auto it = widthSV.begin();
-    auto end = widthSV.end();
+    auto it = widthSV.data();
+    auto end = widthSV.data() + widthSV.size();
     double width{};
     parseDouble(it, end, width);  // First number in the width attribute is the global width
 
@@ -340,8 +340,8 @@ void XmlParser::parseStrokeTag(const XmlParserHelper::AttributeMap& attributeMap
     const auto pressureSV = XmlParserHelper::getAttrib<std::string_view>(xoj::xml_attrs::PRESSURES_STR, attributeMap);
     if (pressureSV) {
         // MrWriter writes pressures in a separate field
-        it = pressureSV->begin();
-        end = pressureSV->end();
+        it = pressureSV->data();
+        end = pressureSV->data() + pressureSV->size();
     }
     // Xournal and Xournal++ use the width field. `it` and `end` pointers are already in place.
 
@@ -384,8 +384,8 @@ void XmlParser::parseStrokeText(std::string_view text) {
     std::vector<Point> pointVector;
     pointVector.reserve(this->pressureBuffer.size() + 1);  // The last point has no pressure value
 
-    auto it = text.begin();
-    const auto end = text.end();
+    auto it = text.data();
+    const auto end = text.data() + text.size();
     auto pit = pressureBuffer.begin();
     double x{}, y{};
     while (parseDouble(it, end, x)) {

--- a/src/core/control/xojfile/XmlParserHelper.cpp
+++ b/src/core/control/xojfile/XmlParserHelper.cpp
@@ -158,8 +158,8 @@ auto XmlParserHelper::parseBgColor(string_utf8_view sv) -> std::optional<Color> 
 auto XmlParserHelper::parseColorCode(std::string_view sv) -> std::optional<Color> {
     if ((!sv.empty()) && (sv[0] == '#')) {
         uint32_t color{};
-        auto [ptr, ec] = std::from_chars(sv.begin() + 1, sv.end(), color, 16);
-        if (ec != std::errc{} || ptr != sv.end()) {
+        auto [ptr, ec] = std::from_chars(sv.data() + 1, sv.data() + sv.size(), color, 16);
+        if (ec != std::errc{} || ptr != (sv.data() + sv.size())) {
             g_warning("XML parser: Unknown color code \"" SV_FMT "\".", SV_ARG(sv));
             return {};
         }

--- a/src/core/control/xojfile/XmlParserHelper.h
+++ b/src/core/control/xojfile/XmlParserHelper.h
@@ -204,9 +204,10 @@ T parseEnum(c_string_utf8_view sv) {
 // Parse numeric types
 template <typename T>
 T parseNumeric(std::string_view sv) {
-    auto it = sv.begin();
-    auto value = ::XmlParserHelper::parseNumeric<T>(it, sv.end());
-    if (it != sv.end()) {
+    auto it = sv.data();
+    const auto end = sv.data() + sv.size();
+    auto value = ::XmlParserHelper::parseNumeric<T>(it, end);
+    if (it != end) {
         throw IncompleteParseError{value};
     }
     return value;

--- a/src/core/gui/PaperFormatUtils.h
+++ b/src/core/gui/PaperFormatUtils.h
@@ -10,6 +10,7 @@
  */
 
 #include <memory>
+#include <string>
 #include <variant>
 #include <vector>
 

--- a/src/core/gui/menus/menubar/Menubar.h
+++ b/src/core/gui/menus/menubar/Menubar.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 #include <string_view>
 
 #include <gio/gio.h>  // for GMenu, GMenuItem...

--- a/src/util/include/util/utf8_view.h
+++ b/src/util/include/util/utf8_view.h
@@ -3,6 +3,7 @@
 
 #include <iterator>
 #include <ranges>
+#include <string_view>
 #include <type_traits>
 
 #include "util/ViewIteratorBase.h"
@@ -101,6 +102,13 @@ struct utf8_t {
         return utf8_view{std::begin(r), std::end(r)};
     }
 
+    // Ensure that string views will always return a utf8_view<const char*, const char*> even if the iterator is
+    // wrapped.
+    template <is_byte T>
+    auto operator()(std::basic_string_view<T> const& r) const {
+        return utf8_view{r.data(), r.data() + r.size()};
+    }
+
     // For some reason, gcc 11 (default on ubuntu 22 LTS) does not recognize std::string as a viewable_range
     template <is_byte T>
     auto operator()(std::basic_string<T> const& r) const {
@@ -117,7 +125,7 @@ inline constexpr utf8_t utf8;
 
 template <std::ranges::viewable_range R>
 constexpr auto operator|(R r, utf8_t const&) {
-    return utf8_view{std::begin(r), std::end(r)};
+    return utf8_t{}(std::forward<R>(r));
 }
 
 template <is_byte T>


### PR DESCRIPTION
This fixes compilation when the MSVC STL is used. While compilation with MSVC itself isn't possible due to [C1061](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/fatal-error-c1061), clang-cl will work fine there.

The main change is that iterators for `std::string_view` are no longer expected to be pointers. In MSVC's STL, the string view iterator is wrapped to be able to use checked iterators. Note that this will also be a problem if a libc++ with `_LIBCPP_ABI_BOUNDED_ITERATORS` is used.

Other than that, two includes for `<string>` were missing.

---

While this allows compilation without MinGW, it isn't enough to run the app. There are two main issues: 
- The gtk3 vcpkg package doesn't include the assets/icons that would otherwise come with [adwaita-icon-theme](https://packages.msys2.org/base/mingw-w64-adwaita-icon-theme) (haven't tested with conan, but I assume it's similar there).
- Both vcpkg and conan don't support compilation of Rust code right now, so they're missing an up-to-date version of librsvg (https://github.com/microsoft/vcpkg/issues/20619, https://github.com/conan-io/conan-center-index/issues/11392#issuecomment-1222129410).