### PR TITLE
Add Lua API app.addTexImages

### DIFF
--- a/plugins/luapi_application.def.lua
+++ b/plugins/luapi_application.def.lua
@@ -386,10 +386,10 @@ function app.addStrokes(opts) end
 --- }
 function app.addTexts(opts) end
 
---- Adds rendered LaTeX elements as specified to the current layer.
+--- Asynchronously adds rendered LaTeX elements as specified to the current layer.
 --- 
 --- Global parameters:
----   - texItems table: array of latex-parameter-tables
+---   - texItems table: array of TeX-parameter-tables
 ---   - cb function: Callback function run after a TexImage has been added
 --- 
 --- @param opts {textItems:{formula:string, color:integer, x:number, y:number, width:number|nil, height:number|nil}[],
@@ -402,6 +402,10 @@ function app.addTexts(opts) end
 ---   - y number: y-position of the box (upper left corner) (required)
 ---   - width number: the width (default: auto)
 ---   - height number: the height (default: auto)
+--- 
+--- cb: callback function(ref_or_msg:userdata|string, no:int) to call when a TexImage has been added
+---     The first argument is either a reference to the TexImage or the error message/Tex generator output
+---     The second argument specifies the corresponding position in the texItems table
 --- 
 --- Example:
 --- 
@@ -423,7 +427,16 @@ function app.addTexts(opts) end
 --- 
 ---   app.addTexImages{
 ---       texItems=texItems,
----       cb=function(ref) print(ref); app.refreshPage() end
+---       cb=function(ref_or_msg, no)
+---              if type(ref_or_msg) == "userdata" then
+---                  print("Added TexImage: ", no)
+---                  print("Address: ", ref_or_msg)
+---              else
+---                  print("An error occured with item: ", no)
+---                  print("TeX generator output: ", ref_or_msg)
+---              end
+---              app.refreshPage()
+---          end
 ---   }
 function app.addTexImages(opts) end
 

--- a/plugins/luapi_application.def.lua
+++ b/plugins/luapi_application.def.lua
@@ -390,11 +390,10 @@ function app.addTexts(opts) end
 --- 
 --- Global parameters:
 ---   - texItems table: array of latex-parameter-tables
----   - cb string: Name of the callback function run after a TexImage has been added
+---   - cb function: Callback function run after a TexImage has been added
 --- 
 --- @param opts {textItems:{formula:string, color:integer, x:number, y:number, width:number|nil, height:number|nil}[],
---- cb:string}
---- }
+--- cb:function}
 --- 
 --- Parameters per texImage:
 ---   - formula string: the tex formula (required)
@@ -422,17 +421,10 @@ function app.addTexts(opts) end
 ---       },
 ---   }
 --- 
----   local refs
---- 
----   function cb(ref)
----      table.insert(refs, ref)
----      if #refs == #texItems then
----          app.refreshPage()
----      end
----   end
---- 
----   refs = {}
----   app.addTexImages{texItems=texItems, cb="cb"}
+---   app.addTexImages{
+---       texItems=texItems,
+---       cb=function(ref) print(ref); app.refreshPage() end
+---   }
 function app.addTexImages(opts) end
 
 --- Returns a list of lua table of the texts (from current selection / current layer / current page / all pages).

--- a/plugins/luapi_application.def.lua
+++ b/plugins/luapi_application.def.lua
@@ -386,6 +386,55 @@ function app.addStrokes(opts) end
 --- }
 function app.addTexts(opts) end
 
+--- Adds rendered LaTeX elements as specified to the current layer.
+--- 
+--- Global parameters:
+---   - texItems table: array of latex-parameter-tables
+---   - cb string: Name of the callback function run after a TexImage has been added
+--- 
+--- @param opts {textItems:{formula:string, color:integer, x:number, y:number, width:number|nil, height:number|nil}[],
+--- cb:string}
+--- }
+--- 
+--- Parameters per texImage:
+---   - formula string: the tex formula (required)
+---   - color integer: RGB hex code for the text-color (default: color of latex tool)
+---   - x number: x-position of the box (upper left corner) (required)
+---   - y number: y-position of the box (upper left corner) (required)
+---   - width number: the width (default: auto)
+---   - height number: the height (default: auto)
+--- 
+--- Example:
+--- 
+---   local texItems = {
+---       {
+---        formula = [[\int_a^b f(x)\ dx]],
+---        x=100,
+---        y=50,
+---        color=0x990000
+---       },
+---       {
+---        formula = [[\mathrm{e}^{i\pi} + 1 = 0]],
+---        x=100,
+---        y=100,
+---        color=0x006600,
+---        height=50,
+---       },
+---   }
+--- 
+---   local refs
+--- 
+---   function cb(ref)
+---      table.insert(refs, ref)
+---      if #refs == #texItems then
+---          app.refreshPage()
+---      end
+---   end
+--- 
+---   refs = {}
+---   app.addTexImages{texItems=texItems, cb="cb"}
+function app.addTexImages(opts) end
+
 --- Returns a list of lua table of the texts (from current selection / current layer / current page / all pages).
 --- When called with "page" to retrieve all elements on the current page, it also adds a field "layer" for the
 --- layer containing the element, and when called with "all" it additionally adds a field "page" containing its page

--- a/plugins/luapi_application.def.lua
+++ b/plugins/luapi_application.def.lua
@@ -391,9 +391,11 @@ function app.addTexts(opts) end
 --- Global parameters:
 ---   - texItems table: array of TeX-parameter-tables
 ---   - cb function: Callback function run after a TexImage has been added
+---   - allowUndoRedoAction string: Decides how the change gets introduced into the undoRedo action list "individual",
+--- "grouped" or "none"
 --- 
 --- @param opts {textItems:{formula:string, color:integer, x:number, y:number, width:number|nil, height:number|nil}[],
---- cb:function}
+--- cb:function, allowUndoRedoAction:string}
 --- 
 --- Parameters per texImage:
 ---   - formula string: the tex formula (required)

--- a/plugins/luapi_application.def.lua
+++ b/plugins/luapi_application.def.lua
@@ -394,7 +394,7 @@ function app.addTexts(opts) end
 ---   - allowUndoRedoAction string: Decides how the change gets introduced into the undoRedo action list "individual",
 --- "grouped" or "none"
 --- 
