### PR TITLE
Small clean up of model/Image.cpp

### DIFF
--- a/src/core/model/Image.cpp
+++ b/src/core/model/Image.cpp
@@ -24,11 +24,6 @@ using xoj::util::Rectangle;
 Image::Image(): Element(ELEMENT_IMAGE) {}
 
 Image::~Image() {
-    if (this->image) {
-        cairo_surface_destroy(this->image);
-        this->image = nullptr;
-    }
-
     if (this->format) {
         gdk_pixbuf_format_free(this->format);
         this->format = nullptr;
@@ -42,7 +37,7 @@ auto Image::clone() const -> ElementPtr {
     img->setColor(this->getColor());
     img->data = this->data;
 
-    img->image = cairo_surface_reference(this->image);
+    img->image = this->image;
     img->snappedBounds = this->snappedBounds;
     img->sizeCalculated = this->sizeCalculated;
 
@@ -62,10 +57,7 @@ void Image::setHeight(double height) {
 void Image::setImage(std::string_view data) { setImage(std::string(data)); }
 
 void Image::setImage(std::string&& data) {
-    if (this->image) {
-        cairo_surface_destroy(this->image);
-        this->image = nullptr;
-    }
+    this->image.reset();
     this->data = std::move(data);
 
     if (this->format) {
@@ -101,28 +93,32 @@ void Image::setImage(std::string&& data) {
     this->format = gdk_pixbuf_format_copy(this->format);
 }
 
-void Image::setImage(GdkPixbuf* img) {
-    if (this->image) {
-        cairo_surface_destroy(this->image);
-        this->image = nullptr;
-    }
-    this->imageSize = {gdk_pixbuf_get_width(img), gdk_pixbuf_get_height(img)};
-
-    this->image = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, this->imageSize.first, this->imageSize.second);
-    xoj_assert(this->image != nullptr);
+static xoj::util::CairoSurfaceSPtr bufferFromPixbuf(GdkPixbuf* img) {
+    xoj::util::CairoSurfaceSPtr res(
+            cairo_image_surface_create(CAIRO_FORMAT_ARGB32, gdk_pixbuf_get_width(img), gdk_pixbuf_get_height(img)),
+            xoj::util::adopt);
+    xoj_assert(res);
 
     // Paint the pixbuf on to the surface
-    cairo_t* cr = cairo_create(this->image);
+    // NOTE: we do this manually instead of using gdk_cairo_surface_create_from_pixbuf
+    // since this does not work in CLI mode.
+    cairo_t* cr = cairo_create(res.get());
     gdk_cairo_set_source_pixbuf(cr, img, 0, 0);
     cairo_paint(cr);
     cairo_destroy(cr);
+    return res;
+}
+
+void Image::setImage(GdkPixbuf* img) {
+    this->imageSize = xoj::util::Size<int>(gdk_pixbuf_get_width(img), gdk_pixbuf_get_height(img));
+    this->image = bufferFromPixbuf(img);
 
     const cairo_write_func_t writeFunc = [](void* bufferPtr, const unsigned char* data,
                                             unsigned int length) -> cairo_status_t {
         reinterpret_cast<decltype(Image::data)*>(bufferPtr)->append(reinterpret_cast<const char*>(data), length);
         return CAIRO_STATUS_SUCCESS;
     };
-    cairo_surface_write_to_png_stream(image, writeFunc, &data);
+    cairo_surface_write_to_png_stream(image.get(), writeFunc, &data);
 }
 
 auto Image::renderBuffer() const -> std::optional<std::string> {
@@ -173,23 +169,12 @@ auto Image::renderBuffer() const -> std::optional<std::string> {
         }
     }
 
-    GdkPixbuf* tmp = gdk_pixbuf_loader_get_pixbuf(loader.get());
+    GdkPixbuf* tmp = gdk_pixbuf_loader_get_pixbuf(loader.get());  // Owned by the GdkPixbufLoader
     xoj_assert(tmp != nullptr);
     xoj::util::GObjectSPtr<GdkPixbuf> pixbuf(gdk_pixbuf_apply_embedded_orientation(tmp), xoj::util::adopt);
 
     this->imageSize = {gdk_pixbuf_get_width(pixbuf.get()), gdk_pixbuf_get_height(pixbuf.get())};
-
-    // TODO: pass in window once this code is refactored into ImageView
-    this->image = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, this->imageSize.first, this->imageSize.second);
-    g_assert(this->image != nullptr);
-
-    // Paint the pixbuf on to the surface
-    // NOTE: we do this manually instead of using gdk_cairo_surface_create_from_pixbuf
-    // since this does not work in CLI mode.
-    cairo_t* cr = cairo_create(this->image);
-    gdk_cairo_set_source_pixbuf(cr, pixbuf.get(), 0, 0);
-    cairo_paint(cr);
-    cairo_destroy(cr);
+    this->image = bufferFromPixbuf(pixbuf.get());
     return std::nullopt;
 }
 
@@ -198,7 +183,7 @@ auto Image::getImage() const -> cairo_surface_t* {
         // An error occurred
         g_warning("%s", opt->c_str());
     }
-    return this->image;
+    return this->image.get();
 }
 
 void Image::scale(double x0, double y0, double fx, double fy, double rotation,
@@ -238,11 +223,7 @@ void Image::readSerialized(ObjectInputStream& in) {
     this->boundingBox.width = in.readDouble();
     this->boundingBox.height = in.readDouble();
 
-    if (this->image) {
-        cairo_surface_destroy(this->image);
-        this->image = nullptr;
-    }
-
+    this->image.reset();
     this->data = in.readImage();
 
     in.endObject();
@@ -260,6 +241,6 @@ const unsigned char* Image::getRawData() const { return reinterpret_cast<const u
 
 size_t Image::getRawDataLength() const { return this->data.size(); }
 
-std::pair<int, int> Image::getImageSize() const { return this->imageSize; }
+xoj::util::Size<int> Image::getImageSize() const { return this->imageSize; }
 
 GdkPixbufFormat* Image::getImageFormat() const { return this->format; }

--- a/src/core/model/Image.h
+++ b/src/core/model/Image.h
@@ -20,6 +20,9 @@
 #include <cairo.h>                  // for cairo_surface_t, cairo_status_t
 #include <gdk-pixbuf/gdk-pixbuf.h>  // for GdkPixbufFormat, GdkPixbuf
 
+#include "util/Size.h"
+#include "util/raii/CairoWrappers.h"
+
 #include "Element.h"  // for Element
 
 class ObjectInputStream;
@@ -72,12 +75,12 @@ public:
     /// Return the length of the raw data.
     size_t getRawDataLength() const;
 
-    /// Return the size of the raw image, or (-1, -1) if the image has not been rendered yet.
-    std::pair<int, int> getImageSize() const;
+    /// Return the size of the raw image, or Image::NO_SIZE if the image has not been rendered yet.
+    xoj::util::Size<int> getImageSize() const;
 
     [[maybe_unused]] GdkPixbufFormat* getImageFormat() const;
 
-    static constexpr std::pair<int, int> NOSIZE = std::make_pair(-1, -1);
+    static constexpr auto NOSIZE = xoj::util::Size<int>{-1, -1};
 
 public:
     // Serialize interface
@@ -89,11 +92,11 @@ private:
 
 private:
     /// Temporary surface used as a render buffer.
-    mutable cairo_surface_t* image = nullptr;
+    mutable xoj::util::raii::CairoSurfaceSPtr image;
 
     /// Image format information.
     mutable GdkPixbufFormat* format = nullptr;
-    mutable std::pair<int, int> imageSize = {-1, -1};
+    mutable xoj::util::Size<int> imageSize = NOSIZE;
 
     std::string data;
 };

--- a/src/core/plugin/luapi_application.h
+++ b/src/core/plugin/luapi_application.h
@@ -3764,12 +3764,12 @@ static int applib_getImages(lua_State* L) {
         lua_pushstring(L, gdk_pixbuf_format_get_name(im->getImageFormat()));
         lua_setfield(L, -2, "format");
 
-        std::pair<int, int> imageSize = im->getImageSize();
+        auto imageSize = im->getImageSize();
         // image width: integer
-        lua_pushinteger(L, imageSize.first);
+        lua_pushinteger(L, imageSize.width);
         lua_setfield(L, -2, "imageWidth");
         // image height: integer
-        lua_pushinteger(L, imageSize.second);
+        lua_pushinteger(L, imageSize.height);
         lua_setfield(L, -2, "imageHeight");
 
         lua_pushlightuserdata(L, const_cast<void*>(static_cast<const void*>(im)));

--- a/src/util/include/util/Rectangle.h
+++ b/src/util/include/util/Rectangle.h
@@ -17,16 +17,18 @@
 
 #include "util/Point.h"
 #include "util/Range.h"
+#include "util/Size.h"
 
 namespace xoj::util {  // Rectangle is already defined in windows.h
 
 template <class T>
-class Rectangle final: private Point<T> {
+class Rectangle final: private Point<T>, private Size<T> {
 public:
     constexpr Rectangle() = default;
-    constexpr Rectangle(T x, T y, T width, T height): Point<T>(x, y), width(width), height(height) {}
+    constexpr Rectangle(T x, T y, T width, T height): Point<T>(x, y), Size<T>{width, height} {}
     constexpr explicit Rectangle(const Range& rect):
-            Point<T>(rect.getX(), rect.getY()), width(rect.getWidth()), height(rect.getHeight()) {}
+            Point<T>(rect.getX(), rect.getY()), Size<T>{rect.getWidth(), rect.getHeight()} {}
+    constexpr Rectangle(const Point<T>& p, const Size<T>& s): Point<T>(p), Size<T>(s) {}
 
     constexpr auto operator==(const Rectangle& other) const -> bool {
         return x == other.x && y == other.y && width == other.width && height == other.height;
@@ -84,12 +86,16 @@ public:
      */
     constexpr auto area() const -> T { return width * height; }
 
+    constexpr bool contains(const xoj::util::Point<T>& p) const {
+        return p.x > x && p.x < x + width && p.y > y && p.y < y + height;
+    }
+
     const Point<T>& getOrigin() const { return *this; }
 
-    T width{};
-    T height{};
     using Point<T>::x;
     using Point<T>::y;
+    using Size<T>::width;
+    using Size<T>::height;
 };
 
 }  // namespace xoj::util

--- a/src/util/include/util/Size.h
+++ b/src/util/include/util/Size.h
@@ -1,0 +1,21 @@
+/*
+ * Xournal++
+ *
+ * A rectangular size
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+namespace xoj::util {
+template <class T>
+struct Size {
+    constexpr bool operator==(const Size<T>&) const = default;
+    T width{};
+    T height{};
+};
+}  // namespace xoj::util

--- a/test/unit_tests/model/ImageTest.cpp
+++ b/test/unit_tests/model/ImageTest.cpp
@@ -34,8 +34,8 @@ TEST(Image, testGetImageApplyOrientation) {
     GdkPixbuf* pixbuf = gdk_pixbuf_loader_get_pixbuf(loader);
 
     // Image size before  orientation
-    auto origImageSize = std::make_pair(gdk_pixbuf_get_width(pixbuf), gdk_pixbuf_get_height(pixbuf));
-    auto rotatedImageSize = std::make_pair(origImageSize.second, origImageSize.first);
+    auto origImageSize = xoj::util::Size<int>(gdk_pixbuf_get_width(pixbuf), gdk_pixbuf_get_height(pixbuf));
+    auto rotatedImageSize = xoj::util::Size<int>(origImageSize.height, origImageSize.width);
     g_object_unref(loader);
 
     image.setImage(imageData);
@@ -48,7 +48,7 @@ TEST(Image, testGetImageApplyOrientation) {
 
     // Test image now have the correct size - which is the image has been rotated.
     EXPECT_EQ(image.getImageSize(), rotatedImageSize);
-    EXPECT_EQ(image.getImageSize(), std::make_pair(130, 500));
-    EXPECT_EQ(std::make_pair(cairo_image_surface_get_width(surface), cairo_image_surface_get_height(surface)),
+    EXPECT_EQ(image.getImageSize(), xoj::util::Size<int>(130, 500));
+    EXPECT_EQ(xoj::util::Size<int>(cairo_image_surface_get_width(surface), cairo_image_surface_get_height(surface)),
               rotatedImageSize);
 }


### PR DESCRIPTION
This PR is a prequel to #7712.

It contains code cleanup in model/Image.cpp:

- Use RAII for the buffer
- Remove code duplication
- Introduce xoj::util::Size for {width, height}