### PR TITLE
patch `libxml2`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -440,8 +440,15 @@ set(CPACK_STRIP_FILES ON) # Debian packages must be stripped from debug messages
 set(CPACK_DEBIAN_PACKAGE_RELEASE 2)
 set(CPACK_DEBIAN_PACKAGE_VERSION "${CPACK_PROJECT_VERSION}")
 set(CPACK_DEBIAN_PACKAGE_SECTION "graphics")
+set(_LIBXML2_DEP "libxml2 (>= 2.0.0)")
+if (CPACK_GENERATOR MATCHES "DEB")
+    pkg_check_modules(LIBXML2 libxml-2.0)
+    if (LIBXML2_VERSION VERSION_GREATER_EQUAL "2.14")
+        set(_LIBXML2_DEP "libxml2-16 (>= 2.0.0)")
+    endif ()
+endif ()
 set(CPACK_DEBIAN_PACKAGE_DEPENDS
-        "libglib2.0-0 (>= 2.32), libgtk-3-0 (>= 3.18), libpoppler-glib8 (>= 0.41.0), libxml2 (>= 2.0.0), libportaudiocpp0 (>= 12), libsndfile1 (>= 1.0.25), liblua5.3-0, libzip4 (>= 1.0.1) | libzip5, zlib1g, libc6, qpdf (>= 10.6.0), libgtksourceview-4-0")
+        "libglib2.0-0 (>= 2.32), libgtk-3-0 (>= 3.18), libpoppler-glib8 (>= 0.41.0), ${_LIBXML2_DEP}, libportaudiocpp0 (>= 12), libsndfile1 (>= 1.0.25), liblua5.3-0, libzip4 (>= 1.0.1) | libzip5, zlib1g, libc6, qpdf (>= 10.6.0), libgtksourceview-4-0")
 set(CPACK_DEBIAN_PACKAGE_SUGGESTS "texlive-base, texlive-latex-extra")  # Latex tool
 # Use debian's arch scheme; we only care about x86/amd64 for now but feel free to add more
 if (${PACKAGE_ARCH} STREQUAL "x86_64")


### PR DESCRIPTION
Ubuntu 26.04 LTS [Resolute Raccoon](https://releases.ubuntu.com/resolute/) was released on April 23, 2026


`CMakeLists.txt`: fixes `CPACK_DEBIAN_PACKAGE_DEPENDS` to emit `libxml2-16` on resolute, `libxml2` broke ABI and the runtime package was renamed [GNOME/libxml2/751](https://gitlab.gnome.org/GNOME/libxml2/-/issues/751) is now virtual with no installation candidate, causing dpkg to fail at install time

delegated build target to #7450