### PR TITLE
Update MacOS deps

### DIFF
--- a/.github/actions/install_deps_mac/action.yml
+++ b/.github/actions/install_deps_mac/action.yml
@@ -10,13 +10,13 @@ runs:
   steps:
   - name: 'Attempt to pull blob from cache'
     id: restore-blob
-    uses: actions/cache/restore@v5
+    uses: actions/cache/restore@v6
     with:
       path: "${{github.workspace}}/blob"
       key: ${{ runner.os }}-${{ runner.arch }}-blob-${{ hashFiles('mac-setup/CI_jhbuild.sh', 'mac-setup/jhbuild-version.lock', 'mac-setup/xournalpp.modules', 'mac-setup/gtk-osx.patch') }}
   - name: 'Install Perl XML::Parser' # Needed for compilation of Intltool in the blob
     if: steps.restore-blob.outputs.cache-hit != 'true'
-    uses: perl-actions/install-with-cpm@v1
+    uses: perl-actions/install-with-cpm@v2
     with:
       install: XML::Parser
   - name: 'Compile blob'
@@ -29,7 +29,7 @@ runs:
       mv xournalpp-binary-blob.tar.gz "${{github.workspace}}/blob/"
   - name: 'Push blob to cache'
     if: steps.restore-blob.outputs.cache-hit != 'true'
-    uses: actions/cache/save@v5
+    uses: actions/cache/save@v6
     with:
       key: ${{ steps.restore-blob.outputs.cache-primary-key }}
       path: "${{github.workspace}}/blob"

--- a/.github/available-build-targets.json
+++ b/.github/available-build-targets.json
@@ -4,7 +4,7 @@
       "displayed_name": "Ubuntu 22.04",
       "runner": "ubuntu-22.04",
       "build_appimage": "true",
-      "run_ci": "true"
+      "run_ci": "false"
     },
     "ubuntu-24": {
       "displayed_name": "Ubuntu 24.04",
@@ -44,7 +44,7 @@
     "mac-x64": {
       "displayed_name": "MacOS x64",
       "runner": "macos-15-intel",
-      "run_ci": "true"
+      "run_ci": "false"
     },
     "mac-arm": {
       "displayed_name": "MacOS ARM",
@@ -59,7 +59,7 @@
       "msystem": "mingw64",
       "msys_package_env": "x86_64",
       "build_portable": "true",
-      "run_ci": "true"
+      "run_ci": "false"
     },
     "windows-arm": {
       "displayed_name": "Windows ARM",
@@ -67,7 +67,7 @@
       "msystem": "clangarm64",
       "msys_package_env": "clang-aarch64",
       "build_portable": "true",
-      "run_ci": "true"
+      "run_ci": "false"
     }
   }
 }

--- a/mac-setup/CI_jhbuild.sh
+++ b/mac-setup/CI_jhbuild.sh
@@ -91,7 +91,8 @@ module_cmakeargs['freetype'] = ' -DFT_DISABLE_BROTLI=TRUE '
 # portaudio may fail with parallel build, so disable parallel building.
 module_makeargs['portaudio'] = ' -j1 '
 
-repos['ftp.gnu.org'] = 'https://ftpmirror.gnu.org/gnu/'
+# Uncomment when ftp.gnu.org is out...
+# repos['ftp.gnu.org'] = 'https://ftpmirror.gnu.org/gnu/'
 
 ### END
 EOF

--- a/mac-setup/CI_jhbuild.sh
+++ b/mac-setup/CI_jhbuild.sh
@@ -92,7 +92,7 @@ module_cmakeargs['freetype'] = ' -DFT_DISABLE_BROTLI=TRUE '
 module_makeargs['portaudio'] = ' -j1 '
 
 # Uncomment when ftp.gnu.org is out...
-# repos['ftp.gnu.org'] = 'https://ftpmirror.gnu.org/gnu/'
+repos['ftp.gnu.org'] = 'https://ftpmirror.gnu.org/gnu/'
 
 ### END
 EOF

--- a/mac-setup/jhbuild-version.lock
+++ b/mac-setup/jhbuild-version.lock
@@ -1,3 +1,3 @@
-gtk-osx=1bf5f79bf88fd423b085e8e3a2058820ed2cc73c
+gtk-osx=cbc5ae1fa25d79bfc031643f251be7c081f06af1
 xournalpp-pipeline-dependencies=42b0fc7991d36dad6e9aa73a3fe26ef2eb1535c7
 deployment_target=11.0

--- a/mac-setup/xournalpp.bundle
+++ b/mac-setup/xournalpp.bundle
@@ -53,19 +53,19 @@
 
   <!-- Lua-GObject and GObject-introspection dependency -->
   <binary>
-    ${prefix}/lib/lua/5.4/LuaGObject/lua_gobject_core.so
+    ${prefix}/lib/lua/5.5/LuaGObject/lua_gobject_core.so
   </binary>
   <binary>
     ${prefix}/lib/libgirepository*.dylib
   </binary>
   <data>
