### PR TITLE
Make LinkDialog compatible with GTK-4

### DIFF
--- a/src/core/gui/dialog/LinkDialog.cpp
+++ b/src/core/gui/dialog/LinkDialog.cpp
@@ -3,6 +3,7 @@
 #include "control/Control.h"           // for Control
 #include "gui/Builder.h"               // for Builder
 #include "gui/GladeSearchpath.h"       // for GladeSearchPath
+#include "util/glib_casts.h"           // for wrap_for_g_callback_v
 #include "util/raii/CStringWrapper.h"  // for OwnedCString
 
 constexpr auto UI_FILE = "linkDialog.glade";
@@ -10,9 +11,9 @@ constexpr auto UI_DIALOG_NAME = "linkDialog";
 
 static void okButtonClicked(GtkButton*, LinkDialog* dialog) { dialog->okButtonPressed(); }
 static void cancelButtonClicked(GtkButton*, LinkDialog* dialog) { dialog->cancelButtonPressed(); }
-static void layoutToogledLeft(GtkButton*, LinkDialog* dialog) { dialog->layoutToggled(LinkAlignment::LEFT); };
-static void layoutToogledCenter(GtkButton*, LinkDialog* dialog) { dialog->layoutToggled(LinkAlignment::CENTER); };
-static void layoutToogledRight(GtkButton*, LinkDialog* dialog) { dialog->layoutToggled(LinkAlignment::RIGHT); };
+static void layoutToggledLeft(GtkButton*, LinkDialog* dialog) { dialog->layoutToggled(LinkAlignment::LEFT); };
+static void layoutToggledCenter(GtkButton*, LinkDialog* dialog) { dialog->layoutToggled(LinkAlignment::CENTER); };
+static void layoutToggledRight(GtkButton*, LinkDialog* dialog) { dialog->layoutToggled(LinkAlignment::RIGHT); };
 static void urlPrefixChangedClb(GtkComboBoxText* source, LinkDialog* dialog) { dialog->urlPrefixChanged(source); };
 
 LinkDialog::LinkDialog(Control* control, std::function<void(LinkDialog*)> callbackOK,
@@ -37,20 +38,20 @@ LinkDialog::LinkDialog(Control* control, std::function<void(LinkDialog*)> callba
     this->linkTypeChooser = GTK_COMBO_BOX_TEXT(builder.get("cbLinkPrefix"));
     this->urlPrefixChanged(this->linkTypeChooser);
 
-    g_signal_connect(G_OBJECT(okButton), "clicked", G_CALLBACK(okButtonClicked), this);
-    g_signal_connect(G_OBJECT(cancelButton), "clicked", G_CALLBACK(cancelButtonClicked), this);
+    g_signal_connect(G_OBJECT(okButton), "clicked", xoj::util::wrap_for_g_callback_v<okButtonClicked>, this);
+    g_signal_connect(G_OBJECT(cancelButton), "clicked", xoj::util::wrap_for_g_callback_v<cancelButtonClicked>, this);
 
 #if GTK_MAJOR_VERSION == 3
-    g_signal_connect(G_OBJECT(layoutLeft), "released", G_CALLBACK(layoutToogledLeft), this);
-    g_signal_connect(G_OBJECT(layoutCenter), "released", G_CALLBACK(layoutToogledCenter), this);
-    g_signal_connect(G_OBJECT(layoutRight), "released", G_CALLBACK(layoutToogledRight), this);
+    g_signal_connect(G_OBJECT(layoutLeft), "released", xoj::util::wrap_for_g_callback_v<layoutToggledLeft>, this);
+    g_signal_connect(G_OBJECT(layoutCenter), "released", xoj::util::wrap_for_g_callback_v<layoutToggledCenter>, this);
+    g_signal_connect(G_OBJECT(layoutRight), "released", xoj::util::wrap_for_g_callback_v<layoutToggledRight>, this);
 #else
-    g_signal_connect(G_OBJECT(layoutLeft), "clicked", G_CALLBACK(layoutToogledLeft), this);
-    g_signal_connect(G_OBJECT(layoutCenter), "clicked", G_CALLBACK(layoutToogledCenter), this);
-    g_signal_connect(G_OBJECT(layoutRight), "clicked", G_CALLBACK(layoutToogledRight), this);
+    g_signal_connect(G_OBJECT(layoutLeft), "clicked", xoj::util::wrap_for_g_callback_v<layoutToggledLeft>, this);
+    g_signal_connect(G_OBJECT(layoutCenter), "clicked", xoj::util::wrap_for_g_callback_v<layoutToggledCenter>, this);
+    g_signal_connect(G_OBJECT(layoutRight), "clicked", xoj::util::wrap_for_g_callback_v<layoutToggledRight>, this);
 #endif
 
-    g_signal_connect(G_OBJECT(linkTypeChooser), "changed", G_CALLBACK(urlPrefixChangedClb), this);
+    g_signal_connect(G_OBJECT(linkTypeChooser), "changed", xoj::util::wrap_for_g_callback_v<urlPrefixChangedClb>, this);
 }
 
 LinkDialog::~LinkDialog() { this->callbackCancel(); };

--- a/src/core/gui/dialog/LinkDialog.cpp
+++ b/src/core/gui/dialog/LinkDialog.cpp
@@ -8,18 +8,11 @@
 constexpr auto UI_FILE = "linkDialog.glade";
 constexpr auto UI_DIALOG_NAME = "linkDialog";
 
-static void okButtonClicked(GtkButton* btn, LinkDialog* dialog) { dialog->okButtonPressed(btn); }
-static void cancelButtonClicked(GtkButton* btn, LinkDialog* dialog) { dialog->cancelButtonPressed(btn); }
-static void textChangedClb(GtkTextBuffer* buffer, LinkDialog* dialog) { dialog->textChanged(buffer); }
-static void layoutToogledLeft(GtkToggleButton* source, LinkDialog* dialog) {
-    dialog->layoutToggled(LinkAlignment::LEFT);
-};
-static void layoutToogledCenter(GtkToggleButton* source, LinkDialog* dialog) {
-    dialog->layoutToggled(LinkAlignment::CENTER);
-};
-static void layoutToogledRight(GtkToggleButton* source, LinkDialog* dialog) {
-    dialog->layoutToggled(LinkAlignment::RIGHT);
-};
+static void okButtonClicked(GtkButton*, LinkDialog* dialog) { dialog->okButtonPressed(); }
+static void cancelButtonClicked(GtkButton*, LinkDialog* dialog) { dialog->cancelButtonPressed(); }
+static void layoutToogledLeft(GtkButton*, LinkDialog* dialog) { dialog->layoutToggled(LinkAlignment::LEFT); };
+static void layoutToogledCenter(GtkButton*, LinkDialog* dialog) { dialog->layoutToggled(LinkAlignment::CENTER); };
+static void layoutToogledRight(GtkButton*, LinkDialog* dialog) { dialog->layoutToggled(LinkAlignment::RIGHT); };
 static void urlPrefixChangedClb(GtkComboBoxText* source, LinkDialog* dialog) { dialog->urlPrefixChanged(source); };
 
 LinkDialog::LinkDialog(Control* control, std::function<void(LinkDialog*)> callbackOK,
@@ -29,10 +22,11 @@ LinkDialog::LinkDialog(Control* control, std::function<void(LinkDialog*)> callba
     Builder builder(control->getGladeSearchPath(), UI_FILE);
 
     this->linkDialog.reset(GTK_WINDOW(builder.get(UI_DIALOG_NAME)));
+
     this->textInput = GTK_TEXT_VIEW(builder.get("inpLinkEditText"));
     this->urlInput = GTK_ENTRY(builder.get("inpLinkEditURL"));
-    this->okButton = GTK_BUTTON(builder.get("btnLinkEditOk"));
-    this->cancelButton = GTK_BUTTON(builder.get("btnLinkEditCancel"));
+    auto* okButton = GTK_BUTTON(builder.get("btOk"));
+    auto* cancelButton = GTK_BUTTON(builder.get("btCancel"));
 
     this->fontChooser = GTK_FONT_CHOOSER(builder.get("btnFontChooser"));
 
@@ -45,15 +39,18 @@ LinkDialog::LinkDialog(Control* control, std::function<void(LinkDialog*)> callba
 
     g_signal_connect(G_OBJECT(okButton), "clicked", G_CALLBACK(okButtonClicked), this);
     g_signal_connect(G_OBJECT(cancelButton), "clicked", G_CALLBACK(cancelButtonClicked), this);
-    g_signal_connect(G_OBJECT(gtk_text_view_get_buffer(this->textInput)), "changed", G_CALLBACK(textChangedClb), this);
 
+#if GTK_MAJOR_VERSION == 3
     g_signal_connect(G_OBJECT(layoutLeft), "released", G_CALLBACK(layoutToogledLeft), this);
     g_signal_connect(G_OBJECT(layoutCenter), "released", G_CALLBACK(layoutToogledCenter), this);
     g_signal_connect(G_OBJECT(layoutRight), "released", G_CALLBACK(layoutToogledRight), this);
+#else
+    g_signal_connect(G_OBJECT(layoutLeft), "clicked", G_CALLBACK(layoutToogledLeft), this);
+    g_signal_connect(G_OBJECT(layoutCenter), "clicked", G_CALLBACK(layoutToogledCenter), this);
+    g_signal_connect(G_OBJECT(layoutRight), "clicked", G_CALLBACK(layoutToogledRight), this);
+#endif
 
     g_signal_connect(G_OBJECT(linkTypeChooser), "changed", G_CALLBACK(urlPrefixChangedClb), this);
-
-    this->setMaxDialogHeight(control->getGtkWindow());
 }
 
 LinkDialog::~LinkDialog() { this->callbackCancel(); };
@@ -65,7 +62,7 @@ void LinkDialog::preset(XojFont font, std::string text, std::string url, LinkAli
     gtk_text_buffer_insert(textBuffer, &start, text.c_str(), static_cast<int>(text.length()));
     gtk_text_view_set_buffer(this->textInput, textBuffer);
     URLPrefix prefix = this->identifyAndShortenURL(url);
-    gtk_entry_set_text(this->urlInput, url.c_str());
+    gtk_editable_set_text(GTK_EDITABLE(this->urlInput), url.c_str());
     gtk_combo_box_set_active_id(GTK_COMBO_BOX(this->linkTypeChooser), std::to_string(static_cast<int>(prefix)).c_str());
     std::string fontName = font.getName() + " " + std::to_string(font.getSize());
     gtk_font_chooser_set_font(this->fontChooser, fontName.c_str());
@@ -83,7 +80,7 @@ std::string LinkDialog::getURL() {
     return res;
 }
 
-void LinkDialog::okButtonPressed(GtkButton* btn) {
+void LinkDialog::okButtonPressed() {
     GtkTextBuffer* text = gtk_text_view_get_buffer(this->textInput);
     GtkTextIter start, end;
     gtk_text_buffer_get_bounds(text, &start, &end);
@@ -92,7 +89,7 @@ void LinkDialog::okButtonPressed(GtkButton* btn) {
         this->linkText = "Link";
     }
 
-    this->linkURL = std::string(gtk_entry_get_text(this->urlInput));
+    this->linkURL = std::string(gtk_editable_get_text(GTK_EDITABLE(this->urlInput)));
     if (!this->isUrlValid(this->linkURL)) {
         this->linkURL = PLACEHOLDER_HTTPS;
     }
@@ -100,22 +97,13 @@ void LinkDialog::okButtonPressed(GtkButton* btn) {
     gtk_window_close(this->linkDialog.get());
 }
 
-void LinkDialog::cancelButtonPressed(GtkButton* btn) { gtk_window_close(this->linkDialog.get()); }
+void LinkDialog::cancelButtonPressed() { gtk_window_close(this->linkDialog.get()); }
 
 bool LinkDialog::isTextValid(const std::string& text) {
     return !std::all_of(text.begin(), text.end(), [](unsigned char c) { return std::isblank(c); });
 }
 
 bool LinkDialog::isUrlValid(const std::string& url) { return !url.empty(); }
-
-void LinkDialog::textChanged(GtkTextBuffer* buffer) {
-    gint lot = gtk_text_buffer_get_line_count(buffer);
-    int width, height;
-    gtk_window_get_size(this->linkDialog.get(), &width, &height);
-    height = DEFAULT_HEIGHT + (std::max(0, (lot - INITIAL_NUMBER_OF_LINES + 1)) * getLineHeight());
-    height = std::min(height, this->maxDialogHeight);
-    gtk_window_resize(this->linkDialog.get(), width, height);
-}
 
 void LinkDialog::layoutToggled(LinkAlignment layout) {
     this->layout = layout;
@@ -168,20 +156,4 @@ URLPrefix LinkDialog::identifyAndShortenURL(std::string& url) {
     } else {
         return URLPrefix::NONE;
     }
-}
-
-void LinkDialog::setMaxDialogHeight(GtkWindow* window) {
-    GdkScreen* screen = gtk_window_get_screen(window);
-    gint monitorID = gdk_screen_get_primary_monitor(screen);
-    GdkRectangle monitor;
-    gdk_screen_get_monitor_geometry(screen, monitorID, &monitor);
-    this->maxDialogHeight = static_cast<int>(static_cast<float>(monitor.height) * MAX_HEIGHT_RATIO);
-}
-
-int LinkDialog::getLineHeight() {
-    gint y, height;
-    GtkTextIter iter;
-    gtk_text_view_get_iter_at_location(this->textInput, &iter, 0, 0);
-    gtk_text_view_get_line_yrange(this->textInput, &iter, &y, &height);
-    return height;
 }

--- a/src/core/gui/dialog/LinkDialog.h
+++ b/src/core/gui/dialog/LinkDialog.h
@@ -40,9 +40,8 @@ public:
     XojFont getFont();
 
 public:
-    void okButtonPressed(GtkButton* btn);
-    void cancelButtonPressed(GtkButton* btn);
-    void textChanged(GtkTextBuffer* buffer);
+    void okButtonPressed();
+    void cancelButtonPressed();
     void layoutToggled(LinkAlignment l);
     void urlPrefixChanged(GtkComboBoxText* source);
 
@@ -51,9 +50,6 @@ private:
     bool isUrlValid(const std::string& url);
     URLPrefix identifyAndShortenURL(std::string& url);
 
-    void setMaxDialogHeight(GtkWindow* window);
-    int getLineHeight();
-
 private:
     xoj::util::GtkWindowUPtr linkDialog;
     std::function<void(LinkDialog*)> callbackOK;
@@ -61,9 +57,6 @@ private:
 
     GtkTextView* textInput = nullptr;
     GtkEntry* urlInput = nullptr;
-
-    GtkButton* okButton = nullptr;
-    GtkButton* cancelButton = nullptr;
 
     GtkFontChooser* fontChooser = nullptr;
 
@@ -76,8 +69,6 @@ private:
     std::string linkText;
     std::string linkURL;
     LinkAlignment layout = LinkAlignment::LEFT;
-
-    int maxDialogHeight = 0;
 
 public:
     inline GtkWindow* getWindow() const { return linkDialog.get(); }

--- a/ui/linkDialog.glade
+++ b/ui/linkDialog.glade
@@ -2,6 +2,16 @@
 <!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.24"/>
+  <object class="GtkImage" id="iconCancel">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">dialog-cancel</property>
+  </object>
+  <object class="GtkImage" id="iconOk">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">dialog-ok</property>
+  </object>
   <object class="GtkImage" id="imgJustifyCenter">
     <property name="visible">True</property>
     <property name="can-focus">False</property>
@@ -94,14 +104,13 @@
                 <property name="can-focus">False</property>
                 <property name="halign">end</property>
                 <property name="valign">center</property>
-                <property name="spacing">10</property>
                 <child>
                   <object class="GtkFontButton" id="btnFontChooser">
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
+                    <property name="margin-end">10</property>
                     <property name="font">Sans 12</property>
-                    <property name="language">de-de</property>
                     <property name="preview-text"/>
                   </object>
                   <packing>
@@ -111,62 +120,46 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkButtonBox" id="btnGroupLayout">
+                  <object class="GtkToggleButton" id="btnLeftLayout">
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="homogeneous">True</property>
-                    <property name="layout-style">expand</property>
-                    <child>
-                      <object class="GtkToggleButton" id="btnLeftLayout">
-                        <property name="visible">True</property>
-                        <property name="can-focus">True</property>
-                        <property name="receives-default">True</property>
-                        <property name="image">imgJustifyLeft</property>
-                        <property name="always-show-image">True</property>
-                        <property name="active">True</property>
-                      </object>
-                      <packing>
-                        <property name="expand">True</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkToggleButton" id="btnCenterLayout">
-                        <property name="visible">True</property>
-                        <property name="can-focus">True</property>
-                        <property name="receives-default">True</property>
-                        <property name="image">imgJustifyCenter</property>
-                        <property name="always-show-image">True</property>
-                      </object>
-                      <packing>
-                        <property name="expand">True</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkToggleButton" id="btnRightLayout">
-                        <property name="visible">True</property>
-                        <property name="can-focus">True</property>
-                        <property name="receives-default">True</property>
-                        <property name="image">imgJustifyRight</property>
-                        <property name="always-show-image">True</property>
-                      </object>
-                      <packing>
-                        <property name="expand">True</property>
-                        <property name="fill">True</property>
-                        <property name="position">2</property>
-                      </packing>
-                    </child>
-                    <style>
-                      <class name="GTK_STYLE_CLASS_LINKED"/>
-                    </style>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
+                    <property name="image">imgJustifyLeft</property>
+                    <property name="always-show-image">True</property>
+                    <property name="active">True</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
-                    <property name="fill">False</property>
+                    <property name="fill">True</property>
                     <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkToggleButton" id="btnCenterLayout">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
+                    <property name="image">imgJustifyCenter</property>
+                    <property name="always-show-image">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkToggleButton" id="btnRightLayout">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
+                    <property name="image">imgJustifyRight</property>
+                    <property name="always-show-image">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">3</property>
                   </packing>
                 </child>
               </object>
@@ -255,18 +248,21 @@
           </packing>
         </child>
         <child>
-          <object class="GtkButtonBox">
+          <object class="GtkBox">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
+            <property name="halign">end</property>
+            <property name="spacing">4</property>
             <property name="homogeneous">True</property>
-            <property name="layout-style">end</property>
             <child>
-              <object class="GtkButton" id="btnLinkEditCancel">
-                <property name="label">gtk-cancel</property>
+              <object class="GtkButton" id="btCancel">
+                <property name="label" translatable="yes">Cancel</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
+                <property name="can-default">True</property>
                 <property name="receives-default">True</property>
-                <property name="use-stock">True</property>
+                <property name="image">iconCancel</property>
+                <accelerator key="Escape" signal="activate"/>
               </object>
               <packing>
                 <property name="expand">True</property>
@@ -275,12 +271,14 @@
               </packing>
             </child>
             <child>
-              <object class="GtkButton" id="btnLinkEditOk">
-                <property name="label">gtk-ok</property>
+              <object class="GtkButton" id="btOk">
+                <property name="label" translatable="yes">Ok</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
+                <property name="can-default">True</property>
+                <property name="has-default">True</property>
                 <property name="receives-default">True</property>
-                <property name="use-stock">True</property>
+                <property name="image">iconOk</property>
               </object>
               <packing>
                 <property name="expand">True</property>
@@ -291,7 +289,7 @@
           </object>
           <packing>
             <property name="expand">False</property>
-            <property name="fill">False</property>
+            <property name="fill">True</property>
             <property name="position">1</property>
           </packing>
         </child>


### PR DESCRIPTION
I didn't notice while reviewing #6841, but some things are incompatible with GTK4. This PR fixes that.
There is one thing I removed for simplicity: the window was getting resized as the user was typing in the GtkTextView. There may be a way to port it but I'm not sure we should.
@rolandlo did you put that in on purpose or was it a leftover of the original PR you didn't really care about?