### PR TITLE
Fix actions names related issues

### DIFF
--- a/src/core/control/layer/LayerController.cpp
+++ b/src/core/control/layer/LayerController.cpp
@@ -1,6 +1,7 @@
 #include "LayerController.h"
 
 #include <memory>   // for __shared_ptr_access, make...
+#include <mutex>    // for unique_lock
 #include <utility>  // for move
 #include <vector>   // for vector
 
@@ -8,16 +9,16 @@
 #include "control/actions/ActionDatabase.h"  // for ActionDatabase
 #include "gui/MainWindow.h"                  // for MainWindow
 #include "gui/XournalView.h"                 // for XournalView
-#include "model/Document.h"                 // for Document
-#include "model/XojPage.h"                  // for XojPage
-#include "undo/InsertLayerUndoAction.h"     // for InsertLayerUndoAction
-#include "undo/MergeLayerDownUndoAction.h"  // for MergeLayerDownUndoAction
-#include "undo/MoveLayerUndoAction.h"       // for MoveLayerUndoAction
-#include "undo/RemoveLayerUndoAction.h"     // for RemoveLayerUndoAction
-#include "undo/UndoAction.h"                // for UndoActionPtr, UndoAction
-#include "undo/UndoRedoHandler.h"           // for UndoRedoHandler
-#include "util/Util.h"                      // for npos
-#include "util/i18n.h"                      // for FS, _F
+#include "model/Document.h"                  // for Document
+#include "model/XojPage.h"                   // for XojPage
+#include "undo/InsertLayerUndoAction.h"      // for InsertLayerUndoAction
+#include "undo/MergeLayerDownUndoAction.h"   // for MergeLayerDownUndoAction
+#include "undo/MoveLayerUndoAction.h"        // for MoveLayerUndoAction
+#include "undo/RemoveLayerUndoAction.h"      // for RemoveLayerUndoAction
+#include "undo/UndoAction.h"                 // for UndoActionPtr, UndoAction
+#include "undo/UndoRedoHandler.h"            // for UndoRedoHandler
+#include "util/Util.h"                       // for npos
+#include "util/i18n.h"                       // for FS, _F
 
 #include "LayerCtrlListener.h"  // for LayerCtrlListener
 
@@ -39,14 +40,75 @@ void LayerController::pageSelected(size_t page) {
 }
 
 void LayerController::insertLayer(PageRef page, Layer* layer, Layer::Index layerPos) {
+    xoj_assert(layer);
+    bool empty = layer->getElements().empty();
+    control->getDocument()->lock();
     page->insertLayer(layer, layerPos);
+    auto id = empty ? npos : control->getDocument()->indexOf(page);
+    control->getDocument()->unlock();
     fireRebuildLayerMenu();
+    if (!empty) {
+        // Rerender the page
+        control->getWindow()->getXournal()->layerChanged(id);
+    }
 }
 
 void LayerController::removeLayer(PageRef page, Layer* layer) {
+    control->getDocument()->lock();
+    bool empty = layer->getElements().empty();
     page->removeLayer(layer);
+    auto id = empty ? npos : control->getDocument()->indexOf(page);
+    control->getDocument()->unlock();
     fireRebuildLayerMenu();
+    if (!empty) {
+        // Rerender the page
+        control->getWindow()->getXournal()->layerChanged(id);
+    }
 }