-    ${prefix}/share/lua/5.4/LuaGObject.lua
+    ${prefix}/share/lua/5.5/LuaGObject.lua
   </data>
   <data>
-    ${prefix}/share/lua/5.4/LuaGObject/*.lua
+    ${prefix}/share/lua/5.5/LuaGObject/*.lua
   </data>
   <data>
-    ${prefix}/share/lua/5.4/LuaGObject/override/*.lua
+    ${prefix}/share/lua/5.5/LuaGObject/override/*.lua
   </data>
   <data>
     ${prefix}/lib/girepository-1.0/*.typelib

--- a/mac-setup/xournalpp.modules
+++ b/mac-setup/xournalpp.modules
@@ -92,7 +92,7 @@
             checkoutdir="libopus-1.5.2"/>
   </cmake>
 
-  <cmake id="libsndfile" cmakeargs="-DBUILD_PROGRAMS=off -DBUILD_EXAMPLES=off -DBUILD_SHARED_LIBS=ON -DENABLE_EXTERNAL_LIBS=ON">
+  <cmake id="libsndfile" cmakeargs="-DBUILD_PROGRAMS=off -DBUILD_EXAMPLES=off -DBUILD_SHARED_LIBS=ON -DENABLE_EXTERNAL_LIBS=ON -DCMAKE_POLICY_VERSION_MINIMUM=3.6">
     <branch repo="github-tarball"
             version="1.2.2"
             module="libsndfile/libsndfile/archive/1.2.2.tar.gz"

--- a/mac-setup/xournalpp.modules
+++ b/mac-setup/xournalpp.modules
@@ -15,10 +15,10 @@
 
   <cmake id="openjpeg">
     <branch repo="github-tarball"
-            module="uclouvain/openjpeg/archive/v2.5.3.tar.gz"
-            version="2.5.3"
-            checkoutdir="openjpeg-2.5.3"
-            hash="sha256:368fe0468228e767433c9ebdea82ad9d801a3ad1e4234421f352c8b06e7aa707"/>
+            module="uclouvain/openjpeg/archive/v2.5.4.tar.gz"
+            version="2.5.4"
+            checkoutdir="openjpeg-2.5.4"
+            hash="sha256:a695fbe19c0165f295a8531b1e4e855cd94d0875d2f88ec4b61080677e27188a"/>
   </cmake>
 
   <cmake id="poppler-data">
@@ -31,9 +31,9 @@
   <!-- For poppler-glib -->
   <cmake id="poppler" cmakeargs="-DENABLE_NSS3=off -DENABLE_GPGME=off -DENABLE_QT5=OFF -DENABLE_QT6=OFF -DBUILD_QT5_TESTS=off -DBUILD_QT6_TESTS=off -DBUILD_CPP_TESTS=off -DENABLE_LCMS=off -DENABLE_LIBCURL=off -DENABLE_BOOST=OFF -DENABLE_CPP=ON -DENABLE_CMS=none -DENABLE_LIBTIFF=off -DCMAKE_INSTALL_NAME_DIR='&#36;&lt;INSTALL_PREFIX&gt;/lib'">
     <branch repo="poppler"
-            version="25.06.0"
-            module="poppler-25.06.0.tar.xz"
-            hash="sha256:8199532d38984fab46dbd0020ec9c40f20e928e33e9b4cc6043572603a821d83"/>
+            version="26.08.0"
+            module="poppler-26.08.0.tar.xz"
+            hash="sha256:dc906e68cea698109706ac6aa3d2c9d4512fcfcac42d90b8afcda486d1b9abd0"/>
     <dependencies>
       <dep package="poppler-data"/>
       <dep package="openjpeg"/>
@@ -76,20 +76,20 @@
   </cmake>
   <cmake id="libflac" cmakeargs="-DBUILD_PROGRAMS=off -DBUILD_EXAMPLES=off -DBUILD_TESTING=off -DINSTALL_MANPAGES=off">
     <branch repo="github-tarball"
-            version="1.4.3"
-            module="xiph/flac/releases/download/1.4.3/flac-1.4.3.tar.xz"
-            hash="sha256:6c58e69cd22348f441b861092b825e591d0b822e106de6eb0ee4d05d27205b70"
-            checkoutdir="libflac-1.4.3"/>
+            version="1.5.0"
+            module="xiph/flac/releases/download/1.5.0/flac-1.5.0.tar.xz"
+            hash="sha256:f2c1c76592a82ffff8413ba3c4a1299b6c7ab06c734dee03fd88630485c2b920"
+            checkoutdir="libflac-1.5.0"/>
     <dependencies>
       <dep package="libogg"/>
     </dependencies>
   </cmake>
   <cmake id="libopus" cmakeargs="">
     <branch repo="github-tarball"
-            version="1.4"
-            module="xiph/opus/archive/refs/tags/v1.4.tar.gz"
-            hash="sha256:659e6b223e42a51b0a898632b9a5f406ccd5c2e00aa526ddd1264789774b94e5"
-            checkoutdir="libopus-1.4"/>
+            version="1.5.2"
+            module="xiph/opus/releases/download/v1.5.2/opus-1.5.2.tar.gz"
+            hash="sha256:65c1d2f78b9f2fb20082c38cbe47c951ad5839345876e46941612ee87f9a7ce1"
+            checkoutdir="libopus-1.5.2"/>
   </cmake>
 
   <cmake id="libsndfile" cmakeargs="-DBUILD_PROGRAMS=off -DBUILD_EXAMPLES=off -DBUILD_SHARED_LIBS=ON -DENABLE_EXTERNAL_LIBS=ON">
@@ -108,10 +108,10 @@
 
   <cmake id="libqpdf" cmakeargs="-DBUILD_SHARED_LIBS=true -DCMAKE_BUILD_TYPE=RelWithDebInfo">
     <branch repo="github-tarball"
-            version="12.2.0"
-            module="qpdf/qpdf/archive/refs/tags/v12.2.0.tar.gz"
-            hash="sha256:2d004611699a94030a594318393f08a7352ab1cf3cee337c5312d4e7eb7f8a4f"
-            checkoutdir="libqpdf-12.2.0"/>
+            version="12.4.1"
+            module="qpdf/qpdf/archive/refs/tags/v12.4.1.tar.gz"
+            hash="sha256:ebab3840fa8f370a1d4a1b4b7b08fad5baebeb5b5fa3cbbda88cd81e4fccecc9"
+            checkoutdir="libqpdf-12.4.1"/>
     <dependencies>
       <dep package="zlib"/>
       <dep package="libjpeg"/>
@@ -127,10 +127,10 @@
              makeinstallargs="INSTALL_TOP='$(DESTDIR)/${prefix}' install"
   >
     <branch repo="lua"
-            version="5.4.8"
-            module="lua-5.4.8.tar.gz"
-            hash="sha256:4f18ddae154e793e46eeab727c59ef1c0c0c2b744e7b94219710d76f530629ae"
-            checkoutdir="lua-5.4.8"/>
+            version="5.4.9"
+            module="lua-5.4.9.tar.gz"
+            hash="sha256:2335b6c582a52654f94612bf10d2f4672805d05329aa6568b1d8cd9e5c6fb8e6"
+            checkoutdir="lua-5.4.9"/>
   </autotools>
 
   <autotools id="lua-gobject"

--- a/mac-setup/xournalpp.modules
+++ b/mac-setup/xournalpp.modules
@@ -127,22 +127,22 @@
              makeinstallargs="INSTALL_TOP='$(DESTDIR)/${prefix}' install"
   >
     <branch repo="lua"
-            version="5.4.9"
-            module="lua-5.4.9.tar.gz"
-            hash="sha256:2335b6c582a52654f94612bf10d2f4672805d05329aa6568b1d8cd9e5c6fb8e6"
-            checkoutdir="lua-5.4.9"/>
+            version="5.5.1"
+            module="lua-5.5.1.tar.gz"
+            hash="sha256:1c4b4068d67061f2a2231ad2b5422e77acea1487ea9890f6320af614f4373dce"
+            checkoutdir="lua-5.5.1"/>
   </autotools>
 
   <autotools id="lua-gobject"
              skip-autogen="true"
              supports-non-srcdir-builds="no"
-             makeinstallargs='LUA_VERSION=5.4 PREFIX="${prefix}" install'
+             makeinstallargs='LUA_VERSION=5.5 PREFIX="${prefix}" install'
   >
     <branch repo="github-tarball"
-            module="vtrlx/LuaGObject/archive/refs/tags/0.10.0.tar.gz"
-            hash="sha256:0b94b6d254a92827cc2efc80fbf40cc237ae7f1c4e1677f8f658c8d4fe393d0c"
-            version="0.10.0"
-            checkoutdir="LuaGObject-0.10.0">
+            module="vtrlx/LuaGObject/archive/refs/tags/0.10.5.tar.gz"
+            hash="sha256:e386fe8e95b1205e83b2c31eb2657142840ea1acfd416973ba010fa27579d581"
+            version="0.10.5"
+            checkoutdir="LuaGObject-0.10.5">
     </branch>
     <dependencies>
       <dep package="lua"/>

--- a/mac-setup/xournalpp.modules
+++ b/mac-setup/xournalpp.modules
@@ -64,7 +64,7 @@
             checkoutdir="libogg-1.3.6"/>
   </cmake>
 
-  <cmake id="libvorbis" cmakeargs="">
+  <cmake id="libvorbis" cmakeargs="-DCMAKE_POLICY_VERSION_MINIMUM=3.6">
     <branch repo="github-tarball"
             version="1.3.7"
             module="xiph/vorbis/releases/download/v1.3.7/libvorbis-1.3.7.tar.gz"


### PR DESCRIPTION
Because of instability of ftpmirror.gnu.org, we have been having issues with the MacOS dependency build CI.

This PR fixes that and bumps the MacOS deps versions as well.

Note: I did not bump lua from 5.4 to 5.5, but we could. @rolandlo would that be safe?