### PR TITLE
feature: preserve hues for dark mode colour inversion

### DIFF
--- a/src/core/control/settings/Settings.cpp
+++ b/src/core/control/settings/Settings.cpp
@@ -203,7 +203,7 @@ void Settings::loadDefault() {
     this->selectionMarkerColor = Colors::xopp_cornflowerblue;
     this->activeSelectionColor = Colors::lawngreen;
 
-    this->recolorParameters = {false, false, Recolor(ColorU8{198, 208, 245}, ColorU8{48, 52, 70})};
+    this->recolorParameters = {false, false, Recolor(ColorU8{198, 208, 245}, ColorU8{48, 52, 70}, false)};
 
     this->backgroundColor = Colors::xopp_gainsboro02;
 
@@ -559,15 +559,21 @@ void Settings::parseItem(xmlDocPtr doc, xmlNodePtr cur) {
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("recolor.sidebar")) == 0) {
         this->recolorParameters.recolorizeSidebarMiniatures =
                 xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0;
+    } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("recolor.hues")) == 0) {
+        this->recolorParameters.recolor =
+                Recolor(this->recolorParameters.recolor.getLight(),
+                        this->recolorParameters.recolor.getDark(),
+                        xmlStrcmp(value, reinterpret_cast<const xmlChar*>("true")) == 0);
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("recolor.light")) == 0) {
         this->recolorParameters.recolor =
                 Recolor(ColorU8(g_ascii_strtoull(reinterpret_cast<const char*>(value), nullptr, 10)),
-                        this->recolorParameters.recolor.getDark());
+                        this->recolorParameters.recolor.getDark(),
+                        this->recolorParameters.recolor.getKeepHues());
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("recolor.dark")) == 0) {
         this->recolorParameters.recolor =
                 Recolor(this->recolorParameters.recolor.getLight(),
-                        ColorU8(g_ascii_strtoull(reinterpret_cast<const char*>(value), nullptr, 10)));
-
+                        ColorU8(g_ascii_strtoull(reinterpret_cast<const char*>(value), nullptr, 10)),
+                        this->recolorParameters.recolor.getKeepHues());
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("backgroundColor")) == 0) {
         this->backgroundColor = Color(g_ascii_strtoull(reinterpret_cast<const char*>(value), nullptr, 10));
     } else if (xmlStrcmp(name, reinterpret_cast<const xmlChar*>("addHorizontalSpace")) == 0) {
@@ -1139,6 +1145,7 @@ void Settings::save() {
 
     xmlNode = saveProperty("recolor.enabled", recolorParameters.recolorizeMainView ? "true" : "false", root);
     xmlNode = saveProperty("recolor.sidebar", recolorParameters.recolorizeSidebarMiniatures ? "true" : "false", root);
+    xmlNode = saveProperty("recolor.hues", recolorParameters.recolor.getKeepHues() ? "true" : "false", root);
     xmlNode = savePropertyUnsigned("recolor.dark", uint32_t(recolorParameters.recolor.getDark()), root);
     xmlNode = savePropertyUnsigned("recolor.light", uint32_t(recolorParameters.recolor.getLight()), root);
 

--- a/src/core/gui/dialog/SettingsDialog.cpp
+++ b/src/core/gui/dialog/SettingsDialog.cpp
@@ -530,6 +530,7 @@ void SettingsDialog::load() {
         const auto& recolor = settings->getRecolorParameters();
         loadCheckbox("cbRecolorDrawingArea", recolor.recolorizeMainView);
         loadCheckbox("cbRecolorPreviewSidebar", recolor.recolorizeSidebarMiniatures);
+        loadCheckbox("cbKeepHues", recolor.recolor.getKeepHues());
         color = Util::argb_to_GdkRGBA(recolor.recolor.getLight());
         gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(builder.get("recolorLight")), &color);
         color = Util::argb_to_GdkRGBA(recolor.recolor.getDark());
@@ -824,7 +825,7 @@ void SettingsDialog::save() {
         gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(builder.get("recolorDark")), &color2);
 
         settings->setRecolorParameters({getCheckbox("cbRecolorDrawingArea"), getCheckbox("cbRecolorPreviewSidebar"),
-                                        Recolor(Util::GdkRGBA_to_argb(color), Util::GdkRGBA_to_argb(color2))});
+                                        Recolor(Util::GdkRGBA_to_argb(color), Util::GdkRGBA_to_argb(color2), getCheckbox("cbKeepHues"))});
     }
 
     settings->setHighlightPosition(getCheckbox("cbHighlightPosition"));