+
+void LayerController::moveLayer(PageRef page, Layer* layer, Layer::Index newPos) {
+    control->getDocument()->lock();
+    page->removeLayer(layer);
+    page->insertLayer(layer, newPos);
+    auto id = control->getDocument()->indexOf(page);
+    control->getDocument()->unlock();
+    fireRebuildLayerMenu();
+    // Rerender the page
+    control->getWindow()->getXournal()->layerChanged(id);
+}
+
+void LayerController::mergeLayers(PageRef page, Layer* bottomLayer, Layer* topLayer) {
+    control->getDocument()->lock();
+    page->removeLayer(topLayer);
+
+    for (auto&& elem: topLayer->clearNoFree()) {
+        bottomLayer->addElement(std::move(elem));
+    }
+    auto id = control->getDocument()->indexOf(page);
+    control->getDocument()->unlock();
+
+    fireRebuildLayerMenu();
+    control->getWindow()->getXournal()->layerChanged(id);  // Rerender the page
+}
+
+void LayerController::moveElementsFromLayerToFreeLayer(PageRef page, Layer* layer,
+                                                       const std::vector<const Element*>& elts, Layer* freeLayer,
+                                                       Layer::Index newLayerId) {
+    control->getDocument()->lock();
+
+    for (const Element* elem: elts) {
+        freeLayer->addElement(layer->removeElement(elem).e);
+    }
+
+    // add the upper layer back at its old pos
+    page->insertLayer(freeLayer, newLayerId);
+    auto id = control->getDocument()->indexOf(page);
+    control->getDocument()->unlock();
+
+    fireRebuildLayerMenu();
+    control->getWindow()->getXournal()->layerChanged(id);  // Rerender the page
+}
+
 
 void LayerController::addListener(LayerCtrlListener* listener) { this->listener.push_back(listener); }
 
