### PR TITLE
fixup: check lua def file on all input file changes

### DIFF
--- a/.github/workflows/gen-lua-def-run.yml
+++ b/.github/workflows/gen-lua-def-run.yml
@@ -8,6 +8,7 @@ on:
       - 'src/core/control/tools/EditSelection.h'
       - 'src/core/enums/generated/Action.NameMap.generated.h'
       - 'src/core/plugin/luapi_application.h'
+      - 'plugins/luapi_application.def.lua'
 
 
 jobs:

--- a/.github/workflows/gen-lua-def-run.yml
+++ b/.github/workflows/gen-lua-def-run.yml
@@ -4,8 +4,11 @@ on:
   pull_request:
     branches: [ "master", "release-*" ]
     paths:
-      - 'src/core/plugin/luapi_application.h'
+      - 'src/core/control/ToolEnums.h'
+      - 'src/core/control/tools/EditSelection.h'
       - 'src/core/enums/generated/Action.NameMap.generated.h'
+      - 'src/core/plugin/luapi_application.h'
+
 
 jobs:
   Test_Lua_definition:

--- a/plugins/luapi_application.def.lua
+++ b/plugins/luapi_application.def.lua
@@ -1206,6 +1206,7 @@ app.C = {
     Tool_selectPdfTextRect = 22,
     Tool_laserPointerPen = 23,
     Tool_laserPointerHighlighter = 24,
+    Tool_link = 25,
     EraserType_none = 0,
     EraserType_default = 1,
     EraserType_whiteout = 2,


### PR DESCRIPTION
should fixup the issues discovered in https://github.com/xournalpp/xournalpp/pull/6823#issuecomment-4718844825.

The trigger for the CI/CD job did not list all files which are processed by the script.

Alternatively, we could of course just run the script on every commit no matter what files have been touched.