### PR TITLE
Remove unnecessary copy of GdkKeyEvent and fix related gcc compilation warning

### DIFF
--- a/src/core/control/tools/TextEditor.cpp
+++ b/src/core/control/tools/TextEditor.cpp
@@ -306,7 +306,7 @@ auto TextEditor::imDeleteSurroundingCallback(GtkIMContext* context, gint offset,
 auto TextEditor::onKeyPressEvent(const KeyEvent& event) -> bool {
 
     // IME needs to handle the input first so the candidate window works correctly
-    if (gtk_im_context_filter_keypress(this->imContext.get(), event.sourceEvent.get())) {
+    if (gtk_im_context_filter_keypress(this->imContext.get(), event.sourceEvent)) {
         this->needImReset = true;
 
         GtkTextIter iter = getIteratorAtCursor(this->buffer.get());
@@ -327,7 +327,7 @@ auto TextEditor::onKeyReleaseEvent(const KeyEvent& event) -> bool {
     GtkTextIter iter = getIteratorAtCursor(this->buffer.get());
 
     if (gtk_text_iter_can_insert(&iter, true) &&
-        gtk_im_context_filter_keypress(this->imContext.get(), event.sourceEvent.get())) {
+        gtk_im_context_filter_keypress(this->imContext.get(), event.sourceEvent)) {
         this->needImReset = true;
         return true;
     }

--- a/src/core/gui/inputdevices/InputContext.cpp
+++ b/src/core/gui/inputdevices/InputContext.cpp
@@ -67,7 +67,7 @@ InputContext::InputContext(Settings* settings, DeviceTestingArea& testing):
     }
 }
 
-template <bool (KeyboardInputHandler::*handler)(KeyEvent) const>
+template <bool (KeyboardInputHandler::*handler)(const KeyEvent&) const>
 static gboolean keyboardCallback(GtkEventControllerKey* self, guint keyval, guint, GdkModifierType state, gpointer d) {
     auto* gdkEvent = gtk_event_controller_get_current_event(GTK_EVENT_CONTROLLER(self));
     KeyEvent e;

--- a/src/core/gui/inputdevices/InputEvents.h
+++ b/src/core/gui/inputdevices/InputEvents.h
@@ -11,7 +11,6 @@
 
 #pragma once
 
-#include <memory>  // for shared_ptr
 #include <string>  // for string
 
 #include <gdk/gdk.h>  // for GdkEvent, gdk_event_free, gdk_event_copy
@@ -47,25 +46,6 @@ enum InputDeviceClass {
     INPUT_DEVICE_IGNORE
 };
 
-struct GdkEventGuard {
-    static inline GdkEvent* safeRef(GdkEvent* source) { return gdk_event_copy(source); }
-
-    GdkEventGuard() = default;
-
-    [[maybe_unused]] explicit GdkEventGuard(GdkEvent* source): event(safeRef(source), &gdk_event_free) {}
-
-    GdkEventGuard& operator=(GdkEvent* source) {
-        event = {safeRef(source), &gdk_event_free};
-        return *this;
-    }
-
-    GdkEvent* get() const { return event.get(); }
-
-    // it's more performant to manage the GdkEvent over C++ than over gdk
-    // Since the gdk_copy is extreme expansive
-    std::shared_ptr<GdkEvent> event{};
-};
-
 struct InputEvent final {
     /*explicit(false)*/ explicit operator bool() const { return device; }
 
@@ -92,7 +72,7 @@ struct KeyEvent final {
     guint keyval{0};
     GdkModifierType state{};  ///< Consumed modifiers have been masked out
 
-    GdkEventGuard sourceEvent;  ///< Original GdkEvent. Avoid using if possible.
+    GdkEvent* sourceEvent;  ///< Original GdkEvent. Avoid using if possible. Will be destroyed when the callback returns
 };
 
 struct InputEvents {

--- a/src/core/gui/inputdevices/KeyboardInputHandler.cpp
+++ b/src/core/gui/inputdevices/KeyboardInputHandler.cpp
@@ -10,6 +10,8 @@ KeyboardInputHandler::KeyboardInputHandler(InputContext* inputContext): inputCon
 
 KeyboardInputHandler::~KeyboardInputHandler() = default;
 
-bool KeyboardInputHandler::keyPressed(KeyEvent e) const { return inputContext->getView()->onKeyPressEvent(e); }
+bool KeyboardInputHandler::keyPressed(const KeyEvent& e) const { return inputContext->getView()->onKeyPressEvent(e); }
 
-bool KeyboardInputHandler::keyReleased(KeyEvent e) const { return inputContext->getView()->onKeyReleaseEvent(e); }
+bool KeyboardInputHandler::keyReleased(const KeyEvent& e) const {
+    return inputContext->getView()->onKeyReleaseEvent(e);
+}

--- a/src/core/gui/inputdevices/KeyboardInputHandler.h
+++ b/src/core/gui/inputdevices/KeyboardInputHandler.h
@@ -19,8 +19,8 @@ private:
 public:
     explicit KeyboardInputHandler(InputContext* inputContext);
     ~KeyboardInputHandler();
-    bool keyPressed(KeyEvent e) const;
-    bool keyReleased(KeyEvent e) const;
+    bool keyPressed(const KeyEvent& e) const;
+    bool keyReleased(const KeyEvent& e) const;
 
 private:
     InputContext* inputContext;


### PR DESCRIPTION
When compiling InputContext.cpp, we get warnings
```
In member function 'constexpr _Tp* std::__new_allocator<_Tp>::allocate(size_type, const void*) [with _Tp = std::_Sp_counted_deleter<_GdkEvent*, void (*)(_GdkEvent*), std::allocator<void>, __gnu_cxx::_S_atomic>]',
    inlined from 'constexpr _Tp* std::allocator< <template-parameter-1-1> >::allocate(std::size_t) [with _Tp = std::_Sp_counted_deleter<_GdkEvent*, void (*)(_GdkEvent*), std::allocator<void>, __gnu_cxx::_S_atomic>]' at /usr/include/c++/16/bits/allocator.h:206:40,
    inlined from 'static constexpr _Tp* std::allocator_traits<std::allocator<_Up> >::allocate(allocator_type&, size_type) [with _Tp = std::_Sp_counted_deleter<_GdkEvent*, void (*)(_GdkEvent*), std::allocator<void>, __gnu_cxx::_S_atomic>]' at /usr/include/c++/16/bits/alloc_traits.h:638:28,
    inlined from 'std::__allocated_ptr<_Alloc> std::__allocate_guarded(_Alloc&) [with _Alloc = allocator<_Sp_counted_deleter<_GdkEvent*, void (*)(_GdkEvent*), allocator<void>, __gnu_cxx::_S_atomic> >]' at /usr/include/c++/16/bits/allocated_ptr.h:103:69,
    inlined from 'std::__shared_count<_Lp>::__shared_count(_Ptr, _Deleter, _Alloc) [with _Ptr = _GdkEvent*; _Deleter = void (*)(_GdkEvent*); _Alloc = std::allocator<void>; <template-parameter-2-4> = void; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]' at /usr/include/c++/16/bits/shared_ptr_base.h:1014:13,
    inlined from 'std::__shared_count<_Lp>::__shared_count(_Ptr, _Deleter) [with _Ptr = _GdkEvent*; _Deleter = void (*)(_GdkEvent*); <template-parameter-2-3> = void; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]' at /usr/include/c++/16/bits/shared_ptr_base.h:1003:57,
    inlined from 'std::__shared_ptr<_Tp, _Lp>::__shared_ptr(_Yp*, _Deleter) [with _Yp = _GdkEvent; _Deleter = void (*)(_GdkEvent*); <template-parameter-2-3> = void; _Tp = _GdkEvent; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]' at /usr/include/c++/16/bits/shared_ptr_base.h:1564:17,
    inlined from 'std::shared_ptr<_Tp>::shared_ptr(_Yp*, _Deleter) [with _Yp = _GdkEvent; _Deleter = void (*)(_GdkEvent*); <template-parameter-2-3> = void; _Tp = _GdkEvent]' at /usr/include/c++/16/bits/shared_ptr.h:231:48,
    inlined from 'GdkEventGuard& GdkEventGuard::operator=(GdkEvent*)' at /home/benjamin/xopp/xournalpp/src/core/gui/inputdevices/InputEvents.h:58:50,
    inlined from 'gboolean keyboardCallback(GtkEventControllerKey*, guint, guint, GdkModifierType, gpointer) [with bool (KeyboardInputHandler::* handler)(KeyEvent) const = &KeyboardInputHandler::keyReleased]' at /home/benjamin/xopp/xournalpp/src/core/gui/inputdevices/InputContext.cpp:77:21:
/usr/include/c++/16/bits/new_allocator.h:162:75: note: at offset 16 into object of size 32 allocated by 'operator new'
  162 |           return static_cast<_Tp*>(_GLIBCXX_OPERATOR_NEW(__n * sizeof(_Tp)));
```
This is fixed by removing the shared_ptr altogether.

As a bonus, it removes an unnecessary call to gdk_event_copy().