### PR TITLE
Fix data-race related segfault in RenderJob::renderToBuffer()

### DIFF
--- a/src/core/control/ToolHandler.cpp
+++ b/src/core/control/ToolHandler.cpp
@@ -558,8 +558,9 @@ void ToolHandler::loadSettings() {
 
 bool ToolHandler::pointActiveToolToButtonTool(Button button) {
     Tool* tool = getButtonTool(button);
-    if (this->activeTool == tool)
+    if (!tool || this->activeTool == tool) {
         return false;
+    }
     this->activeTool = tool;
     return true;
 }

--- a/src/core/gui/inputdevices/InputUtils.cpp
+++ b/src/core/gui/inputdevices/InputUtils.cpp
@@ -7,6 +7,7 @@
 #include "control/settings/ButtonConfig.h"   // for ButtonConfig
 #include "control/settings/Settings.h"       // for Settings
 #include "control/settings/SettingsEnums.h"  // for Button, BUTTON_TOUCH
+#include "util/Assert.h"
 
 
 bool InputUtils::applyButton(ToolHandler* toolHandler, Settings* settings, Button button) {
@@ -16,11 +17,8 @@ bool InputUtils::applyButton(ToolHandler* toolHandler, Settings* settings, Butto
         toolChanged = true;
         ButtonConfig* cfg = settings->getButtonConfig(button);
 
-        // if ToolChange is not activated for this button stay with ToolBartool
-        if (cfg->getAction() == TOOL_NONE)
-            toolChanged = toolHandler->pointActiveToolToToolbarTool();
-        else
-            cfg->applyNoChangeSettings(toolHandler, button);
+        xoj_assert(cfg->getAction() != TOOL_NONE);
+        cfg->applyNoChangeSettings(toolHandler, button);
     }
     return toolChanged;
 }


### PR DESCRIPTION
Fix #7251. 
See [this comment](https://github.com/xournalpp/xournalpp/issues/7251#issuecomment-4885664951) for a description of the issue, explaining why this PR fixes it.


Merging once the CI clears.