--- a/src/util/Recolor.cpp
+++ b/src/util/Recolor.cpp
@@ -2,45 +2,80 @@
 
 #include "util/Color.h"
 
-Recolor::Recolor(const ColorU8& light, const ColorU8& dark): dark(dark), light(light) { recalcDiffAndOff(); }
+Recolor::Recolor(const ColorU8& light, const ColorU8& dark, bool keepHues): dark(dark), light(light), keepHues(keepHues) { recalcDiffAndOff(); }
 
 const ColorU8& Recolor::getDark() const { return dark; }
 
 const ColorU8& Recolor::getLight() const { return light; }
 
+bool Recolor::getKeepHues() const { return keepHues; }
+
 void Recolor::recalcDiffAndOff() {
     difference = ColorU8{
-            static_cast<uint8_t>(std::abs(static_cast<int16_t>(dark.red) - static_cast<int16_t>(light.red))),
+        static_cast<uint8_t>(std::abs(static_cast<int16_t>(dark.red) - static_cast<int16_t>(light.red))),
             static_cast<uint8_t>(std::abs(static_cast<int16_t>(dark.green) - static_cast<int16_t>(light.green))),
             static_cast<uint8_t>(std::abs(static_cast<int16_t>(dark.blue) - static_cast<int16_t>(light.blue)))};
 
     offset = ColorU8{std::min(dark.red, light.red), std::min(dark.green, light.green), std::min(dark.blue, light.blue)};
     ref = ColorU8{
-            static_cast<uint8_t>((light.red < dark.red ? 255 : 0)),
+        static_cast<uint8_t>((light.red < dark.red ? 255 : 0)),
             static_cast<uint8_t>((light.green < dark.green ? 255 : 0)),
             static_cast<uint8_t>((light.blue < dark.blue ? 255 : 0)),
     };
 }
 
 ColorU8 Recolor::convertColor(const ColorU8& other) const {
+    ColorU8 inverted = other;
+    if (keepHues) {
+        int cmin = std::min(std::min(other.red,other.green),other.blue);
+        int cmax = std::max(std::max(other.red,other.green),other.blue);
+        inverted = { static_cast<uint8_t>(cmin + cmax - other.red), static_cast<uint8_t>(cmin + cmax - other.green), static_cast<uint8_t>(cmin + cmax - other.blue) };
+    }
     return ColorU8{
+        static_cast<uint8_t>(
+                std::min(255, std::min(255, std::abs(static_cast<int>(ref.red) - static_cast<int>(inverted.red)) *
+                        static_cast<int>(difference.red) / 255) +
+                    offset.red)),
             static_cast<uint8_t>(
-                    std::min(255, std::min(255, std::abs(static_cast<int>(ref.red) - static_cast<int>(other.red)) *
-                                                        static_cast<int>(difference.red) / 255) +
-                                          offset.red)),
+                    std::min(255, std::min(255, std::abs(static_cast<int>(ref.green) - static_cast<int>(inverted.green)) *
+                            static_cast<int>(difference.green) / 255) +
+                        offset.green)),
             static_cast<uint8_t>(
-                    std::min(255, std::min(255, std::abs(static_cast<int>(ref.green) - static_cast<int>(other.green)) *
-                                                        static_cast<int>(difference.green) / 255) +
-                                          offset.green)),
-            static_cast<uint8_t>(
-                    std::min(255, std::min(255, std::abs(static_cast<int>(ref.blue) - static_cast<int>(other.blue)) *
-                                                        static_cast<int>(difference.blue) / 255) +
-                                          offset.blue)),
+                    std::min(255, std::min(255, std::abs(static_cast<int>(ref.blue) - static_cast<int>(inverted.blue)) *
+                            static_cast<int>(difference.blue) / 255) +
+                        offset.blue)),
     };
 }
 
 void Recolor::recolorCurrentCairoRegion(cairo_t* cr) const {
-    // Apply inversion
+
+    if (cairo_status(cr) != CAIRO_STATUS_SUCCESS) return;
+
+    cairo_identity_matrix(cr);
+
+    if (keepHues) {
+        // Invert hues by copying target surface, inverting, and applying hue operator...
+        cairo_surface_t *target = cairo_get_group_target(cr);
+        cairo_surface_t *copy = cairo_surface_create_similar(target, cairo_surface_get_content(target), cairo_image_surface_get_width(target), cairo_image_surface_get_height(target));
+
+        cairo_t *cr_new = cairo_create(copy);
+        cairo_set_source_surface(cr_new,target,0,0);
+        cairo_paint(cr_new);
+
+        cairo_set_operator(cr_new, CAIRO_OPERATOR_DIFFERENCE);
+        Util::cairo_set_source_rgbi(cr_new, ColorU8{255,255,255});
+        cairo_paint(cr_new);
+
+        // Copy inverted hues back on
+        cairo_set_operator(cr, CAIRO_OPERATOR_HSL_HUE);
+        cairo_set_source_surface(cr,copy,0,0);
+        cairo_paint(cr);
+
+        cairo_surface_destroy(copy);
+        cairo_destroy(cr_new);
+    }
+
+    // Apply (full) inversion
     cairo_set_operator(cr, CAIRO_OPERATOR_DIFFERENCE);
     Util::cairo_set_source_rgbi(cr, ref);
     cairo_paint(cr);

--- a/src/util/include/util/Recolor.h
+++ b/src/util/include/util/Recolor.h
@@ -16,12 +16,13 @@
 class Recolor {
 
 public:
-    Recolor(const ColorU8& light, const ColorU8& dark);
+    Recolor(const ColorU8& light, const ColorU8& dark, bool keepHues);
     Recolor() = default;
 
 public:
     const ColorU8& getDark() const;
     const ColorU8& getLight() const;
+    bool getKeepHues() const;
 
     ColorU8 convertColor(const ColorU8& other) const;
 
@@ -38,7 +39,7 @@ public:
 
 private:
     constexpr friend bool operator==(Recolor const& lhs, Recolor const& rhs) {
-        return lhs.difference == rhs.difference && lhs.offset == rhs.offset && lhs.ref == rhs.ref;
+        return lhs.difference == rhs.difference && lhs.offset == rhs.offset && lhs.ref == rhs.ref && lhs.keepHues == rhs.keepHues;
     }
 
     void recalcDiffAndOff();
@@ -47,6 +48,7 @@ private:
     // parameters set by the user also needed to save the settings to file
     ColorU8 dark = {};
     ColorU8 light = {};
+    bool keepHues = false;
 
     // calculated from above parameters to avoid having to calculate them for every recoloring all over again
     ColorU8 difference = {};  // abs(dark - light)

--- a/ui/settings.glade
+++ b/ui/settings.glade
@@ -3364,6 +3364,21 @@ This setting can make it easier to draw with touch.</property>
                                       </packing>
                                     </child>
                                     <child>
+                                      <object class="GtkCheckButton" id="cbKeepHues">
+                                        <property name="label" translatable="yes">Preserve Hues</property>
+                                        <property name="name">cbKeepHues</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="tooltip-text" translatable="no">Keeps hues (relatively) the same when recoloring, inverting only lightness.</property>
+                                        <property name="draw-indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">0</property>
+                                        <property name="top-attach">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
                                       <object class="GtkColorButton" id="recolorLight">
                                         <property name="name">recolorLight</property>
                                         <property name="visible">True</property>


### PR DESCRIPTION
As mentioned in several comments of https://github.com/xournalpp/xournalpp/pull/6090, the current method for applying custom light/dark colours inverts hues as well as brightness, which causes readability / specific colour use to be lost.

This tiny PR adds an optional setting to (approximately) **preserve the hues**, by naïvely inverting them (using Cairo's HSL_HUE operator on an inverted copy) before the usual processing.
It's a bit janky + laggy -- there's probably a better way to do this -- but it does the job.

<img width="1920" height="1178" alt="image" src="https://github.com/user-attachments/assets/1a567c0b-8368-4a44-b07d-45e87300e3fa" />
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/7c6ee02c-1e3c-4e0c-a0af-8340a0dc24b2" />

Hopefully I didn't break anything :P

(Note -- this doesn't quite work / **inverts the colours instead** on light backgrounds, but the default setting should work fine for those.)