### PR TITLE
Add libxml2-16 (>=2.00) as an alternative in debian/control

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: https://github.com/xournalpp/xournalpp/
 
 Package: xournalpp
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, libglib2.0-0 (>= 2.32), libgtk-3-0 (>= 3.18), libpoppler-glib8 (>= 0.41.0), libxml2 (>= 2.0.0), libportaudiocpp0 (>= 12), libsndfile1 (>= 1.0.25), liblua5.3-0, libzip4 (>= 1.0.1) | libzip5, zlib1g, libc6, librsvg2-2 (>= 2.40), libgtksourceview-4-0, qpdf (>= 10.6)
+Depends: ${shlibs:Depends}, ${misc:Depends}, libglib2.0-0 (>= 2.32), libgtk-3-0 (>= 3.18), libpoppler-glib8 (>= 0.41.0), libxml2 (>= 2.0.0) | libxml2-16 (>= 2.0.0), libportaudiocpp0 (>= 12), libsndfile1 (>= 1.0.25), liblua5.3-0, libzip4 (>= 1.0.1) | libzip5, zlib1g, libc6, librsvg2-2 (>= 2.40), libgtksourceview-4-0, qpdf (>= 10.6)
 Suggests: texlive-base, texlive-latex-extra
 Description: Xournal++ - Open source hand note-taking program
  Xournal++ is a hand note-taking software written in C++ with the target of


### PR DESCRIPTION
This is relevant for Debian packages built with `dpkg-buildpackage` like those on Launchpad for the PPA (which currently cannot be installed on Ubuntu 26.04).

PR #7418 only fixed `CPACK_DEBIAN_PACKAGE_DEPENDS` from the `CMakeLists.txt` file that is used for building Debian packages on Github.

Packages with the wrong dependencies can also be fixed manually using

```term
dpkg-deb -R ./old.deb tmp-dir
nano tmp-dir/DEBIAN/control
dpkg-deb -b tmp-dir new.deb
```

