### PR TITLE
Fix crash when using "Apply to all pages" with Pdf background in PageType popover

### DIFF
--- a/src/core/gui/menus/popoverMenus/PageTypeSelectionPopover.cpp
+++ b/src/core/gui/menus/popoverMenus/PageTypeSelectionPopover.cpp
@@ -338,9 +338,7 @@ GtkWidget* PageTypeSelectionPopover::createPopover() const {
                     self->controller->changeCurrentPageBackground(self->selectedPT.value());
                 }
                 if (self->selectedPageSize && (!self->selectedPT.has_value() || !self->selectedPT->isSpecial())) {
-                    gtk_popover_set_modal(popover, false);
                     self->controller->changeCurrentPageSize(self->selectedPageSize.value());
-                    gtk_popover_set_modal(popover, true);
                 }
             })),
             new std::tuple<const PageTypeSelectionPopover*, GtkPopover*>(this, GTK_POPOVER(popover)),
@@ -386,20 +384,14 @@ GtkWidget* PageTypeSelectionPopover::createPopover() const {
             applyToAllPagesButton, "clicked", G_CALLBACK((+[](GtkWidget*, gpointer pointerTuple) {
                 auto [self, popover] =
                         *static_cast<std::tuple<const PageTypeSelectionPopover*, GtkPopover*>*>(pointerTuple);
-                if (self->selectedPT) {
-                    self->controller->applyBackgroundToAllPages(self->selectedPT.value());
-                } else {
-                    self->controller->applyCurrentPageBackgroundToAll();
-                }
+                const PageRef currentPage = self->control->getCurrentPage();
+                PageType pt = self->selectedPT.value_or(currentPage->getBackgroundType());
+                self->controller->applyBackgroundToAllPages(pt);
 
-                gtk_popover_set_modal(popover, false);
-                if (self->selectedPageSize) {
-                    self->controller->applyPageSizeToAllPages(self->selectedPageSize.value());
-                } else {
-                    const PageRef page = self->control->getCurrentPage();
-                    self->controller->applyPageSizeToAllPages(PaperSize(page->getWidth(), page->getHeight()));
+                if (!pt.isSpecial()) {  // Special backgrounds come with their size
+                    self->controller->applyPageSizeToAllPages(self->selectedPageSize.value_or(
+                            PaperSize(currentPage->getWidth(), currentPage->getHeight())));
                 }
-                gtk_popover_set_modal(popover, true);
             })),
             new std::tuple<const PageTypeSelectionPopover*, GtkPopover*>(this, GTK_POPOVER(popover)),
             xoj::util::closure_notify_cb<std::tuple<const PageTypeSelectionPopover*, GtkPopover*>>, GConnectFlags(0));

--- a/src/core/pdf/popplerapi/PopplerGlibDocument.cpp
+++ b/src/core/pdf/popplerapi/PopplerGlibDocument.cpp
@@ -15,9 +15,9 @@ class XojPdfBookmarkIterator;
 
 using std::string;
 
-PopplerGlibDocument::PopplerGlibDocument() = default;
+PopplerGlibDocument::PopplerGlibDocument(): mutex(std::make_shared<std::mutex>()) {}
 
-PopplerGlibDocument::PopplerGlibDocument(const PopplerGlibDocument& doc): document(doc.document) {
+PopplerGlibDocument::PopplerGlibDocument(const PopplerGlibDocument& doc): document(doc.document), mutex(doc.mutex) {
     if (document) {
         g_object_ref(document);
     }
@@ -35,10 +35,13 @@ void PopplerGlibDocument::assign(XojPdfDocumentInterface* doc) {
         g_object_unref(document);
     }
 
-    document = (dynamic_cast<PopplerGlibDocument*>(doc))->document;
+    auto* popplerdoc = dynamic_cast<PopplerGlibDocument*>(doc);
+    document = popplerdoc->document;
     if (document) {
         g_object_ref(document);
     }
+
+    mutex = popplerdoc->mutex;
 }
 
 auto PopplerGlibDocument::equals(XojPdfDocumentInterface* doc) const -> bool {
@@ -65,10 +68,10 @@ auto PopplerGlibDocument::load(fs::path const& file, string password, GError** e
 
     if (document) {
         g_object_unref(document);
-        document = nullptr;
     }
 
     this->document = poppler_document_new_from_file(uri->c_str(), password.c_str(), error);
+
     return this->document != nullptr;
 }
 
@@ -104,7 +107,7 @@ auto PopplerGlibDocument::getPage(size_t page) const -> XojPdfPageSPtr {
     if (pg == nullptr) {
         return nullptr;
     }
-    XojPdfPageSPtr pageptr = std::make_shared<PopplerGlibPage>(pg, document);
+    XojPdfPageSPtr pageptr = std::make_shared<PopplerGlibPage>(pg, document, mutex);
     g_object_unref(pg);
 
     return pageptr;

--- a/src/core/pdf/popplerapi/PopplerGlibDocument.h
+++ b/src/core/pdf/popplerapi/PopplerGlibDocument.h
@@ -12,7 +12,9 @@
 #pragma once
 
 #include <cstddef>  // for size_t
-#include <string>   // for string
+#include <memory>
+#include <mutex>
+#include <string>  // for string
 
 #include <glib.h>     // for GError, gpointer, gsize
 #include <poppler.h>  // for PopplerDocument
@@ -47,4 +49,5 @@ public:
 
 private:
     PopplerDocument* document = nullptr;
+    std::shared_ptr<std::mutex> mutex;
 };

--- a/src/core/pdf/popplerapi/PopplerGlibPage.cpp
+++ b/src/core/pdf/popplerapi/PopplerGlibPage.cpp
@@ -19,18 +19,18 @@
 #include "PopplerGlibAction.h"  // for PopplerGlibAction
 #include "cairo.h"              // for cairo_region_create, cairo_reg...
 
-PopplerGlibPage::PopplerGlibPage(PopplerPage* page, PopplerDocument* parentDoc): page(page), document(parentDoc) {
+PopplerGlibPage::PopplerGlibPage(PopplerPage* page, PopplerDocument* parentDoc, std::shared_ptr<std::mutex> mutex):
+        page(page), document(parentDoc), mutex(mutex) {
     if (page != nullptr) {
         g_object_ref(page);
     }
 }
 
-PopplerGlibPage::PopplerGlibPage(const PopplerGlibPage& other): page(other.page), document(other.document) {
+PopplerGlibPage::PopplerGlibPage(const PopplerGlibPage& other):
+        page(other.page), document(other.document), mutex(other.mutex) {
     if (page != nullptr) {
         g_object_ref(page);
     }
-
-    document = nullptr;
 }
 
 PopplerGlibPage::~PopplerGlibPage() {
@@ -55,6 +55,7 @@ PopplerGlibPage& PopplerGlibPage::operator=(const PopplerGlibPage& other) {
     }
 
     document = other.document;
+    mutex = other.mutex;
 
     return *this;
 }
@@ -74,6 +75,7 @@ auto PopplerGlibPage::getHeight() const -> double {
 }
 
 void PopplerGlibPage::render(cairo_t* cr) const {
+    std::lock_guard guard(*mutex);
     cairo_save(cr);
     cairo_set_source_rgb(cr, 1., 1., 1.);
     cairo_paint(cr);
@@ -81,7 +83,10 @@ void PopplerGlibPage::render(cairo_t* cr) const {
     cairo_restore(cr);
 }
 
-void PopplerGlibPage::renderForPrinting(cairo_t* cr) const { poppler_page_render_for_printing(page, cr); }
+void PopplerGlibPage::renderForPrinting(cairo_t* cr) const {
+    std::lock_guard guard(*mutex);
+    poppler_page_render_for_printing(page, cr);
+}
 
 auto PopplerGlibPage::getPageId() const -> int { return poppler_page_get_index(page); }
 

--- a/src/core/pdf/popplerapi/PopplerGlibPage.h
+++ b/src/core/pdf/popplerapi/PopplerGlibPage.h
@@ -11,6 +11,8 @@
 
 #pragma once
 
+#include <memory>
+#include <mutex>
 #include <string>  // for string
 #include <vector>  // for vector
 
@@ -22,7 +24,7 @@
 
 class PopplerGlibPage: public XojPdfPage {
 public:
-    PopplerGlibPage(PopplerPage* page, PopplerDocument* doc);
+    PopplerGlibPage(PopplerPage* page, PopplerDocument* doc, std::shared_ptr<std::mutex> mutex);
     PopplerGlibPage(const PopplerGlibPage& other);
     virtual ~PopplerGlibPage();
     PopplerGlibPage& operator=(const PopplerGlibPage& other);
@@ -51,4 +53,5 @@ public:
 private:
     PopplerPage* page;
     PopplerDocument* document;
+    std::shared_ptr<std::mutex> mutex;  ///< Poppler doesn't support parallel renderings. Lock this mutex when rendering
 };


### PR DESCRIPTION
fix #7601

The issue was indeed a parallel rendering of a Poppler page/document, which is not supported.
I added a mutex in PopplerGlibDocument to ensure it never happens again.

Now, there was another problem, with the page size not being applied properly when using this "Apply to all pages" button. This is also fixed.