### PR TITLE
Load settings from system config dirs as fallback

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -1,8 +1,8 @@
 #include "Control.h"
 
-#include <algorithm>   // for max
-#include <cstdlib>     // for size_t
-#include <exception>   // for exce...
+#include <algorithm>  // for max
+#include <cstdlib>    // for size_t
+#include <exception>  // for exce...
 #include <functional>  // for bind
 #include <iterator>    // for end
 #include <memory>      // for make...

--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -136,10 +136,8 @@ Control::Control(GApplication* gtkApp, GladeSearchpath* gladeSearchPath, bool di
     auto saveName = Util::getConfigFile(SETTINGS_XML_FILE);
 
     if (name != saveName) {
-        g_message("Loading settings from system config: %s", name.string().c_str());
         this->settings = new Settings(std::move(saveName), std::move(name));
     } else {
-        g_message("Loading settings from user config: %s", name.string().c_str());
         this->settings = new Settings(std::move(name));
     }
     this->settings->load();

--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -1,8 +1,8 @@
 #include "Control.h"
 
-#include <algorithm>  // for max
-#include <cstdlib>    // for size_t
-#include <exception>  // for exce...
+#include <algorithm>   // for max
+#include <cstdlib>     // for size_t
+#include <exception>   // for exce...
 #include <functional>  // for bind
 #include <iterator>    // for end
 #include <memory>      // for make...
@@ -132,8 +132,16 @@ Control::Control(GApplication* gtkApp, GladeSearchpath* gladeSearchPath, bool di
     this->metadata = new MetadataManager();
     this->cursor = new XournalppCursor(this);
 
-    auto name = Util::getConfigFile(SETTINGS_XML_FILE);
-    this->settings = new Settings(std::move(name));
+    auto name = Util::getConfigFileWithFallback(SETTINGS_XML_FILE);
+    auto saveName = Util::getConfigFile(SETTINGS_XML_FILE);
+
+    if (name != saveName) {
+        g_message("Loading settings from system config: %s", name.string().c_str());
+        this->settings = new Settings(std::move(saveName), std::move(name));
+    } else {
+        g_message("Loading settings from user config: %s", name.string().c_str());
+        this->settings = new Settings(std::move(name));
+    }
     this->settings->load();
     this->loadPaletteFromSettings();
 

--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -21,9 +21,9 @@
 #include "gui/toolbarMenubar/model/ColorPalette.h"  // for Palette
 #include "model/FormatDefinitions.h"                // for FormatUnits, XOJ_...
 #include "util/Color.h"
-#include "util/PathUtil.h"  // for getConfigFile
-#include "util/Util.h"      // for PRECISION_FORMAT_...
-#include "util/i18n.h"      // for _
+#include "util/PathUtil.h"    // for getConfigFile
+#include "util/Util.h"        // for PRECISION_FORMAT_...
+#include "util/i18n.h"        // for _
 #include "util/safe_casts.h"  // for as_unsigned
 #include "util/utf8_view.h"   // for utf8_view
 
@@ -49,7 +49,11 @@ constexpr auto DEFAULT_TOOLBAR = "Portrait";
     com = xmlNewComment((const xmlChar*)(var)); \
     xmlAddPrevSibling(xmlNode, com);
 
-Settings::Settings(fs::path filepath): filepath(std::move(filepath)) { loadDefault(); }
+Settings::Settings(fs::path savePath): savePath(std::move(savePath)), loadPath(this->savePath) { loadDefault(); }
+
+Settings::Settings(fs::path savePath, fs::path loadPath): savePath(std::move(savePath)), loadPath(std::move(loadPath)) {
+    loadDefault();
+}
 
 Settings::~Settings() = default;
 
@@ -835,12 +839,12 @@ void Settings::loadButtonConfig() {
 auto Settings::load() -> bool {
     xmlKeepBlanksDefault(0);
 
-    if (!fs::exists(filepath)) {
-        g_warning("Settings file %s does not exist. Regenerating. ", filepath.string().c_str());
+    if (!fs::exists(loadPath)) {
+        g_warning("Settings file %s does not exist. Regenerating. ", loadPath.string().c_str());
         save();
     }
 
-    xmlDocPtr doc = xmlParseFile(char_cast(filepath.u8string().c_str()));
+    xmlDocPtr doc = xmlParseFile(char_cast(loadPath.u8string().c_str()));
 
     if (doc == nullptr) {
         g_warning("Settings::load:: doc == null, could not load Settings!\n");
@@ -849,14 +853,14 @@ auto Settings::load() -> bool {
 
     xmlNodePtr cur = xmlDocGetRootElement(doc);
     if (cur == nullptr) {
-        g_message("The settings file \"%s\" is empty", filepath.string().c_str());
+        g_message("The settings file \"%s\" is empty", loadPath.string().c_str());
         xmlFreeDoc(doc);
 
         return false;
     }
 
     if (xmlStrcmp(cur->name, reinterpret_cast<const xmlChar*>("settings"))) {
-        g_message("File \"%s\" is of the wrong type", filepath.string().c_str());
+        g_message("File \"%s\" is of the wrong type", loadPath.string().c_str());
         xmlFreeDoc(doc);
 
         return false;
@@ -1249,7 +1253,7 @@ void Settings::save() {
         saveData(root, p.first, p.second);
     }
 
-    xmlSaveFormatFileEnc(char_cast(filepath.u8string().c_str()), doc, "UTF-8", 1);
+    xmlSaveFormatFileEnc(char_cast(savePath.u8string().c_str()), doc, "UTF-8", 1);
     xmlFreeDoc(doc);
 }
 

--- a/src/core/control/settings/Settings.h
+++ b/src/core/control/settings/Settings.h
@@ -104,6 +104,7 @@ private:
 class Settings {
 public:
     /*[[implicit]]*/ Settings(fs::path filepath);
+    /*[[implicit]]*/ Settings(fs::path filepath, fs::path loadPath);
     Settings(const Settings& settings) = delete;
     void operator=(const Settings& settings) = delete;
     virtual ~Settings();
@@ -615,13 +616,19 @@ public:
 
     LatexSettings latexSettings{};
 
-    inline const fs::path& getSettingsFile() const { return filepath; }
+    inline const fs::path& getSettingsFile() const { return savePath; }
 
 private:
     /**
-     *  The config filepath
+     *  The config file path used for saving
      */
-    fs::path filepath;
+    fs::path savePath;
+
+    /**
+     *  The config file path used for loading, may differ from savePath
+     *  when falling back to system directories
+     */
+    fs::path loadPath;
 
 private:
     /**

--- a/src/core/control/settings/Settings.h
+++ b/src/core/control/settings/Settings.h
@@ -103,8 +103,8 @@ private:
 
 class Settings {
 public:
-    /*[[implicit]]*/ Settings(fs::path savePath);
-    /*[[implicit]]*/ Settings(fs::path savePath, fs::path loadPath);
+    explicit Settings(fs::path savePath);
+    Settings(fs::path savePath, fs::path loadPath);
     Settings(const Settings& settings) = delete;
     void operator=(const Settings& settings) = delete;
     virtual ~Settings();

--- a/src/core/control/settings/Settings.h
+++ b/src/core/control/settings/Settings.h
@@ -103,8 +103,8 @@ private:
 
 class Settings {
 public:
-    /*[[implicit]]*/ Settings(fs::path filepath);
-    /*[[implicit]]*/ Settings(fs::path filepath, fs::path loadPath);
+    /*[[implicit]]*/ Settings(fs::path savePath);
+    /*[[implicit]]*/ Settings(fs::path savePath, fs::path loadPath);
     Settings(const Settings& settings) = delete;
     void operator=(const Settings& settings) = delete;
     virtual ~Settings();

--- a/src/util/PathUtil.cpp
+++ b/src/util/PathUtil.cpp
@@ -398,6 +398,33 @@ auto Util::getConfigFile(const fs::path& relativeFileName) -> fs::path {
     return p;
 }
 
+auto Util::getConfigFileWithFallback(const fs::path& relativeFileName) -> fs::path {
+    // Try user config home
+    fs::path userConfigPath = getConfigFile(relativeFileName);
+    if (fs::exists(userConfigPath)) {
+        g_message("Found user config file at: %s", userConfigPath.string().c_str());
+        return userConfigPath;
+    }
+
+    // Look in system config directories
+    g_message("Looking for config file in system config directories");
+    const gchar* const* systemConfigDirs = g_get_system_config_dirs();
+    if (systemConfigDirs != nullptr) {
+        for (int i = 0; systemConfigDirs[i] != nullptr; i++) {
+            fs::path systemConfigPath = GFilename(systemConfigDirs[i]).toPath().value_or(fs::path());
+            systemConfigPath /= CONFIG_FOLDER_NAME;
+            systemConfigPath /= relativeFileName;
+
+            if (fs::exists(systemConfigPath)) {
+                g_message("Found system config file at: %s", systemConfigPath.string().c_str());
+                return systemConfigPath;
+            }
+        }
+    }
+
+    return userConfigPath;
+}
+
 auto Util::getCacheFile(const fs::path& relativeFileName) -> fs::path {
     fs::path p = getCacheSubfolder(relativeFileName.parent_path());
     p /= relativeFileName.filename();

--- a/src/util/PathUtil.cpp
+++ b/src/util/PathUtil.cpp
@@ -1,7 +1,8 @@
 #include "util/PathUtil.h"
 
 #include <algorithm>
-#include <cstdlib>      // for system
+#include <cstdlib>  // for system
+#include <filesystem>
 #include <fstream>      // for ifstream, char_traits, basic_ist...
 #include <iterator>     // for begin
 #include <sstream>      // for stringstream
@@ -401,9 +402,14 @@ auto Util::getConfigFile(const fs::path& relativeFileName) -> fs::path {
 auto Util::getConfigFileWithFallback(const fs::path& relativeFileName) -> fs::path {
     // Try user config home
     fs::path userConfigPath = getConfigFile(relativeFileName);
-    if (fs::exists(userConfigPath)) {
+    std::error_code ec;
+    if (fs::exists(userConfigPath, ec)) {
         g_message("Found user config file at: %s", userConfigPath.string().c_str());
         return userConfigPath;
+    }
+    if (ec) {
+        g_warning("Error checking config path existence (%s): %s", userConfigPath.string().c_str(),
+                  ec.message().c_str());
     }
 
     // Look in system config directories
@@ -411,13 +417,22 @@ auto Util::getConfigFileWithFallback(const fs::path& relativeFileName) -> fs::pa
     const gchar* const* systemConfigDirs = g_get_system_config_dirs();
     if (systemConfigDirs != nullptr) {
         for (int i = 0; systemConfigDirs[i] != nullptr; i++) {
-            fs::path systemConfigPath = GFilename(systemConfigDirs[i]).toPath().value_or(fs::path());
+            auto p = GFilename(systemConfigDirs[i]).toPath();
+            if (!p) {
+                g_warning("Could not convert system config dir to path: %s", systemConfigDirs[i]);
+                continue;
+            }
+            fs::path systemConfigPath = *p;
             systemConfigPath /= CONFIG_FOLDER_NAME;
             systemConfigPath /= relativeFileName;
 
-            if (fs::exists(systemConfigPath)) {
+            if (fs::exists(systemConfigPath, ec)) {
                 g_message("Found system config file at: %s", systemConfigPath.string().c_str());
                 return systemConfigPath;
+            }
+            if (ec) {
+                g_warning("Error checking system config path existence (%s): %s", systemConfigPath.string().c_str(),
+                          ec.message().c_str());
             }
         }
     }

--- a/src/util/PathUtil.cpp
+++ b/src/util/PathUtil.cpp
@@ -1,8 +1,7 @@
 #include "util/PathUtil.h"
 
 #include <algorithm>
-#include <cstdlib>  // for system
-#include <filesystem>
+#include <cstdlib>      // for system
 #include <fstream>      // for ifstream, char_traits, basic_ist...
 #include <iterator>     // for begin
 #include <sstream>      // for stringstream

--- a/src/util/include/util/PathUtil.h
+++ b/src/util/include/util/PathUtil.h
@@ -151,6 +151,7 @@ auto system_single_byte_filename(const fs::path& path) -> std::string;
 [[maybe_unused]] [[nodiscard]] fs::path getDataSubfolder(const fs::path& subfolder = "");
 [[maybe_unused]] [[nodiscard]] fs::path getStateSubfolder(const fs::path& subfolder = "");
 [[maybe_unused]] [[nodiscard]] fs::path getConfigFile(const fs::path& relativeFileName = "");
+[[maybe_unused]] [[nodiscard]] fs::path getConfigFileWithFallback(const fs::path& relativeFileName = "");
 [[maybe_unused]] [[nodiscard]] fs::path getCacheFile(const fs::path& relativeFileName = "");
 [[maybe_unused]] [[nodiscard]] fs::path getTmpDirSubfolder(const fs::path& subfolder = "");
 [[maybe_unused]] [[nodiscard]] fs::path getAutosaveFilepath();


### PR DESCRIPTION
When `settings.xml` file doesn't exist in `XDG_CONFIG_HOME`, try to load from paths in `XDG_CONFIG_DIRS`.
This closes #4657 I guess.

I am not very good in C/C++. After bonking my head for two days, I asked an LLM for help (not vibe coded). If there is some issue in my changes, I will be here to fix it.
