### PR TITLE
Keep the scroll position when selecting 'Fit to Screen'.

### DIFF
--- a/src/core/gui/XournalView.cpp
+++ b/src/core/gui/XournalView.cpp
@@ -571,7 +571,7 @@ void XournalView::zoomChanged() {
 
     layoutPages();
 
-    if (zoom->isZoomPresentationMode() || zoom->isZoomFitMode()) {
+    if (zoom->isZoomPresentationMode()) {
         scrollTo(currentPage);
     } else if (zoom->isZoomSequenceActive()) {
         auto pos = zoom->getScrollPositionAfterZoom();


### PR DESCRIPTION
Currently, if "Fit to Screen" or "Presentation Mode" is selected, the scroll position is forced back to the top of the current page. This was reported in #6861.

This behavior makes sense for Presentation Mode (where the page is locked to the display), but creates a annoying jump in Fit to Screen. In "Fit to Screen" mode it scales based on the page width, but still allows vertical scrolling.

I don't see the reason to force the view to the top of the page when the width was adjusted to fit the screen. I believe the same "reset to top" logic may have been applied to both modes by mistake.

This change ensures that "Fit to Screen" keeps the current vertical position instead of jumping back to the page start when the mode is toggled, like a normal zoom.

Please excuse me if this is the intended behaviour. If so, I would like to hear the reasoning behind it.