### PR TITLE
Tex undo fix

### DIFF
--- a/src/core/control/LatexController.cpp
+++ b/src/core/control/LatexController.cpp
@@ -300,8 +300,8 @@ void LatexController::insertTexImage() {
         auto insertUndoAction = std::make_unique<InsertUndoAction>(page, layer, this->temporaryRender.get());
         groupUndoAction->addAction(std::move(insertUndoAction));
         undo->addUndoAction(std::move(groupUndoAction));
-        Range oldRange(selectedElem->getSnappedBounds());
-        Range newRange(temporaryRender->getSnappedBounds());
+        Range oldRange(selectedElem->boundingRect());
+        Range newRange(temporaryRender->boundingRect());
         Range repaintRange = oldRange.unite(newRange);
         page->fireRangeChanged(repaintRange);
     } else {

--- a/src/core/control/LatexController.cpp
+++ b/src/core/control/LatexController.cpp
@@ -30,6 +30,8 @@
 #include "model/TexImage.h"                  // for TexImage
 #include "model/Text.h"                      // for Text
 #include "model/XojPage.h"                   // for XojPage
+#include "undo/DeleteUndoAction.h"           // for DeleteUndoAction
+#include "undo/GroupUndoAction.h"            // for GroupUndoAction
 #include "undo/InsertUndoAction.h"           // for InsertUndoAction
 #include "undo/UndoRedoHandler.h"            // for UndoRedoHandler
 #include "util/Assert.h"                     // for xoj_assert
@@ -268,7 +270,9 @@ void LatexController::insertTexImage() {
     xoj_assert(this->isValidTex);
     xoj_assert(this->temporaryRender != nullptr);
 
-    auto lock = std::shared_lock(*this->control->getDocument());
+    Document* doc = this->control->getDocument();
+
+    auto lock = std::shared_lock(*doc);
     Layer* layer = page->getSelectedLayer();
     XournalView* xournal = this->control->getWindow()->getXournal();
     auto pageNr = xournal->getCurrentPage();
@@ -280,18 +284,31 @@ void LatexController::insertTexImage() {
     }
     lock.unlock();
 
-    /* Clearing the old image and creating the new one creates two separate undo actions; I don't
-       know yet how to merge that to one. (That bug was already present before.) */
-
     this->control->clearSelectionEndText();
     if (this->selectedElem) {
-        auto sel = SelectionFactory::createFromElementOnActiveLayer(control, page, view, selectedElem);
-        view->getXournal()->deleteSelection(sel.release());
-        this->selectedElem = nullptr;
+        const auto undo = control->getUndoRedoHandler();
+        auto groupUndoAction = std::make_unique<GroupUndoAction>();
+        auto deleteUndoAction = std::make_unique<DeleteUndoAction>(page, false);
+        doc->lock();
+        auto [orig, elementIndex] = layer->removeElement(selectedElem);
+        doc->unlock();
+        if (elementIndex != Element::InvalidIndex) [[likely]] {
+            deleteUndoAction->addElement(layer, std::move(orig), elementIndex);
+        }
+        groupUndoAction->addAction(std::move(deleteUndoAction));
+
+        auto insertUndoAction = std::make_unique<InsertUndoAction>(page, layer, this->temporaryRender.get());
+        groupUndoAction->addAction(std::move(insertUndoAction));
+        undo->addUndoAction(std::move(groupUndoAction));
+        Range oldRange(selectedElem->getSnappedBounds());
+        Range newRange(temporaryRender->getSnappedBounds());
+        Range repaintRange = oldRange.unite(newRange);
+        page->fireRangeChanged(repaintRange);
+    } else {
+        control->getUndoRedoHandler()->addUndoAction(
+                std::make_unique<InsertUndoAction>(page, layer, this->temporaryRender.get()));
     }
 
-    control->getUndoRedoHandler()->addUndoAction(
-            std::make_unique<InsertUndoAction>(page, layer, this->temporaryRender.get()));
 
     // Select element
     auto selection =


### PR DESCRIPTION
Currently, editing a tex object creates two undo actions (one removing the old object and one creating the new one); see #7583. This is a fix for this.

However, I am not sure whether I locked the document as necessary in LatexController::insertTexImage (probably not). Concretely:
- Does one need to acquire a unique lock when calling layer->removeElement?
- Does one need to acquire a unique lock when creating a selected element using SelectionFactory::createFromFloatingElement and setSelection?
- Does one need to acquire a shared lock while using a variable layer (obtained from page->getSelectedLayer())?
(If this is the case, then there's probably also a similar bug in LinkHandler::startEditing, where a layer variable is created within a lock, but still used after the lock.)