### PR TITLE
use GtkFileChooserNative on non-Linux platforms (#3822)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,8 @@ endif()
 
 set(pkg-module-spec "")
 list(APPEND pkg-module-spec "glib-2.0 >= 2.32.0")
-list(APPEND pkg-module-spec "gtk+-3.0 >= 3.18.9")
+# GtkFileChooserNative (used for native Open/Save pickers on Win32/macOS) is GTK 3.20+.
+list(APPEND pkg-module-spec "gtk+-3.0 >= 3.20")
 list(APPEND pkg-module-spec "poppler-glib >= 0.41.0")
 if (APPLE)
   list(APPEND pkg-module-spec "poppler-cpp >= 0.41.0")
@@ -276,7 +277,7 @@ target_link_libraries(external_modules INTERFACE
 
 target_compile_definitions(external_modules INTERFACE
         GLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_40
-        GDK_VERSION_MIN_REQUIRED=GDK_VERSION_3_18
+        GDK_VERSION_MIN_REQUIRED=GDK_VERSION_3_20
         $<$<TARGET_EXISTS:X11::X11>:X11_ENABLED>
         )
 target_link_options(external_modules INTERFACE
@@ -471,7 +472,7 @@ set(CPACK_DEBIAN_PACKAGE_RELEASE 2)
 set(CPACK_DEBIAN_PACKAGE_VERSION "${CPACK_PROJECT_VERSION}")
 set(CPACK_DEBIAN_PACKAGE_SECTION "graphics")
 set(CPACK_DEBIAN_PACKAGE_DEPENDS
-        "libglib2.0-0 (>= 2.32), libgtk-3-0 (>= 3.18), libpoppler-glib8 (>= 0.41.0), libxml2 (>= 2.0.0), libportaudiocpp0 (>= 12), libsndfile1 (>= 1.0.25), liblua5.3-0 | liblua5.4-0, libzip4 (>= 1.0.1) | libzip5, zlib1g, libc6, qpdf (>= 10.6.0), libgtksourceview-4-0")
+        "libglib2.0-0 (>= 2.32), libgtk-3-0 (>= 3.20), libpoppler-glib8 (>= 0.41.0), libxml2 (>= 2.0.0), libportaudiocpp0 (>= 12), libsndfile1 (>= 1.0.25), liblua5.3-0 | liblua5.4-0, libzip4 (>= 1.0.1) | libzip5, zlib1g, libc6, qpdf (>= 10.6.0), libgtksourceview-4-0")
 set(CPACK_DEBIAN_PACKAGE_SUGGESTS "texlive-base, texlive-latex-extra")  # Latex tool
 # Use debian's arch scheme; we only care about x86/amd64 for now but feel free to add more
 if (${PACKAGE_ARCH} STREQUAL "x86_64")

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: https://github.com/xournalpp/xournalpp/
 
 Package: xournalpp
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, libglib2.0-0 (>= 2.32), libgtk-3-0 (>= 3.18), libpoppler-glib8 (>= 0.41.0), libxml2 (>= 2.0.0), libportaudiocpp0 (>= 12), libsndfile1 (>= 1.0.25), liblua5.3-0 | liblua5.4-0, libzip4 (>= 1.0.1) | libzip5, zlib1g, libc6, librsvg2-2 (>= 2.40), libgtksourceview-4-0, qpdf (>= 10.6)
+Depends: ${shlibs:Depends}, ${misc:Depends}, libglib2.0-0 (>= 2.32), libgtk-3-0 (>= 3.20), libpoppler-glib8 (>= 0.41.0), libxml2 (>= 2.0.0), libportaudiocpp0 (>= 12), libsndfile1 (>= 1.0.25), liblua5.3-0 | liblua5.4-0, libzip4 (>= 1.0.1) | libzip5, zlib1g, libc6, librsvg2-2 (>= 2.40), libgtksourceview-4-0, qpdf (>= 10.6)
 Suggests: texlive-base, texlive-latex-extra
 Description: Xournal++ - Open source hand note-taking program
  Xournal++ is a hand note-taking software written in C++ with the target of

--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -2126,16 +2126,15 @@ void Control::saveImpl(bool saveAs, std::function<void(bool)> callback) {
         auto suggestedPath = this->doc->createSaveFoldername(this->settings->getLastSavePath());
         suggestedPath /= this->doc->createSaveFilename(Document::XOPP, this->settings->getDefaultSaveName());
         this->doc->unlock_shared();
-        xoj::SaveExportDialog::showSaveFileDialog(getGtkWindow(), settings, std::move(suggestedPath),
-                                                  [doSave = std::move(doSave), ctrl = this](std::optional<fs::path> p) {
-                                                      if (p && !p->empty()) {
-                                                          ctrl->settings->setLastSavePath(p->parent_path());
-                                                          ctrl->doc->lock();
-                                                          ctrl->doc->setFilepath(std::move(p.value()));
-                                                          ctrl->doc->unlock();
-                                                          doSave();
-                                                      }
-                                                  });
+        xoj::dlg::showXoppSaveDialog(getGtkWindow(), settings, std::move(suggestedPath),
+                                     [doSave = std::move(doSave), ctrl = this](std::optional<fs::path> p) {
+                                         if (p && !p->empty()) {
+                                             ctrl->doc->lock();
+                                             ctrl->doc->setFilepath(std::move(p.value()));
+                                             ctrl->doc->unlock();
+                                             doSave();
+                                         }
+                                     });
     } else {
         doSave();
     }

--- a/src/core/control/jobs/BaseExportJob.cpp
+++ b/src/core/control/jobs/BaseExportJob.cpp
@@ -4,27 +4,28 @@
 
 #include <glib.h>  // for g_warning
 
-#include "control/Control.h"            // for Control
-#include "control/jobs/BlockingJob.h"   // for BlockingJob
-#include "control/settings/Settings.h"  // for Settings
-#include "gui/MainWindow.h"             // for MainWindow
+#include "control/Control.h"                      // for Control
+#include "control/jobs/BlockingJob.h"             // for BlockingJob
+#include "control/settings/Settings.h"            // for Settings
+#include "gui/MainWindow.h"                       // for MainWindow
+#include "gui/dialog/FileChooserFiltersHelper.h"  // for addFilterByExtension
 #include "gui/dialog/XojSaveDlg.h"
-#include "model/Document.h"             // for Document, Document::PDF
-#include "util/PathUtil.h"              // for clearExtensions
-#include "util/PopupWindowWrapper.h"    // for PopupWindowWrapper
-#include "util/XojMsgBox.h"             // for XojMsgBox
-#include "util/glib_casts.h"            // for wrap_for_g_callback_v
-#include "util/i18n.h"                  // for _, FS, _F
+#include "model/Document.h"           // for Document, Document::PDF
+#include "util/PathUtil.h"            // for clearExtensions
+#include "util/PopupWindowWrapper.h"  // for PopupWindowWrapper
+#include "util/XojMsgBox.h"           // for XojMsgBox
+#include "util/glib_casts.h"          // for wrap_for_g_callback_v
+#include "util/i18n.h"                // for _, FS, _F
 
 BaseExportJob::BaseExportJob(Control* control, const std::string& name): BlockingJob(control, name) {}
 
 BaseExportJob::~BaseExportJob() = default;
 
-void BaseExportJob::addFileFilterToDialog(GtkFileChooser* dialog, const std::string& name, const std::string& mime) {
-    GtkFileFilter* filter = gtk_file_filter_new();
-    gtk_file_filter_set_name(filter, name.c_str());
-    gtk_file_filter_add_mime_type(filter, mime.c_str());
-    gtk_file_chooser_add_filter(dialog, filter);
+void BaseExportJob::addFileFilterToDialog(GtkFileChooser* dialog, const std::string& name,
+                                          const std::string& extension) {
+    // Route through the shared native-compatible helper. Using gtk_file_filter_add_mime_type()
+    // here would make GtkFileChooserNative fall back to the GTK dialog on Windows.
+    xoj::addFilterByExtension(dialog, name.c_str(), {extension.c_str()});
 }
 
 auto BaseExportJob::checkOverwriteBackgroundPDF(fs::path const& file) const -> bool {

--- a/src/core/control/jobs/BaseExportJob.cpp
+++ b/src/core/control/jobs/BaseExportJob.cpp
@@ -64,24 +64,20 @@ void BaseExportJob::showFileChooser(std::function<void()> onFileSelected, std::f
         return job->testAndSetFilepath(p);
     };
 
-    auto callback = [settings, onFileSelected = std::move(onFileSelected),
+    auto configure = [job = this](GtkFileChooser* fc) { job->addFilterToDialog(fc); };
+
+    auto callback = [onFileSelected = std::move(onFileSelected),
                      onCancel = std::move(onCancel)](std::optional<fs::path> p) {
         if (p && !p->empty()) {
-            settings->setLastSavePath(p->parent_path());
             onFileSelected();
         } else {
             onCancel();
         }
     };
 
-    auto popup = xoj::popup::PopupWindowWrapper<xoj::SaveExportDialog>(control->getSettings(), std::move(suggestedPath),
-                                                                       _("Export File"), _("Export"),
-                                                                       std::move(pathValidation), std::move(callback));
-
-    auto* fc = GTK_FILE_CHOOSER(popup.getPopup()->getWindow());
-    addFilterToDialog(fc);
-
-    popup.show(GTK_WINDOW(this->control->getWindow()->getWindow()));
+    xoj::dlg::showSaveDialog(GTK_WINDOW(this->control->getWindow()->getWindow()), control->getSettings(),
+                             std::move(suggestedPath), _("Export File"), std::move(configure),
+                             std::move(pathValidation), std::move(callback));
 }
 
 auto BaseExportJob::testAndSetFilepath(const fs::path& file) -> bool {

--- a/src/core/control/jobs/BaseExportJob.h
+++ b/src/core/control/jobs/BaseExportJob.h
@@ -43,7 +43,14 @@ public:
 
 protected:
     virtual void addFilterToDialog(GtkFileChooser* dialog) = 0;
-    static void addFileFilterToDialog(GtkFileChooser* dialog, const std::string& name, const std::string& mimetype);
+    /**
+     * Add a file-extension filter to @p dialog.
+     *
+     * Export file choosers are GtkFileChooserNative. Its Win32 backend only supports
+     * pattern filters, so @p extension must be a plain extension string with leading
+     * dot (e.g. ".pdf"); MIME types would force a fallback to the GTK dialog.
+     */
+    static void addFileFilterToDialog(GtkFileChooser* dialog, const std::string& name, const std::string& extension);
     bool checkOverwriteBackgroundPDF(fs::path const& file) const;
 
     virtual void setExtensionFromFilter(fs::path& p, const char* filterName) const = 0;
@@ -67,8 +74,7 @@ protected:
     class ExportType {
     public:
         std::string extension;
-        std::string mimeType;
 
-        ExportType(std::string ext, std::string mime): extension(std::move(ext)), mimeType(std::move(mime)) {}
+        explicit ExportType(std::string ext): extension(std::move(ext)) {}
     };
 };

--- a/src/core/control/jobs/CustomExportJob.cpp
+++ b/src/core/control/jobs/CustomExportJob.cpp
@@ -25,11 +25,12 @@
 
 
 CustomExportJob::CustomExportJob(Control* control): BaseExportJob(control, _("Custom Export")) {
-    // Supported filters
-    filters.insert({_("PDF files"), ExportType(".pdf", "application/pdf")});
-    filters.insert({_("PNG graphics"), ExportType(".png", "image/png")});
-    filters.insert({_("SVG graphics"), ExportType(".svg", "image/svg+xml")});
-    filters.insert({_("Xournal (Compatibility)"), ExportType(".xoj", "application/x-xojpp")});
+    // Supported filters. Only extensions are stored: export save dialogs are native file
+    // choosers, and their Win32 backend cannot translate MIME types.
+    filters.insert({_("PDF files"), ExportType(".pdf")});
+    filters.insert({_("PNG graphics"), ExportType(".png")});
+    filters.insert({_("SVG graphics"), ExportType(".svg")});
+    filters.insert({_("Xournal (Compatibility)"), ExportType(".xoj")});
 }
 
 CustomExportJob::~CustomExportJob() = default;
@@ -37,7 +38,7 @@ CustomExportJob::~CustomExportJob() = default;
 void CustomExportJob::addFilterToDialog(GtkFileChooser* dialog) {
     // Runs on every filter inside the filters map
     for (auto& filter: filters) {
-        addFileFilterToDialog(dialog, filter.first, filter.second.mimeType);
+        addFileFilterToDialog(dialog, filter.first, filter.second.extension);
     }
 }
 

--- a/src/core/control/jobs/PdfExportJob.cpp
+++ b/src/core/control/jobs/PdfExportJob.cpp
@@ -16,9 +16,7 @@ PdfExportJob::PdfExportJob(Control* control): BaseExportJob(control, _("PDF Expo
 
 PdfExportJob::~PdfExportJob() = default;
 
-void PdfExportJob::addFilterToDialog(GtkFileChooser* dialog) {
-    addFileFilterToDialog(dialog, _("PDF files"), "application/pdf");
-}
+void PdfExportJob::addFilterToDialog(GtkFileChooser* dialog) { addFileFilterToDialog(dialog, _("PDF files"), ".pdf"); }
 
 void PdfExportJob::setExtensionFromFilter(fs::path& file, const char* /*filterName*/) const {
     // Remove any pre-existing extension and adds .pdf

--- a/src/core/gui/dialog/DeviceTestingArea.cpp
+++ b/src/core/gui/dialog/DeviceTestingArea.cpp
@@ -177,17 +177,15 @@ static void saveLog(const std::stringstream& fullLog, const std::stringstream& e
         }
     };
 
-    auto popup = xoj::popup::PopupWindowWrapper<xoj::SaveExportDialog>(
-            nullptr, fs::path(), _("Export Logs"), _("Export"), std::move(pathValidation), std::move(callback));
+    auto configure = [](GtkFileChooser* fc) {
+        GtkFileFilter* filter = gtk_file_filter_new();
+        gtk_file_filter_set_name(filter, "ZIP archive");
+        gtk_file_filter_add_mime_type(filter, "application/zip");
+        gtk_file_chooser_add_filter(fc, filter);
+    };
 
-    auto* fc = GTK_FILE_CHOOSER(popup.getPopup()->getWindow());
-
-    GtkFileFilter* filter = gtk_file_filter_new();
-    gtk_file_filter_set_name(filter, "ZIP archive");
-    gtk_file_filter_add_mime_type(filter, "application/zip");
-    gtk_file_chooser_add_filter(fc, filter);
-
-    popup.show(GTK_WINDOW(gtk_widget_get_ancestor(parent, GTK_TYPE_WINDOW)));
+    xoj::dlg::showSaveDialog(GTK_WINDOW(gtk_widget_get_ancestor(parent, GTK_TYPE_WINDOW)), nullptr, fs::path(),
+                             _("Export Logs"), std::move(configure), std::move(pathValidation), std::move(callback));
 }
 
 DeviceTestingArea::DeviceTestingArea(GladeSearchpath* gladeSearchPath, GtkBox* parent, Settings* settings):

--- a/src/core/gui/dialog/DeviceTestingArea.cpp
+++ b/src/core/gui/dialog/DeviceTestingArea.cpp
@@ -9,6 +9,7 @@
 
 #include "control/settings/Settings.h"
 #include "gui/Builder.h"
+#include "gui/dialog/FileChooserFiltersHelper.h"
 #include "gui/dialog/XojSaveDlg.h"
 #include "gui/inputdevices/InputContext.h"
 #include "gui/inputdevices/InputEvents.h"
@@ -178,10 +179,9 @@ static void saveLog(const std::stringstream& fullLog, const std::stringstream& e
     };
 
     auto configure = [](GtkFileChooser* fc) {
-        GtkFileFilter* filter = gtk_file_filter_new();
-        gtk_file_filter_set_name(filter, "ZIP archive");
-        gtk_file_filter_add_mime_type(filter, "application/zip");
-        gtk_file_chooser_add_filter(fc, filter);
+        // MIME-based filters force GtkFileChooserNative to fall back to the GTK dialog
+        // on Windows, so use the shared extension-based helper instead.
+        xoj::addFilterZip(fc);
     };
 
     xoj::dlg::showSaveDialog(GTK_WINDOW(gtk_widget_get_ancestor(parent, GTK_TYPE_WINDOW)), nullptr, fs::path(),

--- a/src/core/gui/dialog/FileChooserFiltersHelper.cpp
+++ b/src/core/gui/dialog/FileChooserFiltersHelper.cpp
@@ -1,13 +1,54 @@
 #include "FileChooserFiltersHelper.h"
 
+#include <algorithm>
+#include <cctype>
+#include <string>
+
 #include "util/i18n.h"
 
 namespace xoj {
-static void addMimeTypeFilter(GtkFileChooser* fc, const char* name, const char* mime) {
-    GtkFileFilter* filterPdf = gtk_file_filter_new();
-    gtk_file_filter_set_name(filterPdf, name);
-    gtk_file_filter_add_mime_type(filterPdf, mime);
-    gtk_file_chooser_add_filter(fc, filterPdf);
+
+namespace {
+
+/**
+ * Add a glob for @p extension (with leading dot) to @p filter, plus an uppercase sibling.
+ *
+ * Rationale for the uppercase duplicate:
+ *  - Linux GTK: gtk_file_filter_add_pattern() goes through glib's g_pattern_spec, which
+ *    matches case-sensitively. Without the sibling, a file named SCAN.PDF is hidden.
+ *  - Win32 native (IFileDialog): file system matching is case-insensitive, so the sibling
+ *    is redundant but harmless -- critically, it is still a plain pattern glob, which
+ *    keeps the filter translatable to COMDLG_FILTERSPEC and prevents the fallback to the
+ *    built-in GtkFileChooserDialog.
+ *  - macOS native: also case-insensitive by default; same reasoning applies.
+ *
+ * Only the extension portion is upper-cased; the leading "*." is locale-invariant and is
+ * appended verbatim to keep the pattern syntactically identical.
+ */
+void addExtensionPattern(GtkFileFilter* filter, const char* extension) {
+    std::string lowerPattern = "*";
+    lowerPattern += extension;
+    gtk_file_filter_add_pattern(filter, lowerPattern.c_str());
+
+    std::string upperExt = extension;
+    std::transform(upperExt.begin(), upperExt.end(), upperExt.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
+    if (upperExt != extension) {
+        std::string upperPattern = "*";
+        upperPattern += upperExt;
+        gtk_file_filter_add_pattern(filter, upperPattern.c_str());
+    }
+}
+
+}  // namespace
+
+void addFilterByExtension(GtkFileChooser* fc, const char* name, std::initializer_list<const char*> extensions) {
+    GtkFileFilter* filter = gtk_file_filter_new();
+    gtk_file_filter_set_name(filter, name);
+    for (const char* extension: extensions) {
+        addExtensionPattern(filter, extension);
+    }
+    gtk_file_chooser_add_filter(fc, filter);
 }
 
 void addFilterAllFiles(GtkFileChooser* fc) {
@@ -18,27 +59,41 @@ void addFilterAllFiles(GtkFileChooser* fc) {
 }
 
 void addFilterSupported(GtkFileChooser* fc) {
-    GtkFileFilter* filterSupported = gtk_file_filter_new();
-    gtk_file_filter_set_name(filterSupported, _("Supported files"));
-    gtk_file_filter_add_mime_type(filterSupported, "application/x-xojpp");
-    gtk_file_filter_add_mime_type(filterSupported, "application/x-xopp");
-    gtk_file_filter_add_mime_type(filterSupported, "application/x-xopt");
-    gtk_file_filter_add_mime_type(filterSupported, "application/pdf");
-    gtk_file_filter_add_pattern(filterSupported, "*.moj");  // MrWriter
-    gtk_file_chooser_add_filter(fc, filterSupported);
+    addFilterByExtension(fc, _("Supported files"),
+                         {
+                                 ".xopp",
+                                 ".xoj",
+                                 ".xopt",
+                                 ".pdf",
+                                 ".moj",  // MrWriter
+                         });
 }
 
-void addFilterPdf(GtkFileChooser* fc) { addMimeTypeFilter(fc, _("PDF files"), "application/pdf"); }
-void addFilterXoj(GtkFileChooser* fc) { addMimeTypeFilter(fc, _("Xournal files"), "application/x-xojpp"); }
-void addFilterXopp(GtkFileChooser* fc) { addMimeTypeFilter(fc, _("Xournal++ files"), "application/x-xopp"); }
-void addFilterXopt(GtkFileChooser* fc) { addMimeTypeFilter(fc, _("Xournal++ template"), "application/x-xopt"); }
-void addFilterSvg(GtkFileChooser* fc) { addMimeTypeFilter(fc, _("SVG graphics"), "image/svg+xml"); }
-void addFilterPng(GtkFileChooser* fc) { addMimeTypeFilter(fc, _("PNG graphics"), "image/png"); }
+void addFilterPdf(GtkFileChooser* fc) { addFilterByExtension(fc, _("PDF files"), {".pdf"}); }
+void addFilterXoj(GtkFileChooser* fc) { addFilterByExtension(fc, _("Xournal files"), {".xoj"}); }
+void addFilterXopp(GtkFileChooser* fc) { addFilterByExtension(fc, _("Xournal++ files"), {".xopp"}); }
+void addFilterXopt(GtkFileChooser* fc) { addFilterByExtension(fc, _("Xournal++ template"), {".xopt"}); }
+void addFilterSvg(GtkFileChooser* fc) { addFilterByExtension(fc, _("SVG graphics"), {".svg"}); }
+void addFilterPng(GtkFileChooser* fc) { addFilterByExtension(fc, _("PNG graphics"), {".png"}); }
+void addFilterZip(GtkFileChooser* fc) { addFilterByExtension(fc, _("ZIP archive"), {".zip"}); }
 
 void addFilterImages(GtkFileChooser* fc) {
-    GtkFileFilter* filter = gtk_file_filter_new();
-    gtk_file_filter_set_name(filter, _("Image files"));
-    gtk_file_filter_add_pixbuf_formats(filter);
-    gtk_file_chooser_add_filter(fc, filter);
+    // gtk_file_filter_add_pixbuf_formats() would be shorter, but the resulting filter is
+    // backed by GTK's pixbuf loader introspection rather than a plain extension glob, so
+    // the Win32 native backend cannot translate it and GTK falls back to its own dialog.
+    // Hard-coding the extensions keeps the native file picker alive.
+    addFilterByExtension(fc, _("Image files"),
+                         {
+                                 ".png",
+                                 ".jpg",
+                                 ".jpeg",
+                                 ".bmp",
+                                 ".gif",
+                                 ".tif",
+                                 ".tiff",
+                                 ".webp",
+                                 ".svg",
+                                 ".ico",
+                         });
 }
 };  // namespace xoj

--- a/src/core/gui/dialog/FileChooserFiltersHelper.h
+++ b/src/core/gui/dialog/FileChooserFiltersHelper.h
@@ -1,7 +1,7 @@
 /*
  * Xournal++
  *
- * Helper functions to add filters to GtkFileChooserDialogs
+ * Helper functions to add native-compatible filters to GtkFileChoosers
  *
  * @author Xournal++ Team
  * https://github.com/xournalpp/xournalpp
@@ -11,9 +11,25 @@
 
 #pragma once
 
+#include <initializer_list>
+
 #include <gtk/gtk.h>
 
 namespace xoj {
+
+/**
+ * Add a file-extension filter using GtkFileFilter patterns.
+ *
+ * GtkFileChooserNative's Win32 backend cannot translate MIME or custom filters to the
+ * IFileDialog COMDLG_FILTERSPEC structures it uses. When GTK sees an unsupported filter
+ * configuration it silently falls back to the internal GtkFileChooserDialog, which is
+ * why the app would otherwise still show the GTK-styled picker on Windows.
+ *
+ * Pattern filters map directly to COMDLG_FILTERSPEC and keep the native backend active.
+ * Each @p extensions entry is expected to include the leading dot (e.g. ".xopp").
+ */
+void addFilterByExtension(GtkFileChooser* fc, const char* name, std::initializer_list<const char*> extensions);
+
 void addFilterAllFiles(GtkFileChooser* fc);
 void addFilterSupported(GtkFileChooser* fc);
 void addFilterPdf(GtkFileChooser* fc);
@@ -22,5 +38,6 @@ void addFilterXopp(GtkFileChooser* fc);
 void addFilterXopt(GtkFileChooser* fc);
 void addFilterSvg(GtkFileChooser* fc);
 void addFilterPng(GtkFileChooser* fc);
-void addFilterImages(GtkFileChooser* fc);  ///< All images supported by GdkPixbuf
+void addFilterZip(GtkFileChooser* fc);
+void addFilterImages(GtkFileChooser* fc);  ///< Common image file extensions, pattern-based for native choosers
 };  // namespace xoj

--- a/src/core/gui/dialog/NativeFileChooserHelper.cpp
+++ b/src/core/gui/dialog/NativeFileChooserHelper.cpp
@@ -1,0 +1,46 @@
+#include "NativeFileChooserHelper.h"
+
+#include <utility>
+
+namespace xoj::dlg {
+
+namespace {
+
+struct NativeFileChooserSession {
+    xoj::util::GObjectSPtr<GtkFileChooserNative> dialog;
+    xoj::util::move_only_function<void(GtkFileChooser*, gint)> onResponse;
+    gulong signalId = 0;
+};
+
+void onResponseTrampoline(GtkNativeDialog* nativeDialog, gint response, gpointer userData) {
+    auto* session = static_cast<NativeFileChooserSession*>(userData);
+
+    // Detach the handler first so destroying the dialog below cannot re-enter this callback.
+    g_signal_handler_disconnect(nativeDialog, session->signalId);
+
+    // Move state to locals: the callback may take a long time (e.g. show another dialog), and must
+    // not observe `session` being destroyed while it runs.
+    auto dialog = std::move(session->dialog);
+    auto onResponse = std::move(session->onResponse);
+    delete session;
+
+    onResponse(GTK_FILE_CHOOSER(dialog.get()), response);
+
+    gtk_native_dialog_destroy(GTK_NATIVE_DIALOG(dialog.get()));
+}
+
+}  // namespace
+
+void showNativeFileChooser(xoj::util::GObjectSPtr<GtkFileChooserNative> dialog, GtkWindow* parent,
+                           xoj::util::move_only_function<void(GtkFileChooser*, gint)> onResponse) {
+    auto* nativeDialog = GTK_NATIVE_DIALOG(dialog.get());
+    gtk_native_dialog_set_transient_for(nativeDialog, parent);
+    gtk_native_dialog_set_modal(nativeDialog, TRUE);
+
+    auto* session = new NativeFileChooserSession{std::move(dialog), std::move(onResponse), 0};
+    session->signalId = g_signal_connect(nativeDialog, "response", G_CALLBACK(onResponseTrampoline), session);
+
+    gtk_native_dialog_show(nativeDialog);
+}
+
+}  // namespace xoj::dlg

--- a/src/core/gui/dialog/NativeFileChooserHelper.h
+++ b/src/core/gui/dialog/NativeFileChooserHelper.h
@@ -1,0 +1,37 @@
+/*
+ * Xournal++
+ *
+ * Shared lifecycle helper for asynchronous GtkFileChooserNative dialogs.
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+#include <gtk/gtk.h>
+
+#include "util/move_only_function.h"
+#include "util/raii/GObjectSPtr.h"
+
+namespace xoj::dlg {
+
+/**
+ * @brief Show a GtkFileChooserNative asynchronously and destroy it once the user responds.
+ *
+ * Takes ownership of @p dialog, sets it modal and transient for @p parent, connects a response
+ * handler and shows it. When the user responds (accept, cancel, or closes the dialog), @p onResponse
+ * is invoked exactly once with the dialog's GtkFileChooser view and the GTK response id, then the
+ * dialog is destroyed and any internal state is freed.
+ *
+ * @param dialog     The native chooser to show. The helper takes ownership.
+ * @param parent     The parent window for transient_for, or nullptr.
+ * @param onResponse Invoked once with the GtkFileChooser* view of @p dialog and the response id.
+ *                   Safe to capture state by move; destroyed after it returns.
+ */
+void showNativeFileChooser(xoj::util::GObjectSPtr<GtkFileChooserNative> dialog, GtkWindow* parent,
+                           xoj::util::move_only_function<void(GtkFileChooser*, gint)> onResponse);
+
+}  // namespace xoj::dlg

--- a/src/core/gui/dialog/PageTemplateDialog.cpp
+++ b/src/core/gui/dialog/PageTemplateDialog.cpp
@@ -10,11 +10,12 @@
 #include <gdk/gdk.h>      // for GdkRGBA
 #include <glib-object.h>  // for G_CALLBACK, g_signal_c...
 
-#include "control/pagetype/PageTypeHandler.h"  // for PageTypeInfo, PageType...
-#include "control/settings/Settings.h"         // for Settings
-#include "gui/Builder.h"                       // for Builder
-#include "gui/dialog/XojOpenDlg.h"             // for XojOpenDlg
-#include "gui/dialog/XojSaveDlg.h"             // for showSaveDialog
+#include "control/pagetype/PageTypeHandler.h"     // for PageTypeInfo, PageType...
+#include "control/settings/Settings.h"            // for Settings
+#include "gui/Builder.h"                          // for Builder
+#include "gui/dialog/FileChooserFiltersHelper.h"  // for addFilterXopt
+#include "gui/dialog/XojOpenDlg.h"                // for XojOpenDlg
+#include "gui/dialog/XojSaveDlg.h"                // for showSaveDialog
 #include "gui/menus/popoverMenus/PageTypeSelectionPopoverGridOnly.h"
 #include "gui/toolbarMenubar/ToolMenuHandler.h"
 #include "model/FormatDefinitions.h"  // for FormatUnits, XOJ_UNITS
@@ -65,16 +66,16 @@ PageTemplateDialog::PageTemplateDialog(GladeSearchpath* gladeSearchPath, Setting
                              G_CALLBACK(+[](PageTemplateDialog* self) { self->saveToFile(); }), this);
 
     g_signal_connect_swapped(builder.get("btCancel"), "clicked", G_CALLBACK(gtk_window_close), this->getWindow());
-    g_signal_connect_swapped(builder.get("btOk"), "clicked", G_CALLBACK(+[](PageTemplateDialog* self) {
-                                 self->saveToModel();
-                                 self->settings->setPageTemplateSettings(self->model);
-                                 self->toolMenuHandler->setDefaultNewPageType(self->model.getPageInsertType());
-                                 self->toolMenuHandler->setDefaultNewPaperSize(
-                                         self->model.isCopyLastPageSize() ? std::nullopt :
-                                                                            std::optional(PaperSize(self->model)));
-                                 gtk_window_close(self->getWindow());
-                             }),
-                             this);
+    g_signal_connect_swapped(
+            builder.get("btOk"), "clicked", G_CALLBACK(+[](PageTemplateDialog* self) {
+                self->saveToModel();
+                self->settings->setPageTemplateSettings(self->model);
+                self->toolMenuHandler->setDefaultNewPageType(self->model.getPageInsertType());
+                self->toolMenuHandler->setDefaultNewPaperSize(
+                        self->model.isCopyLastPageSize() ? std::nullopt : std::optional(PaperSize(self->model)));
+                gtk_window_close(self->getWindow());
+            }),
+            this);
 
     updateDataFromModel();
 }
@@ -120,10 +121,8 @@ void PageTemplateDialog::saveToFile() {
     suggestedPath /= stime;
 
     auto configure = [](GtkFileChooser* fc) {
-        GtkFileFilter* filterXoj = gtk_file_filter_new();
-        gtk_file_filter_set_name(filterXoj, _("Xournal++ template"));
-        gtk_file_filter_add_mime_type(filterXoj, "application/x-xopt");
-        gtk_file_chooser_add_filter(fc, filterXoj);
+        // Use the shared pattern-based filter so the Win32 native chooser stays native.
+        xoj::addFilterXopt(fc);
     };
 
     auto pathValidation = [](fs::path&, const char*) { return true; };

--- a/src/core/gui/dialog/PageTemplateDialog.cpp
+++ b/src/core/gui/dialog/PageTemplateDialog.cpp
@@ -14,14 +14,14 @@
 #include "control/settings/Settings.h"         // for Settings
 #include "gui/Builder.h"                       // for Builder
 #include "gui/dialog/XojOpenDlg.h"             // for XojOpenDlg
+#include "gui/dialog/XojSaveDlg.h"             // for showSaveDialog
 #include "gui/menus/popoverMenus/PageTypeSelectionPopoverGridOnly.h"
 #include "gui/toolbarMenubar/ToolMenuHandler.h"
 #include "model/FormatDefinitions.h"  // for FormatUnits, XOJ_UNITS
 #include "model/PageType.h"           // for PageType
 #include "util/Color.h"               // for GdkRGBA_to_argb, rgb_t...
-#include "util/PathUtil.h"            // for fromGFile, readString
+#include "util/PathUtil.h"            // for readString
 #include "util/PopupWindowWrapper.h"  // for PopupWindowWrapper
-#include "util/XojMsgBox.h"           // for XojMsgBox
 #include "util/i18n.h"                // for _
 #include "util/serdesstream.h"        // for serdes_stream
 
@@ -112,70 +112,32 @@ void PageTemplateDialog::saveToModel() {
 void PageTemplateDialog::saveToFile() {
     saveToModel();
 
-    GtkWidget* dialog =
-            gtk_file_chooser_dialog_new(_("Save File"), this->getWindow(), GTK_FILE_CHOOSER_ACTION_SAVE, _("_Cancel"),
-                                        GTK_RESPONSE_CANCEL, _("_Save"), GTK_RESPONSE_OK, nullptr);
-
-    GtkFileFilter* filterXoj = gtk_file_filter_new();
-    gtk_file_filter_set_name(filterXoj, _("Xournal++ template"));
-    gtk_file_filter_add_mime_type(filterXoj, "application/x-xopt");
-    gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(dialog), filterXoj);
-
-    if (!settings->getLastSavePath().empty()) {
-        gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(dialog), Util::toGFile(settings->getLastSavePath()).get(),
-                                            nullptr);
-    }
-
     time_t curtime = time(nullptr);
     char stime[128];
     strftime(stime, sizeof(stime), "%F-Template-%H-%M.xopt", localtime(&curtime));
-    fs::path saveFilename = stime;  // There may be an issue here, if the C and C++ locales do not use the same encoding
+    fs::path suggestedPath = settings->getLastSavePath();
+    // There may be an issue here, if the C and C++ locales do not use the same encoding
+    suggestedPath /= stime;
 
-    gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(dialog), Util::toGFilename(saveFilename).c_str());
-
-    class FileDlg final {
-    public:
-        FileDlg(GtkDialog* dialog, PageTemplateDialog* parent): window(GTK_WINDOW(dialog)), parent(parent) {
-            this->signalId = g_signal_connect(
-                    dialog, "response", G_CALLBACK((+[](GtkDialog* dialog, int response, gpointer data) {
-                        FileDlg* self = static_cast<FileDlg*>(data);
-                        if (response == GTK_RESPONSE_OK) {
-                            auto file = Util::fromGFile(
-                                    xoj::util::GObjectSPtr<GFile>(gtk_file_chooser_get_file(GTK_FILE_CHOOSER(dialog)),
-                                                                  xoj::util::adopt)
-                                            .get());
-
-                            auto saveTemplate = [self, dialog](const fs::path& file) {
-                                // Closing the window causes another "response" signal, which we want to ignore
-                                g_signal_handler_disconnect(dialog, self->signalId);
-                                gtk_window_close(GTK_WINDOW(dialog));
-                                self->parent->settings->setLastSavePath(file.parent_path());
-
-                                auto out = serdes_stream<std::ofstream>(file);
-                                out << self->parent->model.toString();
-                            };
-                            XojMsgBox::replaceFileQuestion(GTK_WINDOW(dialog), std::move(file),
-                                                           std::move(saveTemplate));
-                        } else {
-                            // Closing the window causes another "response" signal, which we want to ignore
-                            g_signal_handler_disconnect(dialog, self->signalId);
-                            gtk_window_close(GTK_WINDOW(dialog));  // Deletes self, don't do anything after this
-                        }
-                    })),
-                    this);
-        }
-        ~FileDlg() = default;
-
-        inline GtkWindow* getWindow() const { return window.get(); }
-
-    private:
-        xoj::util::GtkWindowUPtr window;
-        PageTemplateDialog* parent;
-        gulong signalId;
+    auto configure = [](GtkFileChooser* fc) {
+        GtkFileFilter* filterXoj = gtk_file_filter_new();
+        gtk_file_filter_set_name(filterXoj, _("Xournal++ template"));
+        gtk_file_filter_add_mime_type(filterXoj, "application/x-xopt");
+        gtk_file_chooser_add_filter(fc, filterXoj);
     };
 
-    auto popup = xoj::popup::PopupWindowWrapper<FileDlg>(GTK_DIALOG(dialog), this);
-    popup.show(GTK_WINDOW(this->getWindow()));
+    auto pathValidation = [](fs::path&, const char*) { return true; };
+
+    auto callback = [self = this](std::optional<fs::path> selected) {
+        if (!selected || selected->empty()) {
+            return;
+        }
+        auto out = serdes_stream<std::ofstream>(*selected);
+        out << self->model.toString();
+    };
+
+    xoj::dlg::showSaveDialog(this->getWindow(), settings, std::move(suggestedPath), _("Save File"),
+                             std::move(configure), std::move(pathValidation), std::move(callback));
 }
 
 void PageTemplateDialog::loadFromFile() {

--- a/src/core/gui/dialog/XojOpenDlg.cpp
+++ b/src/core/gui/dialog/XojOpenDlg.cpp
@@ -1,17 +1,21 @@
 #include "XojOpenDlg.h"
 
+#include <cstring>  // for strcmp
+#include <utility>
+
 #include "control/settings/Settings.h"  // for Settings
 #include "util/PathUtil.h"              // for fromGFile, toGFile
-#include "util/PopupWindowWrapper.h"    // for PopupWindowWrapper
-#include "util/Util.h"
-#include "util/gtk4_helper.h"         // for gtk_file_chooser_set_current_folder
-#include "util/i18n.h"                // for _
-#include "util/raii/GObjectSPtr.h"    // for GObjectSPtr
-#include "util/raii/GtkWindowUPtr.h"  // for GtkWindowUPtr
+#include "util/Util.h"                  // for execInUiThread
+#include "util/gtk4_helper.h"           // for gtk_file_chooser_set_current_folder
+#include "util/i18n.h"                  // for _
+#include "util/raii/GObjectSPtr.h"      // for GObjectSPtr
 
 #include "FileChooserFiltersHelper.h"
+#include "NativeFileChooserHelper.h"
 
-static void addlastSavePathShortcut(GtkFileChooser* fc, Settings* settings) {
+namespace {
+
+void addlastSavePathShortcut(GtkFileChooser* fc, Settings* settings) {
     auto lastSavePath = settings->getLastSavePath();
     if (!lastSavePath.empty()) {
 #if GTK_MAJOR_VERSION == 3
@@ -22,7 +26,7 @@ static void addlastSavePathShortcut(GtkFileChooser* fc, Settings* settings) {
     }
 }
 
-static void setCurrentFolderToLastOpenPath(GtkFileChooser* fc, Settings* settings) {
+void setCurrentFolderToLastOpenPath(GtkFileChooser* fc, Settings* settings) {
     xoj::util::GObjectSPtr<GFile> currentFolder;
     if (settings && !settings->getLastOpenPath().empty()) {
         currentFolder = Util::toGFile(settings->getLastOpenPath());
@@ -33,8 +37,8 @@ static void setCurrentFolderToLastOpenPath(GtkFileChooser* fc, Settings* setting
 }
 
 template <class... Args>
-static std::function<void(fs::path, Args...)> addSetLastSavePathToCallback(
-        std::function<void(fs::path, Args...)> callback, Settings* settings) {
+std::function<void(fs::path, Args...)> addSetLastSavePathToCallback(std::function<void(fs::path, Args...)> callback,
+                                                                    Settings* settings) {
     return [cb = std::move(callback), settings](fs::path path, Args... args) {
         if (settings && !path.empty()) {
             settings->setLastOpenPath(path.parent_path());
@@ -43,100 +47,64 @@ static std::function<void(fs::path, Args...)> addSetLastSavePathToCallback(
     };
 }
 
-
 constexpr auto ATTACH_CHOICE_ID = "attachPdfChoice";
-static void addAttachChoice(GtkFileChooser* fc) {
+
+void addAttachChoice(GtkFileChooser* fc) {
+    // GtkFileChooserNative ignores add_choice on the Win32 and macOS backends; on those
+    // platforms the attach option is not shown and the default ("false") is used.
     gtk_file_chooser_add_choice(fc, ATTACH_CHOICE_ID, _("Attach file to the journal"), nullptr, nullptr);
     gtk_file_chooser_set_choice(fc, ATTACH_CHOICE_ID, "false");
 }
 
-// Helper class, for a single open dialog
-class FileDlg {
-public:
-    /**
-     * Creates an open file dialog. The callback is only called if a file is actually chosen
-     * @param callback(path, attachPdf)
-     */
-    FileDlg(const char* title, std::function<void(fs::path, bool)> callback);
-    /**
-     * Creates an open file dialog. The callback is only called if a file is actually chosen
-     * @param callback(path)
-     */
-    FileDlg(const char* title, std::function<void(fs::path)> callback);
-    ~FileDlg() = default;
-
-    inline GtkWindow* getWindow() const { return window.get(); }
-
-private:
-    xoj::util::GtkWindowUPtr window;
-
-    std::function<void(fs::path, bool)> callback;
-    gulong signalId{};
-};
-
-static GtkWindow* makeWindow(const char* title) {
-    // Todo(maybe)
-    // Restore previews using https://discourse.gnome.org/t/file-chooser-gtk-4-image-preview/11510/2
-    auto* win = gtk_file_chooser_dialog_new(title, nullptr, GTK_FILE_CHOOSER_ACTION_OPEN, _("_Cancel"),
-                                            GTK_RESPONSE_CANCEL, _("_Open"), GTK_RESPONSE_OK, nullptr);
-    return GTK_WINDOW(win);
+xoj::util::GObjectSPtr<GtkFileChooserNative> makeOpenDialog(const char* title) {
+    return xoj::util::GObjectSPtr<GtkFileChooserNative>(
+            gtk_file_chooser_native_new(title, nullptr, GTK_FILE_CHOOSER_ACTION_OPEN, nullptr, nullptr),
+            xoj::util::adopt);
 }
 
-FileDlg::FileDlg(const char* title, std::function<void(fs::path, bool)> callback):
-        window(makeWindow(title)), callback(std::move(callback)) {
-    this->signalId = g_signal_connect(
-            window.get(), "response", G_CALLBACK(+[](GtkDialog* win, int response, gpointer data) {
-                auto* self = static_cast<FileDlg*>(data);
+/// Build a response handler that extracts the selected path and the attach-choice, then forwards
+/// them to @p callback. The callback is posted via Util::execInUiThread so that any follow-up
+/// dialog is spawned after the native chooser is fully destroyed.
+auto makeOpenHandler(std::function<void(fs::path, bool)> callback)
+        -> xoj::util::move_only_function<void(GtkFileChooser*, gint)> {
+    return [cb = std::move(callback)](GtkFileChooser* fc, gint response) mutable {
+        if (response != GTK_RESPONSE_ACCEPT) {
+            return;
+        }
+        auto path =
+                Util::fromGFile(xoj::util::GObjectSPtr<GFile>(gtk_file_chooser_get_file(fc), xoj::util::adopt).get());
 
-                if (response == GTK_RESPONSE_OK) {
-                    auto path =
-                            Util::fromGFile(xoj::util::GObjectSPtr<GFile>(
-                                                    gtk_file_chooser_get_file(GTK_FILE_CHOOSER(win)), xoj::util::adopt)
-                                                    .get());
+        bool attach = false;
+        if (const char* choice = gtk_file_chooser_get_choice(fc, ATTACH_CHOICE_ID)) {
+            attach = std::strcmp(choice, "true") == 0;
+        }
 
-                    bool attach = false;
-                    if (const char* choice = gtk_file_chooser_get_choice(GTK_FILE_CHOOSER(win), ATTACH_CHOICE_ID);
-                        choice) {
-                        attach = std::strcmp(choice, "true") == 0;
-                    }
-
-                    // We need to call gtk_window_close() before invoking the callback, because if the callback pops up
-                    // another dialog, the first one won't close...
-                    // So we postpone the callback
-                    Util::execInUiThread([cb = std::move(self->callback), path = std::move(path), attach]() {
-                        cb(std::move(path), attach);
-                    });
-                }
-                // Closing the window causes another "response" signal, which we want to ignore
-                g_signal_handler_disconnect(win, self->signalId);
-                gtk_window_close(self->getWindow());  // Destroys *self. Beware!
-            }),
-            this);
+        Util::execInUiThread(
+                [cb = std::move(cb), path = std::move(path), attach]() mutable { cb(std::move(path), attach); });
+    };
 }
 
-FileDlg::FileDlg(const char* title, std::function<void(fs::path)> callback):
-        FileDlg(title, [cb = std::move(callback)](fs::path path, bool) { cb(std::move(path)); }) {}
-
+}  // namespace
 
 void xoj::OpenDlg::showOpenTemplateDialog(GtkWindow* parent, Settings* settings,
                                           std::function<void(fs::path)> callback) {
-    auto popup = xoj::popup::PopupWindowWrapper<FileDlg>(_("Open template file"),
-                                                         addSetLastSavePathToCallback(std::move(callback), settings));
+    auto dialog = makeOpenDialog(_("Open template file"));
+    auto* fc = GTK_FILE_CHOOSER(dialog.get());
 
-    auto* fc = GTK_FILE_CHOOSER(popup.getPopup()->getWindow());
     xoj::addFilterAllFiles(fc);
     xoj::addFilterXopt(fc);
     setCurrentFolderToLastOpenPath(fc, settings);
 
-    popup.show(parent);
+    auto wrapped = addSetLastSavePathToCallback(std::move(callback), settings);
+    xoj::dlg::showNativeFileChooser(
+            std::move(dialog), parent,
+            makeOpenHandler([cb = std::move(wrapped)](fs::path path, bool) mutable { cb(std::move(path)); }));
 }
 
-
 void xoj::OpenDlg::showOpenFileDialog(GtkWindow* parent, Settings* settings, std::function<void(fs::path)> callback) {
-    auto popup = xoj::popup::PopupWindowWrapper<FileDlg>(_("Open file"),
-                                                         addSetLastSavePathToCallback(std::move(callback), settings));
+    auto dialog = makeOpenDialog(_("Open file"));
+    auto* fc = GTK_FILE_CHOOSER(dialog.get());
 
-    auto* fc = GTK_FILE_CHOOSER(popup.getPopup()->getWindow());
     xoj::addFilterSupported(fc);
     xoj::addFilterXoj(fc);
     xoj::addFilterXopt(fc);
@@ -147,15 +115,16 @@ void xoj::OpenDlg::showOpenFileDialog(GtkWindow* parent, Settings* settings, std
     addlastSavePathShortcut(fc, settings);
     setCurrentFolderToLastOpenPath(fc, settings);
 
-    popup.show(parent);
+    auto wrapped = addSetLastSavePathToCallback(std::move(callback), settings);
+    xoj::dlg::showNativeFileChooser(
+            std::move(dialog), parent,
+            makeOpenHandler([cb = std::move(wrapped)](fs::path path, bool) mutable { cb(std::move(path)); }));
 }
 
 void xoj::OpenDlg::showAnnotatePdfDialog(GtkWindow* parent, Settings* settings,
                                          std::function<void(fs::path, bool)> callback) {
-    auto popup = xoj::popup::PopupWindowWrapper<FileDlg>(_("Annotate Pdf file"),
-                                                         addSetLastSavePathToCallback(std::move(callback), settings));
-
-    auto* fc = GTK_FILE_CHOOSER(popup.getPopup()->getWindow());
+    auto dialog = makeOpenDialog(_("Annotate Pdf file"));
+    auto* fc = GTK_FILE_CHOOSER(dialog.get());
 
     xoj::addFilterPdf(fc);
     xoj::addFilterAllFiles(fc);
@@ -165,20 +134,14 @@ void xoj::OpenDlg::showAnnotatePdfDialog(GtkWindow* parent, Settings* settings,
 
     addAttachChoice(fc);
 
-    popup.show(parent);
+    auto wrapped = addSetLastSavePathToCallback(std::move(callback), settings);
+    xoj::dlg::showNativeFileChooser(std::move(dialog), parent, makeOpenHandler(std::move(wrapped)));
 }
 
 void xoj::OpenDlg::showOpenImageDialog(GtkWindow* parent, Settings* settings,
                                        std::function<void(fs::path, bool)> callback) {
-    auto popup = xoj::popup::PopupWindowWrapper<FileDlg>(_("Choose image file"),
-                                                         [cb = std::move(callback), settings](fs::path p, bool attach) {
-                                                             if (auto folder = p.parent_path(); !folder.empty()) {
-                                                                 settings->setLastImagePath(folder);
-                                                             }
-                                                             cb(std::move(p), attach);
-                                                         });
-
-    auto* fc = GTK_FILE_CHOOSER(popup.getPopup()->getWindow());
+    auto dialog = makeOpenDialog(_("Choose image file"));
+    auto* fc = GTK_FILE_CHOOSER(dialog.get());
 
     xoj::addFilterImages(fc);
     xoj::addFilterAllFiles(fc);
@@ -189,14 +152,21 @@ void xoj::OpenDlg::showOpenImageDialog(GtkWindow* parent, Settings* settings,
 
     addAttachChoice(fc);
 
-    popup.show(parent);
+    auto rememberImagePath = [settings, cb = std::move(callback)](fs::path path, bool attach) mutable {
+        if (settings && !path.empty()) {
+            if (auto folder = path.parent_path(); !folder.empty()) {
+                settings->setLastImagePath(folder);
+            }
+        }
+        cb(std::move(path), attach);
+    };
+    xoj::dlg::showNativeFileChooser(std::move(dialog), parent, makeOpenHandler(std::move(rememberImagePath)));
 }
 
 void xoj::OpenDlg::showMultiFormatDialog(GtkWindow* parent, std::vector<std::string> formats,
                                          std::function<void(fs::path)> callback) {
-    auto popup = xoj::popup::PopupWindowWrapper<FileDlg>(_("Open file"), std::move(callback));
-
-    auto* fc = GTK_FILE_CHOOSER(popup.getPopup()->getWindow());
+    auto dialog = makeOpenDialog(_("Open file"));
+    auto* fc = GTK_FILE_CHOOSER(dialog.get());
 
     if (formats.size() > 0) {
         GtkFileFilter* filterSupported = gtk_file_filter_new();
@@ -207,5 +177,7 @@ void xoj::OpenDlg::showMultiFormatDialog(GtkWindow* parent, std::vector<std::str
         gtk_file_chooser_add_filter(fc, filterSupported);
     }
 
-    popup.show(parent);
+    xoj::dlg::showNativeFileChooser(
+            std::move(dialog), parent,
+            makeOpenHandler([cb = std::move(callback)](fs::path path, bool) mutable { cb(std::move(path)); }));
 }

--- a/src/core/gui/dialog/XojOpenDlg.cpp
+++ b/src/core/gui/dialog/XojOpenDlg.cpp
@@ -50,8 +50,10 @@ std::function<void(fs::path, Args...)> addSetLastSavePathToCallback(std::functio
 constexpr auto ATTACH_CHOICE_ID = "attachPdfChoice";
 
 void addAttachChoice(GtkFileChooser* fc) {
-    // GtkFileChooserNative ignores add_choice on the Win32 and macOS backends; on those
-    // platforms the attach option is not shown and the default ("false") is used.
+    // Native backends vary in how much GtkFileChooser "choice" UI they can expose. If a
+    // backend can't render the toggle, the stored default ("false") is still returned by
+    // gtk_file_chooser_get_choice() when the response handler reads it back, so the flow
+    // degrades gracefully.
     gtk_file_chooser_add_choice(fc, ATTACH_CHOICE_ID, _("Attach file to the journal"), nullptr, nullptr);
     gtk_file_chooser_set_choice(fc, ATTACH_CHOICE_ID, "false");
 }

--- a/src/core/gui/dialog/XojSaveDlg.cpp
+++ b/src/core/gui/dialog/XojSaveDlg.cpp
@@ -22,13 +22,24 @@ xoj::util::GObjectSPtr<GtkFileChooserNative> makeSaveDialog(Settings* settings, 
 
     auto* fc = GTK_FILE_CHOOSER(dialog.get());
 
+    // Let the native dialog show its own "file exists" prompt when it can. The post-dialog
+    // replaceFileQuestion() still runs because pathValidation may append an extension that
+    // turns the chosen name into a pre-existing file, which the OS dialog cannot foresee.
+    gtk_file_chooser_set_do_overwrite_confirmation(fc, TRUE);
+
     if (!suggestedPath.empty()) {
         gtk_file_chooser_set_current_folder(fc, Util::toGFile(suggestedPath.parent_path()).get(), nullptr);
         gtk_file_chooser_set_current_name(fc, Util::toGFilename(suggestedPath.filename()).c_str());
     }
     if (settings) {
-        // Silently ignored by the Win32 and macOS native backends.
-        gtk_file_chooser_add_shortcut_folder(fc, Util::toGFile(settings->getLastOpenPath()).get(), nullptr);
+#if !defined(__APPLE__)
+        // Shortcut folders are honoured by the Win32 native backend (mapped to IFileDialog
+        // "places") but the macOS native panel does not support them at all, so skip the
+        // call there to avoid touching features that could still surprise the backend.
+        if (!settings->getLastOpenPath().empty()) {
+            gtk_file_chooser_add_shortcut_folder(fc, Util::toGFile(settings->getLastOpenPath()).get(), nullptr);
+        }
+#endif
     }
 
     return dialog;

--- a/src/core/gui/dialog/XojSaveDlg.cpp
+++ b/src/core/gui/dialog/XojSaveDlg.cpp
@@ -1,91 +1,92 @@
 #include "XojSaveDlg.h"
 
-#include <optional>
+#include <utility>
 
 #include "control/settings/Settings.h"
-#include "util/PathUtil.h"            // for fromGFile, toGFile
-#include "util/PopupWindowWrapper.h"  // for PopupWindowWrapper
-#include "util/Util.h"
+#include "util/PathUtil.h"  // for fromGFile, toGFile, clearExtensions
 #include "util/XojMsgBox.h"
-#include "util/gtk4_helper.h"         // for gtk_file_chooser_set_current_folder
-#include "util/i18n.h"                // for _
-#include "util/raii/GObjectSPtr.h"    // for GObjectSPtr
-#include "util/raii/GtkWindowUPtr.h"  // for GtkWindowUPtr
+#include "util/gtk4_helper.h"       // for gtk_file_chooser_set_current_folder
+#include "util/i18n.h"              // for _
+#include "util/raii/GObjectSPtr.h"  // for GObjectSPtr
 
 #include "FileChooserFiltersHelper.h"
+#include "NativeFileChooserHelper.h"
 
-static GtkWindow* makeWindow(Settings* settings, fs::path suggestedPath, const char* windowTitle,
-                             const char* buttonLabel) {
-    GtkWidget* dialog = gtk_file_chooser_dialog_new(windowTitle, nullptr, GTK_FILE_CHOOSER_ACTION_SAVE, _("_Cancel"),
-                                                    GTK_RESPONSE_CANCEL, buttonLabel, GTK_RESPONSE_OK, nullptr);
+namespace {
+
+xoj::util::GObjectSPtr<GtkFileChooserNative> makeSaveDialog(Settings* settings, const fs::path& suggestedPath,
+                                                            const char* title) {
+    xoj::util::GObjectSPtr<GtkFileChooserNative> dialog(
+            gtk_file_chooser_native_new(title, nullptr, GTK_FILE_CHOOSER_ACTION_SAVE, nullptr, nullptr),
+            xoj::util::adopt);
+
+    auto* fc = GTK_FILE_CHOOSER(dialog.get());
 
     if (!suggestedPath.empty()) {
-        gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(dialog), Util::toGFile(suggestedPath.parent_path()).get(),
-                                            nullptr);
-        gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(dialog),
-                                          Util::toGFilename(suggestedPath.filename()).c_str());
+        gtk_file_chooser_set_current_folder(fc, Util::toGFile(suggestedPath.parent_path()).get(), nullptr);
+        gtk_file_chooser_set_current_name(fc, Util::toGFilename(suggestedPath.filename()).c_str());
     }
     if (settings) {
-        gtk_file_chooser_add_shortcut_folder(GTK_FILE_CHOOSER(dialog), Util::toGFile(settings->getLastOpenPath()).get(),
-                                             nullptr);
+        // Silently ignored by the Win32 and macOS native backends.
+        gtk_file_chooser_add_shortcut_folder(fc, Util::toGFile(settings->getLastOpenPath()).get(), nullptr);
     }
 
-    return GTK_WINDOW(dialog);
+    return dialog;
 }
 
-xoj::SaveExportDialog::SaveExportDialog(Settings* settings, fs::path suggestedPath, const char* windowTitle,
-                                        const char* buttonLabel,
-                                        std::function<bool(fs::path&, const char* filterName)> pathValidation,
-                                        std::function<void(std::optional<fs::path>)> callback):
-        window(makeWindow(settings, std::move(suggestedPath), windowTitle, buttonLabel)),
-        callback(std::move(callback)),
-        pathValidation(std::move(pathValidation)) {
-    this->signalId = g_signal_connect(
-            window.get(), "response", G_CALLBACK(+[](GtkDialog* win, int response, gpointer data) {
-                auto* self = static_cast<SaveExportDialog*>(data);
-                auto* fc = GTK_FILE_CHOOSER(win);
-                if (response == GTK_RESPONSE_OK) {
-                    auto file = Util::fromGFile(
-                            xoj::util::GObjectSPtr<GFile>(gtk_file_chooser_get_file(fc), xoj::util::adopt).get());
-
-                    if (self->pathValidation(file, gtk_file_filter_get_name(gtk_file_chooser_get_filter(fc)))) {
-                        XojMsgBox::replaceFileQuestion(
-                                GTK_WINDOW(win), std::move(file),
-                                std::bind(&SaveExportDialog::close, self, std::placeholders::_1));
-                    }  // else the dialog stays on until a suitable destination is found or cancel is hit.
-                } else {
-                    self->close(std::nullopt);
-                }
-            }),
-            this);
-}
-
-void xoj::SaveExportDialog::close(std::optional<fs::path> path) {
-    // We need to call gtk_window_close() before invoking the callback, because if the callback pops up another dialog,
-    // the first one won't close...
-    // But since gtk_window_close() triggers the destruction of *this, we first move the callback
-    auto cb = std::move(this->callback);
-
-    // Closing the window causes another "response" signal, which we want to ignore
-    g_signal_handler_disconnect(window.get(), signalId);
-    gtk_window_close(window.get());  // Destroys *this. Don't do anything after this call
-
-    cb(std::move(path));
-}
-
-static bool xoppPathValidation(fs::path& p, const char*) {
+bool xoppPathValidation(fs::path& p, const char* /*filterName*/) {
     Util::clearExtensions(p);
     p += ".xopp";
     return true;
 }
 
-void xoj::SaveExportDialog::showSaveFileDialog(GtkWindow* parent, Settings* settings, fs::path suggestedPath,
-                                               std::function<void(std::optional<fs::path>)> callback) {
-    auto popup = xoj::popup::PopupWindowWrapper<SaveExportDialog>(settings, std::move(suggestedPath), _("Save File"),
-                                                                  _("Save"), xoppPathValidation, std::move(callback));
+}  // namespace
 
-    auto* fc = GTK_FILE_CHOOSER(popup.getPopup()->getWindow());
-    xoj::addFilterXopp(fc);
+void xoj::dlg::showSaveDialog(GtkWindow* parent, Settings* settings, fs::path suggestedPath, const char* title,
+                              SaveConfigurator configure, SavePathValidator pathValidation, SavePathCallback callback) {
+    auto dialog = makeSaveDialog(settings, suggestedPath, title);
+    if (configure) {
+        configure(GTK_FILE_CHOOSER(dialog.get()));
+    }
 
-    popup.show(parent);
+    showNativeFileChooser(
+            std::move(dialog), parent,
+            [parent, settings, pathValidation = std::move(pathValidation), callback = std::move(callback)](
+                    GtkFileChooser* fc, gint response) mutable {
+                if (response != GTK_RESPONSE_ACCEPT) {
+                    callback(std::nullopt);
+                    return;
+                }
+
+                auto file = Util::fromGFile(
+                        xoj::util::GObjectSPtr<GFile>(gtk_file_chooser_get_file(fc), xoj::util::adopt).get());
+                const char* filterName = nullptr;
+                if (GtkFileFilter* filter = gtk_file_chooser_get_filter(fc)) {
+                    filterName = gtk_file_filter_get_name(filter);
+                }
+
+                if (!pathValidation(file, filterName)) {
+                    // Validation rejected the path (e.g. writing over the background PDF).
+                    callback(std::nullopt);
+                    return;
+                }
+
+                if (settings && !file.empty()) {
+                    settings->setLastSavePath(file.parent_path());
+                }
+
+                // Post-dialog overwrite confirmation. Also covers the case where
+                // pathValidation appended an extension that turns the target into an
+                // already-existing file, which the native dialog could not anticipate.
+                auto onReplace = [callback](const fs::path& confirmed) { callback(confirmed); };
+                auto onDecline = [callback = std::move(callback)]() { callback(std::nullopt); };
+                XojMsgBox::replaceFileQuestion(parent, std::move(file), std::move(onReplace), std::move(onDecline));
+            });
+}
+
+void xoj::dlg::showXoppSaveDialog(GtkWindow* parent, Settings* settings, fs::path suggestedPath,
+                                  SavePathCallback callback) {
+    showSaveDialog(
+            parent, settings, std::move(suggestedPath), _("Save File"),
+            [](GtkFileChooser* fc) { xoj::addFilterXopp(fc); }, xoppPathValidation, std::move(callback));
 }

--- a/src/core/gui/dialog/XojSaveDlg.h
+++ b/src/core/gui/dialog/XojSaveDlg.h
@@ -1,7 +1,7 @@
 /*
  * Xournal++
  *
- * GTK Save/Export dialog to select destination file
+ * Native save/export file chooser helpers.
  *
  * @author Xournal++ Team
  * https://github.com/xournalpp/xournalpp
@@ -16,41 +16,41 @@
 
 #include <gtk/gtk.h>  // for GtkWindow
 
-#include "util/raii/GtkWindowUPtr.h"
+#include "util/move_only_function.h"
 
 #include "filesystem.h"  // for path
 
 class Settings;
 
-namespace xoj {
-/// Helper class, for a single dialog
-class SaveExportDialog {
-public:
-    /**
-     * Shows a save file dialog. The callback is called with std::nullopt if no path were selected
-     */
-    static void showSaveFileDialog(GtkWindow* parent, Settings* settings, fs::path suggestedPath,
-                                   std::function<void(std::optional<fs::path>)> callback);
+namespace xoj::dlg {
 
-    /**
-     * Creates a save or export file dialog. The callback is called with std::nullopt if no path were selected
-     * @param pathValidation May modify the given path. Returns true if the path is (now) valid for saving/exporting.
-     * @param callback(path)
-     */
-    SaveExportDialog(Settings* settings, fs::path suggestedPath, const char* windowTitle, const char* buttonLabel,
-                     std::function<bool(fs::path&, const char* filterName)> pathValidation,
-                     std::function<void(std::optional<fs::path>)> callback);
-    ~SaveExportDialog() = default;
+/// Predicate used to post-process and validate the path returned by the save dialog.
+/// Implementations may modify @p path (for example, appending a file extension based on the chosen
+/// filter) and return whether the result is acceptable.
+using SavePathValidator = std::function<bool(fs::path& path, const char* filterName)>;
 
-    inline GtkWindow* getWindow() const { return window.get(); }
+/// Invoked after the save dialog closes. The argument holds the chosen path on success, or
+/// std::nullopt if the user cancelled or closed the dialog.
+using SavePathCallback = std::function<void(std::optional<fs::path>)>;
 
-private:
-    /// Closes the dialog and calls the callback on `path`
-    void close(std::optional<fs::path> path);
+/// Optional hook run on the dialog before it is shown. Lets callers add filters, shortcuts, or
+/// other chooser-specific configuration in one place.
+using SaveConfigurator = xoj::util::move_only_function<void(GtkFileChooser*)>;
 
-    xoj::util::GtkWindowUPtr window;
-    std::function<void(std::optional<fs::path>)> callback;
-    std::function<bool(fs::path&, const char* filterName)> pathValidation;
-    gulong signalId{};
-};
-};  // namespace xoj
+/**
+ * Show a native save/export file chooser.
+ *
+ * The dialog uses @p suggestedPath to seed the current folder and filename, honours the optional
+ * @p configure hook, and prompts the user about overwriting an existing file before invoking
+ * @p callback. The overwrite prompt also catches the case where @p pathValidation appends an
+ * extension that changes the target path after the native dialog's own confirmation.
+ *
+ * @p callback is invoked with std::nullopt on cancel/close.
+ */
+void showSaveDialog(GtkWindow* parent, Settings* settings, fs::path suggestedPath, const char* title,
+                    SaveConfigurator configure, SavePathValidator pathValidation, SavePathCallback callback);
+
+/// Convenience wrapper for the main ".xopp" save flow.
+void showXoppSaveDialog(GtkWindow* parent, Settings* settings, fs::path suggestedPath, SavePathCallback callback);
+
+}  // namespace xoj::dlg

--- a/src/core/plugin/luapi_application.h
+++ b/src/core/plugin/luapi_application.h
@@ -280,7 +280,7 @@ static int applib_fileDialogSave(lua_State* L) {
         suggestedPath = "." / suggestedPath;
     }
 
-    auto pathValidation = [](fs::path& p, const char* filterName) { return true; };
+    auto pathValidation = [](fs::path&, const char*) { return true; };
 
     Plugin* plugin = Plugin::getPluginFromLua(L);
     Control* ctrl = plugin->getControl();
@@ -293,14 +293,9 @@ static int applib_fileDialogSave(lua_State* L) {
         }
     };
 
-    auto popup = xoj::popup::PopupWindowWrapper<xoj::SaveExportDialog>(ctrl->getSettings(), std::move(suggestedPath),
-                                                                       _("Save File"), _("Save"),
-                                                                       std::move(pathValidation), std::move(callback));
-
-    auto* fc = GTK_FILE_CHOOSER(popup.getPopup()->getWindow());
-    xoj::addFilterAllFiles(fc);
-
-    popup.show(GTK_WINDOW(ctrl->getWindow()->getWindow()));
+    xoj::dlg::showSaveDialog(
+            GTK_WINDOW(ctrl->getWindow()->getWindow()), ctrl->getSettings(), std::move(suggestedPath), _("Save File"),
+            [](GtkFileChooser* fc) { xoj::addFilterAllFiles(fc); }, std::move(pathValidation), std::move(callback));
 
     return 0;
 }

--- a/src/util/XojMsgBox.cpp
+++ b/src/util/XojMsgBox.cpp
@@ -175,7 +175,8 @@ auto XojMsgBox::askPluginQuestion(const std::string& pluginName, const std::stri
 }
 
 void XojMsgBox::replaceFileQuestion(GtkWindow* win, fs::path file,
-                                    xoj::util::move_only_function<void(const fs::path&)> writeTofile) {
+                                    xoj::util::move_only_function<void(const fs::path&)> writeTofile,
+                                    xoj::util::move_only_function<void()> onCancel) {
     if (!fs::exists(file)) {
         writeTofile(file);
         return;
@@ -190,12 +191,15 @@ void XojMsgBox::replaceFileQuestion(GtkWindow* win, fs::path file,
     gtk_dialog_add_button(GTK_DIALOG(dialog), _("Select another name"), GTK_RESPONSE_CANCEL);
     gtk_dialog_add_button(GTK_DIALOG(dialog), _("Replace"), GTK_RESPONSE_OK);
 
-    xoj::popup::PopupWindowWrapper<XojMsgBox> popup(
-            GTK_DIALOG(dialog), [overwrite = std::move(writeTofile), file = std::move(file)](int response) mutable {
-                if (response == GTK_RESPONSE_OK) {
-                    overwrite(file);
-                }
-            });
+    xoj::popup::PopupWindowWrapper<XojMsgBox> popup(GTK_DIALOG(dialog),
+                                                    [overwrite = std::move(writeTofile), onCancel = std::move(onCancel),
+                                                     file = std::move(file)](int response) mutable {
+                                                        if (response == GTK_RESPONSE_OK) {
+                                                            overwrite(file);
+                                                        } else {
+                                                            onCancel();
+                                                        }
+                                                    });
     popup.show(win);
 }
 

--- a/src/util/include/util/XojMsgBox.h
+++ b/src/util/include/util/XojMsgBox.h
@@ -88,8 +88,10 @@ public:
 
     /**
      * @brief Calls writeToFile(file) if either file is not already present in the filesystem, or is the user answers
-     * "Overwrite" to a popup dialog.
+     * "Overwrite" to a popup dialog. If the user declines to overwrite, @p onCancel is invoked instead; by default
+     * this is a no-op.
      */
-    static void replaceFileQuestion(GtkWindow* win, fs::path file,
-                                    xoj::util::move_only_function<void(const fs::path&)> writeToFile);
+    static void replaceFileQuestion(
+            GtkWindow* win, fs::path file, xoj::util::move_only_function<void(const fs::path&)> writeToFile,
+            xoj::util::move_only_function<void()> onCancel = []() {});
 };


### PR DESCRIPTION
Closes #3822.

This switches the open, save, and export dialogs from `gtk_file_chooser_dialog_new` to `gtk_file_chooser_native_new`, so on Windows you get the real Explorer file picker, on macOS the Cocoa panel, and on Linux the portal file chooser (same as before on most desktops).

## What's in the PR

The series starts with some groundwork and then flips the three remaining call sites:

- A small helper, `NativeFileChooserHelper`, owns the native dialog, handles the async response signal, and destroys the dialog once the caller's response handler returns. All the lifetime fiddliness lives in one place so the callers stay readable.
- `XojOpenDlg` drops its internal `FileDlg` class. Every open flow (regular file, annotate PDF, template, image, multi-format) goes through the helper now.
- `XojSaveDlg` replaces the old `SaveExportDialog` class with two free functions, `showSaveDialog` and `showXoppSaveDialog`. Callers configure the dialog with a small lambda instead of a three-step setup.
- `BaseExportJob::showFileChooser`, `Control::saveImpl`, `DeviceTestingArea::saveLog`, `PageTemplateDialog::saveToFile`, and `applib_fileDialogSave` all use the new API.
- `XojMsgBox::replaceFileQuestion` gains an optional `onCancel` callback. The save flow needs it because the native dialog is already gone by the time the overwrite prompt shows, so we can't just re-open it on cancel.

## A note on the follow-up commit

I tested the first version on Windows and the picker still looked like the GTK one. It turns out calling `gtk_file_chooser_native_new` isn't enough by itself: GTK's Win32 backend only knows how to translate plain extension-pattern filters into the IFileDialog filter format. If the dialog has MIME filters, a custom match callback, or `gtk_file_filter_add_pixbuf_formats`, GTK silently falls back to the internal `GtkFileChooserDialog`. All of our filter helpers were MIME-based, so we were hitting that fallback on every save/open.

The last commit fixes this by converting the filter helpers to use extension patterns (`*.xopp`, `*.pdf`, etc.). A few side effects:

- `ExportType` no longer carries a `mimeType` field. Just the extension is enough now.
- Filters register both lowercase and uppercase globs (`*.pdf` and `*.PDF`) because glib's pattern matching is case-sensitive on Linux. Windows/macOS shell matching is case-insensitive, so the extra pattern is a harmless no-op there.
- Filtering now matches by filename extension rather than by MIME database. For everything Xournal++ actually opens and saves, that's equivalent.

While I was in there I also turned on `gtk_file_chooser_set_do_overwrite_confirmation` on the native dialog and skipped `add_shortcut_folder` on macOS (the native panel doesn't support shortcut folders). The `replaceFileQuestion` prompt still runs afterwards because `pathValidation` can append an extension, which may turn the name into an existing file that the OS dialog couldn't have flagged.

Because `gtk_file_chooser_native_new` is GTK 3.20, I bumped the minimum GTK from 3.18.9 to 3.20 in `CMakeLists.txt` and `debian/control`. All supported runners already ship 3.24+ (Ubuntu 22.04, jhbuild on macOS, MSYS2 mingw64), so no CI targets are affected.

## Commits

- `util: add onCancel callback to replaceFileQuestion` — backward-compatible extension
- `gui: add NativeFileChooserHelper for async native dialogs` — new helper, no callers yet
- `gui: convert XojOpenDlg to GtkFileChooserNative`
- `gui: convert save/export dialogs to GtkFileChooserNative`
- `gui: use extension-pattern filters so native file chooser stays native`

## Testing

Manually verified on Windows (MSYS2 mingw64) that these all show the real Windows file dialog now:

- Save As
- Open
- Export as PDF / custom export (PDF/PNG/SVG/XOJ)
- Annotate PDF
- Insert image
- Preferences → Input → Device testing area → Export logs
- Page template save

No existing unit tests cover these dialogs, and I didn't add new ones. I don't have a macOS machine, so a macOS-equipped reviewer would be very welcome.

## Tradeoffs and edge cases

- The "attach file to the journal" checkbox in the Annotate PDF dialog goes through `gtk_file_chooser_add_choice`. On Windows this maps to `IFileDialogCustomize::AddCheckButton` so it should render natively. On macOS the native panel can't display it, so the option silently falls back to its default ("false"). Happy to add a small follow-up dialog for macOS if reviewers would rather keep the option visible there.
- Narrow case: if `pathValidation` appends an extension that turns the chosen name into an existing file, the user may see two overwrite prompts — one from the OS dialog, one from `replaceFileQuestion`. Fixing this properly needs a refactor of the extension-munging, so I've left it out of scope.
- `PageTemplateDialog`: cancelling the overwrite prompt now closes the flow instead of leaving the file chooser open. The user re-opens save if they want a different name. Minor but worth flagging.

## Note on dormant PR #4161

#4161 (export-job refactor) has been dormant since April 2023. This PR only touches `BaseExportJob::showFileChooser`'s dialog wiring and drops the `mimeType` field on the filter struct, so conflicts should be small.
