### PR TITLE
fix(#7316): add backend parameter to app.export() for PDF export

### DIFF
--- a/.github/workflows/clang-format-applied.yml
+++ b/.github/workflows/clang-format-applied.yml
@@ -11,7 +11,7 @@ jobs:
   clang-format-checking:
     runs-on: ubuntu-latest
     env:
-      CLANG_FORMAT_VERSIONS: "19 18 17"
+      CLANG_FORMAT_VERSIONS: "22 21 20 19"
     steps:
       - uses: actions/checkout@v6
         with:

--- a/plugins/Export/main.lua
+++ b/plugins/Export/main.lua
@@ -9,8 +9,10 @@ local DEFAULT_PATH = "/tmp/temp"  -- change this to get a different default path
 
 function exportPdf()
   local pdfName = getStem() .. "_export.pdf"
-  app.export({["outputFile"] = pdfName})
-  -- use the "range", "background" and "progressiveMode" fields for more customization
+  app.export({
+      ["outputFile"] = pdfName,
+      ["backend"] = "cairo",
+  })  -- use the "range", "background" and "progressiveMode" fields for more customization
 end
 
 function exportSvg()  

--- a/plugins/luapi_application.def.lua
+++ b/plugins/luapi_application.def.lua
@@ -840,7 +840,7 @@ function app.setZoom(zoom) end
 
 --- Exports the current document as a pdf or as a svg or png image
 --- 
---- @param opts {outputFile:string, range:string, background:string, progressiveMode: boolean}
+--- @param opts {outputFile:string, range:string, background:string, progressiveMode: boolean, backend: string}
 --- 
 --- Example 1:
 --- app.export({["outputFile"] = "Test.pdf", ["range"] = "2-5; 7", ["background"] = "none", ["progressiveMode"] = true})
@@ -852,6 +852,10 @@ function app.setZoom(zoom) end
 --- 
 --- Example 3:
 --- app.export({["outputFile"] = "Test.png", ["layerRange"] = "1-2", ["background"] = "all", ["pngWidth"] = 800})
+--- 
+--- Example 4:
+--- app.export({["outputFile"] = "Test.pdf", ["backend"] = "cairo"})
+--- uses the cairo backend for the PDF export, which has a proper support for cropped pages.
 function app.export(opts) end
 
 --- Opens a file and by default asks the user what to do with the old document.

--- a/src/core/control/PdfCache.cpp
+++ b/src/core/control/PdfCache.cpp
@@ -11,6 +11,7 @@
 
 #include "control/settings/Settings.h"  // for Settings
 #include "pdf/base/XojPdfDocument.h"    // for XojPdfDocument
+#include "util/Assert.h"                // for xoj_assert
 #include "util/Range.h"                 // for Range
 #include "util/i18n.h"                  // for _
 #include "util/safe_casts.h"            // for as_unsigned
@@ -37,6 +38,11 @@ public:
     xoj::view::Mask buffer;
 };
 
+static double getPercentZoomChange(double oldZoom, double newZoom) {
+    double averagedZoom = (oldZoom + newZoom) / 2.0;
+    return std::abs(oldZoom - newZoom) * 100.0 / averagedZoom;
+}
+
 PdfCache::PdfCache(const XojPdfDocument& doc, Settings* settings): pdfDocument(doc) { updateSettings(settings); }
 
 PdfCache::~PdfCache() = default;
@@ -57,6 +63,22 @@ void PdfCache::updateSettings(Settings* settings) {
     }
 }
 