---- @param opts {textItems:{formula:string, color:integer, x:number, y:number, width:number|nil, height:number|nil}[],
+--- @param opts {texItems:{formula:string, color:integer, x:number, y:number, width:number|nil, height:number|nil}[],
 --- cb:function, allowUndoRedoAction:string}
 --- 
 --- Parameters per texImage:
@@ -405,9 +405,9 @@ function app.addTexts(opts) end
 ---   - width number: the width (default: auto)
 ---   - height number: the height (default: auto)
 --- 
---- cb: callback function(ref_or_msg:userdata|string, no:int) to call when a TexImage has been added
----     The first argument is either a reference to the TexImage or the error message/Tex generator output
----     The second argument specifies the corresponding position in the texItems table
+--- cb: callback function({userdata|string}[]) to call when all TexImages have been added
+---     The argument passed to the callback function is an array of the same size (and order)
+---     as texItems, consisting of references to the TexImages and error messages/Tex generator outputs
 --- 
 --- Example:
 --- 
@@ -429,13 +429,15 @@ function app.addTexts(opts) end
 --- 
 ---   app.addTexImages{
 ---       texItems=texItems,
----       cb=function(ref_or_msg, no)
----              if type(ref_or_msg) == "userdata" then
----                  print("Added TexImage: ", no)
----                  print("Address: ", ref_or_msg)
----              else
----                  print("An error occured with item: ", no)
----                  print("TeX generator output: ", ref_or_msg)
+---       cb=function(tbl)
+---              for no, ref_or_msg in ipairs(tbl) do
+---                  if type(ref_or_msg) == "userdata" then
+---                      print("Added TexImage: ", no)
+---                      print("Address: ", ref_or_msg)
+---                  else
+---                      print("An error occured with item: ", no)
+---                      print("TeX generator output: ", ref_or_msg)
+---                  end
 ---              end
 ---              app.refreshPage()
 ---          end

--- a/src/core/control/LatexController.cpp
+++ b/src/core/control/LatexController.cpp
@@ -206,6 +206,8 @@ void LatexController::onPdfRenderComplete(GObject* procObj, GAsyncResult* res, L
     if (self->callback) {  // tex formula from plugin
         if (self->isValidTex) {
             self->callback(self->loadRendered(self->initialTex));
+        } else {
+            self->callback(self->texProcessOutput);
         }
         g_clear_object(&proc);
         return;
@@ -382,7 +384,7 @@ void LatexController::insertLatex(PageRef page, Control* ctrl, double x, double 
 static int jobNo = 0;
 
 void LatexController::renderTexImage(Control* ctrl, std::string latex, Color color,
-                                     const std::function<void(std::unique_ptr<TexImage>)>& callback, std::string* errorMessage) {
+                                     const std::function<void(CallbackArg)>& callback, std::string* errorMessage) {
     auto self = std::make_unique<LatexController>(ctrl, jobNo++);
     self->callback = callback;
     self->initialTex = latex;

--- a/src/core/control/LatexController.cpp
+++ b/src/core/control/LatexController.cpp
@@ -154,10 +154,8 @@ void LatexController::onPdfRenderComplete(GObject* procObj, GAsyncResult* res, L
     bool procExited = false;
     GSubprocess* proc = G_SUBPROCESS(procObj);
 
-    std::unique_ptr<LatexController> guard(self);
-    if (!self->callback) {
-        guard.release();  // don't delete the LatexController on exit
-    }
+    // When called from a plugin, this function owns *self and will destroy it upon return
+    std::unique_ptr<LatexController> guard(self->callback ? self : nullptr);
 
     // Extract the process' output and store it.
     {
@@ -408,11 +406,6 @@ void LatexController::renderTexImage(Control* ctrl, std::string latex, Color col
 
     auto* proc = std::get<GSubprocess*>(result);
 
-    // Render the TeX and capture the process' output.
-    char* stdinBuff = nullptr;  // No stdin
-
-    LatexController* self_ptr = self.release();
-
-    g_subprocess_communicate_utf8_async(proc, stdinBuff, nullptr,
-                                        reinterpret_cast<GAsyncReadyCallback>(onPdfRenderComplete), self_ptr);
+    // Render the TeX and capture the process' output. The callback takes ownship of *self
+    g_subprocess_communicate_utf8_async(proc, nullptr, nullptr, xoj::util::wrap_v<onPdfRenderComplete>, self.release());
 }

--- a/src/core/control/LatexController.cpp
+++ b/src/core/control/LatexController.cpp
@@ -52,13 +52,11 @@ using std::string;
 constexpr Color LIGHT_PREVIEW_BACKGROUND = Colors::white;
 constexpr Color DARK_PREVIEW_BACKGROUND = Colors::black;
 
-LatexController::LatexController(Control* control):
+LatexController::LatexController(Control* control, int jobNo):
         control(control),
         settings(control->getSettings()->latexSettings),
-        texTmpDir(Util::getTmpDirSubfolder("tex")),
-        generator(settings) {
-    Util::ensureFolderExists(this->texTmpDir);
-}
+        texTmpDir(Util::getTmpDirSubfolder("tex", jobNo)),
+        generator(settings) {}
 
 LatexController::~LatexController() {
     if (updating_cancellable) {
@@ -156,6 +154,11 @@ void LatexController::onPdfRenderComplete(GObject* procObj, GAsyncResult* res, L
     bool procExited = false;
     GSubprocess* proc = G_SUBPROCESS(procObj);
 
+    std::unique_ptr<LatexController> guard(self);
+    if (!self->callback) {
+        guard.release();  // don't delete the LatexController on exit
+    }
+
     // Extract the process' output and store it.
     {
         char* procStdout_ptr = nullptr;
@@ -198,6 +201,14 @@ void LatexController::onPdfRenderComplete(GObject* procObj, GAsyncResult* res, L
     if (!self->isValidTex) {
         fs::path pdfPath = self->texTmpDir / "tex.pdf";
         fs::remove(pdfPath);
+    }
+
+    if (self->callback) {  // tex formula from plugin
+        if (self->isValidTex) {
+            self->callback(self->loadRendered(self->initialTex));
+        }
+        g_clear_object(&proc);
+        return;
     }
 
     const string currentTex = self->dlg->getBufferContents();
@@ -366,4 +377,40 @@ void LatexController::insertLatex(PageRef page, Control* ctrl, double x, double 
     lock.unlock();
 
     showTexEditDialog(std::move(self));
+}
+
+static int jobNo = 0;
+
+void LatexController::renderTexImage(Control* ctrl, std::string latex, Color color,
+                                     const std::function<void(std::unique_ptr<TexImage>)>& callback, std::string* errorMessage) {
+    auto self = std::make_unique<LatexController>(ctrl, jobNo++);
+    self->callback = callback;
+    self->initialTex = latex;
+
+    auto depStatus = self->findTexDependencies();
+    if (!depStatus.success) {
+        if (errorMessage) {
+            *errorMessage = depStatus.errorMsg;
+        }
+        return;
+    }
+
+    const std::string texContents = LatexGenerator::templateSub(latex, self->latexTemplate, color);
+    auto result = self->generator.asyncRun(self->texTmpDir, texContents);
+    if (auto* err = std::get_if<LatexGenerator::GenError>(&result)) {
+        if (errorMessage) {
+            *errorMessage = err->message;
+        }
+        return;
+    }
+
+    auto* proc = std::get<GSubprocess*>(result);
+
+    // Render the TeX and capture the process' output.
+    char* stdinBuff = nullptr;  // No stdin
+
+    LatexController* self_ptr = self.release();
+
+    g_subprocess_communicate_utf8_async(proc, stdinBuff, nullptr,
+                                        reinterpret_cast<GAsyncReadyCallback>(onPdfRenderComplete), self_ptr);
 }

--- a/src/core/control/LatexController.h
+++ b/src/core/control/LatexController.h
@@ -41,7 +41,7 @@ public:
     LatexController() = delete;
     LatexController(const LatexController& other) = delete;
     LatexController& operator=(const LatexController& other) = delete;
-    LatexController(Control* control);
+    LatexController(Control* control, int jobNo = 0);
     ~LatexController();
 
 public:
@@ -52,6 +52,13 @@ public:
      * An existing text or latex element at the given position is replaced.
      */
     static void insertLatex(PageRef page, Control* ctrl, double x, double y);
+
+    /**
+     * Render a TeX formula to a TexImage without opening the editor dialog.
+     * Returns nullptr on failure and optionally writes a human-readable error.
+     */
+    static void renderTexImage(Control* ctrl, std::string latex, Color color,
+                               const std::function<void(std::unique_ptr<TexImage>)>& callback, std::string* errorMessage = nullptr);
 
 private:
     /**
@@ -94,6 +101,7 @@ private:
      * will be called again.
      */
     static void onPdfRenderComplete(GObject* procObj, GAsyncResult* res, LatexController* self);
+    static void onPluginRenderComplete(GObject* procObj, GAsyncResult* res, LatexController* self);
 
     void updateStatus();
     bool isUpdating();
@@ -194,4 +202,5 @@ private:
     std::unique_ptr<TexImage> temporaryRender;
 
     LatexGenerator generator;
+    std::function<void(std::unique_ptr<TexImage>)> callback;
 };

--- a/src/core/control/LatexController.h
+++ b/src/core/control/LatexController.h
@@ -36,6 +36,8 @@ class Element;
 class LatexSettings;
 class IntEdLatexDialog;
 
+using CallbackArg = std::variant<std::unique_ptr<TexImage>, std::string>;
+
 class LatexController final {
 public:
     LatexController() = delete;
@@ -58,7 +60,7 @@ public:
      * Returns nullptr on failure and optionally writes a human-readable error.
      */
     static void renderTexImage(Control* ctrl, std::string latex, Color color,
-                               const std::function<void(std::unique_ptr<TexImage>)>& callback, std::string* errorMessage = nullptr);
+                               const std::function<void(CallbackArg)>& callback, std::string* errorMessage = nullptr);
 
 private:
     /**
@@ -202,5 +204,6 @@ private:
     std::unique_ptr<TexImage> temporaryRender;
 
     LatexGenerator generator;
-    std::function<void(std::unique_ptr<TexImage>)> callback;
+
+    std::function<void(CallbackArg)> callback;
 };

--- a/src/core/plugin/Plugin.cpp
+++ b/src/core/plugin/Plugin.cpp
@@ -1,6 +1,5 @@
 #include "Plugin.h"
 
-#include <algorithm>  // for max
 #include <array>      // for array
 
 #include <gdk/gdk.h>      // for GdkModifierType
@@ -9,7 +8,6 @@
 
 #include "util/Assert.h"     // for xoj_assert
 #include "util/PathUtil.h"   // for toGFilename
-#include "util/XojMsgBox.h"  // for XojMsgBox
 
 #include "config-features.h"  // for ENABLE_PLUGINS
 
@@ -333,61 +331,6 @@ void Plugin::loadScript() {
         this->valid = false;
         return;
     }
-}
-
-auto Plugin::callFunction(const std::string& fnc, ptrdiff_t mode) -> bool {
-    lua_getglobal(lua.get(), fnc.c_str());
-
-    int numArgs = 0;
-
-    if (mode != std::numeric_limits<ptrdiff_t>::max()) {
-        lua_pushinteger(lua.get(), mode);
-        numArgs = 1;
-    }
-
-    // Run the function
-    if (lua_pcall(lua.get(), numArgs, 0, 0)) {
-        const char* errMsg = lua_tostring(lua.get(), -1);
-        XojMsgBox::showPluginMessage(name, errMsg, true);
-
-        g_warning("Error in Plugin: \"%s\", error: \"%s\"", name.c_str(), errMsg);
-        return false;
-    }
-
-    return true;
-}
-
-auto Plugin::callFunction(const std::string& fnc, const char* s) -> bool {
-    lua_getglobal(lua.get(), fnc.c_str());
-
-    lua_pushstring(lua.get(), s);
-
-    // Run the function
-    if (lua_pcall(lua.get(), 1, 0, 0)) {
-        const char* errMsg = lua_tostring(lua.get(), -1);
-        XojMsgBox::showPluginMessage(name, errMsg, true);
-
-        g_warning("Error in Plugin: \"%s\", error: \"%s\"", name.c_str(), errMsg);
-        return false;
-    }
-
-    return true;
-}
-
-auto Plugin::callFunction(int callbackRef, void* ptr) -> bool {
-    lua_rawgeti(lua.get(), LUA_REGISTRYINDEX, callbackRef);  // pushes the function from the Lua registry onto the stack
-    lua_pushlightuserdata(lua.get(), ptr);
-
-    // Run the function
-    if (lua_pcall(lua.get(), 1, 0, 0)) {
-        const char* errMsg = lua_tostring(lua.get(), -1);
-        XojMsgBox::showPluginMessage(name, errMsg, true);
-
-        g_warning("Error in Plugin: \"%s\", error: \"%s\"", name.c_str(), errMsg);
-        return false;
-    }
-
-    return true;
 }
 
 void Plugin::unrefFunction(int callbackRef) { luaL_unref(lua.get(), LUA_REGISTRYINDEX, callbackRef); }

--- a/src/core/plugin/Plugin.cpp
+++ b/src/core/plugin/Plugin.cpp
@@ -374,9 +374,8 @@ auto Plugin::callFunction(const std::string& fnc, const char* s) -> bool {
     return true;
 }
 
-auto Plugin::callFunction(const std::string& fnc, void* ptr) -> bool {
-    lua_getglobal(lua.get(), fnc.c_str());
-
+auto Plugin::callFunction(int callbackRef, void* ptr) -> bool {
+    lua_rawgeti(lua.get(), LUA_REGISTRYINDEX, callbackRef);  // pushes the function from the Lua registry onto the stack
     lua_pushlightuserdata(lua.get(), ptr);
 
     // Run the function
@@ -391,6 +390,7 @@ auto Plugin::callFunction(const std::string& fnc, void* ptr) -> bool {
     return true;
 }
 
+void Plugin::unrefFunction(int callbackRef) { luaL_unref(lua.get(), LUA_REGISTRYINDEX, callbackRef); }
 
 auto Plugin::getName() const -> std::string const& { return name; }
 auto Plugin::getDescription() const -> std::string const& { return description; }

--- a/src/core/plugin/Plugin.cpp
+++ b/src/core/plugin/Plugin.cpp
@@ -374,6 +374,24 @@ auto Plugin::callFunction(const std::string& fnc, const char* s) -> bool {
     return true;
 }
 
+auto Plugin::callFunction(const std::string& fnc, void* ptr) -> bool {
+    lua_getglobal(lua.get(), fnc.c_str());
+
+    lua_pushlightuserdata(lua.get(), ptr);
+
+    // Run the function
+    if (lua_pcall(lua.get(), 1, 0, 0)) {
+        const char* errMsg = lua_tostring(lua.get(), -1);
+        XojMsgBox::showPluginMessage(name, errMsg, true);
+
+        g_warning("Error in Plugin: \"%s\", error: \"%s\"", name.c_str(), errMsg);
+        return false;
+    }
+
+    return true;
+}
+
+
 auto Plugin::getName() const -> std::string const& { return name; }
 auto Plugin::getDescription() const -> std::string const& { return description; }
 auto Plugin::getAuthor() const -> std::string const& { return author; }

--- a/src/core/plugin/Plugin.h
+++ b/src/core/plugin/Plugin.h
@@ -11,10 +11,13 @@
 
 #pragma once
 
-#include <cstddef>  // for size_t
-#include <limits>   // for numeric_limits
-#include <memory>   // for unique_ptr
+#include <algorithm>  // for max
+#include <cstddef>    // for size_t
+#include <limits>     // for numeric_limits
+#include <memory>     // for unique_ptr
+#include <type_traits>
 #include <unordered_map>
+#include <utility>
 
 #include "config-features.h"  // for ENABLE_PLUGINS
 
@@ -26,6 +29,7 @@
 
 #include <gtk/gtk.h>  // for GtkWidget, GtkWindow
 
+#include "util/XojMsgBox.h"  // for XojMsgBox
 #include "util/raii/GObjectSPtr.h"
 
 #include "filesystem.h"  // for path
@@ -101,6 +105,10 @@ struct LuaDeleter {
     void operator()(lua_State* ptr) const { lua_close(ptr); }
 };
 
+namespace detail {
+template <typename T>
+constexpr bool always_false = false;
+}
 class Plugin final {
 public:
     Plugin(Control* control, std::string name, fs::path path);
@@ -191,14 +199,68 @@ private:
     /// Add the plugin folder to the lua path
     void addPluginToLuaPath();
 
+    /// Helpers for calling Lua functions
+
+    template <typename F>
+    void pushFunction(F&& function) {
+        using CleanF = std::decay_t<F>;
+        // push the function onto the stack
+        if constexpr (std::is_convertible_v<CleanF, std::string_view>) {  // global function given by its name
+            std::string_view functionName(function);
+            lua_getglobal(lua.get(), functionName.data());
+        } else if constexpr (std::is_same_v<CleanF, int>) {  // function given through its ref on the Lua registry
+            int callbackRef = static_cast<int>(function);
+            lua_rawgeti(lua.get(), LUA_REGISTRYINDEX, callbackRef);
+        } else {
+            static_assert(detail::always_false<F>, "Unhandled case for specifying function");
+        }
+    }
+
+    template <typename A>
+    void pushArgument(A&& arg) {
+        using CleanA = std::decay_t<A>;
+        // push the argument onto the stack
+        if constexpr (std::is_convertible_v<CleanA, std::string_view>) {  // string arg
+            std::string_view str(arg);
+            lua_pushstring(lua.get(), str.data());
+        } else if constexpr (std::is_pointer_v<CleanA>) {  // pointer arg
+            void* ptr = const_cast<void*>(static_cast<const void*>(arg));
+            lua_pushlightuserdata(lua.get(), ptr);
+        } else if constexpr (std::is_same_v<CleanA, bool>) {  // boolean arg
+            bool b = static_cast<bool>(arg);
+            lua_pushboolean(lua.get(), b);
+        } else if constexpr (std::is_integral_v<CleanA>) {  // integral arg except of bool
+            ptrdiff_t n = static_cast<ptrdiff_t>(arg);
+            lua_pushinteger(lua.get(), n);
+        } else {
+            static_assert(detail::always_false<A>, "Unhandled case for specifying argument");
+        }
+    }
+
 public:
     /// Get Plugin from lua engine
     static auto getPluginFromLua(lua_State* lua) -> Plugin*;
 
-    /// Execute lua function
-    auto callFunction(const std::string& fnc, ptrdiff_t mode = std::numeric_limits<ptrdiff_t>::max()) -> bool;
-    auto callFunction(const std::string& fnc, const char* s) -> bool;
-    auto callFunction(int callbackRef, void* ptr) -> bool;
+    /// Call a Lua function either given through the name of a global function or through its ref on the Lua registry
+    template <typename F, typename... Args>
+    bool callFunction(F&& function, Args&&... args) {
+        // Push function and arguments
+        pushFunction(std::forward<F>(function));
+        (pushArgument(std::forward<Args>(args)), ...);
+
+        // Run the function
+        constexpr int argCount = sizeof...(Args);
+        if (lua_pcall(lua.get(), argCount, 0, 0) != LUA_OK) {  // extra arguments are discarded
+            const char* errMsg = lua_tostring(lua.get(), -1);
+            XojMsgBox::showPluginMessage(name, errMsg, true);
+
+            g_warning("Error in Plugin: \"%s\", error: \"%s\"", name.c_str(), errMsg);
+            return false;
+        }
+
+        return true;
+    }
+
     void unrefFunction(int callbackRef);
 
 private:

--- a/src/core/plugin/Plugin.h
+++ b/src/core/plugin/Plugin.h
@@ -198,7 +198,8 @@ public:
     /// Execute lua function
     auto callFunction(const std::string& fnc, ptrdiff_t mode = std::numeric_limits<ptrdiff_t>::max()) -> bool;
     auto callFunction(const std::string& fnc, const char* s) -> bool;
-    auto callFunction(const std::string& fnc, void* ptr) -> bool;
+    auto callFunction(int callbackRef, void* ptr) -> bool;
+    void unrefFunction(int callbackRef);
 
 private:
     Control* control;                                      ///< The main controller

--- a/src/core/plugin/Plugin.h
+++ b/src/core/plugin/Plugin.h
@@ -198,6 +198,7 @@ public:
     /// Execute lua function
     auto callFunction(const std::string& fnc, ptrdiff_t mode = std::numeric_limits<ptrdiff_t>::max()) -> bool;
     auto callFunction(const std::string& fnc, const char* s) -> bool;
+    auto callFunction(const std::string& fnc, void* ptr) -> bool;
 
 private:
     Control* control;                                      ///< The main controller

--- a/src/core/plugin/Plugin.h
+++ b/src/core/plugin/Plugin.h
@@ -15,9 +15,11 @@
 #include <cstddef>    // for size_t
 #include <limits>     // for numeric_limits
 #include <memory>     // for unique_ptr
+#include <ranges>
 #include <type_traits>
 #include <unordered_map>
 #include <utility>
+#include <variant>
 
 #include "config-features.h"  // for ENABLE_PLUGINS
 
@@ -108,7 +110,17 @@ struct LuaDeleter {
 namespace detail {
 template <typename T>
 constexpr bool always_false = false;
-}
+
+// Trait to detect if a type is a std::variant
+template <typename T>
+struct is_variant: std::false_type {};
+template <typename... Ts>
+struct is_variant<std::variant<Ts...>>: std::true_type {};
+
+template <typename T>
+inline constexpr bool is_variant_v = is_variant<T>::value;
+}  // namespace detail
+
 class Plugin final {
 public:
     Plugin(Control* control, std::string name, fs::path path);
@@ -232,6 +244,16 @@ private:
         } else if constexpr (std::is_integral_v<CleanA>) {  // integral arg except of bool
             ptrdiff_t n = static_cast<ptrdiff_t>(arg);
             lua_pushinteger(lua.get(), n);
+        } else if constexpr (std::ranges::forward_range<CleanA>) {  // list, vector, ...
+            lua_newtable(lua.get());
+            int i = 1;
+            for (auto const& item: arg) {
+                lua_pushinteger(lua.get(), i++);  // key
+                pushArgument(item);               // value
+                lua_settable(lua.get(), -3);      // insert
+            }
+        } else if constexpr (detail::is_variant_v<CleanA>) {
+            std::visit([this](auto&& a) { pushArgument(a); }, arg);
         } else {
             static_assert(detail::always_false<A>, "Unhandled case for specifying argument");
         }

--- a/src/core/plugin/luapi_application.h
+++ b/src/core/plugin/luapi_application.h
@@ -1641,11 +1641,10 @@ static int applib_addTexts(lua_State* L) {
  *
  * Global parameters:
  *   - texItems table: array of latex-parameter-tables
- *   - cb string: Name of the callback function run after a TexImage has been added
+ *   - cb function: Callback function run after a TexImage has been added
  *
  * @param opts {textItems:{formula:string, color:integer, x:number, y:number, width:number|nil, height:number|nil}[],
-cb:string}
-}
+ * cb:function}
  *
  * Parameters per texImage:
  *   - formula string: the tex formula (required)
@@ -1673,17 +1672,10 @@ cb:string}
  *       },
  *   }
  *
- *   local refs
- *
- *   function cb(ref)
- *      table.insert(refs, ref)
- *      if #refs == #texItems then
- *          app.refreshPage()
- *      end
- *   end
- *
- *   refs = {}
- *   app.addTexImages{texItems=texItems, cb="cb"}
+ *   app.addTexImages{
+ *       texItems=texItems,
+ *       cb=function(ref) print(ref); app.refreshPage() end
+ *   }
  */
 static int applib_addTexImages(lua_State* L) {
     Plugin* plugin = Plugin::getPluginFromLua(L);
@@ -1702,8 +1694,8 @@ static int applib_addTexImages(lua_State* L) {
     luaL_checktype(L, 1, LUA_TTABLE);
 
     lua_getfield(L, 1, "cb");
-    const char* cb = lua_tostring(L, -1);
-    lua_pop(L, 1);  // pop the value of "cb"
+    int callbackRef =
+            luaL_ref(L, LUA_REGISTRYINDEX);  // stores the function in the Lua registry and pops it from the stack
 
     lua_getfield(L, 1, "texItems");
     if (!lua_istable(L, -1)) {
@@ -1779,7 +1771,7 @@ static int applib_addTexImages(lua_State* L) {
 
         LatexController::renderTexImage(
                 control, formula, col,
-                [control, layer, texItems, index, numItems, plugin, cb = std::string(cb), x, y,
+                [control, layer, texItems, index, numItems, plugin, callbackRef, x, y,
                 width, height](std::unique_ptr<TexImage> texImage) {
                     if (!texImage) {  // handle error properly (TODO)
                         g_message("TexItem could not be added");
@@ -1804,7 +1796,11 @@ static int applib_addTexImages(lua_State* L) {
                     texItems->push_back(texImagePtr);
                     layer->addElement(std::move(texImage));
 
-                    plugin->callFunction(cb, const_cast<void*>(static_cast<const void*>(texImagePtr)));
+                    plugin->callFunction(callbackRef, const_cast<void*>(static_cast<const void*>(texImagePtr)));
+
+                    if (texItems->size() == numItems) {
+                        plugin->unrefFunction(callbackRef);
+                    }
 
                     PageRef const& page = control->getCurrentPage();
                     Layer* layer = page->getSelectedLayer();

--- a/src/core/plugin/luapi_application.h
+++ b/src/core/plugin/luapi_application.h
@@ -1796,7 +1796,7 @@ static int applib_addTexImages(lua_State* L) {
                     texItems->push_back(texImagePtr);
                     layer->addElement(std::move(texImage));
 
-                    plugin->callFunction(callbackRef, const_cast<void*>(static_cast<const void*>(texImagePtr)));
+                    plugin->callFunction(callbackRef, texImagePtr);
 
                     if (texItems->size() == numItems) {
                         plugin->unrefFunction(callbackRef);

--- a/src/core/plugin/luapi_application.h
+++ b/src/core/plugin/luapi_application.h
@@ -1710,6 +1710,9 @@ static int applib_addTexImages(lua_State* L) {
     luaL_checktype(L, 1, LUA_TTABLE);
 
     lua_getfield(L, 1, "cb");
+    if (!lua_isfunction(L, -1)) {
+        return luaL_error(L, "Missing callback function!/'cb' must be a function!");
+    }
     int callbackRef =
             luaL_ref(L, LUA_REGISTRYINDEX);  // stores the function in the Lua registry and pops it from the stack
 
@@ -1827,7 +1830,10 @@ static int applib_addTexImages(lua_State* L) {
                     }
                     auto* texImagePtr = texImage.get();
                     texItems->push_back(texImagePtr);
-                    layer->addElement(std::move(texImage));
+                    {
+                        std::lock_guard lock(*control->getDocument());
+                        layer->addElement(std::move(texImage));
+                    }
                     if (allowUndoRedoAction == "individual") {
                         undo->addUndoAction(std::make_unique<InsertUndoAction>(page, layer, texImagePtr));
                     } else if (allowUndoRedoAction == "grouped" && index == numItems) {

--- a/src/core/plugin/luapi_application.h
+++ b/src/core/plugin/luapi_application.h
@@ -1637,10 +1637,10 @@ static int applib_addTexts(lua_State* L) {
 }
 
 /**
- * Adds rendered LaTeX elements as specified to the current layer.
+ * Asynchronously adds rendered LaTeX elements as specified to the current layer.
  *
  * Global parameters:
- *   - texItems table: array of latex-parameter-tables
+ *   - texItems table: array of TeX-parameter-tables
  *   - cb function: Callback function run after a TexImage has been added
  *
  * @param opts {textItems:{formula:string, color:integer, x:number, y:number, width:number|nil, height:number|nil}[],
@@ -1653,6 +1653,10 @@ static int applib_addTexts(lua_State* L) {
  *   - y number: y-position of the box (upper left corner) (required)
  *   - width number: the width (default: auto)
  *   - height number: the height (default: auto)
+ *
+ * cb: callback function(ref_or_msg:userdata|string, no:int) to call when a TexImage has been added
+ *     The first argument is either a reference to the TexImage or the error message/Tex generator output
+ *     The second argument specifies the corresponding position in the texItems table
  *
  * Example:
  *
@@ -1674,7 +1678,16 @@ static int applib_addTexts(lua_State* L) {
  *
  *   app.addTexImages{
  *       texItems=texItems,
- *       cb=function(ref) print(ref); app.refreshPage() end
+ *       cb=function(ref_or_msg, no)
+ *              if type(ref_or_msg) == "userdata" then
+ *                  print("Added TexImage: ", no)
+ *                  print("Address: ", ref_or_msg)
+ *              else
+ *                  print("An error occured with item: ", no)
+ *                  print("TeX generator output: ", ref_or_msg)
+ *              end
+ *              app.refreshPage()
+ *          end
  *   }
  */
 static int applib_addTexImages(lua_State* L) {
@@ -1771,12 +1784,16 @@ static int applib_addTexImages(lua_State* L) {
 
         LatexController::renderTexImage(
                 control, formula, col,
-                [control, layer, texItems, index, numItems, plugin, callbackRef, x, y,
-                width, height](std::unique_ptr<TexImage> texImage) {
-                    if (!texImage) {  // handle error properly (TODO)
-                        g_message("TexItem could not be added");
+                [control, layer, texItems, index, numItems, plugin, callbackRef, x, y, width, height](CallbackArg arg) {
+                    if (std::holds_alternative<std::string>(arg)) {
+                        std::string msg = std::get<std::string>(arg);
+                        if (msg.empty()) {
+                            msg = "TexItem could not be added";
+                        }
+                        plugin->callFunction(callbackRef, msg, index);
                         return;
                     }
+                    auto texImage = std::get<std::unique_ptr<TexImage>>(std::move(arg));
                     texImage->setOrigin(x, y);
 
                     const auto& box = texImage->getBoundingBox();
@@ -1796,7 +1813,7 @@ static int applib_addTexImages(lua_State* L) {
                     texItems->push_back(texImagePtr);
                     layer->addElement(std::move(texImage));
 
-                    plugin->callFunction(callbackRef, texImagePtr);
+                    plugin->callFunction(callbackRef, texImagePtr, index);
 
                     if (texItems->size() == numItems) {
                         plugin->unrefFunction(callbackRef);
@@ -1809,6 +1826,9 @@ static int applib_addTexImages(lua_State* L) {
                 },
                 &errorMessage);
 
+        if (!errorMessage.empty()) {
+            return luaL_error(L, "%s", errorMessage.c_str());
+        }
         lua_pop(L, 7);  // pop values read out from the texItems table + texItems-table itself
     }
 

--- a/src/core/plugin/luapi_application.h
+++ b/src/core/plugin/luapi_application.h
@@ -1642,9 +1642,11 @@ static int applib_addTexts(lua_State* L) {
  * Global parameters:
  *   - texItems table: array of TeX-parameter-tables
  *   - cb function: Callback function run after a TexImage has been added
- *
+ *   - allowUndoRedoAction string: Decides how the change gets introduced into the undoRedo action list "individual",
+ * "grouped" or "none"
+
  * @param opts {textItems:{formula:string, color:integer, x:number, y:number, width:number|nil, height:number|nil}[],
- * cb:function}
+ * cb:function, allowUndoRedoAction:string}
  *
  * Parameters per texImage:
  *   - formula string: the tex formula (required)
@@ -1695,6 +1697,7 @@ static int applib_addTexImages(lua_State* L) {
     Control* control = plugin->getControl();
     PageRef const& page = control->getCurrentPage();
     Layer* layer = page->getSelectedLayer();
+    UndoRedoHandler* undo = control->getUndoRedoHandler();
 
     // get default color
     ToolHandler* toolHandler = control->getToolHandler();
@@ -1709,6 +1712,15 @@ static int applib_addTexImages(lua_State* L) {
     lua_getfield(L, 1, "cb");
     int callbackRef =
             luaL_ref(L, LUA_REGISTRYINDEX);  // stores the function in the Lua registry and pops it from the stack
+
+    // Check how the user wants to handle undoing
+    lua_getfield(L, 1, "allowUndoRedoAction");
+    std::string allowUndoRedoAction = luaL_optstring(L, -1, "grouped");
+    if (allowUndoRedoAction != "grouped" && allowUndoRedoAction != "individual" && allowUndoRedoAction != "none") {
+        return luaL_error(L, "Unrecognized undo/redo option: %s", allowUndoRedoAction.c_str());
+    }
+    lua_pop(L, 1);
+
 
     lua_getfield(L, 1, "texItems");
     if (!lua_istable(L, -1)) {
@@ -1784,11 +1796,15 @@ static int applib_addTexImages(lua_State* L) {
 
         LatexController::renderTexImage(
                 control, formula, col,
-                [control, layer, texItems, index, numItems, plugin, callbackRef, x, y, width, height](CallbackArg arg) {
+                [control, page, layer, undo, texItems, index, numItems, plugin, callbackRef, x, y, allowUndoRedoAction,
+                 width, height](CallbackArg arg) {
                     if (std::holds_alternative<std::string>(arg)) {
                         std::string msg = std::get<std::string>(arg);
                         if (msg.empty()) {
                             msg = "TexItem could not be added";
+                        }
+                        if (allowUndoRedoAction == "grouped" && index == numItems) {
+                            undo->addUndoAction(std::make_unique<InsertsUndoAction>(page, layer, *texItems.get()));
                         }
                         plugin->callFunction(callbackRef, msg, index);
                         return;
@@ -1812,17 +1828,17 @@ static int applib_addTexImages(lua_State* L) {
                     auto* texImagePtr = texImage.get();
                     texItems->push_back(texImagePtr);
                     layer->addElement(std::move(texImage));
+                    if (allowUndoRedoAction == "individual") {
+                        undo->addUndoAction(std::make_unique<InsertUndoAction>(page, layer, texImagePtr));
+                    } else if (allowUndoRedoAction == "grouped" && index == numItems) {
+                        undo->addUndoAction(std::make_unique<InsertsUndoAction>(page, layer, *texItems.get()));
+                    }
 
                     plugin->callFunction(callbackRef, texImagePtr, index);
 
                     if (texItems->size() == numItems) {
                         plugin->unrefFunction(callbackRef);
                     }
-
-                    PageRef const& page = control->getCurrentPage();
-                    Layer* layer = page->getSelectedLayer();
-                    UndoRedoHandler* undo = control->getUndoRedoHandler();
-                    undo->addUndoAction(std::make_unique<InsertUndoAction>(page, layer, texImagePtr));
                 },
                 &errorMessage);
 

--- a/src/core/plugin/luapi_application.h
+++ b/src/core/plugin/luapi_application.h
@@ -24,6 +24,7 @@
 
 #include "control/Control.h"
 #include "control/ExportHelper.h"
+#include "control/LatexController.h"
 #include "control/PageBackgroundChangeController.h"
 #include "control/ScrollHandler.h"
 #include "control/Tool.h"
@@ -54,6 +55,7 @@
 #include "model/SplineSegment.h"
 #include "model/Stroke.h"
 #include "model/StrokeStyle.h"
+#include "model/TexImage.h"
 #include "model/Text.h"
 #include "model/XojPage.h"  // IWYU pragma: keep for XojPage
 #include "plugin/Plugin.h"
@@ -1632,6 +1634,189 @@ static int applib_addTexts(lua_State* L) {
 
     refsHelper(L, texts);
     return 1;
+}
+
+/**
+ * Adds rendered LaTeX elements as specified to the current layer.
+ *
+ * Global parameters:
+ *   - texItems table: array of latex-parameter-tables
+ *   - cb string: Name of the callback function run after a TexImage has been added
+ *
+ * @param opts {textItems:{formula:string, color:integer, x:number, y:number, width:number|nil, height:number|nil}[],
+cb:string}
+}
+ *
+ * Parameters per texImage:
+ *   - formula string: the tex formula (required)
+ *   - color integer: RGB hex code for the text-color (default: color of latex tool)
+ *   - x number: x-position of the box (upper left corner) (required)
+ *   - y number: y-position of the box (upper left corner) (required)
+ *   - width number: the width (default: auto)
+ *   - height number: the height (default: auto)
+ *
+ * Example:
+ *
+ *   local texItems = {
+ *       {
+ *        formula = [[\int_a^b f(x)\ dx]],
+ *        x=100,
+ *        y=50,
+ *        color=0x990000
+ *       },
+ *       {
+ *        formula = [[\mathrm{e}^{i\pi} + 1 = 0]],
+ *        x=100,
+ *        y=100,
+ *        color=0x006600,
+ *        height=50,
+ *       },
+ *   }
+ *
+ *   local refs
+ *
+ *   function cb(ref)
+ *      table.insert(refs, ref)
+ *      if #refs == #texItems then
+ *          app.refreshPage()
+ *      end
+ *   end
+ *
+ *   refs = {}
+ *   app.addTexImages{texItems=texItems, cb="cb"}
+ */
+static int applib_addTexImages(lua_State* L) {
+    Plugin* plugin = Plugin::getPluginFromLua(L);
+    Control* control = plugin->getControl();
+    PageRef const& page = control->getCurrentPage();
+    Layer* layer = page->getSelectedLayer();
+
+    // get default color
+    ToolHandler* toolHandler = control->getToolHandler();
+    Tool& tool = toolHandler->getTool(TOOL_LATEX);
+    Color default_color = tool.getColor();
+
+    auto texItems = std::make_shared<std::vector<Element const*>>();
+
+    lua_settop(L, 1);
+    luaL_checktype(L, 1, LUA_TTABLE);
+
+    lua_getfield(L, 1, "cb");
+    const char* cb = lua_tostring(L, -1);
+    lua_pop(L, 1);  // pop the value of "cb"
+
+    lua_getfield(L, 1, "texItems");
+    if (!lua_istable(L, -1)) {
+        return luaL_error(L, "Missing texItems table!");
+    }
+
+    size_t numItems = lua_rawlen(L, -1);
+    for (size_t index = 1; index <= numItems; index++) {
+        lua_pushinteger(L, as_signed(index));
+        lua_gettable(L, -2);
+        luaL_checktype(L, -1, LUA_TTABLE);
+
+        lua_getfield(L, -1, "formula");
+        lua_getfield(L, -2, "x");
+        lua_getfield(L, -3, "y");
+        lua_getfield(L, -4, "width");
+        lua_getfield(L, -5, "height");
+        lua_getfield(L, -6, "color");
+
+        // stack now has following:
+        //    1 = global params table
+        //   -8 = textItems array
+        //   -7 = current tex-params table
+        //   -6 = formula
+        //   -5 = x
+        //   -4 = y
+        //   -3 = width
+        //   -2 = height
+        //   -1 = color
+
+        if (!lua_isstring(L, -6)) {
+            return luaL_error(L, "Missing formula!/'formula' must be a string");
+        }
+        std::string formula = lua_tostring(L, -6);
+
+        if (!lua_isnumber(L, -5)) {
+            return luaL_error(L, "Missing X-Coordinate!/must be a number");
+        }
+        double x = lua_tonumber(L, -5);
+
+        if (!lua_isnumber(L, -4)) {
+            return luaL_error(L, "Missing Y-Coordinate!/must be a number");
+        }
+        double y = lua_tonumber(L, -4);
+
+        if (!lua_isnil(L, -3) && !lua_isnumber(L, -3)) {
+            return luaL_error(L, "'width' must be a number or unset");
+        }
+        double width = luaL_optnumber(L, -3, 0);
+
+        if (!lua_isnil(L, -2) && !lua_isnumber(L, -2)) {
+            return luaL_error(L, "'height' must be a number or unset");
+        }
+        double height = luaL_optnumber(L, -2, 0);
+
+        Color col;
+        if (lua_isinteger(L, -1)) {  // Check if the color was provided
+            auto color = static_cast<uint32_t>(as_unsigned(lua_tointeger(L, -1)));
+            if (color > 0xffffff) {
+                std::stringstream msg;
+                msg << "Color 0x" << std::hex << color << " is no valid RGB color.";
+                return luaL_error(L, msg.str().c_str());  // luaL_error does not support %x for hex numbers
+            }
+            col = Color(color | 0xff000000U);
+        } else if (lua_isnil(L, -3)) {
+            col = default_color;
+        } else {
+            return luaL_error(L, "'color' must be an integer/hex-code or unset");
+        }
+
+
+        std::string errorMessage;
+
+        LatexController::renderTexImage(
+                control, formula, col,
+                [control, layer, texItems, index, numItems, plugin, cb = std::string(cb), x, y,
+                width, height](std::unique_ptr<TexImage> texImage) {
+                    if (!texImage) {  // handle error properly (TODO)
+                        g_message("TexItem could not be added");
+                        return;
+                    }
+                    texImage->setOrigin(x, y);
+
+                    const auto& box = texImage->getBoundingBox();
+                    if (width != 0 && height != 0) {
+                        texImage->setWidth(width);
+                        texImage->setHeight(height);
+                    } else if (height != 0) {
+                        double ratio = box.width / box.height;
+                        texImage->setHeight(height);
+                        texImage->setWidth(box.width != 0 ? height * ratio : 10);
+                    } else if (width != 0) {
+                        const double ratio = box.height / box.width;
+                        texImage->setWidth(width);
+                        texImage->setHeight(box.height != 0 ? width * ratio : 10);
+                    }
+                    auto* texImagePtr = texImage.get();
+                    texItems->push_back(texImagePtr);
+                    layer->addElement(std::move(texImage));
+
+                    plugin->callFunction(cb, const_cast<void*>(static_cast<const void*>(texImagePtr)));
+
+                    PageRef const& page = control->getCurrentPage();
+                    Layer* layer = page->getSelectedLayer();
+                    UndoRedoHandler* undo = control->getUndoRedoHandler();
+                    undo->addUndoAction(std::make_unique<InsertUndoAction>(page, layer, texImagePtr));
+                },
+                &errorMessage);
+
+        lua_pop(L, 7);  // pop values read out from the texItems table + texItems-table itself
+    }
+
+    return 0;
 }
 
 /**
@@ -4263,6 +4448,7 @@ static const luaL_Reg applib[] = {
         {"addStrokes", applib_addStrokes},
         {"addSplines", applib_addSplines},
         {"addImages", applib_addImages},
+        {"addTexImages", applib_addTexImages},
         {"addTexts", applib_addTexts},
         {"addLinks", applib_addLinks},
         {"addToSelection", applib_addToSelection},

--- a/src/core/plugin/luapi_application.h
+++ b/src/core/plugin/luapi_application.h
@@ -16,6 +16,7 @@
 #include <memory>
 #include <sstream>
 #include <unordered_set>
+#include <variant>
 
 #include <gtk/gtk.h>
 #include <pango/pango.h>
@@ -1645,7 +1646,7 @@ static int applib_addTexts(lua_State* L) {
  *   - allowUndoRedoAction string: Decides how the change gets introduced into the undoRedo action list "individual",
  * "grouped" or "none"
 
- * @param opts {textItems:{formula:string, color:integer, x:number, y:number, width:number|nil, height:number|nil}[],
+ * @param opts {texItems:{formula:string, color:integer, x:number, y:number, width:number|nil, height:number|nil}[],
  * cb:function, allowUndoRedoAction:string}
  *
  * Parameters per texImage:
@@ -1656,9 +1657,9 @@ static int applib_addTexts(lua_State* L) {
  *   - width number: the width (default: auto)
  *   - height number: the height (default: auto)
  *
- * cb: callback function(ref_or_msg:userdata|string, no:int) to call when a TexImage has been added
- *     The first argument is either a reference to the TexImage or the error message/Tex generator output
- *     The second argument specifies the corresponding position in the texItems table
+ * cb: callback function({userdata|string}[]) to call when all TexImages have been added
+ *     The argument passed to the callback function is an array of the same size (and order)
+ *     as texItems, consisting of references to the TexImages and error messages/Tex generator outputs
  *
  * Example:
  *
@@ -1680,13 +1681,15 @@ static int applib_addTexts(lua_State* L) {
  *
  *   app.addTexImages{
  *       texItems=texItems,
- *       cb=function(ref_or_msg, no)
- *              if type(ref_or_msg) == "userdata" then
- *                  print("Added TexImage: ", no)
- *                  print("Address: ", ref_or_msg)
- *              else
- *                  print("An error occured with item: ", no)
- *                  print("TeX generator output: ", ref_or_msg)
+ *       cb=function(tbl)
+ *              for no, ref_or_msg in ipairs(tbl) do
+ *                  if type(ref_or_msg) == "userdata" then
+ *                      print("Added TexImage: ", no)
+ *                      print("Address: ", ref_or_msg)
+ *                  else
+ *                      print("An error occured with item: ", no)
+ *                      print("TeX generator output: ", ref_or_msg)
+ *                  end
  *              end
  *              app.refreshPage()
  *          end
@@ -1695,9 +1698,6 @@ static int applib_addTexts(lua_State* L) {
 static int applib_addTexImages(lua_State* L) {
     Plugin* plugin = Plugin::getPluginFromLua(L);
     Control* control = plugin->getControl();
-    PageRef const& page = control->getCurrentPage();
-    Layer* layer = page->getSelectedLayer();
-    UndoRedoHandler* undo = control->getUndoRedoHandler();
 
     // get default color
     ToolHandler* toolHandler = control->getToolHandler();
@@ -1730,7 +1730,12 @@ static int applib_addTexImages(lua_State* L) {
         return luaL_error(L, "Missing texItems table!");
     }
 
-    size_t numItems = lua_rawlen(L, -1);
+    const size_t numItems = lua_rawlen(L, -1);
+    auto args = std::make_shared<std::vector<std::variant<std::string, TexImage*>>>(numItems, nullptr);
+    auto texImagesOwn = std::make_shared<std::vector<std::unique_ptr<TexImage>>>();
+    texImagesOwn->resize(numItems);
+    auto count = std::make_shared<size_t>(0);
+
     for (size_t index = 1; index <= numItems; index++) {
         lua_pushinteger(L, as_signed(index));
         lua_gettable(L, -2);
@@ -1799,50 +1804,58 @@ static int applib_addTexImages(lua_State* L) {
 
         LatexController::renderTexImage(
                 control, formula, col,
-                [control, page, layer, undo, texItems, index, numItems, plugin, callbackRef, x, y, allowUndoRedoAction,
-                 width, height](CallbackArg arg) {
+                [control, texItems, index, numItems, plugin, callbackRef, x, y, allowUndoRedoAction, width, height,
+                 args, texImagesOwn, count](CallbackArg arg) {
                     if (std::holds_alternative<std::string>(arg)) {
                         std::string msg = std::get<std::string>(arg);
                         if (msg.empty()) {
                             msg = "TexItem could not be added";
                         }
-                        if (allowUndoRedoAction == "grouped" && index == numItems) {
-                            undo->addUndoAction(std::make_unique<InsertsUndoAction>(page, layer, *texItems.get()));
+                        args->at(index - 1) = msg;
+                    } else {
+                        auto texImage = std::get<std::unique_ptr<TexImage>>(std::move(arg));
+                        texImage->setOrigin(x, y);
+
+                        const auto& box = texImage->getBoundingBox();
+                        if (width != 0 && height != 0) {
+                            texImage->setWidth(width);
+                            texImage->setHeight(height);
+                        } else if (height != 0) {
+                            double ratio = box.width / box.height;
+                            texImage->setHeight(height);
+                            texImage->setWidth(box.width != 0 ? height * ratio : 10);
+                        } else if (width != 0) {
+                            const double ratio = box.height / box.width;
+                            texImage->setWidth(width);
+                            texImage->setHeight(box.height != 0 ? width * ratio : 10);
                         }
-                        plugin->callFunction(callbackRef, msg, index);
-                        return;
+                        auto* texImagePtr = texImage.get();
+                        texItems->push_back(texImagePtr);
+                        texImagesOwn->at(index - 1) = std::move(texImage);
+                        args->at(index - 1) = texImagePtr;
                     }
-                    auto texImage = std::get<std::unique_ptr<TexImage>>(std::move(arg));
-                    texImage->setOrigin(x, y);
+                    if (++(*count) == numItems) {
+                        PageRef const& page = control->getCurrentPage();
+                        Layer* layer = page->getSelectedLayer();
+                        UndoRedoHandler* undo = control->getUndoRedoHandler();
 
-                    const auto& box = texImage->getBoundingBox();
-                    if (width != 0 && height != 0) {
-                        texImage->setWidth(width);
-                        texImage->setHeight(height);
-                    } else if (height != 0) {
-                        double ratio = box.width / box.height;
-                        texImage->setHeight(height);
-                        texImage->setWidth(box.width != 0 ? height * ratio : 10);
-                    } else if (width != 0) {
-                        const double ratio = box.height / box.width;
-                        texImage->setWidth(width);
-                        texImage->setHeight(box.height != 0 ? width * ratio : 10);
-                    }
-                    auto* texImagePtr = texImage.get();
-                    texItems->push_back(texImagePtr);
-                    {
-                        std::lock_guard lock(*control->getDocument());
-                        layer->addElement(std::move(texImage));
-                    }
-                    if (allowUndoRedoAction == "individual") {
-                        undo->addUndoAction(std::make_unique<InsertUndoAction>(page, layer, texImagePtr));
-                    } else if (allowUndoRedoAction == "grouped" && index == numItems) {
-                        undo->addUndoAction(std::make_unique<InsertsUndoAction>(page, layer, *texItems.get()));
-                    }
-
-                    plugin->callFunction(callbackRef, texImagePtr, index);
-
-                    if (texItems->size() == numItems) {
+                        {
+                            std::lock_guard lock(*control->getDocument());
+                            for (auto& img: *texImagesOwn) {
+                                if (!img) {
+                                    continue;
+                                }
+                                layer->addElement(std::move(img));
+                            }
+                        }
+                        if (allowUndoRedoAction == "individual") {
+                            for (auto& img: *texItems) {
+                                undo->addUndoAction(std::make_unique<InsertUndoAction>(page, layer, img));
+                            }
+                        } else if (allowUndoRedoAction == "grouped") {
+                            undo->addUndoAction(std::make_unique<InsertsUndoAction>(page, layer, *texItems));
+                        }
+                        plugin->callFunction(callbackRef, *args);
                         plugin->unrefFunction(callbackRef);
                     }
                 },

--- a/src/core/plugin/luapi_application.h
+++ b/src/core/plugin/luapi_application.h
@@ -1698,6 +1698,8 @@ static int applib_addTexts(lua_State* L) {
 static int applib_addTexImages(lua_State* L) {
     Plugin* plugin = Plugin::getPluginFromLua(L);
     Control* control = plugin->getControl();
+    PageRef const& page = control->getCurrentPage();
+    Layer* layer = page->getSelectedLayer();
 
     // get default color
     ToolHandler* toolHandler = control->getToolHandler();
@@ -1805,7 +1807,7 @@ static int applib_addTexImages(lua_State* L) {
         LatexController::renderTexImage(
                 control, formula, col,
                 [control, texItems, index, numItems, plugin, callbackRef, x, y, allowUndoRedoAction, width, height,
-                 args, texImagesOwn, count](CallbackArg arg) {
+                 args, texImagesOwn, count, page, layer](CallbackArg arg) {
                     if (std::holds_alternative<std::string>(arg)) {
                         std::string msg = std::get<std::string>(arg);
                         if (msg.empty()) {
@@ -1835,10 +1837,20 @@ static int applib_addTexImages(lua_State* L) {
                         args->at(index - 1) = texImagePtr;
                     }
                     if (++(*count) == numItems) {
-                        PageRef const& page = control->getCurrentPage();
-                        Layer* layer = page->getSelectedLayer();
-                        UndoRedoHandler* undo = control->getUndoRedoHandler();
+                        auto p = control->getDocument()->indexOf(page);
+                        if (p == npos) {
+                            g_warning("Page does not exist any more. Cannot insert TeX images");
+                            plugin->unrefFunction(callbackRef);
+                            return;
+                        }
+                        auto layers = page->getLayers();
+                        if (std::find(layers.begin(), layers.end(), layer) == layers.end()) {
+                            g_warning("Layer does not exist any more. Cannot insert TeX images");
+                            plugin->unrefFunction(callbackRef);
+                            return;
+                        }
 
+                        UndoRedoHandler* undo = control->getUndoRedoHandler();
                         {
                             std::lock_guard lock(*control->getDocument());
                             for (auto& img: *texImagesOwn) {

--- a/src/util/PathUtil.cpp
+++ b/src/util/PathUtil.cpp
@@ -404,9 +404,9 @@ auto Util::getCacheFile(const fs::path& relativeFileName) -> fs::path {
     return p;
 }
 
-auto Util::getTmpDirSubfolder(const fs::path& subfolder) -> fs::path {
+auto Util::getTmpDirSubfolder(const fs::path& subfolder, int jobNo) -> fs::path {
     auto p = GFilename(g_get_tmp_dir()).toPath().value_or(fs::path());
-    p /= FS(_F("xournalpp-{1}") % Util::getPid());
+    p /= FS(_F("xournalpp-{1}-job-{2}") % Util::getPid() % jobNo);
     p /= subfolder;
     return Util::ensureFolderExists(p);
 }

--- a/src/util/include/util/PathUtil.h
+++ b/src/util/include/util/PathUtil.h
@@ -152,7 +152,7 @@ auto system_single_byte_filename(const fs::path& path) -> std::string;
 [[maybe_unused]] [[nodiscard]] fs::path getStateSubfolder(const fs::path& subfolder = "");
 [[maybe_unused]] [[nodiscard]] fs::path getConfigFile(const fs::path& relativeFileName = "");
 [[maybe_unused]] [[nodiscard]] fs::path getCacheFile(const fs::path& relativeFileName = "");
-[[maybe_unused]] [[nodiscard]] fs::path getTmpDirSubfolder(const fs::path& subfolder = "");
+[[maybe_unused]] [[nodiscard]] fs::path getTmpDirSubfolder(const fs::path& subfolder = "", int jobNo = 0);
 [[maybe_unused]] [[nodiscard]] fs::path getAutosaveFilepath();
 [[maybe_unused]] [[nodiscard]] fs::path getGettextFilepath(fs::path const& localeDir);
 [[maybe_unused]] [[nodiscard]] fs::path getDataPath();


### PR DESCRIPTION
Follow up on #7440 

Apart from addressing reviewer comments there, the TeX rendering is now happening asynchronously (and simultaneously) like it should (otherwise the whole app would be blocked during rendering, which may take seconds).

There are still some things to be addressed:
- [x] Proper error handling
- [x] Lifetime of the LatexController
- [x] options for undo/redo
- [x] replace function name string by function
- [x] order of TexImages may be different from order provided by the user

Question: The user can specify a callback function in Lua. Currently it runs every time a TexImage has been rendered. Would it be better that the callback only runs after all TexImages have been rendered?