### PR TITLE
add Ubuntu 26.04 (resolute) build target

### DIFF
--- a/.github/available-build-targets.json
+++ b/.github/available-build-targets.json
@@ -28,6 +28,16 @@
       "displayed_name": "Ubuntu 24.04 ARM",
       "runner": "ubuntu-24.04-arm",
       "run_ci": "false"
+    },
+    "ubuntu-26": {
+      "displayed_name": "Ubuntu 26.04",
+      "runner": "ubuntu-26.04",
+      "run_ci": "false"
+    },
+    "ubuntu-26-arm": {
+      "displayed_name": "Ubuntu 26.04 ARM",
+      "runner": "ubuntu-26.04-arm",
+      "run_ci": "false"
     }
   },
   "macos_targets": {


### PR DESCRIPTION
**blocker**

- GitHub Actions ubuntu-26.04 runners are not yet available, tracked in actions/runner-images#13964
- #7418