### PR TITLE
fix(pdf): return nullptr from getPage() when page index is out of bounds

### DIFF
--- a/src/core/pdf/popplerapi/PopplerGlibDocument.cpp
+++ b/src/core/pdf/popplerapi/PopplerGlibDocument.cpp
@@ -101,6 +101,9 @@ auto PopplerGlibDocument::getPage(size_t page) const -> XojPdfPageSPtr {
     }
 
     PopplerPage* pg = poppler_document_get_page(document, int(page));
+    if (pg == nullptr) {
+        return nullptr;
+    }
     XojPdfPageSPtr pageptr = std::make_shared<PopplerGlibPage>(pg, document);
     g_object_unref(pg);
 


### PR DESCRIPTION
This is the bug fix separated from PR https://github.com/xournalpp/xournalpp/pull/7411

Problem: PopplerGlibDocument::getPage() previously constructed a PopplerGlibPage object wrapping a null PopplerPage* when poppler_document_get_page() returned NULL (e.g. page index exceeded the document's page count). This produced a non-null shared_ptr to an invalid page, defeating all downstream null checks.

Before-fix errors: PdfCache::render()'s null check passed despite the invalid page, then poppler_page_get_size() and other Poppler methods were called on NULL, triggering:

    Poppler-CRITICAL **: poppler_page_get_size: assertion
    'POPPLER_IS_PAGE(page)' failed

Impact: PdfCache::render() null-checks getPage()'s return value to render a gray background for missing pages:

    auto popplerPage = pdfDocument.getPage(pdfPageNo);
    if (!popplerPage) {
        renderMissingPdfPage(cr, pageWidth, pageHeight);
        return;
    }

Since getPage() returned a non-null (but invalid) shared_ptr for out-of-bounds pages, this guard never triggered. Calling Poppler methods on the null PopplerPage* caused the render to fail with internal state corruption—not just for the missing page, but for subsequent renders of OTHER pages that shared the same cache or render context.

Symptom: after PDF auto-reload reduced the page count (e.g. 3 pages → 2 pages), the out-of-bounds pages correctly showed gray background on initial render. However, the corrupted state from the failed render propagated to valid pages as well: on the next zoom in/out, even pages that still existed in the PDF also turned into gray backgrounds.

Fix: return nullptr when poppler_document_get_page() returns NULL. All callers already handle null correctly; the old behavior violated the function's contract of returning a valid page or null, and the invalid object corrupted internal caches for unrelated pages.

