### PR TITLE
Fix Pdf background pick dialog

### DIFF
--- a/src/core/gui/dialog/backgroundSelect/BackgroundSelectDialogBase.cpp
+++ b/src/core/gui/dialog/backgroundSelect/BackgroundSelectDialogBase.cpp
@@ -107,3 +107,5 @@ void BackgroundSelectDialogBase::setSelected(size_t selected) {
         gtk_widget_set_sensitive(okButton, true);
     }
 }
+
+void BackgroundSelectDialogBase::ok() { gtk_button_clicked(GTK_BUTTON(okButton)); }

--- a/src/core/gui/dialog/backgroundSelect/BackgroundSelectDialogBase.cpp
+++ b/src/core/gui/dialog/backgroundSelect/BackgroundSelectDialogBase.cpp
@@ -59,7 +59,6 @@ void BackgroundSelectDialogBase::layout() {
     int x = 0;
     int y = 0;
     int row_height = 0;
-    int max_row_width = 0;
 
     auto width = gtk_adjustment_get_page_size(gtk_scrolled_window_get_hadjustment(scrolledWindow));
 
@@ -69,7 +68,6 @@ void BackgroundSelectDialogBase::layout() {
         }
 
         if (x + p->getWidth() > width) {
-            max_row_width = std::max(max_row_width, x);
             y += row_height;
             x = 0;
             row_height = 0;
@@ -79,9 +77,6 @@ void BackgroundSelectDialogBase::layout() {
         row_height = std::max(row_height, p->getHeight());
         x += p->getWidth();
     }
-    max_row_width = std::max(max_row_width, x);
-
-    gtk_widget_set_size_request(GTK_WIDGET(this->container), max_row_width, y + row_height);
 }
 
 void BackgroundSelectDialogBase::populate() {

--- a/src/core/gui/dialog/backgroundSelect/BackgroundSelectDialogBase.h
+++ b/src/core/gui/dialog/backgroundSelect/BackgroundSelectDialogBase.h
@@ -33,6 +33,8 @@ public:
     Settings* getSettings();
     void setSelected(size_t selected);
 
+    void ok();  ///< As if the Ok button was clicked
+
     inline GtkWindow* getWindow() const { return window.get(); }
 
 protected:

--- a/src/core/gui/dialog/backgroundSelect/BaseElementView.cpp
+++ b/src/core/gui/dialog/backgroundSelect/BaseElementView.cpp
@@ -22,9 +22,13 @@ BaseElementView::BaseElementView(size_t id, BackgroundSelectDialogBase* dlg): dl
 #if GTK_MAJOR_VERSION == 3
     gtk_widget_show(this->widget);
     gtk_widget_add_events(widget, GDK_BUTTON_PRESS_MASK);
-    g_signal_connect(this->widget, "button-press-event", G_CALLBACK(+[](GtkWidget*, GdkEventButton*, gpointer d) {
+    g_signal_connect(this->widget, "button-press-event", G_CALLBACK(+[](GtkWidget*, GdkEventButton* e, gpointer d) {
                          auto* element = static_cast<BaseElementView*>(d);
-                         element->dlg->setSelected(element->id);
+                         if (e->type == GDK_BUTTON_PRESS) {
+                             element->dlg->setSelected(element->id);
+                         } else if (e->type == GDK_2BUTTON_PRESS) {
+                             element->dlg->ok();
+                         }
                          return true;
                      }),
                      this);
@@ -34,9 +38,11 @@ BaseElementView::BaseElementView(size_t id, BackgroundSelectDialogBase* dlg): dl
     gtk_gesture_single_set_button(GTK_GESTURE_SINGLE(ctrl), GDK_BUTTON_PRIMARY);
     g_signal_connect(ctrl, "pressed",
                      G_CALLBACK(+[](GtkGestureClick* g, gint n_press, gdouble x, gdouble y, gpointer d) {
+                         auto* element = static_cast<BaseElementView*>(d);
                          if (n_press == 1) {
-                             auto* element = static_cast<BaseElementView*>(d);
                              element->dlg->setSelected(element->id);
+                         } else if (n_press == 2) {
+                             element->dlg->ok();
                          }
                      }),
                      this);

--- a/src/core/gui/dialog/backgroundSelect/PdfPagesDialog.cpp
+++ b/src/core/gui/dialog/backgroundSelect/PdfPagesDialog.cpp
@@ -91,4 +91,8 @@ void PdfPagesDialog::onlyNotUsedCallback(GtkToggleButton* tb, PdfPagesDialog* dl
 
     dlg->layout();
     dlg->updateOkButton();
+
+    // For some reason (a bug in GtkViewport, maybe?), the GtkFixed's size is not always updated here.
+    // This hack seems to fix that...
+    gtk_widget_queue_resize(gtk_widget_get_parent(GTK_WIDGET(dlg->container)));
 }


### PR DESCRIPTION
Fixes both #7589 and #7590.
The fix to #7589 is a bit of a hack. I couldn't pinpoint the root of the problem (besides the GtkFixed never being reallocated for some reason).
#7590 is technically a feature rather than a bug, but the changes are so minimal I think it's ok.