### PR TITLE
Fix Laser pointer configuration assigned to button

### DIFF
--- a/src/core/control/Tool.cpp
+++ b/src/core/control/Tool.cpp
@@ -3,9 +3,11 @@
 #include <optional>
 #include <utility>
 
-Tool::Tool(std::string name, ToolType type, Color color, unsigned int capabilities,
-           std::optional<std::array<double, toolSizes>> thickness):
-        name{std::move(name)}, type{type}, thickness{std::move(thickness)}, capabilities{capabilities} {
+Tool::Tool(std::string name, ToolType type, Color color, std::optional<std::array<double, toolSizes>> thickness):
+        name{std::move(name)},
+        type{type},
+        thickness{std::move(thickness)},
+        capabilities{xoj::tool::typeToCapabilities(type)} {
     setColor(color);
 }
 
@@ -19,11 +21,11 @@ auto Tool::getName() const -> std::string { return this->name; }
 
 auto Tool::getToolType() const -> ToolType { return this->type; }
 
-void Tool::setCapability(unsigned int capability, bool enabled) {
+void Tool::setCapability(ToolCapabilities capability, bool enabled) {
     if (enabled) {
-        this->capabilities |= capability;
+        this->capabilities = static_cast<ToolCapabilities>(this->capabilities | capability);
     } else {
-        this->capabilities &= ~capability;
+        this->capabilities = static_cast<ToolCapabilities>(this->capabilities & ~capability);
     }
 }
 

--- a/src/core/control/Tool.h
+++ b/src/core/control/Tool.h
@@ -29,8 +29,7 @@ public:
      */
     static constexpr int toolSizes = 5;
 
-    Tool(std::string name, ToolType type, Color color, unsigned int capabilities,
-         std::optional<std::array<double, Tool::toolSizes>> thickness);
+    Tool(std::string name, ToolType type, Color color, std::optional<std::array<double, Tool::toolSizes>> thickness);
     /**
      * @brief Construct a new Tool object based on another tool.
      * @param t tool to use as basis for new copy.
@@ -61,7 +60,7 @@ public:
     bool isDrawingTool() const;
 
 protected:
-    void setCapability(unsigned int capability, bool enabled);
+    void setCapability(ToolCapabilities capability, bool enabled);
 
 private:
     void operator=(const Tool& t);
@@ -72,7 +71,7 @@ private:
 
     std::optional<std::array<double, toolSizes>> thickness;
 
-    unsigned int capabilities;
+    ToolCapabilities capabilities;
 
     friend class ToolHandler;
 };

--- a/src/core/control/ToolEnums.cpp
+++ b/src/core/control/ToolEnums.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>  // for find, remove_if
 
 #include "model/StrokeStyle.h"
+#include "util/Assert.h"
 
 
 auto toolSizeFromString(const std::string& size) -> ToolSize {
@@ -97,4 +98,45 @@ auto strokeTypeFromString(const std::string& type) -> StrokeType {
 
 bool xoj::tool::isPdfSelectionTool(ToolType toolType) {
     return toolType == TOOL_SELECT_PDF_TEXT_LINEAR || toolType == TOOL_SELECT_PDF_TEXT_RECT;
+}
+
+static constexpr auto makeToolCaps() {
+    std::array<std::underlying_type_t<ToolCapabilities>, TOOL_COUNT> caps;
+
+    caps[TOOL_PEN - TOOL_PEN] = TOOL_CAP_COLOR | TOOL_CAP_SIZE | TOOL_CAP_RULER | TOOL_CAP_RECTANGLE |
+                                TOOL_CAP_ELLIPSE | TOOL_CAP_ARROW | TOOL_CAP_DOUBLE_ARROW | TOOL_CAP_SPLINE |
+                                TOOL_CAP_RECOGNIZER | TOOL_CAP_FILL | TOOL_CAP_LINE_STYLE;
+    caps[TOOL_ERASER - TOOL_PEN] = TOOL_CAP_SIZE;
+    caps[TOOL_HIGHLIGHTER - TOOL_PEN] = TOOL_CAP_COLOR | TOOL_CAP_SIZE | TOOL_CAP_RULER | TOOL_CAP_RECTANGLE |
+                                        TOOL_CAP_ELLIPSE | TOOL_CAP_ARROW | TOOL_CAP_DOUBLE_ARROW | TOOL_CAP_SPLINE |
+                                        TOOL_CAP_RECOGNIZER | TOOL_CAP_FILL;
+    caps[TOOL_TEXT - TOOL_PEN] = TOOL_CAP_COLOR;
+    caps[TOOL_IMAGE - TOOL_PEN] = TOOL_CAP_NONE;
+    caps[TOOL_SELECT_RECT - TOOL_PEN] = TOOL_CAP_NONE;
+    caps[TOOL_SELECT_REGION - TOOL_PEN] = TOOL_CAP_NONE;
+    caps[TOOL_SELECT_MULTILAYER_RECT - TOOL_PEN] = TOOL_CAP_NONE;
+    caps[TOOL_SELECT_MULTILAYER_REGION - TOOL_PEN] = TOOL_CAP_NONE;
+    caps[TOOL_SELECT_OBJECT - TOOL_PEN] = TOOL_CAP_NONE;
+    caps[TOOL_VERTICAL_SPACE - TOOL_PEN] = TOOL_CAP_NONE;
+    caps[TOOL_HAND - TOOL_PEN] = TOOL_CAP_NONE;
+    caps[TOOL_PLAY_OBJECT - TOOL_PEN] = TOOL_CAP_NONE;
+    caps[TOOL_DRAW_RECT - TOOL_PEN] = TOOL_CAP_NONE;
+    caps[TOOL_DRAW_ELLIPSE - TOOL_PEN] = TOOL_CAP_NONE;
+    caps[TOOL_DRAW_ARROW - TOOL_PEN] = TOOL_CAP_NONE;
+    caps[TOOL_DRAW_DOUBLE_ARROW - TOOL_PEN] = TOOL_CAP_NONE;
+    caps[TOOL_DRAW_COORDINATE_SYSTEM - TOOL_PEN] = TOOL_CAP_NONE;
+    caps[TOOL_DRAW_SPLINE - TOOL_PEN] = TOOL_CAP_NONE;
+    caps[TOOL_FLOATING_TOOLBOX - TOOL_PEN] = TOOL_CAP_NONE;
+    caps[TOOL_SELECT_PDF_TEXT_LINEAR - TOOL_PEN] = TOOL_CAP_COLOR;
+    caps[TOOL_SELECT_PDF_TEXT_RECT - TOOL_PEN] = TOOL_CAP_COLOR;
+    caps[TOOL_LASER_POINTER_PEN - TOOL_PEN] = TOOL_CAP_COLOR | TOOL_CAP_SIZE;
+    caps[TOOL_LASER_POINTER_HIGHLIGHTER - TOOL_PEN] = TOOL_CAP_COLOR | TOOL_CAP_SIZE;
+
+    return caps;
+}
+
+auto xoj::tool::typeToCapabilities(ToolType type) -> ToolCapabilities {
+    static constexpr auto caps = makeToolCaps();
+    xoj_assert(type >= TOOL_PEN && type - TOOL_PEN < TOOL_COUNT);
+    return static_cast<ToolCapabilities>(caps[type - TOOL_PEN]);
 }

--- a/src/core/control/ToolEnums.h
+++ b/src/core/control/ToolEnums.h
@@ -194,4 +194,7 @@ static constexpr auto strokeTypeToString(StrokeType type) -> std::string_view {
 namespace xoj::tool {
 /// \return Whether the provided tool is used for selecting objects on a PDF.
 bool isPdfSelectionTool(ToolType toolType);
+
+ToolCapabilities typeToCapabilities(ToolType type);
+static inline bool hasCapability(ToolType type, ToolCapabilities cap) { return typeToCapabilities(type) & cap; }
 }  // namespace xoj::tool

--- a/src/core/control/ToolHandler.cpp
+++ b/src/core/control/ToolHandler.cpp
@@ -29,8 +29,7 @@ ToolHandler::ToolHandler(ToolListener* stateChangeListener, ActionDatabase* acti
 
 class ToolSelectPDFText: public Tool {
 public:
-    ToolSelectPDFText(std::string name, ToolType type, Color color):
-            Tool(name, type, color, TOOL_CAP_COLOR, std::nullopt) {}
+    ToolSelectPDFText(std::string name, ToolType type, Color color): Tool(name, type, color, std::nullopt) {}
 
     ~ToolSelectPDFText() override{};
 
@@ -53,19 +52,14 @@ void ToolHandler::initTools() {
     thickness[TOOL_SIZE_MEDIUM] = 1.41;
     thickness[TOOL_SIZE_THICK] = 2.26;
     thickness[TOOL_SIZE_VERY_THICK] = 5.67;
-    tools[TOOL_PEN - TOOL_PEN] = std::make_unique<Tool>(
-            "pen", TOOL_PEN, Colors::xopp_royalblue,
-            TOOL_CAP_COLOR | TOOL_CAP_SIZE | TOOL_CAP_RULER | TOOL_CAP_RECTANGLE | TOOL_CAP_ELLIPSE | TOOL_CAP_ARROW |
-                    TOOL_CAP_DOUBLE_ARROW | TOOL_CAP_SPLINE | TOOL_CAP_RECOGNIZER | TOOL_CAP_FILL | TOOL_CAP_LINE_STYLE,
-            thickness);
+    tools[TOOL_PEN - TOOL_PEN] = std::make_unique<Tool>("pen", TOOL_PEN, Colors::xopp_royalblue, thickness);
 
     thickness[TOOL_SIZE_VERY_FINE] = 1;
     thickness[TOOL_SIZE_FINE] = 2.83;
     thickness[TOOL_SIZE_MEDIUM] = 8.50;
     thickness[TOOL_SIZE_THICK] = 12;
     thickness[TOOL_SIZE_VERY_THICK] = 18;
-    tools[TOOL_ERASER - TOOL_PEN] =
-            std::make_unique<Tool>("eraser", TOOL_ERASER, Colors::black, TOOL_CAP_SIZE, thickness);
+    tools[TOOL_ERASER - TOOL_PEN] = std::make_unique<Tool>("eraser", TOOL_ERASER, Colors::black, thickness);
 
     // highlighter thicknesses = 1, 3, 7 mm
     thickness[TOOL_SIZE_VERY_FINE] = 1;
@@ -73,62 +67,55 @@ void ToolHandler::initTools() {
     thickness[TOOL_SIZE_MEDIUM] = 8.50;
     thickness[TOOL_SIZE_THICK] = 19.84;
     thickness[TOOL_SIZE_VERY_THICK] = 30;
-    tools[TOOL_HIGHLIGHTER - TOOL_PEN] = std::make_unique<Tool>(
-            "highlighter", TOOL_HIGHLIGHTER, Colors::yellow,
-            TOOL_CAP_COLOR | TOOL_CAP_SIZE | TOOL_CAP_RULER | TOOL_CAP_RECTANGLE | TOOL_CAP_ELLIPSE | TOOL_CAP_ARROW |
-                    TOOL_CAP_DOUBLE_ARROW | TOOL_CAP_SPLINE | TOOL_CAP_RECOGNIZER | TOOL_CAP_FILL,
-            thickness);
+    tools[TOOL_HIGHLIGHTER - TOOL_PEN] =
+            std::make_unique<Tool>("highlighter", TOOL_HIGHLIGHTER, Colors::yellow, thickness);
 
-    tools[TOOL_TEXT - TOOL_PEN] =
-            std::make_unique<Tool>("text", TOOL_TEXT, Colors::black, TOOL_CAP_COLOR, std::nullopt);
+    tools[TOOL_TEXT - TOOL_PEN] = std::make_unique<Tool>("text", TOOL_TEXT, Colors::black, std::nullopt);
 
-    tools[TOOL_IMAGE - TOOL_PEN] =
-            std::make_unique<Tool>("image", TOOL_IMAGE, Colors::black, TOOL_CAP_NONE, std::nullopt);
+    tools[TOOL_IMAGE - TOOL_PEN] = std::make_unique<Tool>("image", TOOL_IMAGE, Colors::black, std::nullopt);
 
     tools[TOOL_SELECT_RECT - TOOL_PEN] =
-            std::make_unique<Tool>("selectRect", TOOL_SELECT_RECT, Colors::black, TOOL_CAP_NONE, std::nullopt);
+            std::make_unique<Tool>("selectRect", TOOL_SELECT_RECT, Colors::black, std::nullopt);
 
     tools[TOOL_SELECT_REGION - TOOL_PEN] =
-            std::make_unique<Tool>("selectRegion", TOOL_SELECT_REGION, Colors::black, TOOL_CAP_NONE, std::nullopt);
+            std::make_unique<Tool>("selectRegion", TOOL_SELECT_REGION, Colors::black, std::nullopt);
 
     tools[TOOL_SELECT_MULTILAYER_RECT - TOOL_PEN] =
-            std::make_unique<Tool>("selectMultiLayerRect", TOOL_SELECT_MULTILAYER_RECT, Colors::black, TOOL_CAP_NONE, std::nullopt);
+            std::make_unique<Tool>("selectMultiLayerRect", TOOL_SELECT_MULTILAYER_RECT, Colors::black, std::nullopt);
 
-    tools[TOOL_SELECT_MULTILAYER_REGION - TOOL_PEN] =
-            std::make_unique<Tool>("selectMultiLayerRegion", TOOL_SELECT_MULTILAYER_REGION, Colors::black, TOOL_CAP_NONE, std::nullopt);
+    tools[TOOL_SELECT_MULTILAYER_REGION - TOOL_PEN] = std::make_unique<Tool>(
+            "selectMultiLayerRegion", TOOL_SELECT_MULTILAYER_REGION, Colors::black, std::nullopt);
 
     tools[TOOL_SELECT_OBJECT - TOOL_PEN] =
-            std::make_unique<Tool>("selectObject", TOOL_SELECT_OBJECT, Colors::black, TOOL_CAP_NONE, std::nullopt);
+            std::make_unique<Tool>("selectObject", TOOL_SELECT_OBJECT, Colors::black, std::nullopt);
 
     tools[TOOL_VERTICAL_SPACE - TOOL_PEN] =
-            std::make_unique<Tool>("verticalSpace", TOOL_VERTICAL_SPACE, Colors::black, TOOL_CAP_NONE, std::nullopt);
+            std::make_unique<Tool>("verticalSpace", TOOL_VERTICAL_SPACE, Colors::black, std::nullopt);
 
-    tools[TOOL_HAND - TOOL_PEN] =
-            std::make_unique<Tool>("hand", TOOL_HAND, Colors::black, TOOL_CAP_NONE, std::nullopt);
+    tools[TOOL_HAND - TOOL_PEN] = std::make_unique<Tool>("hand", TOOL_HAND, Colors::black, std::nullopt);
 
     tools[TOOL_PLAY_OBJECT - TOOL_PEN] =
-            std::make_unique<Tool>("playObject", TOOL_PLAY_OBJECT, Colors::black, TOOL_CAP_NONE, std::nullopt);
+            std::make_unique<Tool>("playObject", TOOL_PLAY_OBJECT, Colors::black, std::nullopt);
 
-    tools[TOOL_DRAW_RECT - TOOL_PEN] =
-            std::make_unique<Tool>("drawRect", TOOL_DRAW_RECT, Colors::black, TOOL_CAP_NONE, std::nullopt);
+    tools[TOOL_DRAW_RECT - TOOL_PEN] = std::make_unique<Tool>("drawRect", TOOL_DRAW_RECT, Colors::black, std::nullopt);
 
     tools[TOOL_DRAW_ELLIPSE - TOOL_PEN] =
-            std::make_unique<Tool>("drawEllipse", TOOL_DRAW_ELLIPSE, Colors::black, TOOL_CAP_NONE, std::nullopt);
+            std::make_unique<Tool>("drawEllipse", TOOL_DRAW_ELLIPSE, Colors::black, std::nullopt);
 
     tools[TOOL_DRAW_ARROW - TOOL_PEN] =
-            std::make_unique<Tool>("drawArrow", TOOL_DRAW_ARROW, Colors::black, TOOL_CAP_NONE, std::nullopt);
+            std::make_unique<Tool>("drawArrow", TOOL_DRAW_ARROW, Colors::black, std::nullopt);
 
-    tools[TOOL_DRAW_DOUBLE_ARROW - TOOL_PEN] = std::make_unique<Tool>("drawDoubleArrow", TOOL_DRAW_DOUBLE_ARROW,
-                                                                      Colors::black, TOOL_CAP_NONE, std::nullopt);
+    tools[TOOL_DRAW_DOUBLE_ARROW - TOOL_PEN] =
+            std::make_unique<Tool>("drawDoubleArrow", TOOL_DRAW_DOUBLE_ARROW, Colors::black, std::nullopt);
 
-    tools[TOOL_DRAW_COORDINATE_SYSTEM - TOOL_PEN] = std::make_unique<Tool>(
-            "drawCoordinateSystem", TOOL_DRAW_COORDINATE_SYSTEM, Colors::black, TOOL_CAP_NONE, std::nullopt);
+    tools[TOOL_DRAW_COORDINATE_SYSTEM - TOOL_PEN] =
+            std::make_unique<Tool>("drawCoordinateSystem", TOOL_DRAW_COORDINATE_SYSTEM, Colors::black, std::nullopt);
 
     tools[TOOL_DRAW_SPLINE - TOOL_PEN] =
-            std::make_unique<Tool>("drawSpline", TOOL_DRAW_SPLINE, Colors::black, TOOL_CAP_NONE, std::nullopt);
+            std::make_unique<Tool>("drawSpline", TOOL_DRAW_SPLINE, Colors::black, std::nullopt);
 
-    tools[TOOL_FLOATING_TOOLBOX - TOOL_PEN] = std::make_unique<Tool>("showFloatingToolbox", TOOL_FLOATING_TOOLBOX,
-                                                                     Colors::black, TOOL_CAP_NONE, std::nullopt);
+    tools[TOOL_FLOATING_TOOLBOX - TOOL_PEN] =
+            std::make_unique<Tool>("showFloatingToolbox", TOOL_FLOATING_TOOLBOX, Colors::black, std::nullopt);
 
     tools[TOOL_SELECT_PDF_TEXT_LINEAR - TOOL_PEN] =
             std::make_unique<ToolSelectPDFText>("selectPdfTextLinear", TOOL_SELECT_PDF_TEXT_LINEAR, Colors::black);
@@ -141,16 +128,15 @@ void ToolHandler::initTools() {
     thickness[TOOL_SIZE_MEDIUM] = 2.4;
     thickness[TOOL_SIZE_THICK] = 4;
     thickness[TOOL_SIZE_VERY_THICK] = 7;
-    tools[TOOL_LASER_POINTER_PEN - TOOL_PEN] = std::make_unique<Tool>(
-            "laserPointerPen", TOOL_LASER_POINTER_PEN, Colors::red, TOOL_CAP_COLOR | TOOL_CAP_SIZE, thickness);
+    tools[TOOL_LASER_POINTER_PEN - TOOL_PEN] =
+            std::make_unique<Tool>("laserPointerPen", TOOL_LASER_POINTER_PEN, Colors::red, thickness);
     thickness[TOOL_SIZE_VERY_FINE] = 1;
     thickness[TOOL_SIZE_FINE] = 2.83;
     thickness[TOOL_SIZE_MEDIUM] = 8.50;
     thickness[TOOL_SIZE_THICK] = 19.84;
     thickness[TOOL_SIZE_VERY_THICK] = 30;
     tools[TOOL_LASER_POINTER_HIGHLIGHTER - TOOL_PEN] =
-            std::make_unique<Tool>("laserPointerHighlighter", TOOL_LASER_POINTER_HIGHLIGHTER, Colors::red,
-                                   TOOL_CAP_COLOR | TOOL_CAP_SIZE, thickness);
+            std::make_unique<Tool>("laserPointerHighlighter", TOOL_LASER_POINTER_HIGHLIGHTER, Colors::red, thickness);
 
     this->eraserButtonTool = std::make_unique<Tool>(*tools[TOOL_HIGHLIGHTER - TOOL_PEN]);
     this->stylusButton1Tool = std::make_unique<Tool>(*tools[TOOL_HIGHLIGHTER - TOOL_PEN]);

--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -755,7 +755,7 @@ void Settings::loadDeviceClasses() {
 void Settings::loadButtonConfig() {
     SElement& s = getCustomElement("buttonConfig");
 
-    for (int i = 0; i < BUTTON_COUNT; i++) {
+    for (size_t i = 0; i < BUTTON_COUNT; i++) {
         SElement& e = s.child(buttonToString(static_cast<Button>(i)));
         const auto& cfg = buttonConfig[i];
 
@@ -764,48 +764,44 @@ void Settings::loadButtonConfig() {
             ToolType type = toolTypeFromString(sType);
             cfg->action = type;
 
-            if (type == TOOL_PEN) {
-                string strokeType;
-                cfg->strokeType =
-                        e.getString("strokeType", strokeType) ? strokeTypeFromString(strokeType) : STROKE_TYPE_NONE;
-            }
-
-            if (type == TOOL_PEN || type == TOOL_HIGHLIGHTER) {
-                string drawingType;
-                if (e.getString("drawingType", drawingType)) {
-                    cfg->drawingType = drawingTypeFromString(drawingType);
+            if (type != TOOL_NONE) {
+                if (type == TOOL_PEN) {
+                    string strokeType;
+                    cfg->strokeType =
+                            e.getString("strokeType", strokeType) ? strokeTypeFromString(strokeType) : STROKE_TYPE_NONE;
                 }
 
-                string sSize;
-                if (e.getString("size", sSize)) {
-                    cfg->size = toolSizeFromString(sSize);
-                } else {
-                    // If not specified: do not change
-                    cfg->size = TOOL_SIZE_NONE;
-                }
-            }
-
-            if (type == TOOL_PEN || type == TOOL_HIGHLIGHTER || type == TOOL_TEXT) {
-                if (int iColor; e.getInt("color", iColor)) {
-                    cfg->color = Color(as_unsigned(iColor));
-                }
-            }
-
-            if (type == TOOL_ERASER) {
-                string sEraserMode;
-                if (e.getString("eraserMode", sEraserMode)) {
-                    cfg->eraserMode = eraserTypeFromString(sEraserMode);
-                } else {
-                    // If not specified: do not change
-                    cfg->eraserMode = ERASER_TYPE_NONE;
+                if (type == TOOL_PEN || type == TOOL_HIGHLIGHTER) {
+                    string drawingType;
+                    if (e.getString("drawingType", drawingType)) {
+                        cfg->drawingType = drawingTypeFromString(drawingType);
+                    }
                 }
 
-                string sSize;
-                if (e.getString("size", sSize)) {
-                    cfg->size = toolSizeFromString(sSize);
-                } else {
-                    // If not specified: do not change
-                    cfg->size = TOOL_SIZE_NONE;
+                if (type == TOOL_ERASER) {
+                    std::string sEraserMode;
+                    if (e.getString("eraserMode", sEraserMode)) {
+                        cfg->eraserMode = eraserTypeFromString(sEraserMode);
+                    } else {
+                        // If not specified: do not change
+                        cfg->eraserMode = ERASER_TYPE_NONE;
+                    }
+                }
+
+                if (xoj::tool::hasCapability(type, TOOL_CAP_SIZE)) {
+                    std::string sSize;
+                    if (e.getString("size", sSize)) {
+                        cfg->size = toolSizeFromString(sSize);
+                    } else {
+                        // If not specified: do not change
+                        cfg->size = TOOL_SIZE_NONE;
+                    }
+                }
+
+                if (xoj::tool::hasCapability(type, TOOL_CAP_COLOR)) {
+                    if (int iColor; e.getInt("color", iColor)) {
+                        cfg->color = Color(as_unsigned(iColor));
+                    }
                 }
             }
 
@@ -926,29 +922,33 @@ void Settings::saveButtonConfig() {
     SElement& s = getCustomElement("buttonConfig");
     s.clear();
 
-    for (int i = 0; i < BUTTON_COUNT; i++) {
+    for (size_t i = 0; i < BUTTON_COUNT; i++) {
         SElement& e = s.child(buttonToString(static_cast<Button>(i)));
         const auto& cfg = buttonConfig[i];
 
         ToolType const type = cfg->action;
         e.setString("tool", toolTypeToString(type).data());
 
-        if (type == TOOL_PEN) {
-            e.setString("strokeType", strokeTypeToString(cfg->strokeType).data());
-        }
+        if (type != TOOL_NONE) {
+            if (type == TOOL_PEN) {
+                e.setString("strokeType", strokeTypeToString(cfg->strokeType).data());
+            }
 
-        if (type == TOOL_PEN || type == TOOL_HIGHLIGHTER) {
-            e.setString("drawingType", drawingTypeToString(cfg->drawingType).data());
-            e.setString("size", toolSizeToString(cfg->size).data());
-        }
+            if (type == TOOL_PEN || type == TOOL_HIGHLIGHTER) {
+                e.setString("drawingType", drawingTypeToString(cfg->drawingType).data());
+            }
 
-        if (type == TOOL_PEN || type == TOOL_HIGHLIGHTER || type == TOOL_TEXT) {
-            e.setIntHex("color", int32_t(uint32_t(cfg->color)));
-        }
+            if (type == TOOL_ERASER) {
+                e.setString("eraserMode", eraserTypeToString(cfg->eraserMode).data());
+            }
 
-        if (type == TOOL_ERASER) {
-            e.setString("eraserMode", eraserTypeToString(cfg->eraserMode).data());
-            e.setString("size", toolSizeToString(cfg->size).data());
+            if (xoj::tool::hasCapability(type, TOOL_CAP_SIZE)) {
+                e.setString("size", toolSizeToString(cfg->size).data());
+            }
+
+            if (xoj::tool::hasCapability(type, TOOL_CAP_COLOR)) {
+                e.setIntHex("color", int32_t(uint32_t(cfg->color)));
+            }
         }
 
         // Touch device

--- a/src/core/gui/PdfFloatingToolbox.cpp
+++ b/src/core/gui/PdfFloatingToolbox.cpp
@@ -71,6 +71,9 @@ void PdfFloatingToolbox::show(int x, int y) {
     gtk_widget_translate_coordinates(gtk_widget_get_toplevel(this->floatingToolbox), GTK_WIDGET(overlay.get()), x, y,
                                      &this->position.x, &this->position.y);
     this->show();
+
+    // Record the color now: the active tool may change while the toolbox is up (e.g. if the tool is linked to a button)
+    this->color = theMainWindow->getXournal()->getControl()->getToolHandler()->getColor();
 }
 
 void PdfFloatingToolbox::hide() {
@@ -174,8 +177,6 @@ void PdfFloatingToolbox::createStrokes(PdfMarkerStyle position, PdfMarkerStyle w
     PageRef page = control->getCurrentPage();
     Layer* layer = page->getSelectedLayer();
 
-    auto color = theMainWindow->getXournal()->getControl()->getToolHandler()->getColor();
-
     Range dirtyRange;
     std::vector<ElementPtr> strokes;
     for (XojPdfRectangle rect: textRects) {
@@ -192,7 +193,7 @@ void PdfFloatingToolbox::createStrokes(PdfMarkerStyle position, PdfMarkerStyle w
         const double w = width == PdfMarkerStyle::WIDTH_TEXT_LINE ? 1 : rectWidth;
 
         auto stroke = std::make_unique<Stroke>();
-        stroke->setColor(color);
+        stroke->setColor(this->color);
         stroke->setFill(markerOpacity);
         stroke->setToolType(StrokeTool::HIGHLIGHTER);
         stroke->setWidth(w);

--- a/src/core/gui/PdfFloatingToolbox.h
+++ b/src/core/gui/PdfFloatingToolbox.h
@@ -1,15 +1,15 @@
 #pragma once
 
-#include <cstdint>    // for uint8_t
-#include <memory>     // for unique_ptr
+#include <cstdint>  // for uint8_t
+#include <memory>   // for unique_ptr
 
 #include <gdk/gdk.h>  // for GdkRectangle
 #include <glib.h>     // for gboolean
 #include <gtk/gtk.h>  // for GtkButton, GtkOverlay
 
 #include "pdf/base/XojPdfPage.h"    // for XojPdfPageSelectionStyle
+#include "util/Color.h"             // for Color
 #include "util/raii/GObjectSPtr.h"  // for GObjectSPtr
-#include "util/Color.h"  // for Color
 
 class MainWindow;
 class PdfElemSelection;

--- a/src/core/gui/PdfFloatingToolbox.h
+++ b/src/core/gui/PdfFloatingToolbox.h
@@ -9,6 +9,7 @@
 
 #include "pdf/base/XojPdfPage.h"    // for XojPdfPageSelectionStyle
 #include "util/raii/GObjectSPtr.h"  // for GObjectSPtr
+#include "util/Color.h"  // for Color
 
 class MainWindow;
 class PdfElemSelection;
@@ -82,6 +83,7 @@ private:
 private:
     GtkWidget* floatingToolbox;
     MainWindow* theMainWindow;
+    Color color;  ///< Used for strokes/highlighting
 
     /// The overlay that the toolbox should be displayed in.
     xoj::util::GObjectSPtr<GtkOverlay> overlay;

--- a/src/core/gui/dialog/ButtonConfigGui.cpp
+++ b/src/core/gui/dialog/ButtonConfigGui.cpp
@@ -276,9 +276,9 @@ void ButtonConfigGui::enableDisableTools() {
     gtk_tree_model_get_value(model, &iter, 2, &value);
     auto action = static_cast<ToolType>(g_value_get_int(&value));
 
-    gtk_widget_set_visible(cbThickness, xoj::tool::hasCapability(action, TOOL_CAP_SIZE));
-    gtk_widget_set_visible(colorButton, xoj::tool::hasCapability(action, TOOL_CAP_COLOR));
-    gtk_widget_set_visible(cbDrawingType, xoj::tool::hasCapability(action, TOOL_CAP_RECTANGLE));
+    gtk_widget_set_visible(cbThickness, action != TOOL_NONE && xoj::tool::hasCapability(action, TOOL_CAP_SIZE));
+    gtk_widget_set_visible(colorButton, action != TOOL_NONE && xoj::tool::hasCapability(action, TOOL_CAP_COLOR));
+    gtk_widget_set_visible(cbDrawingType, action != TOOL_NONE && xoj::tool::hasCapability(action, TOOL_CAP_RECTANGLE));
     gtk_widget_set_visible(cbEraserType, action == TOOL_ERASER);
     gtk_widget_set_visible(cbStrokeType, action == TOOL_PEN);
 }

--- a/src/core/gui/dialog/ButtonConfigGui.cpp
+++ b/src/core/gui/dialog/ButtonConfigGui.cpp
@@ -276,67 +276,9 @@ void ButtonConfigGui::enableDisableTools() {
     gtk_tree_model_get_value(model, &iter, 2, &value);
     auto action = static_cast<ToolType>(g_value_get_int(&value));
 
-    switch (action) {
-        case TOOL_PEN:
-            gtk_widget_set_visible(cbThickness, true);
-            gtk_widget_set_visible(colorButton, true);
-            gtk_widget_set_visible(cbDrawingType, true);
-            gtk_widget_set_visible(cbEraserType, false);
-            gtk_widget_set_visible(cbStrokeType, true);
-            break;
-        case TOOL_HIGHLIGHTER:
-            gtk_widget_set_visible(cbThickness, true);
-            gtk_widget_set_visible(colorButton, true);
-            gtk_widget_set_visible(cbDrawingType, true);
-            gtk_widget_set_visible(cbEraserType, false);
-            gtk_widget_set_visible(cbStrokeType, false);
-            break;
-
-        case TOOL_ERASER:
-            gtk_widget_set_visible(cbThickness, true);
-            gtk_widget_set_visible(colorButton, false);
-            gtk_widget_set_visible(cbDrawingType, false);
-            gtk_widget_set_visible(cbEraserType, true);
-            gtk_widget_set_visible(cbStrokeType, false);
-            break;
-
-        case TOOL_TEXT:
-        case TOOL_SELECT_PDF_TEXT_LINEAR:
-        case TOOL_SELECT_PDF_TEXT_RECT:
-            gtk_widget_set_visible(cbThickness, false);
-            gtk_widget_set_visible(colorButton, true);
-            gtk_widget_set_visible(cbDrawingType, false);
-            gtk_widget_set_visible(cbEraserType, false);
-            gtk_widget_set_visible(cbStrokeType, false);
-            break;
-
-        case TOOL_LASER_POINTER_PEN:
-        case TOOL_LASER_POINTER_HIGHLIGHTER:
-            gtk_widget_set_visible(cbThickness, true);
-            gtk_widget_set_visible(colorButton, true);
-            gtk_widget_set_visible(cbDrawingType, false);
-            gtk_widget_set_visible(cbEraserType, false);
-            gtk_widget_set_visible(cbStrokeType, false);
-            break;
-
-        case TOOL_NONE:
-        case TOOL_IMAGE:
-            // case TOOL_DRAW_RECT:
-            // case TOOL_DRAW_ELLIPSE:
-        case TOOL_SELECT_RECT:
-        case TOOL_SELECT_REGION:
-        case TOOL_SELECT_MULTILAYER_RECT:
-        case TOOL_SELECT_MULTILAYER_REGION:
-        case TOOL_VERTICAL_SPACE:
-        case TOOL_HAND:
-            gtk_widget_set_visible(cbThickness, false);
-            gtk_widget_set_visible(colorButton, false);
-            gtk_widget_set_visible(cbDrawingType, false);
-            gtk_widget_set_visible(cbEraserType, false);
-            gtk_widget_set_visible(cbStrokeType, false);
-            break;
-        default:
-            g_warning("Unhandled tool in ButtonConfigGui");
-            break;
-    }
+    gtk_widget_set_visible(cbThickness, xoj::tool::hasCapability(action, TOOL_CAP_SIZE));
+    gtk_widget_set_visible(colorButton, xoj::tool::hasCapability(action, TOOL_CAP_COLOR));
+    gtk_widget_set_visible(cbDrawingType, xoj::tool::hasCapability(action, TOOL_CAP_RECTANGLE));
+    gtk_widget_set_visible(cbEraserType, action == TOOL_ERASER);
+    gtk_widget_set_visible(cbStrokeType, action == TOOL_PEN);
 }

--- a/src/core/gui/dialog/ButtonConfigGui.cpp
+++ b/src/core/gui/dialog/ButtonConfigGui.cpp
@@ -285,8 +285,6 @@ void ButtonConfigGui::enableDisableTools() {
             gtk_widget_set_visible(cbStrokeType, true);
             break;
         case TOOL_HIGHLIGHTER:
-        case TOOL_SELECT_PDF_TEXT_LINEAR:
-        case TOOL_SELECT_PDF_TEXT_RECT:
             gtk_widget_set_visible(cbThickness, true);
             gtk_widget_set_visible(colorButton, true);
             gtk_widget_set_visible(cbDrawingType, true);
@@ -303,6 +301,8 @@ void ButtonConfigGui::enableDisableTools() {
             break;
 
         case TOOL_TEXT:
+        case TOOL_SELECT_PDF_TEXT_LINEAR:
+        case TOOL_SELECT_PDF_TEXT_RECT:
             gtk_widget_set_visible(cbThickness, false);
             gtk_widget_set_visible(colorButton, true);
             gtk_widget_set_visible(cbDrawingType, false);


### PR DESCRIPTION
Fixes #7524 

This PR makes sure that color and size are stored in the settings file depending on the tool's capabilities, instead of the hard-coded "pen or highlighter (or text)". Doing this required a little bit more work than I hoped though (see changes in ToolEnums and ToolHandler).

I tested a dozen cases, so hopefully I did not introduce any new bug. Note that the transfer of information (the tool capabilities) from ToolHandler to ToolEnums was automated (copied + regex) so there should not be any new issues because of that.

@mjg Would you be able to test this and confirm is works?