### PR TITLE
Clear modifier states when stylus leaves the screen

### DIFF
--- a/src/core/gui/inputdevices/StylusInputHandler.cpp
+++ b/src/core/gui/inputdevices/StylusInputHandler.cpp
@@ -103,6 +103,8 @@ auto StylusInputHandler::handleImpl(InputEvent const& event) -> bool {
     if (event.type == LEAVE_EVENT) {
         this->inputContext->getHandRecognition()->unblock();
         this->actionLeaveWindow(event);
+        this->modifier2 = false;
+        this->modifier3 = false;
     }
 
     // Trigger end of action if pen tip leaves screen or mouse button is released


### PR DESCRIPTION
Fixes #6833. See #7483 for more context. This should not cause any issues since the modifiers should be off when the stylus leaves the screen. For my stylus, it's modifiers 2 and 3, but I do not know how it would affect other tablets, so testing would be necessary.