### PR TITLE
Dynamic Highlighter Operator Selection Based on the Background Color's Luminance 

### DIFF
--- a/src/core/control/tools/StrokeHandler.cpp
+++ b/src/core/control/tools/StrokeHandler.cpp
@@ -278,13 +278,10 @@ void StrokeHandler::onButtonDoublePressEvent(const PositionInputData&, double) {
 auto StrokeHandler::createView(xoj::view::Repaintable* parent) const -> std::unique_ptr<xoj::view::OverlayView> {
     xoj_assert(this->stroke);
     const Stroke& s = *this->stroke;
-
-    // Calculate operator based on background luminance for highlighters
     cairo_operator_t op = CAIRO_OPERATOR_OVER;
+
     if (s.getToolType() == StrokeTool::HIGHLIGHTER) {
-        const auto& bgColor = page->getBackgroundColor();
-        double luminance = (0.2126 * bgColor.red + 0.7152 * bgColor.green + 0.0722 * bgColor.blue) / 255.0;
-        op = (luminance > 0.5) ? CAIRO_OPERATOR_MULTIPLY : CAIRO_OPERATOR_SCREEN;
+        op = page->getBackgroundColor().getHighlighterOperator();
     }
 
     if (s.getFill() != -1) {

--- a/src/core/control/tools/StrokeHandler.cpp
+++ b/src/core/control/tools/StrokeHandler.cpp
@@ -278,6 +278,15 @@ void StrokeHandler::onButtonDoublePressEvent(const PositionInputData&, double) {
 auto StrokeHandler::createView(xoj::view::Repaintable* parent) const -> std::unique_ptr<xoj::view::OverlayView> {
     xoj_assert(this->stroke);
     const Stroke& s = *this->stroke;
+
+    // Calculate operator based on background luminance for highlighters
+    cairo_operator_t op = CAIRO_OPERATOR_OVER;
+    if (s.getToolType() == StrokeTool::HIGHLIGHTER) {
+        const auto& bgColor = page->getBackgroundColor();
+        double luminance = (0.2126 * bgColor.red + 0.7152 * bgColor.green + 0.0722 * bgColor.blue) / 255.0;
+        op = (luminance > 0.5) ? CAIRO_OPERATOR_MULTIPLY : CAIRO_OPERATOR_SCREEN;
+    }
+
     if (s.getFill() != -1) {
         if (s.getToolType() == StrokeTool::HIGHLIGHTER) {
             // Filled highlighter requires to wipe the mask entirely at every iteration
@@ -287,7 +296,7 @@ auto StrokeHandler::createView(xoj::view::Repaintable* parent) const -> std::uni
             return std::make_unique<xoj::view::StrokeToolFilledView>(this, s, parent);
         }
     } else {
-        return std::make_unique<xoj::view::StrokeToolView>(this, s, parent);
+        return std::make_unique<xoj::view::StrokeToolView>(this, s, parent, op);
     }
 }
 

--- a/src/core/model/XojPage.cpp
+++ b/src/core/model/XojPage.cpp
@@ -150,6 +150,9 @@ void XojPage::setBackgroundType(const PageType& bgType) {
     if (!bgType.isImagePage()) {
         this->backgroundImage.free();
     }
+    if (bgType.isSpecial()) {
+        this->backgroundColor = Colors::white;
+    }
 }
 
 auto XojPage::getBackgroundType() const -> PageType { return this->bgType; }

--- a/src/core/view/DocumentView.cpp
+++ b/src/core/view/DocumentView.cpp
@@ -74,6 +74,9 @@ void DocumentView::drawPage(ConstPageRef page, cairo_t* cr, bool dontRenderEditi
 
     xoj::view::Context context{cr, (xoj::view::NonAudioTreatment)this->markAudioStroke,
                                (xoj::view::EditionTreatment) !this->dontRenderEditingStroke, xoj::view::NORMAL_COLOR};
+    const auto& bgColor = page->getBackgroundColor();
+    // calculate luminance using the ITU-R BT.709 luminance formula, bgColor is in range [0,255] the formula expect [0,1] so divide result by 255
+    context.backgroundColorLuminance = (0.2126 * bgColor.red + 0.7152 * bgColor.green + 0.0722 * bgColor.blue) / 255.0;
     for (const Layer* layer: page->getLayersView()) {
         if (layer->isVisible()) {
             xoj::view::LayerView layerView(layer);

--- a/src/core/view/DocumentView.cpp
+++ b/src/core/view/DocumentView.cpp
@@ -74,9 +74,7 @@ void DocumentView::drawPage(ConstPageRef page, cairo_t* cr, bool dontRenderEditi
 
     xoj::view::Context context{cr, (xoj::view::NonAudioTreatment)this->markAudioStroke,
                                (xoj::view::EditionTreatment) !this->dontRenderEditingStroke, xoj::view::NORMAL_COLOR};
-    const auto& bgColor = page->getBackgroundColor();
-    // calculate luminance using the ITU-R BT.709 luminance formula, bgColor is in range [0,255] the formula expect [0,1] so divide result by 255
-    context.backgroundColorLuminance = (0.2126 * bgColor.red + 0.7152 * bgColor.green + 0.0722 * bgColor.blue) / 255.0;
+    context.highlighterOperator = page->getBackgroundColor().getHighlighterOperator();
     for (const Layer* layer: page->getLayersView()) {
         if (layer->isVisible()) {
             xoj::view::LayerView layerView(layer);

--- a/src/core/view/StrokeView.cpp
+++ b/src/core/view/StrokeView.cpp
@@ -119,14 +119,8 @@ void StrokeView::draw(const Context& ctx) const {
          * Highlighter without filling.
          */
         Util::cairo_set_source_rgbi(cr, s->getColor(), OPACITY_HIGHLIGHTER);
-        // Use luminance value from context to determine the operator
-        if (ctx.backgroundColorLuminance > 0.5) {
-            cairo_set_operator(cr, CAIRO_OPERATOR_MULTIPLY);
-        } else {
-            // The screen operator lightens the bakcground and keeps text visilbe
-            //   which is expected when highlighting dark backgrounds.
-            cairo_set_operator(cr, CAIRO_OPERATOR_SCREEN);
-        }
+        // Use the context helper function to get the operator
+            cairo_set_operator(cr, ctx.getHighlighterOperator());
     } else {
         /**
          * Normal pen
@@ -167,7 +161,7 @@ void StrokeView::draw(const Context& ctx) const {
         }
 
         // Blit the mask onto the given cairo context
-        cairo_set_operator(ctx.cr, highlighter ? CAIRO_OPERATOR_MULTIPLY : CAIRO_OPERATOR_OVER);
+        cairo_set_operator(ctx.cr, highlighter ? ctx.getHighlighterOperator() : CAIRO_OPERATOR_OVER);
 
         Util::cairo_set_source_rgbi(ctx.cr, s->getColor(), groupAlpha);
 

--- a/src/core/view/StrokeView.cpp
+++ b/src/core/view/StrokeView.cpp
@@ -119,7 +119,14 @@ void StrokeView::draw(const Context& ctx) const {
          * Highlighter without filling.
          */
         Util::cairo_set_source_rgbi(cr, s->getColor(), OPACITY_HIGHLIGHTER);
-        cairo_set_operator(cr, CAIRO_OPERATOR_MULTIPLY);
+        // Use luminance value from context to determine the operator
+        if (ctx.backgroundColorLuminance > 0.5) {
+            cairo_set_operator(cr, CAIRO_OPERATOR_MULTIPLY);
+        } else {
+            // The screen operator lightens the bakcground and keeps text visilbe
+            //   which is expected when highlighting dark backgrounds.
+            cairo_set_operator(cr, CAIRO_OPERATOR_SCREEN);
+        }
     } else {
         /**
          * Normal pen

--- a/src/core/view/StrokeView.cpp
+++ b/src/core/view/StrokeView.cpp
@@ -119,8 +119,7 @@ void StrokeView::draw(const Context& ctx) const {
          * Highlighter without filling.
          */
         Util::cairo_set_source_rgbi(cr, s->getColor(), OPACITY_HIGHLIGHTER);
-        // Use the context helper function to get the operator
-            cairo_set_operator(cr, ctx.getHighlighterOperator());
+        cairo_set_operator(cr, ctx.highlighterOperator);
     } else {
         /**
          * Normal pen
@@ -161,7 +160,7 @@ void StrokeView::draw(const Context& ctx) const {
         }
 
         // Blit the mask onto the given cairo context
-        cairo_set_operator(ctx.cr, highlighter ? ctx.getHighlighterOperator() : CAIRO_OPERATOR_OVER);
+        cairo_set_operator(ctx.cr, highlighter ? ctx.highlighterOperator : CAIRO_OPERATOR_OVER);
 
         Util::cairo_set_source_rgbi(ctx.cr, s->getColor(), groupAlpha);
 

--- a/src/core/view/View.h
+++ b/src/core/view/View.h
@@ -32,6 +32,10 @@ public:
     ColorTreatment noColor;
     double backgroundColorLuminance = 1.0; // setting default once to white (1.0)
 
+    [[nodiscard]] cairo_operator_t getHighlighterOperator() const noexcept {
+        return (backgroundColorLuminance > 0.5) ? CAIRO_OPERATOR_MULTIPLY : CAIRO_OPERATOR_SCREEN;
+    }
+
     static Context createDefault(cairo_t* cr) { return {cr, NORMAL_NON_AUDIO, HIDE_CURRENT_EDITING, NORMAL_COLOR}; }
     static Context createColorBlind(cairo_t* cr) { return {cr, NORMAL_NON_AUDIO, HIDE_CURRENT_EDITING, COLORBLIND}; }
 };

--- a/src/core/view/View.h
+++ b/src/core/view/View.h
@@ -30,6 +30,7 @@ public:
     NonAudioTreatment fadeOutNonAudio;
     EditionTreatment showCurrentEdition;
     ColorTreatment noColor;
+    double backgroundColorLuminance = 1.0; // setting default once to white (1.0)
 
     static Context createDefault(cairo_t* cr) { return {cr, NORMAL_NON_AUDIO, HIDE_CURRENT_EDITING, NORMAL_COLOR}; }
     static Context createColorBlind(cairo_t* cr) { return {cr, NORMAL_NON_AUDIO, HIDE_CURRENT_EDITING, COLORBLIND}; }

--- a/src/core/view/View.h
+++ b/src/core/view/View.h
@@ -30,11 +30,7 @@ public:
     NonAudioTreatment fadeOutNonAudio;
     EditionTreatment showCurrentEdition;
     ColorTreatment noColor;
-    double backgroundColorLuminance = 1.0; // setting default once to white (1.0)
-
-    [[nodiscard]] cairo_operator_t getHighlighterOperator() const noexcept {
-        return (backgroundColorLuminance > 0.5) ? CAIRO_OPERATOR_MULTIPLY : CAIRO_OPERATOR_SCREEN;
-    }
+    cairo_operator_t highlighterOperator = CAIRO_OPERATOR_MULTIPLY;
 
     static Context createDefault(cairo_t* cr) { return {cr, NORMAL_NON_AUDIO, HIDE_CURRENT_EDITING, NORMAL_COLOR}; }
     static Context createColorBlind(cairo_t* cr) { return {cr, NORMAL_NON_AUDIO, HIDE_CURRENT_EDITING, COLORBLIND}; }

--- a/src/core/view/overlays/BaseStrokeToolView.cpp
+++ b/src/core/view/overlays/BaseStrokeToolView.cpp
@@ -12,9 +12,9 @@
 
 using namespace xoj::view;
 
-BaseStrokeToolView::BaseStrokeToolView(Repaintable* parent, const Stroke& stroke):
+BaseStrokeToolView::BaseStrokeToolView(Repaintable* parent, const Stroke& stroke, cairo_operator_t op):
         ToolView(parent),
-        cairoOp(stroke.getToolType() == StrokeTool::HIGHLIGHTER ? CAIRO_OPERATOR_MULTIPLY : CAIRO_OPERATOR_OVER),
+        cairoOp(op),
         strokeColor(strokeColorWithAlpha(stroke)),
         lineStyle(stroke.getLineStyle()),
         strokeWidth(stroke.getWidth()) {}

--- a/src/core/view/overlays/BaseStrokeToolView.h
+++ b/src/core/view/overlays/BaseStrokeToolView.h
@@ -25,7 +25,7 @@ class Repaintable;
 
 class BaseStrokeToolView: public ToolView {
 protected:
-    BaseStrokeToolView(Repaintable* parent, const Stroke& stroke);
+    BaseStrokeToolView(Repaintable* parent, const Stroke& stroke, cairo_operator_t op = CAIRO_OPERATOR_OVER);
     ~BaseStrokeToolView() noexcept override;
 
     /**

--- a/src/core/view/overlays/StrokeToolView.cpp
+++ b/src/core/view/overlays/StrokeToolView.cpp
@@ -17,8 +17,8 @@
 
 using namespace xoj::view;
 
-StrokeToolView::StrokeToolView(const StrokeHandler* strokeHandler, const Stroke& stroke, Repaintable* parent):
-        BaseStrokeToolView(parent, stroke), strokeHandler(strokeHandler), pointBuffer(stroke.getPointVector()) {
+StrokeToolView::StrokeToolView(const StrokeHandler* strokeHandler, const Stroke& stroke, Repaintable* parent, cairo_operator_t op):
+        BaseStrokeToolView(parent, stroke, op), strokeHandler(strokeHandler), pointBuffer(stroke.getPointVector()) {
     this->registerToPool(strokeHandler->getViewPool());
     parent->flagDirtyRegion(Range(stroke.getBoundingBox()));
 }
@@ -113,7 +113,7 @@ void StrokeToolView::on(StrokeToolView::StrokeReplacementRequest, const Stroke& 
     xoj_assert(this->strokeColor == strokeColorWithAlpha(newStroke));
     xoj_assert(this->lineStyle == newStroke.getLineStyle());
     xoj_assert(this->cairoOp ==
-               (newStroke.getToolType() == StrokeTool::HIGHLIGHTER ? CAIRO_OPERATOR_MULTIPLY : CAIRO_OPERATOR_OVER));
+               (newStroke.getToolType() == StrokeTool::HIGHLIGHTER ? this->cairoOp : CAIRO_OPERATOR_OVER));
 }
 
 void StrokeToolView::deleteOn(StrokeToolView::FinalizationRequest, const Range& rg) {

--- a/src/core/view/overlays/StrokeToolView.h
+++ b/src/core/view/overlays/StrokeToolView.h
@@ -30,7 +30,7 @@ class Repaintable;
 
 class StrokeToolView: public BaseStrokeToolView, public xoj::util::Listener<StrokeToolView> {
 public:
-    StrokeToolView(const StrokeHandler* strokeHandler, const Stroke& stroke, Repaintable* parent);
+    StrokeToolView(const StrokeHandler* strokeHandler, const Stroke& stroke, Repaintable* parent, cairo_operator_t op = CAIRO_OPERATOR_OVER);
     virtual ~StrokeToolView() noexcept;
 
     bool isViewOf(const OverlayBase* overlay) const override;

--- a/src/util/include/util/Color.h
+++ b/src/util/include/util/Color.h
@@ -65,6 +65,19 @@ struct ColorU8 {
     };
 
     constexpr auto isLight() const -> bool { return uint32_t(red) + uint32_t(green) + uint32_t(blue) > 0x180U; }
+
+    constexpr auto getRelativeLuminance() const -> double {
+        // The ITU-R BT.709 luminance formula, colors belong [0,255] the formula expects [0,1], so divide result by 255.
+        return (0.2126 * red + 0.7152 * green + 0.0722 * blue) / 255.0;
+    }
+
+    constexpr auto isDark() const -> bool {
+        return getRelativeLuminance() <= 0.5;
+    }
+
+    constexpr auto getHighlighterOperator() const -> cairo_operator_t {
+        return isDark() ? CAIRO_OPERATOR_SCREEN : CAIRO_OPERATOR_MULTIPLY;
+    }
 };
 
 static_assert(sizeof(ColorU8) == sizeof(uint32_t), "Color is not 32 bit");

--- a/test/unit_tests/model/XojPageTest.cpp
+++ b/test/unit_tests/model/XojPageTest.cpp
@@ -26,3 +26,37 @@ TEST(XojPageTest, SetBackgroundTypeResetsColorForSpecialBackgrounds) {
     // 5. Verify color is reset to white again
     EXPECT_EQ(page.getBackgroundColor(), Colors::white);
 }
+
+TEST(PageBackgroundTest, HighlighterOperatorUpdatesOnBackgroundTransitions) {
+    XojPage page(595.0, 842.0);
+    PageType imageBg(PageTypeFormat::Image);
+    PageType pdfBg(PageTypeFormat::Pdf);
+    constexpr Color lightBg{0xf1f1f1};
+    constexpr Color darkBg{0x1e1e1e};
+
+    // Light Page tests (Multiply):
+    //    plain, PDF, plain, Image
+    page.setBackgroundColor(lightBg);
+    EXPECT_FALSE(page.getBackgroundColor().isDark());
+    EXPECT_EQ(page.getBackgroundColor().getHighlighterOperator(), CAIRO_OPERATOR_MULTIPLY);
+
+    page.setBackgroundType(pdfBg);
+    EXPECT_EQ(page.getBackgroundColor().getHighlighterOperator(), CAIRO_OPERATOR_MULTIPLY);
+
+    page.setBackgroundColor(lightBg);
+    page.setBackgroundType(imageBg);
+    EXPECT_EQ(page.getBackgroundColor().getHighlighterOperator(), CAIRO_OPERATOR_MULTIPLY);
+
+    // Dark Page tests (Screen):
+    //    plain, PDF, plain, Image
+    page.setBackgroundColor(darkBg);
+    EXPECT_TRUE(page.getBackgroundColor().isDark());
+    EXPECT_EQ(page.getBackgroundColor().getHighlighterOperator(), CAIRO_OPERATOR_SCREEN);
+
+    page.setBackgroundType(pdfBg);
+    EXPECT_EQ(page.getBackgroundColor().getHighlighterOperator(), CAIRO_OPERATOR_MULTIPLY);
+
+    page.setBackgroundColor(darkBg);
+    page.setBackgroundType(imageBg);
+    EXPECT_EQ(page.getBackgroundColor().getHighlighterOperator(), CAIRO_OPERATOR_MULTIPLY);
+}

--- a/test/unit_tests/model/XojPageTest.cpp
+++ b/test/unit_tests/model/XojPageTest.cpp
@@ -1,0 +1,28 @@
+#include <gtest/gtest.h>
+
+#include "model/PageType.h"
+#include "model/XojPage.h"
+#include "util/Color.h"
+
+TEST(XojPageTest, SetBackgroundTypeResetsColorForSpecialBackgrounds) {
+    XojPage page(595.0, 842.0);  // Standard page dimensions
+
+    // 1. Set a dark background color initially
+    page.setBackgroundColor(Color(0x1E1E1E));
+    EXPECT_EQ(page.getBackgroundColor(), Color(0x1E1E1E));
+
+    // 2. Transition background type to Image
+    PageType imageBg(PageTypeFormat::Image);
+    page.setBackgroundType(imageBg);
+
+    // 3. Verify color is reset to default white
+    EXPECT_EQ(page.getBackgroundColor(), Colors::white);
+
+    // 4. Test PDF background transition as well
+    page.setBackgroundColor(Color(0x000000));
+    PageType pdfBg(PageTypeFormat::Pdf);
+    page.setBackgroundType(pdfBg);
+
+    // 5. Verify color is reset to white again
+    EXPECT_EQ(page.getBackgroundColor(), Colors::white);
+}

--- a/test/unit_tests/util/ColorTest.cpp
+++ b/test/unit_tests/util/ColorTest.cpp
@@ -55,3 +55,29 @@ TEST(UtilColor, testColorToRGBAndBack) {
         EXPECT_EQ(color2, Util::GdkRGBA_to_argb(Util::argb_to_GdkRGBA(color2)));
     }
 }
+
+TEST(UtilColor, RelativeLuminanceAndHighlighterOperator) {
+    EXPECT_NEAR(Colors::black.getRelativeLuminance(), 0.0, 1e-4);
+    EXPECT_NEAR(Colors::white.getRelativeLuminance(), 1.0, 1e-4);
+
+    // Individual BT.709 channel weight verification
+    constexpr Color pureRed{0xffff0000U};
+    constexpr Color pureGreen{0xff00ff00U};
+    constexpr Color pureBlue{0xff0000ffU};
+    EXPECT_NEAR(pureRed.getRelativeLuminance(), 0.2126, 1e-4);
+    EXPECT_NEAR(pureGreen.getRelativeLuminance(), 0.7152, 1e-4);
+    EXPECT_NEAR(pureBlue.getRelativeLuminance(), 0.0722, 1e-4);
+
+    EXPECT_TRUE(Colors::black.isDark());
+    EXPECT_FALSE(Colors::white.isDark());
+
+    constexpr Color justAboveHalf{0xff808080U}; // RGB(128,128,128) -> Luminance ≈ 0.5019
+    constexpr Color justBelowHalf{0xff787878U}; // RGB(120,120,120) -> Luminance ≈ 0.4705
+    EXPECT_FALSE(justAboveHalf.isDark());
+    EXPECT_TRUE(justBelowHalf.isDark());
+
+    EXPECT_EQ(Colors::white.getHighlighterOperator(), CAIRO_OPERATOR_MULTIPLY);
+    EXPECT_EQ(Colors::black.getHighlighterOperator(), CAIRO_OPERATOR_SCREEN);
+    EXPECT_EQ(justAboveHalf.getHighlighterOperator(), CAIRO_OPERATOR_MULTIPLY);
+    EXPECT_EQ(justBelowHalf.getHighlighterOperator(), CAIRO_OPERATOR_SCREEN);
+}


### PR DESCRIPTION
> ⚠️ **Note:** This PR is stacked on top of PR #7637  (`reset background color when changing bgType`). 
> Please merge PR #7637 first! Once #7637 is merged, this PR's diff will automatically clean up.

## Description
This PR adds dynamic cairo operator selection for the highlighter (between multiply and screen) based on the page's background color's luminance.

### Why this PR is needed?
Before, highlights always used CAIRO_OPERATOR_MULTIPLY. However on dark backgrounds that makes the highlights unable to be seen. 

This PR uses dynamic operator selection in `util/Color.h` such that if the luminance (calculated by the ITU-R BT.709 formula) of the background color is > 0.5 the operator used is Multiply (light background) and if luminance <= 0.5 the operator used is Screen (dark backgrounds).

## Related Issues
Fixes #2900

## Type of Change
- Bug fix (non-breaking change fixing an issue)

## How Has This Been Tested?
- **Unit Tests Added:**
  - Added math & threshold tests in `test/util/ColorTest.cpp`.
  - Added paper mode & background color transition tests in `test/model/PageBackgroundTest.cpp`.
- **Manual Verification:**
  - Verified highlighter readability on dark plain, light plain PDF pages, and image background types.
  - Tested both filled and unfilled highlighter tools.
  - Verfied Cairo operator, luminance and background color for Overlay and Rendered strokes using g_message logs

## The Working Fix Implementation

https://github.com/user-attachments/assets/76893bc3-2cb0-4977-ad6a-c70c7e356f3b

