### PR TITLE
Use PDF's CropBox instead of MediaBox for QPDF overlays in export

### DIFF
--- a/src/core/pdf/base/QPdfExport.cpp
+++ b/src/core/pdf/base/QPdfExport.cpp
@@ -121,7 +121,7 @@ bool QPdfExport::overlayAndSave(const fs::path& saveDestination, std::stringstre
                     // Generate content to place the form XObject centered within destination page's trim box.
                     QPDFMatrix m;
                     std::string content =
-                            page.placeFormXObject(localXObj, name, page.getMediaBox().getArrayAsRectangle(), m);
+                            page.placeFormXObject(localXObj, name, page.getCropBox().getArrayAsRectangle(), m);
                     if (!content.empty()) {
                         // Append the content to the page's content. Surround the original content with q...Q to
                         // the new content from the page's original content.


### PR DESCRIPTION
Fix #7699
The PDF page's CropBox is supposed to be "what is displayed on screen", so I'm assuming that is what Poppler does. I could not find any documentation on this though.
