### PR TITLE
feat: Show full path of files in "Recent Documents" menu (fixes: #7460)

### DIFF
--- a/src/core/gui/menus/menubar/RecentDocumentsSubmenu.cpp
+++ b/src/core/gui/menus/menubar/RecentDocumentsSubmenu.cpp
@@ -64,10 +64,9 @@ auto createRecentMenuItem(const GtkRecentInfo* info, size_t i) {
 }
 
 auto createRemoveMenuItem(const GtkRecentInfo* info, size_t i) {
-    std::string label =
-        FS(FORMAT_STR("{1}. {2} {3}") % (i + 1) %
-           C_("The selected document will be removed from the recent files list", "Dismiss") %
-           getRecentDisplayLabel(info));
+    std::string label = FS(FORMAT_STR("{1}. {2} {3}") % (i + 1) %
+                           C_("The selected document will be removed from the recent files list", "Dismiss") %
+                           getRecentDisplayLabel(info));
 
     std::string action = G_ACTION_NAMESPACE;
     action += REMOVE_ACTION_NAME;

--- a/src/core/gui/menus/menubar/RecentDocumentsSubmenu.cpp
+++ b/src/core/gui/menus/menubar/RecentDocumentsSubmenu.cpp
@@ -46,6 +46,7 @@ auto getRecentDisplayLabel(const GtkRecentInfo* info) -> std::string {
         label = gtk_recent_info_get_display_name(const_cast<GtkRecentInfo*>(info));
     }
 
+    // escape underscore
     StringUtils::replaceAllChars(label, {replace_pair('_', "__")});
     return label;
 }

--- a/src/core/gui/menus/menubar/RecentDocumentsSubmenu.cpp
+++ b/src/core/gui/menus/menubar/RecentDocumentsSubmenu.cpp
@@ -29,18 +29,29 @@ constexpr auto REMOVE_ACTION_NAME = "remove-file-at";
 constexpr auto DISABLED_ACTION_NAME = "always-disabled-action";
 constexpr auto CLEAR_LIST_ACTION_NAME = "clear-recent-files";
 
+constexpr size_t MAX_PATH_DISPLAY_LENGTH = 80;
+
 void recentManagerChangedCallback(GtkRecentManager* /*manager*/, RecentDocumentsSubmenu* recentDocsSubmenu) {
     recentDocsSubmenu->updateMenu();
 }
 
 void clearRecentFilesCallback(GSimpleAction*, GVariant*, gpointer) { RecentManager::clearRecentFiles(); }
 
-auto createRecentMenuItem(const GtkRecentInfo* info, size_t i) {
-    std::string display_name = gtk_recent_info_get_display_name(const_cast<GtkRecentInfo*>(info));
+auto getRecentDisplayLabel(const GtkRecentInfo* info) -> std::string {
+    std::string label;
+    if (auto path = Util::fromUri(gtk_recent_info_get_uri(const_cast<GtkRecentInfo*>(info)))) {
+        auto u8path = path->u8string();
+        label = StringUtils::ellipsizeLeft(char_cast(u8path), MAX_PATH_DISPLAY_LENGTH);
+    } else {
+        label = gtk_recent_info_get_display_name(const_cast<GtkRecentInfo*>(info));
+    }
 
-    // escape underscore
-    StringUtils::replaceAllChars(display_name, {replace_pair('_', "__")});
-    std::string label = FS(FORMAT_STR("{1}. {2}") % (i + 1) % display_name);
+    StringUtils::replaceAllChars(label, {replace_pair('_', "__")});
+    return label;
+}
+
+auto createRecentMenuItem(const GtkRecentInfo* info, size_t i) {
+    std::string label = FS(FORMAT_STR("{1}. {2}") % (i + 1) % getRecentDisplayLabel(info));
 
     std::string action = G_ACTION_NAMESPACE;
     action += OPEN_ACTION_NAME;
@@ -52,13 +63,10 @@ auto createRecentMenuItem(const GtkRecentInfo* info, size_t i) {
 }
 
 auto createRemoveMenuItem(const GtkRecentInfo* info, size_t i) {
-    std::string display_name = gtk_recent_info_get_display_name(const_cast<GtkRecentInfo*>(info));
-
-    // escape underscore
-    StringUtils::replaceAllChars(display_name, {replace_pair('_', "__")});
     std::string label =
-            FS(FORMAT_STR("{1}. {2} {3}") % (i + 1) %
-               C_("The selected document will be removed from the recent files list", "Dismiss") % display_name);
+        FS(FORMAT_STR("{1}. {2} {3}") % (i + 1) %
+           C_("The selected document will be removed from the recent files list", "Dismiss") %
+           getRecentDisplayLabel(info));
 
     std::string action = G_ACTION_NAMESPACE;
     action += REMOVE_ACTION_NAME;

--- a/src/util/StringUtils.cpp
+++ b/src/util/StringUtils.cpp
@@ -86,8 +86,11 @@ auto StringUtils::iequals(const string& a, const string& b) -> bool {
     return result == 0;
 }
 
-auto StringUtils::ellipsize(std::string_view sv, std::size_t max_width) -> std::string {
-    constexpr std::string_view ELLIPSIS_STR = "...";
+namespace {
+
+constexpr std::string_view ELLIPSIS_STR = "...";
+
+auto ellipsize(std::string_view sv, std::size_t max_width, bool fromLeft) -> std::string {
     xoj_assert(max_width > ELLIPSIS_STR.size());
     const auto length = g_utf8_strlen(sv.data(), as_signed(sv.size()));
 
@@ -95,13 +98,31 @@ auto StringUtils::ellipsize(std::string_view sv, std::size_t max_width) -> std::
         return std::string{sv};
     }
 
-    const auto bytes_kept = static_cast<std::size_t>(
-            g_utf8_offset_to_pointer(sv.data(), as_signed(max_width - ELLIPSIS_STR.size())) - sv.data());
+    const auto kept = as_signed(max_width - ELLIPSIS_STR.size());
+    const char* boundary = g_utf8_offset_to_pointer(sv.data(), fromLeft ? length - kept : kept);
+    const std::string_view keptPart =
+            fromLeft ? sv.substr(static_cast<std::size_t>(boundary - sv.data())) : sv.substr(0, static_cast<std::size_t>(boundary - sv.data()));
+
     std::string str;
-    str.reserve(bytes_kept + ELLIPSIS_STR.size());
-    str.append(sv.data(), bytes_kept);
-    str.append(ELLIPSIS_STR);
+    str.reserve(keptPart.size() + ELLIPSIS_STR.size());
+    if (fromLeft) {
+        str.append(ELLIPSIS_STR);
+        str.append(keptPart);
+    } else {
+        str.append(keptPart);
+        str.append(ELLIPSIS_STR);
+    }
     return str;
+}
+
+}  // namespace
+
+auto StringUtils::ellipsize(std::string_view sv, std::size_t max_width) -> std::string {
+    return ::ellipsize(sv, max_width, false);
+}
+
+auto StringUtils::ellipsizeLeft(std::string_view sv, std::size_t max_width) -> std::string {
+    return ::ellipsize(sv, max_width, true);
 }
 
 auto StringUtils::markup_escape(std::string_view sv) -> std::string {

--- a/src/util/StringUtils.cpp
+++ b/src/util/StringUtils.cpp
@@ -100,8 +100,8 @@ auto ellipsize(std::string_view sv, std::size_t max_width, bool fromLeft) -> std
 
     const auto kept = as_signed(max_width - ELLIPSIS_STR.size());
     const char* boundary = g_utf8_offset_to_pointer(sv.data(), fromLeft ? length - kept : kept);
-    const std::string_view keptPart =
-            fromLeft ? sv.substr(static_cast<std::size_t>(boundary - sv.data())) : sv.substr(0, static_cast<std::size_t>(boundary - sv.data()));
+    const std::string_view keptPart = fromLeft ? sv.substr(static_cast<std::size_t>(boundary - sv.data())) :
+                                                 sv.substr(0, static_cast<std::size_t>(boundary - sv.data()));
 
     std::string str;
     str.reserve(keptPart.size() + ELLIPSIS_STR.size());

--- a/src/util/include/util/StringUtils.h
+++ b/src/util/include/util/StringUtils.h
@@ -29,6 +29,7 @@ std::string rtrim(std::string str);
 std::string trim(std::string str);
 bool iequals(const std::string& a, const std::string& b);
 std::string ellipsize(std::string_view sv, std::size_t max_width = 100);
+std::string ellipsizeLeft(std::string_view sv, std::size_t max_width = 100);
 std::string markup_escape(std::string_view sv);
 
 /**

--- a/test/unit_tests/util/StringUtilsTest.cpp
+++ b/test/unit_tests/util/StringUtilsTest.cpp
@@ -97,3 +97,36 @@ TEST(UtilStringUtils, testEllipsize) {
         }
     }
 }
+
+TEST(UtilStringUtils, testEllipsizeLeft) {
+    struct TestCase {
+        std::string_view str;   // original string
+        std::size_t max_width;  // in code points
+        bool ellipsized;        // expected result
+    };
+
+    constexpr std::array<TestCase, 5> cases = {{
+            {"short string", 20, false},
+            {"very looooooooong string", 20, true},
+            {"éééééaouüüüüüüöööödèèû", 10, true},
+            {"CJK \xE4\xB8\x96\xE7\x95\x8C", 6, false},
+            {"\xE4\xB8\x96\xE7\x95\x8C\xE4\xB8\x96\xE7\x95\x8C\xE4\xB8\x96\xE7\x95\x8C", 5, true},
+    }};
+    for (const auto& tc: cases) {
+        auto out = StringUtils::ellipsizeLeft(tc.str, tc.max_width);
+
+        EXPECT_TRUE(g_utf8_validate(out.c_str(), out.size(), nullptr))
+                << "Ellipsizing string \"" << tc.str << "\" produced invalid UTF-8";
+
+        if (tc.ellipsized) {
+            EXPECT_EQ(g_utf8_strlen(out.c_str(), out.size()), tc.max_width)
+                    << "Ellipsizing string \"" << tc.str << "\" produced a string of the wrong size";
+            EXPECT_TRUE(StringUtils::startsWith(out, "...")) << '"' << out << "\" does not start with an ellipsis";
+            // The trailing part of the original string must be preserved.
+            EXPECT_TRUE(StringUtils::endsWith(tc.str, std::string_view(out).substr(3)))
+                    << '"' << out << "\" does not keep the end of the original string";
+        } else {
+            EXPECT_EQ(out, tc.str) << "String should not have been ellipsized";
+        }
+    }
+}


### PR DESCRIPTION
# Summary
This PR addresses issue https://github.com/xournalpp/xournalpp/issues/7460

* Now when looking at "Recent Documents" menu it shows the full path of files in that list.

Testing:
* Add unit testing for `StringUtils#ellipsizeLeft` method

You can see this live, inside the program when clicking on `File -> Recent Documents"