+void PdfCache::evictAllExcept(const std::unordered_set<size_t>& retainedPdfPages) {
+    std::lock_guard<std::mutex> lock(this->renderMutex);
+
+    for (auto& entry: this->data) {
+        xoj_assert(entry);
+        xoj_assert(entry->popplerPage);
+
+        const size_t pdfPageNo = static_cast<size_t>(entry->popplerPage->getPageId());
+        if (retainedPdfPages.find(pdfPageNo) == retainedPdfPages.end()) {
+            entry.reset();
+        }
+    }
+
+    this->data.erase(std::remove(this->data.begin(), this->data.end(), nullptr), this->data.end());
+}
+
 auto PdfCache::lookup(size_t pdfPageNo) const -> const PdfCacheEntry* {
     for (auto& e: this->data) {
         if (static_cast<size_t>(e->popplerPage->getPageId()) == pdfPageNo) {
@@ -68,8 +90,18 @@ auto PdfCache::lookup(size_t pdfPageNo) const -> const PdfCacheEntry* {
 }
 
 auto PdfCache::cache(XojPdfPageSPtr popplerPage, xoj::view::Mask&& buffer) -> const PdfCacheEntry* {
-    if (this->data.size() > this->maxSize) {
-        this->data.resize(this->maxSize);
+    xoj_assert(this->maxSize > 0);
+    xoj_assert(popplerPage);
+    const auto pageId = popplerPage->getPageId();
+
+    auto existingIt = std::find_if(this->data.begin(), this->data.end(),
+                                   [pageId](const auto& entry) { return entry->popplerPage->getPageId() == pageId; });
+    if (existingIt != this->data.end()) {
+        this->data.erase(existingIt);
+    }
+
+    if (this->data.size() >= this->maxSize) {
+        this->data.resize(this->maxSize - 1);
     }
 
     this->data.emplace_front(
@@ -86,12 +118,10 @@ void PdfCache::render(cairo_t* cr, size_t pdfPageNo, double zoom, double pageWid
     bool needsRefresh = cacheResult == nullptr;
 
     if (!needsRefresh) {
-        double averagedZoom = (zoom + cacheResult->buffer.getZoom()) / 2.0;
-        double percentZoomChange = std::abs(cacheResult->buffer.getZoom() - zoom) * 100.0 / averagedZoom;
-
         // If we do have a cached result, is its rendering quality
         // acceptable for our current zoom?
-        needsRefresh = (zoom > 1.0 && percentZoomChange > this->zoomRefreshThreshold);
+        needsRefresh =
+                (zoom > 1.0 && getPercentZoomChange(cacheResult->buffer.getZoom(), zoom) > this->zoomRefreshThreshold);
     }
 
     if (needsRefresh) {
@@ -108,6 +138,11 @@ void PdfCache::render(cairo_t* cr, size_t pdfPageNo, double zoom, double pageWid
         xoj::view::Mask buffer(cairo_get_target(cr), Range(0, 0, popplerPage->getWidth(), popplerPage->getHeight()),
                                renderZoom, CAIRO_CONTENT_COLOR_ALPHA);
         popplerPage->render(buffer.get());
+        if (this->maxSize == 0) {
+            buffer.paintTo(cr);
+            return;
+        }
+
         cacheResult = cache(popplerPage, std::move(buffer));
     }
 

--- a/src/core/control/PdfCache.h
+++ b/src/core/control/PdfCache.h
@@ -14,6 +14,7 @@
 #include <cstddef>  // for size_t
 #include <deque>    // for deque
 #include <mutex>    // for mutex
+#include <unordered_set>
 
 #include <cairo.h>  // for cairo_t, cairo_surface_t
 
@@ -59,6 +60,11 @@ public:
     void setMaxSize(size_t newSize);
 
     void updateSettings(Settings* settings);
+
+    /**
+     * @brief Remove cached renderings for PDF pages that are not retained.
+     */
+    void evictAllExcept(const std::unordered_set<size_t>& retainedPdfPages);
 
     /**
      * @brief Renders an error background, for when the pdf page cannot be rendered

--- a/src/core/control/ToolEnums.h
+++ b/src/core/control/ToolEnums.h
@@ -171,9 +171,8 @@ enum ToolCapabilities : unsigned int {
     TOOL_CAP_RECOGNIZER = 1 << 7,
     TOOL_CAP_FILL = 1 << 8,
     TOOL_CAP_COORDINATE_SYSTEM = 1 << 9,
-    TOOL_CAP_DASH_LINE = 1 << 10,
-    TOOL_CAP_SPLINE = 1 << 11,
-    TOOL_CAP_LINE_STYLE = 1 << 12
+    TOOL_CAP_SPLINE = 1 << 10,
+    TOOL_CAP_LINE_STYLE = 1 << 11
 };
 
 enum StrokeType {

--- a/src/core/control/ToolHandler.cpp
+++ b/src/core/control/ToolHandler.cpp
@@ -56,8 +56,7 @@ void ToolHandler::initTools() {
     tools[TOOL_PEN - TOOL_PEN] = std::make_unique<Tool>(
             "pen", TOOL_PEN, Colors::xopp_royalblue,
             TOOL_CAP_COLOR | TOOL_CAP_SIZE | TOOL_CAP_RULER | TOOL_CAP_RECTANGLE | TOOL_CAP_ELLIPSE | TOOL_CAP_ARROW |
-                    TOOL_CAP_DOUBLE_ARROW | TOOL_CAP_SPLINE | TOOL_CAP_RECOGNIZER | TOOL_CAP_FILL | TOOL_CAP_DASH_LINE |
-                    TOOL_CAP_LINE_STYLE,
+                    TOOL_CAP_DOUBLE_ARROW | TOOL_CAP_SPLINE | TOOL_CAP_RECOGNIZER | TOOL_CAP_FILL | TOOL_CAP_LINE_STYLE,
             thickness);
 
     thickness[TOOL_SIZE_VERY_FINE] = 1;

--- a/src/core/control/settings/ButtonConfig.cpp
+++ b/src/core/control/settings/ButtonConfig.cpp
@@ -17,81 +17,85 @@ ButtonConfig::~ButtonConfig() = default;
 
 auto ButtonConfig::getDisableDrawing() const -> bool { return this->disableDrawing; }
 
-auto ButtonConfig::getDrawingType() -> DrawingType { return this->drawingType; }
+auto ButtonConfig::getDrawingType() const -> DrawingType { return this->drawingType; }
 
-auto ButtonConfig::getAction() -> ToolType { return this->action; }
+auto ButtonConfig::getAction() const -> ToolType { return this->action; }
 
-void ButtonConfig::initButton(ToolHandler* toolHandler, Button button) {
+void ButtonConfig::initButton(ToolHandler* toolHandler, Button button) const {
     if (this->action == TOOL_NONE) {
         return;
     }
 
     toolHandler->resetButtonTool(this->action, button);
+    const Tool& t = toolHandler->getTool(this->action);
 
-    if (this->action == TOOL_PEN || this->action == TOOL_HIGHLIGHTER || this->action == TOOL_ERASER) {
-        if (this->size != TOOL_SIZE_NONE) {
-            toolHandler->setButtonSize(this->size, button);
-        }
-        if (this->action == TOOL_PEN)
-            if (this->strokeType != STROKE_TYPE_NONE)
-                toolHandler->setButtonStrokeType(this->strokeType, button);
-        if (this->action == TOOL_PEN || this->action == TOOL_HIGHLIGHTER) {
-            toolHandler->setButtonColor(this->color, button);
-            if (this->drawingType != DRAWING_TYPE_DONT_CHANGE)
-                toolHandler->setButtonDrawingType(this->drawingType, button);
-        }
-        if (this->action == TOOL_ERASER) {
-            if (this->eraserMode != ERASER_TYPE_NONE)
-                toolHandler->setButtonEraserType(this->eraserMode, button);
-        }
+    if (t.hasCapability(TOOL_CAP_SIZE) && this->size != TOOL_SIZE_NONE) {
+        toolHandler->setButtonSize(this->size, button);
+    }
+    if (t.hasCapability(TOOL_CAP_COLOR)) {
+        toolHandler->setButtonColor(this->color, button);
+    }
+    if (t.hasCapability(TOOL_CAP_LINE_STYLE) && this->strokeType != STROKE_TYPE_NONE) {
+        toolHandler->setButtonStrokeType(this->strokeType, button);
+    }
+
+    // No TOOL_CAP_BLA for that
+    if ((this->action == TOOL_PEN || this->action == TOOL_HIGHLIGHTER) &&
+        this->drawingType != DRAWING_TYPE_DONT_CHANGE) {
+        toolHandler->setButtonDrawingType(this->drawingType, button);
+    }
+    if (this->action == TOOL_ERASER && this->eraserMode != ERASER_TYPE_NONE) {
+        toolHandler->setButtonEraserType(this->eraserMode, button);
     }
 }
 
-void ButtonConfig::applyConfigToToolbarTool(ToolHandler* toolHandler) {
+void ButtonConfig::applyConfigToToolbarTool(ToolHandler* toolHandler) const {
     if (this->action == TOOL_NONE) {
         return;
     }
     toolHandler->selectTool(this->action);
+    const Tool* t = toolHandler->getActiveTool();
 
-    if (this->action == TOOL_PEN || this->action == TOOL_HIGHLIGHTER || this->action == TOOL_ERASER) {
-        if (this->size != TOOL_SIZE_NONE) {
-            toolHandler->setSize(this->size);
-        }
-        if (this->action == TOOL_PEN || this->action == TOOL_HIGHLIGHTER) {
-            toolHandler->setColor(this->color, false);
-            if (this->drawingType != DRAWING_TYPE_DONT_CHANGE)
-                toolHandler->setDrawingType(this->drawingType);
-        }
-        if (this->action == TOOL_ERASER) {
-            if (this->eraserMode != ERASER_TYPE_NONE)
-                toolHandler->setEraserType(this->eraserMode);
-        }
-        if (this->action == TOOL_PEN && this->strokeType != STROKE_TYPE_NONE) {
-            toolHandler->setLineStyle(strokeTypeToLineStyle(this->strokeType));
-        }
+    if (t->hasCapability(TOOL_CAP_SIZE) && this->size != TOOL_SIZE_NONE) {
+        toolHandler->setSize(this->size);
+    }
+    if (t->hasCapability(TOOL_CAP_COLOR)) {
+        toolHandler->setColor(this->color, false);
+    }
+    if (t->hasCapability(TOOL_CAP_LINE_STYLE) && this->strokeType != STROKE_TYPE_NONE) {
+        toolHandler->setLineStyle(strokeTypeToLineStyle(this->strokeType));
+    }
+
+    // No TOOL_CAP_BLA for that
+    if ((this->action == TOOL_PEN || this->action == TOOL_HIGHLIGHTER) &&
+        this->drawingType != DRAWING_TYPE_DONT_CHANGE) {
+        toolHandler->setDrawingType(this->drawingType);
+    }
+    if (this->action == TOOL_ERASER && this->eraserMode != ERASER_TYPE_NONE) {
+        toolHandler->setEraserType(this->eraserMode);
     }
 }
 
-auto ButtonConfig::applyNoChangeSettings(ToolHandler* toolHandler, Button button) -> bool {
+auto ButtonConfig::applyNoChangeSettings(ToolHandler* toolHandler, Button button) const -> bool {
     if (this->action == TOOL_NONE) {
         return false;
     }
-    if (this->action == TOOL_PEN || this->action == TOOL_HIGHLIGHTER || this->action == TOOL_ERASER) {
-        Tool const& correspondingTool = toolHandler->getTool(this->action);
+    Tool const& t = toolHandler->getTool(this->action);
 
-        if (this->size == TOOL_SIZE_NONE) {
-            toolHandler->setButtonSize(correspondingTool.getSize(), button);
-        }
-        if (this->action == TOOL_PEN || this->action == TOOL_HIGHLIGHTER) {
-            if (this->drawingType == DRAWING_TYPE_DONT_CHANGE)
-                toolHandler->setButtonDrawingType(correspondingTool.getDrawingType(), button);
-        }
-        if (this->action == TOOL_ERASER) {
-            if (this->eraserMode == ERASER_TYPE_NONE)
-                toolHandler->setButtonEraserType(correspondingTool.getEraserType(), button);
-        }
-        if (this->action == TOOL_PEN && this->strokeType == STROKE_TYPE_NONE)
-            toolHandler->setButtonStrokeType(correspondingTool.getLineStyle(), button);
+    if (t.hasCapability(TOOL_CAP_SIZE) && this->size == TOOL_SIZE_NONE) {
+        toolHandler->setButtonSize(t.getSize(), button);
+    }
+    if (t.hasCapability(TOOL_CAP_LINE_STYLE) && this->strokeType == STROKE_TYPE_NONE) {
+        toolHandler->setButtonStrokeType(t.getLineStyle(), button);
+    }
+
+    // No TOOL_CAP_BLA for that
+    if ((this->action == TOOL_PEN || this->action == TOOL_HIGHLIGHTER) &&
+        this->drawingType == DRAWING_TYPE_DONT_CHANGE) {
+        toolHandler->setButtonDrawingType(t.getDrawingType(), button);
+    }
+    if (this->action == TOOL_ERASER && this->eraserMode == ERASER_TYPE_NONE) {
+        toolHandler->setButtonEraserType(t.getEraserType(), button);
     }
 
     return true;

--- a/src/core/control/settings/ButtonConfig.h
+++ b/src/core/control/settings/ButtonConfig.h
@@ -38,7 +38,7 @@ public:
      * @return true if some action was selected
      * @return false if no action was selected
      */
-    bool applyNoChangeSettings(ToolHandler* toolHandler, Button button);
+    bool applyNoChangeSettings(ToolHandler* toolHandler, Button button) const;
 
     /**
      * @brief Initialize Button tool
@@ -48,7 +48,7 @@ public:
      * @param toolHandler
      * @param button
      */
-    void initButton(ToolHandler* toolHandler, Button button);
+    void initButton(ToolHandler* toolHandler, Button button) const;
 
     /**
      * @brief Apply the Config to the toolbar Tool
@@ -56,12 +56,12 @@ public:
      *
      * @param toolHandler
      */
-    void applyConfigToToolbarTool(ToolHandler* toolHandler);
+    void applyConfigToToolbarTool(ToolHandler* toolHandler) const;
 
 
-    ToolType getAction();
+    ToolType getAction() const;
     bool getDisableDrawing() const;
-    DrawingType getDrawingType();
+    DrawingType getDrawingType() const;
 
 private:
     ToolType action;

--- a/src/core/gui/XournalView.cpp
+++ b/src/core/gui/XournalView.cpp
@@ -4,6 +4,7 @@
 #include <iterator>   // for begin
 #include <memory>     // for unique_ptr, make_unique
 #include <optional>   // for optional
+#include <unordered_set>
 
 #include <gdk/gdk.h>         // for GdkEventKey, GDK_SHIF...
 #include <gdk/gdkkeysyms.h>  // for GDK_KEY_Page_Down
@@ -59,7 +60,7 @@ std::pair<size_t, size_t> XournalView::preloadPageBounds(size_t page, size_t max
     const size_t preloadBefore = this->control->getSettings()->getPreloadPagesBefore();
     const size_t preloadAfter = this->control->getSettings()->getPreloadPagesAfter();
     const size_t lower = page > preloadBefore ? page - preloadBefore : 0;
-    const size_t upper = std::min(maxPage, page + preloadAfter);
+    const size_t upper = std::min(maxPage, page + preloadAfter + 1);
     return {lower, upper};
 }
 
@@ -121,13 +122,26 @@ auto XournalView::cleanupBufferCache() -> void {
     const auto& [pagesLower, pagesUpper] = this->preloadPageBounds(this->currentPage, this->viewPages.size());
     xoj_assert(pagesLower <= pagesUpper);
 
+    std::unordered_set<size_t> retainedPdfPages;
+
     for (size_t i = 0; i < this->viewPages.size(); i++) {
         auto&& page = this->viewPages[i];
-        const size_t pageNum = i + 1;
-        const bool isPreload = pagesLower <= pageNum && pageNum <= pagesUpper;
-        if (!isPreload && !page->isVisible() && page->hasBuffer()) {
+        const bool isPreload = pagesLower <= i && i < pagesUpper;
+        const bool shouldRetain = isPreload || page->isVisible();
+
+        if (shouldRetain) {
+            const size_t pdfPageNo = page->getPage()->getPdfPageNr();
+            if (pdfPageNo != npos) {
+                retainedPdfPages.insert(pdfPageNo);
+            }
+            continue;
+        } else if (page->hasBuffer()) {
             page->deleteViewBuffer();
         }
+    }
+
+    if (this->cache) {
+        this->cache->evictAllExcept(retainedPdfPages);
     }
 }
 

--- a/src/core/gui/dialog/ButtonConfigGui.cpp
+++ b/src/core/gui/dialog/ButtonConfigGui.cpp
@@ -310,6 +310,15 @@ void ButtonConfigGui::enableDisableTools() {
             gtk_widget_set_visible(cbStrokeType, false);
             break;
 
+        case TOOL_LASER_POINTER_PEN:
+        case TOOL_LASER_POINTER_HIGHLIGHTER:
+            gtk_widget_set_visible(cbThickness, true);
+            gtk_widget_set_visible(colorButton, true);
+            gtk_widget_set_visible(cbDrawingType, false);
+            gtk_widget_set_visible(cbEraserType, false);
+            gtk_widget_set_visible(cbStrokeType, false);
+            break;
+
         case TOOL_NONE:
         case TOOL_IMAGE:
             // case TOOL_DRAW_RECT:
@@ -327,6 +336,7 @@ void ButtonConfigGui::enableDisableTools() {
             gtk_widget_set_visible(cbStrokeType, false);
             break;
         default:
+            g_warning("Unhandled tool in ButtonConfigGui");
             break;
     }
 }

--- a/src/core/gui/inputdevices/touchdisable/TouchDisableX11.cpp
+++ b/src/core/gui/inputdevices/touchdisable/TouchDisableX11.cpp
@@ -45,6 +45,7 @@ void TouchDisableX11::init() {
             touch = devices + i;
         }
     }
+    XFreeDeviceList(devices);
 
     if (touch == nullptr) {
         g_warning("Could not find touchscreen device for disabling");

--- a/src/core/gui/inputdevices/touchdisable/TouchDisableX11.cpp
+++ b/src/core/gui/inputdevices/touchdisable/TouchDisableX11.cpp
@@ -2,6 +2,8 @@
 
 #ifdef X11_ENABLED
 
+#include <vector>  // for vector
+
 #include <X11/Xatom.h>          // for XA_INTEGER
 #include <X11/extensions/XI.h>  // for XI_TOUCHSCREEN
 #include <gdk/gdk.h>            // for gdk_display_get_default
@@ -11,10 +13,10 @@
 TouchDisableX11::TouchDisableX11() = default;
 
 TouchDisableX11::~TouchDisableX11() {
-    if (touchdev) {
-        XCloseDevice(display, touchdev);
-        touchdev = nullptr;
+    for (auto dev: touchdevs) {
+        XCloseDevice(display, dev);
     }
+    touchdevs.clear();
 
     display = nullptr;
 }
@@ -34,51 +36,50 @@ void TouchDisableX11::init() {
 
 
     int inputDeviceCount = 0;
-    XID touchId = 0;
     XDeviceInfo* devices = XListInputDevices(display, &inputDeviceCount);
     for (int i = 0; i < inputDeviceCount; i++) {
-        if (touchId == 0 && devices[i].type == touchAtom) {
-            touchId = devices[i].id;
-        }
+        if (devices[i].type == touchAtom) {
+            const auto dev = XOpenDevice(display, devices[i].id);
+            if (!dev) {
+                g_warning("Failed to open touch device \"%s\"", devices[i].name);
+                continue;
+            }
 
-        if (devices[i].id == touchId) {
-            touch = devices + i;
+            g_message("X11 Touch disabler active for device \"%s\"", devices[i].name);
+            touchdevs.emplace_back(dev);
         }
     }
     XFreeDeviceList(devices);
 
-    if (touch == nullptr) {
+    if (touchdevs.empty()) {
         g_warning("Could not find touchscreen device for disabling");
         return;
     }
-
-    touchdev = XOpenDevice(display, touch->id);
-    if (!touchdev) {
-        g_warning("Failed to open touch device \"%s\"", touch->name);
-        return;
-    }
-
-    g_message("X11 Touch disabler active for device \"%s\"", touch->name);
 
     enabledAtom = XInternAtom(display, "Device Enabled", false);
 }
 
 void TouchDisableX11::enableTouch() {
-    if (!touchdev) {
+    if (touchdevs.empty()) {
         return;
     }
 
     unsigned char value = 1;
-    XChangeDeviceProperty(display, touchdev, enabledAtom, XA_INTEGER, 8, PropModeReplace, &value, 1);
+    for (auto dev: touchdevs) {
+        XChangeDeviceProperty(display, dev, enabledAtom, XA_INTEGER, 8, PropModeReplace, &value, 1);
+    }
     g_message("X11 Touch enabled");
 }
 
 void TouchDisableX11::disableTouch() {
-    if (!touchdev) {
+    if (touchdevs.empty()) {
         return;
     }
+
     unsigned char value = 0;
-    XChangeDeviceProperty(display, touchdev, enabledAtom, XA_INTEGER, 8, PropModeReplace, &value, 1);
+    for (auto dev: touchdevs) {
+        XChangeDeviceProperty(display, dev, enabledAtom, XA_INTEGER, 8, PropModeReplace, &value, 1);
+    }
     g_message("X11 Touch disabled");
 }
 

--- a/src/core/gui/inputdevices/touchdisable/TouchDisableX11.h
+++ b/src/core/gui/inputdevices/touchdisable/TouchDisableX11.h
@@ -13,6 +13,8 @@
 
 #ifdef X11_ENABLED
 
+#include <vector>  // for vector
+
 #include <X11/X.h>                  // for Atom, None
 #include <X11/Xlib.h>               // for Display
 #include <X11/extensions/XInput.h>  // for XDevice, XDeviceInfo
@@ -42,14 +44,9 @@ private:
     Atom touchAtom = None;
 
     /**
-     * Touch device
+     * Touch devices
      */
-    XDeviceInfo* touch = nullptr;
-
-    /**
-     * Touch device
-     */
-    XDevice* touchdev = nullptr;
+    std::vector<XDevice*> touchdevs;
 
     /**
      * Enable flag

--- a/src/core/gui/menus/popoverMenus/PageTypeSelectionPopover.cpp
+++ b/src/core/gui/menus/popoverMenus/PageTypeSelectionPopover.cpp
@@ -222,6 +222,18 @@ unsigned int PageTypeSelectionPopover::getComboBoxIndexForPaperSize(const std::o
     return customPaperSizeIndex;  // Custom option is returned if no matching format is found
 }
 GtkWidget* PageTypeSelectionPopover::createPopover() const {
+    /**
+     * Used to connect to GAction changes: the GAction can outlive the widget. This ensures the callback is disabled
+     * when the widget is destroyed. Like g_signal_connect_object() except the callback data contains a pointer to *this
+     */
+    auto connectToLonglivedAction = [this](GSimpleAction* act, const char* signalname, GCallback cb, GtkWidget* w) {
+        auto* closure =
+                g_cclosure_new(cb, new std::pair<GtkWidget*, const PageTypeSelectionPopover*>(w, this),
+                               xoj::util::closure_notify_cb<std::pair<GtkWidget*, const PageTypeSelectionPopover*>>);
+        g_object_watch_closure(G_OBJECT(w), closure);
+        g_signal_connect_closure(G_OBJECT(act), signalname, closure, GConnectFlags(0));
+    };
+
     GtkWidget* popover = gtk_popover_new();
 
     // Todo(cpp20): constexpr this
@@ -296,6 +308,23 @@ GtkWidget* PageTypeSelectionPopover::createPopover() const {
                      const_cast<PageTypeSelectionPopover*>(this));
     gtk_box_append(pageFormatBox, pageFormatComboBox);
 
+    connectToLonglivedAction(
+            this->typeSelectionAction.get(), "notify::state",
+            G_CALLBACK((+[](GObject* a, GParamSpec*, gpointer pointerTuple) {
+                auto [pageFormatCB, self] =
+                        *static_cast<std::pair<GtkWidget*, const PageTypeSelectionPopover*>*>(pointerTuple);
+                xoj::util::GVariantSPtr state(g_action_get_state(G_ACTION(a)), xoj::util::adopt);
+                auto selectedIndex = getGVariantValue<size_t>(state.get());
+                // Enable page format selection for all page types except special ones (PDF and image)
+                bool shouldPageFormatSettingsBeEnabled =
+                        selectedIndex == COPY_CURRENT_PLACEHOLDER || selectedIndex < self->types->getPageTypes().size();
+                gtk_widget_set_sensitive(pageFormatCB, shouldPageFormatSettingsBeEnabled);
+
+                g_simple_action_set_enabled(self->orientationAction.get(),
+                                            shouldPageFormatSettingsBeEnabled && self->selectedPageSize.has_value());
+            })),
+            pageFormatComboBox);
+
     gtk_box_append(box, GTK_WIDGET(specialTypesGrid));
     gtk_box_append(box, createSeparator());
     gtk_box_append(box, GTK_WIDGET(pageFormatBox));
@@ -325,41 +354,27 @@ GtkWidget* PageTypeSelectionPopover::createPopover() const {
     gtk_widget_set_sensitive(applyToCurrentPageButton,
                              this->selectedPT.has_value() || this->selectedPageSize.has_value());
 
-    auto userdataPointerTuple = new std::tuple<GtkButton*, const PageTypeSelectionPopover*, GtkComboBox*>(
-            GTK_BUTTON(applyToCurrentPageButton), this, GTK_COMBO_BOX(pageFormatComboBox));
-    g_signal_connect_data(
+    connectToLonglivedAction(
             this->typeSelectionAction.get(), "notify::state",
             G_CALLBACK((+[](GObject* a, GParamSpec*, gpointer pointerTuple) {
-                auto [btn, self, pageFormatCB] =
-                        *static_cast<std::tuple<GtkButton*, const PageTypeSelectionPopover*, GtkComboBox*>*>(
-                                pointerTuple);
+                auto [btn, self] = *static_cast<std::pair<GtkWidget*, const PageTypeSelectionPopover*>*>(pointerTuple);
                 xoj::util::GVariantSPtr state(g_action_get_state(G_ACTION(a)), xoj::util::adopt);
                 auto selectedIndex = getGVariantValue<size_t>(state.get());
-                gtk_widget_set_sensitive(GTK_WIDGET(btn), selectedIndex != COPY_CURRENT_PLACEHOLDER ||
-                                                                  self->selectedPageSize.has_value());
-                // Enable page format selection for all page types except special ones (PDF and image)
-                bool shouldPageFormatSettingsBeEnabled =
-                        selectedIndex == COPY_CURRENT_PLACEHOLDER || selectedIndex < self->types->getPageTypes().size();
-                gtk_widget_set_sensitive(GTK_WIDGET(pageFormatCB), shouldPageFormatSettingsBeEnabled);
-
-                g_simple_action_set_enabled(self->orientationAction.get(),
-                                            shouldPageFormatSettingsBeEnabled && self->selectedPageSize.has_value());
+                gtk_widget_set_sensitive(
+                        btn, selectedIndex != COPY_CURRENT_PLACEHOLDER || self->selectedPageSize.has_value());
             })),
-            userdataPointerTuple,
-            xoj::util::closure_notify_cb<std::tuple<GtkButton*, const PageTypeSelectionPopover*, GtkComboBox*>>,
-            GConnectFlags(0));
+            applyToCurrentPageButton);
 
-    g_signal_connect_data(
+    connectToLonglivedAction(
             this->pageSizeChangedAction.get(), "activate",
             G_CALLBACK((+[](GSimpleAction*, GVariant*, gpointer pointerTuple) {
-                auto [btn, self] = *static_cast<std::tuple<GtkWidget*, const PageTypeSelectionPopover*>*>(pointerTuple);
+                auto [btn, self] = *static_cast<std::pair<GtkWidget*, const PageTypeSelectionPopover*>*>(pointerTuple);
                 gtk_widget_set_sensitive(btn, self->selectedPT.has_value() || self->selectedPageSize.has_value());
             })),
-            new std::tuple<GtkWidget*, const PageTypeSelectionPopover*>(applyToCurrentPageButton, this),
-            xoj::util::closure_notify_cb<std::tuple<GtkWidget*, const PageTypeSelectionPopover*>>, GConnectFlags(0));
+            applyToCurrentPageButton);
 
     g_signal_connect_object(this->comboBoxChangeSelectionAction.get(), "activate",
-                            G_CALLBACK(+[](GSimpleAction* action, GVariant* comboBoxIndex, gpointer comboBoxPtr) {
+                            G_CALLBACK(+[](GSimpleAction*, GVariant* comboBoxIndex, gpointer comboBoxPtr) {
                                 auto* comboBox = static_cast<GtkWidget*>(comboBoxPtr);
                                 gtk_combo_box_set_active(GTK_COMBO_BOX(comboBox),
                                                          static_cast<gint>(getGVariantValue<guint32>(comboBoxIndex)));

--- a/src/core/plugin/luapi_application.h
+++ b/src/core/plugin/luapi_application.h
@@ -2954,7 +2954,7 @@ static int applib_setZoom(lua_State* L) {
 /**
  * Exports the current document as a pdf or as a svg or png image
  *
- * @param opts {outputFile:string, range:string, background:string, progressiveMode: boolean}
+ * @param opts {outputFile:string, range:string, background:string, progressiveMode: boolean, backend: string}
  *
  * Example 1:
  * app.export({["outputFile"] = "Test.pdf", ["range"] = "2-5; 7", ["background"] = "none", ["progressiveMode"] = true})
@@ -2966,6 +2966,10 @@ static int applib_setZoom(lua_State* L) {
  *
  * Example 3:
  * app.export({["outputFile"] = "Test.png", ["layerRange"] = "1-2", ["background"] = "all", ["pngWidth"] = 800})
+ *
+ * Example 4:
+ * app.export({["outputFile"] = "Test.pdf", ["backend"] = "cairo"})
+ * uses the cairo backend for the PDF export, which has a proper support for cropped pages.
  **/
 static int applib_export(lua_State* L) {
     Plugin* plugin = Plugin::getPluginFromLua(L);
@@ -2976,6 +2980,7 @@ static int applib_export(lua_State* L) {
     lua_settop(L, 1);
     luaL_checktype(L, 1, LUA_TTABLE);
 
+    lua_getfield(L, 1, "backend");
     lua_getfield(L, 1, "outputFile");
     lua_getfield(L, 1, "range");
     lua_getfield(L, 1, "layerRange");
@@ -2987,6 +2992,7 @@ static int applib_export(lua_State* L) {
 
     // stack now has following:
     //    1 = param table
+    //   -9 = backend
     //   -8 = outputFile
     //   -7 = range
     //   -6 = layerRange
@@ -3000,6 +3006,7 @@ static int applib_export(lua_State* L) {
     const char* range = luaL_optstring(L, -7, nullptr);
     const char* layerRange = luaL_optstring(L, -6, nullptr);
     const char* background = luaL_optstring(L, -5, "all");
+    const char* backend = luaL_optstring(L, -9, "default");
     bool progressiveMode = lua_toboolean(L, -4);  // true unless nil or false
     int pngDpi = static_cast<int>(luaL_optinteger(L, -3, -1));
     int pngWidth = static_cast<int>(luaL_optinteger(L, -2, -1));
@@ -3012,6 +3019,15 @@ static int applib_export(lua_State* L) {
         bgType = EXPORT_BACKGROUND_NONE;
     }
 
+
+    /* "backend" selects the PDF export backend ("qpdf" or "cairo").
+         The Cairo backend correctly handles cropped PDF pages where the crop box
+         origin differs from the media box, avoiding text shifting on export (#7316).
+         Defaults to "qpdf" for backwards compatibility. */
+
+    ExportBackend backendType = ExportBackend::DEFAULT;
+    backendType = ExportBackend::fromString(backend);
+
     if (outputFile == nullptr) {
         return luaL_error(L, "Missing output file!");
     }
@@ -3021,15 +3037,12 @@ static int applib_export(lua_State* L) {
 
     try {
         if (extension == ".pdf") {
-            ExportHelper::exportPdf(doc, outputFile, range, layerRange, bgType, progressiveMode);
+            ExportHelper::exportPdf(doc, outputFile, range, layerRange, bgType, progressiveMode, backendType);
         } else if (extension == ".svg" || extension == ".png") {
             ExportHelper::exportImg(doc, outputFile, range, layerRange, pngDpi, pngWidth, pngHeight, bgType);
         }
     } catch (const std::exception& e) {
         return luaL_error(L, "Error exporting document: %s", e.what());
-    }
-
-    return 0;
 }
 
 /**


### PR DESCRIPTION
## Problem
When exporting a PDF with cropped pages, text annotations are shifted
because the qpdf backend does not account for the crop box offset
relative to the media box origin (fixes #7316).

## Solution (suggested by @rolandlo ) 
Expose the export backend as a `backend` parameter to the Lua
`app.export()` API, accepting `"qpdf"` (default, backwards compatible)
or `"cairo"`. The Cairo backend correctly handles crop box offsets.

The Export plugin's `exportPdf()` now defaults to `"cairo"` to fix
the shift for users of that plugin, as suggested by @rolandlo 

## Testing
1. Download `demo_unbook.zip` from #7316
2. Open `demo_unbook.xopp` in Xournal++
3. Export via Plugin → Export → exportPdf
4. Verify text is no longer shifted in the output PDF

## Notes
- The underlying coordinate issue in the qpdf path is not fixed here;
  this exposes a workaround via the Cairo backend
- Default backend for `app.export()` remains `"default"` which is QPDF at the time for compatibility