### PR TITLE
Fix "System default" audio device resolving to null device instead of default

### DIFF
--- a/src/core/audio/PortAudioConsumer.cpp
+++ b/src/core/audio/PortAudioConsumer.cpp
@@ -30,8 +30,12 @@ auto PortAudioConsumer::getOutputDevices() const -> std::vector<DeviceInfo> {
 }
 
 auto PortAudioConsumer::getSelectedOutputDevice() const -> DeviceInfo {
+    PaDeviceIndex idx = this->audioPlayer.getSettings().getAudioOutputDevice();
+    if (idx == -1) {
+        return DeviceInfo(&sys.defaultOutputDevice(), true);
+    }
     try {
-        return DeviceInfo(&sys.deviceByIndex(this->audioPlayer.getSettings().getAudioOutputDevice()), true);
+        return DeviceInfo(&sys.deviceByIndex(idx), true);
     } catch (const portaudio::PaException& e) {
         g_warning("PortAudioConsumer: Selected output device was not found - fallback to default output device\nCaused "
                   "by: %s",

--- a/src/core/audio/PortAudioProducer.cpp
+++ b/src/core/audio/PortAudioProducer.cpp
@@ -31,8 +31,12 @@ auto PortAudioProducer::getInputDevices() const -> std::vector<DeviceInfo> {
 }
 
 auto PortAudioProducer::getSelectedInputDevice() const -> DeviceInfo {
+    PaDeviceIndex idx = this->settings.getAudioInputDevice();
+    if (idx == -1) {
+        return DeviceInfo(&sys.defaultInputDevice(), true);
+    }
     try {
-        return DeviceInfo(&sys.deviceByIndex(this->settings.getAudioInputDevice()), true);
+        return DeviceInfo(&sys.deviceByIndex(idx), true);
     } catch (const portaudio::PaException& e) {
         g_message(
                 "PortAudioProducer: Selected input device not found - fallback to default input device\nCaused by: %s",


### PR DESCRIPTION
When audio device is set to "System default", `deviceByIndex(-1)` returns the null device instead of the actual default.

fixed by checking for -1 upfront and call `defaultInputDevice()`/`defaultOutputDevice()` instead

fixes #1826 (it is already closed)