### PR TITLE
Fix(model): Reset backgroundColor to white when changing page type to image or PDF (i.e. special)

### DIFF
--- a/src/core/model/XojPage.cpp
+++ b/src/core/model/XojPage.cpp
@@ -150,6 +150,9 @@ void XojPage::setBackgroundType(const PageType& bgType) {
     if (!bgType.isImagePage()) {
         this->backgroundImage.free();
     }
+    if (bgType.isSpecial()) {
+        this->backgroundColor = Colors::white;
+    }
 }
 
 auto XojPage::getBackgroundType() const -> PageType { return this->bgType; }

--- a/test/unit_tests/model/XojPageTest.cpp
+++ b/test/unit_tests/model/XojPageTest.cpp
@@ -1,0 +1,28 @@
+#include <gtest/gtest.h>
+
+#include "model/PageType.h"
+#include "model/XojPage.h"
+#include "util/Color.h"
+
+TEST(XojPageTest, SetBackgroundTypeResetsColorForSpecialBackgrounds) {
+    XojPage page(595.0, 842.0);  // Standard page dimensions
+
+    // 1. Set a dark background color initially
+    page.setBackgroundColor(Color(0x1E1E1E));
+    EXPECT_EQ(page.getBackgroundColor(), Color(0x1E1E1E));
+
+    // 2. Transition background type to Image
+    PageType imageBg(PageTypeFormat::Image);
+    page.setBackgroundType(imageBg);
+
+    // 3. Verify color is reset to default white
+    EXPECT_EQ(page.getBackgroundColor(), Colors::white);
+
+    // 4. Test PDF background transition as well
+    page.setBackgroundColor(Color(0x000000));
+    PageType pdfBg(PageTypeFormat::Pdf);
+    page.setBackgroundType(pdfBg);
+
+    // 5. Verify color is reset to white again
+    EXPECT_EQ(page.getBackgroundColor(), Colors::white);
+}


### PR DESCRIPTION
# Summary
This PR fixes an issue where switching a page's background type to an Image or Pdf via `XojPage::setBackgroundType()` did not update or reset the internal backgroundColor attribute.

If a page previously had a custom or dark background color, XojPage::getBackgroundColor() would continue returning the old color in memory even though .xopp file reloads assumes white paper background for Image and PDF pages.

## Why This Is Needed
Dynamic rendering systems that inspect `XojPage::getBackgroundColor()` to adjust dynamic draw parameters (e.g., dynamic highlighter cairo operator selection based on page luminance) receive stale color data when users switch background types dynamically during an active session.

## Changes Made:
- Updated `XojPage::setBackgroundType()` to reset `backgroundColor` to `Colors::white` whenever the target `bgType` is special (i.e., Image or Pdf).
- Added a unit test to verify backgroundColor state transitions in XojPage.

## **How Has This Been Tested?**

1. **Unit Tests:** Added GoogleTest coverage verifying that `XojPage::setBackgroundType()` resets `backgroundColor` to `Colors::white` when transitioning from a dark background to an Image or PDF.

2. **Manual Testing:**
* Created a page with a dark background.
* Switched background type to an Image.
* Verified visually changing the page type to plain creates a page with white background.
* Verified that saving and reopening `.xopp` files remains consistent.

## **Worth Noting**:
- Whenever page type is changed to a special type the background color is changed to white, thus if the page type was later changed to a non-special type (e.g.) plain, it is a plain page with *white* background not the user specified default background color.
- The unit test code was generated using Gemini Flash 3.6 Extended thinking.
- **Related Issues**: Closes #7635 and prevents a corner case failure in the upcoming dynamic highlighter operator for light and dark backgrounds fix (#2900), specifically when transitioning a dark background page to a special background type.