@@ -104,14 +166,18 @@ void LayerController::hideAllLayer() { showOrHideAllLayer(false); }
  * Show / Hide all layer on the current page
  */
 void LayerController::showOrHideAllLayer(bool show) {
+    auto lock = std::unique_lock(*control->getDocument());
     PageRef page = getCurrentPage();
     for (Layer::Index i = 1; i <= page->getLayerCount(); i++) { page->setLayerVisible(i, show); }
+    lock.unlock();
 
     fireLayerVisibilityChanged();
 }
 
 void LayerController::addNewLayer(bool belowCurrentLayer) {
     control->clearSelectionEndText();
+
+    auto lock = std::unique_lock(*control->getDocument());
     PageRef p = getCurrentPage();
     if (!p) {
         return;
@@ -121,6 +187,7 @@ void LayerController::addNewLayer(bool belowCurrentLayer) {
     xoj_assert(p->getSelectedLayerId() > 0);
     auto layerPos = belowCurrentLayer ? p->getSelectedLayerId() - 1 : p->getSelectedLayerId();
     p->insertLayer(l, layerPos);
+    lock.unlock();
 
     control->getUndoRedoHandler()->addUndoAction(std::make_unique<InsertLayerUndoAction>(this, p, l, layerPos));
 
@@ -131,6 +198,7 @@ void LayerController::addNewLayer(bool belowCurrentLayer) {
 void LayerController::deleteCurrentLayer() {
     control->clearSelectionEndText();
 
+    auto lock = std::unique_lock(*control->getDocument());
     PageRef p = getCurrentPage();
     auto pId = selectedPage;
     if (!p) {
@@ -144,6 +212,7 @@ void LayerController::deleteCurrentLayer() {
     Layer* l = p->getSelectedLayer();
 
     p->removeLayer(l);
+    lock.unlock();
 
     MainWindow* win = control->getWindow();
     if (win) {
@@ -158,6 +227,7 @@ void LayerController::deleteCurrentLayer() {
 void LayerController::moveCurrentLayer(bool up) {
     control->clearSelectionEndText();
 
+    auto lock = std::unique_lock(*control->getDocument());
     PageRef p = getCurrentPage();
     auto pId = selectedPage;
     if (!p) {
@@ -188,6 +258,7 @@ void LayerController::moveCurrentLayer(bool up) {
     // index 0 in the vector... confusing...
     auto newIndex = up ? lId : lId - 2;
     p->insertLayer(currentLayer, newIndex);
+    lock.unlock();
 
     MainWindow* win = control->getWindow();
     if (win) {
@@ -203,6 +274,7 @@ void LayerController::moveCurrentLayer(bool up) {
 void LayerController::mergeCurrentLayerDown() {
     control->clearSelectionEndText();
 
+    auto lock = std::shared_lock(*control->getDocument());
     PageRef page = getCurrentPage();
     auto pageID = selectedPage;
     if (page == nullptr) {
@@ -240,6 +312,8 @@ void LayerController::mergeCurrentLayerDown() {
 
     UndoActionPtr undo_redo_action =
             std::make_unique<MergeLayerDownUndoAction>(this, page, currentLayer, layerID - 1, layerBelow, pageID);
+    lock.unlock();
+    // The mutex is locked in RW in redo()
     undo_redo_action->redo(this->control);
 
     control->getUndoRedoHandler()->addUndoAction(std::move(undo_redo_action));
@@ -250,6 +324,7 @@ void LayerController::mergeCurrentLayerDown() {
 void LayerController::copyCurrentLayer() {
     control->clearSelectionEndText();
 
+    auto lock = std::unique_lock(*control->getDocument());
     PageRef p = getCurrentPage();
     auto pId = selectedPage;
     if (!p) {
@@ -264,6 +339,7 @@ void LayerController::copyCurrentLayer() {
     Layer* cloned = l->clone();
 
     p->insertLayer(cloned, lId);
+    lock.unlock();
 
     MainWindow* win = control->getWindow();
     if (win) {
@@ -296,12 +372,14 @@ void LayerController::switchToLay(Layer::Index layerId, bool hideShow, bool clea
         control->clearSelectionEndText();
     }
 
+    auto lock = std::shared_lock(*control->getDocument());
     PageRef p = getCurrentPage();
     if (!p) {
         return;
     }
 
     p->setSelectedLayerId(layerId);
+    lock.unlock();
     fireSelectedLayerChanged();
 
     if (hideShow) {
@@ -334,25 +412,30 @@ auto LayerController::getCurrentLayerId() const -> Layer::Index {
     return page->getSelectedLayerId();
 }
 
-auto LayerController::getCurrentLayerName() const -> std::string {
-    PageRef page = getCurrentPage();
-
-    if (page == nullptr) {
+/// Make sure the document's mutex is locked when calling this
+static auto getLayerNameOnPage(const PageRef& page, Layer::Index id) -> std::string {
+    if (page == nullptr || id > page->getLayerCount()) {
         return "Unknown layer name";
-    }
-
-    auto currentID = getCurrentLayerId();
-
-    if (currentID == 0) {  // If is background
+    } else if (id == 0) {  // If is background
         return page->getBackgroundName();
-    } else if (auto layer = page->getSelectedLayer(); layer->hasName()) {
+    } else if (auto layer = page->getLayersView()[id - 1]; layer->hasName()) {
         return layer->getName();
     } else {
-        return FS(_F("Layer {1}") % static_cast<long>(currentID));
+        return FS(_F("Layer {1}") % static_cast<long>(id));
     }
 }
 
+auto LayerController::getCurrentLayerName() const -> std::string {
+    auto lock = std::shared_lock(*control->getDocument());
+    return getLayerNameOnPage(getCurrentPage(), getCurrentLayerId());
+}
+auto LayerController::getLayerNameById(Layer::Index id) const -> std::string {
+    auto lock = std::shared_lock(*control->getDocument());
+    return getLayerNameOnPage(getCurrentPage(), id);
+}
+
 void LayerController::setCurrentLayerName(const std::string& newName) {
+    auto lock = std::unique_lock(*control->getDocument());
     PageRef page = getCurrentPage();
 
     if (page == nullptr) {
@@ -364,28 +447,7 @@ void LayerController::setCurrentLayerName(const std::string& newName) {
     } else {  // Any other layer
         page->getSelectedLayer()->setName(newName);
     }
+    lock.unlock();
 
     fireRebuildLayerMenu();
-}
-
-std::string LayerController::getLayerNameById(Layer::Index id) const {
-    PageRef page = getCurrentPage();
-
-    if (page == nullptr) {
-        return "Unknown layer name";
-    }
-
-    if (id == 0) {
-        return page->getBackgroundName();
-    }
-
-    auto previousId = page->getSelectedLayerId();
-    if (previousId == id) {
-        return getCurrentLayerName();
-    }
-    page->setSelectedLayerId(id);
-    std::string name = getCurrentLayerName();
-    page->setSelectedLayerId(previousId);
-
-    return name;
 }

--- a/src/core/control/layer/LayerController.h
+++ b/src/core/control/layer/LayerController.h
@@ -37,6 +37,13 @@ public:
     void insertLayer(PageRef page, Layer* layer, Layer::Index layerPos);
     /// Remove a layer, without adding an UndoAction
     void removeLayer(PageRef page, Layer* layer);
+    /// Moves a Layer to a new index, without adding an UndoAction. Assumes `layer` is in `page`
+    void moveLayer(PageRef page, Layer* layer, Layer::Index newPos);
+    /// Move every elements of topLayer onto bottomLayer and removes topLayer, without adding an UndoAction
+    void mergeLayers(PageRef page, Layer* bottomLayer, Layer* topLayer);
+    /// Move the given elements from `layer` to `freeLayer` and add `freeLayer` to the page at the given position
+    void moveElementsFromLayerToFreeLayer(PageRef page, Layer* layer, const std::vector<const Element*>& elts,
+                                          Layer* freeLayer, Layer::Index newLayerId);
 
     // Listener handling
 public:

--- a/src/core/enums/Action.enum.h
+++ b/src/core/enums/Action.enum.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
 
 #include <glib.h>  // for g_warning
@@ -184,11 +185,11 @@ constexpr auto Action_toString(Action value) -> const char* {
     return ACTION_NAMES[static_cast<size_t>(value)];
 }
 
-constexpr auto Action_fromString(const std::string_view value) -> Action {
+constexpr auto Action_fromString(const std::string_view value) -> std::optional<Action> {
     for (size_t n = 0; n < xoj::to_underlying(Action::ENUMERATOR_COUNT); n++) {
         if (value == ACTION_NAMES[n]) {
             return static_cast<Action>(n);
         }
     }
-    return Action::NEW_FILE;
+    return std::nullopt;
 }

--- a/src/core/plugin/luapi_application.h
+++ b/src/core/plugin/luapi_application.h
@@ -610,7 +610,11 @@ static int applib_changeActionState(lua_State* L) {
     if (actionStr == nullptr) {
         return luaL_error(L, "Missing action!");
     }
-    Action action = Action_fromString(actionStr);
+    auto optAction = Action_fromString(actionStr);
+    if (!optAction) {
+        return luaL_error(L, "Invalid action name: \"%s\"", actionStr);
+    }
+    Action action = optAction.value();
 
     Plugin* plugin = Plugin::getPluginFromLua(L);
     Control* control = plugin->getControl();
@@ -645,7 +649,11 @@ static int applib_getActionState(lua_State* L) {
     if (actionStr == nullptr) {
         return luaL_error(L, "Missing action!");
     }
-    Action action = Action_fromString(actionStr);
+    auto optAction = Action_fromString(actionStr);
+    if (!optAction) {
+        return luaL_error(L, "Invalid action name: \"%s\"", actionStr);
+    }
+    Action action = optAction.value();
     Plugin* plugin = Plugin::getPluginFromLua(L);
     Control* control = plugin->getControl();
     auto* actionDB = control->getActionDatabase();
@@ -672,10 +680,14 @@ static int applib_activateAction(lua_State* L) {
     if (actionStr == nullptr) {
         return luaL_error(L, "Missing action!");
     }
+    auto optAction = Action_fromString(actionStr);
+    if (!optAction) {
+        return luaL_error(L, "Invalid action name: \"%s\"", actionStr);
+    }
+    Action action = optAction.value();
     Plugin* plugin = Plugin::getPluginFromLua(L);
     Control* control = plugin->getControl();
     auto* actionDB = control->getActionDatabase();
-    Action action = Action_fromString(actionStr);
     GAction* gAction = G_ACTION(actionDB->getAction(action).get());
 
     auto* type = g_action_get_parameter_type(gAction);

--- a/src/core/undo/InsertLayerUndoAction.cpp
+++ b/src/core/undo/InsertLayerUndoAction.cpp
@@ -1,10 +1,6 @@
 #include "InsertLayerUndoAction.h"
 
-#include "control/Control.h"                // for Control
 #include "control/layer/LayerController.h"  // for LayerController
-#include "gui/MainWindow.h"                 // for MainWindow
-#include "gui/XournalView.h"                // for XournalView
-#include "model/Document.h"                 // for Document
 #include "model/Layer.h"                    // for Layer, Layer::Index
 #include "model/PageRef.h"                  // for PageRef
 #include "undo/UndoAction.h"                // for UndoAction
@@ -29,23 +25,14 @@ InsertLayerUndoAction::~InsertLayerUndoAction() {
 auto InsertLayerUndoAction::getText() -> std::string { return _("Insert layer"); }
 
 auto InsertLayerUndoAction::undo(Control* control) -> bool {
-    Document* doc = control->getDocument();
-    doc->lock();
     layerController->removeLayer(this->page, this->layer);
-    doc->unlock();
     this->undone = true;
 
     return true;
 }
 
 auto InsertLayerUndoAction::redo(Control* control) -> bool {
-    Document* doc = control->getDocument();
-    doc->lock();
     layerController->insertLayer(this->page, this->layer, layerPosition);
-    auto id = doc->indexOf(this->page);
-    doc->unlock();
-    control->getWindow()->getXournal()->layerChanged(id);
-
     this->undone = false;
 
     return true;

--- a/src/core/undo/MergeLayerDownUndoAction.cpp
+++ b/src/core/undo/MergeLayerDownUndoAction.cpp
@@ -4,11 +4,7 @@
 #include <utility>
 #include <vector>  // for vector
 
-#include "control/Control.h"                // for Control
 #include "control/layer/LayerController.h"  // for LayerController
-#include "gui/MainWindow.h"                 // for MainWindow
-#include "gui/XournalView.h"                // for XournalView
-#include "model/Document.h"
 #include "model/Layer.h"                    // for Layer, Layer::Index
 #include "model/PageRef.h"                  // for PageRef
 #include "model/XojPage.h"                  // for XojPage
@@ -29,6 +25,7 @@ MergeLayerDownUndoAction::MergeLayerDownUndoAction(LayerController* layerControl
         UndoAction("MergeLayerDownUndoAction"),
         layerController(layerController),
         upperLayer(upperLayer),
+        upperLayerElements(this->upperLayer->getElementsView().clone()),
         upperLayerPos(upperLayerPos),
         upperLayerID(upperLayerPos + 1),
         lowerLayer(lowerLayer),
@@ -40,79 +37,18 @@ MergeLayerDownUndoAction::MergeLayerDownUndoAction(LayerController* layerControl
 auto MergeLayerDownUndoAction::getText() -> std::string { return _("Merge layer down"); }
 
 auto MergeLayerDownUndoAction::undo(Control* control) -> bool {
-    Document* doc = control->getDocument();
-    doc->lock();
-    // remove all elements present in the upper layer from the lower layer again
-    for (const Element* elem: upperLayerElements) {
-        this->upperLayer->addElement(this->lowerLayer->removeElement(elem).e);
-    }
-
-    // add the upper layer back at its old pos
-    layerController->insertLayer(this->page, this->upperLayer, upperLayerPos);
-    // set the selected layer back to the ID of the upper layer
+    layerController->moveElementsFromLayerToFreeLayer(this->page, this->lowerLayer, this->upperLayerElements,
+                                                      this->upperLayer, this->upperLayerID);
     this->page->setSelectedLayerId(this->upperLayerID);
-
-    doc->unlock();
-
     this->undone = true;
-
-    this->triggerUIUpdate(control);
 
     return true;
 }
 
 auto MergeLayerDownUndoAction::redo(Control* control) -> bool {
-    Document* doc = control->getDocument();
-    doc->lock();
-    // remove the upper layer
-    layerController->removeLayer(this->page, this->upperLayer);
-
-    this->upperLayerElements = this->upperLayer->getElementsView().clone();
-    auto elements = this->upperLayer->clearNoFree();
-    // add all elements back to the lower layer
-    for (auto&& elem: elements) {
-        this->lowerLayer->addElement(std::move(elem));
-    }
-    // set the selected layer back to the ID of the lower layer
+    layerController->mergeLayers(this->page, this->lowerLayer, this->upperLayer);
     this->page->setSelectedLayerId(this->lowerLayerID);
-
-    doc->unlock();
-
     this->undone = false;
 
-    this->triggerUIUpdate(control);
-
     return true;
-}
-
-void MergeLayerDownUndoAction::triggerUIUpdate(Control* control) {
-    /*
-     * NOTE: (call order relevant to avoid deadlock)
-     *     When this implementation is called by the `UndoRedoHandler` the
-     *     document is locked. Calling `layerChanged` adds a render job which
-     *     can only be processed when the document is unlocked again, but might
-     *     have already claimed `Scheduler::jobRunningMutex`.
-     *     `fireRebuildLayerMenu` will wait for `jobRunningMutex` to be free,
-     *     so calling `fireRebuildLayerMenu` AFTER `layerChanged` will likely
-     *     result in a DEADLOCK.
-     */
-
-    /*
-     * Rebuild the layer menu, so that the correct new layer selection is
-     * properly displayed in the sidebar. Without this, the visually displayed
-     * selection defaults to the top layer while the actual selection is the
-     * newly merged layer; there would be a mismatch without rebuilding the
-     * menu this way.
-     */
-    layerController->fireRebuildLayerMenu();
-
-    /*
-     * Under some circumstance (e.g. the layer below is not set to visible)
-     * merging might change the appearance of the page, so `layerChanged` is
-     * employed to rerender the page.
-     */
-    MainWindow* win = control->getWindow();
-    if (win) {
-        win->getXournal()->layerChanged(this->selectedPage);
-    }
 }

--- a/src/core/undo/MergeLayerDownUndoAction.h
+++ b/src/core/undo/MergeLayerDownUndoAction.h
@@ -34,8 +34,6 @@ public:
     std::string getText() override;
 
 private:
-    void triggerUIUpdate(Control* control);
-
     LayerController* layerController;
 
     Layer* upperLayer;

--- a/src/core/undo/MoveLayerUndoAction.cpp
+++ b/src/core/undo/MoveLayerUndoAction.cpp
@@ -1,14 +1,10 @@
 #include "MoveLayerUndoAction.h"
 
-#include "control/Control.h"
 #include "control/layer/LayerController.h"  // for LayerController
-#include "model/Document.h"
 #include "model/Layer.h"                    // for Layer, Layer::Index
 #include "model/PageRef.h"                  // for PageRef
 #include "undo/UndoAction.h"                // for UndoAction
 #include "util/i18n.h"                      // for _
-
-class Control;
 
 MoveLayerUndoAction::MoveLayerUndoAction(LayerController* layerController, const PageRef& page, Layer* layer,
                                          Layer::Index oldLayerPos, Layer::Index newLayerPos):
@@ -28,24 +24,14 @@ MoveLayerUndoAction::~MoveLayerUndoAction() {
 auto MoveLayerUndoAction::getText() -> std::string { return _("Move layer"); }
 
 auto MoveLayerUndoAction::undo(Control* control) -> bool {
-    Document* doc = control->getDocument();
-    doc->lock();
-    layerController->removeLayer(this->page, this->layer);
-    layerController->insertLayer(this->page, this->layer, oldLayerPos);
-    doc->unlock();
-
+    layerController->moveLayer(this->page, this->layer, oldLayerPos);
     this->undone = true;
 
     return true;
 }
 
 auto MoveLayerUndoAction::redo(Control* control) -> bool {
-    Document* doc = control->getDocument();
-    doc->lock();
-    layerController->removeLayer(this->page, this->layer);
-    layerController->insertLayer(this->page, this->layer, newLayerPos);
-    doc->unlock();
-
+    layerController->moveLayer(this->page, this->layer, newLayerPos);
     this->undone = false;
 
     return true;

--- a/src/core/undo/RemoveLayerUndoAction.cpp
+++ b/src/core/undo/RemoveLayerUndoAction.cpp
@@ -1,10 +1,6 @@
 #include "RemoveLayerUndoAction.h"
 
-#include "control/Control.h"                // for Control
 #include "control/layer/LayerController.h"  // for LayerController
-#include "gui/MainWindow.h"                 // for MainWindow
-#include "gui/XournalView.h"                // for XournalView
-#include "model/Document.h"                 // for Document
 #include "model/Layer.h"                    // for Layer, Layer::Index
 #include "model/PageRef.h"                  // for PageRef
 #include "undo/UndoAction.h"                // for UndoAction
@@ -27,25 +23,14 @@ RemoveLayerUndoAction::~RemoveLayerUndoAction() {
 auto RemoveLayerUndoAction::getText() -> std::string { return _("Delete layer"); }
 
 auto RemoveLayerUndoAction::undo(Control* control) -> bool {
-    Document* doc = control->getDocument();
-    doc->lock();
     layerController->insertLayer(this->page, this->layer, this->layerPos);
-    auto id = doc->indexOf(this->page);
-    doc->unlock();
-    control->getWindow()->getXournal()->layerChanged(id);
     this->undone = true;
 
     return true;
 }
 
 auto RemoveLayerUndoAction::redo(Control* control) -> bool {
-    Document* doc = control->getDocument();
-    doc->lock();
     layerController->removeLayer(page, layer);
-    auto id = doc->indexOf(this->page);
-    doc->unlock();
-    control->getWindow()->getXournal()->layerChanged(id);
-
     this->undone = false;
 
     return true;

--- a/test/unit_tests/control/ActionDatabaseTest.cpp
+++ b/test/unit_tests/control/ActionDatabaseTest.cpp
@@ -66,7 +66,12 @@ void exploreMenu(GMenuModel* m) {
             EXPECT_TRUE(pos != 0);
             std::string prefix = value.substr(0, pos);
             std::string action = value.substr(pos + 1);
-            Action a = Action_fromString(action);
+            auto opta = Action_fromString(action);
+            EXPECT_TRUE(opta) << "Invalid action name in menu: \"" << action << "\"";
+            if (!opta) {
+                continue;
+            }
+            auto a = opta.value();
 
             xoj::util::GVariantSPtr target(g_menu_model_get_item_attribute_value(m, i, "target", nullptr),
                                            xoj::util::adopt);

--- a/ui/mainmenubar.xml
+++ b/ui/mainmenubar.xml
@@ -480,7 +480,7 @@
     </item>
     <item>
      <attribute name="label" translatable="yes">Merge Layer Down</attribute>
-     <attribute name="action">win.merge-layer-down</attribute>
+     <attribute name="action">win.layer-merge-down</attribute>
      <attribute name="accel">&lt;Ctrl&gt;m</attribute>
     </item>
     <item>


### PR DESCRIPTION
Fixes several issues:

1. Lock the document mutex upon layer actions. Fix #7412
2. Check validity of action names in Plugin interface
3. Fix wrong action name in mainmenubar.xml and make test unit verify those actions names