### PR TITLE
Make pen strokes starting outside page area act like hand tool

### DIFF
--- a/src/core/control/ToolHandler.cpp
+++ b/src/core/control/ToolHandler.cpp
@@ -571,6 +571,13 @@ bool ToolHandler::pointActiveToolToButtonTool(Button button) {
     return true;
 }
 
+bool ToolHandler::pointActiveToolToToolType(ToolType type) {
+    if (this->activeTool->type == type)
+        return false;
+    this->activeTool = &getTool(type);
+    return true;
+}
+
 bool ToolHandler::pointActiveToolToToolbarTool() {
     if (this->activeTool == this->toolbarSelectedTool)
         return false;

--- a/src/core/control/ToolHandler.h
+++ b/src/core/control/ToolHandler.h
@@ -337,6 +337,14 @@ public:
      */
     bool pointActiveToolToButtonTool(Button button);
     /**
+     * @brief Point the active tool to the tool of the given type
+     *
+     * @param type ToolType the tool type to switch to
+     * @return true if the active toolpointer was changed
+     * @return false if the active toolpointer was not changed (it was already pointing to the given tool type)
+     */
+    bool pointActiveToolToToolType(ToolType type);
+    /**
      * @brief Point the active tool to tool selected in the toolbar
      *
      * @return true if the active toolpointer was changed

--- a/src/core/gui/inputdevices/PenInputHandler.cpp
+++ b/src/core/gui/inputdevices/PenInputHandler.cpp
@@ -94,6 +94,8 @@ auto PenInputHandler::actionStart(InputEvent const& event) -> bool {
     if (!changeTool(event))
         return false;
 
+    this->inputStartedOutsidePageArea = currentPage == nullptr;
+
     // Used for pressure inference
     this->lastPressure = 0.0;
 
@@ -116,15 +118,17 @@ auto PenInputHandler::actionStart(InputEvent const& event) -> bool {
     cursor->setMouseDown(true);
 
 
-    // Save the starting offset when hand-tool is selected to get a reference for the scroll-offset
-    if (toolType == TOOL_HAND) {
+    // Save the starting offset when hand-tool is selected (or the input starts outside a page area and thus
+    // acts like the hand tool) to get a reference for the scroll-offset
+    if (toolType == TOOL_HAND || this->inputStartedOutsidePageArea) {
         this->scrollStartPosition = event.absolute;
     }
 
     this->sequenceStartPage = currentPage;
 
     // hand tool don't change the selection, so you can scroll e.g. with your touchscreen without remove the selection
-    bool changeSelection = xournal->selection && toolHandler->getToolType() != TOOL_HAND;
+    bool changeSelection =
+            xournal->selection && toolHandler->getToolType() != TOOL_HAND && !this->inputStartedOutsidePageArea;
     if ((event.state & GDK_SHIFT_MASK)) {
         // When tap single selection is enabled
         if (toolHandler->supportsTapFilter() && inputContext->getSettings()->getStrokeFilterEnabled()) {
@@ -292,7 +296,7 @@ auto PenInputHandler::actionMotion(InputEvent const& event) -> bool {
 
     this->changeTool(event);
 
-    if (toolHandler->getToolType() == TOOL_HAND) {
+    if (toolHandler->getToolType() == TOOL_HAND || this->inputStartedOutsidePageArea) {
         if (this->deviceClassPressed) {
             this->handleScrollEvent(event);
             return true;
@@ -407,6 +411,8 @@ auto PenInputHandler::actionEnd(InputEvent const& event) -> bool {
     EditSelection* selection = xournal->view->getSelection();
 
     cursor->setMouseDown(false);
+
+    this->inputStartedOutsidePageArea = false;
 
     bool cancelAction = isCurrentTapSelection(event);
 

--- a/src/core/gui/inputdevices/PenInputHandler.cpp
+++ b/src/core/gui/inputdevices/PenInputHandler.cpp
@@ -97,12 +97,18 @@ auto PenInputHandler::actionStart(InputEvent const& event) -> bool {
     // Used for pressure inference
     this->lastPressure = 0.0;
 
-    // Flag running input
     ToolHandler* toolHandler = this->inputContext->getToolHandler();
+
+    // If the input starts outside a page, we make it act as hand tool instead.
+    if (currentPage == nullptr && toolHandler->pointActiveToolToToolType(TOOL_HAND)) {
+        this->inputStartedOutsidePageArea = true;
+        toolHandler->fireToolChanged();
+    }
+    
     ToolType toolType = toolHandler->getToolType();
 
-    //
     if (toolType != TOOL_IMAGE) {
+        // Flag running input
         this->inputRunning = true;
     } else {
         this->deviceClassPressed = false;
@@ -124,7 +130,7 @@ auto PenInputHandler::actionStart(InputEvent const& event) -> bool {
     this->sequenceStartPage = currentPage;
 
     // hand tool don't change the selection, so you can scroll e.g. with your touchscreen without remove the selection
-    bool changeSelection = xournal->selection && toolHandler->getToolType() != TOOL_HAND;
+    bool changeSelection = xournal->selection && toolType != TOOL_HAND;
     if ((event.state & GDK_SHIFT_MASK)) {
         // When tap single selection is enabled
         if (toolHandler->supportsTapFilter() && inputContext->getSettings()->getStrokeFilterEnabled()) {
@@ -290,7 +296,10 @@ auto PenInputHandler::actionMotion(InputEvent const& event) -> bool {
     GtkXournal* xournal = this->inputContext->getXournal();
     ToolHandler* toolHandler = this->inputContext->getToolHandler();
 
-    this->changeTool(event);
+    // If this is a drag starting outside the page area, we'd have set active tool to HAND.
+    // In this case we don't want changeTool to change it back to the toolbar / button tool.
+    if (!this->inputStartedOutsidePageArea)
+        this->changeTool(event);
 
     if (toolHandler->getToolType() == TOOL_HAND) {
         if (this->deviceClassPressed) {
@@ -407,6 +416,8 @@ auto PenInputHandler::actionEnd(InputEvent const& event) -> bool {
     EditSelection* selection = xournal->view->getSelection();
 
     cursor->setMouseDown(false);
+
+    this->inputStartedOutsidePageArea = false;
 
     bool cancelAction = isCurrentTapSelection(event);
 

--- a/src/core/gui/inputdevices/PenInputHandler.h
+++ b/src/core/gui/inputdevices/PenInputHandler.h
@@ -64,6 +64,13 @@ protected:
     xoj::util::Point<double> scrollOffsetVector{0., 0.};
 
     /**
+     * Whether the current input sequence started outside of a page area (e.g. on the margins between or beside
+     * pages). Such input sequences act as if the hand tool were selected: dragging scrolls the view, independent
+     * of the currently active tool.
+     */
+    bool inputStartedOutsidePageArea = false;
+
+    /**
      * Flag whether pen is within the widget
      */
     bool penInWidget = false;


### PR DESCRIPTION
Implements what is requested in #7258.

I take lectures with Xournal++ and they get to dozens of pages long, at which point using the scrollbar is not precise enough. Being able to scroll with the stylus is extremely useful!

Tested:

[Screencast.webm](https://github.com/user-attachments/assets/dd154164-8e57-4988-a9b1-3285694a957c)

Also, I haven't set up the compiler environment properly (I used the flatpak build pipeline to build and test this), so I haven't run the formatter, linter, etc. I hope this is not a problem since the changes are very simple.