### PR TITLE
Add mutex locks for lua write functions

### DIFF
--- a/src/core/plugin/luapi_application.h
+++ b/src/core/plugin/luapi_application.h
@@ -1050,7 +1050,10 @@ static void addStrokeHelper(lua_State* L, std::unique_ptr<Stroke> stroke) {
     lua_pop(L, 5);  // Finally done with all that Lua data.
 
     // Add the stroke
-    layer->addElement(std::move(stroke));
+    {
+        std::lock_guard lock(*ctrl->getDocument());
+        layer->addElement(std::move(stroke));
+    }
     return;
 }
 
@@ -1532,7 +1535,10 @@ static int applib_addTexts(lua_State* L) {
 
         // Finish building the Text and apply it to the layer.
         texts.push_back(text.get());
-        layer->addElement(std::move(text));
+        {
+            std::lock_guard lock(*control->getDocument());
+            layer->addElement(std::move(text));
+        }
         // Onto the next text
     }
 
@@ -2015,6 +2021,8 @@ static int applib_changeBackgroundPdfPageNr(lua_State* L) {
         }
     }
     if (selected < doc->getPdfPageCount()) {
+        std::lock_guard lock(*doc);
+
         // no need to set a type, if we set the page number the type is also set
         page->setBackgroundPdfPageNr(selected);
 
@@ -2761,6 +2769,7 @@ static int applib_setBackgroundName(lua_State* L) {
 
     if (lua_isstring(L, 1)) {
         auto name = lua_tostring(L, 1);
+        std::lock_guard lock(*control->getDocument());
         page->setBackgroundName(name);
     }
 


### PR DESCRIPTION
I wrote a Lua plugin that adds a toolbar button to duplicate a selection of strokes and texts (this is possible with a right mouse click but that's not applicable when in tablet mode). It works, but whenever I select more than a few strokes and try to duplicate them, Xournal++ crashes on `app.addStrokes`.

Via `git bisect` I found out that the first bad commit that caused this crash is 8f80d2625fdf020c5dd7c8d973d294b87b72a122. Previously, [Control::getCurrentPage](https://github.com/xournalpp/xournalpp/blob/967dc49889c23eee9cc81c0866d3ccb2a37adbde/src/core/control/Control.cpp#L1128) used an exclusive lock, but since that commit it uses a shared lock. That introduced this problem because [addStrokeHelper](https://github.com/xournalpp/xournalpp/blob/967dc49889c23eee9cc81c0866d3ccb2a37adbde/src/core/plugin/luapi_application.h#L1026) called `getCurrentPage` and before the change waited until the lock was acquired.
Now that `getCurrentPage` uses a shared lock, the lock can be acquired while something else (I don't know exactly what) also holds that shared lock. But since `addStrokeHelper` also writes (i.e. adds strokes) this caused the crash.

To fix this, I added exclusive locks in [luapi_application.h](https://github.com/xournalpp/xournalpp/blob/master/src/core/plugin/luapi_application.h) in `addStrokeHelper` and a few other places where `getCurrentPage` is called and a write operation is done.

If anyone wants to verify the crash, [here](https://github.com/user-attachments/files/29180344/DuplicateSelection.zip) is my Lua plugin and [here](https://github.com/user-attachments/files/29180372/2026-06-21-Notiz-14-46.zip) is a zip with a Xournal++ file inside where it consistently crashes for me when I select everything and try to duplicate it using the plugin.