### PR TITLE
Refactor Element position

### DIFF
--- a/src/core/control/ClipboardHandler.cpp
+++ b/src/core/control/ClipboardHandler.cpp
@@ -77,10 +77,9 @@ auto ClipboardHandler::cut() -> bool {
 }
 
 auto ElementCompareFunc(const Element* a, const Element* b) -> bool {
-    if (a->getY() == b->getY()) {
-        return (a->getX() - b->getX()) < 0;
-    }
-    return (a->getY() - b->getY()) < 0;
+    const auto& pa = a->getOrigin();
+    const auto& pb = b->getOrigin();
+    return pa.y < pb.y || (pa.y == pb.y && pa.x < pb.x);
 }
 
 static GdkAtom atomSvg1 = gdk_atom_intern_static_string("image/svg");

--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -2403,14 +2403,12 @@ void Control::clipboardPaste(ElementPtr e) {
 
     win->getXournal()->getPasteTarget(x, y);
 
-    double width = e->getElementWidth();
-    double height = e->getElementHeight();
+    const auto& box = e->getBoundingBox();
 
-    x = std::max(0.0, x - width / 2);
-    y = std::max(0.0, y - height / 2);
+    x = std::max(0.0, x - box.width / 2);
+    y = std::max(0.0, y - box.height / 2);
 
-    e->setX(x);
-    e->setY(y);
+    e->setOrigin(x, y);
 
     undoRedo->addUndoAction(std::make_unique<InsertUndoAction>(page, layer, e.get()));
     auto sel = SelectionFactory::createFromFloatingElement(this, page, layer, view, std::move(e));

--- a/src/core/control/GeometryToolController.cpp
+++ b/src/core/control/GeometryToolController.cpp
@@ -73,8 +73,7 @@ void GeometryToolController::markOrigin() {
     const auto undo = control->getUndoRedoHandler();
     undo->addUndoAction(std::make_unique<InsertUndoAction>(page, layer, ptr));
 
-
-    const Rectangle<double> rect{ptr->getX(), ptr->getY(), ptr->getElementWidth(), ptr->getElementHeight()};
+    const Rectangle<double>& rect = ptr->getBoundingBox();
     view->rerenderRect(rect.x, rect.y, rect.width, rect.height);
 }
 
@@ -92,7 +91,7 @@ void GeometryToolController::addStrokeToLayer() {
 
     const auto undo = control->getUndoRedoHandler();
     undo->addUndoAction(std::make_unique<InsertUndoAction>(page, layer, ptr));
-    const Rectangle<double> rect{ptr->getX(), ptr->getY(), ptr->getElementWidth(), ptr->getElementHeight()};
+    const Rectangle<double>& rect = ptr->getBoundingBox();
     view->rerenderRect(rect.x, rect.y, rect.width, rect.height);
     geometryTool->setStroke(nullptr);
     xournal->getCursor()->updateCursor();

--- a/src/core/control/LatexController.cpp
+++ b/src/core/control/LatexController.cpp
@@ -250,11 +250,11 @@ auto LatexController::loadRendered(string renderedTex) -> std::unique_ptr<TexIma
         return nullptr;
     }
 
-    img->setX(posx);
-    img->setY(posy);
+    img->setOrigin(posx, posy);
     img->setText(std::move(renderedTex));
     if (std::abs(imgheight) > 1024 * std::numeric_limits<double>::epsilon()) {
-        double ratio = img->getElementWidth() / img->getElementHeight();
+        const auto& box = img->getBoundingBox();
+        double ratio = box.width / box.height;
         if (ratio == 0) {
             img->setWidth(imgwidth == 0 ? 10 : imgwidth);
         } else {
@@ -300,8 +300,8 @@ void LatexController::insertTexImage() {
         auto insertUndoAction = std::make_unique<InsertUndoAction>(page, layer, this->temporaryRender.get());
         groupUndoAction->addAction(std::move(insertUndoAction));
         undo->addUndoAction(std::move(groupUndoAction));
-        Range oldRange(selectedElem->boundingRect());
-        Range newRange(temporaryRender->boundingRect());
+        Range oldRange(selectedElem->getBoundingBox());
+        Range newRange(temporaryRender->getBoundingBox());
         Range repaintRange = oldRange.unite(newRange);
         page->fireRangeChanged(repaintRange);
     } else {
@@ -338,8 +338,7 @@ void LatexController::insertLatex(PageRef page, Control* ctrl, double x, double 
     auto& el = page->getSelectedLayer()->getElements();
     for (auto e = el.rbegin(); e != el.rend(); ++e) {
         if ((*e)->getType() == ELEMENT_TEXIMAGE || (*e)->getType() == ELEMENT_TEXT) {
-            GdkRectangle matchRect = {gint(x), gint(y), 1, 1};
-            if ((*e)->intersectsArea(&matchRect)) {
+            if ((*e)->hasBoundingBoxContaining(x, y)) {
                 self->selectedElem = (*e).get();
                 break;
             }
@@ -361,8 +360,8 @@ void LatexController::insertLatex(PageRef page, Control* ctrl, double x, double 
             xoj_assert(false);
         }
 
-        self->imgwidth = self->selectedElem->getElementWidth();
-        self->imgheight = self->selectedElem->getElementHeight();
+        self->imgwidth = self->selectedElem->getBoundingBox().width;
+        self->imgheight = self->selectedElem->getBoundingBox().height;
 
     } else {
         self->posx = x;

--- a/src/core/control/tools/EditSelection.cpp
+++ b/src/core/control/tools/EditSelection.cpp
@@ -62,7 +62,7 @@ static auto computeBoxes(const InsertionOrder& elts) -> std::pair<Range, Range> 
             [](auto&& p, auto&& q) {
                 return std::pair<Range, Range>(p.first.unite(q.first), p.second.unite(q.second));
             },
-            [](auto&& e) { return std::make_pair(Range(e.e->boundingRect()), Range(e.e->getSnappedBounds())); });
+            [](auto&& e) { return std::make_pair(Range(e.e->getBoundingBox()), Range(e.e->getSnappedBounds())); });
 }
 
 auto createFromFloatingElement(Control* ctrl, const PageRef& page, Layer* layer, XojPageView* view, ElementPtr eOwn)
@@ -70,7 +70,7 @@ auto createFromFloatingElement(Control* ctrl, const PageRef& page, Layer* layer,
     auto* e = eOwn.get();  // Order of parameter evaluation is unspecified, eOwn.get() must be evaluated before moving
     InsertionOrder i{1};
     i[0] = InsertionPosition{std::move(eOwn)};
-    return std::make_unique<EditSelection>(ctrl, std::move(i), page, layer, view, Range(e->boundingRect()),
+    return std::make_unique<EditSelection>(ctrl, std::move(i), page, layer, view, Range(e->getBoundingBox()),
                                            Range(e->getSnappedBounds()));
 }
 
@@ -94,7 +94,7 @@ auto createFromElementOnActiveLayer(Control* ctrl, const PageRef& page, XojPageV
         return layer->removeElementAt(e, pos);
     }();
     page->fireElementChanged(e);
-    return std::make_unique<EditSelection>(ctrl, std::move(i), page, layer, view, Range(e->boundingRect()),
+    return std::make_unique<EditSelection>(ctrl, std::move(i), page, layer, view, Range(e->getBoundingBox()),
                                            Range(e->getSnappedBounds()));
 }
 

--- a/src/core/control/tools/EditSelectionContents.cpp
+++ b/src/core/control/tools/EditSelectionContents.cpp
@@ -204,44 +204,19 @@ auto EditSelectionContents::setFill(int alphaPen, int alphaHighligther) -> UndoA
  * (or nullptr if there are no Text elements)
  */
 auto EditSelectionContents::setFont(const XojFont& font) -> UndoActionPtr {
-    double x1 = std::numeric_limits<double>::quiet_NaN();
-    double x2 = std::numeric_limits<double>::quiet_NaN();
-    double y1 = std::numeric_limits<double>::quiet_NaN();
-    double y2 = std::numeric_limits<double>::quiet_NaN();
-
     auto undo = std::make_unique<FontUndoAction>(this->sourcePage, this->sourceLayer);
+    bool foundOne = false;
 
     for (Element* e: this->selected) {
         if (e->getType() == ELEMENT_TEXT) {
             Text* t = dynamic_cast<Text*>(e);
             undo->addStroke(t, t->getFont(), font);
-
-            if (std::isnan(x1)) {
-                x1 = t->getX();
-                y1 = t->getY();
-                x2 = t->getX() + t->getElementWidth();
-                y2 = t->getY() + t->getElementHeight();
-            } else {
-                // size with old font
-                x1 = std::min(x1, t->getX());
-                y1 = std::min(y1, t->getY());
-
-                x2 = std::max(x2, t->getX() + t->getElementWidth());
-                y2 = std::max(y2, t->getY() + t->getElementHeight());
-            }
-
             t->setFont(font);
-
-            // size with new font
-            x1 = std::min(x1, t->getX());
-            y1 = std::min(y1, t->getY());
-
-            x2 = std::max(x2, t->getX() + t->getElementWidth());
-            y2 = std::max(y2, t->getY() + t->getElementHeight());
+            foundOne = true;
         }
     }
 
-    if (!std::isnan(x1)) {
+    if (foundOne) {
         this->deleteViewBuffer();
         this->sourceView->getXournal()->repaintSelection();
         return undo;

--- a/src/core/control/tools/EraseHandler.cpp
+++ b/src/core/control/tools/EraseHandler.cpp
@@ -45,20 +45,22 @@ EraseHandler::~EraseHandler() {
  */
 void EraseHandler::erase(double x, double y) {
     this->halfEraserSize = this->handler->getThickness();
-    GdkRectangle eraserRect = {gint(x - halfEraserSize), gint(y - halfEraserSize), gint(halfEraserSize * 2),
-                               gint(halfEraserSize * 2)};
+    xoj::util::Rectangle<double> eraserRect(x - halfEraserSize, y - halfEraserSize, 2 * halfEraserSize,
+                                            2 * halfEraserSize);
 
-    Range range(x, y);
+    Range rerenderRange;
 
     Layer* l = page->getSelectedLayer();
 
     for (Element* e: xoj::refElementContainer(l->getElements())) {
-        if (e->getType() == ELEMENT_STROKE && e->intersectsArea(&eraserRect)) {
-            eraseStroke(l, dynamic_cast<Stroke*>(e), x, y, range);
+        if (e->getType() == ELEMENT_STROKE && e->getBoundingBox().intersects(eraserRect)) {
+            eraseStroke(l, dynamic_cast<Stroke*>(e), x, y, rerenderRange);
         }
     }
 
-    this->view->rerenderRange(range);
+    if (!rerenderRange.empty()) {
+        this->view->rerenderRange(rerenderRange);
+    }
 }
 
 void EraseHandler::eraseStroke(Layer* l, Stroke* s, double x, double y, Range& range) {
@@ -78,8 +80,7 @@ void EraseHandler::eraseStroke(Layer* l, Stroke* s, double x, double y, Range& r
             if (pos == -1) {
                 return;
             }
-            range.addPoint(s->getX(), s->getY());
-            range.addPoint(s->getX() + s->getElementWidth(), s->getY() + s->getElementHeight());
+            range = range.unite(Range(s->getBoundingBox()));
 
             // removed the if statement - this prevents us from putting multiple elements into a
             // stroke erase operation, but it also prevents the crashing and layer issues!

--- a/src/core/control/tools/ImageHandler.cpp
+++ b/src/core/control/tools/ImageHandler.cpp
@@ -105,12 +105,11 @@ bool ImageHandler::addImageToDocument(std::unique_ptr<Image> img, PageRef page, 
 
 void ImageHandler::automaticScaling(Image& img, PageRef page, int width, int height) {
     double zoom = 1;
-    double x = img.getX();
-    double y = img.getY();
+    const auto& p = img.getOrigin();
 
-    if (x + width > page->getWidth() || y + height > page->getHeight()) {
-        double const maxZoomX = (page->getWidth() - x) / width;
-        double const maxZoomY = (page->getHeight() - y) / height;
+    if (p.x + width > page->getWidth() || p.y + height > page->getHeight()) {
+        double const maxZoomX = (page->getWidth() - p.x) / width;
+        double const maxZoomY = (page->getHeight() - p.y) / height;
         zoom = std::min(maxZoomX, maxZoomY);
     }
 
@@ -127,8 +126,7 @@ void ImageHandler::automaticScaling(Image& img, PageRef page) {
 void ImageHandler::insertImageWithSize(PageRef page, const xoj::util::Rectangle<double>& space) {
     chooseAndCreateImage([space, page, ctrl = control](std::unique_ptr<Image> img) {
         xoj_assert(img);
-        img->setX(space.x);
-        img->setY(space.y);
+        img->setOrigin(space.x, space.y);
         auto [width, height] = img->getImageSize();
 
         if (static_cast<int>(space.width) != 0 && static_cast<int>(space.height) != 0) {
@@ -138,12 +136,15 @@ void ImageHandler::insertImageWithSize(PageRef page, const xoj::util::Rectangle<
             img->setHeight(scaling * height);
 
             // center
-            if (img->getElementHeight() < space.height) {
-                img->setY(img->getY() + ((space.height - img->getElementHeight()) * 0.5));
+            const auto& box = img->getBoundingBox();
+            xoj::util::Point<double> move(0, 0);
+            if (box.height < space.height) {
+                move.y = (space.height - box.height) * 0.5;
             }
-            if (img->getElementWidth() < space.width) {
-                img->setX(img->getX() + ((space.width - img->getElementWidth()) * 0.5));
+            if (box.width < space.width) {
+                move.x = (space.width - box.width) * 0.5;
             }
+            img->move(move.x, move.y);
         } else {
             // zero space is selected, scale original image size down to fit on the page
             automaticScaling(*img, page);

--- a/src/core/control/tools/LaserPointerHandler.cpp
+++ b/src/core/control/tools/LaserPointerHandler.cpp
@@ -58,7 +58,7 @@ void LaserPointerHandler::onButtonReleaseEvent(const PositionInputData& pos, dou
     this->hasFinishedStrokes = true;
     this->strokehandler->finalizeStroke(pos.pressure);
     this->viewPool->dispatch(xoj::view::LaserPointerView::FINISH_STROKE_REQUEST,
-                             Range(this->strokehandler->getStroke()->boundingRect()));
+                             Range(this->strokehandler->getStroke()->getBoundingBox()));
     this->strokehandler.reset();
     this->fadeoutTimer =
             g_timeout_add(this->fadeoutStartDelay, xoj::util::wrap_for_once_v<triggerFadeoutCallback>, this);
@@ -71,7 +71,7 @@ bool LaserPointerHandler::onMotionNotifyEvent(const PositionInputData& pos, doub
 void LaserPointerHandler::onSequenceCancelEvent() {
     auto s = std::move(this->strokehandler);
     if (s && s->getStroke()) {
-        Range rg(s->getStroke()->boundingRect());
+        Range rg(s->getStroke()->getBoundingBox());
         this->viewPool->dispatch(xoj::view::LaserPointerView::INPUT_CANCELLATION_REQUEST, rg);
     }
     if (this->hasFinishedStrokes) {

--- a/src/core/control/tools/LinkHandler.cpp
+++ b/src/core/control/tools/LinkHandler.cpp
@@ -94,22 +94,20 @@ void LinkHandler::startEditing(const PageRef& page, const int x, const int y) {
                 []() {});
         dialog.show(control->getGtkWindow());
     } else {
-        double posX = linkElement->getX();
-        double posY = linkElement->getY();
+        auto pos = linkElement->getOrigin();  // Copy before unlocking the mutex
         lock.unlock();
 
         this->highlightPopover->linkTo(linkElement);
         auto dialog = xoj::popup::PopupWindowWrapper<LinkDialog>(
                 this->control,
-                [this, linkElement, page = page, posX, posY](LinkDialog* dlg) {
+                [this, linkElement, page = page, pos](LinkDialog* dlg) {
                     auto linkOwn = std::make_unique<Link>();
                     Link* link = linkOwn.get();
                     link->setText(dlg->getText());
                     link->setUrl(dlg->getURL());
                     link->setAlignment(dlg->getLayout());
                     link->setFont(dlg->getFont());
-                    link->setX(posX);
-                    link->setY(posY);
+                    link->setOrigin(pos.x, pos.y);
 
                     const auto undo = control->getUndoRedoHandler();
                     auto groupUndoAction = std::make_unique<GroupUndoAction>();

--- a/src/core/control/tools/StrokeHandler.cpp
+++ b/src/core/control/tools/StrokeHandler.cpp
@@ -127,7 +127,7 @@ void StrokeHandler::drawSegmentTo(const Point& point) {
 void StrokeHandler::onSequenceCancelEvent() {
     if (this->stroke) {
         this->viewPool->dispatchAndClear(xoj::view::StrokeToolView::CANCELLATION_REQUEST,
-                                         Range(this->stroke->boundingRect()));
+                                         Range(this->stroke->getBoundingBox()));
         stroke.reset();
     }
 }
@@ -245,12 +245,7 @@ void StrokeHandler::strokeRecognizerDetected(std::unique_ptr<Stroke> recognized,
     layer->addElement(std::move(recognized));
     doc->unlock();
 
-    Range range(recognizedPtr->getX(), recognizedPtr->getY());
-    range.addPoint(recognizedPtr->getX() + recognizedPtr->getElementWidth(),
-                   recognizedPtr->getY() + recognizedPtr->getElementHeight());
-
-    range.addPoint(strokePtr->getX(), strokePtr->getY());
-    range.addPoint(strokePtr->getX() + strokePtr->getElementWidth(), strokePtr->getY() + strokePtr->getElementHeight());
+    Range range = Range(recognizedPtr->getBoundingBox()).unite(Range(strokePtr->getBoundingBox()));
 
     this->viewPool->dispatch(xoj::view::StrokeToolView::STROKE_REPLACEMENT_REQUEST, *recognizedPtr);
 

--- a/src/core/control/tools/TextEditor.cpp
+++ b/src/core/control/tools/TextEditor.cpp
@@ -161,7 +161,7 @@ TextEditor::TextEditor(Control* control, const PageRef& page, GtkWidget* xournal
 
     if (this->originalTextElement) {
         // If editing a preexisting text, put the cursor at the right location
-        this->mousePressed(x - textElement->getX(), y - textElement->getY());
+        this->mousePressed(x, y);
     } else if (this->cursorBlink) {
         blinkCallback(this);
     } else {
@@ -194,17 +194,18 @@ TextEditor::TextEditor(Control* control, const PageRef& page, GtkWidget* xournal
                                      if (!self->viewPool->empty()) {
                                          // We use the first view as the main view
                                          auto* text = self->getTextElement();
-                                         auto zoom = self->viewPool->front().getZoom();
-                                         double dx = offsetX / zoom;
-                                         double dy = offsetY / zoom;
-                                         if (text->getX() + dx > 0 &&
-                                             text->getX() + dx < self->page->getWidth() -
-                                                                         self->getContentBoundingBox().getWidth() &&
-                                             text->getY() + dy > 0 &&
-                                             text->getY() + dy < self->page->getHeight() -
-                                                                         self->getContentBoundingBox().getHeight()) {
+                                         const auto zoom = self->viewPool->front().getZoom();
+                                         const xoj::util::Point<double> move(offsetX / zoom, offsetY / zoom);
+                                         const auto newOrigin = text->getOrigin() + move;
+                                         const double width = self->currentWrapWidth == Text::NO_WRAP ?
+                                                                      self->getContentBoundingBox().getWidth() :
+                                                                      self->currentWrapWidth;
+                                         if (newOrigin.x > 0 && newOrigin.x + width < self->page->getWidth() &&
+                                             newOrigin.y > 0 &&
+                                             newOrigin.y + self->getContentBoundingBox().getHeight() <
+                                                     self->page->getHeight()) {
                                              // The text stays entirely in the page
-                                             text->move(dx, dy);
+                                             text->move(move.x, move.y);
                                              self->repaintEditor(true);
                                          }
                                      }
@@ -249,7 +250,8 @@ TextEditor::TextEditor(Control* control, const PageRef& page, GtkWidget* xournal
                                                  if (double newVal = self->currentWrapWidth +
                                                                      offsetX / self->viewPool->front().getZoom();
                                                      newVal > 0 &&
-                                                     newVal < self->page->getWidth() - self->getTextElement()->getX()) {
+                                                     newVal < self->page->getWidth() -
+                                                                      self->getTextElement()->getOrigin().x) {
                                                      // The new width does not overflow out of the page
                                                      self->currentWrapWidth = newVal;
                                                      self->layoutStatus = LayoutStatus::NEEDS_WRAP_WIDTH_UPDATE;
@@ -685,12 +687,14 @@ void TextEditor::markPos(double x, double y, bool extendSelection) {
 void TextEditor::mousePressed(double x, double y) {
     this->mouseDown = true;
     // Todo select if SHIFT is pressed
-    markPos(x, y, false);
+    const auto& origin = textElement->getOrigin();
+    this->markPos(x - origin.x, y - origin.y, false);
 }
 
 void TextEditor::mouseMoved(double x, double y) {
     if (this->mouseDown) {
-        markPos(x, y, true);
+        const auto& origin = textElement->getOrigin();
+        this->markPos(x - origin.x, y - origin.y, true);
     }
 }
 
@@ -764,8 +768,9 @@ void TextEditor::updateCursorBox() {
     if (!viewPool->empty()) {
         // Inform the IM of the cursor location (for word selection popup's location)
         // We use the first view as the main view, as far as the IM is concerned
+        const auto& origin = textElement->getOrigin();
         auto box = viewPool->front().toWidgetCoordinates(
-                xoj::util::Rectangle<double>(this->cursorBox).translated(textElement->getX(), textElement->getY()));
+                xoj::util::Rectangle<double>(this->cursorBox).translated(origin.x, origin.y));
 
         GdkRectangle cursorRect;  // cursor position in window coordinates
         cursorRect.x = static_cast<int>(box.x);
@@ -1006,7 +1011,8 @@ void TextEditor::blinkCallback(TextEditor* te) {
     te->blinkTimer = g_timeout_add(time, xoj::util::wrap_for_once_v<blinkCallback>, te);
 
     Range dirtyRange = te->cursorBox;
-    dirtyRange.translate(te->textElement->getX(), te->textElement->getY());
+    const auto& origin = te->textElement->getOrigin();
+    dirtyRange.translate(origin.x, origin.y);
     te->viewPool->dispatch(xoj::view::TextEditionView::FLAG_DIRTY_REGION, dirtyRange);
 }
 
@@ -1062,16 +1068,15 @@ auto TextEditor::computeBoundingBox() const -> Range {
     pango_layout_get_size(getUpToDateLayout(), &w, &h);
     double width = (static_cast<double>(w)) / PANGO_SCALE;
     double height = (static_cast<double>(h)) / PANGO_SCALE;
-    double x = textElement->getX();
-    double y = textElement->getY();
+    const auto& p = textElement->getOrigin();
 
     // Warning: `width` can be negative (e.g. for languages written from right to left)
 
     if (double wrap = this->currentWrapWidth; wrap != Text::NO_WRAP) {
         width = std::copysign(std::max(std::abs(width), wrap), width);
     }
-    Range res(x, y);
-    res.addPoint(x + width, y + height);
+    Range res(p.x, p.y);
+    res.addPoint(p.x + width, p.y + height);
     return res;
 }
 
@@ -1131,7 +1136,9 @@ void TextEditor::repaintCursorAfterChange() {
     Range dirtyRange = this->cursorBox;
     this->updateCursorBox();
     dirtyRange = dirtyRange.unite(this->cursorBox);
-    dirtyRange.translate(this->textElement->getX(), this->textElement->getY());
+    const auto& origin = this->textElement->getOrigin();
+
+    dirtyRange.translate(origin.x, origin.y);
     this->viewPool->dispatch(xoj::view::TextEditionView::FLAG_DIRTY_REGION, dirtyRange);
 }
 
@@ -1202,12 +1209,9 @@ void TextEditor::initializeEditionAt(double x, double y) {
 
     // Should we reverse this loop to select the most recent text rather than the oldest?
     for (auto&& e: this->page->getSelectedLayer()->getElements()) {
-        if (e->getType() == ELEMENT_TEXT) {
-            GdkRectangle matchRect = {gint(x), gint(y), 1, 1};
-            if (e->intersectsArea(&matchRect)) {
-                text = dynamic_cast<Text*>(e.get());
-                break;
-            }
+        if (e->getType() == ELEMENT_TEXT && e->hasBoundingBoxContaining(x, y)) {
+            text = dynamic_cast<Text*>(e.get());
+            break;
         }
     }
 
@@ -1216,8 +1220,7 @@ void TextEditor::initializeEditionAt(double x, double y) {
         this->textElement = std::make_unique<Text>();
         this->textElement->setColor(h->getColor());
         this->textElement->setFont(control->getSettings()->getFont());
-        this->textElement->setX(x);
-        this->textElement->setY(y - this->textElement->getElementHeight() / 2);
+        this->textElement->setOrigin(x, y - this->textElement->getBoundingBox().height / 2);
 
 #ifdef ENABLE_AUDIO
         if (auto audioController = control->getAudioController(); audioController && audioController->isRecording()) {

--- a/src/core/control/tools/TextEditor.h
+++ b/src/core/control/tools/TextEditor.h
@@ -55,8 +55,8 @@ public:
 
     bool onKeyPressEvent(const KeyEvent& event);
     bool onKeyReleaseEvent(const KeyEvent& event);
-    void mousePressed(double x, double y);
-    void mouseMoved(double x, double y);
+    void mousePressed(double x, double y);  ///< Coordinates are in Page coordinates
+    void mouseMoved(double x, double y);    ///< Coordinates are in Page coordinates
     void mouseReleased();
 
     /**
@@ -122,7 +122,7 @@ private:
 
     /**
      * @brief Compute the cursor's location
-     * @return The bounding box of the cursor, in TextBox coordinates (i.e relative to the text box upper left corner)
+     * @return The bounding box of the cursor, in TextBox coordinates (i.e relative to the text's getOrigin())
      *          The bounding box is returned even if the cursor is currently not visible (blinking...)
      * WARNING: The returned box may have width == 0 (if in insertion mode or at the end of a line). In this case, the
      *          width of the displayed cursor should be decided by the view class (depending on zoom for instance)

--- a/src/core/control/tools/VerticalToolHandler.cpp
+++ b/src/core/control/tools/VerticalToolHandler.cpp
@@ -48,8 +48,9 @@ void VerticalToolHandler::adoptElements(const Side side) {
 
     // Add new elements based on position
     for (const Element* e: this->layer->getElementsView().clone()) {
-        if ((side == Side::Below && e->getY() >= this->startY) ||
-            (side == Side::Above && e->getY() + e->getElementHeight() <= this->startY)) {
+        const auto& box = e->getBoundingBox();
+        if ((side == Side::Below && box.y >= this->startY) ||
+            (side == Side::Above && box.y + box.height <= this->startY)) {
             this->elements.push_back(this->layer->removeElement(e).e);
         }
     }
@@ -105,7 +106,7 @@ void VerticalToolHandler::forEachElement(std::function<void(const Element*)> f) 
 auto VerticalToolHandler::computeElementsBoundingBox() const -> Range {
     Range rg;
     for (auto const& e: this->elements) {
-        rg = rg.unite(Range(e->boundingRect()));
+        rg = rg.unite(Range(e->getBoundingBox()));
     }
     return rg;
 }

--- a/src/core/control/xojfile/LoadHandler.cpp
+++ b/src/core/control/xojfile/LoadHandler.cpp
@@ -358,8 +358,7 @@ void LoadHandler::addText(std::string font, double size, double x, double y, Col
     XojFont& f = this->text->getFont();
     f.setName(std::move(font));
     f.setSize(size);
-    this->text->setX(x);
-    this->text->setY(y);
+    this->text->setOrigin(x, y);
     this->text->setColor(color);
     this->text->setWrap(wrap.value_or(Text::NO_WRAP));
 
@@ -382,8 +381,7 @@ void LoadHandler::addImage(double left, double top, double right, double bottom)
     xoj_assert(!this->image);
     this->image = std::make_unique<Image>();
 
-    this->image->setX(left);
-    this->image->setY(top);
+    this->image->setOrigin(left, top);
     this->image->setWidth(right - left);
     this->image->setHeight(bottom - top);
 }
@@ -427,8 +425,7 @@ void LoadHandler::addTexImage(double left, double top, double right, double bott
     xoj_assert(!this->teximage);
     this->teximage = std::make_unique<TexImage>();
 
-    this->teximage->setX(left);
-    this->teximage->setY(top);
+    this->teximage->setOrigin(left, top);
     this->teximage->setWidth(right - left);
     this->teximage->setHeight(bottom - top);
 
@@ -464,8 +461,7 @@ void LoadHandler::addLink(TextAlignment align, std::string font, double size, do
 
     this->link->setUrl(std::string(url.c_str()));
 
-    this->link->setX(x);
-    this->link->setY(y);
+    this->link->setOrigin(x, y);
 
     XojFont& f = this->link->getFont();
     f.setName(std::move(font));

--- a/src/core/control/xojfile/SaveHandler.cpp
+++ b/src/core/control/xojfile/SaveHandler.cpp
@@ -191,8 +191,9 @@ void SaveHandler::visitLayer(XmlNode* page, const Layer* l) {
 
             text->setAttrib(xoj::xml_attrs::FONT_STR, f.getName().c_str());
             text->setAttrib(xoj::xml_attrs::SIZE_STR, f.getSize());
-            text->setAttrib(xoj::xml_attrs::X_COORD_STR, t->getX());
-            text->setAttrib(xoj::xml_attrs::Y_COORD_STR, t->getY());
+            const auto& origin = t->getOrigin();
+            text->setAttrib(xoj::xml_attrs::X_COORD_STR, origin.x);
+            text->setAttrib(xoj::xml_attrs::Y_COORD_STR, origin.y);
             text->setAttrib(xoj::xml_attrs::COLOR_STR, getColorStr(t->getColor()).c_str());
             if (auto w = t->getWrap(); w != Text::NO_WRAP) {
                 text->setAttrib(xoj::xml_attrs::WRAP_STR, w);
@@ -206,20 +207,22 @@ void SaveHandler::visitLayer(XmlNode* page, const Layer* l) {
 
             image->setImage(i->getImage());
 
-            image->setAttrib(xoj::xml_attrs::LEFT_POS_STR, i->getX());
-            image->setAttrib(xoj::xml_attrs::TOP_POS_STR, i->getY());
-            image->setAttrib(xoj::xml_attrs::RIGHT_POS_STR, i->getX() + i->getElementWidth());
-            image->setAttrib(xoj::xml_attrs::BOTTOM_POS_STR, i->getY() + i->getElementHeight());
+            Range r(i->getBoundingBox());
+            image->setAttrib(xoj::xml_attrs::LEFT_POS_STR, r.minX);
+            image->setAttrib(xoj::xml_attrs::TOP_POS_STR, r.minY);
+            image->setAttrib(xoj::xml_attrs::RIGHT_POS_STR, r.maxX);
+            image->setAttrib(xoj::xml_attrs::BOTTOM_POS_STR, r.maxY);
         } else if (e->getType() == ELEMENT_TEXIMAGE) {
             auto* i = dynamic_cast<const TexImage*>(e);
             auto* image = new XmlTexNode(TAG_NAMES[TagType::TEXIMAGE], std::string(i->getBinaryData()));
             layer->addChild(image);
 
             image->setAttrib(xoj::xml_attrs::TEXT_STR, i->getText().c_str());
-            image->setAttrib(xoj::xml_attrs::LEFT_POS_STR, i->getX());
-            image->setAttrib(xoj::xml_attrs::TOP_POS_STR, i->getY());
-            image->setAttrib(xoj::xml_attrs::RIGHT_POS_STR, i->getX() + i->getElementWidth());
-            image->setAttrib(xoj::xml_attrs::BOTTOM_POS_STR, i->getY() + i->getElementHeight());
+            Range r(i->getBoundingBox());
+            image->setAttrib(xoj::xml_attrs::LEFT_POS_STR, r.minX);
+            image->setAttrib(xoj::xml_attrs::TOP_POS_STR, r.minY);
+            image->setAttrib(xoj::xml_attrs::RIGHT_POS_STR, r.maxX);
+            image->setAttrib(xoj::xml_attrs::BOTTOM_POS_STR, r.maxY);
         } else if (e->getType() == ELEMENT_LINK) {
             auto* l = dynamic_cast<const Link*>(e);
             auto* link = new XmlTextNode(TAG_NAMES[TagType::LINK], l->getText());
@@ -230,8 +233,9 @@ void SaveHandler::visitLayer(XmlNode* page, const Layer* l) {
             link->setAttrib(xoj::xml_attrs::ALIGN_STR, l->getAlignment());
             link->setAttrib(xoj::xml_attrs::FONT_STR, f.getName().c_str());
             link->setAttrib(xoj::xml_attrs::SIZE_STR, f.getSize());
-            link->setAttrib(xoj::xml_attrs::X_COORD_STR, l->getX());
-            link->setAttrib(xoj::xml_attrs::Y_COORD_STR, l->getY());
+            const auto& origin = l->getOrigin();
+            link->setAttrib(xoj::xml_attrs::X_COORD_STR, origin.x);
+            link->setAttrib(xoj::xml_attrs::Y_COORD_STR, origin.y);
             link->setAttrib(xoj::xml_attrs::COLOR_STR, getColorStr(l->getColor()).c_str());
             link->setAttrib(xoj::xml_attrs::URL_STR, l->getUrl().c_str());
         }

--- a/src/core/gui/LegacyRedrawable.cpp
+++ b/src/core/gui/LegacyRedrawable.cpp
@@ -3,8 +3,9 @@
 #include "model/Element.h"  // for Element
 #include "util/Range.h"     // for Range
 
-void LegacyRedrawable::repaintElement(Element* e) const {
-    repaintArea(e->getX(), e->getY(), e->getElementWidth() + e->getX(), e->getElementHeight() + e->getY());
+void LegacyRedrawable::repaintElement(const Element* e) const {
+    Range r(e->getBoundingBox());
+    repaintArea(r.minX, r.minY, r.maxX, r.maxY);
 }
 
 void LegacyRedrawable::repaintRect(double x, double y, double width, double height) const {
@@ -14,5 +15,6 @@ void LegacyRedrawable::repaintRect(double x, double y, double width, double heig
 void LegacyRedrawable::rerenderRange(const Range& r) { rerenderRect(r.getX(), r.getY(), r.getWidth(), r.getHeight()); }
 
 void LegacyRedrawable::rerenderElement(const Element* e) {
-    rerenderRect(e->getX(), e->getY(), e->getElementWidth(), e->getElementHeight());
+    const auto& rect = e->getBoundingBox();
+    rerenderRect(rect.x, rect.y, rect.width, rect.height);
 }

--- a/src/core/gui/LegacyRedrawable.h
+++ b/src/core/gui/LegacyRedrawable.h
@@ -47,7 +47,7 @@ public:
      */
     virtual void repaintArea(double x1, double y1, double x2, double y2) const = 0;
     [[maybe_unused]] void repaintRect(double x, double y, double width, double height) const;
-    [[maybe_unused]] void repaintElement(Element* e) const;
+    [[maybe_unused]] void repaintElement(const Element* e) const;
 
     /**
      * Call this if you only need to redraw the view, this means the buffer will be painted again,

--- a/src/core/gui/LinkPopover.cpp
+++ b/src/core/gui/LinkPopover.cpp
@@ -58,7 +58,7 @@ void LinkPopover::updateRect() {
         this->rect = std::nullopt;
         return;
     }
-    this->rect = this->link->boundingRect();
+    this->rect = this->link->getBoundingBox();
 }
 
 void LinkPopover::updateLabel() {

--- a/src/core/gui/PageView.cpp
+++ b/src/core/gui/PageView.cpp
@@ -180,7 +180,7 @@ void XojPageView::startText(double x, double y) {
         if (const auto& box = this->textEditor->getContentBoundingBox(); !box.contains(x, y)) {
             endText();
         } else {
-            this->textEditor->mousePressed(x - box.getX(), y - box.getY());
+            this->textEditor->mousePressed(x, y);
         }
     }
 
@@ -568,8 +568,7 @@ auto XojPageView::onMotionNotifyEvent(const PositionInputData& pos) -> bool {
         XournalppCursor* cursor = getXournal()->getCursor();
         cursor->setInvisible(false);
 
-        const Text* text = this->textEditor->getTextElement();
-        this->textEditor->mouseMoved(x - text->getX(), y - text->getY());
+        this->textEditor->mouseMoved(x, y);
     } else if (this->laserPointer && this->laserPointer->onMotionNotifyEvent(pos, zoom)) {
         // used this event
     } else if (h->getToolType() == TOOL_ERASER && h->getEraserType() != ERASER_TYPE_WHITEOUT && this->inEraser) {
@@ -1174,7 +1173,7 @@ void XojPageView::elementChanged(const Element* elem) {
      */
     const bool noRerender = inputHandler && elem == inputHandler->getStroke() &&
                             page->getSelectedLayerId() == page->getLayerCount() &&
-                            getVisiblePart().contains(elem->boundingRect());
+                            getVisiblePart().contains(elem->getBoundingBox());
     if (!noRerender) {
         rerenderElement(elem);
     }

--- a/src/core/gui/PageViewFindObjectHelper.h
+++ b/src/core/gui/PageViewFindObjectHelper.h
@@ -14,8 +14,8 @@
 // No include needed, this is included after PageView.h
 
 #include <limits>
-#include <mutex>
 #include <optional>
+#include <shared_mutex>
 
 #include "control/AudioController.h"
 #include "control/Control.h"

--- a/src/core/model/Element.cpp
+++ b/src/core/model/Element.cpp
@@ -6,6 +6,7 @@
 
 #include <glib.h>  // for gint
 
+#include "util/Point.h"
 #include "util/safe_casts.h"                      // for as_unsigned
 #include "util/serializing/ObjectInputStream.h"   // for ObjectInputStream
 #include "util/serializing/ObjectOutputStream.h"  // for ObjectOutputStream
@@ -16,32 +17,15 @@ Element::Element(ElementType type): type(type) {}
 
 auto Element::getType() const -> ElementType { return this->type; }
 
-void Element::setX(double x) {
-    this->x = x;
-    this->sizeCalculated = false;
-}
-
-void Element::setY(double y) {
-    this->y = y;
-    this->sizeCalculated = false;
-}
-
-auto Element::getX() const -> double {
+auto Element::getBoundingBox() const -> const Rectangle<double>& {
     if (!this->sizeCalculated) {
         this->sizeCalculated = true;
         calcSize();
     }
-    return x;
+    return this->boundingBox;
 }
 
-auto Element::getY() const -> double {
-    if (!this->sizeCalculated) {
-        this->sizeCalculated = true;
-        calcSize();
-    }
-    return y;
-}
-auto Element::getSnappedBounds() const -> Rectangle<double> {
+auto Element::getSnappedBounds() const -> const Rectangle<double>& {
     if (!this->sizeCalculated) {
         this->sizeCalculated = true;
         calcSize();
@@ -49,83 +33,51 @@ auto Element::getSnappedBounds() const -> Rectangle<double> {
     return this->snappedBounds;
 }
 
+void Element::setOrigin(double x, double y) {
+    this->boundingBox.x = x;
+    this->boundingBox.y = y;
+    this->sizeCalculated = false;
+}
+
+auto Element::getOrigin() const -> const xoj::util::Point<double>& { return boundingBox.getOrigin(); }
+
 void Element::move(double dx, double dy) {
-    this->x += dx;
-    this->y += dy;
+    this->boundingBox = this->boundingBox.translated(dx, dy);
     this->snappedBounds = this->snappedBounds.translated(dx, dy);
-}
-
-auto Element::getElementWidth() const -> double {
-    if (!this->sizeCalculated) {
-        this->sizeCalculated = true;
-        calcSize();
-    }
-    return this->width;
-}
-
-auto Element::getElementHeight() const -> double {
-    if (!this->sizeCalculated) {
-        this->sizeCalculated = true;
-        calcSize();
-    }
-    return this->height;
-}
-
-auto Element::boundingRect() const -> Rectangle<double> {
-    return Rectangle<double>(getX(), getY(), getElementWidth(), getElementHeight());
 }
 
 void Element::setColor(Color color) { this->color = color; }
 
 auto Element::getColor() const -> Color { return this->color; }
 
-auto Element::intersectsArea(const GdkRectangle* src) const -> bool {
-    // compute the smallest rectangle with integer coordinates containing the bounding box and having width, height > 0
-    auto x = getX();
-    auto y = getY();
-    auto x1 = gint(std::floor(getX()));
-    auto y1 = gint(std::floor(getY()));
-    auto x2 = gint(std::ceil(x + getElementWidth()));
-    auto y2 = gint(std::ceil(y + getElementHeight()));
-    GdkRectangle rect = {x1, y1, std::max(1, x2 - x1), std::max(1, y2 - y1)};
-
-    return gdk_rectangle_intersect(src, &rect, nullptr);
-}
-
 auto Element::intersectsArea(double x, double y, double width, double height) const -> bool {
-    double dest_x = NAN, dest_y = NAN;
-    double dest_w = NAN, dest_h = NAN;
-
-    dest_x = std::max(getX(), x);
-    dest_y = std::max(getY(), y);
-    dest_w = std::min(getX() + getElementWidth(), x + width) - dest_x;
-    dest_h = std::min(getY() + getElementHeight(), y + height) - dest_y;
-
-    return (dest_w > 0 && dest_h > 0);
+    return this->getBoundingBox().intersects(xoj::util::Rectangle<double>(x, y, width, height)).has_value();
 }
 
 auto Element::distanceTo(double x, double y) const -> double {
-    // Coordinates of the point in the bounding rectangle that is the closest to (x,y).
-    double projX = std::clamp(x, getX(), getX() + getElementWidth());
-    double projY = std::clamp(y, getY(), getY() + getElementHeight());
+    const auto& box = this->getBoundingBox();
+    // Coordinates of the point in the bounding box that is the closest to (x,y).
+    double projX = std::clamp(x, box.x, box.x + box.width);
+    double projY = std::clamp(y, box.y, box.y + box.height);
     return std::hypot(x - projX, y - projY);
 }
 
 auto Element::hasBoundingBoxContaining(double x, double y) const -> bool {
-    return x >= getX() && x <= getX() + getElementWidth() && y >= getY() && y <= getY() + getElementHeight();
+    return Range(this->getBoundingBox()).contains(x, y);
 }
 
 auto Element::isInSelection(ShapeContainer* container) const -> bool {
-    if (!container->contains(getX(), getY())) {
+    const auto& box = this->getBoundingBox();
+    if (!container->contains(box.x, box.y)) {
         return false;
     }
-    if (!container->contains(getX() + getElementWidth(), getY())) {
+    if (!container->contains(box.x + box.width, box.y)) {
         return false;
     }
-    if (!container->contains(getX(), getY() + getElementHeight())) {
+    if (!container->contains(box.x, box.y + box.height)) {
         return false;
     }
-    if (!container->contains(getX() + getElementWidth(), getY() + getElementHeight())) {
+    if (!container->contains(box.x + box.width, box.y + box.height)) {
         return false;
     }
 
@@ -138,8 +90,9 @@ auto Element::rescaleWithMirror() const -> bool { return false; }
 void Element::serialize(ObjectOutputStream& out) const {
     out.writeObject("Element");
 
-    out.writeDouble(this->x);
-    out.writeDouble(this->y);
+    const auto& pt = getOrigin();
+    out.writeDouble(pt.x);
+    out.writeDouble(pt.y);
     out.writeUInt(uint32_t(this->color));
 
     out.endObject();
@@ -148,8 +101,9 @@ void Element::serialize(ObjectOutputStream& out) const {
 void Element::readSerialized(ObjectInputStream& in) {
     in.readObject("Element");
 
-    this->x = in.readDouble();
-    this->y = in.readDouble();
+    double x = in.readDouble();
+    double y = in.readDouble();
+    setOrigin(x, y);
     this->color = Color(in.readUInt());
 
     in.endObject();

--- a/src/core/model/Element.h
+++ b/src/core/model/Element.h
@@ -24,6 +24,11 @@
 class ObjectInputStream;
 class ObjectOutputStream;
 
+namespace xoj::util {
+template <class T>
+class Point;
+};
+
 enum ElementType { ELEMENT_STROKE = 1, ELEMENT_IMAGE, ELEMENT_TEXIMAGE, ELEMENT_TEXT, ELEMENT_LINK };
 
 class ShapeContainer {
@@ -49,10 +54,9 @@ public:
 public:
     ElementType getType() const;
 
-    void setX(double x);
-    void setY(double y);
-    double getX() const;
-    double getY() const;
+    /// Move the element to (x,y).
+    virtual void setOrigin(double x, double y);
+    virtual const xoj::util::Point<double>& getOrigin() const;
 
     virtual void move(double dx, double dy);
     virtual void scale(double x0, double y0, double fx, double fy, double rotation, bool restoreLineWidth) = 0;
@@ -61,14 +65,10 @@ public:
     void setColor(Color color);
     Color getColor() const;
 
-    double getElementWidth() const;
-    double getElementHeight() const;
+    const xoj::util::Rectangle<double>& getSnappedBounds() const;
 
-    xoj::util::Rectangle<double> getSnappedBounds() const;
+    const xoj::util::Rectangle<double>& getBoundingBox() const;
 
-    xoj::util::Rectangle<double> boundingRect() const;
-
-    virtual bool intersectsArea(const GdkRectangle* src) const;
     virtual bool intersectsArea(double x, double y, double width, double height) const;
     /// Returns the distance between the element "as drawn" and the point (x,y)
     virtual double distanceTo(double x, double y) const;
@@ -92,17 +92,13 @@ protected:
     virtual void calcSize() const = 0;
 
 protected:
-    // If the size has been calculated
+    /// Whether the size has been calculated or not
     mutable bool sizeCalculated = false;
 
-    mutable double width = 0;
-    mutable double height = 0;
+    /// Rectangular area containing the element as drawn
+    mutable xoj::util::Rectangle<double> boundingBox{};
 
-    // The position on the screen
-    mutable double x = 0;
-    mutable double y = 0;
-
-    // The position and dimensions on the screen used for snapping
+    /// The position and dimensions on the screen used for snapping
     mutable xoj::util::Rectangle<double> snappedBounds{};
 
 private:

--- a/src/core/model/GeometryTool.cpp
+++ b/src/core/model/GeometryTool.cpp
@@ -40,9 +40,7 @@ void GeometryTool::setStroke(Stroke* s) { this->stroke = s; }
 auto GeometryTool::computeRepaintRange(Range rg) const -> Range {
     Range lastRange = this->lastRepaintRange;
     if (this->stroke) {
-        rg.addPoint(this->stroke->getX(), this->stroke->getY());
-        rg.addPoint(this->stroke->getX() + this->stroke->getElementWidth(),
-                    this->stroke->getY() + this->stroke->getElementHeight());
+        rg = rg.unite(Range(this->stroke->getBoundingBox()));
     }
     this->lastRepaintRange = rg;
     return rg.unite(lastRange);

--- a/src/core/model/Image.cpp
+++ b/src/core/model/Image.cpp
@@ -38,11 +38,8 @@ Image::~Image() {
 auto Image::clone() const -> ElementPtr {
     auto img = std::make_unique<Image>();
 
-    img->x = this->x;
-    img->y = this->y;
+    img->boundingBox = this->boundingBox;
     img->setColor(this->getColor());
-    img->width = this->width;
-    img->height = this->height;
     img->data = this->data;
 
     img->image = cairo_surface_reference(this->image);
@@ -53,12 +50,12 @@ auto Image::clone() const -> ElementPtr {
 }
 
 void Image::setWidth(double width) {
-    this->width = width;
+    this->boundingBox.width = width;
     this->calcSize();
 }
 
 void Image::setHeight(double height) {
-    this->height = height;
+    this->boundingBox.height = height;
     this->calcSize();
 }
 
@@ -206,15 +203,15 @@ auto Image::getImage() const -> cairo_surface_t* {
 
 void Image::scale(double x0, double y0, double fx, double fy, double rotation,
                   bool) {  // line width scaling option is not used
-    this->x -= x0;
-    this->x *= fx;
-    this->x += x0;
-    this->y -= y0;
-    this->y *= fy;
-    this->y += y0;
+    this->boundingBox.x -= x0;
+    this->boundingBox.x *= fx;
+    this->boundingBox.x += x0;
+    this->boundingBox.y -= y0;
+    this->boundingBox.y *= fy;
+    this->boundingBox.y += y0;
 
-    this->width *= fx;
-    this->height *= fy;
+    this->boundingBox.width *= fx;
+    this->boundingBox.height *= fy;
     this->calcSize();
 }
 
@@ -225,8 +222,8 @@ void Image::serialize(ObjectOutputStream& out) const {
 
     this->Element::serialize(out);
 
-    out.writeDouble(this->width);
-    out.writeDouble(this->height);
+    out.writeDouble(this->boundingBox.width);
+    out.writeDouble(this->boundingBox.height);
 
     out.writeImage(this->data);
 
@@ -238,8 +235,8 @@ void Image::readSerialized(ObjectInputStream& in) {
 
     this->Element::readSerialized(in);
 
-    this->width = in.readDouble();
-    this->height = in.readDouble();
+    this->boundingBox.width = in.readDouble();
+    this->boundingBox.height = in.readDouble();
 
     if (this->image) {
         cairo_surface_destroy(this->image);
@@ -253,7 +250,7 @@ void Image::readSerialized(ObjectInputStream& in) {
 }
 
 void Image::calcSize() const {
-    this->snappedBounds = Rectangle<double>(this->x, this->y, this->width, this->height);
+    this->snappedBounds = this->boundingBox;
     this->sizeCalculated = true;
 }
 

--- a/src/core/model/Link.cpp
+++ b/src/core/model/Link.cpp
@@ -22,10 +22,7 @@ void Link::setText(std::string text) { this->text = text; }
 
 std::string Link::getText() const { return this->text; }
 
-void Link::setTextPos(double x, double y) {
-    this->setX(x - PADDING);
-    this->setY(y - PADDING);
-}
+void Link::setTextPos(double x, double y) { this->setOrigin(x - PADDING, y - PADDING); }
 
 void Link::setUrl(std::string url) { this->url = url; }
 
@@ -81,8 +78,8 @@ void Link::scale(double x0, double y0, double fx, double fy, double rotation, bo
     textPos -= xoj::util::Point(x0, y0);
     textPos *= fx;
     textPos += xoj::util::Point(x0, y0);
-    this->x = textPos.x - PADDING;
-    this->y = textPos.y - PADDING;
+    this->boundingBox.x = textPos.x - PADDING;
+    this->boundingBox.y = textPos.y - PADDING;
 
     double size = this->font.getSize() * fx;
     this->font.setSize(size);
@@ -98,10 +95,7 @@ ElementPtr Link::clone() const {
     link->text = this->text;
     link->url = this->url;
     link->setColor(this->getColor());
-    link->x = this->x;
-    link->y = this->y;
-    link->width = this->width;
-    link->height = this->height;
+    link->boundingBox = this->boundingBox;
     link->snappedBounds = this->snappedBounds;
     link->sizeCalculated = this->sizeCalculated;
     return link;
@@ -114,9 +108,10 @@ void Link::calcSize() const {
     pango_layout_get_size(layout.get(), &w, &h);
     double textWidth = (static_cast<double>(w)) / PANGO_SCALE;
     double textHeight = (static_cast<double>(h)) / PANGO_SCALE;
-    this->width = textWidth + 2 * PADDING;
-    this->height = textHeight + 2 * PADDING;
-    this->snappedBounds = xoj::util::Rectangle<double>(this->x + PADDING, this->y + PADDING, textWidth, textHeight);
+    this->boundingBox.width = textWidth + 2 * PADDING;
+    this->boundingBox.height = textHeight + 2 * PADDING;
+    this->snappedBounds = xoj::util::Rectangle<double>(this->boundingBox.x + PADDING, this->boundingBox.y + PADDING,
+                                                       textWidth, textHeight);
 };
 
 auto Link::createPangoLayout() const -> xoj::util::GObjectSPtr<PangoLayout> {

--- a/src/core/model/Stroke.cpp
+++ b/src/core/model/Stroke.cpp
@@ -50,17 +50,17 @@ using xoj::util::Rectangle;
 #endif
 
 template <typename Float>
-constexpr void updateBoundingBox(Float& x, Float& y, Float& width, Float& height, Point const& p, double half_width) {
+constexpr void updateBoundingBox(Rectangle<Float>& box, Point const& p, double half_width) {
     {
-        Float x2 = x + width;
-        Float y2 = y + height;
+        Float x2 = box.x + box.width;
+        Float y2 = box.y + box.height;
 
-        x = std::min(x, p.x - half_width);
-        y = std::min(y, p.y - half_width);
+        box.x = std::min(box.x, p.x - half_width);
+        box.y = std::min(box.y, p.y - half_width);
         x2 = std::max(x2, p.x + half_width);
         y2 = std::max(y2, p.y + half_width);
-        width = x2 - x;
-        height = y2 - y;
+        box.width = x2 - box.x;
+        box.height = y2 - box.y;
     }
 }
 
@@ -102,10 +102,7 @@ auto Stroke::cloneStroke() const -> std::unique_ptr<Stroke> {
     auto s = std::make_unique<Stroke>();
     s->applyStyleFrom(this);
     s->points = this->points;
-    s->x = this->x;
-    s->y = this->y;
-    s->Element::width = this->Element::width;
-    s->Element::height = this->Element::height;
+    s->boundingBox = this->boundingBox;
     s->snappedBounds = this->snappedBounds;
     s->sizeCalculated = this->sizeCalculated;
     return s;
@@ -254,7 +251,7 @@ void Stroke::addPoint(const Point& p) {
     if (hasPressure()) {
         updateBoundsLastTwoPressures();
     } else {
-        updateBoundingBox(Element::x, Element::y, Element::width, Element::height, p, 0.5 * this->width);
+        updateBoundingBox(Element::boundingBox, p, 0.5 * this->width);
         updateSnappedBounds(Element::snappedBounds, p);
     }
 }
@@ -294,10 +291,11 @@ void Stroke::setPointVectorInternal(const Range* const snappingBox) {
     } else {
         xoj_assert(snappingBox->isValid());
         this->snappedBounds = xoj::util::Rectangle<double>(*snappingBox);
-        Element::x = snappingBox->minX - 0.5 * this->width;
-        Element::y = snappingBox->minY - 0.5 * this->width;
-        Element::width = snappingBox->getWidth() + this->width;
-        Element::height = snappingBox->getHeight() + this->width;
+
+        this->boundingBox.x = snappingBox->minX - 0.5 * this->width;
+        this->boundingBox.y = snappingBox->minY - 0.5 * this->width;
+        this->boundingBox.width = snappingBox->getWidth() + this->width;
+        this->boundingBox.height = snappingBox->getHeight() + this->width;
         this->sizeCalculated = true;
     }
 }
@@ -328,8 +326,7 @@ void Stroke::move(double dx, double dy) {
         point.x += dx;
         point.y += dy;
     }
-    Element::x += dx;
-    Element::y += dy;
+    this->boundingBox = this->boundingBox.translated(dx, dy);
     Element::snappedBounds = Element::snappedBounds.translated(dx, dy);
 }
 
@@ -395,8 +392,8 @@ void Stroke::updateBoundsLastTwoPressures() {
     double pressure = p2.z;
 
     updateSnappedBounds(snappedBounds, p);
-    updateBoundingBox(Element::x, Element::y, Element::width, Element::height, p, 0.5 * pressure);
-    updateBoundingBox(Element::x, Element::y, Element::width, Element::height, p2, 0.5 * pressure);
+    updateBoundingBox(boundingBox, p, 0.5 * pressure);
+    updateBoundingBox(boundingBox, p2, 0.5 * pressure);
 }
 
 void Stroke::scalePressure(double factor) {
@@ -815,14 +812,7 @@ auto Stroke::intersectWithPaddedBox(const PaddedBox& box, size_t firstIndex, siz
  */
 void Stroke::calcSize() const {
     if (this->points.empty()) {
-        Element::x = 0;
-        Element::y = 0;
-
-        // The size of the rectangle, not the size of the pen!
-        Element::width = 0;
-        Element::height = 0;
-
-        // used for snapping
+        Element::boundingBox = Rectangle<double>{};
         Element::snappedBounds = Rectangle<double>{};
     }
 
@@ -849,10 +839,7 @@ void Stroke::calcSize() const {
     auto maxX = maxSnapX + halfThick;
     auto maxY = maxSnapY + halfThick;
 
-    Element::x = minX;
-    Element::y = minY;
-    Element::width = maxX - minX;
-    Element::height = maxY - minY;
+    Element::boundingBox = Rectangle<double>(minX, minY, maxX - minX, maxY - minY);
     Element::snappedBounds = Rectangle<double>(minSnapX, minSnapY, maxSnapX - minSnapX, maxSnapY - minSnapY);
 }
 

--- a/src/core/model/TexImage.cpp
+++ b/src/core/model/TexImage.cpp
@@ -30,11 +30,8 @@ void TexImage::freeImageAndPdf() {
 auto TexImage::cloneTexImage() const -> std::unique_ptr<TexImage> {
 
     auto img = std::make_unique<TexImage>();
-    img->x = this->x;
-    img->y = this->y;
+    img->boundingBox = this->boundingBox;
     img->setColor(this->getColor());
-    img->width = this->width;
-    img->height = this->height;
     img->text = this->text;
     img->snappedBounds = this->snappedBounds;
     img->sizeCalculated = this->sizeCalculated;
@@ -53,12 +50,12 @@ auto TexImage::cloneTexImage() const -> std::unique_ptr<TexImage> {
 auto TexImage::clone() const -> ElementPtr { return cloneTexImage(); }
 
 void TexImage::setWidth(double width) {
-    this->width = width;
+    this->boundingBox.width = width;
     this->calcSize();
 }
 
 void TexImage::setHeight(double height) {
-    this->height = height;
+    this->boundingBox.height = height;
     this->calcSize();
 }
 
@@ -99,9 +96,9 @@ auto TexImage::loadData(std::string&& bytes, GError** err) -> bool {
         if (!pdf.get() || poppler_document_get_n_pages(this->pdf.get()) < 1) {
             return false;
         }
-        if (std::abs(this->width * this->height) <= std::numeric_limits<double>::epsilon()) {
+        if (std::abs(this->boundingBox.area()) <= std::numeric_limits<double>::epsilon()) {
             xoj::util::GObjectSPtr<PopplerPage> page(poppler_document_get_page(this->pdf.get(), 0), xoj::util::adopt);
-            poppler_page_get_size(page.get(), &this->width, &this->height);
+            poppler_page_get_size(page.get(), &this->boundingBox.width, &this->boundingBox.height);
         }
     } else if (type == "PNG") {
         this->image = cairo_image_surface_create_from_png_stream(
@@ -120,11 +117,11 @@ auto TexImage::getPdf() const -> PopplerDocument* { return this->pdf.get(); }
 void TexImage::scale(double x0, double y0, double fx, double fy, double rotation,
                      bool) {  // line width scaling option is not used
 
-    this->x = (this->x - x0) * fx + x0;
-    this->y = (this->y - y0) * fy + y0;
+    this->boundingBox.x = (this->boundingBox.x - x0) * fx + x0;
+    this->boundingBox.y = (this->boundingBox.y - y0) * fy + y0;
 
-    this->width *= fx;
-    this->height *= fy;
+    this->boundingBox.width *= fx;
+    this->boundingBox.height *= fy;
     this->calcSize();
 }
 
@@ -137,8 +134,8 @@ void TexImage::serialize(ObjectOutputStream& out) const {
 
     this->Element::serialize(out);
 
-    out.writeDouble(this->width);
-    out.writeDouble(this->height);
+    out.writeDouble(this->boundingBox.width);
+    out.writeDouble(this->boundingBox.height);
     out.writeString(this->text);
 
     out.writeString(this->binaryData);
@@ -151,8 +148,8 @@ void TexImage::readSerialized(ObjectInputStream& in) {
 
     this->Element::readSerialized(in);
 
-    this->width = in.readDouble();
-    this->height = in.readDouble();
+    this->boundingBox.width = in.readDouble();
+    this->boundingBox.height = in.readDouble();
     this->text = in.readString();
 
     freeImageAndPdf();
@@ -165,6 +162,6 @@ void TexImage::readSerialized(ObjectInputStream& in) {
 }
 
 void TexImage::calcSize() const {
-    this->snappedBounds = Rectangle<double>(this->x, this->y, this->width, this->height);
+    this->snappedBounds = this->boundingBox;
     this->sizeCalculated = true;
 }

--- a/src/core/model/Text.cpp
+++ b/src/core/model/Text.cpp
@@ -32,10 +32,7 @@ auto Text::cloneText() const -> std::unique_ptr<Text> {
     text->font = this->font;
     text->text = this->text;
     text->setColor(this->getColor());
-    text->x = this->x;
-    text->y = this->y;
-    text->width = this->width;
-    text->height = this->height;
+    text->boundingBox = this->boundingBox;
     text->cloneAudioData(this);
     text->snappedBounds = this->snappedBounds;
     text->sizeCalculated = this->sizeCalculated;
@@ -77,8 +74,8 @@ void Text::calcSize() const {
     int w = 0;
     int h = 0;
     pango_layout_get_size(layout.get(), &w, &h);
-    this->width = (static_cast<double>(w)) / PANGO_SCALE;
-    this->height = (static_cast<double>(h)) / PANGO_SCALE;
+    this->boundingBox.width = (static_cast<double>(w)) / PANGO_SCALE;
+    this->boundingBox.height = (static_cast<double>(h)) / PANGO_SCALE;
     this->updateSnapping();
 }
 
@@ -118,12 +115,12 @@ void Text::scale(double x0, double y0, double fx, double fy, double rotation,
         Stacktrace::printStacktrace();
     }
 
-    this->x -= x0;
-    this->x *= fx;
-    this->x += x0;
-    this->y -= y0;
-    this->y *= fy;
-    this->y += y0;
+    this->boundingBox.x -= x0;
+    this->boundingBox.x *= fx;
+    this->boundingBox.x += x0;
+    this->boundingBox.y -= y0;
+    this->boundingBox.y *= fy;
+    this->boundingBox.y += y0;
 
     double size = this->font.getSize() * fx;
     this->font.setSize(size);
@@ -169,9 +166,7 @@ void Text::readSerialized(ObjectInputStream& in) {
     in.endObject();
 }
 
-void Text::updateSnapping() const {
-    this->snappedBounds = Rectangle<double>(this->x, this->y, this->width, this->height);
-}
+void Text::updateSnapping() const { this->snappedBounds = this->boundingBox; }
 
 auto Text::findText(const std::string& search) const -> std::vector<XojPdfRectangle> {
     size_t patternLength = search.length();
@@ -184,8 +179,9 @@ auto Text::findText(const std::string& search) const -> std::vector<XojPdfRectan
 
 
     std::string text = StringUtils::toLowerCase(this->text);
-
     std::string pattern = StringUtils::toLowerCase(search);
+
+    const auto& origin = this->getOrigin();
 
     std::vector<XojPdfRectangle> list;
 
@@ -193,12 +189,12 @@ auto Text::findText(const std::string& search) const -> std::vector<XojPdfRectan
         XojPdfRectangle mark;
         PangoRectangle rect = {0};
         pango_layout_index_to_pos(layout.get(), static_cast<int>(pos), &rect);
-        mark.x1 = (static_cast<double>(rect.x)) / PANGO_SCALE + this->getX();
-        mark.y1 = (static_cast<double>(rect.y)) / PANGO_SCALE + this->getY();
+        mark.x1 = (static_cast<double>(rect.x)) / PANGO_SCALE + origin.x;
+        mark.y1 = (static_cast<double>(rect.y)) / PANGO_SCALE + origin.y;
 
         pango_layout_index_to_pos(layout.get(), static_cast<int>(pos + patternLength - 1), &rect);
-        mark.x2 = (static_cast<double>(rect.x) + rect.width) / PANGO_SCALE + this->getX();
-        mark.y2 = (static_cast<double>(rect.y) + rect.height) / PANGO_SCALE + this->getY();
+        mark.x2 = (static_cast<double>(rect.x) + rect.width) / PANGO_SCALE + origin.x;
+        mark.y2 = (static_cast<double>(rect.y) + rect.height) / PANGO_SCALE + origin.y;
 
         list.push_back(mark);
     }

--- a/src/core/model/eraser/ErasableStroke.cpp
+++ b/src/core/model/eraser/ErasableStroke.cpp
@@ -69,9 +69,7 @@ void ErasableStroke::beginErasure(const IntersectionParametersContainer& paddedI
                 range.addPoint(p2.x, p2.y);
             } else {
                 // The stroke was split in two or more (and possibly shrank). Need to rerender its entire box.
-                range.addPoint(this->stroke.getX(), this->stroke.getY());
-                range.addPoint(this->stroke.getX() + this->stroke.getElementWidth(),
-                               this->stroke.getY() + this->stroke.getElementHeight());
+                range = range.unite(Range(this->stroke.getBoundingBox()));
             }
         } else if (subsections.size() > 1) {
             /**

--- a/src/core/plugin/luapi_application.h
+++ b/src/core/plugin/luapi_application.h
@@ -1597,12 +1597,10 @@ static int applib_addTexts(lua_State* L) {
         if (!lua_isnumber(L, -2)) {  // Check if x was provided
             return luaL_error(L, "Missing X-Coordinate!/must be a number");
         }
-        text->setX(lua_tonumber(L, -2));
-
         if (!lua_isnumber(L, -1)) {  // Check if y was provided
             return luaL_error(L, "Missing Y-Coordinate!/must be a number");
         }
-        text->setY(lua_tonumber(L, -1));
+        text->setOrigin(lua_tonumber(L, -2), lua_tonumber(L, -1));
 
         lua_pop(L, 8);  // remove values read out from the text table + text-table itself
 
@@ -1725,16 +1723,18 @@ static int applib_getTexts(lua_State* L) {
         lua_pushinteger(L, as_signed(uint32_t(t->getColor()) & 0xffffffU));
         lua_setfield(L, -2, "color");  // add color to text
 
-        lua_pushnumber(L, t->getX());
+        auto [x, y] = t->getOrigin();
+        lua_pushnumber(L, x);
         lua_setfield(L, -2, "x");  // add x coordindate to text
 
-        lua_pushnumber(L, t->getY());
+        lua_pushnumber(L, y);
         lua_setfield(L, -2, "y");  // add y coordinate to text
 
-        lua_pushnumber(L, t->getElementWidth());
+        const auto& box = t->getBoundingBox();
+        lua_pushnumber(L, box.width);
         lua_setfield(L, -2, "width");  // add width to text
 
-        lua_pushnumber(L, t->getElementHeight());
+        lua_pushnumber(L, box.height);
         lua_setfield(L, -2, "height");  // add height to text
 
         lua_pushlightuserdata(L, const_cast<void*>(static_cast<const void*>(t)));
@@ -3279,8 +3279,7 @@ static int applib_addImages(lua_State* L) {
         }
 
         auto [width, height] = img->getImageSize();
-        img->setX(x);
-        img->setY(y);
+        img->setOrigin(x, y);
 
         // apply width/height parameter
         if (maxWidthParam != -1 && maxHeightParam != -1) {
@@ -3400,20 +3399,23 @@ static int applib_getImages(lua_State* L) {
         lua_pushinteger(L, ++currImageNo);  // index for later (settable)
         lua_newtable(L);                    // create table for current image
 
+
+        auto [x, y] = im->getOrigin();
         // "x": number
-        lua_pushnumber(L, im->getX());
+        lua_pushnumber(L, x);
         lua_setfield(L, -2, "x");
 
         // "y": number
-        lua_pushnumber(L, im->getY());
+        lua_pushnumber(L, y);
         lua_setfield(L, -2, "y");
 
+        const auto& box = im->getBoundingBox();
         // "width": number
-        lua_pushnumber(L, im->getElementWidth());
+        lua_pushnumber(L, box.width);
         lua_setfield(L, -2, "width");
 
         // "height": number
-        lua_pushnumber(L, im->getElementHeight());
+        lua_pushnumber(L, box.height);
         lua_setfield(L, -2, "height");
 
         // data: string (can be optimized via lual_Buffer)

--- a/src/core/undo/ColorUndoAction.cpp
+++ b/src/core/undo/ColorUndoAction.cpp
@@ -39,27 +39,19 @@ auto ColorUndoAction::undo(Control* control) -> bool {
         return true;
     }
 
+    Range range;
     Document* doc = control->getDocument();
     doc->lock();
-    ColorUndoActionEntry* e = this->data.front();
-    double x1 = e->e->getX();
-    double x2 = e->e->getX() + e->e->getElementWidth();
-    double y1 = e->e->getY();
-    double y2 = e->e->getY() + e->e->getElementHeight();
 
     for (ColorUndoActionEntry* e: this->data) {
         e->e->setColor(e->oldColor);
-
-        x1 = std::min(x1, e->e->getX());
-        x2 = std::max(x2, e->e->getX() + e->e->getElementWidth());
-        y1 = std::min(y1, e->e->getY());
-        y2 = std::max(y2, e->e->getY() + e->e->getElementHeight());
+        range = range.unite(Range(e->e->getBoundingBox()));
     }
 
     doc->unlock();
 
-    Rectangle rect(x1, y1, x2 - x1, y2 - y1);
-    this->page->fireRectChanged(rect);
+    xoj_assert(!range.empty());
+    this->page->fireRangeChanged(range);
 
     return true;
 }
@@ -69,27 +61,19 @@ auto ColorUndoAction::redo(Control* control) -> bool {
         return true;
     }
 
+    Range range;
     Document* doc = control->getDocument();
     doc->lock();
-    ColorUndoActionEntry* e = this->data.front();
-    double x1 = e->e->getX();
-    double x2 = e->e->getX() + e->e->getElementWidth();
-    double y1 = e->e->getY();
-    double y2 = e->e->getY() + e->e->getElementHeight();
 
     for (ColorUndoActionEntry* e: this->data) {
         e->e->setColor(e->newColor);
-
-        x1 = std::min(x1, e->e->getX());
-        x2 = std::max(x2, e->e->getX() + e->e->getElementWidth());
-        y1 = std::min(y1, e->e->getY());
-        y2 = std::max(y2, e->e->getY() + e->e->getElementHeight());
+        range = range.unite(Range(e->e->getBoundingBox()));
     }
 
     doc->unlock();
 
-    Rectangle rect(x1, y1, x2 - x1, y2 - y1);
-    this->page->fireRectChanged(rect);
+    xoj_assert(!range.empty());
+    this->page->fireRangeChanged(range);
 
     return true;
 }

--- a/src/core/undo/FillUndoAction.cpp
+++ b/src/core/undo/FillUndoAction.cpp
@@ -44,19 +44,18 @@ auto FillUndoAction::undo(Control* control) -> bool {
         return true;
     }
 
+    Range range;
     Document* doc = control->getDocument();
     doc->lock();
-    FillUndoActionEntry* e = this->data.front();
-    Range range(e->s->getX(), e->s->getY());
 
     for (FillUndoActionEntry* e: this->data) {
         e->s->setFill(e->originalFill);
-
-        range.addPoint(e->s->getX(), e->s->getY());
-        range.addPoint(e->s->getX() + e->s->getElementWidth(), e->s->getY() + e->s->getElementHeight());
+        range = range.unite(Range(e->s->getBoundingBox()));
     }
 
     doc->unlock();
+
+    xoj_assert(!range.empty());
     this->page->fireRangeChanged(range);
 
     return true;
@@ -67,19 +66,18 @@ auto FillUndoAction::redo(Control* control) -> bool {
         return true;
     }
 
+    Range range;
     Document* doc = control->getDocument();
     doc->lock();
-    FillUndoActionEntry* e = this->data.front();
-    Range range(e->s->getX(), e->s->getY());
 
     for (FillUndoActionEntry* e: this->data) {
         e->s->setFill(e->newFill);
-
-        range.addPoint(e->s->getX(), e->s->getY());
-        range.addPoint(e->s->getX() + e->s->getElementWidth(), e->s->getY() + e->s->getElementHeight());
+        range = range.unite(Range(e->s->getBoundingBox()));
     }
 
     doc->unlock();
+
+    xoj_assert(!range.empty());
     this->page->fireRangeChanged(range);
 
     return true;

--- a/src/core/undo/FontUndoAction.cpp
+++ b/src/core/undo/FontUndoAction.cpp
@@ -46,34 +46,20 @@ auto FontUndoAction::undo(Control* control) -> bool {
         return true;
     }
 
+    Range r;
     Document* doc = control->getDocument();
     doc->lock();
-    FontUndoActionEntry* e = this->data.front();
-    double x1 = e->e->getX();
-    double x2 = e->e->getX() + e->e->getElementWidth();
-    double y1 = e->e->getY();
-    double y2 = e->e->getY() + e->e->getElementHeight();
 
     for (FontUndoActionEntry* e: this->data) {
-        // size with old font
-        x1 = std::min(x1, e->e->getX());
-        x2 = std::max(x2, e->e->getX() + e->e->getElementWidth());
-        y1 = std::min(y1, e->e->getY());
-        y2 = std::max(y2, e->e->getY() + e->e->getElementHeight());
-
+        r = r.unite(Range(e->e->getBoundingBox()));
         e->e->setFont(e->oldFont);
-
-        // size with new font
-        x1 = std::min(x1, e->e->getX());
-        x2 = std::max(x2, e->e->getX() + e->e->getElementWidth());
-        y1 = std::min(y1, e->e->getY());
-        y2 = std::max(y2, e->e->getY() + e->e->getElementHeight());
+        r = r.unite(Range(e->e->getBoundingBox()));
     }
 
     doc->unlock();
 
-    Rectangle<double> rect(x1, y1, x2 - x1, y2 - y1);
-    this->page->fireRectChanged(rect);
+    xoj_assert(!r.empty());
+    this->page->fireRangeChanged(r);
 
     return true;
 }
@@ -83,34 +69,20 @@ auto FontUndoAction::redo(Control* control) -> bool {
         return true;
     }
 
+    Range r;
     Document* doc = control->getDocument();
     doc->lock();
-    FontUndoActionEntry* e = this->data.front();
-    double x1 = e->e->getX();
-    double x2 = e->e->getX() + e->e->getElementWidth();
-    double y1 = e->e->getY();
-    double y2 = e->e->getY() + e->e->getElementHeight();
 
     for (FontUndoActionEntry* e: this->data) {
-        // size with old font
-        x1 = std::min(x1, e->e->getX());
-        x2 = std::max(x2, e->e->getX() + e->e->getElementWidth());
-        y1 = std::min(y1, e->e->getY());
-        y2 = std::max(y2, e->e->getY() + e->e->getElementHeight());
-
+        r = r.unite(Range(e->e->getBoundingBox()));
         e->e->setFont(e->newFont);
-
-        // size with new font
-        x1 = std::min(x1, e->e->getX());
-        x2 = std::max(x2, e->e->getX() + e->e->getElementWidth());
-        y1 = std::min(y1, e->e->getY());
-        y2 = std::max(y2, e->e->getY() + e->e->getElementHeight());
+        r = r.unite(Range(e->e->getBoundingBox()));
     }
 
     doc->unlock();
 
-    Rectangle<double> rect(x1, y1, x2 - x1, y2 - y1);
-    this->page->fireRectChanged(rect);
+    xoj_assert(!r.empty());
+    this->page->fireRangeChanged(r);
 
     return true;
 }

--- a/src/core/undo/LineStyleUndoAction.cpp
+++ b/src/core/undo/LineStyleUndoAction.cpp
@@ -28,27 +28,19 @@ auto LineStyleUndoAction::undo(Control* control) -> bool {
         return true;
     }
 
+    Range r;
     Document* doc = control->getDocument();
     doc->lock();
-    LineStyleUndoActionEntry e = this->data.front();
-    double x1 = e.s->getX();
-    double x2 = e.s->getX() + e.s->getElementWidth();
-    double y1 = e.s->getY();
-    double y2 = e.s->getY() + e.s->getElementHeight();
 
     for (LineStyleUndoActionEntry& e: this->data) {
         e.s->setLineStyle(e.oldStyle);
-
-        x1 = std::min(x1, e.s->getX());
-        x2 = std::max(x2, e.s->getX() + e.s->getElementWidth());
-        y1 = std::min(y1, e.s->getY());
-        y2 = std::max(y2, e.s->getY() + e.s->getElementHeight());
+        r = r.unite(Range(e.s->getBoundingBox()));
     }
 
     doc->unlock();
 
-    Rectangle rect(x1, y1, x2 - x1, y2 - y1);
-    this->page->fireRectChanged(rect);
+    xoj_assert(!r.empty());
+    this->page->fireRangeChanged(r);
 
     return true;
 }
@@ -58,27 +50,19 @@ auto LineStyleUndoAction::redo(Control* control) -> bool {
         return true;
     }
 
+    Range r;
     Document* doc = control->getDocument();
     doc->lock();
-    LineStyleUndoActionEntry e = this->data.front();
-    double x1 = e.s->getX();
-    double x2 = e.s->getX() + e.s->getElementWidth();
-    double y1 = e.s->getY();
-    double y2 = e.s->getY() + e.s->getElementHeight();
 
     for (LineStyleUndoActionEntry& e: this->data) {
         e.s->setLineStyle(e.newStyle);
-
-        x1 = std::min(x1, e.s->getX());
-        x2 = std::max(x2, e.s->getX() + e.s->getElementWidth());
-        y1 = std::min(y1, e.s->getY());
-        y2 = std::max(y2, e.s->getY() + e.s->getElementHeight());
+        r = r.unite(Range(e.s->getBoundingBox()));
     }
 
     doc->unlock();
 
-    Rectangle rect(x1, y1, x2 - x1, y2 - y1);
-    this->page->fireRectChanged(rect);
+    xoj_assert(!r.empty());
+    this->page->fireRangeChanged(r);
 
     return true;
 }

--- a/src/core/undo/RotateUndoAction.cpp
+++ b/src/core/undo/RotateUndoAction.cpp
@@ -40,18 +40,18 @@ void RotateUndoAction::applyRotation(double rotation, Document* doc) {
         return;
     }
 
+    Range r;
     doc->lock();
-    Range r(elements.front()->getX(), elements.front()->getY());
 
     for (Element* e: this->elements) {
-        r.addPoint(e->getX(), e->getY());
-        r.addPoint(e->getX() + e->getElementWidth(), e->getY() + e->getElementHeight());
+        r = r.unite(Range(e->getBoundingBox()));
         e->rotate(this->x0, this->y0, rotation);
-        r.addPoint(e->getX(), e->getY());
-        r.addPoint(e->getX() + e->getElementWidth(), e->getY() + e->getElementHeight());
+        r = r.unite(Range(e->getBoundingBox()));
     }
 
     doc->unlock();
+
+    xoj_assert(!r.empty());
     this->page->fireRangeChanged(r);
 }
 

--- a/src/core/undo/ScaleUndoAction.cpp
+++ b/src/core/undo/ScaleUndoAction.cpp
@@ -45,14 +45,12 @@ void ScaleUndoAction::applyScale(double fx, double fy, bool restoreLineWidth, Do
     }
 
     doc->lock();
-    Range r(elements.front()->getX(), elements.front()->getY());
+    Range r;
 
     for (Element* e: this->elements) {
-        r.addPoint(e->getX(), e->getY());
-        r.addPoint(e->getX() + e->getElementWidth(), e->getY() + e->getElementHeight());
+        r = r.unite(Range(e->getBoundingBox()));
         e->scale(this->x0, this->y0, fx, fy, this->rotation, restoreLineWidth);
-        r.addPoint(e->getX(), e->getY());
-        r.addPoint(e->getX() + e->getElementWidth(), e->getY() + e->getElementHeight());
+        r = r.unite(Range(e->getBoundingBox()));
     }
     doc->unlock();
 

--- a/src/core/undo/SizeUndoAction.cpp
+++ b/src/core/undo/SizeUndoAction.cpp
@@ -75,12 +75,12 @@ auto SizeUndoAction::undo(Control* control) -> bool {
 
     Range range;
     for (SizeUndoActionEntry* e: this->data) {
-        range = range.unite(Range(e->s->boundingRect()));
+        range = range.unite(Range(e->s->getBoundingBox()));
 
         e->s->setWidth(e->originalWidth);
         e->s->setPressure(e->originalPressure);
 
-        range = range.unite(Range(e->s->boundingRect()));
+        range = range.unite(Range(e->s->getBoundingBox()));
     }
 
     doc->unlock();
@@ -100,12 +100,12 @@ auto SizeUndoAction::redo(Control* control) -> bool {
 
     Range range;
     for (SizeUndoActionEntry* e: this->data) {
-        range = range.unite(Range(e->s->boundingRect()));
+        range = range.unite(Range(e->s->getBoundingBox()));
 
         e->s->setWidth(e->newWidth);
         e->s->setPressure(e->newPressure);
 
-        range = range.unite(Range(e->s->boundingRect()));
+        range = range.unite(Range(e->s->getBoundingBox()));
     }
 
     doc->unlock();

--- a/src/core/undo/TextBoxUndoAction.cpp
+++ b/src/core/undo/TextBoxUndoAction.cpp
@@ -28,8 +28,8 @@ auto TextBoxUndoAction::getText() -> std::string { return _("Edit text"); }
 auto TextBoxUndoAction::undo(Control* control) -> bool {
     Document* doc = control->getDocument();
     doc->lock();
-    auto rect = element->boundingRect();
-    rect.unite(oldelement->boundingRect());
+    auto rect = element->getBoundingBox();
+    rect.unite(oldelement->getBoundingBox());
 
     // swap them to be memory safe
     auto elementPtr = this->layer->removeElement(std::exchange(this->element, this->oldelement.get())).e;

--- a/src/core/view/ImageView.cpp
+++ b/src/core/view/ImageView.cpp
@@ -3,6 +3,7 @@
 #include <cairo.h>  // for cairo_image_surface_get_height, cairo_image...
 
 #include "model/Image.h"  // for Image
+#include "util/Point.h"   // for Point
 #include "view/View.h"    // for Context, OPACITY_NO_AUDIO, view
 
 using namespace xoj::view;
@@ -27,12 +28,14 @@ void ImageView::draw(const Context& ctx) const {
 
     cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
 
-    double xFactor = image->getElementWidth() / width;
-    double yFactor = image->getElementHeight() / height;
+    const auto& box = image->getBoundingBox();
+    double xFactor = box.width / width;
+    double yFactor = box.height / height;
 
     cairo_scale(cr, xFactor, yFactor);
 
-    cairo_set_source_surface(cr, img, image->getX() / xFactor, image->getY() / yFactor);
+    auto [x, y] = image->getOrigin();
+    cairo_set_source_surface(cr, img, x / xFactor, y / yFactor);
     // make images translucent when highlighting elements with audio, as they can not have audio
     if (ctx.fadeOutNonAudio) {
         cairo_paint_with_alpha(cr, OPACITY_NO_AUDIO);

--- a/src/core/view/StrokeView.cpp
+++ b/src/core/view/StrokeView.cpp
@@ -72,7 +72,7 @@ void StrokeView::draw(const Context& ctx) const {
         /**
          * Create a mask tailored to the stroke's bounding box
          */
-        mask = Mask(cairo_get_target(ctx.cr), Range(s->boundingRect()), zoom);
+        mask = Mask(cairo_get_target(ctx.cr), Range(s->getBoundingBox()), zoom);
         cr = mask.get();
     }
 

--- a/src/core/view/TexImageView.cpp
+++ b/src/core/view/TexImageView.cpp
@@ -2,11 +2,12 @@
 
 #include <string>  // for string
 
-#include <cairo.h>             // for cairo_paint_with_alpha, cairo_scale
-#include <glib.h>              // for g_warning
-#include <poppler.h>           // for PopplerPage, PopplerDocument, g_clear_...
+#include <cairo.h>    // for cairo_paint_with_alpha, cairo_scale
+#include <glib.h>     // for g_warning
+#include <poppler.h>  // for PopplerPage, PopplerDocument, g_clear_...
 
 #include "model/TexImage.h"  // for TexImage
+#include "util/Point.h"      // for Point
 #include "view/View.h"       // for Context, OPACITY_NO_AUDIO, view
 
 using namespace xoj::view;
@@ -22,6 +23,8 @@ void TexImageView::draw(const Context& ctx) const {
 
     PopplerDocument* pdf = texImage->getPdf();
     cairo_surface_t* img = texImage->getImage();
+    const auto& origin = texImage->getOrigin();
+    const auto& box = texImage->getBoundingBox();
 
     if (pdf != nullptr) {
         if (poppler_document_get_n_pages(pdf) < 1) {
@@ -35,11 +38,11 @@ void TexImageView::draw(const Context& ctx) const {
         double pageHeight = 0;
         poppler_page_get_size(page, &pageWidth, &pageHeight);
 
-        double xFactor = texImage->getElementWidth() / pageWidth;
-        double yFactor = texImage->getElementHeight() / pageHeight;
+        double xFactor = box.width / pageWidth;
+        double yFactor = box.height / pageHeight;
 
         cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
-        cairo_translate(cr, texImage->getX(), texImage->getY());
+        cairo_translate(cr, origin.x, origin.y);
         cairo_scale(cr, xFactor, yFactor);
 
         auto surfType = cairo_surface_get_type(cairo_get_target(cr));
@@ -74,12 +77,12 @@ void TexImageView::draw(const Context& ctx) const {
 
         cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
 
-        double xFactor = texImage->getElementWidth() / width;
-        double yFactor = texImage->getElementHeight() / height;
+        double xFactor = box.width / width;
+        double yFactor = box.height / height;
 
         cairo_scale(cr, xFactor, yFactor);
 
-        cairo_set_source_surface(cr, img, texImage->getX() / xFactor, texImage->getY() / yFactor);
+        cairo_set_source_surface(cr, img, origin.x / xFactor, origin.y / yFactor);
         // Make TeX images translucent when highlighting audio strokes as they can not have audio
         if (ctx.fadeOutNonAudio) {
             cairo_paint_with_alpha(cr, OPACITY_NO_AUDIO);

--- a/src/core/view/TextView.cpp
+++ b/src/core/view/TextView.cpp
@@ -43,7 +43,8 @@ void TextView::draw(const Context& ctx) const {
         Util::cairo_set_source_rgbi(ctx.cr, text->getColor());
     }
 
-    cairo_translate(ctx.cr, text->getX(), text->getY());
+    const auto& origin = text->getOrigin();
+    cairo_translate(ctx.cr, origin.x, origin.y);
 
     auto layout = initPango(ctx.cr, text);
     const std::string& content = text->getText();

--- a/src/core/view/overlays/StrokeToolView.cpp
+++ b/src/core/view/overlays/StrokeToolView.cpp
@@ -20,7 +20,7 @@ using namespace xoj::view;
 StrokeToolView::StrokeToolView(const StrokeHandler* strokeHandler, const Stroke& stroke, Repaintable* parent):
         BaseStrokeToolView(parent, stroke), strokeHandler(strokeHandler), pointBuffer(stroke.getPointVector()) {
     this->registerToPool(strokeHandler->getViewPool());
-    parent->flagDirtyRegion(Range(stroke.boundingRect()));
+    parent->flagDirtyRegion(Range(stroke.getBoundingBox()));
 }
 
 StrokeToolView::~StrokeToolView() noexcept { this->unregisterFromPool(); }

--- a/src/core/view/overlays/TextEditionView.cpp
+++ b/src/core/view/overlays/TextEditionView.cpp
@@ -56,9 +56,9 @@ void TextEditionView::draw(cairo_t* cr) const {
         }
         cairo_set_operator(cr, CAIRO_OPERATOR_DIFFERENCE);
         cairo_set_source_rgb(cr, 1, 1, 1);
-        const Text* textElement = this->textEditor->getTextElement();
-        cairo_rectangle(cr, cursorBox.minX + textElement->getX(), cursorBox.minY + textElement->getY(),
-                        cursorBox.getWidth(), cursorBox.getHeight());
+        const auto& origin = this->textEditor->getTextElement()->getOrigin();
+        cairo_rectangle(cr, cursorBox.minX + origin.x, cursorBox.minY + origin.y, cursorBox.getWidth(),
+                        cursorBox.getHeight());
         cairo_fill(cr);
     }
 }
@@ -69,8 +69,9 @@ void TextEditionView::drawWithoutDrawingAids(cairo_t* cr) const {
     const Text* textElement = this->textEditor->getTextElement();
     Util::cairo_set_source_rgbi(cr, textElement->getColor());
 
+    const auto& origin = textElement->getOrigin();
     // From now on, coordinates are in textElement coordinates
-    cairo_translate(cr, textElement->getX(), textElement->getY());
+    cairo_translate(cr, origin.x, origin.y);
 
     // The data is owned by textEditor
     PangoLayout* layout = this->textEditor->getUpToDateLayout();

--- a/src/util/include/util/Rectangle.h
+++ b/src/util/include/util/Rectangle.h
@@ -15,17 +15,18 @@
 #include <iosfwd>
 #include <optional>
 
+#include "util/Point.h"
 #include "util/Range.h"
 
 namespace xoj::util {  // Rectangle is already defined in windows.h
 
 template <class T>
-class Rectangle final {
+class Rectangle final: private Point<T> {
 public:
     constexpr Rectangle() = default;
-    constexpr Rectangle(T x, T y, T width, T height): x(x), y(y), width(width), height(height) {}
+    constexpr Rectangle(T x, T y, T width, T height): Point<T>(x, y), width(width), height(height) {}
     constexpr explicit Rectangle(const Range& rect):
-            x(rect.getX()), y(rect.getY()), width(rect.getWidth()), height(rect.getHeight()) {}
+            Point<T>(rect.getX(), rect.getY()), width(rect.getWidth()), height(rect.getHeight()) {}
 
     constexpr auto operator==(const Rectangle& other) const -> bool {
         return x == other.x && y == other.y && width == other.width && height == other.height;
@@ -83,10 +84,12 @@ public:
      */
     constexpr auto area() const -> T { return width * height; }
 
-    T x{};
-    T y{};
+    const Point<T>& getOrigin() const { return *this; }
+
     T width{};
     T height{};
+    using Point<T>::x;
+    using Point<T>::y;
 };
 
 }  // namespace xoj::util

--- a/test/unit_tests/control/LoadHandlerTest.cpp
+++ b/test/unit_tests/control/LoadHandlerTest.cpp
@@ -112,10 +112,10 @@ static void testLoadStoreLoadHelper(const fs::path& filepath, double tol = 1e-8)
         const Element* a = elements1[i];
         const Element* b = elements2[i];
         EXPECT_EQ(a->getType(), b->getType());
-        EXPECT_TRUE(coordEq(a->getX(), b->getX()));
-        EXPECT_TRUE(coordEq(a->getY(), b->getY()));
-        EXPECT_TRUE(coordEq(a->getElementWidth(), b->getElementWidth()));
-        EXPECT_TRUE(coordEq(a->getElementHeight(), b->getElementHeight()));
+        EXPECT_TRUE(coordEq(a->getOrigin().x, b->getOrigin().x));
+        EXPECT_TRUE(coordEq(a->getOrigin().y, b->getOrigin().y));
+        EXPECT_TRUE(coordEq(a->getBoundingBox().width, b->getBoundingBox().width));
+        EXPECT_TRUE(coordEq(a->getBoundingBox().height, b->getBoundingBox().height));
         EXPECT_EQ(a->getColor(), b->getColor());
         switch (a->getType()) {
             case ELEMENT_STROKE: {
@@ -495,10 +495,10 @@ TEST(ControlLoadHandler, testImage) {
     ASSERT_NE(img, nullptr) << "Element should be an image";
     ASSERT_EQ(img->getType(), ELEMENT_IMAGE) << "Element should be an image";
 
-    EXPECT_DOUBLE_EQ(img->getX(), 41.637795);
-    EXPECT_DOUBLE_EQ(img->getY(), 164.94488);
-    EXPECT_NEAR(img->getElementWidth(), 512.0, 1e-5);
-    EXPECT_NEAR(img->getElementHeight(), 512.0, 1e-5);
+    EXPECT_DOUBLE_EQ(img->getOrigin().x, 41.637795);
+    EXPECT_DOUBLE_EQ(img->getOrigin().y, 164.94488);
+    EXPECT_NEAR(img->getBoundingBox().width, 512.0, 1e-5);
+    EXPECT_NEAR(img->getBoundingBox().height, 512.0, 1e-5);
 
     EXPECT_GT(img->getRawDataLength(), 0);
     EXPECT_NE(img->getRawData(), nullptr);
@@ -594,10 +594,10 @@ TEST(ControlLoadHandler, testLatex) {
 
     EXPECT_STREQ(teximage->getText().c_str(), "x^2") << "TeX image has wrong text contents";
 
-    EXPECT_DOUBLE_EQ(teximage->getX(), 14.937);
-    EXPECT_DOUBLE_EQ(teximage->getY(), 15.715);
-    EXPECT_DOUBLE_EQ(teximage->getElementWidth(), 20.126);
-    EXPECT_DOUBLE_EQ(teximage->getElementHeight(), 18.57);
+    EXPECT_DOUBLE_EQ(teximage->getOrigin().x, 14.937);
+    EXPECT_DOUBLE_EQ(teximage->getOrigin().y, 15.715);
+    EXPECT_DOUBLE_EQ(teximage->getBoundingBox().width, 20.126);
+    EXPECT_DOUBLE_EQ(teximage->getBoundingBox().height, 18.57);
 
     EXPECT_FALSE(teximage->getBinaryData().empty());
 }


### PR DESCRIPTION
This PR cleans up the position related functions in Element:

1. Element::getX/getY/setX/setY/getElementWidth/getElementHeight are removed
2. In most places, the getters are replaced by the more efficient Element::getBoundingBox() (renamed from boundingRect())
3. In the few places where the intent is to get the position of the element (rather than its "ink" bounding box), getX()/getY() are replaced by a getOrigin()
4. The setters setX/setY are replaced by a setOrigin()

The motivation for this lies in #7594 (see this [comment](https://github.com/xournalpp/xournalpp/pull/7594#issuecomment-4956079770)): there is no reason a priori for an element's positioning origin to be the same as its ink bounding box's upper-left corner. In fact the setters setX/setY do not really make sense (and certainly don't work as expected) for Stroke already.

Another example where this distinction will become useful: if and when we implement object rotation, then the origin of (say) an Image should be the upper-left corner (or maybe the center) of the unrotated image, while the ink bounding box is much larger.