### PR TITLE
Introduce RectangularElement

### DIFF
--- a/src/core/control/Control.cpp
+++ b/src/core/control/Control.cpp
@@ -2417,7 +2417,7 @@ void Control::clipboardPaste(ElementPtr e) {
     x = std::max(0.0, x - box.width / 2);
     y = std::max(0.0, y - box.height / 2);
 
-    e->setOrigin(x, y);
+    e->move(x, y);
 
     undoRedo->addUndoAction(std::make_unique<InsertUndoAction>(page, layer, e.get()));
     auto sel = SelectionFactory::createFromFloatingElement(this, page, layer, view, std::move(e));

--- a/src/core/control/LatexController.cpp
+++ b/src/core/control/LatexController.cpp
@@ -285,8 +285,8 @@ void LatexController::insertTexImage() {
         if (elementIndex != Element::InvalidIndex) [[likely]] {
             xoj_assert(orig.get() == this->selectedElem);
             // Set the size: preserve the height and aspect ratio
-            const auto& origBox = this->selectedElem->getBoundingBox();
-            const auto& nativeSize = this->temporaryRender->getBoundingBox();
+            const auto& origBox = this->selectedElem->getSnappedBounds();
+            const auto& nativeSize = this->temporaryRender->getSnappedBounds();
             this->temporaryRender->setWidth(nativeSize.width != 0 && nativeSize.height != 0 ?
                                                     nativeSize.width * origBox.height / nativeSize.height :
                                                     10.);

--- a/src/core/model/Element.cpp
+++ b/src/core/model/Element.cpp
@@ -33,19 +33,6 @@ auto Element::getSnappedBounds() const -> const Rectangle<double>& {
     return this->snappedBounds;
 }
 
-void Element::setOrigin(double x, double y) {
-    this->boundingBox.x = x;
-    this->boundingBox.y = y;
-    this->sizeCalculated = false;
-}
-
-auto Element::getOrigin() const -> const xoj::util::Point<double>& { return boundingBox.getOrigin(); }
-
-void Element::move(double dx, double dy) {
-    this->boundingBox = this->boundingBox.translated(dx, dy);
-    this->snappedBounds = this->snappedBounds.translated(dx, dy);
-}
-
 void Element::setColor(Color color) { this->color = color; }
 
 auto Element::getColor() const -> Color { return this->color; }
@@ -54,34 +41,8 @@ auto Element::intersectsArea(double x, double y, double width, double height) co
     return this->getBoundingBox().intersects(xoj::util::Rectangle<double>(x, y, width, height)).has_value();
 }
 
-auto Element::distanceTo(double x, double y) const -> double {
-    const auto& box = this->getBoundingBox();
-    // Coordinates of the point in the bounding box that is the closest to (x,y).
-    double projX = std::clamp(x, box.x, box.x + box.width);
-    double projY = std::clamp(y, box.y, box.y + box.height);
-    return std::hypot(x - projX, y - projY);
-}
-
 auto Element::hasBoundingBoxContaining(double x, double y) const -> bool {
     return Range(this->getBoundingBox()).contains(x, y);
-}
-
-auto Element::isInSelection(ShapeContainer* container) const -> bool {
-    const auto& box = this->getBoundingBox();
-    if (!container->contains(box.x, box.y)) {
-        return false;
-    }
-    if (!container->contains(box.x + box.width, box.y)) {
-        return false;
-    }
-    if (!container->contains(box.x, box.y + box.height)) {
-        return false;
-    }
-    if (!container->contains(box.x + box.width, box.y + box.height)) {
-        return false;
-    }
-
-    return true;
 }
 
 auto Element::rescaleOnlyAspectRatio() const -> bool { return false; }
@@ -90,9 +51,6 @@ auto Element::rescaleWithMirror() const -> bool { return false; }
 void Element::serialize(ObjectOutputStream& out) const {
     out.writeObject("Element");
 
-    const auto& pt = getOrigin();
-    out.writeDouble(pt.x);
-    out.writeDouble(pt.y);
     out.writeUInt(uint32_t(this->color));
 
     out.endObject();
@@ -101,9 +59,6 @@ void Element::serialize(ObjectOutputStream& out) const {
 void Element::readSerialized(ObjectInputStream& in) {
     in.readObject("Element");
 
-    double x = in.readDouble();
-    double y = in.readDouble();
-    setOrigin(x, y);
     this->color = Color(in.readUInt());
 
     in.endObject();

--- a/src/core/model/Element.h
+++ b/src/core/model/Element.h
@@ -26,7 +26,7 @@ class ObjectOutputStream;
 
 namespace xoj::util {
 template <class T>
-class Point;
+struct Point;
 };
 
 enum ElementType { ELEMENT_STROKE = 1, ELEMENT_IMAGE, ELEMENT_TEXIMAGE, ELEMENT_TEXT, ELEMENT_LINK };
@@ -44,6 +44,10 @@ using ElementPtr = std::unique_ptr<Element>;
 class Element: public Serializable {
 protected:
     Element(ElementType type);
+    Element(const Element&) = default;
+    Element& operator=(const Element&) = default;
+    Element(Element&&) = default;
+    Element& operator=(Element&&) = default;
 
 public:
     ~Element() override = default;
@@ -54,11 +58,9 @@ public:
 public:
     ElementType getType() const;
 
-    /// Move the element to (x,y).
-    virtual void setOrigin(double x, double y);
-    virtual const xoj::util::Point<double>& getOrigin() const;
+    virtual const xoj::util::Point<double>& getOrigin() const = 0;
 
-    virtual void move(double dx, double dy);
+    virtual void move(double dx, double dy) = 0;
     virtual void scale(double x0, double y0, double fx, double fy, double rotation, bool restoreLineWidth) = 0;
     virtual void rotate(double x0, double y0, double th) = 0;
 
@@ -69,12 +71,13 @@ public:
 
     const xoj::util::Rectangle<double>& getBoundingBox() const;
 
-    virtual bool intersectsArea(double x, double y, double width, double height) const;
-    /// Returns the distance between the element "as drawn" and the point (x,y)
-    virtual double distanceTo(double x, double y) const;
-    virtual bool hasBoundingBoxContaining(double x, double y) const;
+    /// Returns true if the element's bounding box intersects the given rectangle, in Page coordinates
+    bool intersectsArea(double x, double y, double width, double height) const;
+    /// Returns the distance between the element "as drawn" and the point (x,y), in Page coordinates
+    virtual double distanceTo(double x, double y) const = 0;
+    bool hasBoundingBoxContaining(double x, double y) const;
 
-    virtual bool isInSelection(ShapeContainer* container) const;
+    virtual bool isInSelection(ShapeContainer* container) const = 0;
 
     virtual bool rescaleOnlyAspectRatio() const;
     virtual bool rescaleWithMirror() const;

--- a/src/core/model/Image.cpp
+++ b/src/core/model/Image.cpp
@@ -21,7 +21,7 @@
 
 using xoj::util::Rectangle;
 
-Image::Image(): Element(ELEMENT_IMAGE) {}
+Image::Image(): RectangularElement(ELEMENT_IMAGE) {}
 
 Image::~Image() {
     if (this->format) {
@@ -32,25 +32,21 @@ Image::~Image() {
 
 auto Image::clone() const -> ElementPtr {
     auto img = std::make_unique<Image>();
+    static_cast<RectangularElement&>(*img) = *this;
 
-    img->boundingBox = this->boundingBox;
-    img->setColor(this->getColor());
     img->data = this->data;
-
     img->image = this->image;
-    img->snappedBounds = this->snappedBounds;
-    img->sizeCalculated = this->sizeCalculated;
 
     return img;
 }
 
 void Image::setWidth(double width) {
-    this->boundingBox.width = width;
+    this->snappedBounds.width = width;
     this->calcSize();
 }
 
 void Image::setHeight(double height) {
-    this->boundingBox.height = height;
+    this->snappedBounds.height = height;
     this->calcSize();
 }
 
@@ -186,29 +182,13 @@ auto Image::getImage() const -> cairo_surface_t* {
     return this->image.get();
 }
 
-void Image::scale(double x0, double y0, double fx, double fy, double rotation,
-                  bool) {  // line width scaling option is not used
-    this->boundingBox.x -= x0;
-    this->boundingBox.x *= fx;
-    this->boundingBox.x += x0;
-    this->boundingBox.y -= y0;
-    this->boundingBox.y *= fy;
-    this->boundingBox.y += y0;
-
-    this->boundingBox.width *= fx;
-    this->boundingBox.height *= fy;
-    this->calcSize();
-}
-
-void Image::rotate(double x0, double y0, double th) {}
-
 void Image::serialize(ObjectOutputStream& out) const {
     out.writeObject("Image");
 
-    this->Element::serialize(out);
+    this->RectangularElement::serialize(out);
 
-    out.writeDouble(this->boundingBox.width);
-    out.writeDouble(this->boundingBox.height);
+    out.writeDouble(this->snappedBounds.width);
+    out.writeDouble(this->snappedBounds.height);
 
     out.writeImage(this->data);
 
@@ -218,10 +198,10 @@ void Image::serialize(ObjectOutputStream& out) const {
 void Image::readSerialized(ObjectInputStream& in) {
     in.readObject("Image");
 
-    this->Element::readSerialized(in);
+    this->RectangularElement::readSerialized(in);
 
-    this->boundingBox.width = in.readDouble();
-    this->boundingBox.height = in.readDouble();
+    this->snappedBounds.width = in.readDouble();
+    this->snappedBounds.height = in.readDouble();
 
     this->image.reset();
     this->data = in.readImage();
@@ -231,7 +211,7 @@ void Image::readSerialized(ObjectInputStream& in) {
 }
 
 void Image::calcSize() const {
-    this->snappedBounds = this->boundingBox;
+    this->boundingBox = this->snappedBounds;
     this->sizeCalculated = true;
 }
 

--- a/src/core/model/Image.h
+++ b/src/core/model/Image.h
@@ -23,13 +23,13 @@
 #include "util/Size.h"
 #include "util/raii/CairoWrappers.h"
 
-#include "Element.h"  // for Element
+#include "RectangularElement.h"
 
 class ObjectInputStream;
 class ObjectOutputStream;
 
 
-class Image: public Element {
+class Image: public RectangularElement {
 public:
     Image();
     Image(const Image&) = delete;
@@ -61,9 +61,6 @@ public:
 
     /// Returns the internal surface that contains the rendered image data.
     cairo_surface_t* getImage() const;
-
-    void scale(double x0, double y0, double fx, double fy, double rotation, bool restoreLineWidth) override;
-    void rotate(double x0, double y0, double th) override;
 
     auto clone() const -> ElementPtr override;
 

--- a/src/core/model/Link.cpp
+++ b/src/core/model/Link.cpp
@@ -1,6 +1,5 @@
 #include "Link.h"
 
-#include "model/Element.h"                        // for ELEMENT_TEXT, Eleme...
 #include "model/Font.h"                           // for XojFont
 #include "util/Color.h"                           // for Colors
 #include "util/Point.h"                           // for Point
@@ -11,7 +10,7 @@
 
 #include "TextAlignment.h"
 
-Link::Link(): Element(ELEMENT_LINK) {
+Link::Link(): RectangularElement(ELEMENT_LINK) {
     this->font.setName("Sans");
     this->font.setSize(12);
     this->setColor(Colors::magenta);
@@ -22,7 +21,11 @@ void Link::setText(std::string text) { this->text = text; }
 
 std::string Link::getText() const { return this->text; }
 
-void Link::setTextPos(double x, double y) { this->setOrigin(x - PADDING, y - PADDING); }
+void Link::setTextPos(double x, double y) {
+    this->snappedBounds.x = x;
+    this->snappedBounds.y = y;
+    this->sizeCalculated = false;
+}
 
 void Link::setUrl(std::string url) { this->url = url; }
 
@@ -37,7 +40,7 @@ auto Link::getFont() const -> const XojFont& { return this->font; }
 void Link::serialize(ObjectOutputStream& out) const {
     out.writeObject("Link");
 
-    Element::serialize(out);
+    RectangularElement::serialize(out);
 
     out.writeString(this->text);
 
@@ -53,7 +56,7 @@ void Link::serialize(ObjectOutputStream& out) const {
 void Link::readSerialized(ObjectInputStream& in) {
     in.readObject("Link");
 
-    Element::readSerialized(in);
+    RectangularElement::readSerialized(in);
 
     this->text = in.readString();
 
@@ -74,12 +77,8 @@ void Link::scale(double x0, double y0, double fx, double fy, double rotation, bo
         Stacktrace::printStacktrace();
     }
 
-    xoj::util::Point<double> textPos{this->snappedBounds.x, this->snappedBounds.y};
-    textPos -= xoj::util::Point(x0, y0);
-    textPos *= fx;
-    textPos += xoj::util::Point(x0, y0);
-    this->boundingBox.x = textPos.x - PADDING;
-    this->boundingBox.y = textPos.y - PADDING;
+    this->snappedBounds.x = (this->snappedBounds.x - x0) * fx + x0;
+    this->snappedBounds.y = (this->snappedBounds.y - y0) * fy + y0;
 
     double size = this->font.getSize() * fx;
     this->font.setSize(size);
@@ -87,17 +86,13 @@ void Link::scale(double x0, double y0, double fx, double fy, double rotation, bo
     sizeCalculated = false;
 };
 
-void Link::rotate(double x0, double y0, double th) {};
-
 ElementPtr Link::clone() const {
     auto link = std::make_unique<Link>();
+    static_cast<RectangularElement&>(*link) = *this;
+
     link->font = this->font;
     link->text = this->text;
     link->url = this->url;
-    link->setColor(this->getColor());
-    link->boundingBox = this->boundingBox;
-    link->snappedBounds = this->snappedBounds;
-    link->sizeCalculated = this->sizeCalculated;
     return link;
 };
 
@@ -106,12 +101,12 @@ void Link::calcSize() const {
     pango_layout_set_text(layout.get(), this->text.c_str(), static_cast<int>(this->text.length()));
     int w = 0, h = 0;
     pango_layout_get_size(layout.get(), &w, &h);
-    double textWidth = (static_cast<double>(w)) / PANGO_SCALE;
-    double textHeight = (static_cast<double>(h)) / PANGO_SCALE;
-    this->boundingBox.width = textWidth + 2 * PADDING;
-    this->boundingBox.height = textHeight + 2 * PADDING;
-    this->snappedBounds = xoj::util::Rectangle<double>(this->boundingBox.x + PADDING, this->boundingBox.y + PADDING,
-                                                       textWidth, textHeight);
+    this->snappedBounds.width = static_cast<double>(w) / PANGO_SCALE;
+    this->snappedBounds.height = static_cast<double>(h) / PANGO_SCALE;
+    this->boundingBox = xoj::util::Rectangle<double>(this->snappedBounds.x - PADDING, this->snappedBounds.y - PADDING,
+                                                     this->snappedBounds.width + 2 * PADDING,
+                                                     this->snappedBounds.height + 2 * PADDING);
+    sizeCalculated = true;
 };
 
 auto Link::createPangoLayout() const -> xoj::util::GObjectSPtr<PangoLayout> {

--- a/src/core/model/Link.h
+++ b/src/core/model/Link.h
@@ -18,15 +18,14 @@
 
 #include "util/raii/GObjectSPtr.h"  // For GObjectSPtr
 
-#include "Element.h"  // for Element
-#include "Font.h"     // for XojFont
+#include "Font.h"  // for XojFont
+#include "RectangularElement.h"
 #include "TextAlignment.h"
 
-class Element;
 class ObjectInputStream;
 class ObjectOutputStream;
 
-class Link: public Element {
+class Link: public RectangularElement {
 public:
     Link();
     ~Link() override = default;
@@ -50,16 +49,9 @@ public:
     xoj::util::GObjectSPtr<PangoLayout> createPangoLayout() const;
 
 public:
-    /**
-     * @override (required)
-     */
     void scale(double x0, double y0, double fx, double fy, double rotation, bool restoreLineWidth) override;
-    void rotate(double x0, double y0, double th) override;
     ElementPtr clone() const override;
 
-    /**
-     * @override (optional)
-     */
     void serialize(ObjectOutputStream& out) const override;
     void readSerialized(ObjectInputStream& in) override;
     bool rescaleOnlyAspectRatio() const override;

--- a/src/core/model/Point.cpp
+++ b/src/core/model/Point.cpp
@@ -4,9 +4,9 @@
 
 #include "util/Rectangle.h"  // for Rectangle
 
-Point::Point(double x, double y): x(x), y(y) {}
+Point::Point(double x, double y): xoj::util::Point<double>(x, y) {}
 
-Point::Point(double x, double y, double z): x(x), y(y), z(z) {}
+Point::Point(double x, double y, double z): xoj::util::Point<double>(x, y), z(z) {}
 
 auto Point::lineLengthTo(const Point& p) const -> double { return std::hypot(this->x - p.x, this->y - p.y); }
 

--- a/src/core/model/Point.h
+++ b/src/core/model/Point.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "util/Point.h"
 
 namespace xoj::util {
 template <class T>
@@ -21,7 +22,7 @@ class Rectangle;
  * @class Point
  * @brief Representation of a point.
  */
-class Point {
+class Point: private xoj::util::Point<double> {
 public:
     Point() = default;
     ~Point() = default;
@@ -82,16 +83,21 @@ public:
      */
     bool isInside(const xoj::util::Rectangle<double>& rect) const;
 
+    /**
+     * @brief Get the position of the point
+     */
+    inline const xoj::util::Point<double>& getPosition() const { return *this; }
+
 public:
     /**
      * @brief Private storage for x coordinate.
      */
-    double x = 0;
+    using xoj::util::Point<double>::x;
 
     /**
      * @brief Private storage for y coordinate.
      */
-    double y = 0;
+    using xoj::util::Point<double>::y;
 
     /**
      * @brief Private storage for pressure.

--- a/src/core/model/RectangularElement.cpp
+++ b/src/core/model/RectangularElement.cpp
@@ -1,0 +1,78 @@
+#include "RectangularElement.h"
+
+#include <algorithm>  // for clamp
+
+#include "util/Assert.h"
+#include "util/Point.h"
+#include "util/serializing/ObjectInputStream.h"   // for ObjectInputStream
+#include "util/serializing/ObjectOutputStream.h"  // for ObjectOutputStream
+
+static constexpr auto SERIALIZATION_NAME = "RectangularElement";
+
+RectangularElement::RectangularElement(ElementType type): Element(type) {}
+
+void RectangularElement::setOrigin(double x, double y) {
+    this->snappedBounds.x = x;
+    this->snappedBounds.y = y;
+    this->sizeCalculated = false;
+}
+
+void RectangularElement::move(double dx, double dy) {
+    this->boundingBox = this->boundingBox.translated(dx, dy);
+    this->snappedBounds = this->snappedBounds.translated(dx, dy);
+}
+
+void RectangularElement::scale(double x0, double y0, double fx, double fy, double rotation, bool) {
+    xoj_assert(rotation == 0);
+    this->snappedBounds.x = (this->snappedBounds.x - x0) * fx + x0;
+    this->snappedBounds.y = (this->snappedBounds.y - y0) * fy + y0;
+    this->snappedBounds.width *= fx;
+    this->snappedBounds.height *= fy;
+    this->sizeCalculated = false;
+}
+
+void RectangularElement::rotate(double x0, double y0, double th) {}
+
+auto RectangularElement::distanceTo(double x, double y) const -> double {
+    // Coordinates of the point in the rectangle that is the closest to (x,y)
+    xoj::util::Point<double> proj(std::clamp(x, snappedBounds.x, snappedBounds.x + snappedBounds.width),
+                                  std::clamp(y, snappedBounds.y, snappedBounds.y + snappedBounds.height));
+    return proj.distance({x, y});
+}
+
+auto RectangularElement::isInSelection(ShapeContainer* container) const -> bool {
+    // We consider a rectangular element is selected if its 4 corners are selected.
+    // This is not perfect and could give counterintuitive results in corner cases when using the lasso
+    const auto& origin = this->snappedBounds.getOrigin();
+    const auto v1 = origin + xoj::util::Point<double>{0., snappedBounds.height};
+    const auto v2 = origin + xoj::util::Point<double>{snappedBounds.width, 0.};
+    for (auto&& p: {origin, v1, v2, v1 + v2 - origin}) {
+        // The 4 corners of the rectangle cutting out our element
+        if (!container->contains(p.x, p.y)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void RectangularElement::serialize(ObjectOutputStream& out) const {
+    out.writeObject(SERIALIZATION_NAME);
+
+    Element::serialize(out);
+
+    out.writeDouble(snappedBounds.x);
+    out.writeDouble(snappedBounds.y);
+
+    out.endObject();
+}
+
+void RectangularElement::readSerialized(ObjectInputStream& in) {
+    in.readObject(SERIALIZATION_NAME);
+
+    Element::readSerialized(in);
+
+    snappedBounds.x = in.readDouble();
+    snappedBounds.y = in.readDouble();
+
+    in.endObject();
+}

--- a/src/core/model/RectangularElement.h
+++ b/src/core/model/RectangularElement.h
@@ -1,0 +1,41 @@
+/*
+ * Xournal++
+ *
+ * An element with a somewhat intrinsic rectangular shape
+ *
+ * @author Xournal++ Team
+ * https://github.com/xournalpp/xournalpp
+ *
+ * @license GNU GPLv2 or later
+ */
+
+#pragma once
+
+#include "Element.h"
+
+class RectangularElement: public Element {
+protected:
+    RectangularElement(ElementType type);
+
+public:
+    ~RectangularElement() override = default;
+    RectangularElement(const RectangularElement&) = default;
+    RectangularElement& operator=(const RectangularElement&) = default;
+    RectangularElement(RectangularElement&&) = default;
+    RectangularElement& operator=(RectangularElement&&) = default;
+
+    inline const xoj::util::Point<double>& getOrigin() const override { return snappedBounds.getOrigin(); }
+    void setOrigin(double x, double y);
+
+    void move(double dx, double dy) override;
+    void scale(double x0, double y0, double fx, double fy, double rotation, bool restoreLineWidth) override;
+    void rotate(double x0, double y0, double th) override;
+
+    /// Returns the distance between the element "as drawn" and the point (x,y)
+    double distanceTo(double x, double y) const override;
+
+    bool isInSelection(ShapeContainer* container) const override;
+
+    void serialize(ObjectOutputStream& out) const override;
+    void readSerialized(ObjectInputStream& in) override;
+};

--- a/src/core/model/Stroke.cpp
+++ b/src/core/model/Stroke.cpp
@@ -332,6 +332,11 @@ void Stroke::move(double dx, double dy) {
     Element::snappedBounds = Element::snappedBounds.translated(dx, dy);
 }
 
+auto Stroke::getOrigin() const -> const xoj::util::Point<double>& {
+    xoj_assert(!this->points.empty());
+    return points.front().getPosition();
+}
+
 void Stroke::rotate(double x0, double y0, double th) {
     cairo_matrix_t rotMatrix;
     cairo_matrix_init_identity(&rotMatrix);

--- a/src/core/model/Stroke.h
+++ b/src/core/model/Stroke.h
@@ -188,6 +188,8 @@ public:
     bool hasPressure() const;
     double getAvgPressure() const;
 
+    const xoj::util::Point<double>& getOrigin() const override;
+
     void move(double dx, double dy) override;
     void scale(double x0, double y0, double fx, double fy, double rotation, bool restoreLineWidth) override;
     void rotate(double x0, double y0, double th) override;

--- a/src/core/model/TexImage.cpp
+++ b/src/core/model/TexImage.cpp
@@ -12,7 +12,7 @@
 #include "util/serializing/ObjectInputStream.h"   // for ObjectInputStream
 #include "util/serializing/ObjectOutputStream.h"  // for ObjectOutputStream
 
-TexImage::TexImage(): Element(ELEMENT_TEXIMAGE) { this->sizeCalculated = true; }
+TexImage::TexImage(): RectangularElement(ELEMENT_TEXIMAGE) { this->sizeCalculated = true; }
 
 TexImage::~TexImage() { freeImageAndPdf(); }
 
@@ -23,11 +23,9 @@ void TexImage::freeImageAndPdf() {
 
 auto TexImage::cloneTexImage() const -> std::unique_ptr<TexImage> {
     auto img = std::make_unique<TexImage>();
-    img->boundingBox = this->boundingBox;
-    img->setColor(this->getColor());
+    static_cast<RectangularElement&>(*img) = *this;
+
     img->text = this->text;
-    img->snappedBounds = this->snappedBounds;
-    img->sizeCalculated = this->sizeCalculated;
 
     // Clone has a copy of our PDF.
     img->pdf = this->pdf;
@@ -43,12 +41,12 @@ auto TexImage::cloneTexImage() const -> std::unique_ptr<TexImage> {
 auto TexImage::clone() const -> ElementPtr { return cloneTexImage(); }
 
 void TexImage::setWidth(double width) {
-    this->boundingBox.width = width;
+    this->snappedBounds.width = width;
     this->calcSize();
 }
 
 void TexImage::setHeight(double height) {
-    this->boundingBox.height = height;
+    this->snappedBounds.height = height;
     this->calcSize();
 }
 
@@ -89,9 +87,9 @@ auto TexImage::loadData(std::string&& bytes, GError** err) -> bool {
         if (!pdf.get() || poppler_document_get_n_pages(this->pdf.get()) < 1) {
             return false;
         }
-        if (std::abs(this->boundingBox.area()) <= std::numeric_limits<double>::epsilon()) {
+        if (std::abs(this->snappedBounds.area()) <= std::numeric_limits<double>::epsilon()) {
             xoj::util::GObjectSPtr<PopplerPage> page(poppler_document_get_page(this->pdf.get(), 0), xoj::util::adopt);
-            poppler_page_get_size(page.get(), &this->boundingBox.width, &this->boundingBox.height);
+            poppler_page_get_size(page.get(), &this->snappedBounds.width, &this->snappedBounds.height);
         }
     } else if (type == "PNG") {
         this->image.reset(cairo_image_surface_create_from_png_stream(
@@ -108,28 +106,13 @@ auto TexImage::getImage() const -> cairo_surface_t* { return this->image.get(); 
 
 auto TexImage::getPdf() const -> PopplerDocument* { return this->pdf.get(); }
 
-void TexImage::scale(double x0, double y0, double fx, double fy, double rotation,
-                     bool) {  // line width scaling option is not used
-
-    this->boundingBox.x = (this->boundingBox.x - x0) * fx + x0;
-    this->boundingBox.y = (this->boundingBox.y - y0) * fy + y0;
-
-    this->boundingBox.width *= fx;
-    this->boundingBox.height *= fy;
-    this->calcSize();
-}
-
-void TexImage::rotate(double x0, double y0, double th) {
-    // Rotation for TexImages not yet implemented
-}
-
 void TexImage::serialize(ObjectOutputStream& out) const {
     out.writeObject("TexImage");
 
-    this->Element::serialize(out);
+    this->RectangularElement::serialize(out);
 
-    out.writeDouble(this->boundingBox.width);
-    out.writeDouble(this->boundingBox.height);
+    out.writeDouble(this->snappedBounds.width);
+    out.writeDouble(this->snappedBounds.height);
     out.writeString(this->text);
 
     out.writeString(this->binaryData);
@@ -140,10 +123,10 @@ void TexImage::serialize(ObjectOutputStream& out) const {
 void TexImage::readSerialized(ObjectInputStream& in) {
     in.readObject("TexImage");
 
-    this->Element::readSerialized(in);
+    this->RectangularElement::readSerialized(in);
 
-    this->boundingBox.width = in.readDouble();
-    this->boundingBox.height = in.readDouble();
+    this->snappedBounds.width = in.readDouble();
+    this->snappedBounds.height = in.readDouble();
     this->text = in.readString();
 
     std::string data = in.readString();
@@ -154,6 +137,6 @@ void TexImage::readSerialized(ObjectInputStream& in) {
 }
 
 void TexImage::calcSize() const {
-    this->snappedBounds = this->boundingBox;
+    this->boundingBox = this->snappedBounds;
     this->sizeCalculated = true;
 }

--- a/src/core/model/TexImage.cpp
+++ b/src/core/model/TexImage.cpp
@@ -12,23 +12,16 @@
 #include "util/serializing/ObjectInputStream.h"   // for ObjectInputStream
 #include "util/serializing/ObjectOutputStream.h"  // for ObjectOutputStream
 
-using xoj::util::Rectangle;
-
 TexImage::TexImage(): Element(ELEMENT_TEXIMAGE) { this->sizeCalculated = true; }
 
 TexImage::~TexImage() { freeImageAndPdf(); }
 
 void TexImage::freeImageAndPdf() {
-    if (this->image) {
-        cairo_surface_destroy(this->image);
-        this->image = nullptr;
-    }
-
+    this->image.reset();
     this->pdf.reset();
 }
 
 auto TexImage::cloneTexImage() const -> std::unique_ptr<TexImage> {
-
     auto img = std::make_unique<TexImage>();
     img->boundingBox = this->boundingBox;
     img->setColor(this->getColor());
@@ -101,8 +94,9 @@ auto TexImage::loadData(std::string&& bytes, GError** err) -> bool {
             poppler_page_get_size(page.get(), &this->boundingBox.width, &this->boundingBox.height);
         }
     } else if (type == "PNG") {
-        this->image = cairo_image_surface_create_from_png_stream(
-                reinterpret_cast<cairo_read_func_t>(&cairoReadFunction), this);
+        this->image.reset(cairo_image_surface_create_from_png_stream(
+                                  reinterpret_cast<cairo_read_func_t>(&cairoReadFunction), this),
+                          xoj::util::adopt);
     } else {
         g_warning("Unknown Latex image type: \"%s\"", type.c_str());
     }
@@ -110,7 +104,7 @@ auto TexImage::loadData(std::string&& bytes, GError** err) -> bool {
     return true;
 }
 
-auto TexImage::getImage() const -> cairo_surface_t* { return this->image; }
+auto TexImage::getImage() const -> cairo_surface_t* { return this->image.get(); }
 
 auto TexImage::getPdf() const -> PopplerDocument* { return this->pdf.get(); }
 
@@ -151,8 +145,6 @@ void TexImage::readSerialized(ObjectInputStream& in) {
     this->boundingBox.width = in.readDouble();
     this->boundingBox.height = in.readDouble();
     this->text = in.readString();
-
-    freeImageAndPdf();
 
     std::string data = in.readString();
     this->loadData(std::move(data), nullptr);

--- a/src/core/model/TexImage.h
+++ b/src/core/model/TexImage.h
@@ -18,6 +18,7 @@
 #include <glib.h>     // for GError
 #include <poppler.h>  // for PopplerDocument
 
+#include "util/raii/CairoWrappers.h"
 #include "util/raii/GObjectSPtr.h"  // for GObjectSPtr
 
 #include "Element.h"  // for Element
@@ -95,7 +96,7 @@ private:
     /**
      * Tex image, if rendered as image. Note: this is deprecated and subject to removal in a later version.
      */
-    cairo_surface_t* image = nullptr;
+    xoj::util::CairoSurfaceSPtr image;
 
     /**
      * PNG Image / PDF Document

--- a/src/core/model/TexImage.h
+++ b/src/core/model/TexImage.h
@@ -21,13 +21,13 @@
 #include "util/raii/CairoWrappers.h"
 #include "util/raii/GObjectSPtr.h"  // for GObjectSPtr
 
-#include "Element.h"  // for Element
+#include "RectangularElement.h"
 
 class ObjectInputStream;
 class ObjectOutputStream;
 
 
-class TexImage: public Element {
+class TexImage: public RectangularElement {
 public:
     TexImage();
     TexImage(const TexImage&) = delete;
@@ -56,9 +56,6 @@ public:
      * The document needs to be referenced, if it will be hold somewhere
      */
     PopplerDocument* getPdf() const;
-
-    void scale(double x0, double y0, double fx, double fy, double rotation, bool restoreLineWidth) override;
-    void rotate(double x0, double y0, double th) override;
 
     // text tag to alow latex
     void setText(std::string text);

--- a/src/core/model/Text.cpp
+++ b/src/core/model/Text.cpp
@@ -20,7 +20,7 @@
 
 using xoj::util::Rectangle;
 
-Text::Text(): Element(ELEMENT_TEXT) {
+Text::Text(): RectangularElement(ELEMENT_TEXT) {
     this->font.setName("Sans");
     this->font.setSize(12);
 }
@@ -29,13 +29,11 @@ Text::~Text() = default;
 
 auto Text::cloneText() const -> std::unique_ptr<Text> {
     auto text = std::make_unique<Text>();
+    static_cast<RectangularElement&>(*text) = *this;
     static_cast<AudioContent&>(*text) = *this;
+
     text->font = this->font;
     text->text = this->text;
-    text->setColor(this->getColor());
-    text->boundingBox = this->boundingBox;
-    text->snappedBounds = this->snappedBounds;
-    text->sizeCalculated = this->sizeCalculated;
     text->inEditing = this->inEditing;
     text->wrapWidth = this->wrapWidth;
     text->align = this->align;
@@ -101,14 +99,6 @@ Text::Boxes Text::computeBoxesForLayout(PangoLayout* layout, xoj::util::Point<do
     return res;
 }
 
-void Text::setOrigin(double x, double y) {
-    this->snappedBounds.x = x;
-    this->snappedBounds.y = y;
-    this->sizeCalculated = false;  // Recompute Element::x,y
-}
-
-auto Text::getOrigin() const -> const xoj::util::Point<double>& { return this->snappedBounds.getOrigin(); }
-
 void Text::calcSize() const {
     auto layout = createPangoLayout();
     pango_layout_set_text(layout.get(), this->text.c_str(), static_cast<int>(this->text.length()));
@@ -158,12 +148,8 @@ void Text::scale(double x0, double y0, double fx, double fy, double rotation,
         Stacktrace::printStacktrace();
     }
 
-    this->boundingBox.x -= x0;
-    this->boundingBox.x *= fx;
-    this->boundingBox.x += x0;
-    this->boundingBox.y -= y0;
-    this->boundingBox.y *= fy;
-    this->boundingBox.y += y0;
+    this->snappedBounds.x = (this->snappedBounds.x - x0) * fx + x0;
+    this->snappedBounds.y = (this->snappedBounds.y - y0) * fy + y0;
 
     double size = this->font.getSize() * fx;
     this->font.setSize(size);
@@ -175,8 +161,6 @@ void Text::scale(double x0, double y0, double fx, double fy, double rotation,
     sizeCalculated = false;
 }
 
-void Text::rotate(double x0, double y0, double th) {}
-
 auto Text::isInEditing() const -> bool { return this->inEditing; }
 
 auto Text::rescaleOnlyAspectRatio() const -> bool { return true; }
@@ -184,7 +168,7 @@ auto Text::rescaleOnlyAspectRatio() const -> bool { return true; }
 void Text::serialize(ObjectOutputStream& out) const {
     out.writeObject("Text");
 
-    this->Element::serialize(out);
+    this->RectangularElement::serialize(out);
     this->AudioContent::serialize(out);
 
     out.writeString(this->text);
@@ -201,7 +185,7 @@ void Text::serialize(ObjectOutputStream& out) const {
 void Text::readSerialized(ObjectInputStream& in) {
     in.readObject("Text");
 
-    this->Element::readSerialized(in);
+    this->RectangularElement::readSerialized(in);
     this->AudioContent::readSerialized(in);
 
     this->text = in.readString();

--- a/src/core/model/Text.h
+++ b/src/core/model/Text.h
@@ -20,15 +20,15 @@
 #include "util/raii/GObjectSPtr.h"
 
 #include "AudioContent.h"
-#include "Element.h"
-#include "Font.h"          // for XojFont
+#include "Font.h"  // for XojFont
+#include "RectangularElement.h"
 #include "TextAlignment.h"
 
 class ObjectInputStream;
 class ObjectOutputStream;
 class XojPdfRectangle;
 
-class Text: public Element, public AudioContent {
+class Text: public RectangularElement, public AudioContent {
 public:
     Text();
     ~Text() override;
@@ -52,10 +52,6 @@ public:
     void updatePangoFont(PangoLayout* layout) const;
 
     void scale(double x0, double y0, double fx, double fy, double rotation, bool restoreLineWidth) override;
-    void rotate(double x0, double y0, double th) override;
-
-    void setOrigin(double x, double y) override;
-    const xoj::util::Point<double>& getOrigin() const override;
 
     bool rescaleOnlyAspectRatio() const override;
 


### PR DESCRIPTION
This PR is a prequel to #7712 and is based on #7720, #7721 and #7722.

It adds a new base class RectangularElement (derived from Element) for Text, Image, TexImage and Link.
It corresponds to those elements whose natural shape is rectangular.

[As such, it does not change much (besides a tiny semantics improvement of the code base), but it will be necessary for #7712, as those REctangularElements are exactly those for which a transformation matrix is needed]

This should only be reviewed/merged once #7720, #7721 and #7722 have been merged.