### PR TITLE
Fix false "impossible event" discards when panning with hand tool

### DIFF
--- a/src/core/gui/inputdevices/PenInputHandler.cpp
+++ b/src/core/gui/inputdevices/PenInputHandler.cpp
@@ -293,6 +293,7 @@ auto PenInputHandler::actionMotion(InputEvent const& event) -> bool {
     this->changeTool(event);
 
     if (toolHandler->getToolType() == TOOL_HAND) {
+        this->updateLastEvent(event);
         if (this->deviceClassPressed) {
             this->handleScrollEvent(event);
             return true;

--- a/src/core/gui/inputdevices/StylusInputHandler.cpp
+++ b/src/core/gui/inputdevices/StylusInputHandler.cpp
@@ -89,8 +89,8 @@ auto StylusInputHandler::handleImpl(InputEvent const& event) -> bool {
 
     // Check if enter/leave events occur in possible locations. This is a bug of the hardware (there are such devices!)
     if ((event.type == ENTER_EVENT || event.type == LEAVE_EVENT) && this->deviceClassPressed && this->lastEvent) {
-        if (std::abs(event.relative.x - lastEvent.relative.x) > 100 ||
-            std::abs(event.relative.y - lastEvent.relative.y) > 100) {
+        if (std::abs(event.absolute.x - lastEvent.absolute.x) > 100 ||
+            std::abs(event.absolute.y - lastEvent.absolute.y) > 100) {
             g_message("Discard impossible event - this is a sign of bugged hardware or drivers");
             return true;
         }


### PR DESCRIPTION
rn when holding hand tool with the tip of the stylus going out and then in the window it fires false positive

```
xopp-Message: xx:xx:xx.xxx: Discard impossible event - this is a sign of bugged hardware or drivers
```

which is not true