### PR TITLE
Fix failing assertion in InputUtils::applyButton()

### DIFF
--- a/src/core/control/ToolHandler.cpp
+++ b/src/core/control/ToolHandler.cpp
@@ -13,9 +13,11 @@
 #include "control/actions/ActionDatabase.h"
 #include "control/settings/Settings.h"  // for SElement, Settings
 #include "model/StrokeStyle.h"          // for StrokeStyle
+#include "util/Assert.h"
 #include "util/Color.h"
 #include "util/Stacktrace.h"  // for Stac...
 #include "util/safe_casts.h"  // for as_unsigned
+
 
 class LineStyle;
 
@@ -138,13 +140,6 @@ void ToolHandler::initTools() {
     tools[TOOL_LASER_POINTER_HIGHLIGHTER - TOOL_PEN] =
             std::make_unique<Tool>("laserPointerHighlighter", TOOL_LASER_POINTER_HIGHLIGHTER, Colors::red, thickness);
 
-    this->eraserButtonTool = std::make_unique<Tool>(*tools[TOOL_HIGHLIGHTER - TOOL_PEN]);
-    this->stylusButton1Tool = std::make_unique<Tool>(*tools[TOOL_HIGHLIGHTER - TOOL_PEN]);
-    this->stylusButton2Tool = std::make_unique<Tool>(*tools[TOOL_HIGHLIGHTER - TOOL_PEN]);
-    this->mouseMiddleButtonTool = std::make_unique<Tool>(*tools[TOOL_HIGHLIGHTER - TOOL_PEN]);
-    this->mouseRightButtonTool = std::make_unique<Tool>(*tools[TOOL_HIGHLIGHTER - TOOL_PEN]);
-    this->touchDrawingButtonTool = std::make_unique<Tool>(*tools[TOOL_HIGHLIGHTER - TOOL_PEN]);
-
     this->toolbarSelectedTool = &getTool(TOOL_PEN);
     this->activeTool = &getTool(TOOL_PEN);
 }
@@ -162,6 +157,7 @@ void ToolHandler::setEraserType(EraserType eraserType) {
 
 void ToolHandler::setButtonEraserType(EraserType eraserType, Button button) {
     Tool* tool = getButtonTool(button);
+    xoj_assert(tool);
     tool->setEraserType(eraserType);
 }
 
@@ -335,6 +331,7 @@ void ToolHandler::setButtonSize(ToolSize size, Button button) {
         g_warning("ToolHandler::setSize: Invalid size! %i", size);
 
     Tool* tool = getButtonTool(button);
+    xoj_assert(tool);
     tool->setSize(clippedSize);
 }
 
@@ -361,6 +358,7 @@ void ToolHandler::setColor(Color color, bool userSelection) {
 
 void ToolHandler::setButtonColor(Color color, Button button) {
     Tool* tool = this->getButtonTool(button);
+    xoj_assert(tool);
     tool->setColor(color);
 }
 
@@ -403,6 +401,7 @@ void ToolHandler::setDrawingType(DrawingType drawingType) {
 
 void ToolHandler::setButtonDrawingType(DrawingType drawingType, Button button) {
     Tool* tool = getButtonTool(button);
+    xoj_assert(tool);
     tool->setDrawingType(drawingType);
 }
 
@@ -412,6 +411,7 @@ void ToolHandler::setButtonStrokeType(StrokeType strokeType, Button button) {
 
 void ToolHandler::setButtonStrokeType(const LineStyle& lineStyle, Button button) {
     Tool* tool = getButtonTool(button);
+    xoj_assert(tool);
     tool->setLineStyle(lineStyle);
 }
 
@@ -670,28 +670,28 @@ auto ToolHandler::getButtonTool(Button button) const -> Tool* {
 }
 
 void ToolHandler::resetButtonTool(ToolType type, Button button) {
-    auto& tool = *(tools[type - TOOL_PEN]);
+    auto t = type == TOOL_NONE ? nullptr : std::make_unique<Tool>(*tools[type - TOOL_PEN]);
     switch (button) {
         case Button::BUTTON_ERASER:
-            this->eraserButtonTool.reset(new Tool(tool));
+            this->eraserButtonTool = std::move(t);
             break;
         case Button::BUTTON_STYLUS_ONE:
-            this->stylusButton1Tool.reset(new Tool(tool));
+            this->stylusButton1Tool = std::move(t);
             break;
         case Button::BUTTON_STYLUS_TWO:
-            this->stylusButton2Tool.reset(new Tool(tool));
+            this->stylusButton2Tool = std::move(t);
             break;
         case Button::BUTTON_MOUSE_LEFT:
-            this->mouseLeftButtonTool.reset(new Tool(tool));
+            this->mouseLeftButtonTool = std::move(t);
             break;
         case Button::BUTTON_MOUSE_MIDDLE:
-            this->mouseMiddleButtonTool.reset(new Tool(tool));
+            this->mouseMiddleButtonTool = std::move(t);
             break;
         case Button::BUTTON_MOUSE_RIGHT:
-            this->mouseRightButtonTool.reset(new Tool(tool));
+            this->mouseRightButtonTool = std::move(t);
             break;
         case Button::BUTTON_TOUCH:
-            this->touchDrawingButtonTool.reset(new Tool(tool));
+            this->touchDrawingButtonTool = std::move(t);
             break;
         default:
             g_error("This button is not defined for ToolHandler.");

--- a/src/core/control/settings/ButtonConfig.cpp
+++ b/src/core/control/settings/ButtonConfig.cpp
@@ -22,11 +22,12 @@ auto ButtonConfig::getDrawingType() const -> DrawingType { return this->drawingT
 auto ButtonConfig::getAction() const -> ToolType { return this->action; }
 
 void ButtonConfig::initButton(ToolHandler* toolHandler, Button button) const {
+    toolHandler->resetButtonTool(this->action, button);
+
     if (this->action == TOOL_NONE) {
         return;
     }
 
-    toolHandler->resetButtonTool(this->action, button);
     const Tool& t = toolHandler->getTool(this->action);
 
     if (t.hasCapability(TOOL_CAP_SIZE) && this->size != TOOL_SIZE_NONE) {

--- a/src/core/gui/inputdevices/InputUtils.cpp
+++ b/src/core/gui/inputdevices/InputUtils.cpp
@@ -11,16 +11,15 @@
 
 
 bool InputUtils::applyButton(ToolHandler* toolHandler, Settings* settings, Button button) {
-    bool toolChanged = false;
     // if active tool already points to the correct tool nothing needs to be done
     if (toolHandler->pointActiveToolToButtonTool(button)) {
-        toolChanged = true;
         ButtonConfig* cfg = settings->getButtonConfig(button);
 
         xoj_assert(cfg->getAction() != TOOL_NONE);
         cfg->applyNoChangeSettings(toolHandler, button);
+        return true;
     }
-    return toolChanged;
+    return false;
 }
 
 bool InputUtils::touchDrawingDisallowed(ToolHandler* toolHandler, Settings* settings) {


### PR DESCRIPTION
In #7581, I introduced a failing assert. This was due my lack of attention to the fact the pointer `ToolHandler::mouseRightButtonTool` (and its friends) were pointing to some random Tool (instead of the more intuitive nullptr) if the corresponding button was set to TOOL_NONE.

This PR fixes that by setting `ToolHandler::mouseRightButtonTool` (and peers) to nullptr when no tool is tied to the button.

I hope I got this right this time...

Note: To anyone testing this PR, please make sure you compile it with `-DCMAKE_BUILD_TYPE=Debug` to enable the asserts.